### PR TITLE
fix: show visible placeholder for missing token logos

### DIFF
--- a/components/base/BaseAvatar.vue
+++ b/components/base/BaseAvatar.vue
@@ -12,7 +12,7 @@ const images = computed(() => {
     return {
       label: labels[index],
       src: s,
-      state: shallowReactive(useImage({ src: s })),
+      state: reactive(useImage({ src: s })),
     }
   })
 })
@@ -32,11 +32,11 @@ const images = computed(() => {
       />
       <div
         v-else
-        class="w-24 h-24 flex items-center justify-center font-semibold overflow-hidden rounded-full bg-center bg-cover flex-shrink-0 [&.icon--16]:!w-16 [&.icon--16]:!h-16 [&.icon--18]:!w-18 [&.icon--18]:!h-18 [&.icon--20]:!w-20 [&.icon--20]:!h-20 [&.icon--20]:text-[8px] [&.icon--24]:!w-24 [&.icon--24]:!h-24 [&.icon--32]:!w-32 [&.icon--32]:!h-32 [&.icon--36]:!w-36 [&.icon--36]:!h-36 [&.icon--38]:!w-38 [&.icon--38]:!h-38 [&.icon--40]:!w-40 [&.icon--40]:!h-40 [&.icon--46]:!w-46 [&.icon--46]:!h-46 [&.icon--46]:text-[16px] [&:not(:first-child)]:-ml-8 [&.icon--38:not(:first-child)]:-ml-18 [&.icon--40:not(:first-child)]:-ml-20 [&.icon--46:not(:first-child)]:-ml-18"
+        class="w-24 h-24 flex items-center justify-center font-semibold overflow-hidden rounded-full bg-center bg-cover flex-shrink-0 border border-line-subtle [&.icon--16]:!w-16 [&.icon--16]:!h-16 [&.icon--18]:!w-18 [&.icon--18]:!h-18 [&.icon--20]:!w-20 [&.icon--20]:!h-20 [&.icon--20]:text-[8px] [&.icon--24]:!w-24 [&.icon--24]:!h-24 [&.icon--32]:!w-32 [&.icon--32]:!h-32 [&.icon--36]:!w-36 [&.icon--36]:!h-36 [&.icon--38]:!w-38 [&.icon--38]:!h-38 [&.icon--40]:!w-40 [&.icon--40]:!h-40 [&.icon--46]:!w-46 [&.icon--46]:!h-46 [&.icon--46]:text-[16px] [&:not(:first-child)]:-ml-8 [&.icon--38:not(:first-child)]:-ml-18 [&.icon--40:not(:first-child)]:-ml-20 [&.icon--46:not(:first-child)]:-ml-18"
         v-bind="$attrs"
-        :style="{ backgroundColor: label ? stringToColor(image.label || '') : 'var(--c-euler-dark-400)' }"
+        :style="{ backgroundColor: image.label ? stringToColor(image.label) : 'var(--neutral-300)', color: image.label ? '#ffffff' : 'var(--c-euler-dark-800)' }"
       >
-        {{ image.label ? image.label.slice(0, 2) : '' }}
+        {{ image.label ? image.label.slice(0, 2) : '?' }}
       </div>
     </template>
   </div>

--- a/components/entities/chains/SelectChainModal.vue
+++ b/components/entities/chains/SelectChainModal.vue
@@ -31,6 +31,7 @@ const onClick = (chainId: number) => {
         <BaseAvatar
           class="mr-8 w-32 h-32"
           :src="`/chains/${chain.id}.webp`"
+          :label="chain.name"
         />
         {{ chain.name }}
       </div>

--- a/components/entities/portfolio/PortfolioBrevisRewardItem.vue
+++ b/components/entities/portfolio/PortfolioBrevisRewardItem.vue
@@ -109,7 +109,8 @@ const onClaimClick = async () => {
         <div class="flex items-center">
           <BaseAvatar
             v-if="vault"
-            :src="getAssetLogoUrl(vault.asset.address)"
+            :src="getAssetLogoUrl(vault.asset.symbol)"
+            :label="vault.asset.symbol"
             class="icon--40"
           />
           <div class="ml-12">

--- a/components/entities/reward/RewardUnlockItem.vue
+++ b/components/entities/reward/RewardUnlockItem.vue
@@ -135,6 +135,7 @@ const onUnlockClick = async () => {
     >
       <BaseAvatar
         src="/img/euler-default.png"
+        label="EUL"
         class="icon--40"
       />
       <h4 class="text-h5 ml-12">

--- a/components/entities/vault/ChooseCollateralModal.vue
+++ b/components/entities/vault/ChooseCollateralModal.vue
@@ -36,6 +36,7 @@ const handleClose = () => {
     >
       <BaseAvatar
         :src="getAssetLogoUrl(getOptionSymbol(option))"
+        :label="getOptionSymbol(option)"
         class="icon--36 mr-10"
       />
       <div class="flex-grow">

--- a/components/entities/vault/overview/VaultOverviewBlockOracleAdapters.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockOracleAdapters.vue
@@ -187,6 +187,7 @@ const formatAdapterPrice = (adapter: OracleAdapterEntry) => {
               <BaseAvatar
                 v-if="adapter.logo"
                 :src="adapter.logo"
+                :label="adapter.name"
                 class="icon--20"
               />
               <SvgIcon

--- a/components/entities/vault/overview/VaultOverviewModal.vue
+++ b/components/entities/vault/overview/VaultOverviewModal.vue
@@ -30,6 +30,7 @@ const tabs = computed(() => {
       label: 'Position details',
       value: undefined,
       avatars: [getAssetLogoUrl(pair.collateral.asset.symbol), getAssetLogoUrl(pair.borrow.asset.symbol)],
+      symbols: [pair.collateral.asset.symbol, pair.borrow.asset.symbol],
     },
   ]
   if (extraVault) {
@@ -41,6 +42,7 @@ const tabs = computed(() => {
         label: extraVault.asset.symbol,
         value: 'multiply-collateral',
         avatars: [getAssetLogoUrl(extraVault.asset.symbol)],
+        symbols: [extraVault.asset.symbol],
       })
     }
   }
@@ -51,6 +53,7 @@ const tabs = computed(() => {
       label: vault.asset.symbol,
       value: `collateral-${index}`,
       avatars: [getAssetLogoUrl(vault.asset.symbol)],
+      symbols: [vault.asset.symbol],
     })
   })
 
@@ -58,6 +61,7 @@ const tabs = computed(() => {
     label: pair.borrow.asset.symbol,
     value: 'borrow',
     avatars: [getAssetLogoUrl(pair.borrow.asset.symbol)],
+    symbols: [pair.borrow.asset.symbol],
   })
   return list
 })
@@ -99,7 +103,7 @@ const onVaultClick = (address: string) => {
     >
       <template #default="{ tab: slotTab }">
         <div class="flex items-center gap-8">
-          <BaseAvatar :src="slotTab.avatars as string[]" />
+          <BaseAvatar :src="slotTab.avatars as string[]" :label="slotTab.symbols" />
           {{ slotTab.label }}
         </div>
       </template>

--- a/components/layout/TheHeader.vue
+++ b/components/layout/TheHeader.vue
@@ -160,7 +160,7 @@ onClickOutside(reference, () => {
           icon-right
           @click="onChainButtonClick"
         >
-          <BaseAvatar :src="`/chains/${chainId}.webp`" />
+          <BaseAvatar :src="`/chains/${chainId}.webp`" :label="String(chainId)" />
         </UiButton>
         <UiButton
           :icon="isConnected ? 'arrow-down' : 'plus'"

--- a/pages/borrow/[collateral]/[borrow]/index.vue
+++ b/pages/borrow/[collateral]/[borrow]/index.vue
@@ -209,16 +209,19 @@ const tabs = computed(() => {
       label: 'Pair details',
       value: undefined,
       avatars: [getAssetLogoUrl(pair.value.collateral.asset.symbol), getAssetLogoUrl(pair.value.borrow.asset.symbol)],
+      symbols: [pair.value.collateral.asset.symbol, pair.value.borrow.asset.symbol],
     },
     {
       label: pair.value.collateral.asset.symbol,
       value: 'collateral',
       avatars: [getAssetLogoUrl(pair.value.collateral.asset.symbol)],
+      symbols: [pair.value.collateral.asset.symbol],
     },
     {
       label: pair.value.borrow.asset.symbol,
       value: 'borrow',
       avatars: [getAssetLogoUrl(pair.value.borrow.asset.symbol)],
+      symbols: [pair.value.borrow.asset.symbol],
     },
   ]
   if (formTab.value === 'multiply' && multiplySupplyVault.value) {
@@ -230,6 +233,7 @@ const tabs = computed(() => {
         label: multiplySupplyVault.value.asset.symbol,
         value: 'multiply-collateral',
         avatars: [getAssetLogoUrl(multiplySupplyVault.value.asset.symbol)],
+        symbols: [multiplySupplyVault.value.asset.symbol],
       })
     }
   }
@@ -1889,7 +1893,7 @@ watch(formTab, () => {
       >
         <template #default="{ tab: slotTab }">
           <div class="flex items-center gap-8">
-            <BaseAvatar :src="slotTab.avatars as string[]" />
+            <BaseAvatar :src="slotTab.avatars as string[]" :label="slotTab.symbols" />
 
             {{ slotTab.label }}
           </div>

--- a/utils/string-utils.ts
+++ b/utils/string-utils.ts
@@ -73,7 +73,7 @@ export const preciseNumber = (value: string | number, decimals = 36) => {
   return Intl.NumberFormat('en-US', { maximumFractionDigits: decimals, useGrouping: false }).format(Number(value))
 }
 
-export const stringToColor = (value: string, saturation = 20, lightness = 20) => {
+export const stringToColor = (value: string, saturation = 40, lightness = 45) => {
   let hash = 0
   for (let i = 0; i < value.length; i++) {
     hash = value.charCodeAt(i) + ((hash << 5) - hash)


### PR DESCRIPTION
## Summary

- **Root cause fix**: `BaseAvatar` used `shallowReactive(useImage(...))` which doesn't unwrap refs — `image.state.isReady` was always the truthy Ref object, so the `v-else` fallback never rendered. Changed to `reactive()`.
- **Fallback styling**: visible background colors (via `stringToColor` with bumped defaults), white text on colored circles, `?` for missing labels, subtle border for edge visibility.
- **Bug fix**: `PortfolioBrevisRewardItem` passed `vault.asset.address` (hex address) to `getAssetLogoUrl` instead of `vault.asset.symbol`, so the logo always failed to match.
- **Added `:label` props** across all `BaseAvatar` usages (tab headers, modals, chain selectors) so fallback initials display correctly.