### PR TITLE
feat: add "From savings" repay tab

### DIFF
--- a/components/entities/operation/OperationReviewModal.vue
+++ b/components/entities/operation/OperationReviewModal.vue
@@ -45,7 +45,7 @@ interface REULUnlockInfo {
   daysUntilMaturity: number
 }
 
-const { type, asset, assetIconUrl, campaignInfo, reulUnlockInfo, amount, onConfirm, fee, plan, swapToAsset, swapToAmount, supplyingAssetForBorrow, supplyingAmount } = defineProps<{
+const { type, asset, assetIconUrl, campaignInfo, reulUnlockInfo, amount, onConfirm, fee, plan, swapToAsset, swapToAmount, supplyingAssetForBorrow, supplyingAmount, transferAmounts } = defineProps<{
   type?: 'supply' | 'withdraw' | 'borrow' | 'repay' | 'swap' | 'transfer' | 'reward' | 'brevis-reward' | 'reul-unlock' | 'disableCollateral'
   asset: VaultAsset
   assetIconUrl?: string
@@ -61,6 +61,8 @@ const { type, asset, assetIconUrl, campaignInfo, reulUnlockInfo, amount, onConfi
   onConfirm: () => void
   subAccount?: string
   hasBorrows?: boolean
+  /** Known amounts for transferFromMax steps, keyed by vault address (lowercase) */
+  transferAmounts?: Record<string, string>
 }>()
 
 const { chain, address: walletAddress, chainId: currentChainId } = useWagmi()
@@ -232,7 +234,7 @@ const resolveAmountFromCalldata = (data: string, targetContract: string): { deco
   return { decoded: false }
 }
 
-const getAssetInfoForStep = (label: string, data: string, targetContract: string, usedSupply: { value: boolean }, usedBorrow: { value: boolean }, usedSwapTo: { value: boolean }): StepAssetInfo | undefined => {
+const getAssetInfoForStep = (label: string, data: string, targetContract: string, usedSupply: { value: boolean }, usedBorrow: { value: boolean }, usedSwapTo: { value: boolean }, lastWithdrawAmount: { value: string | undefined }): StepAssetInfo | undefined => {
   if (label === 'Enable collateral' || label === 'Enable controller' || label === 'Disable collateral' || label === 'Disable controller') {
     return getVaultAssetInfo(data, targetContract)
   }
@@ -245,6 +247,9 @@ const getAssetInfoForStep = (label: string, data: string, targetContract: string
     }
     const resolved = resolveAmountFromCalldata(data, targetContract)
     const displayAmount = resolved.isMax ? 'remaining' : (resolved.decoded ? resolved.amount : amount)
+    if (label === 'Withdraw' && resolved.decoded && resolved.amount) {
+      lastWithdrawAmount.value = resolved.amount
+    }
     return { symbol: asset.symbol, address: asset.address, amount: displayAmount }
   }
 
@@ -252,11 +257,15 @@ const getAssetInfoForStep = (label: string, data: string, targetContract: string
     if (swapToAsset && swapToAmount) {
       return { symbol: swapToAsset.symbol, address: swapToAsset.address, amount: swapToAmount }
     }
-    // skim always deposits whatever tokens are available — amount param is just a minimum check
+    // skim: decode the amount from calldata when available, fall back to "remaining"
     try {
       const targetVault = getVault(getAddress(targetContract))
       if (targetVault?.asset) {
-        return { symbol: targetVault.asset.symbol, address: targetVault.asset.address, amount: 'remaining' }
+        const resolved = resolveAmountFromCalldata(data, targetContract)
+        const displayAmount = resolved.decoded && !resolved.isMax && resolved.amount
+          ? resolved.amount
+          : 'remaining'
+        return { symbol: targetVault.asset.symbol, address: targetVault.asset.address, amount: displayAmount }
       }
     }
     catch { /* ignore */ }
@@ -264,7 +273,10 @@ const getAssetInfoForStep = (label: string, data: string, targetContract: string
   }
 
   if (label === 'Transfer' || label === 'Transfer to account') {
-    const transferAmount = label === 'Transfer to account' ? 'remaining' : undefined
+    const knownAmount = label === 'Transfer to account' && transferAmounts
+      ? transferAmounts[targetContract.toLowerCase()]
+      : undefined
+    const transferAmount = knownAmount || (label === 'Transfer to account' ? 'remaining' : undefined)
     try {
       const targetVault = getVault(getAddress(targetContract))
       if (targetVault?.asset) return { symbol: targetVault.asset.symbol, address: targetVault.asset.address, amount: transferAmount }
@@ -286,7 +298,8 @@ const getAssetInfoForStep = (label: string, data: string, targetContract: string
   }
 
   if (label === 'Swap') {
-    return { symbol: asset.symbol, address: asset.address, amount }
+    // Use the precise amount from the preceding withdraw step if available
+    return { symbol: asset.symbol, address: asset.address, amount: lastWithdrawAmount.value || amount }
   }
 
   if (label === 'Verify min received') {
@@ -298,6 +311,25 @@ const getAssetInfoForStep = (label: string, data: string, targetContract: string
   }
 
   if (label === 'Verify max debt') {
+    // verifyDebtMax(address vault, address account, uint256 maxDebt, uint256 currentDebt)
+    // Decode the vault (param 0) and maxDebt (param 2) directly from calldata
+    if (data.length >= 202) {
+      try {
+        const debtVaultAddr = getAddress(`0x${data.slice(34, 74)}`)
+        const debtVault = getVault(debtVaultAddr)
+        if (debtVault?.asset) {
+          const maxDebt = BigInt(`0x${data.slice(138, 202)}`)
+          const debtAmount = maxDebt === MAX_UINT256
+            ? 'max'
+            : formatUnits(maxDebt, Number(debtVault.asset.decimals))
+          return { symbol: debtVault.asset.symbol, address: debtVault.asset.address, amount: debtAmount }
+        }
+      }
+      catch { /* fall through */ }
+    }
+    if (swapToAsset && swapToAmount) {
+      return { symbol: swapToAsset.symbol, address: swapToAsset.address, amount: swapToAmount }
+    }
     return { symbol: asset.symbol, address: asset.address, amount }
   }
 
@@ -316,6 +348,7 @@ const displaySteps = computed((): DisplayStep[] => {
   const usedSupply = { value: false }
   const usedBorrow = { value: false }
   const usedSwapTo = { value: false }
+  const lastWithdrawAmount: { value: string | undefined } = { value: undefined }
 
   for (const step of plan.steps) {
     if (step.type === 'evc-batch') {
@@ -343,7 +376,7 @@ const displaySteps = computed((): DisplayStep[] => {
         for (const item of batchItems) {
           index++
           const label = decodeBatchItemLabel(item.data)
-          const stepAssetInfo = getAssetInfoForStep(label, item.data, item.targetContract, usedSupply, usedBorrow, usedSwapTo)
+          const stepAssetInfo = getAssetInfoForStep(label, item.data, item.targetContract, usedSupply, usedBorrow, usedSwapTo, lastWithdrawAmount)
           const secondAsset = supplyingAssetForBorrow || swapToAsset
           let toAssetInfo: StepAssetInfo | undefined
           if (label === 'Swap' && swapToAsset && swapToAmount) {

--- a/components/entities/portfolio/PortfolioBrevisRewardItem.vue
+++ b/components/entities/portfolio/PortfolioBrevisRewardItem.vue
@@ -19,6 +19,7 @@ const { runSimulation, simulationError } = useTxPlanSimulation()
 
 const vault = ref(campaign.vault_address ? await getVault(campaign.vault_address) : undefined)
 const isClaiming = ref(false)
+const isPreparing = ref(false)
 const plan = ref<TxPlan | null>(null)
 const rewardAmount = computed(() => Number.parseFloat(campaign.reward_info.reward_amt))
 const rewardUsdValue = computed(() => rewardAmount.value * Number.parseFloat(campaign.reward_info.reward_usd_price))
@@ -56,6 +57,8 @@ const claim = async () => {
 }
 
 const onClaimClick = async () => {
+  if (isPreparing.value) return
+  isPreparing.value = true
   try {
     await ensureWalletOnSiteChain()
 
@@ -96,6 +99,9 @@ const onClaimClick = async () => {
   catch (e) {
     console.warn(e)
   }
+  finally {
+    isPreparing.value = false
+  }
 }
 </script>
 
@@ -134,7 +140,7 @@ const onClaimClick = async () => {
       </div>
       <UiButton
         rounded
-        :loading="isClaiming"
+        :loading="isClaiming || isPreparing"
         @click="onClaimClick"
       >
         Claim

--- a/components/entities/portfolio/PortfolioEarnItem.vue
+++ b/components/entities/portfolio/PortfolioEarnItem.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
+import { useAccount } from '@wagmi/vue'
 import { getAssetUsdValue, formatAssetValue } from '~/services/pricing/priceProvider'
 import { getAssetLogoUrl } from '~/composables/useTokens'
 import { isVaultBlockedByCountry } from '~/composables/useGeoBlock'
-import type { AccountDepositPosition } from '~/entities/account'
+import { type AccountDepositPosition, getSubAccountIndex } from '~/entities/account'
 import type { EarnVault } from '~/entities/vault'
 import { VaultOverviewModal, VaultSupplyApyModal } from '#components'
 import { useModal } from '~/components/ui/composables/useModal'
@@ -11,6 +12,14 @@ import { nanoToValue, roundAndCompactTokens } from '~/utils/crypto-utils'
 
 const { position } = defineProps<{ position: AccountDepositPosition }>()
 const modal = useModal()
+
+const { address } = useAccount()
+const { portfolioAddress } = useEulerAccount()
+const ownerAddress = computed(() => portfolioAddress.value || address.value || '')
+const subAccountIndex = computed(() => {
+  if (!ownerAddress.value || !position.subAccount) return 0
+  return getSubAccountIndex(ownerAddress.value, position.subAccount)
+})
 
 const { getSupplyRewardApy, hasSupplyRewards, getSupplyRewardCampaigns } = useRewardsApy()
 const { getIntrinsicApy } = useIntrinsicApy()
@@ -186,7 +195,7 @@ const onClick = () => {
           </UiButton>
           <UiButton
             variant="primary-stroke"
-            :to="{ path: `/earn/${vault.address}/withdraw`, query: { subAccount: position.subAccount } }"
+            :to="`/earn/${vault.address}/${subAccountIndex}/withdraw`"
             rounded
           >
             Withdraw

--- a/components/entities/portfolio/PortfolioRewardItem.vue
+++ b/components/entities/portfolio/PortfolioRewardItem.vue
@@ -18,6 +18,7 @@ const { chainId: walletChainId, switchChain } = useWagmi()
 const { runSimulation, simulationError } = useTxPlanSimulation()
 
 const isClaiming = ref(false)
+const isPreparing = ref(false)
 const plan = ref<TxPlan | null>(null)
 
 const amount = computed(() => nanoToValue(reward.amount, reward.token.decimals))
@@ -64,6 +65,8 @@ const claim = async () => {
 }
 
 const onClaimClick = async () => {
+  if (isPreparing.value) return
+  isPreparing.value = true
   try {
     await ensureWalletOnSiteChain()
 
@@ -99,6 +102,9 @@ const onClaimClick = async () => {
   }
   catch (e) {
     console.warn(e)
+  }
+  finally {
+    isPreparing.value = false
   }
 }
 </script>
@@ -136,7 +142,7 @@ const onClaimClick = async () => {
       </div>
       <UiButton
         rounded
-        :loading="isClaiming"
+        :loading="isClaiming || isPreparing"
         @click="onClaimClick"
       >
         Claim

--- a/components/entities/portfolio/PortfolioSavingItem.vue
+++ b/components/entities/portfolio/PortfolioSavingItem.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useAccount } from '@wagmi/vue'
 import { type Vault } from '~/entities/vault'
 import { getUtilisationWarning } from '~/composables/useVaultWarnings'
 import { getAssetUsdValue, formatAssetValue } from '~/services/pricing/priceProvider'
@@ -6,12 +7,20 @@ import { getAssetLogoUrl } from '~/composables/useTokens'
 import { isVaultBlockedByCountry } from '~/composables/useGeoBlock'
 import { formatNumber, compactNumber, formatCompactUsdValue, formatSmartAmount } from '~/utils/string-utils'
 import { nanoToValue, roundAndCompactTokens } from '~/utils/crypto-utils'
-import type { AccountDepositPosition } from '~/entities/account'
+import { type AccountDepositPosition, getSubAccountIndex } from '~/entities/account'
 import { VaultOverviewModal, VaultSupplyApyModal } from '#components'
 import { useModal } from '~/components/ui/composables/useModal'
 
 const { position } = defineProps<{ position: AccountDepositPosition }>()
 const modal = useModal()
+
+const { address } = useAccount()
+const { portfolioAddress } = useEulerAccount()
+const ownerAddress = computed(() => portfolioAddress.value || address.value || '')
+const subAccountIndex = computed(() => {
+  if (!ownerAddress.value || !position.subAccount) return 0
+  return getSubAccountIndex(ownerAddress.value, position.subAccount)
+})
 
 const { withIntrinsicSupplyApy, getIntrinsicApy } = useIntrinsicApy()
 const { getSupplyRewardApy, hasSupplyRewards, getSupplyRewardCampaigns } = useRewardsApy()
@@ -199,14 +208,14 @@ const onClick = () => {
           </UiButton>
           <UiButton
             variant="primary-stroke"
-            :to="{ path: `/lend/${vault.address}/withdraw`, query: { subAccount: position.subAccount } }"
+            :to="`/lend/${vault.address}/${subAccountIndex}/withdraw`"
             rounded
           >
             Withdraw
           </UiButton>
           <UiButton
             variant="primary-stroke"
-            :to="isGeoBlocked ? undefined : { path: `/lend/${vault.address}/swap`, query: { subAccount: position.subAccount } }"
+            :to="isGeoBlocked ? undefined : `/lend/${vault.address}/${subAccountIndex}/swap`"
             :disabled="isGeoBlocked"
             rounded
           >
@@ -316,14 +325,14 @@ const onClick = () => {
           </UiButton>
           <UiButton
             variant="primary-stroke"
-            :to="{ path: `/lend/${vault.address}/withdraw`, query: { subAccount: position.subAccount } }"
+            :to="`/lend/${vault.address}/${subAccountIndex}/withdraw`"
             rounded
           >
             Withdraw
           </UiButton>
           <UiButton
             variant="primary-stroke"
-            :to="isGeoBlocked ? undefined : { path: `/lend/${vault.address}/swap`, query: { subAccount: position.subAccount } }"
+            :to="isGeoBlocked ? undefined : `/lend/${vault.address}/${subAccountIndex}/swap`"
             :disabled="isGeoBlocked"
             rounded
           >

--- a/components/entities/reward/RewardUnlockItem.vue
+++ b/components/entities/reward/RewardUnlockItem.vue
@@ -19,6 +19,7 @@ const { runSimulation, simulationError } = useTxPlanSimulation()
 const { item } = defineProps<{ item: REULLock }>()
 
 const isUnlocking = ref(false)
+const isPreparing = ref(false)
 const plan = ref<TxPlan | null>(null)
 
 const reulToken = computed(() => {
@@ -79,6 +80,8 @@ const unlock = async () => {
 }
 
 const onUnlockClick = async () => {
+  if (isPreparing.value) return
+  isPreparing.value = true
   try {
     await ensureWalletOnSiteChain()
 
@@ -126,6 +129,9 @@ const onUnlockClick = async () => {
   catch (e) {
     console.warn(e)
   }
+  finally {
+    isPreparing.value = false
+  }
 }
 </script>
 
@@ -170,7 +176,7 @@ const onUnlockClick = async () => {
       <UiButton
         variant="primary-stroke"
         rounded
-        :loading="isUnlocking"
+        :loading="isUnlocking || isPreparing"
         @click="onUnlockClick"
       >
         Unlock

--- a/components/entities/vault/ChooseCollateralModal.vue
+++ b/components/entities/vault/ChooseCollateralModal.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { getAssetLogoUrl } from '~/composables/useTokens'
+import { getProductByVault } from '~/composables/useEulerLabels'
 import type { CollateralOption } from '~/entities/vault'
 import { formatNumber } from '~/utils/string-utils'
 
@@ -13,10 +14,25 @@ const { productName, symbol, collateralOptions, selected = 0, title = 'Select co
   onSave: any
 }>()
 
+const { isEscrowVault } = useVaultRegistry()
+
 const searchQuery = ref('')
 const selectedIdx = ref(selected)
-const getOptionLabel = (option: CollateralOption) => option.label || productName
+const getOptionLabel = (option: CollateralOption) => {
+  if (option.vaultAddress && isEscrowVault(option.vaultAddress)) return 'Escrowed collateral'
+  if (option.label) return option.label
+  if (option.vaultAddress) {
+    const product = getProductByVault(option.vaultAddress)
+    if (product?.name) return product.name
+  }
+  return productName
+}
 const getOptionSymbol = (option: CollateralOption) => option.symbol || symbol
+const getOptionType = (option: CollateralOption) => {
+  if (option.type === 'escrow') return 'escrow'
+  if (option.vaultAddress && isEscrowVault(option.vaultAddress)) return 'escrow'
+  return option.type
+}
 
 const filteredOptions = computed(() => {
   if (!searchQuery.value) return collateralOptions.map((option, idx) => ({ option, idx }))
@@ -73,22 +89,16 @@ const handleClose = () => {
           <div class="text-h5 flex items-center">
             {{ getOptionSymbol(option) }}
             <div
-              v-if="option.type === 'wallet'"
+              v-if="getOptionType(option) === 'wallet'"
               class="ml-6 text-[12px] leading-[16px] py-4 px-8 rounded-8 bg-[#A1F4E01A] text-aquamarine-600"
             >
               Wallet
             </div>
             <div
-              v-else-if="option.type === 'saving'"
+              v-else-if="getOptionType(option) === 'saving'"
               class="ml-6 text-[12px] leading-[16px] py-4 px-8 rounded-8 bg-[#CBC0951A] text-yellow-600"
             >
               Savings
-            </div>
-            <div
-              v-else-if="option.type === 'escrow'"
-              class="ml-6 text-[12px] leading-[16px] py-4 px-8 rounded-8 bg-[var(--c-aquamarine-opaque-200)] text-aquamarine-600"
-            >
-              Escrowed collateral
             </div>
             <span
               v-for="tag in (option.tags || [])"

--- a/composables/useEulerAccount.ts
+++ b/composables/useEulerAccount.ts
@@ -551,11 +551,13 @@ const updateBorrowPositions = async (
     borrowPositions.value = allPositions
 
     // Build set of (subAccount, collateralVault) pairs used as collateral
+    // Must include ALL enabled collateral vaults, not just the primary one
     const usageSet = new Set<string>()
     for (const pos of allPositions) {
       const subAccount = getAddress(pos.subAccount)
-      const collateralAddress = getAddress(pos.collateral.address)
-      usageSet.add(`${subAccount}:${collateralAddress}`)
+      for (const addr of pos.collaterals ?? [pos.collateral.address]) {
+        usageSet.add(`${subAccount}:${getAddress(addr)}`)
+      }
     }
     collateralUsageSet.value = usageSet
 

--- a/composables/useEulerOperations.ts
+++ b/composables/useEulerOperations.ts
@@ -467,6 +467,7 @@ export const useEulerOperations = () => {
     disableCollateral,
     liabilityVault,
     enabledCollaterals,
+    isDebtSwap = false,
   }: {
     quote: SwapApiQuote
     swapperMode: SwapperMode
@@ -477,6 +478,9 @@ export const useEulerOperations = () => {
     disableCollateral?: string
     liabilityVault?: string
     enabledCollaterals?: string[]
+    /** When true, uses borrow (not withdraw) on the input vault, enables a controller
+     *  on accountOut, and disables the old controller after the swap. */
+    isDebtSwap?: boolean
   }) => {
     if (!address.value || !eulerCoreAddresses.value || !eulerPeripheryAddresses.value) {
       throw new Error('Wallet not connected or addresses not available')
@@ -500,7 +504,9 @@ export const useEulerOperations = () => {
       throw new Error('Swap amount is zero')
     }
 
-    const isDebtSwap = isRepay && quote.accountIn.toLowerCase() !== quote.accountOut.toLowerCase()
+    // isDebtSwap controls whether the input side uses borrow (true) or withdraw (false).
+    // Callers must explicitly opt in — different accountIn/accountOut doesn't imply debt swap
+    // (e.g. savings repay withdraws from a different sub-account, not a borrow).
     const verifierData = buildSwapVerifierData({
       quote,
       swapperMode,
@@ -1830,6 +1836,7 @@ export const useEulerOperations = () => {
     disableCollateral,
     liabilityVault,
     enabledCollaterals,
+    isDebtSwap = false,
   }: {
     quote: SwapApiQuote
     swapperMode?: SwapperMode
@@ -1840,6 +1847,7 @@ export const useEulerOperations = () => {
     disableCollateral?: string
     liabilityVault?: string
     enabledCollaterals?: string[]
+    isDebtSwap?: boolean
   }): Promise<TxPlan> => {
     const { evcCalls, evcAddress, totalValue } = await buildSwapEvcCalls({
       quote,
@@ -1851,6 +1859,7 @@ export const useEulerOperations = () => {
       disableCollateral,
       liabilityVault,
       enabledCollaterals,
+      isDebtSwap,
     })
 
     return {
@@ -2095,12 +2104,14 @@ export const useEulerOperations = () => {
       data: hooks.getDataForCall(borrowVaultAddr, 'skim', [amount, subAccountAddr]) as Hash,
     })
 
-    // Burn shares to repay debt
+    // Burn shares to repay debt — use amount - 1n to avoid share rounding mismatch:
+    // skim credits toSharesDown(amount) shares, but repayWithShares burns toSharesUp(amount),
+    // which can be 1 share more. Reducing by 1 wei keeps it within the skimmed balance.
     evcCalls.push({
       targetContract: borrowVaultAddr,
       onBehalfOfAccount: subAccountAddr,
       value: 0n,
-      data: hooks.getDataForCall(borrowVaultAddr, 'repayWithShares', [amount, subAccountAddr]) as Hash,
+      data: hooks.getDataForCall(borrowVaultAddr, 'repayWithShares', [amount > 0n ? amount - 1n : 0n, subAccountAddr]) as Hash,
     })
 
     const totalValue = sumCallValues(evcCalls)
@@ -2561,17 +2572,32 @@ export const useEulerOperations = () => {
     const hasSigned = await hasSignature(userAddr)
     const tosData = await getTosData()
 
+    const sameVault = savingsVaultAddr.toLowerCase() === borrowVaultAddr.toLowerCase()
+
     const hooks = new SaHooksBuilder()
-    hooks.addContractInterface(savingsVaultAddr, vaultWithdrawAbi)
-    hooks.addContractInterface(borrowVaultAddr, [...vaultSkimAbi, ...vaultRepayWithSharesAbi])
+    if (sameVault) {
+      // Same vault: repayWithShares directly burns savings shares to repay borrow debt
+      hooks.addContractInterface(savingsVaultAddr, vaultRepayWithSharesAbi)
+    }
+    else {
+      hooks.addContractInterface(savingsVaultAddr, vaultWithdrawAbi)
+      hooks.addContractInterface(borrowVaultAddr, [...vaultSkimAbi, ...vaultRepayWithSharesAbi])
+    }
     if (!hasSigned && enableTermsOfUseSignature) {
       hooks.addContractInterface(tosSignerAddress, tosSignerWriteAbi)
     }
 
     const evcCalls: EVCCall[] = []
 
-    // No Pyth updates needed — savings sub-account has no borrows (no health check on withdraw),
-    // and skim + repayWithShares on borrow sub-account only reduce debt (no health-worsening operation).
+    console.log('[buildSavingsRepayPlan]', {
+      savingsVaultAddr,
+      borrowVaultAddr,
+      sameVault,
+      amount: amount.toString(),
+      savingsSubAccountAddr,
+      borrowSubAccountAddr,
+      userAddr,
+    })
 
     // TOS signing
     if (!hasSigned && enableTermsOfUseSignature) {
@@ -2583,31 +2609,49 @@ export const useEulerOperations = () => {
       })
     }
 
-    // 1. Withdraw from savings vault, send underlying to borrow vault
-    evcCalls.push({
-      targetContract: savingsVaultAddr,
-      onBehalfOfAccount: savingsSubAccountAddr,
-      value: 0n,
-      data: hooks.getDataForCall(savingsVaultAddr, 'withdraw', [amount, borrowVaultAddr, savingsSubAccountAddr]) as Hash,
-    })
-
-    // 2. Skim on borrow vault (converts tokens to shares for borrowSubAccount)
-    evcCalls.push({
-      targetContract: borrowVaultAddr,
-      onBehalfOfAccount: borrowSubAccountAddr,
-      value: 0n,
-      data: hooks.getDataForCall(borrowVaultAddr, 'skim', [amount, borrowSubAccountAddr]) as Hash,
-    })
-
-    // 3. Burn shares to repay debt
-    evcCalls.push({
-      targetContract: borrowVaultAddr,
-      onBehalfOfAccount: borrowSubAccountAddr,
-      value: 0n,
-      data: hooks.getDataForCall(borrowVaultAddr, 'repayWithShares', [amount, borrowSubAccountAddr]) as Hash,
-    })
+    if (sameVault) {
+      // Same vault: burn shares from savings sub-account, repay debt on borrow sub-account.
+      // No withdraw/skim needed — avoids vault cash liquidity requirements.
+      evcCalls.push({
+        targetContract: savingsVaultAddr,
+        onBehalfOfAccount: savingsSubAccountAddr,
+        value: 0n,
+        data: hooks.getDataForCall(savingsVaultAddr, 'repayWithShares', [amount, borrowSubAccountAddr]) as Hash,
+      })
+    }
+    else {
+      // Different vaults: withdraw underlying → skim → repayWithShares
+      // repayWithShares uses amount - 1n to avoid share rounding mismatch:
+      // skim credits toSharesDown(amount) shares, but repayWithShares burns toSharesUp(amount),
+      // which can be 1 share more. Reducing by 1 wei keeps it within the skimmed balance.
+      evcCalls.push({
+        targetContract: savingsVaultAddr,
+        onBehalfOfAccount: savingsSubAccountAddr,
+        value: 0n,
+        data: hooks.getDataForCall(savingsVaultAddr, 'withdraw', [amount, borrowVaultAddr, savingsSubAccountAddr]) as Hash,
+      })
+      evcCalls.push({
+        targetContract: borrowVaultAddr,
+        onBehalfOfAccount: borrowSubAccountAddr,
+        value: 0n,
+        data: hooks.getDataForCall(borrowVaultAddr, 'skim', [amount, borrowSubAccountAddr]) as Hash,
+      })
+      evcCalls.push({
+        targetContract: borrowVaultAddr,
+        onBehalfOfAccount: borrowSubAccountAddr,
+        value: 0n,
+        data: hooks.getDataForCall(borrowVaultAddr, 'repayWithShares', [amount > 0n ? amount - 1n : 0n, borrowSubAccountAddr]) as Hash,
+      })
+    }
 
     const totalValue = sumCallValues(evcCalls)
+
+    console.log('[buildSavingsRepayPlan] evcCalls', evcCalls.map((c, i) => ({
+      i,
+      target: c.targetContract,
+      onBehalf: c.onBehalfOfAccount,
+      data: c.data.slice(0, 10),
+    })))
 
     return {
       kind: 'savings-repay',
@@ -2683,16 +2727,23 @@ export const useEulerOperations = () => {
       console.warn('[buildSavingsFullRepayPlan] failed to read pre-existing deposit', err)
     }
 
+    const sameVault = savingsVaultAddr.toLowerCase() === borrowVaultAddr.toLowerCase()
+    const collateralAddresses = enabledCollaterals || []
+
     const hooks = new SaHooksBuilder()
-    hooks.addContractInterface(savingsVaultAddr, [...vaultWithdrawAbi, ...vaultSkimAbi, ...vaultTransferFromMaxAbi])
-    hooks.addContractInterface(borrowVaultAddr, [...vaultSkimAbi, ...vaultRepayWithSharesAbi, ...evcDisableControllerAbi, ...vaultRedeemAbi])
+    if (sameVault) {
+      hooks.addContractInterface(savingsVaultAddr, [
+        ...vaultRepayWithSharesAbi, ...evcDisableControllerAbi, ...vaultTransferFromMaxAbi,
+      ])
+    }
+    else {
+      hooks.addContractInterface(savingsVaultAddr, [...vaultWithdrawAbi, ...vaultSkimAbi, ...vaultTransferFromMaxAbi])
+      hooks.addContractInterface(borrowVaultAddr, [...vaultSkimAbi, ...vaultRepayWithSharesAbi, ...evcDisableControllerAbi, ...vaultRedeemAbi])
+    }
     hooks.addContractInterface(evcAddress, evcDisableCollateralAbi)
     if (!hasSigned && enableTermsOfUseSignature) {
       hooks.addContractInterface(tosSignerAddress, tosSignerWriteAbi)
     }
-
-    // Register collateral vault ABIs for transferFromMax
-    const collateralAddresses = enabledCollaterals || []
     for (const collateralAddr of collateralAddresses) {
       hooks.addContractInterface(collateralAddr as Address, vaultTransferFromMaxAbi)
     }
@@ -2711,40 +2762,62 @@ export const useEulerOperations = () => {
       })
     }
 
-    // 1. Withdraw from savings vault (slightly more than debt for interest)
-    const adjustedAmount = adjustForInterest(amount)
-    evcCalls.push({
-      targetContract: savingsVaultAddr,
-      onBehalfOfAccount: savingsSubAccountAddr,
-      value: 0n,
-      data: hooks.getDataForCall(savingsVaultAddr, 'withdraw', [adjustedAmount, borrowVaultAddr, savingsSubAccountAddr]) as Hash,
-    })
+    if (sameVault) {
+      // Same vault: burn shares from savings sub-account to repay all debt on borrow sub-account.
+      // No withdraw/skim/redeem needed — avoids vault cash liquidity requirements.
+      evcCalls.push({
+        targetContract: savingsVaultAddr,
+        onBehalfOfAccount: savingsSubAccountAddr,
+        value: 0n,
+        data: hooks.getDataForCall(savingsVaultAddr, 'repayWithShares', [maxUint256, borrowSubAccountAddr]) as Hash,
+      })
+    }
+    else {
+      // Different vaults: withdraw → skim → repayWithShares → redeem excess → skim back
+      const adjustedAmount = adjustForInterest(amount)
+      evcCalls.push({
+        targetContract: savingsVaultAddr,
+        onBehalfOfAccount: savingsSubAccountAddr,
+        value: 0n,
+        data: hooks.getDataForCall(savingsVaultAddr, 'withdraw', [adjustedAmount, borrowVaultAddr, savingsSubAccountAddr]) as Hash,
+      })
+      evcCalls.push({
+        targetContract: borrowVaultAddr,
+        onBehalfOfAccount: borrowSubAccountAddr,
+        value: 0n,
+        data: hooks.getDataForCall(borrowVaultAddr, 'skim', [adjustedAmount, borrowSubAccountAddr]) as Hash,
+      })
+      evcCalls.push({
+        targetContract: borrowVaultAddr,
+        onBehalfOfAccount: borrowSubAccountAddr,
+        value: 0n,
+        data: hooks.getDataForCall(borrowVaultAddr, 'repayWithShares', [maxUint256, borrowSubAccountAddr]) as Hash,
+      })
+      // Redeem excess shares from borrow vault, return tokens to savings vault
+      evcCalls.push({
+        targetContract: borrowVaultAddr,
+        onBehalfOfAccount: borrowSubAccountAddr,
+        value: 0n,
+        data: hooks.getDataForCall(borrowVaultAddr, 'redeem', [maxUint256, savingsVaultAddr, borrowSubAccountAddr]) as Hash,
+      })
+      // Re-deposit returned tokens into savings vault
+      evcCalls.push({
+        targetContract: savingsVaultAddr,
+        onBehalfOfAccount: savingsSubAccountAddr,
+        value: 0n,
+        data: hooks.getDataForCall(savingsVaultAddr, 'skim', [preExistingBorrowDeposit, savingsSubAccountAddr]) as Hash,
+      })
+    }
 
-    // 2. Skim on borrow vault (convert tokens to shares)
+    // Disable controller (no more debt)
     evcCalls.push({
-      targetContract: borrowVaultAddr,
+      targetContract: sameVault ? savingsVaultAddr : borrowVaultAddr,
       onBehalfOfAccount: borrowSubAccountAddr,
       value: 0n,
-      data: hooks.getDataForCall(borrowVaultAddr, 'skim', [adjustedAmount, borrowSubAccountAddr]) as Hash,
+      data: hooks.getDataForCall(sameVault ? savingsVaultAddr : borrowVaultAddr, 'disableController', []) as Hash,
     })
 
-    // 3. Repay ALL debt with shares
-    evcCalls.push({
-      targetContract: borrowVaultAddr,
-      onBehalfOfAccount: borrowSubAccountAddr,
-      value: 0n,
-      data: hooks.getDataForCall(borrowVaultAddr, 'repayWithShares', [maxUint256, borrowSubAccountAddr]) as Hash,
-    })
-
-    // 4. Disable controller (no more debt)
-    evcCalls.push({
-      targetContract: borrowVaultAddr,
-      onBehalfOfAccount: borrowSubAccountAddr,
-      value: 0n,
-      data: hooks.getDataForCall(borrowVaultAddr, 'disableController', []) as Hash,
-    })
-
-    // 5. Disable collateral (safe after disableController — no health check)
+    // Disable collateral (safe after disableController — no health check)
     for (const collateralAddr of collateralAddresses) {
       evcCalls.push({
         targetContract: evcAddress,
@@ -2754,23 +2827,7 @@ export const useEulerOperations = () => {
       })
     }
 
-    // 6. Redeem ALL remaining shares from borrow vault, send tokens to savings vault
-    evcCalls.push({
-      targetContract: borrowVaultAddr,
-      onBehalfOfAccount: borrowSubAccountAddr,
-      value: 0n,
-      data: hooks.getDataForCall(borrowVaultAddr, 'redeem', [maxUint256, savingsVaultAddr, borrowSubAccountAddr]) as Hash,
-    })
-
-    // 7. Skim on savings vault (re-deposit returned tokens)
-    evcCalls.push({
-      targetContract: savingsVaultAddr,
-      onBehalfOfAccount: savingsSubAccountAddr,
-      value: 0n,
-      data: hooks.getDataForCall(savingsVaultAddr, 'skim', [preExistingBorrowDeposit, savingsSubAccountAddr]) as Hash,
-    })
-
-    // 8. Transfer collateral shares from borrow sub-account to main account
+    // Transfer collateral shares from borrow sub-account to main account
     const isMainAccount = borrowSubAccountAddr.toLowerCase() === userAddr.toLowerCase()
     if (!isMainAccount) {
       for (const collateralAddr of collateralAddresses) {
@@ -2783,7 +2840,7 @@ export const useEulerOperations = () => {
       }
     }
 
-    // 9. Transfer remaining savings shares to main account
+    // Transfer remaining savings shares to main account
     const isSavingsMainAccount = savingsSubAccountAddr.toLowerCase() === userAddr.toLowerCase()
     if (!isSavingsMainAccount) {
       evcCalls.push({
@@ -2817,6 +2874,99 @@ export const useEulerOperations = () => {
    * Builds the swap EVC calls (which handle withdraw from savingsSubAccount via quote.accountIn),
    * then appends position cleanup: disableController, disableCollateral, transferFromMax for each collateral.
    */
+  const buildSwapCollateralFullRepayPlan = async ({
+    quote,
+    swapperMode = SwapperMode.EXACT_IN,
+    targetDebt = 0n,
+    currentDebt = 0n,
+    liabilityVault,
+    enabledCollaterals,
+  }: {
+    quote: SwapApiQuote
+    swapperMode?: SwapperMode
+    targetDebt?: bigint
+    currentDebt?: bigint
+    liabilityVault?: string
+    enabledCollaterals?: string[]
+  }): Promise<TxPlan> => {
+    if (!address.value || !eulerCoreAddresses.value) {
+      throw new Error('Wallet not connected or addresses not available')
+    }
+
+    const userAddr = address.value as Address
+    const evcAddress = eulerCoreAddresses.value.evc as Address
+    const subAccountAddr = quote.accountIn as Address
+
+    const { evcCalls, totalValue: swapValue } = await buildSwapEvcCalls({
+      quote,
+      swapperMode,
+      isRepay: true,
+      targetDebt,
+      currentDebt,
+      liabilityVault,
+      enabledCollaterals,
+    })
+
+    // Append position cleanup calls
+    const hooks = new SaHooksBuilder()
+    const borrowVaultAddr = quote.receiver as Address
+    hooks.addContractInterface(borrowVaultAddr, evcDisableControllerAbi)
+    hooks.addContractInterface(evcAddress, evcDisableCollateralAbi)
+
+    const collateralAddresses = enabledCollaterals || []
+    for (const collateralAddr of collateralAddresses) {
+      hooks.addContractInterface(collateralAddr as Address, vaultTransferFromMaxAbi)
+    }
+
+    // Disable controller (debt is fully repaid)
+    evcCalls.push({
+      targetContract: borrowVaultAddr,
+      onBehalfOfAccount: subAccountAddr,
+      value: 0n,
+      data: hooks.getDataForCall(borrowVaultAddr, 'disableController', []) as Hash,
+    })
+
+    // Disable collateral
+    for (const collateralAddr of collateralAddresses) {
+      evcCalls.push({
+        targetContract: evcAddress,
+        onBehalfOfAccount: '0x0000000000000000000000000000000000000000' as Address,
+        value: 0n,
+        data: hooks.getDataForCall(evcAddress, 'disableCollateral', [subAccountAddr, collateralAddr as Address]) as Hash,
+      })
+    }
+
+    // Transfer collateral shares to main account
+    const isMainAccount = subAccountAddr.toLowerCase() === userAddr.toLowerCase()
+    if (!isMainAccount) {
+      for (const collateralAddr of collateralAddresses) {
+        evcCalls.push({
+          targetContract: collateralAddr as Address,
+          onBehalfOfAccount: subAccountAddr,
+          value: 0n,
+          data: hooks.getDataForCall(collateralAddr as Address, 'transferFromMax', [subAccountAddr, userAddr]) as Hash,
+        })
+      }
+    }
+
+    const totalValue = sumCallValues(evcCalls)
+
+    return {
+      kind: 'swap-collateral-full-repay',
+      steps: [
+        {
+          type: 'evc-batch',
+          label: 'Full repay with collateral swap via EVC',
+          to: evcAddress,
+          abi: EVC_ABI,
+          functionName: 'batch',
+          args: [evcCalls as never],
+          value: totalValue,
+        },
+      ],
+    }
+  }
+
   const buildSwapSavingsFullRepayPlan = async ({
     quote,
     swapperMode = SwapperMode.EXACT_IN,
@@ -2929,6 +3079,7 @@ export const useEulerOperations = () => {
     buildSameAssetFullRepayPlan,
     buildSameAssetDebtSwapPlan,
     buildDisableCollateralPlan,
+    buildSwapCollateralFullRepayPlan,
     buildSavingsRepayPlan,
     buildSavingsFullRepayPlan,
     buildSwapSavingsFullRepayPlan,

--- a/composables/useEulerOperations.ts
+++ b/composables/useEulerOperations.ts
@@ -2539,14 +2539,12 @@ export const useEulerOperations = () => {
     amount,
     savingsSubAccount,
     borrowSubAccount,
-    enabledCollaterals,
   }: {
     savingsVaultAddress: string
     borrowVaultAddress: string
     amount: bigint
     savingsSubAccount: string
     borrowSubAccount: string
-    enabledCollaterals?: string[]
   }): Promise<TxPlan> => {
     if (!address.value || !eulerCoreAddresses.value || !eulerPeripheryAddresses.value) {
       throw new Error('Wallet not connected or addresses not available')
@@ -2572,12 +2570,8 @@ export const useEulerOperations = () => {
 
     const evcCalls: EVCCall[] = []
 
-    // Pyth updates for borrow sub-account health check
-    const effectiveCollaterals = resolveEffectiveCollaterals(enabledCollaterals)
-    const { calls: pythCalls } = await preparePythUpdatesForHealthCheck(borrowVaultAddress, effectiveCollaterals, userAddr)
-    if (pythCalls.length) {
-      evcCalls.push(...pythCalls as EVCCall[])
-    }
+    // No Pyth updates needed — savings sub-account has no borrows (no health check on withdraw),
+    // and skim + repayWithShares on borrow sub-account only reduce debt (no health-worsening operation).
 
     // TOS signing
     if (!hasSigned && enableTermsOfUseSignature) {

--- a/composables/useEulerOperations.ts
+++ b/composables/useEulerOperations.ts
@@ -2528,6 +2528,395 @@ export const useEulerOperations = () => {
     }
   }
 
+  /**
+   * Repay debt using savings from a different sub-account (same underlying asset, partial).
+   * Withdraws from the savings vault on savingsSubAccount, skims into borrow vault on borrowSubAccount,
+   * then burns shares to repay debt.
+   */
+  const buildSavingsRepayPlan = async ({
+    savingsVaultAddress,
+    borrowVaultAddress,
+    amount,
+    savingsSubAccount,
+    borrowSubAccount,
+    enabledCollaterals,
+  }: {
+    savingsVaultAddress: string
+    borrowVaultAddress: string
+    amount: bigint
+    savingsSubAccount: string
+    borrowSubAccount: string
+    enabledCollaterals?: string[]
+  }): Promise<TxPlan> => {
+    if (!address.value || !eulerCoreAddresses.value || !eulerPeripheryAddresses.value) {
+      throw new Error('Wallet not connected or addresses not available')
+    }
+
+    const savingsVaultAddr = savingsVaultAddress as Address
+    const borrowVaultAddr = borrowVaultAddress as Address
+    const userAddr = address.value as Address
+    const evcAddress = eulerCoreAddresses.value.evc as Address
+    const tosSignerAddress = eulerPeripheryAddresses.value.termsOfUseSigner as Address
+    const savingsSubAccountAddr = savingsSubAccount as Address
+    const borrowSubAccountAddr = borrowSubAccount as Address
+
+    const hasSigned = await hasSignature(userAddr)
+    const tosData = await getTosData()
+
+    const hooks = new SaHooksBuilder()
+    hooks.addContractInterface(savingsVaultAddr, vaultWithdrawAbi)
+    hooks.addContractInterface(borrowVaultAddr, [...vaultSkimAbi, ...vaultRepayWithSharesAbi])
+    if (!hasSigned && enableTermsOfUseSignature) {
+      hooks.addContractInterface(tosSignerAddress, tosSignerWriteAbi)
+    }
+
+    const evcCalls: EVCCall[] = []
+
+    // Pyth updates for borrow sub-account health check
+    const effectiveCollaterals = resolveEffectiveCollaterals(enabledCollaterals)
+    const { calls: pythCalls } = await preparePythUpdatesForHealthCheck(borrowVaultAddress, effectiveCollaterals, userAddr)
+    if (pythCalls.length) {
+      evcCalls.push(...pythCalls as EVCCall[])
+    }
+
+    // TOS signing
+    if (!hasSigned && enableTermsOfUseSignature) {
+      evcCalls.push({
+        targetContract: tosSignerAddress,
+        onBehalfOfAccount: userAddr,
+        value: 0n,
+        data: hooks.getDataForCall(tosSignerAddress, 'signTermsOfUse', [tosData.tosMessage, tosData.tosMessageHash]) as Hash,
+      })
+    }
+
+    // 1. Withdraw from savings vault, send underlying to borrow vault
+    evcCalls.push({
+      targetContract: savingsVaultAddr,
+      onBehalfOfAccount: savingsSubAccountAddr,
+      value: 0n,
+      data: hooks.getDataForCall(savingsVaultAddr, 'withdraw', [amount, borrowVaultAddr, savingsSubAccountAddr]) as Hash,
+    })
+
+    // 2. Skim on borrow vault (converts tokens to shares for borrowSubAccount)
+    evcCalls.push({
+      targetContract: borrowVaultAddr,
+      onBehalfOfAccount: borrowSubAccountAddr,
+      value: 0n,
+      data: hooks.getDataForCall(borrowVaultAddr, 'skim', [amount, borrowSubAccountAddr]) as Hash,
+    })
+
+    // 3. Burn shares to repay debt
+    evcCalls.push({
+      targetContract: borrowVaultAddr,
+      onBehalfOfAccount: borrowSubAccountAddr,
+      value: 0n,
+      data: hooks.getDataForCall(borrowVaultAddr, 'repayWithShares', [amount, borrowSubAccountAddr]) as Hash,
+    })
+
+    const totalValue = sumCallValues(evcCalls)
+
+    return {
+      kind: 'savings-repay',
+      steps: [
+        {
+          type: 'evc-batch',
+          label: 'Repay with savings via EVC',
+          to: evcAddress,
+          abi: EVC_ABI,
+          functionName: 'batch',
+          args: [evcCalls as never],
+          value: totalValue,
+        },
+      ],
+    }
+  }
+
+  /**
+   * Full repay using savings from a different sub-account (same underlying asset).
+   * Withdraws from savings, repays all debt, disables controller + collateral,
+   * returns excess to savings vault, and transfers all positions back to main account.
+   */
+  const buildSavingsFullRepayPlan = async ({
+    savingsVaultAddress,
+    borrowVaultAddress,
+    amount,
+    savingsSubAccount,
+    borrowSubAccount,
+    enabledCollaterals,
+  }: {
+    savingsVaultAddress: string
+    borrowVaultAddress: string
+    amount: bigint
+    savingsSubAccount: string
+    borrowSubAccount: string
+    enabledCollaterals?: string[]
+  }): Promise<TxPlan> => {
+    if (!address.value || !eulerCoreAddresses.value || !eulerPeripheryAddresses.value) {
+      throw new Error('Wallet not connected or addresses not available')
+    }
+
+    const savingsVaultAddr = savingsVaultAddress as Address
+    const borrowVaultAddr = borrowVaultAddress as Address
+    const userAddr = address.value as Address
+    const evcAddress = eulerCoreAddresses.value.evc as Address
+    const tosSignerAddress = eulerPeripheryAddresses.value.termsOfUseSigner as Address
+    const savingsSubAccountAddr = savingsSubAccount as Address
+    const borrowSubAccountAddr = borrowSubAccount as Address
+
+    const hasSigned = await hasSignature(userAddr)
+    const tosData = await getTosData()
+
+    // Pre-flight: read pre-existing deposit in borrow vault
+    let preExistingBorrowDeposit = 0n
+    try {
+      const balanceOfResult = await rpcProvider.readContract({
+        address: borrowVaultAddr,
+        abi: erc20BalanceOfAbi,
+        functionName: 'balanceOf',
+        args: [borrowSubAccountAddr],
+      }) as bigint
+      if (balanceOfResult > 0n) {
+        const assetsResult = await rpcProvider.readContract({
+          address: borrowVaultAddr,
+          abi: vaultConvertToAssetsAbi,
+          functionName: 'convertToAssets',
+          args: [balanceOfResult],
+        }) as bigint
+        preExistingBorrowDeposit = assetsResult
+      }
+    }
+    catch (err) {
+      console.warn('[buildSavingsFullRepayPlan] failed to read pre-existing deposit', err)
+    }
+
+    const hooks = new SaHooksBuilder()
+    hooks.addContractInterface(savingsVaultAddr, [...vaultWithdrawAbi, ...vaultSkimAbi, ...vaultTransferFromMaxAbi])
+    hooks.addContractInterface(borrowVaultAddr, [...vaultSkimAbi, ...vaultRepayWithSharesAbi, ...evcDisableControllerAbi, ...vaultRedeemAbi])
+    hooks.addContractInterface(evcAddress, evcDisableCollateralAbi)
+    if (!hasSigned && enableTermsOfUseSignature) {
+      hooks.addContractInterface(tosSignerAddress, tosSignerWriteAbi)
+    }
+
+    // Register collateral vault ABIs for transferFromMax
+    const collateralAddresses = enabledCollaterals || []
+    for (const collateralAddr of collateralAddresses) {
+      hooks.addContractInterface(collateralAddr as Address, vaultTransferFromMaxAbi)
+    }
+
+    const evcCalls: EVCCall[] = []
+
+    // No Pyth updates needed — batch ends with disableController (no health check)
+
+    // TOS signing
+    if (!hasSigned && enableTermsOfUseSignature) {
+      evcCalls.push({
+        targetContract: tosSignerAddress,
+        onBehalfOfAccount: userAddr,
+        value: 0n,
+        data: hooks.getDataForCall(tosSignerAddress, 'signTermsOfUse', [tosData.tosMessage, tosData.tosMessageHash]) as Hash,
+      })
+    }
+
+    // 1. Withdraw from savings vault (slightly more than debt for interest)
+    const adjustedAmount = adjustForInterest(amount)
+    evcCalls.push({
+      targetContract: savingsVaultAddr,
+      onBehalfOfAccount: savingsSubAccountAddr,
+      value: 0n,
+      data: hooks.getDataForCall(savingsVaultAddr, 'withdraw', [adjustedAmount, borrowVaultAddr, savingsSubAccountAddr]) as Hash,
+    })
+
+    // 2. Skim on borrow vault (convert tokens to shares)
+    evcCalls.push({
+      targetContract: borrowVaultAddr,
+      onBehalfOfAccount: borrowSubAccountAddr,
+      value: 0n,
+      data: hooks.getDataForCall(borrowVaultAddr, 'skim', [adjustedAmount, borrowSubAccountAddr]) as Hash,
+    })
+
+    // 3. Repay ALL debt with shares
+    evcCalls.push({
+      targetContract: borrowVaultAddr,
+      onBehalfOfAccount: borrowSubAccountAddr,
+      value: 0n,
+      data: hooks.getDataForCall(borrowVaultAddr, 'repayWithShares', [maxUint256, borrowSubAccountAddr]) as Hash,
+    })
+
+    // 4. Disable controller (no more debt)
+    evcCalls.push({
+      targetContract: borrowVaultAddr,
+      onBehalfOfAccount: borrowSubAccountAddr,
+      value: 0n,
+      data: hooks.getDataForCall(borrowVaultAddr, 'disableController', []) as Hash,
+    })
+
+    // 5. Disable collateral (safe after disableController — no health check)
+    for (const collateralAddr of collateralAddresses) {
+      evcCalls.push({
+        targetContract: evcAddress,
+        onBehalfOfAccount: '0x0000000000000000000000000000000000000000' as Address,
+        value: 0n,
+        data: hooks.getDataForCall(evcAddress, 'disableCollateral', [borrowSubAccountAddr, collateralAddr as Address]) as Hash,
+      })
+    }
+
+    // 6. Redeem ALL remaining shares from borrow vault, send tokens to savings vault
+    evcCalls.push({
+      targetContract: borrowVaultAddr,
+      onBehalfOfAccount: borrowSubAccountAddr,
+      value: 0n,
+      data: hooks.getDataForCall(borrowVaultAddr, 'redeem', [maxUint256, savingsVaultAddr, borrowSubAccountAddr]) as Hash,
+    })
+
+    // 7. Skim on savings vault (re-deposit returned tokens)
+    evcCalls.push({
+      targetContract: savingsVaultAddr,
+      onBehalfOfAccount: savingsSubAccountAddr,
+      value: 0n,
+      data: hooks.getDataForCall(savingsVaultAddr, 'skim', [preExistingBorrowDeposit, savingsSubAccountAddr]) as Hash,
+    })
+
+    // 8. Transfer collateral shares from borrow sub-account to main account
+    const isMainAccount = borrowSubAccountAddr.toLowerCase() === userAddr.toLowerCase()
+    if (!isMainAccount) {
+      for (const collateralAddr of collateralAddresses) {
+        evcCalls.push({
+          targetContract: collateralAddr as Address,
+          onBehalfOfAccount: borrowSubAccountAddr,
+          value: 0n,
+          data: hooks.getDataForCall(collateralAddr as Address, 'transferFromMax', [borrowSubAccountAddr, userAddr]) as Hash,
+        })
+      }
+    }
+
+    // 9. Transfer remaining savings shares to main account
+    const isSavingsMainAccount = savingsSubAccountAddr.toLowerCase() === userAddr.toLowerCase()
+    if (!isSavingsMainAccount) {
+      evcCalls.push({
+        targetContract: savingsVaultAddr,
+        onBehalfOfAccount: savingsSubAccountAddr,
+        value: 0n,
+        data: hooks.getDataForCall(savingsVaultAddr, 'transferFromMax', [savingsSubAccountAddr, userAddr]) as Hash,
+      })
+    }
+
+    const totalValue = sumCallValues(evcCalls)
+
+    return {
+      kind: 'savings-full-repay',
+      steps: [
+        {
+          type: 'evc-batch',
+          label: 'Full repay with savings via EVC',
+          to: evcAddress,
+          abi: EVC_ABI,
+          functionName: 'batch',
+          args: [evcCalls as never],
+          value: totalValue,
+        },
+      ],
+    }
+  }
+
+  /**
+   * Full repay using a cross-asset swap from savings.
+   * Builds the swap EVC calls (which handle withdraw from savingsSubAccount via quote.accountIn),
+   * then appends position cleanup: disableController, disableCollateral, transferFromMax for each collateral.
+   */
+  const buildSwapSavingsFullRepayPlan = async ({
+    quote,
+    swapperMode = SwapperMode.EXACT_IN,
+    targetDebt = 0n,
+    currentDebt = 0n,
+    liabilityVault,
+    enabledCollaterals,
+  }: {
+    quote: SwapApiQuote
+    swapperMode?: SwapperMode
+    targetDebt?: bigint
+    currentDebt?: bigint
+    liabilityVault?: string
+    enabledCollaterals?: string[]
+  }): Promise<TxPlan> => {
+    if (!address.value || !eulerCoreAddresses.value) {
+      throw new Error('Wallet not connected or addresses not available')
+    }
+
+    const userAddr = address.value as Address
+    const evcAddress = eulerCoreAddresses.value.evc as Address
+    const borrowSubAccountAddr = quote.accountOut as Address
+
+    // Build the swap calls (withdraw from savings sub-account, swap, verify debt reduction)
+    const { evcCalls, totalValue: swapValue } = await buildSwapEvcCalls({
+      quote,
+      swapperMode,
+      isRepay: true,
+      targetDebt,
+      currentDebt,
+      liabilityVault,
+      enabledCollaterals,
+    })
+
+    // Append position cleanup calls
+    const hooks = new SaHooksBuilder()
+    const borrowVaultAddr = quote.receiver as Address
+    hooks.addContractInterface(borrowVaultAddr, evcDisableControllerAbi)
+    hooks.addContractInterface(evcAddress, evcDisableCollateralAbi)
+
+    const collateralAddresses = enabledCollaterals || []
+    for (const collateralAddr of collateralAddresses) {
+      hooks.addContractInterface(collateralAddr as Address, vaultTransferFromMaxAbi)
+    }
+
+    // Disable controller (debt is fully repaid)
+    evcCalls.push({
+      targetContract: borrowVaultAddr,
+      onBehalfOfAccount: borrowSubAccountAddr,
+      value: 0n,
+      data: hooks.getDataForCall(borrowVaultAddr, 'disableController', []) as Hash,
+    })
+
+    // Disable collateral
+    for (const collateralAddr of collateralAddresses) {
+      evcCalls.push({
+        targetContract: evcAddress,
+        onBehalfOfAccount: '0x0000000000000000000000000000000000000000' as Address,
+        value: 0n,
+        data: hooks.getDataForCall(evcAddress, 'disableCollateral', [borrowSubAccountAddr, collateralAddr as Address]) as Hash,
+      })
+    }
+
+    // Transfer collateral shares to main account
+    const isMainAccount = borrowSubAccountAddr.toLowerCase() === userAddr.toLowerCase()
+    if (!isMainAccount) {
+      for (const collateralAddr of collateralAddresses) {
+        evcCalls.push({
+          targetContract: collateralAddr as Address,
+          onBehalfOfAccount: borrowSubAccountAddr,
+          value: 0n,
+          data: hooks.getDataForCall(collateralAddr as Address, 'transferFromMax', [borrowSubAccountAddr, userAddr]) as Hash,
+        })
+      }
+    }
+
+    const totalValue = sumCallValues(evcCalls)
+
+    return {
+      kind: 'swap-savings-full-repay',
+      steps: [
+        {
+          type: 'evc-batch',
+          label: 'Full repay with savings swap via EVC',
+          to: evcAddress,
+          abi: EVC_ABI,
+          functionName: 'batch',
+          args: [evcCalls as never],
+          value: totalValue,
+        },
+      ],
+    }
+  }
+
   return {
     executeTxPlan,
     simulateTxPlan,
@@ -2546,5 +2935,8 @@ export const useEulerOperations = () => {
     buildSameAssetFullRepayPlan,
     buildSameAssetDebtSwapPlan,
     buildDisableCollateralPlan,
+    buildSavingsRepayPlan,
+    buildSavingsFullRepayPlan,
+    buildSwapSavingsFullRepayPlan,
   }
 }

--- a/composables/useEulerOperations.ts
+++ b/composables/useEulerOperations.ts
@@ -2589,16 +2589,6 @@ export const useEulerOperations = () => {
 
     const evcCalls: EVCCall[] = []
 
-    console.log('[buildSavingsRepayPlan]', {
-      savingsVaultAddr,
-      borrowVaultAddr,
-      sameVault,
-      amount: amount.toString(),
-      savingsSubAccountAddr,
-      borrowSubAccountAddr,
-      userAddr,
-    })
-
     // TOS signing
     if (!hasSigned && enableTermsOfUseSignature) {
       evcCalls.push({
@@ -2645,13 +2635,6 @@ export const useEulerOperations = () => {
     }
 
     const totalValue = sumCallValues(evcCalls)
-
-    console.log('[buildSavingsRepayPlan] evcCalls', evcCalls.map((c, i) => ({
-      i,
-      target: c.targetContract,
-      onBehalf: c.onBehalfOfAccount,
-      data: c.data.slice(0, 10),
-    })))
 
     return {
       kind: 'savings-repay',

--- a/composables/useRepaySavingsOptions.ts
+++ b/composables/useRepaySavingsOptions.ts
@@ -9,22 +9,20 @@ import { nanoToValue } from '~/utils/crypto-utils'
 
 /**
  * Provides eligible savings positions that can be used to repay debt.
- * Filters out securitize vaults (restricted withdrawals) and exposes each
- * savings position as a selectable option with vault, sub-account, and balance.
+ * Only includes standard EVK vaults — Earn vaults have an incompatible ABI
+ * and Securitize vaults have restricted withdrawals.
  */
 export const useRepaySavingsOptions = () => {
   const { depositPositions } = useEulerAccount()
-  const { isSecuritizeVault } = useVaultRegistry()
+  const { isEvkVault } = useVaultRegistry()
   const { withIntrinsicSupplyApy, version: intrinsicVersion } = useIntrinsicApy()
   const { getSupplyRewardApy, version: rewardsVersion } = useRewardsApy()
 
   const savingsPositions = computed(() => {
     return depositPositions.value.filter((position) => {
-      // Exclude securitize vaults — can't withdraw freely
-      if (isSecuritizeVault(position.vault.address)) {
+      if (!isEvkVault(position.vault.address)) {
         return false
       }
-      // Must have a positive balance
       if (position.assets <= 0n) {
         return false
       }

--- a/composables/useRepaySavingsOptions.ts
+++ b/composables/useRepaySavingsOptions.ts
@@ -1,0 +1,84 @@
+import { getAddress, type Address } from 'viem'
+import { getProductByVault } from '~/composables/useEulerLabels'
+import { useIntrinsicApy } from '~/composables/useIntrinsicApy'
+import { useVaultRegistry } from '~/composables/useVaultRegistry'
+import type { AccountDepositPosition } from '~/entities/account'
+import type { CollateralOption, Vault } from '~/entities/vault'
+import { getAssetUsdValueOrZero } from '~/services/pricing/priceProvider'
+import { nanoToValue } from '~/utils/crypto-utils'
+
+/**
+ * Provides eligible savings positions that can be used to repay debt.
+ * Filters out securitize vaults (restricted withdrawals) and exposes each
+ * savings position as a selectable option with vault, sub-account, and balance.
+ */
+export const useRepaySavingsOptions = () => {
+  const { depositPositions } = useEulerAccount()
+  const { isSecuritizeVault } = useVaultRegistry()
+  const { withIntrinsicSupplyApy, version: intrinsicVersion } = useIntrinsicApy()
+  const { getSupplyRewardApy, version: rewardsVersion } = useRewardsApy()
+
+  const savingsPositions = computed(() => {
+    return depositPositions.value.filter((position) => {
+      // Exclude securitize vaults — can't withdraw freely
+      if (isSecuritizeVault(position.vault.address)) {
+        return false
+      }
+      // Must have a positive balance
+      if (position.assets <= 0n) {
+        return false
+      }
+      return true
+    })
+  })
+
+  const savingsVaults = computed(() => {
+    return savingsPositions.value.map(position => position.vault as Vault)
+  })
+
+  const savingsOptions = ref<CollateralOption[]>([])
+  let optionsVersion = 0
+
+  watchEffect(async () => {
+    const positions = savingsPositions.value
+    void rewardsVersion.value
+    void intrinsicVersion.value
+    const myVersion = ++optionsVersion
+
+    const options = await Promise.all(positions.map(async (position) => {
+      const vault = position.vault
+      const amount = nanoToValue(position.assets, vault.asset.decimals)
+      const product = getProductByVault(vault.address)
+      const baseApy = nanoToValue(vault.interestRateInfo.supplyAPY || 0n, 25)
+      const apy = withIntrinsicSupplyApy(baseApy, vault.asset.symbol) + getSupplyRewardApy(vault.address)
+
+      return {
+        type: 'vault' as const,
+        amount,
+        price: await getAssetUsdValueOrZero(amount, vault, 'off-chain'),
+        apy,
+        symbol: vault.asset.symbol,
+        assetAddress: vault.asset.address,
+        label: product.name || vault.name,
+        vaultAddress: vault.address,
+      }
+    }))
+
+    if (myVersion !== optionsVersion) return
+    savingsOptions.value = options
+  })
+
+  const getSavingsPosition = (vaultAddress: string): AccountDepositPosition | undefined => {
+    const normalized = getAddress(vaultAddress)
+    return savingsPositions.value.find(
+      position => getAddress(position.vault.address) === normalized,
+    )
+  }
+
+  return {
+    savingsPositions,
+    savingsVaults,
+    savingsOptions,
+    getSavingsPosition,
+  }
+}

--- a/composables/useTxPlanSimulation.ts
+++ b/composables/useTxPlanSimulation.ts
@@ -18,6 +18,7 @@ export const useTxPlanSimulation = () => {
       return true
     }
     catch (e) {
+      console.log('[runSimulation] raw error', e)
       simulationError.value = getTxErrorMessage(e)
       return false
     }

--- a/composables/useTxPlanSimulation.ts
+++ b/composables/useTxPlanSimulation.ts
@@ -18,7 +18,6 @@ export const useTxPlanSimulation = () => {
       return true
     }
     catch (e) {
-      console.log('[runSimulation] raw error', e)
       simulationError.value = getTxErrorMessage(e)
       return false
     }

--- a/entities/account.ts
+++ b/entities/account.ts
@@ -77,6 +77,15 @@ export const getSubAccountIndex = (ownerAddress: string, subAccountAddress: stri
   return Number(owner ^ subAccount)
 }
 
+/**
+ * Derives the full sub-account address from owner address and sub-account index.
+ * Reverse of getSubAccountIndex: address = ownerAddress XOR index
+ */
+export const getSubAccountAddress = (ownerAddress: string, index: number): string => {
+  const owner = BigInt(getAddress(ownerAddress))
+  return getAddress(pad(toHex(owner ^ BigInt(index), { size: 20 }), { size: 20 }))
+}
+
 export const getNewSubAccount = async (ownerAddress: string) => {
   const { SUBGRAPH_URL } = useEulerConfig()
 

--- a/pages/borrow/[collateral]/[borrow]/index.vue
+++ b/pages/borrow/[collateral]/[borrow]/index.vue
@@ -84,7 +84,9 @@ const balance = ref(0n)
 const savingBalance = ref(0n)
 const savingAssets = ref(0n)
 const isSubmitting = ref(false)
+const isPreparing = ref(false)
 const isMultiplySubmitting = ref(false)
+const isMultiplyPreparing = ref(false)
 const isEstimatesLoading = ref(false)
 const plan = ref<TxPlan | null>(null)
 const multiplyPlan = ref<TxPlan | null>(null)
@@ -1054,11 +1056,13 @@ const onMultiplyCollateralChange = (selectedIndex: number) => {
   }
 }
 const submitMultiply = async () => {
-  if (isGeoBlocked.value || isMultiplyRestricted.value) return
-  await guardWithTerms(async () => {
-    if (isMultiplySubmitting.value || !isConnected.value) {
-      return
-    }
+  if (isMultiplyPreparing.value || isGeoBlocked.value || isMultiplyRestricted.value) return
+  isMultiplyPreparing.value = true
+  try {
+    await guardWithTerms(async () => {
+      if (isMultiplySubmitting.value || !isConnected.value) {
+        return
+      }
     if (!multiplySupplyVault.value || !multiplyLongVault.value || !multiplyShortVault.value) {
       return
     }
@@ -1160,7 +1164,11 @@ const submitMultiply = async () => {
         },
       },
     })
-  })
+    })
+  }
+  finally {
+    isMultiplyPreparing.value = false
+  }
 }
 const sendMultiply = async () => {
   if (!multiplyPlanParams.value) {
@@ -1190,17 +1198,19 @@ const sendMultiply = async () => {
   }
 }
 const submit = async () => {
-  if (isGeoBlocked.value || isBorrowRestricted.value) return
-  await guardWithTerms(async () => {
-    // TODO: Validate
-    if (!isConnected.value) {
-      isSubmitting.value = false
-      return
-    }
+  if (isPreparing.value || isGeoBlocked.value || isBorrowRestricted.value) return
+  isPreparing.value = true
+  try {
+    await guardWithTerms(async () => {
+      // TODO: Validate
+      if (!isConnected.value) {
+        isSubmitting.value = false
+        return
+      }
 
-    if (!borrowVault.value || !collateralVault.value) {
-      return
-    }
+      if (!borrowVault.value || !collateralVault.value) {
+        return
+      }
 
     const collateralAmountNano = valueToNano(collateralAmount.value || '0', collateralVault.value?.decimals)
     const borrowAmountNano = valueToNano(borrowAmount.value || '0', borrowVault.value?.decimals)
@@ -1263,7 +1273,11 @@ const submit = async () => {
         },
       },
     })
-  })
+    })
+  }
+  finally {
+    isPreparing.value = false
+  }
 }
 const send = async () => {
   try {
@@ -1917,14 +1931,14 @@ watch(formTab, () => {
           <VaultFormSubmit
             v-if="formTab === 'borrow'"
             :disabled="reviewBorrowDisabled"
-            :loading="isSubmitting"
+            :loading="isSubmitting || isPreparing"
           >
             {{ reviewBorrowLabel }}
           </VaultFormSubmit>
           <VaultFormSubmit
             v-else-if="formTab === 'multiply'"
             :disabled="reviewMultiplyDisabled"
-            :loading="isMultiplySubmitting"
+            :loading="isMultiplySubmitting || isMultiplyPreparing"
           >
             {{ reviewMultiplyLabel }}
           </VaultFormSubmit>

--- a/pages/earn/[vault]/[subAccount]/withdraw.vue
+++ b/pages/earn/[vault]/[subAccount]/withdraw.vue
@@ -37,6 +37,7 @@ const subAccount = computed(() => {
 
 const isLoading = ref(false)
 const isSubmitting = ref(false)
+const isPreparing = ref(false)
 const isEstimatesLoading = ref(false)
 const amount = ref('')
 const plan = ref<TxPlan | null>(null)
@@ -118,44 +119,51 @@ const updateBalance = async () => {
   delta.value = assetsBalance.value
 }
 const submit = async () => {
-  await guardWithTerms(async () => {
-    if (!asset.value?.address) {
-      return
-    }
-
-    const isMax = FixedPoint.fromValue(assetsBalance.value, asset.value?.decimals).lte(amountFixed.value)
-
-    try {
-      plan.value = isMax
-        ? await buildRedeemPlan(vaultAddress, amountFixed.value.value, sharesBalance.value, isMax, subAccount.value)
-        : await buildWithdrawPlan(vaultAddress, amountFixed.value.value, subAccount.value)
-    }
-    catch (e) {
-      console.warn('[OperationReviewModal] failed to build plan', e)
-      plan.value = null
-    }
-
-    if (plan.value) {
-      const ok = await runSimulation(plan.value)
-      if (!ok) {
+  if (isPreparing.value) return
+  isPreparing.value = true
+  try {
+    await guardWithTerms(async () => {
+      if (!asset.value?.address) {
         return
       }
-    }
 
-    modal.open(OperationReviewModal, {
-      props: {
-        type: 'withdraw',
-        asset: asset.value,
-        amount: amount.value,
-        plan: plan.value || undefined,
-        onConfirm: () => {
-          setTimeout(() => {
-            send()
-          }, 400)
+      const isMax = FixedPoint.fromValue(assetsBalance.value, asset.value?.decimals).lte(amountFixed.value)
+
+      try {
+        plan.value = isMax
+          ? await buildRedeemPlan(vaultAddress, amountFixed.value.value, sharesBalance.value, isMax, subAccount.value)
+          : await buildWithdrawPlan(vaultAddress, amountFixed.value.value, subAccount.value)
+      }
+      catch (e) {
+        console.warn('[OperationReviewModal] failed to build plan', e)
+        plan.value = null
+      }
+
+      if (plan.value) {
+        const ok = await runSimulation(plan.value)
+        if (!ok) {
+          return
+        }
+      }
+
+      modal.open(OperationReviewModal, {
+        props: {
+          type: 'withdraw',
+          asset: asset.value,
+          amount: amount.value,
+          plan: plan.value || undefined,
+          onConfirm: () => {
+            setTimeout(() => {
+              send()
+            }, 400)
+          },
         },
-      },
+      })
     })
-  })
+  }
+  finally {
+    isPreparing.value = false
+  }
 }
 const send = async () => {
   try {
@@ -318,7 +326,7 @@ watch(amount, async () => {
 
         <div class="flex flex-col gap-8 laptop:col-start-1 laptop:row-start-2">
           <VaultFormSubmit
-            :loading="isSubmitting"
+            :loading="isSubmitting || isPreparing"
             :disabled="reviewWithdrawDisabled"
           >
             {{ reviewWithdrawLabel }}

--- a/pages/earn/[vault]/[subAccount]/withdraw.vue
+++ b/pages/earn/[vault]/[subAccount]/withdraw.vue
@@ -10,6 +10,7 @@ import {
   type EarnVault,
   type VaultAsset,
 } from '~/entities/vault'
+import { getSubAccountAddress } from '~/entities/account'
 import { getAssetUsdValueOrZero } from '~/services/pricing/priceProvider'
 import type { TxPlan } from '~/entities/txPlan'
 import { formatNumber, formatSmartAmount } from '~/utils/string-utils'
@@ -28,7 +29,11 @@ const { fetchVaultShareBalance } = useWallets()
 const { runSimulation, simulationError, clearSimulationError } = useTxPlanSimulation()
 const { getSupplyRewardApy } = useRewardsApy()
 const vaultAddress = route.params.vault as string
-const subAccount = route.query.subAccount as string | undefined
+const subAccountIndex = Number(route.params.subAccount)
+const subAccount = computed(() => {
+  if (!address.value || isNaN(subAccountIndex)) return undefined
+  return getSubAccountAddress(address.value, subAccountIndex)
+})
 
 const isLoading = ref(false)
 const isSubmitting = ref(false)
@@ -95,7 +100,7 @@ const fetchShareBalance = async () => {
     sharesBalance.value = 0n
     return
   }
-  sharesBalance.value = await fetchVaultShareBalance(vault.value.address, subAccount)
+  sharesBalance.value = await fetchVaultShareBalance(vault.value.address, subAccount.value)
 }
 
 const updateBalance = async () => {
@@ -122,8 +127,8 @@ const submit = async () => {
 
     try {
       plan.value = isMax
-        ? await buildRedeemPlan(vaultAddress, amountFixed.value.value, sharesBalance.value, isMax, subAccount)
-        : await buildWithdrawPlan(vaultAddress, amountFixed.value.value, subAccount)
+        ? await buildRedeemPlan(vaultAddress, amountFixed.value.value, sharesBalance.value, isMax, subAccount.value)
+        : await buildWithdrawPlan(vaultAddress, amountFixed.value.value, subAccount.value)
     }
     catch (e) {
       console.warn('[OperationReviewModal] failed to build plan', e)
@@ -162,8 +167,8 @@ const send = async () => {
 
     const isMax = FixedPoint.fromValue(assetsBalance.value, asset.value?.decimals).lte(amountFixed.value)
     const txPlan = isMax
-      ? await buildRedeemPlan(vaultAddress, amountFixed.value.value, sharesBalance.value, isMax, subAccount)
-      : await buildWithdrawPlan(vaultAddress, amountFixed.value.value, subAccount)
+      ? await buildRedeemPlan(vaultAddress, amountFixed.value.value, sharesBalance.value, isMax, subAccount.value)
+      : await buildWithdrawPlan(vaultAddress, amountFixed.value.value, subAccount.value)
     await executeTxPlan(txPlan)
 
     modal.close()
@@ -306,7 +311,7 @@ watch(amount, async () => {
               class="text-p2 flex items-center gap-4"
             >
               {{ formatSmartAmount(nanoToValue(assetsBalance, asset.decimals)) }} <span class="text-p3 text-content-tertiary">{{ asset.symbol }}</span>
-              <span class="text-p3 text-content-tertiary">≈ ${{ formatNumber(assetsBalanceUsd) }}</span>
+              <span class="text-p3 text-content-tertiary">&asymp; ${{ formatNumber(assetsBalanceUsd) }}</span>
             </p>
           </SummaryRow>
         </VaultFormInfoBlock>

--- a/pages/earn/[vault]/index.vue
+++ b/pages/earn/[vault]/index.vue
@@ -31,6 +31,7 @@ const { getSupplyRewardApy, hasSupplyRewards, getSupplyRewardCampaigns } = useRe
 
 const isLoading = ref(false)
 const isSubmitting = ref(false)
+const isPreparing = ref(false)
 const isEstimatesLoading = ref(false)
 const amount = ref('')
 const plan = ref<TxPlan | null>(null)
@@ -97,47 +98,53 @@ const estimateSupplyAPYDisplay = computed(() => {
   return formatNumber(estimateSupplyAPY.value)
 })
 const submit = async () => {
-  if (isGeoBlocked.value) return
-  await guardWithTerms(async () => {
-    if (!asset.value?.address) {
-      return
-    }
-
-    try {
-      plan.value = await buildSupplyPlan(
-        vaultAddress,
-        asset.value.address,
-        valueToNano(amount.value || '0', asset.value.decimals),
-        undefined,
-        { includePermit2Call: false },
-      )
-    }
-    catch (e) {
-      console.warn('[OperationReviewModal] failed to build plan', e)
-      plan.value = null
-    }
-
-    if (plan.value) {
-      const ok = await runSimulation(plan.value)
-      if (!ok) {
+  if (isPreparing.value || isGeoBlocked.value) return
+  isPreparing.value = true
+  try {
+    await guardWithTerms(async () => {
+      if (!asset.value?.address) {
         return
       }
-    }
 
-    modal.open(OperationReviewModal, {
-      props: {
-        type: 'supply',
-        asset: asset.value,
-        amount: amount.value,
-        plan: plan.value || undefined,
-        onConfirm: () => {
-          setTimeout(() => {
-            send()
-          }, 400)
+      try {
+        plan.value = await buildSupplyPlan(
+          vaultAddress,
+          asset.value.address,
+          valueToNano(amount.value || '0', asset.value.decimals),
+          undefined,
+          { includePermit2Call: false },
+        )
+      }
+      catch (e) {
+        console.warn('[OperationReviewModal] failed to build plan', e)
+        plan.value = null
+      }
+
+      if (plan.value) {
+        const ok = await runSimulation(plan.value)
+        if (!ok) {
+          return
+        }
+      }
+
+      modal.open(OperationReviewModal, {
+        props: {
+          type: 'supply',
+          asset: asset.value,
+          amount: amount.value,
+          plan: plan.value || undefined,
+          onConfirm: () => {
+            setTimeout(() => {
+              send()
+            }, 400)
+          },
         },
-      },
+      })
     })
-  })
+  }
+  finally {
+    isPreparing.value = false
+  }
 }
 const send = async () => {
   try {
@@ -330,7 +337,7 @@ watch(address, () => {
         />
         <VaultFormSubmit
           :disabled="reviewSupplyDisabled"
-          :loading="isSubmitting"
+          :loading="isSubmitting || isPreparing"
         >
           {{ reviewSupplyLabel }}
         </VaultFormSubmit>

--- a/pages/lend/[vault]/[subAccount]/swap.vue
+++ b/pages/lend/[vault]/[subAccount]/swap.vue
@@ -4,6 +4,7 @@ import { getAddress, formatUnits, isAddress, zeroAddress, type Address } from 'v
 import { OperationReviewModal, SlippageSettingsModal } from '#components'
 import { useTermsOfUseGate } from '~/composables/useTermsOfUseGate'
 import { type Vault, type SecuritizeVault, isSecuritizeVault, fetchSecuritizeVault } from '~/entities/vault'
+import { getSubAccountAddress } from '~/entities/account'
 import { getAssetUsdValue } from '~/services/pricing/priceProvider'
 import { useEulerProductOfVault } from '~/composables/useEulerLabels'
 import { isVaultBlockedByCountry, getVaultTags } from '~/composables/useGeoBlock'
@@ -38,6 +39,12 @@ const { runSimulation, simulationError, clearSimulationError } = useTxPlanSimula
 const openSlippageSettings = () => {
   modal.open(SlippageSettingsModal)
 }
+
+const subAccountIndex = Number(route.params.subAccount)
+const subAccount = computed(() => {
+  if (!address.value || isNaN(subAccountIndex)) return undefined
+  return getSubAccountAddress(address.value, subAccountIndex)
+})
 
 const isLoading = ref(false)
 const isSubmitting = ref(false)
@@ -74,6 +81,18 @@ const { collateralOptions, collateralVaults } = useSwapCollateralOptions({ curre
 const getVaultAddress = () => route.params.vault as string
 const getTargetAddress = () => (typeof route.query.to === 'string' ? route.query.to : '')
 
+const normalizeAddress = (addr?: string) => {
+  if (!addr) {
+    return ''
+  }
+  try {
+    return getAddress(addr)
+  }
+  catch {
+    return ''
+  }
+}
+
 const loadVaults = async () => {
   isLoading.value = true
   try {
@@ -109,18 +128,6 @@ await loadVaults()
 watch([() => route.params.vault, () => route.query.to], () => {
   loadVaults()
 })
-
-const normalizeAddress = (address?: string) => {
-  if (!address) {
-    return ''
-  }
-  try {
-    return getAddress(address)
-  }
-  catch {
-    return ''
-  }
-}
 
 const syncToVault = () => {
   if (!fromVault.value) {
@@ -186,7 +193,10 @@ const savingPosition = computed(() => {
   if (!currentAddress) {
     return null
   }
-  return depositPositions.value.find(position => normalizeAddress(position.vault.address) === currentAddress) || null
+  return depositPositions.value.find(position =>
+    normalizeAddress(position.vault.address) === currentAddress
+    && (!subAccount.value || normalizeAddress(position.subAccount) === normalizeAddress(subAccount.value)),
+  ) || null
 })
 
 const balance = computed(() => {

--- a/pages/lend/[vault]/[subAccount]/swap.vue
+++ b/pages/lend/[vault]/[subAccount]/swap.vue
@@ -48,6 +48,7 @@ const subAccount = computed(() => {
 
 const isLoading = ref(false)
 const isSubmitting = ref(false)
+const isPreparing = ref(false)
 const plan = ref<TxPlan | null>(null)
 const fromAmount = ref('')
 const toAmount = ref('')
@@ -496,48 +497,54 @@ const buildPlan = async (): Promise<TxPlan> => {
 }
 
 const submit = async () => {
-  if (isGeoBlocked.value) return
-  await guardWithTerms(async () => {
-    if (isSubmitting.value || !fromVault.value) {
-      return
-    }
-    if (!isSameAsset.value && !selectedQuote.value) {
-      return
-    }
-
-    try {
-      plan.value = await buildPlan()
-    }
-    catch (e) {
-      console.warn('[OperationReviewModal] failed to build plan', e)
-      showError('Failed to build transaction')
-      plan.value = null
-      return
-    }
-
-    if (plan.value) {
-      const ok = await runSimulation(plan.value)
-      if (!ok) {
+  if (isPreparing.value || isGeoBlocked.value) return
+  isPreparing.value = true
+  try {
+    await guardWithTerms(async () => {
+      if (isSubmitting.value || !fromVault.value) {
         return
       }
-    }
+      if (!isSameAsset.value && !selectedQuote.value) {
+        return
+      }
 
-    modal.open(OperationReviewModal, {
-      props: {
-        type: isSameAsset.value ? 'transfer' : 'swap',
-        asset: fromVault.value.asset,
-        amount: fromAmount.value,
-        swapToAsset: toVault.value?.asset,
-        swapToAmount: toAmount.value,
-        plan: plan.value || undefined,
-        onConfirm: () => {
-          setTimeout(() => {
-            send()
-          }, 400)
+      try {
+        plan.value = await buildPlan()
+      }
+      catch (e) {
+        console.warn('[OperationReviewModal] failed to build plan', e)
+        showError('Failed to build transaction')
+        plan.value = null
+        return
+      }
+
+      if (plan.value) {
+        const ok = await runSimulation(plan.value)
+        if (!ok) {
+          return
+        }
+      }
+
+      modal.open(OperationReviewModal, {
+        props: {
+          type: isSameAsset.value ? 'transfer' : 'swap',
+          asset: fromVault.value.asset,
+          amount: fromAmount.value,
+          swapToAsset: toVault.value?.asset,
+          swapToAmount: toAmount.value,
+          plan: plan.value || undefined,
+          onConfirm: () => {
+            setTimeout(() => {
+              send()
+            }, 400)
+          },
         },
-      },
+      })
     })
-  })
+  }
+  finally {
+    isPreparing.value = false
+  }
 }
 
 const send = async () => {
@@ -728,7 +735,7 @@ const send = async () => {
           <div class="flex flex-col gap-8 laptop:col-start-1 laptop:row-start-2">
             <VaultFormSubmit
               :disabled="reviewSwapDisabled"
-              :loading="isSubmitting"
+              :loading="isSubmitting || isPreparing"
             >
               {{ reviewSwapLabel }}
             </VaultFormSubmit>

--- a/pages/lend/[vault]/[subAccount]/withdraw.vue
+++ b/pages/lend/[vault]/[subAccount]/withdraw.vue
@@ -42,6 +42,7 @@ const subAccount = computed(() => {
 
 const isLoading = ref(false)
 const isSubmitting = ref(false)
+const isPreparing = ref(false)
 const isEstimatesLoading = ref(false)
 const amount = ref('')
 const plan = ref<TxPlan | null>(null)
@@ -151,44 +152,51 @@ const updateBalance = async () => {
   delta.value = assetsBalance.value
 }
 const submit = async () => {
-  await guardWithTerms(async () => {
-    if (!asset.value?.address) {
-      return
-    }
-
-    const isMax = FixedPoint.fromValue(assetsBalance.value, asset.value?.decimals).lte(amountFixed.value)
-
-    try {
-      plan.value = isMax
-        ? await buildRedeemPlan(vaultAddress, amountFixed.value.value, sharesBalance.value, isMax, subAccount.value)
-        : await buildWithdrawPlan(vaultAddress, amountFixed.value.value, subAccount.value)
-    }
-    catch (e) {
-      console.warn('[OperationReviewModal] failed to build plan', e)
-      plan.value = null
-    }
-
-    if (plan.value) {
-      const ok = await runSimulation(plan.value)
-      if (!ok) {
+  if (isPreparing.value) return
+  isPreparing.value = true
+  try {
+    await guardWithTerms(async () => {
+      if (!asset.value?.address) {
         return
       }
-    }
 
-    modal.open(OperationReviewModal, {
-      props: {
-        type: 'withdraw',
-        asset: asset.value,
-        amount: amount.value,
-        plan: plan.value || undefined,
-        onConfirm: () => {
-          setTimeout(() => {
-            send()
-          }, 400)
+      const isMax = FixedPoint.fromValue(assetsBalance.value, asset.value?.decimals).lte(amountFixed.value)
+
+      try {
+        plan.value = isMax
+          ? await buildRedeemPlan(vaultAddress, amountFixed.value.value, sharesBalance.value, isMax, subAccount.value)
+          : await buildWithdrawPlan(vaultAddress, amountFixed.value.value, subAccount.value)
+      }
+      catch (e) {
+        console.warn('[OperationReviewModal] failed to build plan', e)
+        plan.value = null
+      }
+
+      if (plan.value) {
+        const ok = await runSimulation(plan.value)
+        if (!ok) {
+          return
+        }
+      }
+
+      modal.open(OperationReviewModal, {
+        props: {
+          type: 'withdraw',
+          asset: asset.value,
+          amount: amount.value,
+          plan: plan.value || undefined,
+          onConfirm: () => {
+            setTimeout(() => {
+              send()
+            }, 400)
+          },
         },
-      },
+      })
     })
-  })
+  }
+  finally {
+    isPreparing.value = false
+  }
 }
 const send = async () => {
   try {
@@ -353,7 +361,7 @@ watch(amount, async () => {
 
         <div class="flex flex-col gap-8 laptop:col-start-1 laptop:row-start-2">
           <VaultFormSubmit
-            :loading="isSubmitting"
+            :loading="isSubmitting || isPreparing"
             :disabled="reviewWithdrawDisabled"
           >
             {{ reviewWithdrawLabel }}

--- a/pages/lend/[vault]/[subAccount]/withdraw.vue
+++ b/pages/lend/[vault]/[subAccount]/withdraw.vue
@@ -13,6 +13,7 @@ import {
   type SecuritizeVault,
   type VaultAsset,
 } from '~/entities/vault'
+import { getSubAccountAddress } from '~/entities/account'
 import { getUtilisationWarning } from '~/composables/useVaultWarnings'
 import { getAssetUsdValueOrZero } from '~/services/pricing/priceProvider'
 import type { TxPlan } from '~/entities/txPlan'
@@ -33,7 +34,11 @@ const { runSimulation, simulationError, clearSimulationError } = useTxPlanSimula
 const { getSupplyRewardApy } = useRewardsApy()
 const { withIntrinsicSupplyApy } = useIntrinsicApy()
 const vaultAddress = route.params.vault as string
-const subAccount = route.query.subAccount as string | undefined
+const subAccountIndex = Number(route.params.subAccount)
+const subAccount = computed(() => {
+  if (!address.value || isNaN(subAccountIndex)) return undefined
+  return getSubAccountAddress(address.value, subAccountIndex)
+})
 
 const isLoading = ref(false)
 const isSubmitting = ref(false)
@@ -129,7 +134,7 @@ const fetchShareBalance = async () => {
     sharesBalance.value = 0n
     return
   }
-  sharesBalance.value = await fetchVaultShareBalance(vault.value.address, subAccount)
+  sharesBalance.value = await fetchVaultShareBalance(vault.value.address, subAccount.value)
 }
 const updateBalance = async () => {
   if (!isConnected.value || sharesBalance.value === 0n) {
@@ -155,8 +160,8 @@ const submit = async () => {
 
     try {
       plan.value = isMax
-        ? await buildRedeemPlan(vaultAddress, amountFixed.value.value, sharesBalance.value, isMax, subAccount)
-        : await buildWithdrawPlan(vaultAddress, amountFixed.value.value, subAccount)
+        ? await buildRedeemPlan(vaultAddress, amountFixed.value.value, sharesBalance.value, isMax, subAccount.value)
+        : await buildWithdrawPlan(vaultAddress, amountFixed.value.value, subAccount.value)
     }
     catch (e) {
       console.warn('[OperationReviewModal] failed to build plan', e)
@@ -195,8 +200,8 @@ const send = async () => {
 
     const isMax = FixedPoint.fromValue(assetsBalance.value, asset.value?.decimals).lte(amountFixed.value)
     const txPlan = isMax
-      ? await buildRedeemPlan(vaultAddress, amountFixed.value.value, sharesBalance.value, isMax, subAccount)
-      : await buildWithdrawPlan(vaultAddress, amountFixed.value.value, subAccount)
+      ? await buildRedeemPlan(vaultAddress, amountFixed.value.value, sharesBalance.value, isMax, subAccount.value)
+      : await buildWithdrawPlan(vaultAddress, amountFixed.value.value, subAccount.value)
     await executeTxPlan(txPlan)
 
     modal.close()

--- a/pages/lend/[vault]/index.vue
+++ b/pages/lend/[vault]/index.vue
@@ -72,6 +72,7 @@ const { getSupplyRewardApy, hasSupplyRewards, getSupplyRewardCampaigns } = useRe
 // State
 const isLoading = ref(false)
 const isSubmitting = ref(false)
+const isPreparing = ref(false)
 const isEstimatesLoading = ref(false)
 const amount = ref('')
 const plan = ref<TxPlan | null>(null)
@@ -294,47 +295,53 @@ const load = async () => {
 }
 
 const submit = async () => {
-  if (isGeoBlocked.value) return
-  await guardWithTerms(async () => {
-    if (!asset.value?.address) {
-      return
-    }
-
-    try {
-      plan.value = await buildSupplyPlan(
-        vaultAddress,
-        asset.value.address,
-        valueToNano(amount.value || '0', asset.value.decimals),
-        undefined,
-        { includePermit2Call: false },
-      )
-    }
-    catch (e) {
-      console.warn('[OperationReviewModal] failed to build plan', e)
-      plan.value = null
-    }
-
-    if (plan.value) {
-      const ok = await runSimulation(plan.value)
-      if (!ok) {
+  if (isPreparing.value || isGeoBlocked.value) return
+  isPreparing.value = true
+  try {
+    await guardWithTerms(async () => {
+      if (!asset.value?.address) {
         return
       }
-    }
 
-    modal.open(OperationReviewModal, {
-      props: {
-        type: 'supply',
-        asset: asset.value,
-        amount: amount.value,
-        plan: plan.value || undefined,
-        onConfirm: () => {
-          setTimeout(() => {
-            send()
-          }, 400)
+      try {
+        plan.value = await buildSupplyPlan(
+          vaultAddress,
+          asset.value.address,
+          valueToNano(amount.value || '0', asset.value.decimals),
+          undefined,
+          { includePermit2Call: false },
+        )
+      }
+      catch (e) {
+        console.warn('[OperationReviewModal] failed to build plan', e)
+        plan.value = null
+      }
+
+      if (plan.value) {
+        const ok = await runSimulation(plan.value)
+        if (!ok) {
+          return
+        }
+      }
+
+      modal.open(OperationReviewModal, {
+        props: {
+          type: 'supply',
+          asset: asset.value,
+          amount: amount.value,
+          plan: plan.value || undefined,
+          onConfirm: () => {
+            setTimeout(() => {
+              send()
+            }, 400)
+          },
         },
-      },
+      })
     })
-  })
+  }
+  finally {
+    isPreparing.value = false
+  }
 }
 
 const send = async () => {
@@ -555,7 +562,7 @@ watch(address, () => {
           />
           <VaultFormSubmit
             :disabled="reviewSupplyDisabled"
-            :loading="isSubmitting"
+            :loading="isSubmitting || isPreparing"
           >
             {{ reviewSupplyLabel }}
           </VaultFormSubmit>

--- a/pages/portfolio/rewards.vue
+++ b/pages/portfolio/rewards.vue
@@ -1,10 +1,27 @@
 <script setup lang="ts">
 import { useAccount } from '@wagmi/vue'
+import { nanoToValue } from '~/utils/crypto-utils'
 
 const { isConnected } = useAccount()
 const { rewards, isRewardsLoading } = useMerkl()
 const { userRewards: brevisRewards, isRewardsLoading: isBrevisRewardsLoading } = useBrevis()
 const { locks, isLocksLoading } = useREULLocks()
+
+const sortedRewards = computed(() => {
+  return [...rewards.value].sort((a, b) => {
+    const aUsd = (nanoToValue(a.amount, a.token.decimals) - nanoToValue(a.claimed, a.token.decimals)) * (a.token.price || 0)
+    const bUsd = (nanoToValue(b.amount, b.token.decimals) - nanoToValue(b.claimed, b.token.decimals)) * (b.token.price || 0)
+    return bUsd - aUsd
+  })
+})
+
+const sortedBrevisRewards = computed(() => {
+  return [...brevisRewards.value].sort((a, b) => {
+    const aUsd = (Number.parseFloat(a.reward_info.reward_amt) || 0) * (Number.parseFloat(a.reward_info.reward_usd_price) || 0)
+    const bUsd = (Number.parseFloat(b.reward_info.reward_amt) || 0) * (Number.parseFloat(b.reward_info.reward_usd_price) || 0)
+    return bUsd - aUsd
+  })
+})
 </script>
 
 <template>
@@ -46,7 +63,7 @@ const { locks, isLocksLoading } = useREULLocks()
           class="flex-1 min-h-[100px]"
         >
           <PortfolioList
-            :items="rewards"
+            :items="sortedRewards"
             type="rewards"
           />
         </div>
@@ -88,7 +105,7 @@ const { locks, isLocksLoading } = useREULLocks()
           class="flex-1 min-h-[100px]"
         >
           <PortfolioList
-            :items="brevisRewards"
+            :items="sortedBrevisRewards"
             type="brevis-rewards"
           />
         </div>

--- a/pages/portfolio/saving.vue
+++ b/pages/portfolio/saving.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
 import { useAccount } from '@wagmi/vue'
+import type { AccountDepositPosition } from '~/entities/account'
+import { getAssetUsdValueOrZero } from '~/services/pricing/priceProvider'
 
 const { isConnected } = useAccount()
 const { depositPositions, isDepositsLoaded } = useEulerAccount()
@@ -8,6 +10,29 @@ const { isEarnVault } = useVaultRegistry()
 
 const earnItems = computed(() => depositPositions.value.filter(p => isEarnVault(p.vault.address)))
 const lendItems = computed(() => depositPositions.value.filter(p => !isEarnVault(p.vault.address)))
+
+const sortByUsdValue = async (positions: AccountDepositPosition[]): Promise<AccountDepositPosition[]> => {
+  if (positions.length <= 1) return positions
+  const withValues = await Promise.all(
+    positions.map(async (p) => ({
+      position: p,
+      usdValue: await getAssetUsdValueOrZero(p.assets, p.vault, 'off-chain'),
+    })),
+  )
+  return withValues
+    .sort((a, b) => b.usdValue - a.usdValue)
+    .map(item => item.position)
+}
+
+const sortedEarnItems = ref<AccountDepositPosition[]>([])
+const sortedLendItems = ref<AccountDepositPosition[]>([])
+
+watchEffect(async () => {
+  sortedEarnItems.value = await sortByUsdValue(earnItems.value)
+})
+watchEffect(async () => {
+  sortedLendItems.value = await sortByUsdValue(lendItems.value)
+})
 </script>
 
 <template>
@@ -48,7 +73,7 @@ const lendItems = computed(() => depositPositions.value.filter(p => !isEarnVault
         class="flex-1"
       >
         <PortfolioList
-          :items="earnItems"
+          :items="sortedEarnItems"
           type="earn"
         />
         <div
@@ -96,7 +121,7 @@ const lendItems = computed(() => depositPositions.value.filter(p => !isEarnVault
         class="flex-1"
       >
         <PortfolioList
-          :items="lendItems"
+          :items="sortedLendItems"
           type="lend"
         />
       </div>

--- a/pages/position/[number]/borrow/index.vue
+++ b/pages/position/[number]/borrow/index.vue
@@ -42,6 +42,7 @@ const collateralAmount = ref('')
 const balance = ref(0n)
 const isLoading = ref(false)
 const isSubmitting = ref(false)
+const isPreparing = ref(false)
 const isBalanceLoading = ref(false)
 const isEstimatesLoading = ref(false)
 const plan = ref<TxPlan | null>(null)
@@ -207,51 +208,57 @@ const updateBalance = async () => {
   isBalanceLoading.value = false
 }
 const submit = async () => {
-  if (isGeoBlocked.value || isBorrowRestricted.value) return
-  await guardWithTerms(async () => {
-    if (!borrowVault.value || !collateralVault.value) {
-      return
-    }
-
-    try {
-      plan.value = await buildBorrowPlan(
-        collateralVault.value.address,
-        collateralVault.value.asset.address,
-        0n,
-        borrowVault.value.address,
-        valueToNano(borrowAmount.value || '0', borrowVault.value.decimals),
-        position.value?.subAccount,
-        { includePermit2Call: false, enabledCollaterals: position.value?.collaterals },
-      )
-    }
-    catch (e) {
-      console.warn('[OperationReviewModal] failed to build plan', e)
-      plan.value = null
-    }
-
-    if (plan.value) {
-      const ok = await runSimulation(plan.value)
-      if (!ok) {
+  if (isPreparing.value || isGeoBlocked.value || isBorrowRestricted.value) return
+  isPreparing.value = true
+  try {
+    await guardWithTerms(async () => {
+      if (!borrowVault.value || !collateralVault.value) {
         return
       }
-    }
 
-    modal.open(OperationReviewModal, {
-      props: {
-        type: 'borrow',
-        asset: borrowVault.value?.asset,
-        amount: borrowAmount.value,
-        plan: plan.value || undefined,
-        subAccount: position.value?.subAccount,
-        hasBorrows: (position.value?.borrowed || 0n) > 0n,
-        onConfirm: () => {
-          setTimeout(() => {
-            send()
-          }, 400)
+      try {
+        plan.value = await buildBorrowPlan(
+          collateralVault.value.address,
+          collateralVault.value.asset.address,
+          0n,
+          borrowVault.value.address,
+          valueToNano(borrowAmount.value || '0', borrowVault.value.decimals),
+          position.value?.subAccount,
+          { includePermit2Call: false, enabledCollaterals: position.value?.collaterals },
+        )
+      }
+      catch (e) {
+        console.warn('[OperationReviewModal] failed to build plan', e)
+        plan.value = null
+      }
+
+      if (plan.value) {
+        const ok = await runSimulation(plan.value)
+        if (!ok) {
+          return
+        }
+      }
+
+      modal.open(OperationReviewModal, {
+        props: {
+          type: 'borrow',
+          asset: borrowVault.value?.asset,
+          amount: borrowAmount.value,
+          plan: plan.value || undefined,
+          subAccount: position.value?.subAccount,
+          hasBorrows: (position.value?.borrowed || 0n) > 0n,
+          onConfirm: () => {
+            setTimeout(() => {
+              send()
+            }, 400)
+          },
         },
-      },
+      })
     })
-  })
+  }
+  finally {
+    isPreparing.value = false
+  }
 }
 const send = async () => {
   try {
@@ -492,7 +499,7 @@ onUnmounted(() => {
         <div class="flex flex-col gap-8 laptop:col-start-1 laptop:row-start-2">
           <VaultFormSubmit
             :disabled="reviewBorrowDisabled"
-            :loading="isSubmitting"
+            :loading="isSubmitting || isPreparing"
           >
             {{ reviewBorrowLabel }}
           </VaultFormSubmit>

--- a/pages/position/[number]/borrow/swap.vue
+++ b/pages/position/[number]/borrow/swap.vue
@@ -57,6 +57,7 @@ const positionIndex = route.params.number as string
 
 const isLoading = ref(false)
 const isSubmitting = ref(false)
+const isPreparing = ref(false)
 const plan = ref<TxPlan | null>(null)
 const fromAmount = ref('')
 const toAmount = ref('')
@@ -674,41 +675,47 @@ const buildDebtSwapPlan = async (): Promise<TxPlan | null> => {
 }
 
 const submit = async () => {
-  if (isGeoBlocked.value) return
-  await guardWithTerms(async () => {
-    if (isSubmitting.value || !fromVault.value || !toVault.value) return
+  if (isPreparing.value || isGeoBlocked.value) return
+  isPreparing.value = true
+  try {
+    await guardWithTerms(async () => {
+      if (isSubmitting.value || !fromVault.value || !toVault.value) return
 
-    try {
-      plan.value = await buildDebtSwapPlan()
-    }
-    catch (e) {
-      showError('Failed to build transaction')
-      plan.value = null
-      return
-    }
+      try {
+        plan.value = await buildDebtSwapPlan()
+      }
+      catch (e) {
+        showError('Failed to build transaction')
+        plan.value = null
+        return
+      }
 
-    if (plan.value) {
-      const ok = await runSimulation(plan.value)
-      if (!ok) return
-    }
+      if (plan.value) {
+        const ok = await runSimulation(plan.value)
+        if (!ok) return
+      }
 
-    modal.open(OperationReviewModal, {
-      props: {
-        type: 'swap',
-        asset: fromVault.value.asset,
-        amount: fromAmount.value,
-        // Same-asset: omit swapToAsset/swapToAmount so skim steps show "remaining" instead of amounts
-        swapToAsset: isSameAsset.value ? undefined : toVault.value?.asset,
-        swapToAmount: isSameAsset.value ? undefined : toAmount.value,
-        plan: plan.value || undefined,
-        onConfirm: () => {
-          setTimeout(() => {
-            send()
-          }, 400)
+      modal.open(OperationReviewModal, {
+        props: {
+          type: 'swap',
+          asset: fromVault.value.asset,
+          amount: fromAmount.value,
+          // Same-asset: omit swapToAsset/swapToAmount so skim steps show "remaining" instead of amounts
+          swapToAsset: isSameAsset.value ? undefined : toVault.value?.asset,
+          swapToAmount: isSameAsset.value ? undefined : toAmount.value,
+          plan: plan.value || undefined,
+          onConfirm: () => {
+            setTimeout(() => {
+              send()
+            }, 400)
+          },
         },
-      },
+      })
     })
-  })
+  }
+  finally {
+    isPreparing.value = false
+  }
 }
 
 const send = async () => {
@@ -837,7 +844,7 @@ const send = async () => {
             <div class="flex flex-col gap-8 laptop:col-start-1 laptop:row-start-2">
               <VaultFormSubmit
                 :disabled="reviewSwapDisabled"
-                :loading="isSubmitting"
+                :loading="isSubmitting || isPreparing"
               >
                 {{ reviewSwapLabel }}
               </VaultFormSubmit>

--- a/pages/position/[number]/collateral/swap.vue
+++ b/pages/position/[number]/collateral/swap.vue
@@ -71,6 +71,7 @@ const positionIndex = route.params.number as string
 
 const isLoading = ref(false)
 const isSubmitting = ref(false)
+const isPreparing = ref(false)
 const plan = ref<TxPlan | null>(null)
 const fromAmount = ref('')
 const toAmount = ref('')
@@ -776,48 +777,54 @@ const buildPlan = async (): Promise<TxPlan> => {
 }
 
 const submit = async () => {
-  if (isGeoBlocked.value) return
-  await guardWithTerms(async () => {
-    if (isSubmitting.value || !fromVault.value) {
-      return
-    }
-    if (!isSameAsset.value && !selectedQuote.value) {
-      return
-    }
-
-    try {
-      plan.value = await buildPlan()
-    }
-    catch (e) {
-      console.warn('[OperationReviewModal] failed to build plan', e)
-      showError('Failed to build transaction')
-      plan.value = null
-      return
-    }
-
-    if (plan.value) {
-      const ok = await runSimulation(plan.value)
-      if (!ok) {
+  if (isPreparing.value || isGeoBlocked.value) return
+  isPreparing.value = true
+  try {
+    await guardWithTerms(async () => {
+      if (isSubmitting.value || !fromVault.value) {
         return
       }
-    }
+      if (!isSameAsset.value && !selectedQuote.value) {
+        return
+      }
 
-    modal.open(OperationReviewModal, {
-      props: {
-        type: isSameAsset.value ? 'transfer' : 'swap',
-        asset: fromVault.value.asset,
-        amount: fromAmount.value,
-        swapToAsset: toVault.value?.asset,
-        swapToAmount: toAmount.value,
-        plan: plan.value || undefined,
-        onConfirm: () => {
-          setTimeout(() => {
-            send()
-          }, 400)
+      try {
+        plan.value = await buildPlan()
+      }
+      catch (e) {
+        console.warn('[OperationReviewModal] failed to build plan', e)
+        showError('Failed to build transaction')
+        plan.value = null
+        return
+      }
+
+      if (plan.value) {
+        const ok = await runSimulation(plan.value)
+        if (!ok) {
+          return
+        }
+      }
+
+      modal.open(OperationReviewModal, {
+        props: {
+          type: isSameAsset.value ? 'transfer' : 'swap',
+          asset: fromVault.value.asset,
+          amount: fromAmount.value,
+          swapToAsset: toVault.value?.asset,
+          swapToAmount: toAmount.value,
+          plan: plan.value || undefined,
+          onConfirm: () => {
+            setTimeout(() => {
+              send()
+            }, 400)
+          },
         },
-      },
+      })
     })
-  })
+  }
+  finally {
+    isPreparing.value = false
+  }
 }
 
 const send = async () => {
@@ -944,7 +951,7 @@ const send = async () => {
             <div class="flex flex-col gap-8 laptop:col-start-1 laptop:row-start-2">
               <VaultFormSubmit
                 :disabled="reviewSwapDisabled"
-                :loading="isSubmitting"
+                :loading="isSubmitting || isPreparing"
               >
                 {{ reviewSwapLabel }}
               </VaultFormSubmit>

--- a/pages/position/[number]/index.vue
+++ b/pages/position/[number]/index.vue
@@ -54,6 +54,7 @@ type PositionCollateral = {
 
 const position: Ref<AccountBorrowPosition | undefined> = ref()
 const isSubmitting = ref(false)
+const isPreparing = ref(false)
 const collateralItems = ref<PositionCollateral[]>([])
 const isCollateralsLoading = ref(false)
 const disableCollateralErrorVault = ref<string | null>(null)
@@ -495,44 +496,51 @@ const loadCollaterals = async () => {
 }
 
 const disableCollateral = async (vault: Vault) => {
-  clearDisableCollateralSimulationError()
-  disableCollateralErrorVault.value = null
-  let plan: TxPlan | null = null
+  if (isPreparing.value) return
+  isPreparing.value = true
   try {
-    plan = await buildDisableCollateralPlan(
-      position.value!.subAccount,
-      vault.address,
-      position.value!.borrow.address,
-      position.value!.collaterals,
-    )
-  }
-  catch (e) {
-    console.warn('[OperationReviewModal] failed to build plan', e)
-  }
-
-  if (plan) {
-    const ok = await runDisableCollateralSimulation(plan)
-    if (!ok) {
-      disableCollateralErrorVault.value = getAddress(vault.address)
-      return
+    clearDisableCollateralSimulationError()
+    disableCollateralErrorVault.value = null
+    let plan: TxPlan | null = null
+    try {
+      plan = await buildDisableCollateralPlan(
+        position.value!.subAccount,
+        vault.address,
+        position.value!.borrow.address,
+        position.value!.collaterals,
+      )
     }
-  }
+    catch (e) {
+      console.warn('[OperationReviewModal] failed to build plan', e)
+    }
 
-  modal.open(OperationReviewModal, {
-    props: {
-      type: 'disableCollateral',
-      asset: position.value!.borrow.asset,
-      amount: '0',
-      plan: plan || undefined,
-      subAccount: position.value?.subAccount,
-      hasBorrows: (position.value?.borrowed || 0n) > 0n,
-      onConfirm: () => {
-        setTimeout(() => {
-          send(vault.address)
-        }, 400)
+    if (plan) {
+      const ok = await runDisableCollateralSimulation(plan)
+      if (!ok) {
+        disableCollateralErrorVault.value = getAddress(vault.address)
+        return
+      }
+    }
+
+    modal.open(OperationReviewModal, {
+      props: {
+        type: 'disableCollateral',
+        asset: position.value!.borrow.asset,
+        amount: '0',
+        plan: plan || undefined,
+        subAccount: position.value?.subAccount,
+        hasBorrows: (position.value?.borrowed || 0n) > 0n,
+        onConfirm: () => {
+          setTimeout(() => {
+            send(vault.address)
+          }, 400)
+        },
       },
-    },
-  })
+    })
+  }
+  finally {
+    isPreparing.value = false
+  }
 }
 const send = async (collateralAddress: string) => {
   try {
@@ -1065,7 +1073,7 @@ watch(isConnected, () => {
                   size="medium"
                   variant="primary"
                   rounded
-                  :loading="isSubmitting"
+                  :loading="isSubmitting || isPreparing"
                   @click="disableCollateral(collateral.vault as Vault)"
                 >
                   Disable collateral

--- a/pages/position/[number]/multiply.vue
+++ b/pages/position/[number]/multiply.vue
@@ -64,6 +64,7 @@ const position: Ref<AccountBorrowPosition | null> = ref(null)
 
 const isLoading = ref(false)
 const isSubmitting = ref(false)
+const isPreparing = ref(false)
 const plan = ref<TxPlan | null>(null)
 const planParams = ref<MultiplyPlanParams | null>(null)
 
@@ -616,11 +617,13 @@ const onMultiplierInput = () => {
 }
 
 const submitMultiply = async () => {
-  if (isGeoBlocked.value || isMultiplyRestricted.value) return
-  await guardWithTerms(async () => {
-    if (isSubmitting.value || !isConnected.value) {
-      return
-    }
+  if (isPreparing.value || isGeoBlocked.value || isMultiplyRestricted.value) return
+  isPreparing.value = true
+  try {
+    await guardWithTerms(async () => {
+      if (isSubmitting.value || !isConnected.value) {
+        return
+      }
     if (!multiplySupplyVault.value || !multiplyLongVault.value || !multiplyShortVault.value) {
       return
     }
@@ -692,7 +695,11 @@ const submitMultiply = async () => {
         },
       },
     })
-  })
+    })
+  }
+  finally {
+    isPreparing.value = false
+  }
 }
 
 const sendMultiply = async () => {
@@ -912,7 +919,7 @@ watch([multiplyMinMultiplier, multiplyMaxMultiplier], ([min, max]) => {
 
           <VaultFormSubmit
             :disabled="reviewMultiplyDisabled"
-            :loading="isSubmitting"
+            :loading="isSubmitting || isPreparing"
           >
             {{ reviewMultiplyLabel }}
           </VaultFormSubmit>

--- a/pages/position/[number]/repay.vue
+++ b/pages/position/[number]/repay.vue
@@ -1464,6 +1464,8 @@ const submitSavings = async () => {
         type: 'repay',
         asset: savingsVault.value.asset,
         amount: savingsAmount.value,
+        swapToAsset: !savingsIsSameAsset.value ? borrowVault.value.asset : undefined,
+        swapToAmount: !savingsIsSameAsset.value ? savingsDebtAmount.value : undefined,
         plan: plan.value || undefined,
         subAccount: position.value?.subAccount,
         hasBorrows: (position.value?.borrowed || 0n) > 0n,

--- a/pages/position/[number]/repay.vue
+++ b/pages/position/[number]/repay.vue
@@ -1380,7 +1380,6 @@ const buildSavingsRepay = async (): Promise<TxPlan> => {
       amount: debtNano,
       savingsSubAccount: savingsPos.subAccount,
       borrowSubAccount: position.value.subAccount,
-      enabledCollaterals: position.value.collaterals,
     })
   }
 

--- a/pages/position/[number]/repay.vue
+++ b/pages/position/[number]/repay.vue
@@ -25,10 +25,10 @@ const route = useRoute()
 const router = useRouter()
 const modal = useModal()
 const { error } = useToast()
-const { buildRepayPlan, buildFullRepayPlan, buildSwapPlan, buildSameAssetRepayPlan, buildSameAssetFullRepayPlan, buildSavingsRepayPlan, buildSavingsFullRepayPlan, buildSwapSavingsFullRepayPlan, executeTxPlan } = useEulerOperations()
+const { buildRepayPlan, buildFullRepayPlan, buildSwapPlan, buildSameAssetRepayPlan, buildSameAssetFullRepayPlan, buildSwapCollateralFullRepayPlan, buildSavingsRepayPlan, buildSavingsFullRepayPlan, buildSwapSavingsFullRepayPlan, executeTxPlan } = useEulerOperations()
 const { isConnected, address } = useAccount()
 const positionIndex = route.params.number as string
-const { isPositionsLoading, isPositionsLoaded, refreshAllPositions, getPositionBySubAccountIndex } = useEulerAccount()
+const { isPositionsLoading, isPositionsLoaded, isDepositsLoaded, refreshAllPositions, getPositionBySubAccountIndex } = useEulerAccount()
 const { getSupplyRewardApy, getBorrowRewardApy } = useRewardsApy()
 const { withIntrinsicBorrowApy, withIntrinsicSupplyApy } = useIntrinsicApy()
 const { eulerLensAddresses, isReady: isEulerAddressesReady, loadEulerConfig } = useEulerAddresses()
@@ -50,6 +50,7 @@ const swapPriceInvert = usePriceInvert(
 
 const isLoading = ref(false)
 const isSubmitting = ref(false)
+const isPreparing = ref(false)
 const isEstimatesLoading = ref(false)
 const amount = ref('')
 const formTab = ref<'wallet' | 'collateral' | 'savings'>('wallet')
@@ -447,6 +448,7 @@ const load = async () => {
   }
   isLoading.value = true
   await until(isPositionsLoaded).toBe(true)
+  await until(isDepositsLoaded).toBe(true)
 
   try {
     position.value = getPositionBySubAccountIndex(+positionIndex)
@@ -1304,8 +1306,19 @@ const requestSavingsQuote = useDebounceFn(async () => {
 watch([savingsEffectiveQuote, savingsSwapDirection], () => {
   if (!savingsEffectiveQuote.value || !savingsVault.value || !borrowVault.value) return
   if (savingsSwapDirection.value === SwapperMode.EXACT_IN) {
+    const amountOut = BigInt(savingsEffectiveQuote.value.amountOut || 0)
+    const currentDebt = position.value?.borrowed || 0n
+    // If savings more than covers the debt, switch to TARGET_DEBT 100% to limit
+    // the savings amount to just what's needed for the full debt
+    if (amountOut >= currentDebt && currentDebt > 0n) {
+      savingsSwapDirection.value = SwapperMode.TARGET_DEBT
+      savingsDebtPercent.value = 100
+      savingsDebtAmount.value = trimTrailingZeros(formatUnits(currentDebt, Number(borrowVault.value.asset.decimals)))
+      requestSavingsQuote()
+      return
+    }
     savingsDebtAmount.value = formatSignificant(formatUnits(
-      BigInt(savingsEffectiveQuote.value.amountOut || 0),
+      amountOut,
       Number(borrowVault.value.asset.decimals),
     ))
   }
@@ -1421,37 +1434,51 @@ const buildSavingsRepay = async (): Promise<TxPlan> => {
 }
 
 const submitSavings = async () => {
-  if (isSubmitting.value || !position.value || !borrowVault.value || !savingsVault.value) return
+  if (isPreparing.value || isSubmitting.value || !position.value || !borrowVault.value || !savingsVault.value) return
   if (!savingsIsSameAsset.value && !savingsSelectedQuote.value) return
 
+  isPreparing.value = true
   try {
-    plan.value = await buildSavingsRepay()
-  }
-  catch (e) {
-    console.warn('[OperationReviewModal] failed to build savings plan', e)
-    plan.value = null
-  }
+    try {
+      plan.value = await buildSavingsRepay()
+    }
+    catch (e) {
+      console.warn('[OperationReviewModal] failed to build savings plan', e)
+      plan.value = null
+    }
 
-  if (plan.value) {
-    const ok = await runSimulation(plan.value)
-    if (!ok) return
-  }
+    if (plan.value) {
+      const ok = await runSimulation(plan.value)
+      if (!ok) return
+    }
 
-  modal.open(OperationReviewModal, {
-    props: {
-      type: 'repay',
-      asset: savingsVault.value.asset,
-      amount: savingsAmount.value,
-      plan: plan.value || undefined,
-      subAccount: position.value?.subAccount,
-      hasBorrows: (position.value?.borrowed || 0n) > 0n,
-      onConfirm: () => {
-        setTimeout(() => {
-          sendSavings()
-        }, 400)
+    // Build known transfer amounts for the review modal (collateral is untouched during savings repay)
+    const transferAmounts: Record<string, string> = {}
+    if (collateralVault.value && position.value?.supplied) {
+      const addr = collateralVault.value.address.toLowerCase()
+      transferAmounts[addr] = nanoToValue(position.value.supplied, collateralVault.value.decimals).toString()
+    }
+
+    modal.open(OperationReviewModal, {
+      props: {
+        type: 'repay',
+        asset: savingsVault.value.asset,
+        amount: savingsAmount.value,
+        plan: plan.value || undefined,
+        subAccount: position.value?.subAccount,
+        hasBorrows: (position.value?.borrowed || 0n) > 0n,
+        transferAmounts,
+        onConfirm: () => {
+          setTimeout(() => {
+            sendSavings()
+          }, 400)
+        },
       },
-    },
-  })
+    })
+  }
+  finally {
+    isPreparing.value = false
+  }
 }
 
 const sendSavings = async () => {
@@ -1491,58 +1518,64 @@ const updateBalance = async () => {
     .value
 }
 const submit = async () => {
-  if (!position.value || !borrowVault.value || !collateralVault.value) {
+  if (isPreparing.value || !position.value || !borrowVault.value || !collateralVault.value) {
     return
   }
 
-  const amountNano = valueToNano(amount.value || '0', borrowVault.value.asset.decimals)
-  const shouldFullRepay = balance.value <= amountNano
-
+  isPreparing.value = true
   try {
-    plan.value = shouldFullRepay
-      ? await buildFullRepayPlan(
-        borrowVault.value.address,
-        borrowVault.value.asset.address,
-        amountNano,
-        position.value.subAccount,
-        position.value.collaterals ?? [collateralVault.value.address],
-        { includePermit2Call: false },
-      )
-      : await buildRepayPlan(
-        borrowVault.value.address,
-        borrowVault.value.asset.address,
-        amountNano,
-        position.value.subAccount,
-        { includePermit2Call: false },
-      )
-  }
-  catch (e) {
-    console.warn('[OperationReviewModal] failed to build plan', e)
-    plan.value = null
-  }
+    const amountNano = valueToNano(amount.value || '0', borrowVault.value.asset.decimals)
+    const shouldFullRepay = balance.value <= amountNano
 
-  if (plan.value) {
-    const ok = await runSimulation(plan.value)
-    if (!ok) {
-      return
+    try {
+      plan.value = shouldFullRepay
+        ? await buildFullRepayPlan(
+          borrowVault.value.address,
+          borrowVault.value.asset.address,
+          amountNano,
+          position.value.subAccount,
+          position.value.collaterals ?? [collateralVault.value.address],
+          { includePermit2Call: false },
+        )
+        : await buildRepayPlan(
+          borrowVault.value.address,
+          borrowVault.value.asset.address,
+          amountNano,
+          position.value.subAccount,
+          { includePermit2Call: false },
+        )
     }
-  }
+    catch (e) {
+      console.warn('[OperationReviewModal] failed to build plan', e)
+      plan.value = null
+    }
 
-  modal.open(OperationReviewModal, {
-    props: {
-      type: 'repay',
-      asset: position.value!.borrow.asset,
-      amount: amount.value,
-      plan: plan.value || undefined,
-      subAccount: position.value?.subAccount,
-      hasBorrows: (position.value?.borrowed || 0n) > 0n,
-      onConfirm: () => {
-        setTimeout(() => {
-          send()
-        }, 400)
+    if (plan.value) {
+      const ok = await runSimulation(plan.value)
+      if (!ok) {
+        return
+      }
+    }
+
+    modal.open(OperationReviewModal, {
+      props: {
+        type: 'repay',
+        asset: position.value!.borrow.asset,
+        amount: amount.value,
+        plan: plan.value || undefined,
+        subAccount: position.value?.subAccount,
+        hasBorrows: (position.value?.borrowed || 0n) > 0n,
+        onConfirm: () => {
+          setTimeout(() => {
+            send()
+          }, 400)
+        },
       },
-    },
-  })
+    })
+  }
+  finally {
+    isPreparing.value = false
+  }
 }
 
 const onSubmitForm = async () => {
@@ -1601,6 +1634,18 @@ const buildSwapRepayPlan = async (): Promise<TxPlan> => {
     targetDebt = debtAmountNano >= currentDebt ? 0n : currentDebt - debtAmountNano
   }
 
+  const isFullRepay = targetDebt === 0n && swapMode === SwapperMode.TARGET_DEBT
+  if (isFullRepay) {
+    return buildSwapCollateralFullRepayPlan({
+      quote: swapSelectedQuote.value,
+      swapperMode: swapMode,
+      targetDebt,
+      currentDebt,
+      liabilityVault: borrowVault.value.address,
+      enabledCollaterals: position.value.collaterals,
+    })
+  }
+
   return buildSwapPlan({
     quote: swapSelectedQuote.value,
     swapperMode: swapMode,
@@ -1613,43 +1658,49 @@ const buildSwapRepayPlan = async (): Promise<TxPlan> => {
 }
 
 const submitSwap = async () => {
-  if (isSubmitting.value || !position.value || !borrowVault.value || !swapCollateralVault.value) {
+  if (isPreparing.value || isSubmitting.value || !position.value || !borrowVault.value || !swapCollateralVault.value) {
     return
   }
   if (!swapIsSameAsset.value && !swapSelectedQuote.value) {
     return
   }
 
+  isPreparing.value = true
   try {
-    plan.value = await buildSwapRepayPlan()
-  }
-  catch (e) {
-    console.warn('[OperationReviewModal] failed to build plan', e)
-    plan.value = null
-  }
-
-  if (plan.value) {
-    const ok = await runSimulation(plan.value)
-    if (!ok) {
-      return
+    try {
+      plan.value = await buildSwapRepayPlan()
     }
-  }
+    catch (e) {
+      console.warn('[OperationReviewModal] failed to build plan', e)
+      plan.value = null
+    }
 
-  modal.open(OperationReviewModal, {
-    props: {
-      type: 'repay',
-      asset: swapCollateralVault.value.asset,
-      amount: collateralAmount.value,
-      plan: plan.value || undefined,
-      subAccount: position.value?.subAccount,
-      hasBorrows: (position.value?.borrowed || 0n) > 0n,
-      onConfirm: () => {
-        setTimeout(() => {
-          sendSwap()
-        }, 400)
+    if (plan.value) {
+      const ok = await runSimulation(plan.value)
+      if (!ok) {
+        return
+      }
+    }
+
+    modal.open(OperationReviewModal, {
+      props: {
+        type: 'repay',
+        asset: swapCollateralVault.value.asset,
+        amount: collateralAmount.value,
+        plan: plan.value || undefined,
+        subAccount: position.value?.subAccount,
+        hasBorrows: (position.value?.borrowed || 0n) > 0n,
+        onConfirm: () => {
+          setTimeout(() => {
+            sendSwap()
+          }, 400)
+        },
       },
-    },
-  })
+    })
+  }
+  finally {
+    isPreparing.value = false
+  }
 }
 
 const sendSwap = async () => {
@@ -2035,7 +2086,7 @@ onUnmounted(() => {
             </VaultFormInfoButton>
             <VaultFormSubmit
               :disabled="reviewRepayDisabled"
-              :loading="isSubmitting"
+              :loading="isSubmitting || isPreparing"
             >
               {{ reviewRepayLabel }}
             </VaultFormSubmit>
@@ -2219,7 +2270,7 @@ onUnmounted(() => {
             <VaultFormSubmit
               :disabled="reviewRepayDisabled"
               :disabled-reason="swapDisabledReason"
-              :loading="isSubmitting"
+              :loading="isSubmitting || isPreparing"
             >
               {{ reviewRepayLabel }}
             </VaultFormSubmit>
@@ -2239,6 +2290,7 @@ onUnmounted(() => {
               :vault="savingsVault"
               :collateral-options="savingsOptions"
               :balance="savingsBalance"
+              maxable
               @input="onSavingsAmountInput"
               @change-collateral="onSavingsVaultChange"
             />
@@ -2373,7 +2425,7 @@ onUnmounted(() => {
             </VaultFormInfoButton>
             <VaultFormSubmit
               :disabled="reviewRepayDisabled"
-              :loading="isSubmitting"
+              :loading="isSubmitting || isPreparing"
             >
               {{ reviewRepayLabel }}
             </VaultFormSubmit>

--- a/pages/position/[number]/repay.vue
+++ b/pages/position/[number]/repay.vue
@@ -14,6 +14,7 @@ import type { TxPlan } from '~/entities/txPlan'
 import { SwapperMode } from '~/entities/swap'
 import { eulerAccountLensABI } from '~/entities/euler/abis'
 import { useSwapCollateralOptions } from '~/composables/useSwapCollateralOptions'
+import { useRepaySavingsOptions } from '~/composables/useRepaySavingsOptions'
 import { useSwapQuotesParallel } from '~/composables/useSwapQuotesParallel'
 import { useTermsOfUseGate } from '~/composables/useTermsOfUseGate'
 import { getQuoteAmount } from '~/utils/swapQuotes'
@@ -24,7 +25,7 @@ const route = useRoute()
 const router = useRouter()
 const modal = useModal()
 const { error } = useToast()
-const { buildRepayPlan, buildFullRepayPlan, buildSwapPlan, buildSameAssetRepayPlan, buildSameAssetFullRepayPlan, executeTxPlan } = useEulerOperations()
+const { buildRepayPlan, buildFullRepayPlan, buildSwapPlan, buildSameAssetRepayPlan, buildSameAssetFullRepayPlan, buildSavingsRepayPlan, buildSavingsFullRepayPlan, buildSwapSavingsFullRepayPlan, executeTxPlan } = useEulerOperations()
 const { isConnected, address } = useAccount()
 const positionIndex = route.params.number as string
 const { isPositionsLoading, isPositionsLoaded, refreshAllPositions, getPositionBySubAccountIndex } = useEulerAccount()
@@ -51,7 +52,7 @@ const isLoading = ref(false)
 const isSubmitting = ref(false)
 const isEstimatesLoading = ref(false)
 const amount = ref('')
-const formTab = ref<'wallet' | 'collateral'>('wallet')
+const formTab = ref<'wallet' | 'collateral' | 'savings'>('wallet')
 const collateralAmount = ref('')
 const debtAmount = ref('')
 const repaySwapDirection = ref(SwapperMode.EXACT_IN)
@@ -65,10 +66,18 @@ const estimateUserLTV = ref(0n)
 const estimateHealth = ref(0n)
 const estimatesError = ref('')
 
-const formTabs = computed(() => [
-  { label: 'From wallet', value: 'wallet' },
-  { label: 'Swap collateral', value: 'collateral' },
-])
+const { savingsPositions, savingsVaults, savingsOptions, getSavingsPosition } = useRepaySavingsOptions()
+
+const formTabs = computed(() => {
+  const tabs = [
+    { label: 'From wallet', value: 'wallet' },
+    { label: 'Swap collateral', value: 'collateral' },
+  ]
+  if (savingsPositions.value.length > 0) {
+    tabs.push({ label: 'From savings', value: 'savings' })
+  }
+  return tabs
+})
 
 const borrowVault = computed(() => position.value?.borrow)
 const collateralVault = computed(() => position.value?.collateral)
@@ -78,6 +87,244 @@ const swapCollateralAssets = ref(0n)
 const swapCollateralBalance = computed(() => swapCollateralAssets.value)
 const swapDebtBalance = computed(() => position.value?.borrowed || 0n)
 const isEligibleForLiquidation = computed(() => isPositionEligibleForLiquidation(position.value))
+
+// --- Savings tab state ---
+const savingsVault: Ref<Vault | undefined> = ref()
+const savingsAmount = ref('')
+const savingsDebtAmount = ref('')
+const savingsSwapDirection = ref(SwapperMode.EXACT_IN)
+const savingsDebtPercent = ref(0)
+const savingsAssets = ref(0n)
+const savingsBalance = computed(() => savingsAssets.value)
+const savingsDebtBalance = computed(() => position.value?.borrowed || 0n)
+const savingsPriceInvert = usePriceInvert(
+  () => savingsVault.value?.asset.symbol,
+  () => borrowVault.value?.asset.symbol,
+)
+const savingsProduct = useEulerProductOfVault(computed(() => savingsVault.value?.address || ''))
+
+const savingsIsSameAsset = computed(() => {
+  if (!savingsVault.value || !borrowVault.value) {
+    return false
+  }
+  return normalizeAddress(savingsVault.value.asset.address) === normalizeAddress(borrowVault.value.asset.address)
+})
+
+const savingsExactInQuotes = useSwapQuotesParallel({ amountField: 'amountOut', compare: 'max' })
+const savingsTargetDebtQuotes = useSwapQuotesParallel({ amountField: 'amountIn', compare: 'min' })
+
+const savingsSwapQuoteCardsSorted = computed(() => savingsSwapDirection.value === SwapperMode.EXACT_IN
+  ? savingsExactInQuotes.sortedQuoteCards.value
+  : savingsTargetDebtQuotes.sortedQuoteCards.value)
+const savingsSelectedProvider = computed(() => savingsSwapDirection.value === SwapperMode.EXACT_IN
+  ? savingsExactInQuotes.selectedProvider.value
+  : savingsTargetDebtQuotes.selectedProvider.value)
+const savingsSelectedQuote = computed(() => savingsSwapDirection.value === SwapperMode.EXACT_IN
+  ? savingsExactInQuotes.selectedQuote.value
+  : savingsTargetDebtQuotes.selectedQuote.value)
+const savingsEffectiveQuote = computed(() => savingsSwapDirection.value === SwapperMode.EXACT_IN
+  ? savingsExactInQuotes.effectiveQuote.value
+  : savingsTargetDebtQuotes.effectiveQuote.value)
+const savingsProvidersCount = computed(() => savingsSwapDirection.value === SwapperMode.EXACT_IN
+  ? savingsExactInQuotes.providersCount.value
+  : savingsTargetDebtQuotes.providersCount.value)
+const savingsIsQuoteLoading = computed(() => savingsSwapDirection.value === SwapperMode.EXACT_IN
+  ? savingsExactInQuotes.isLoading.value
+  : savingsTargetDebtQuotes.isLoading.value)
+const savingsQuoteError = computed(() => savingsSwapDirection.value === SwapperMode.EXACT_IN
+  ? savingsExactInQuotes.quoteError.value
+  : savingsTargetDebtQuotes.quoteError.value)
+const savingsQuotesStatusLabel = computed(() => savingsSwapDirection.value === SwapperMode.EXACT_IN
+  ? savingsExactInQuotes.statusLabel.value
+  : savingsTargetDebtQuotes.statusLabel.value)
+const savingsQuote = computed(() => savingsEffectiveQuote.value || null)
+
+const savingsSpent = computed(() => {
+  if (savingsIsSameAsset.value && savingsVault.value) {
+    if (savingsAmount.value) {
+      try { return valueToNano(savingsAmount.value, savingsVault.value.asset.decimals) }
+      catch { return null }
+    }
+    if (savingsDebtAmount.value && borrowVault.value) {
+      try { return valueToNano(savingsDebtAmount.value, borrowVault.value.asset.decimals) }
+      catch { return null }
+    }
+    return null
+  }
+  if (!savingsQuote.value) {
+    return null
+  }
+  try {
+    return BigInt(savingsQuote.value.amountIn || 0)
+  }
+  catch {
+    return null
+  }
+})
+const savingsDebtRepaid = computed(() => {
+  if (savingsIsSameAsset.value && borrowVault.value) {
+    if (savingsDebtAmount.value) {
+      try { return valueToNano(savingsDebtAmount.value, borrowVault.value.asset.decimals) }
+      catch { return null }
+    }
+    if (savingsAmount.value && savingsVault.value) {
+      try { return valueToNano(savingsAmount.value, savingsVault.value.asset.decimals) }
+      catch { return null }
+    }
+    return null
+  }
+  if (!savingsQuote.value) {
+    return null
+  }
+  try {
+    return BigInt(savingsQuote.value.amountOut || 0)
+  }
+  catch {
+    return null
+  }
+})
+
+// Savings summary computeds (async values)
+const savingsValueUsd = ref<number | null>(null)
+watchEffect(async () => {
+  if (!savingsVault.value) {
+    savingsValueUsd.value = null
+    return
+  }
+  savingsValueUsd.value = (await getAssetUsdValue(savingsAssets.value, savingsVault.value, 'off-chain')) ?? null
+})
+
+const savingsBorrowValueUsd = ref<number | null>(null)
+watchEffect(async () => {
+  if (!borrowVault.value || !position.value) {
+    savingsBorrowValueUsd.value = null
+    return
+  }
+  savingsBorrowValueUsd.value = (await getAssetUsdValue(position.value.borrowed, borrowVault.value, 'off-chain')) ?? null
+})
+
+const savingsNextBorrowValueUsd = ref<number | null>(null)
+watchEffect(async () => {
+  if (!borrowVault.value || !position.value || savingsDebtRepaid.value === null) {
+    savingsNextBorrowValueUsd.value = null
+    return
+  }
+  const nextBorrow = position.value.borrowed - savingsDebtRepaid.value
+  savingsNextBorrowValueUsd.value = (await getAssetUsdValue(nextBorrow > 0n ? nextBorrow : 0n, borrowVault.value, 'off-chain')) ?? null
+})
+
+const savingsCurrentHealth = computed(() => {
+  if (!position.value) return null
+  return nanoToValue(position.value.health, 18)
+})
+const savingsCurrentLtv = computed(() => {
+  if (!position.value) return null
+  return nanoToValue(position.value.userLTV, 18)
+})
+const savingsCurrentLiquidationLtv = computed(() => {
+  if (!position.value) return null
+  return nanoToValue(position.value.liquidationLTV, 2)
+})
+const savingsBorrowAmountAfter = computed(() => {
+  if (!borrowVault.value || !position.value || savingsDebtRepaid.value === null) return null
+  const nextBorrow = position.value.borrowed - savingsDebtRepaid.value
+  return nanoToValue(nextBorrow > 0n ? nextBorrow : 0n, borrowVault.value.decimals)
+})
+const savingsCollateralAmountAfter = computed(() => {
+  // Collateral is unchanged when repaying from savings
+  if (!collateralVault.value || !position.value) return null
+  return nanoToValue(position.value.supplied || 0n, collateralVault.value.decimals)
+})
+const savingsNextLtv = computed(() => {
+  if (savingsBorrowAmountAfter.value === null || savingsCollateralAmountAfter.value === null || !oraclePriceRatio.value) return null
+  if (savingsBorrowAmountAfter.value === 0) return 0
+  if (oraclePriceRatio.value <= 0 || savingsCollateralAmountAfter.value <= 0) return null
+  return (savingsBorrowAmountAfter.value / (savingsCollateralAmountAfter.value * oraclePriceRatio.value)) * 100
+})
+const savingsNextHealth = computed(() => {
+  if (!savingsCurrentLiquidationLtv.value || savingsNextLtv.value === null) return null
+  if (savingsNextLtv.value <= 0) return Infinity
+  return savingsCurrentLiquidationLtv.value / savingsNextLtv.value
+})
+
+const savingsSwapCurrentPrice = computed(() => {
+  if (!savingsQuote.value || !savingsVault.value || !borrowVault.value) return null
+  const amountOut = Number(formatUnits(BigInt(savingsQuote.value.amountOut), Number(borrowVault.value.asset.decimals)))
+  const amountIn = Number(formatUnits(BigInt(savingsQuote.value.amountIn), Number(savingsVault.value.asset.decimals)))
+  if (!amountOut || !amountIn) return null
+  return {
+    value: amountOut / amountIn,
+    symbol: `${borrowVault.value.asset.symbol}/${savingsVault.value.asset.symbol}`,
+  }
+})
+const savingsSwapSummary = computed(() => {
+  if (!savingsQuote.value || !savingsVault.value || !borrowVault.value) return null
+  const amountIn = formatUnits(BigInt(savingsQuote.value.amountIn), Number(savingsVault.value.asset.decimals))
+  const amountOut = formatUnits(BigInt(savingsQuote.value.amountOut), Number(borrowVault.value.asset.decimals))
+  return {
+    from: `${formatNumber(amountIn)} ${savingsVault.value.asset.symbol}`,
+    to: `${formatSignificant(amountOut)} ${borrowVault.value.asset.symbol}`,
+  }
+})
+const savingsPriceImpact = ref<number | null>(null)
+watchEffect(async () => {
+  if (!savingsQuote.value || !savingsVault.value || !borrowVault.value) {
+    savingsPriceImpact.value = null
+    return
+  }
+  const [amountInUsd, amountOutUsd] = await Promise.all([
+    getAssetUsdValue(BigInt(savingsQuote.value.amountIn), savingsVault.value, 'off-chain'),
+    getAssetUsdValue(BigInt(savingsQuote.value.amountOut), borrowVault.value, 'off-chain'),
+  ])
+  if (!amountInUsd || !amountOutUsd) {
+    savingsPriceImpact.value = null
+    return
+  }
+  const impact = (amountOutUsd / amountInUsd - 1) * 100
+  savingsPriceImpact.value = Number.isFinite(impact) ? impact : null
+})
+const savingsRoutedVia = computed(() => {
+  if (!savingsQuote.value?.route?.length) return null
+  return savingsQuote.value.route.map(route => route.providerName).join(', ')
+})
+
+const savingsRouteItems = computed(() => {
+  if (!borrowVault.value || !savingsVault.value) return []
+  const bestProvider = savingsSwapQuoteCardsSorted.value[0]?.provider
+  const isExactIn = savingsSwapDirection.value === SwapperMode.EXACT_IN
+  return savingsSwapQuoteCardsSorted.value.map((card) => {
+    const amount = getQuoteAmount(card.quote, isExactIn ? 'amountOut' : 'amountIn')
+    const symbol = isExactIn ? borrowVault.value!.asset.symbol : savingsVault.value!.asset.symbol
+    const amountLabel = formatSignificant(
+      formatUnits(amount, Number(isExactIn ? borrowVault.value!.asset.decimals : savingsVault.value!.asset.decimals)),
+    )
+    const diffPct = (isExactIn ? savingsExactInQuotes.getQuoteDiffPct : savingsTargetDebtQuotes.getQuoteDiffPct)(card.quote)
+    const badge = card.provider === bestProvider
+      ? { label: 'Best', tone: 'best' as const }
+      : diffPct !== null
+        ? { label: `-${diffPct.toFixed(2)}%`, tone: 'worse' as const }
+        : undefined
+    return {
+      provider: card.provider,
+      amount: amountLabel,
+      symbol,
+      routeLabel: card.quote.route?.length
+        ? `via ${card.quote.route.map(route => route.providerName).join(', ')}`
+        : '-',
+      badge,
+    }
+  })
+})
+
+const isSavingsSubmitDisabled = computed(() => {
+  if (!isConnected.value) return false
+  if (!savingsVault.value || !borrowVault.value) return true
+  if (!savingsDebtAmount.value && !savingsAmount.value) return true
+  if (savingsIsSameAsset.value) return false
+  if (savingsQuoteError.value) return true
+  if (!savingsSelectedQuote.value) return true
+  return false
+})
 
 const isSubmitDisabled = computed(() => {
   if (!isConnected.value) return false
@@ -117,7 +364,9 @@ const swapDisabledReason = computed(() => {
 })
 const reviewRepayLabel = getSubmitLabel('Review Repay')
 const reviewRepayDisabled = getSubmitDisabled(computed(() => {
-  return formTab.value === 'wallet' ? isSubmitDisabled.value : isSwapSubmitDisabled.value
+  if (formTab.value === 'wallet') return isSubmitDisabled.value
+  if (formTab.value === 'savings') return isSavingsSubmitDisabled.value
+  return isSwapSubmitDisabled.value
 }))
 const collateralSupplyRewardApy = computed(() => getSupplyRewardApy(collateralVault.value?.address || ''))
 const borrowRewardApy = computed(() => getBorrowRewardApy(borrowVault.value?.address || '', collateralVault.value?.address || ''))
@@ -208,6 +457,11 @@ const load = async () => {
     estimateUserLTV.value = position.value?.userLTV || 0n
     estimateHealth.value = position.value?.health || 0n
     swapCollateralVault.value = position.value?.collateral as Vault | undefined
+    // Initialize savings vault to first available savings position
+    if (savingsVaults.value.length > 0) {
+      savingsVault.value = savingsVaults.value[0] as Vault
+      updateSavingsBalance()
+    }
   }
   catch (e) {
     showError('Unable to load Vault')
@@ -857,6 +1111,373 @@ watch([swapEffectiveQuote, repaySwapDirection], () => {
     collateralAmount.value = formatSignificant(collateralAmount.value)
   }
 })
+
+// --- Savings tab handlers ---
+
+const resetSavingsQuoteState = () => {
+  savingsExactInQuotes.reset()
+  savingsTargetDebtQuotes.reset()
+}
+
+const updateSavingsBalance = () => {
+  if (!savingsVault.value) {
+    savingsAssets.value = 0n
+    return
+  }
+  const pos = getSavingsPosition(savingsVault.value.address)
+  savingsAssets.value = pos?.assets || 0n
+}
+
+const onSavingsVaultChange = (selectedIndex: number) => {
+  clearSimulationError()
+  const nextVault = savingsVaults.value[selectedIndex]
+  if (!nextVault) return
+  if (!savingsVault.value || normalizeAddress(savingsVault.value.address) !== normalizeAddress(nextVault.address)) {
+    savingsVault.value = nextVault as Vault
+    savingsAmount.value = ''
+    savingsDebtAmount.value = ''
+    resetSavingsQuoteState()
+  }
+}
+
+const onSavingsAmountInput = () => {
+  clearSimulationError()
+  savingsDebtAmount.value = ''
+  savingsSwapDirection.value = SwapperMode.EXACT_IN
+  requestSavingsQuote()
+}
+
+const onSavingsDebtInput = () => {
+  clearSimulationError()
+  savingsAmount.value = ''
+  savingsSwapDirection.value = SwapperMode.TARGET_DEBT
+  const currentDebt = getCurrentDebt()
+  let amountNano = 0n
+  try {
+    amountNano = valueToNano(savingsDebtAmount.value || '0', borrowVault.value?.asset.decimals)
+  }
+  catch {
+    amountNano = 0n
+  }
+  if (currentDebt > 0n && amountNano > 0n) {
+    savingsDebtPercent.value = Math.min(100, Math.max(0, Math.round(Number(amountNano * 100n / currentDebt))))
+  }
+  else {
+    savingsDebtPercent.value = 0
+  }
+  requestSavingsQuote()
+}
+
+const onSavingsPercentInput = () => {
+  clearSimulationError()
+  savingsAmount.value = ''
+  savingsSwapDirection.value = SwapperMode.TARGET_DEBT
+  const currentDebt = getCurrentDebt()
+  if (!borrowVault.value || currentDebt <= 0n) {
+    savingsDebtAmount.value = ''
+    savingsDebtPercent.value = 0
+    resetSavingsQuoteState()
+    return
+  }
+  const percent = Math.min(100, Math.max(0, savingsDebtPercent.value || 0))
+  const amountNano = (currentDebt * BigInt(Math.round(percent * 100))) / 10_000n
+  savingsDebtAmount.value = trimTrailingZeros(formatUnits(amountNano, Number(borrowVault.value.asset.decimals)))
+  requestSavingsQuote()
+}
+
+const selectSavingsProvider = (provider: string) => {
+  if (savingsSwapDirection.value === SwapperMode.EXACT_IN) {
+    savingsExactInQuotes.selectProvider(provider)
+  }
+  else {
+    savingsTargetDebtQuotes.selectProvider(provider)
+  }
+}
+
+const onRefreshSavingsQuotes = () => {
+  resetSavingsQuoteState()
+  const activeQuotes = savingsSwapDirection.value === SwapperMode.EXACT_IN
+    ? savingsExactInQuotes
+    : savingsTargetDebtQuotes
+  activeQuotes.isLoading.value = true
+  requestSavingsQuote()
+}
+
+const requestSavingsQuote = useDebounceFn(async () => {
+  if (!position.value || !savingsVault.value || !borrowVault.value) {
+    resetSavingsQuoteState()
+    return
+  }
+
+  if (savingsIsSameAsset.value) {
+    const currentDebt = position.value.borrowed || 0n
+    if (savingsSwapDirection.value === SwapperMode.EXACT_IN && savingsAmount.value) {
+      try {
+        const savingsNano = valueToNano(savingsAmount.value, savingsVault.value.asset.decimals)
+        if (savingsNano > currentDebt && currentDebt > 0n) {
+          savingsAmount.value = trimTrailingZeros(formatUnits(currentDebt, Number(borrowVault.value.asset.decimals)))
+        }
+      }
+      catch { /* ignore parse errors */ }
+      savingsDebtAmount.value = savingsAmount.value
+    }
+    if (savingsSwapDirection.value === SwapperMode.TARGET_DEBT && savingsDebtAmount.value) {
+      savingsAmount.value = savingsDebtAmount.value
+    }
+    resetSavingsQuoteState()
+    return
+  }
+
+  // Cross-asset: get savings sub-account for accountIn
+  const savingsPos = getSavingsPosition(savingsVault.value.address)
+  const savingsSubAccount = (savingsPos?.subAccount || address.value || zeroAddress) as Address
+  const borrowSubAccount = (position.value.subAccount || address.value || zeroAddress) as Address
+  const currentDebt = position.value.borrowed || 0n
+
+  if (savingsSwapDirection.value === SwapperMode.EXACT_IN) {
+    if (!savingsAmount.value) {
+      resetSavingsQuoteState()
+      return
+    }
+    let amount: bigint
+    try {
+      amount = valueToNano(savingsAmount.value, savingsVault.value.asset.decimals)
+    }
+    catch {
+      resetSavingsQuoteState()
+      return
+    }
+    if (!amount || amount <= 0n) {
+      resetSavingsQuoteState()
+      return
+    }
+    await savingsExactInQuotes.requestQuotes({
+      tokenIn: savingsVault.value.asset.address as Address,
+      tokenOut: borrowVault.value.asset.address as Address,
+      accountIn: savingsSubAccount,
+      accountOut: borrowSubAccount,
+      amount,
+      vaultIn: savingsVault.value.address as Address,
+      receiver: borrowVault.value.address as Address,
+      slippage: slippage.value,
+      swapperMode: SwapperMode.EXACT_IN,
+      isRepay: true,
+      targetDebt: 0n,
+      currentDebt,
+    })
+    return
+  }
+
+  if (!savingsDebtAmount.value) {
+    resetSavingsQuoteState()
+    return
+  }
+  let amount: bigint
+  try {
+    amount = valueToNano(savingsDebtAmount.value, borrowVault.value.asset.decimals)
+  }
+  catch {
+    resetSavingsQuoteState()
+    return
+  }
+  if (!amount || amount <= 0n) {
+    resetSavingsQuoteState()
+    return
+  }
+  const targetDebt = amount >= currentDebt ? 0n : currentDebt - amount
+  await savingsTargetDebtQuotes.requestQuotes({
+    tokenIn: savingsVault.value.asset.address as Address,
+    tokenOut: borrowVault.value.asset.address as Address,
+    accountIn: savingsSubAccount,
+    accountOut: borrowSubAccount,
+    amount,
+    vaultIn: savingsVault.value.address as Address,
+    receiver: borrowVault.value.address as Address,
+    slippage: slippage.value,
+    swapperMode: SwapperMode.TARGET_DEBT,
+    isRepay: true,
+    targetDebt,
+    currentDebt,
+  })
+}, 500)
+
+watch([savingsEffectiveQuote, savingsSwapDirection], () => {
+  if (!savingsEffectiveQuote.value || !savingsVault.value || !borrowVault.value) return
+  if (savingsSwapDirection.value === SwapperMode.EXACT_IN) {
+    savingsDebtAmount.value = formatSignificant(formatUnits(
+      BigInt(savingsEffectiveQuote.value.amountOut || 0),
+      Number(borrowVault.value.asset.decimals),
+    ))
+  }
+  else {
+    savingsAmount.value = formatSignificant(formatUnits(
+      BigInt(savingsEffectiveQuote.value.amountIn || 0),
+      Number(savingsVault.value.asset.decimals),
+    ))
+  }
+})
+
+watch([savingsVault, slippage], () => {
+  clearSimulationError()
+  if (savingsAmount.value || savingsDebtAmount.value) {
+    requestSavingsQuote()
+  }
+})
+
+watch(savingsVault, () => {
+  updateSavingsBalance()
+})
+
+watch(savingsDebtAmount, () => {
+  if (formTab.value !== 'savings') return
+  const currentDebt = getCurrentDebt()
+  if (!borrowVault.value || currentDebt <= 0n) {
+    savingsDebtPercent.value = 0
+    return
+  }
+  let amountNano = 0n
+  try {
+    amountNano = valueToNano(savingsDebtAmount.value || '0', borrowVault.value.asset.decimals)
+  }
+  catch {
+    amountNano = 0n
+  }
+  savingsDebtPercent.value = amountNano > 0n
+    ? Math.min(100, Math.max(0, Math.round(Number(amountNano * 100n / currentDebt))))
+    : 0
+})
+
+const buildSavingsRepay = async (): Promise<TxPlan> => {
+  if (!position.value || !borrowVault.value || !savingsVault.value) {
+    throw new Error('Position or vaults not loaded')
+  }
+
+  const savingsPos = getSavingsPosition(savingsVault.value.address)
+  if (!savingsPos) {
+    throw new Error('Savings position not found')
+  }
+
+  if (savingsIsSameAsset.value) {
+    const debtNano = savingsDebtAmount.value
+      ? valueToNano(savingsDebtAmount.value, borrowVault.value.asset.decimals)
+      : valueToNano(savingsAmount.value, savingsVault.value.asset.decimals)
+    const currentDebtVal = getCurrentDebt()
+    const isFullRepay = debtNano >= currentDebtVal
+
+    if (isFullRepay) {
+      return buildSavingsFullRepayPlan({
+        savingsVaultAddress: savingsVault.value.address,
+        borrowVaultAddress: borrowVault.value.address,
+        amount: currentDebtVal,
+        savingsSubAccount: savingsPos.subAccount,
+        borrowSubAccount: position.value.subAccount,
+        enabledCollaterals: position.value.collaterals,
+      })
+    }
+    return buildSavingsRepayPlan({
+      savingsVaultAddress: savingsVault.value.address,
+      borrowVaultAddress: borrowVault.value.address,
+      amount: debtNano,
+      savingsSubAccount: savingsPos.subAccount,
+      borrowSubAccount: position.value.subAccount,
+      enabledCollaterals: position.value.collaterals,
+    })
+  }
+
+  // Cross-asset swap from savings
+  if (!savingsSelectedQuote.value) {
+    throw new Error('No quote selected')
+  }
+
+  const currentDebt = getCurrentDebt()
+  const swapMode = savingsSwapDirection.value
+  let targetDebt = 0n
+  if (swapMode === SwapperMode.TARGET_DEBT && savingsDebtAmount.value) {
+    const debtAmountNano = valueToNano(savingsDebtAmount.value, borrowVault.value.asset.decimals)
+    targetDebt = debtAmountNano >= currentDebt ? 0n : currentDebt - debtAmountNano
+  }
+
+  // Check if this is a full repay via swap
+  const isFullRepay = targetDebt === 0n && swapMode === SwapperMode.TARGET_DEBT
+  if (isFullRepay) {
+    return buildSwapSavingsFullRepayPlan({
+      quote: savingsSelectedQuote.value,
+      swapperMode: swapMode,
+      targetDebt,
+      currentDebt,
+      liabilityVault: borrowVault.value.address,
+      enabledCollaterals: position.value.collaterals,
+    })
+  }
+
+  return buildSwapPlan({
+    quote: savingsSelectedQuote.value,
+    swapperMode: swapMode,
+    isRepay: true,
+    targetDebt,
+    currentDebt,
+    liabilityVault: borrowVault.value.address,
+    enabledCollaterals: position.value.collaterals,
+  })
+}
+
+const submitSavings = async () => {
+  if (isSubmitting.value || !position.value || !borrowVault.value || !savingsVault.value) return
+  if (!savingsIsSameAsset.value && !savingsSelectedQuote.value) return
+
+  try {
+    plan.value = await buildSavingsRepay()
+  }
+  catch (e) {
+    console.warn('[OperationReviewModal] failed to build savings plan', e)
+    plan.value = null
+  }
+
+  if (plan.value) {
+    const ok = await runSimulation(plan.value)
+    if (!ok) return
+  }
+
+  modal.open(OperationReviewModal, {
+    props: {
+      type: 'repay',
+      asset: savingsVault.value.asset,
+      amount: savingsAmount.value,
+      plan: plan.value || undefined,
+      subAccount: position.value?.subAccount,
+      hasBorrows: (position.value?.borrowed || 0n) > 0n,
+      onConfirm: () => {
+        setTimeout(() => {
+          sendSavings()
+        }, 400)
+      },
+    },
+  })
+}
+
+const sendSavings = async () => {
+  if (!position.value || !borrowVault.value || !savingsVault.value) return
+  if (!savingsIsSameAsset.value && !savingsSelectedQuote.value) return
+  try {
+    isSubmitting.value = true
+    const txPlan = await buildSavingsRepay()
+    await executeTxPlan(txPlan)
+
+    modal.close()
+    refreshAllPositions(eulerLensAddresses.value, address.value as string)
+    setTimeout(() => {
+      router.replace('/portfolio')
+    }, 400)
+  }
+  catch (e) {
+    error('Transaction failed')
+    console.warn(e)
+  }
+  finally {
+    isSubmitting.value = false
+  }
+}
+
 const updateBalance = async () => {
   if (!isConnected.value || !position.value || !borrowVault.value) {
     balance.value = 0n
@@ -929,6 +1550,9 @@ const onSubmitForm = async () => {
   await guardWithTerms(async () => {
     if (formTab.value === 'wallet') {
       await submit()
+    }
+    else if (formTab.value === 'savings') {
+      await submitSavings()
     }
     else {
       await submitSwap()
@@ -1213,7 +1837,18 @@ watch(amount, async () => {
 watch(formTab, () => {
   clearSimulationError()
   resetSwapQuoteState()
+  resetSavingsQuoteState()
   if (formTab.value === 'wallet') {
+    collateralAmount.value = ''
+    debtAmount.value = ''
+    repaySwapDirection.value = SwapperMode.EXACT_IN
+    savingsAmount.value = ''
+    savingsDebtAmount.value = ''
+    savingsDebtPercent.value = 0
+  }
+  else if (formTab.value === 'savings') {
+    amount.value = ''
+    walletRepayPercent.value = 0
     collateralAmount.value = ''
     debtAmount.value = ''
     repaySwapDirection.value = SwapperMode.EXACT_IN
@@ -1221,6 +1856,9 @@ watch(formTab, () => {
   else {
     amount.value = ''
     walletRepayPercent.value = 0
+    savingsAmount.value = ''
+    savingsDebtAmount.value = ''
+    savingsDebtPercent.value = 0
   }
 })
 
@@ -1406,7 +2044,7 @@ onUnmounted(() => {
         </div>
       </template>
 
-      <template v-else>
+      <template v-else-if="formTab === 'collateral'">
         <div class="grid gap-16 laptop:grid-cols-[minmax(0,1fr)_360px] laptop:items-start">
           <div class="flex flex-col gap-16 w-full">
             <UiToast
@@ -1582,6 +2220,160 @@ onUnmounted(() => {
             <VaultFormSubmit
               :disabled="reviewRepayDisabled"
               :disabled-reason="swapDisabledReason"
+              :loading="isSubmitting"
+            >
+              {{ reviewRepayLabel }}
+            </VaultFormSubmit>
+          </div>
+        </div>
+      </template>
+
+      <template v-else-if="formTab === 'savings'">
+        <div class="grid gap-16 laptop:grid-cols-[minmax(0,1fr)_360px] laptop:items-start">
+          <div class="flex flex-col gap-16 w-full">
+            <AssetInput
+              v-if="savingsVault"
+              v-model="savingsAmount"
+              label="Savings to use"
+              :desc="savingsProduct.name"
+              :asset="savingsVault.asset"
+              :vault="savingsVault"
+              :collateral-options="savingsOptions"
+              :balance="savingsBalance"
+              @input="onSavingsAmountInput"
+              @change-collateral="onSavingsVaultChange"
+            />
+            <AssetInput
+              v-if="borrowVault"
+              v-model="savingsDebtAmount"
+              label="Debt to repay"
+              :desc="name"
+              :asset="borrowVault.asset"
+              :vault="borrowVault"
+              :balance="savingsDebtBalance"
+              maxable
+              @input="onSavingsDebtInput"
+            />
+            <UiRange
+              v-if="borrowVault"
+              v-model="savingsDebtPercent"
+              label="Percent of debt to repay"
+              :min="0"
+              :max="100"
+              :step="1"
+              :number-filter="(n: number) => `${n}%`"
+              @update:model-value="onSavingsPercentInput"
+            />
+
+            <SwapRouteSelector
+              v-if="!savingsIsSameAsset"
+              :items="savingsRouteItems"
+              :selected-provider="savingsSelectedProvider"
+              :status-label="savingsQuotesStatusLabel"
+              :is-loading="savingsIsQuoteLoading"
+              :empty-message="savingsProvidersCount ? 'No quotes found' : 'Enter amount to fetch quotes'"
+              @select="selectSavingsProvider"
+              @refresh="onRefreshSavingsQuotes"
+            />
+
+            <UiToast
+              v-if="savingsQuoteError && !savingsIsSameAsset"
+              title="Swap quote"
+              variant="warning"
+              :description="savingsQuoteError"
+              size="compact"
+            />
+            <UiToast
+              v-if="simulationError"
+              title="Error"
+              variant="error"
+              :description="simulationError"
+              size="compact"
+            />
+          </div>
+
+          <VaultFormInfoBlock
+            :loading="!savingsIsSameAsset && savingsIsQuoteLoading"
+            variant="card"
+            class="w-full laptop:max-w-[360px]"
+          >
+            <template v-if="!savingsIsSameAsset">
+              <SummaryRow label="Swap price" align-top>
+                <SummaryPriceValue
+                  :value="savingsSwapCurrentPrice ? formatSmartAmount(savingsPriceInvert.invertValue(savingsSwapCurrentPrice.value)) : undefined"
+                  :symbol="savingsPriceInvert.displaySymbol"
+                  invertible
+                  @invert="savingsPriceInvert.toggle"
+                />
+              </SummaryRow>
+            </template>
+            <template v-else>
+              <SummaryRow label="Transfer">
+                <p class="text-p2">
+                  1:1 (same asset, no slippage)
+                </p>
+              </SummaryRow>
+            </template>
+            <SummaryRow label="LTV">
+              <SummaryValue
+                :before="savingsCurrentLtv !== null ? formatNumber(savingsCurrentLtv) : undefined"
+                :after="savingsNextLtv !== null && (savingsQuote || savingsIsSameAsset) ? formatNumber(savingsNextLtv) : undefined"
+                suffix="%"
+              />
+            </SummaryRow>
+            <SummaryRow label="Health score">
+              <SummaryValue
+                :before="savingsCurrentHealth !== null ? formatHealthScore(savingsCurrentHealth) : undefined"
+                :after="savingsNextHealth !== null && (savingsQuote || savingsIsSameAsset) ? formatHealthScore(savingsNextHealth) : undefined"
+              />
+            </SummaryRow>
+            <template v-if="!savingsIsSameAsset">
+              <SummaryRow label="Swap" align-top>
+                <p class="text-p2 text-right flex flex-col items-end">
+                  <span>{{ savingsSwapSummary ? savingsSwapSummary.from : '-' }}</span>
+                  <span
+                    v-if="savingsSwapSummary"
+                    class="text-content-tertiary text-p3"
+                  >
+                    {{ savingsSwapSummary.to }}
+                  </span>
+                </p>
+              </SummaryRow>
+              <SummaryRow label="Price impact">
+                <p class="text-p2">
+                  {{ savingsPriceImpact !== null ? `${formatNumber(savingsPriceImpact, 2, 2)}%` : '-' }}
+                </p>
+              </SummaryRow>
+              <SummaryRow label="Slippage tolerance">
+                <button
+                  type="button"
+                  class="flex items-center gap-6 text-p2"
+                  @click="openSlippageSettings"
+                >
+                  <span>{{ formatNumber(slippage, 2, 0) }}%</span>
+                  <SvgIcon
+                    name="edit"
+                    class="!w-16 !h-16 text-accent-600"
+                  />
+                </button>
+              </SummaryRow>
+              <SummaryRow label="Routed via">
+                <p class="text-p2 text-right">
+                  {{ savingsRoutedVia || '-' }}
+                </p>
+              </SummaryRow>
+            </template>
+          </VaultFormInfoBlock>
+
+          <div class="flex flex-col gap-8 laptop:col-start-1 laptop:row-start-2">
+            <VaultFormInfoButton
+              :pair="position"
+              :disabled="isLoading || isSubmitting"
+            >
+              Pair information
+            </VaultFormInfoButton>
+            <VaultFormSubmit
+              :disabled="reviewRepayDisabled"
               :loading="isSubmitting"
             >
               {{ reviewRepayLabel }}

--- a/pages/position/[number]/supply.vue
+++ b/pages/position/[number]/supply.vue
@@ -51,6 +51,7 @@ const priceInvert = usePriceInvert(
 
 const isLoading = ref(false)
 const isSubmitting = ref(false)
+const isPreparing = ref(false)
 const isEstimatesLoading = ref(false)
 const amount = ref('')
 const plan = ref<TxPlan | null>(null)
@@ -234,49 +235,55 @@ const updateBalance = async () => {
   balance.value = await fetchSingleBalance(collateralVault.value.asset.address)
 }
 const submit = async () => {
-  if (isGeoBlocked.value) return
-  await guardWithTerms(async () => {
-    if (!collateralVault.value?.asset.address) {
-      return
-    }
-
-    try {
-      plan.value = await buildSupplyPlan(
-        collateralVault.value.address,
-        collateralVault.value.asset.address,
-        valueToNano(amount.value || '0', collateralVault.value.asset.decimals),
-        position.value?.subAccount,
-        { includePermit2Call: false },
-      )
-    }
-    catch (e) {
-      console.warn('[OperationReviewModal] failed to build plan', e)
-      plan.value = null
-    }
-
-    if (plan.value) {
-      const ok = await runSimulation(plan.value)
-      if (!ok) {
+  if (isPreparing.value || isGeoBlocked.value) return
+  isPreparing.value = true
+  try {
+    await guardWithTerms(async () => {
+      if (!collateralVault.value?.asset.address) {
         return
       }
-    }
 
-    modal.open(OperationReviewModal, {
-      props: {
-        type: 'supply',
-        asset: asset.value,
-        amount: amount.value,
-        plan: plan.value || undefined,
-        subAccount: position.value?.subAccount,
-        hasBorrows: (position.value?.borrowed || 0n) > 0n,
-        onConfirm: () => {
-          setTimeout(() => {
-            send()
-          }, 400)
+      try {
+        plan.value = await buildSupplyPlan(
+          collateralVault.value.address,
+          collateralVault.value.asset.address,
+          valueToNano(amount.value || '0', collateralVault.value.asset.decimals),
+          position.value?.subAccount,
+          { includePermit2Call: false },
+        )
+      }
+      catch (e) {
+        console.warn('[OperationReviewModal] failed to build plan', e)
+        plan.value = null
+      }
+
+      if (plan.value) {
+        const ok = await runSimulation(plan.value)
+        if (!ok) {
+          return
+        }
+      }
+
+      modal.open(OperationReviewModal, {
+        props: {
+          type: 'supply',
+          asset: asset.value,
+          amount: amount.value,
+          plan: plan.value || undefined,
+          subAccount: position.value?.subAccount,
+          hasBorrows: (position.value?.borrowed || 0n) > 0n,
+          onConfirm: () => {
+            setTimeout(() => {
+              send()
+            }, 400)
+          },
         },
-      },
+      })
     })
-  })
+  }
+  finally {
+    isPreparing.value = false
+  }
 }
 const send = async () => {
   try {
@@ -498,7 +505,7 @@ onUnmounted(() => {
           />
           <VaultFormSubmit
             :disabled="reviewSupplyDisabled"
-            :loading="isSubmitting"
+            :loading="isSubmitting || isPreparing"
           >
             {{ reviewSupplyLabel }}
           </VaultFormSubmit>

--- a/pages/position/[number]/withdraw.vue
+++ b/pages/position/[number]/withdraw.vue
@@ -53,6 +53,7 @@ const positionIndex = route.params.number as string
 
 const isLoading = ref(false)
 const isSubmitting = ref(false)
+const isPreparing = ref(false)
 const isEstimatesLoading = ref(false)
 const amount = ref('')
 const plan = ref<TxPlan | null>(null)
@@ -236,48 +237,54 @@ const load = async () => {
   }
 }
 const submit = async () => {
-  if (isGeoBlocked.value) return
-  await guardWithTerms(async () => {
-    if (!asset.value?.address || !collateralVault.value?.address) {
-      return
-    }
-
-    try {
-      plan.value = await buildWithdrawPlan(
-        collateralVault.value.address,
-        valueToNano(amount.value || '0', asset.value.decimals),
-        position.value?.subAccount,
-        { includePythUpdate: (position.value?.borrowed || 0n) > 0n, liabilityVault: borrowVault.value?.address, enabledCollaterals: position.value?.collaterals },
-      )
-    }
-    catch (e) {
-      console.warn('[OperationReviewModal] failed to build plan', e)
-      plan.value = null
-    }
-
-    if (plan.value) {
-      const ok = await runSimulation(plan.value)
-      if (!ok) {
+  if (isPreparing.value || isGeoBlocked.value) return
+  isPreparing.value = true
+  try {
+    await guardWithTerms(async () => {
+      if (!asset.value?.address || !collateralVault.value?.address) {
         return
       }
-    }
 
-    modal.open(OperationReviewModal, {
-      props: {
-        type: 'withdraw',
-        asset: asset.value,
-        amount: amount.value,
-        plan: plan.value || undefined,
-        subAccount: position.value?.subAccount,
-        hasBorrows: (position.value?.borrowed || 0n) > 0n,
-        onConfirm: () => {
-          setTimeout(() => {
-            send()
-          }, 400)
+      try {
+        plan.value = await buildWithdrawPlan(
+          collateralVault.value.address,
+          valueToNano(amount.value || '0', asset.value.decimals),
+          position.value?.subAccount,
+          { includePythUpdate: (position.value?.borrowed || 0n) > 0n, liabilityVault: borrowVault.value?.address, enabledCollaterals: position.value?.collaterals },
+        )
+      }
+      catch (e) {
+        console.warn('[OperationReviewModal] failed to build plan', e)
+        plan.value = null
+      }
+
+      if (plan.value) {
+        const ok = await runSimulation(plan.value)
+        if (!ok) {
+          return
+        }
+      }
+
+      modal.open(OperationReviewModal, {
+        props: {
+          type: 'withdraw',
+          asset: asset.value,
+          amount: amount.value,
+          plan: plan.value || undefined,
+          subAccount: position.value?.subAccount,
+          hasBorrows: (position.value?.borrowed || 0n) > 0n,
+          onConfirm: () => {
+            setTimeout(() => {
+              send()
+            }, 400)
+          },
         },
-      },
+      })
     })
-  })
+  }
+  finally {
+    isPreparing.value = false
+  }
 }
 const send = async () => {
   try {
@@ -492,7 +499,7 @@ watch(amount, async () => {
           />
           <VaultFormSubmit
             :disabled="reviewWithdrawDisabled"
-            :loading="isSubmitting"
+            :loading="isSubmitting || isPreparing"
           >
             {{ reviewWithdrawLabel }}
           </VaultFormSubmit>


### PR DESCRIPTION
## Summary

- Adds a third tab ("From savings") to the repay page, allowing users to repay debt using savings from deposit positions on other sub-accounts
- Supports same-asset flows (direct withdraw → skim → repayWithShares) and cross-asset flows (swap via existing swap API)
- Full repay cleans up the position entirely: disables controller/collateral, returns excess to savings, transfers all shares back to main account
- Tab only appears when the user has eligible savings positions (non-securitize, non-zero balance)

### New files
- `composables/useRepaySavingsOptions.ts` — filters deposit positions to eligible savings options

### Modified files
- `composables/useEulerOperations.ts` — 3 new plan builders: `buildSavingsRepayPlan`, `buildSavingsFullRepayPlan`, `buildSwapSavingsFullRepayPlan`
- `pages/position/[number]/repay.vue` — savings tab UI, state management, quote integration, plan building

## Test plan

- [x] Same-asset partial repay: user has USDC savings and USDC debt → withdraw from savings, skim+repayWithShares
- [x] Same-asset full repay: same as above + disableController, disableCollateral, transfer collateral back
- [x] Cross-asset partial repay: user has WETH savings and USDC debt → swap via swapper, verify debt reduction
- [x] Cross-asset full repay: same as above + position cleanup
- [x] Tab hidden when no eligible savings positions exist
- [x] Savings on main account (sub-account 0) vs different sub-account both work
- [x] All plans pass simulateTxPlan() before showing review modal