### PR TITLE
fix: give SecuritizeVault assetPriceInfo so standard pricing works

### DIFF
--- a/components/entities/asset/AssetInput.vue
+++ b/components/entities/asset/AssetInput.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
-import { formatUnits, type Address } from 'viem'
+import { formatUnits } from 'viem'
 import type { Vault, SecuritizeVault, VaultAsset, CollateralOption, EarnVault } from '~/entities/vault'
 import { getAssetUsdPrice } from '~/services/pricing/priceProvider'
-import { backendPriceToBigInt, fetchBackendPrice, isBackendConfigured } from '~/services/pricing/backendClient'
 import { nanoToValue } from '~/utils/crypto-utils'
 import { compactNumber, formatSmartAmount, trimTrailingZeros } from '~/utils/string-utils'
 import { ChooseCollateralModal } from '#components'
@@ -19,7 +18,7 @@ const props = defineProps<{
   collateralOptions?: CollateralOption[]
   collateralModalTitle?: string
   readonly?: boolean
-  priceOverride?: number // For vaults without standard price info (e.g., securitize)
+  priceOverride?: number // USD unit price for assets without a vault (e.g., swap-to-deposit)
   swappable?: boolean // When true, asset pill shows dropdown arrow and emits click-asset
 }>()
 const emits = defineEmits(['input', 'change-collateral', 'click-asset'])
@@ -28,7 +27,6 @@ const model = defineModel<string>({ default: '' })
 const inputEl = useTemplateRef<HTMLInputElement>('inputEl')
 const modal = useModal()
 const isFocused = ref(false)
-const { chainId } = useEulerAddresses()
 
 const selectedIdx = ref(0)
 const friendlyBalance = computed(() => nanoToValue(props.balance ?? 0n, props.asset?.decimals || 18))
@@ -54,15 +52,6 @@ watchEffect(async () => {
     const priceInfo = await getAssetUsdPrice(props.vault, 'off-chain')
     usdUnitPrice.value = priceInfo ? nanoToValue(priceInfo.amountOutMid, 18) : null
     return
-  }
-
-  if (isBackendConfigured()) {
-    const backendPrice = await fetchBackendPrice(props.asset.address as Address, chainId.value)
-    if (backendPrice) {
-      const mid = backendPriceToBigInt(backendPrice.price)
-      usdUnitPrice.value = mid > 0n ? nanoToValue(mid, 18) : null
-      return
-    }
   }
 
   usdUnitPrice.value = null

--- a/components/entities/asset/AssetInput.vue
+++ b/components/entities/asset/AssetInput.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
-import { formatUnits } from 'viem'
+import { formatUnits, type Address } from 'viem'
 import type { Vault, SecuritizeVault, VaultAsset, CollateralOption, EarnVault } from '~/entities/vault'
 import { getAssetUsdPrice } from '~/services/pricing/priceProvider'
+import { backendPriceToBigInt, fetchBackendPrice, isBackendConfigured } from '~/services/pricing/backendClient'
 import { nanoToValue } from '~/utils/crypto-utils'
 import { compactNumber, formatSmartAmount, trimTrailingZeros } from '~/utils/string-utils'
 import { ChooseCollateralModal } from '#components'
@@ -27,6 +28,7 @@ const model = defineModel<string>({ default: '' })
 const inputEl = useTemplateRef<HTMLInputElement>('inputEl')
 const modal = useModal()
 const isFocused = ref(false)
+const { chainId } = useEulerAddresses()
 
 const selectedIdx = ref(0)
 const friendlyBalance = computed(() => nanoToValue(props.balance ?? 0n, props.asset?.decimals || 18))
@@ -48,12 +50,22 @@ watch(() => props.collateralOptions, (options) => {
 const usdUnitPrice = ref<number | null>(null)
 
 watchEffect(async () => {
-  if (!props.vault) {
-    usdUnitPrice.value = null
+  if (props.vault) {
+    const priceInfo = await getAssetUsdPrice(props.vault, 'off-chain')
+    usdUnitPrice.value = priceInfo ? nanoToValue(priceInfo.amountOutMid, 18) : null
     return
   }
-  const priceInfo = await getAssetUsdPrice(props.vault, 'off-chain')
-  usdUnitPrice.value = priceInfo ? nanoToValue(priceInfo.amountOutMid, 18) : null
+
+  if (isBackendConfigured()) {
+    const backendPrice = await fetchBackendPrice(props.asset.address as Address, chainId.value)
+    if (backendPrice) {
+      const mid = backendPriceToBigInt(backendPrice.price)
+      usdUnitPrice.value = mid > 0n ? nanoToValue(mid, 18) : null
+      return
+    }
+  }
+
+  usdUnitPrice.value = null
 })
 
 // Display price (synchronous computed — tracks model.value reactively)

--- a/components/entities/portfolio/PortfolioSavingItem.vue
+++ b/components/entities/portfolio/PortfolioSavingItem.vue
@@ -32,7 +32,6 @@ const utilisationWarning = computed(() => {
 
 // Check if securitize vault by type field
 const isSecuritize = computed(() => 'type' in vault.value && vault.value.type === 'securitize')
-const regularVault = computed(() => isSecuritize.value ? null : vault.value as Vault)
 
 const rewardsExist = computed(() => hasSupplyRewards(vault.value.address))
 const supplyApy = computed(() => {
@@ -55,11 +54,7 @@ const displayName = computed(() => {
 const supplyValueDisplay = ref('-')
 
 const updateSupplyValueDisplay = async () => {
-  if (!regularVault.value) {
-    supplyValueDisplay.value = `${formatSmartAmount(nanoToValue(position.assets, vault.value.asset.decimals))} ${vault.value.asset.symbol}`
-    return
-  }
-  const price = await formatAssetValue(position.assets, regularVault.value, 'off-chain')
+  const price = await formatAssetValue(position.assets, vault.value, 'off-chain')
   supplyValueDisplay.value = price.hasPrice ? formatCompactUsdValue(price.usdValue) : price.display
 }
 
@@ -70,11 +65,7 @@ watchEffect(() => {
 const hasPrice = ref(false)
 
 const updateHasPrice = async () => {
-  if (!regularVault.value) {
-    hasPrice.value = false
-    return
-  }
-  const price = await getAssetUsdValue(position.assets, regularVault.value, 'off-chain')
+  const price = await getAssetUsdValue(position.assets, vault.value, 'off-chain')
   hasPrice.value = price !== undefined && price > 0
 }
 
@@ -85,11 +76,7 @@ watchEffect(() => {
 const projectedEarningsPerMonth = ref('—')
 
 const updateProjectedEarningsPerMonth = async () => {
-  if (!regularVault.value) {
-    projectedEarningsPerMonth.value = '—'
-    return
-  }
-  const price = await getAssetUsdValue(position.assets, regularVault.value, 'off-chain')
+  const price = await getAssetUsdValue(position.assets, vault.value, 'off-chain')
   if (price === undefined || price === 0) {
     projectedEarningsPerMonth.value = '—'
     return
@@ -298,10 +285,10 @@ const onClick = () => {
               {{ supplyValueDisplay }}
             </div>
             <div
-              v-if="regularVault && hasPrice"
+              v-if="hasPrice"
               class="text-content-tertiary text-p3"
             >
-              ~ {{ roundAndCompactTokens(position.assets, regularVault.decimals) }}
+              ~ {{ roundAndCompactTokens(position.assets, vault.decimals) }}
               {{ vault.asset.symbol }}
             </div>
           </div>

--- a/components/entities/vault/overview/SecuritizeVaultOverview.vue
+++ b/components/entities/vault/overview/SecuritizeVaultOverview.vue
@@ -116,7 +116,7 @@ loadRiskParameters()
 const priceDisplay = ref('-')
 
 watchEffect(async () => {
-  const price = await formatAssetValue(1, vault as unknown as Vault, 'off-chain')
+  const price = await formatAssetValue(1, vault, 'off-chain')
   priceDisplay.value = price.hasPrice ? formatUsdValue(price.usdValue) : '-'
 })
 
@@ -124,7 +124,7 @@ watchEffect(async () => {
 const totalSupplyDisplay = ref('-')
 
 watchEffect(async () => {
-  const price = await formatAssetValue(vault.totalAssets, vault as unknown as Vault, 'off-chain')
+  const price = await formatAssetValue(vault.totalAssets, vault, 'off-chain')
   totalSupplyDisplay.value = price.hasPrice ? formatCompactUsdValue(price.usdValue) : price.display
 })
 
@@ -136,7 +136,7 @@ watchEffect(async () => {
     supplyCapDisplay.value = '∞'
     return
   }
-  const price = await formatAssetValue(vault.supplyCap, vault as unknown as Vault, 'off-chain')
+  const price = await formatAssetValue(vault.supplyCap, vault, 'off-chain')
   supplyCapDisplay.value = price.hasPrice ? formatCompactUsdValue(price.usdValue) : price.display
 })
 
@@ -259,7 +259,7 @@ const supplyCapPercentageDisplay = computed(() => {
           label="Vault type"
         >
           <VaultTypeChip
-            :vault="vault as unknown as Vault"
+            :vault="vault"
             type="securitize"
           />
         </VaultOverviewLabelValue>

--- a/entities/vault/fetcher.ts
+++ b/entities/vault/fetcher.ts
@@ -250,6 +250,14 @@ export const fetchSecuritizeVault = async (vaultAddress: string): Promise<Securi
     // supplyCapResolved may not exist on all vaults
   }
 
+  const assetPriceInfo = eulerLensAddresses.value?.utilsLens
+    ? await resolveAssetPriceInfo(
+      EVM_PROVIDER_URL,
+      eulerLensAddresses.value.utilsLens,
+      data.asset as string,
+    )
+    : undefined
+
   return {
     type: 'securitize',
     verified: verifiedVaultAddresses.value.includes(vaultAddress),
@@ -278,6 +286,7 @@ export const fetchSecuritizeVault = async (vaultAddress: string): Promise<Securi
       cash: data.totalAssets,
       supplyAPY: 0n,
     },
+    assetPriceInfo,
   } as SecuritizeVault
 }
 

--- a/entities/vault/types.ts
+++ b/entities/vault/types.ts
@@ -69,6 +69,9 @@ export interface SecuritizeVault extends Erc4626Vault {
   supply: bigint // Same as totalAssets (no borrowing)
   borrow: bigint // Always 0 (securitize vaults can't be borrowed from)
   interestRateInfo: VaultInterestRateInfo // Zero-valued
+  assetPriceInfo?: {
+    amountOutMid: bigint
+  }
 }
 export interface Vault {
   verified: boolean

--- a/pages/lend/[vault]/[subAccount]/swap.vue
+++ b/pages/lend/[vault]/[subAccount]/swap.vue
@@ -30,7 +30,6 @@ const subAccount = computed(() => {
 const fromVault: Ref<Vault | SecuritizeVault | undefined> = ref()
 const toVault: Ref<Vault | undefined> = ref()
 
-const isFromSecuritizeVault = computed(() => fromVault.value && 'type' in fromVault.value && fromVault.value.type === 'securitize')
 const fromVaultAsRegular = computed(() => fromVault.value as Vault | undefined)
 const { collateralOptions, collateralVaults } = useSwapCollateralOptions({ currentVault: fromVaultAsRegular })
 
@@ -196,7 +195,7 @@ watch([() => route.params.vault, () => route.query.to], () => {
               :desc="fromProduct.name"
               label="From"
               :asset="fromVault.asset"
-              :vault="isFromSecuritizeVault ? undefined : (fromVault as Vault)"
+              :vault="fromVault"
               :balance="balance"
               maxable
               @input="onFromInput"

--- a/pages/lend/[vault]/index.vue
+++ b/pages/lend/[vault]/index.vue
@@ -717,7 +717,7 @@ watch(address, () => {
             label="Deposit amount"
             :desc="name"
             :asset="needsSwap && selectedAsset ? selectedAsset : asset"
-            :vault="needsSwap ? undefined : vault"
+            :vault="needsSwap ? undefined : (vault || securitizeVault)"
             :price-override="needsSwap ? swapAssetUsdPrice : undefined"
             :balance="activeBalance"
             maxable

--- a/pages/position/[number]/collateral/swap.vue
+++ b/pages/position/[number]/collateral/swap.vue
@@ -13,7 +13,6 @@ import {
   getAssetUsdValue,
   getAssetOraclePrice,
   getCollateralOraclePrice,
-  getCollateralUsdPrice,
   conservativePriceRatioNumber,
   getCollateralUsdValueOrZero,
 } from '~/services/pricing/priceProvider'
@@ -273,20 +272,6 @@ const getCollateralValueUsdLocal = async (amount: bigint) => {
   if (!borrowVault.value || !fromVault.value) return 0
   return getCollateralUsdValueOrZero(amount, borrowVault.value, fromVault.value as Vault, 'off-chain')
 }
-const collateralPricePerUnit = ref<number | undefined>(undefined)
-watchEffect(async () => {
-  if (!borrowVault.value || !fromVault.value) {
-    collateralPricePerUnit.value = undefined
-    return
-  }
-  const priceInfo = await getCollateralUsdPrice(borrowVault.value, fromVault.value as Vault, 'off-chain')
-  if (!priceInfo?.amountOutMid) {
-    collateralPricePerUnit.value = undefined
-    return
-  }
-  collateralPricePerUnit.value = nanoToValue(priceInfo.amountOutMid, 18)
-})
-
 // ── ROE ──────────────────────────────────────────────────────────────────
 const supplyValueUsd = ref<number | null>(null)
 watchEffect(async () => {
@@ -456,9 +441,8 @@ const nextLiquidationPrice = computed(() => {
               :desc="fromProduct.name"
               label="From"
               :asset="fromVault.asset"
-              :vault="isFromSecuritize ? undefined : (fromVault as Vault)"
+              :vault="fromVault"
               :balance="balance"
-              :price-override="isFromSecuritize ? collateralPricePerUnit : undefined"
               maxable
               @input="onFromInput"
             />

--- a/services/pricing/priceProvider.ts
+++ b/services/pricing/priceProvider.ts
@@ -290,7 +290,7 @@ const getAssetUsdPriceFromOracle = async (
 
   // Earn/Escrow/Securitize vaults - use UtilsLens (assetPriceInfo is already in USD)
   if (usesUtilsLensPricing(vault)) {
-    const priceInfo = (vault as Vault | EarnVault).assetPriceInfo
+    const priceInfo = (vault as Vault | EarnVault | SecuritizeVault).assetPriceInfo
     if (priceInfo?.amountOutMid) {
       const mid = priceInfo.amountOutMid
       return { amountOutMid: mid, amountOutAsk: mid, amountOutBid: mid }


### PR DESCRIPTION
## Summary

Supersedes #43. Instead of adding backend fallback workarounds for securitize pricing, this gives `SecuritizeVault` the same `assetPriceInfo` field that `Vault` and `EarnVault` already have — populated via `resolveAssetPriceInfo` during fetch. Then `getAssetUsdPrice(securitizeVault, 'off-chain')` just works (backend preferred, UtilsLens fallback).

**Core fix (3 files):**
- Add `assetPriceInfo` to `SecuritizeVault` type
- Call `resolveAssetPriceInfo` in `fetchSecuritizeVault` (same pattern as `fetchEarnVault`)
- Fix cast in `getAssetUsdPriceFromOracle` to include `SecuritizeVault`

**Simplifications enabled (5 files):**
- Remove `priceOverride` prop and backend fallback from `AssetInput`
- Remove `vault=undefined` workaround in collateral swap and lend swap pages
- Remove securitize pricing bypass in `PortfolioSavingItem`
- Remove unsafe `as unknown as Vault` casts in `SecuritizeVaultOverview`

Net -33 lines.

## Test plan

- [ ] Securitize collateral swap shows USD price on "From" AssetInput
- [ ] Lend swap page with securitize vault shows USD price
- [ ] Portfolio savings list shows USD values for securitize positions
- [ ] Securitize vault overview shows USD price, total supply, supply cap
- [ ] Regular vaults still price correctly
- [ ] Earn vaults still price correctly