### PR TITLE
fix: show deprecation badges on portfolio position cards

### DIFF
--- a/components/entities/portfolio/PortfolioBorrowItem.vue
+++ b/components/entities/portfolio/PortfolioBorrowItem.vue
@@ -25,6 +25,7 @@ import {
 import { eulerAccountLensABI } from '~/entities/euler/abis'
 import { useVaultRegistry } from '~/composables/useVaultRegistry'
 import { isAnyVaultBlockedByCountry } from '~/composables/useGeoBlock'
+import { isVaultDeprecated } from '~/utils/eulerLabelsUtils'
 
 const { position } = defineProps<{ position: AccountBorrowPosition }>()
 
@@ -66,6 +67,9 @@ const collateralSymbolLabel = computed(() => {
 const pairSymbols = computed(() => `${collateralSymbolLabel.value}/${position.borrow.asset.symbol}`)
 
 const isGeoBlocked = computed(() => isAnyVaultBlockedByCountry(position.collateral.address, position.borrow.address))
+const isAnyDeprecated = computed(() =>
+  isVaultDeprecated(position.collateral.address) || isVaultDeprecated(position.borrow.address),
+)
 
 const isAnyUnverified = computed(() => {
   const collateralUnverified = 'verified' in position.collateral && !position.collateral.verified
@@ -313,6 +317,17 @@ onMounted(() => {
                   class="!w-14 !h-14"
                 />
                 Restricted
+              </span>
+              <span
+                v-if="isAnyDeprecated"
+                class="inline-flex items-center gap-4 rounded-8 px-8 py-2 bg-warning-100 text-warning-500 text-p5"
+                title="One or more vaults in this position have been deprecated."
+              >
+                <SvgIcon
+                  name="warning"
+                  class="!w-14 !h-14"
+                />
+                Deprecated
               </span>
             </div>
             <div class="text-h5 text-content-primary truncate">

--- a/components/entities/portfolio/PortfolioEarnItem.vue
+++ b/components/entities/portfolio/PortfolioEarnItem.vue
@@ -2,6 +2,7 @@
 import { useAccount } from '@wagmi/vue'
 import { getAssetUsdValue, formatAssetValue } from '~/services/pricing/priceProvider'
 import { isVaultBlockedByCountry } from '~/composables/useGeoBlock'
+import { isVaultDeprecated } from '~/utils/eulerLabelsUtils'
 import { type AccountDepositPosition, getSubAccountIndex } from '~/entities/account'
 import type { EarnVault } from '~/entities/vault'
 import { VaultOverviewModal, VaultSupplyApyModal } from '#components'
@@ -28,6 +29,7 @@ const rewardsExist = computed(() => hasSupplyRewards(vault.value.address))
 
 const product = useEulerProductOfVault(computed(() => vault.value.address))
 const isGeoBlocked = computed(() => isVaultBlockedByCountry(vault.value.address))
+const isDeprecated = computed(() => isVaultDeprecated(vault.value.address))
 const isUnverified = computed(() => 'verified' in vault.value && !vault.value.verified)
 const displayName = computed(() => product.name || vault.value.name)
 
@@ -122,6 +124,17 @@ const onClick = () => {
                 class="!w-14 !h-14"
               />
               Restricted
+            </span>
+            <span
+              v-if="isDeprecated"
+              class="inline-flex items-center gap-4 rounded-8 px-8 py-2 bg-warning-100 text-warning-500 text-p5"
+              title="This vault has been deprecated."
+            >
+              <SvgIcon
+                name="warning"
+                class="!w-14 !h-14"
+              />
+              Deprecated
             </span>
           </div>
           <div class="text-h5 text-content-primary">

--- a/components/entities/portfolio/PortfolioSavingItem.vue
+++ b/components/entities/portfolio/PortfolioSavingItem.vue
@@ -4,6 +4,7 @@ import type { Vault } from '~/entities/vault'
 import { getUtilisationWarning } from '~/composables/useVaultWarnings'
 import { getAssetUsdValue, formatAssetValue } from '~/services/pricing/priceProvider'
 import { isVaultBlockedByCountry } from '~/composables/useGeoBlock'
+import { isVaultDeprecated } from '~/utils/eulerLabelsUtils'
 import { formatNumber, compactNumber, formatCompactUsdValue, formatSmartAmount } from '~/utils/string-utils'
 import { nanoToValue, roundAndCompactTokens } from '~/utils/crypto-utils'
 import { type AccountDepositPosition, getSubAccountIndex } from '~/entities/account'
@@ -45,6 +46,7 @@ const supplyApyWithRewards = computed(() => supplyApy.value + getSupplyRewardApy
 
 const product = useEulerProductOfVault(computed(() => vault.value.address))
 const isGeoBlocked = computed(() => isVaultBlockedByCountry(vault.value.address))
+const isDeprecated = computed(() => isVaultDeprecated(vault.value.address))
 const isEscrow = computed(() => 'vaultCategory' in vault.value && vault.value.vaultCategory === 'escrow')
 const isUnverified = computed(() => 'verified' in vault.value && !vault.value.verified)
 const displayName = computed(() => {
@@ -159,6 +161,17 @@ const onClick = () => {
               />
               Restricted
             </span>
+            <span
+              v-if="isDeprecated"
+              class="inline-flex items-center gap-4 rounded-8 px-8 py-2 bg-warning-100 text-warning-500 text-p5"
+              title="This vault has been deprecated."
+            >
+              <SvgIcon
+                name="warning"
+                class="!w-14 !h-14"
+              />
+              Deprecated
+            </span>
           </div>
           <div class="text-h5 text-content-primary">
             {{ vault.asset.symbol }}
@@ -246,10 +259,6 @@ const onClick = () => {
               :name="displayName"
               :is-unverified="isUnverified"
             />
-            <VaultWarningIcon
-              :warning="utilisationWarning"
-              tooltip-placement="top-start"
-            />
             <span
               v-if="isGeoBlocked"
               class="inline-flex items-center gap-4 rounded-8 px-8 py-2 bg-warning-100 text-warning-500 text-p5"
@@ -261,6 +270,21 @@ const onClick = () => {
               />
               Restricted
             </span>
+            <span
+              v-if="isDeprecated"
+              class="inline-flex items-center gap-4 rounded-8 px-8 py-2 bg-warning-100 text-warning-500 text-p5"
+              title="This vault has been deprecated."
+            >
+              <SvgIcon
+                name="warning"
+                class="!w-14 !h-14"
+              />
+              Deprecated
+            </span>
+            <VaultWarningIcon
+              :warning="utilisationWarning"
+              tooltip-placement="top-start"
+            />
           </div>
           <div class="text-h5 text-content-primary">
             {{ vault.asset.symbol }}


### PR DESCRIPTION
## Summary
- Add "Deprecated" warning badges to savings (EVK + securitize), earn, and borrow position cards on the portfolio page
- Reuses the existing `isVaultDeprecated()` utility which checks both earn-specific deprecation (`earn-vaults.json`) and product-level deprecation
- For borrow positions, checks both collateral and borrow vaults for deprecation
- Badge ordering: Restricted → Deprecated → utilisation warning (where applicable)

## Test plan
- [ ] Connect wallet with positions in deprecated vaults; confirm badge appears on portfolio savings cards
- [ ] Confirm badge appears on portfolio borrow cards when either collateral or borrow vault is deprecated
- [ ] Cross-check: same vaults show "Deprecated" on market pages and vault detail modals
- [ ] Verify no badge appears for non-deprecated vaults