### PR TITLE
fix: hide wallet APY and add source indicator chip

### DIFF
--- a/components/entities/asset/AssetInput.vue
+++ b/components/entities/asset/AssetInput.vue
@@ -20,6 +20,7 @@ const props = defineProps<{
   readonly?: boolean
   priceOverride?: number // For vaults without standard price info (e.g., securitize)
   swappable?: boolean // When true, asset pill shows dropdown arrow and emits click-asset
+  selectedSource?: 'wallet' | 'saving' // Source indicator chip when multiple collateral options exist
 }>()
 const emits = defineEmits(['input', 'change-collateral', 'click-asset'])
 const model = defineModel<string>({ default: '' })
@@ -46,7 +47,18 @@ const emitInputNow = () => {
   emits('input')
 }
 
-const selectedIdx = ref(0)
+const getSelectedIdx = () => {
+  if (props.selectedSource && props.collateralOptions?.length) {
+    const idx = props.collateralOptions.findIndex(o => o.type === props.selectedSource)
+    if (idx >= 0) return idx
+  }
+  return 0
+}
+const selectedIdx = ref(getSelectedIdx())
+watch(
+  [() => props.selectedSource, () => props.collateralOptions],
+  () => { selectedIdx.value = getSelectedIdx() },
+)
 const friendlyBalance = computed(() => nanoToValue(props.balance ?? 0n, props.asset?.decimals || 18))
 
 // Auto-advance past disabled options (blocked/restricted vaults)
@@ -183,19 +195,35 @@ const openChooseCollateralModal = () => {
       >
 
       <div
-        class="bg-euler-dark-500 text-p3 font-semibold gap-8 flex items-center justify-center px-12 h-36 rounded-[40px] whitespace-nowrap cursor-pointer"
+        class="bg-euler-dark-500 text-p3 font-semibold gap-8 flex items-center justify-center px-12 min-h-36 py-6 rounded-[40px] whitespace-nowrap cursor-pointer"
         @click="swappable ? emits('click-asset') : openChooseCollateralModal()"
       >
         <AssetAvatar
           :asset="asset"
           size="20"
         />
-        {{ asset.symbol }}
-        <SvgIcon
-          v-if="swappable || (collateralOptions?.length ?? 0) > 1"
-          class="text-euler-dark-800 !w-16 !h-16"
-          name="arrow-down"
-        />
+        <div class="flex flex-col items-start">
+          <span class="flex items-center gap-8">
+            {{ asset.symbol }}
+            <SvgIcon
+              v-if="swappable || (collateralOptions?.length ?? 0) > 1"
+              class="text-euler-dark-800 !w-16 !h-16"
+              name="arrow-down"
+            />
+          </span>
+          <span
+            v-if="selectedSource === 'wallet' && (collateralOptions?.length ?? 0) > 1"
+            class="text-[10px] leading-[12px] text-aquamarine-600"
+          >
+            Wallet
+          </span>
+          <span
+            v-else-if="selectedSource === 'saving' && (collateralOptions?.length ?? 0) > 1"
+            class="text-[10px] leading-[12px] text-yellow-600"
+          >
+            Savings
+          </span>
+        </div>
       </div>
     </div>
     <div

--- a/components/entities/vault/ChooseCollateralModal.vue
+++ b/components/entities/vault/ChooseCollateralModal.vue
@@ -10,7 +10,7 @@ const { productName, symbol, collateralOptions, selected = 0, title = 'Select co
   collateralOptions: CollateralOption[]
   selected?: number
   title?: string
-  onSave: any
+  onSave: (selectedIndex: number) => void
 }>()
 
 const { isEscrowVault } = useVaultRegistry()
@@ -112,7 +112,10 @@ const handleClose = () => {
             </span>
           </div>
         </div>
-        <div class="text-right grow-1">
+        <div
+          v-if="getOptionType(option) !== 'wallet'"
+          class="text-right grow-1"
+        >
           <div class="text-euler-dark-900 mb-2">
             APY
           </div>

--- a/pages/borrow/[collateral]/[borrow]/index.vue
+++ b/pages/borrow/[collateral]/[borrow]/index.vue
@@ -444,6 +444,7 @@ watch(formTab, () => {
                 :price-override="borrow.borrowNeedsSwap.value ? borrow.borrowSwapAssetUsdPrice.value : borrow.collateralUnitPrice.value"
                 :balance="borrow.borrowActiveBalance.value"
                 :collateral-options="borrow.borrowNeedsSwap.value ? undefined : (borrow.collateralOptions.value as CollateralOption[])"
+                :selected-source="borrow.isSavingCollateral.value ? 'saving' : 'wallet'"
                 maxable
                 @input="borrow.onCollateralInput"
                 @change-collateral="borrow.onChangeCollateral"
@@ -639,6 +640,7 @@ watch(formTab, () => {
                     :vault="multiply.multiplySupplyVault.value"
                     :balance="multiply.multiplyBalance.value"
                     :collateral-options="multiply.multiplyCollateralOptions.value"
+                    :selected-source="multiply.isMultiplySavingCollateral.value ? 'saving' : 'wallet'"
                     maxable
                     @input="multiply.onMultiplyInput"
                     @change-collateral="multiply.onMultiplyCollateralChange"


### PR DESCRIPTION
## Summary
- Hide APY column for wallet options in the collateral selection modal (wallet assets don't earn yield)
- Add a Wallet/Savings source label inside the asset input pill so users can see which source is active
- Sync modal selection highlight with parent state across tab switches
- Fix `onSave` prop type from `any` to proper function signature

## Test plan
- [ ] Open borrow page with both wallet balance and savings for same asset
- [ ] Open collateral modal — wallet option should not show APY, savings should
- [ ] Select savings — pill shows "Savings" label under the symbol
- [ ] Switch to multiply tab and back to borrow — chip and modal highlight stay in sync
- [ ] Verify chip doesn't appear when only one collateral option exists