### PR TITLE
fix: browser back button broken on vault detail pages

### DIFF
--- a/components/entities/portfolio/PortfolioBorrowItem.vue
+++ b/components/entities/portfolio/PortfolioBorrowItem.vue
@@ -280,7 +280,7 @@ onMounted(() => {
 
 <template>
   <NuxtLink
-    :to="`/position/${subAccountIndex}`"
+    :to="{ path: `/position/${subAccountIndex}`, query: { network: $route.query.network } }"
     class="block no-underline bg-surface rounded-xl border border-line-subtle shadow-card transition-all duration-default ease-default hover:shadow-card-hover hover:border-line-emphasis"
   >
     <div class="flex py-16 px-16 pb-12 border-b border-line-default">

--- a/components/entities/portfolio/PortfolioEarnItem.vue
+++ b/components/entities/portfolio/PortfolioEarnItem.vue
@@ -190,7 +190,7 @@ const onClick = () => {
           @click.stop
         >
           <UiButton
-            :to="isGeoBlocked ? undefined : `/earn/${vault.address}/`"
+            :to="isGeoBlocked ? undefined : { path: `/earn/${vault.address}/`, query: { network: $route.query.network } }"
             :disabled="isGeoBlocked"
             rounded
           >
@@ -198,7 +198,7 @@ const onClick = () => {
           </UiButton>
           <UiButton
             variant="primary-stroke"
-            :to="`/earn/${vault.address}/${subAccountIndex}/withdraw`"
+            :to="{ path: `/earn/${vault.address}/${subAccountIndex}/withdraw`, query: { network: $route.query.network } }"
             rounded
           >
             Withdraw

--- a/components/entities/portfolio/PortfolioSavingItem.vue
+++ b/components/entities/portfolio/PortfolioSavingItem.vue
@@ -202,7 +202,7 @@ const onClick = () => {
           @click.stop
         >
           <UiButton
-            :to="isGeoBlocked ? undefined : `/lend/${vault.address}/`"
+            :to="isGeoBlocked ? undefined : { path: `/lend/${vault.address}/`, query: { network: $route.query.network } }"
             :disabled="isGeoBlocked"
             rounded
           >
@@ -210,14 +210,14 @@ const onClick = () => {
           </UiButton>
           <UiButton
             variant="primary-stroke"
-            :to="`/lend/${vault.address}/${subAccountIndex}/withdraw`"
+            :to="{ path: `/lend/${vault.address}/${subAccountIndex}/withdraw`, query: { network: $route.query.network } }"
             rounded
           >
             Withdraw
           </UiButton>
           <UiButton
             variant="primary-stroke"
-            :to="isGeoBlocked ? undefined : `/lend/${vault.address}/${subAccountIndex}/swap`"
+            :to="isGeoBlocked ? undefined : { path: `/lend/${vault.address}/${subAccountIndex}/swap`, query: { network: $route.query.network } }"
             :disabled="isGeoBlocked"
             rounded
           >
@@ -324,7 +324,7 @@ const onClick = () => {
           @click.stop
         >
           <UiButton
-            :to="isGeoBlocked ? undefined : `/lend/${vault.address}/`"
+            :to="isGeoBlocked ? undefined : { path: `/lend/${vault.address}/`, query: { network: $route.query.network } }"
             :disabled="isGeoBlocked"
             rounded
           >
@@ -332,14 +332,14 @@ const onClick = () => {
           </UiButton>
           <UiButton
             variant="primary-stroke"
-            :to="`/lend/${vault.address}/${subAccountIndex}/withdraw`"
+            :to="{ path: `/lend/${vault.address}/${subAccountIndex}/withdraw`, query: { network: $route.query.network } }"
             rounded
           >
             Withdraw
           </UiButton>
           <UiButton
             variant="primary-stroke"
-            :to="isGeoBlocked ? undefined : `/lend/${vault.address}/${subAccountIndex}/swap`"
+            :to="isGeoBlocked ? undefined : { path: `/lend/${vault.address}/${subAccountIndex}/swap`, query: { network: $route.query.network } }"
             :disabled="isGeoBlocked"
             rounded
           >

--- a/components/entities/vault/SecuritizeVaultItem.vue
+++ b/components/entities/vault/SecuritizeVaultItem.vue
@@ -83,7 +83,7 @@ watchEffect(async () => {
   <NuxtLink
     class="block no-underline text-content-primary bg-surface rounded-12 border border-line-default shadow-card hover:shadow-card-hover hover:border-line-emphasis transition-all"
     :class="isGeoBlocked ? 'opacity-50' : ''"
-    :to="`/lend/${vault.address}`"
+    :to="{ path: `/lend/${vault.address}`, query: { network: $route.query.network } }"
   >
     <div class="flex pb-12 p-16 border-b border-line-subtle">
       <AssetAvatar

--- a/components/entities/vault/VaultBorrowItem.vue
+++ b/components/entities/vault/VaultBorrowItem.vue
@@ -188,9 +188,12 @@ const onMaxRoeInfoIconClick = (event: MouseEvent) => {
   })
 }
 
-const linkPath = computed(
-  () => `/borrow/${pair.collateral.address}/${pair.borrow.address}`,
-)
+const route = useRoute()
+
+const linkPath = computed(() => ({
+  path: `/borrow/${pair.collateral.address}/${pair.borrow.address}`,
+  query: { network: route.query.network },
+}))
 </script>
 
 <template>

--- a/components/entities/vault/VaultCollateralExposureModal.vue
+++ b/components/entities/vault/VaultCollateralExposureModal.vue
@@ -7,6 +7,7 @@ import { useVaultRegistry } from '~/composables/useVaultRegistry'
 
 const emits = defineEmits(['close'])
 const router = useRouter()
+const route = useRoute()
 const { vault } = defineProps<{ vault: Vault }>()
 const { get: registryGet } = useVaultRegistry()
 
@@ -55,7 +56,7 @@ const formatTimeRemaining = (seconds: bigint): string => {
 
 const onCollateralClick = (address: string) => {
   emits('close')
-  router.push(`/lend/${address}`)
+  router.push({ path: `/lend/${address}`, query: { network: route.query.network } })
 }
 </script>
 

--- a/components/entities/vault/VaultEarnItem.vue
+++ b/components/entities/vault/VaultEarnItem.vue
@@ -92,7 +92,7 @@ const onSupplyInfoIconClick = (event: MouseEvent) => {
   <NuxtLink
     class="block no-underline bg-surface rounded-xl border border-line-subtle shadow-card transition-all duration-default ease-default hover:shadow-card-hover hover:border-line-emphasis"
     :class="isGeoBlocked ? 'opacity-50' : ''"
-    :to="`/earn/${vault.address}`"
+    :to="{ path: `/earn/${vault.address}`, query: { network: $route.query.network } }"
   >
     <div class="flex py-16 px-16 pb-12 border-b border-line-default">
       <AssetAvatar

--- a/components/entities/vault/VaultItem.vue
+++ b/components/entities/vault/VaultItem.vue
@@ -156,7 +156,7 @@ watchEffect(async () => {
   <NuxtLink
     class="block no-underline text-content-primary bg-surface rounded-12 border border-line-default shadow-card hover:shadow-card-hover hover:border-line-emphasis transition-all"
     :class="isGeoBlocked ? 'opacity-50' : ''"
-    :to="`/lend/${vault.address}`"
+    :to="{ path: `/lend/${vault.address}`, query: { network: $route.query.network } }"
   >
     <div class="flex pb-12 p-16 border-b border-line-subtle">
       <AssetAvatar

--- a/components/entities/vault/overview/VaultOverviewModal.vue
+++ b/components/entities/vault/overview/VaultOverviewModal.vue
@@ -6,6 +6,7 @@ import type { AccountBorrowPosition } from '~/entities/account'
 
 const emits = defineEmits(['close'])
 const router = useRouter()
+const route = useRoute()
 
 const { pair, vault, earnVault, extraVault, securitizeVault, collateralVaults, title = 'Market information' } = defineProps<{ pair?: AnyBorrowVaultPair | AccountBorrowPosition, vault?: Vault, earnVault?: EarnVault, extraVault?: Vault, securitizeVault?: SecuritizeVault, collateralVaults?: (Vault | SecuritizeVault)[], title?: string }>()
 
@@ -80,7 +81,7 @@ const activeCollateralVault = computed(() => {
 
 const onVaultClick = (address: string) => {
   emits('close')
-  router.push(`/lend/${address}`)
+  router.push({ path: `/lend/${address}`, query: { network: route.query.network } })
 }
 </script>
 

--- a/composables/useUrlQuerySync.ts
+++ b/composables/useUrlQuerySync.ts
@@ -13,6 +13,14 @@ export function useUrlQuerySync(params: UrlSyncParam[]): void {
 
   const managedKeys = new Set(params.map(p => p.queryKey))
   let isSyncing = false
+  const isActive = ref(true)
+
+  onActivated(() => {
+    isActive.value = true
+  })
+  onDeactivated(() => {
+    isActive.value = false
+  })
 
   // Read URL → refs on init
   for (const param of params) {
@@ -54,7 +62,7 @@ export function useUrlQuerySync(params: UrlSyncParam[]): void {
   }
 
   const syncRefsToUrl = async () => {
-    if (isSyncing) return
+    if (isSyncing || !isActive.value) return
     isSyncing = true
     try {
       await router.replace({ query: buildQuery() })
@@ -70,7 +78,7 @@ export function useUrlQuerySync(params: UrlSyncParam[]): void {
   watch(
     params.map(p => p.ref),
     () => {
-      if (isSyncing) return
+      if (isSyncing || !isActive.value) return
       if (debounceTimer) clearTimeout(debounceTimer)
       debounceTimer = setTimeout(syncRefsToUrl, 50)
     },
@@ -82,7 +90,7 @@ export function useUrlQuerySync(params: UrlSyncParam[]): void {
   watch(
     () => route.query,
     () => {
-      if (isSyncing) return
+      if (isSyncing || !isActive.value) return
 
       // Cancel any pending debounced sync — the route just changed externally,
       // so a stale debounced sync could overwrite non-managed params (e.g. network)

--- a/pages/borrow/[collateral]/[borrow]/index.vue
+++ b/pages/borrow/[collateral]/[borrow]/index.vue
@@ -396,19 +396,19 @@ watch(formTab, () => {
             v-else-if="tab === 'collateral'"
             :vault="(pair.collateral as Vault)"
             desktop-overview
-            @vault-click="(address: string) => router.push(`/lend/${address}`)"
+            @vault-click="(address: string) => router.push({ path: `/lend/${address}`, query: { network: route.query.network } })"
           />
           <VaultOverview
             v-else-if="tab === 'multiply-collateral' && multiply.multiplySupplyVault.value"
             :vault="multiply.multiplySupplyVault.value"
             desktop-overview
-            @vault-click="(address: string) => router.push(`/lend/${address}`)"
+            @vault-click="(address: string) => router.push({ path: `/lend/${address}`, query: { network: route.query.network } })"
           />
           <VaultOverview
             v-else-if="tab === 'borrow'"
             :vault="pair.borrow"
             desktop-overview
-            @vault-click="(address: string) => router.push(`/lend/${address}`)"
+            @vault-click="(address: string) => router.push({ path: `/lend/${address}`, query: { network: route.query.network } })"
           />
         </Transition>
       </div>

--- a/pages/earn/[vault]/index.vue
+++ b/pages/earn/[vault]/index.vue
@@ -241,7 +241,7 @@ watch(address, () => {
           v-if="vault"
           :vault="vault as EarnVault"
           desktop-overview
-          @vault-click="(address: string) => router.push(`/lend/${address}`)"
+          @vault-click="(address: string) => router.push({ path: `/lend/${address}`, query: { network: route.query.network } })"
         />
       </div>
       <div class="flex flex-col gap-16 w-full laptop:flex-[45] laptop:sticky laptop:top-[88px] laptop:self-start">

--- a/pages/lend/[vault]/index.vue
+++ b/pages/lend/[vault]/index.vue
@@ -654,7 +654,7 @@ watch(address, () => {
           v-if="features.hasOverview && vault && vaultType === 'evk'"
           :vault="vault"
           desktop-overview
-          @vault-click="(address: string) => router.push(`/lend/${address}`)"
+          @vault-click="(address: string) => router.push({ path: `/lend/${address}`, query: { network: route.query.network } })"
         />
         <!-- Securitize Vault Overview -->
         <SecuritizeVaultOverview


### PR DESCRIPTION
## Summary

- All vault/position navigation links (NuxtLink `:to`, `router.push()`) now include `query: { network: route.query.network }`, preventing the network middleware from needing to redirect-with-push on every click — which was creating phantom history entries that broke the browser back button
- Adds a deactivation guard to `useUrlQuerySync` so keepalive pages (LendPage, EarnPage, etc.) stop injecting stale filter params into vault detail page URLs while deactivated

## Test plan

- [ ] Lend page → click vault → back button → should return to lend page
- [ ] Lend page (Base) → switch to Berachain → click vault → back → should return to lend page on Berachain
- [ ] Set non-default sort on lend → click vault → vault detail URL should NOT have sort params → back → sort still active
- [ ] Earn page → click earn vault → back → should return to earn page
- [ ] Portfolio → click position → back → should return to portfolio
- [ ] Borrow page → click borrow pair → back → should return to borrow page
- [ ] Vault detail → click collateral vault in overview → back → should return to original vault