### PR TITLE
feat: add ramp down modal to liquidation LTV

### DIFF
--- a/components/entities/vault/VaultRampDownModal.vue
+++ b/components/entities/vault/VaultRampDownModal.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+import { DateTime } from 'luxon'
+import { formatNumber } from '~/utils/string-utils'
+import { nanoToValue } from '~/utils/crypto-utils'
+import type { LTVRampConfig } from '~/entities/vault/ltv'
+
+const emits = defineEmits(['close'])
+const { liquidationLTV, targetTimestamp } = defineProps<LTVRampConfig>()
+
+const rampTimeRemaining = computed(() => DateTime.fromSeconds(Number(targetTimestamp)))
+
+const handleClose = () => {
+  emits('close')
+}
+</script>
+
+<template>
+  <BaseModalWrapper
+    title="LTV ramping"
+    @close="handleClose"
+  >
+    <div class="mb-24">
+      <div class="flex justify-between items-center pb-16 border-b border-euler-dark-600">
+        <div>
+          <p class="mb-4">
+            Target LLTV
+          </p>
+          <p class="text-euler-dark-900">
+            Final LLTV after ramp
+          </p>
+        </div>
+        <div class="text-h5">
+          {{ `${formatNumber(nanoToValue(liquidationLTV, 2), 2)}%` }}
+        </div>
+      </div>
+      <div class="flex justify-between items-center mt-16">
+        <div>
+          <p class="mb-4">
+            Ramp time ends
+          </p>
+          <p class="text-euler-dark-900">
+            Time remaining until ramp ends
+          </p>
+        </div>
+        <div class="text-h5">
+          {{ rampTimeRemaining.toRelative({ base: DateTime.now(), style: 'short' }) }}
+        </div>
+      </div>
+    </div>
+  </BaseModalWrapper>
+</template>

--- a/components/entities/vault/VaultRampDownModal.vue
+++ b/components/entities/vault/VaultRampDownModal.vue
@@ -7,7 +7,7 @@ import type { LTVRampConfig } from '~/entities/vault/ltv'
 const emits = defineEmits(['close'])
 const { liquidationLTV, targetTimestamp } = defineProps<LTVRampConfig>()
 
-const rampTimeRemaining = computed(() => DateTime.fromSeconds(Number(targetTimestamp)))
+const rampEndTime = computed(() => DateTime.fromSeconds(Number(targetTimestamp)))
 
 const handleClose = () => {
   emits('close')
@@ -16,17 +16,14 @@ const handleClose = () => {
 
 <template>
   <BaseModalWrapper
-    title="LTV ramping"
+    title="Liquidation LTV ramping"
     @close="handleClose"
   >
     <div class="mb-24">
       <div class="flex justify-between items-center pb-16 border-b border-euler-dark-600">
         <div>
           <p class="mb-4">
-            Target LLTV
-          </p>
-          <p class="text-euler-dark-900">
-            Final LLTV after ramp
+            Liquidation LTV after ramp
           </p>
         </div>
         <div class="text-h5">
@@ -36,14 +33,11 @@ const handleClose = () => {
       <div class="flex justify-between items-center mt-16">
         <div>
           <p class="mb-4">
-            Ramp time ends
-          </p>
-          <p class="text-euler-dark-900">
-            Time remaining until ramp ends
+            Ramp ends
           </p>
         </div>
         <div class="text-h5">
-          {{ rampTimeRemaining.toRelative({ base: DateTime.now(), style: 'short' }) }}
+          {{ rampEndTime.toRelative({ base: DateTime.now(), style: 'short' }) }}
         </div>
       </div>
     </div>

--- a/components/entities/vault/overview/SecuritizeVaultOverviewPairBlockGeneral.vue
+++ b/components/entities/vault/overview/SecuritizeVaultOverviewPairBlockGeneral.vue
@@ -1,25 +1,17 @@
 <script setup lang="ts">
 import { formatNumber, formatSignificant } from '~/utils/string-utils'
 import { nanoToValue } from '~/utils/crypto-utils'
-import { type SecuritizeBorrowVaultPair, getCurrentLiquidationLTV, isLiquidationLTVRamping, getRampTimeRemaining } from '~/entities/vault'
+import { type SecuritizeBorrowVaultPair, getCurrentLiquidationLTV, isLiquidationLTVRamping } from '~/entities/vault'
 import { getAssetOraclePrice } from '~/services/pricing/priceProvider'
 import { getMaxMultiplier, getMaxRoe } from '~/utils/leverage'
 import { useModal } from '~/components/ui/composables/useModal'
-import { VaultBorrowApyModal, VaultSupplyApyModal } from '#components'
+import { VaultBorrowApyModal, VaultRampDownModal, VaultSupplyApyModal } from '#components'
+import type { LTVRampConfig } from '~/entities/vault/ltv'
 
 const { pair } = defineProps<{ pair: SecuritizeBorrowVaultPair }>()
 
 const currentLiquidationLTV = computed(() => getCurrentLiquidationLTV(pair))
 const isRamping = computed(() => isLiquidationLTVRamping(pair))
-
-const formatTimeRemaining = (seconds: bigint): string => {
-  const days = Number(seconds) / 86400
-  if (days >= 1) return `${Math.ceil(days)} day${Math.ceil(days) > 1 ? 's' : ''}`
-  const hours = Number(seconds) / 3600
-  if (hours >= 1) return `${Math.ceil(hours)} hour${Math.ceil(hours) > 1 ? 's' : ''}`
-  const minutes = Number(seconds) / 60
-  return `${Math.ceil(minutes)} minute${Math.ceil(minutes) > 1 ? 's' : ''}`
-}
 
 const modal = useModal()
 const { withIntrinsicBorrowApy, getIntrinsicApy, getIntrinsicApyInfo } = useIntrinsicApy()
@@ -86,6 +78,12 @@ const onBorrowInfoIconClick = () => {
       intrinsicApyInfo: getIntrinsicApyInfo(pair.borrow.asset.address),
       campaigns: borrowRewardInfo.value,
     },
+  })
+}
+
+const onRampDownInfoIconClick = (event: MouseEvent, pair: LTVRampConfig) => {
+  modal.open(VaultRampDownModal, {
+    props: pair,
   })
 }
 </script>
@@ -182,16 +180,12 @@ const onBorrowInfoIconClick = () => {
             title="Liquidation LTV ramping down"
           />
           <span>{{ `${formatNumber(nanoToValue(currentLiquidationLTV, 2), 2)}%` }}</span>
-          <span
+          <SvgIcon
             v-if="isRamping"
-            @click.stop.prevent
-          >
-            <UiFootnote
-              title="LTV Ramping"
-              :text="`The Liquidation LTV for this pair is being reduced. Target: ${formatNumber(nanoToValue(pair.liquidationLTV, 2), 2)}%. Time remaining: ${formatTimeRemaining(getRampTimeRemaining(pair))}.`"
-              class="[--ui-footnote-icon-color:var(--c-content-tertiary)]"
-            />
-          </span>
+            class="!w-20 !h-20 text-content-muted cursor-pointer hover:text-content-secondary"
+            name="info-circle"
+            @click.stop.prevent="onRampDownInfoIconClick($event, pair)"
+          />
         </div>
       </VaultOverviewLabelValue>
     </div>

--- a/components/entities/vault/overview/SecuritizeVaultOverviewPairBlockGeneral.vue
+++ b/components/entities/vault/overview/SecuritizeVaultOverviewPairBlockGeneral.vue
@@ -169,24 +169,28 @@ const onRampDownInfoIconClick = (event: MouseEvent, pair: LTVRampConfig) => {
         label="Max LTV"
         :value="`${formatNumber(nanoToValue(pair.borrowLTV, 2), 2)}%`"
       />
-      <VaultOverviewLabelValue
-        label="Liquidation LTV"
-      >
-        <div class="flex items-center gap-4">
+      <VaultOverviewLabelValue>
+        <template #label>
+          <span class="flex items-center gap-4">
+            Liquidation LTV
+            <SvgIcon
+              v-if="isRamping"
+              class="!w-20 !h-20 text-content-muted cursor-pointer hover:text-content-secondary"
+              name="info-circle"
+              @click.stop.prevent="onRampDownInfoIconClick($event, pair)"
+            />
+          </span>
+        </template>
+        <span class="flex items-center gap-4">
           <SvgIcon
             v-if="isRamping"
             name="arrow-top-right"
-            class="!w-14 !h-14 text-warning-500 shrink-0 rotate-180"
+            class="!w-14 !h-14 text-warning-500 shrink-0 rotate-180 cursor-pointer"
             title="Liquidation LTV ramping down"
-          />
-          <span>{{ `${formatNumber(nanoToValue(currentLiquidationLTV, 2), 2)}%` }}</span>
-          <SvgIcon
-            v-if="isRamping"
-            class="!w-20 !h-20 text-content-muted cursor-pointer hover:text-content-secondary"
-            name="info-circle"
             @click.stop.prevent="onRampDownInfoIconClick($event, pair)"
           />
-        </div>
+          {{ `${formatNumber(nanoToValue(currentLiquidationLTV, 2), 2)}%` }}
+        </span>
       </VaultOverviewLabelValue>
     </div>
   </div>

--- a/components/entities/vault/overview/VaultOverviewBlockBorrow.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockBorrow.vue
@@ -2,8 +2,13 @@
 import { formatNumber } from '~/utils/string-utils'
 import { nanoToValue } from '~/utils/crypto-utils'
 import type { Vault, SecuritizeVault } from '~/entities/vault'
-import { getCurrentLiquidationLTV, isLiquidationLTVRamping, getRampTimeRemaining } from '~/entities/vault'
+import type { LTVRampConfig } from '~/entities/vault/ltv'
+import { getCurrentLiquidationLTV, isLiquidationLTVRamping } from '~/entities/vault'
+import { useModal } from '~/components/ui/composables/useModal'
 import { useVaultRegistry } from '~/composables/useVaultRegistry'
+import { VaultRampDownModal } from '#components'
+
+const modal = useModal()
 
 const emits = defineEmits<{
   'vault-click': [address: string]
@@ -13,6 +18,12 @@ const { get: registryGet } = useVaultRegistry()
 
 const onCollateralClick = (address: string) => {
   emits('vault-click', address)
+}
+
+const onRampDownInfoIconClick = (event: MouseEvent, pair: LTVRampConfig) => {
+  modal.open(VaultRampDownModal, {
+    props: pair,
+  })
 }
 
 // Build collateral pairs from ALL collateralLTVs where currentLiquidationLTV > 0
@@ -49,20 +60,6 @@ const allCollateralPairs = computed(() => {
   // Sort by borrow LTV descending (highest first)
   return pairs.sort((a, b) => (b.borrowLTV > a.borrowLTV ? 1 : b.borrowLTV < a.borrowLTV ? -1 : 0))
 })
-
-// Helper to format time remaining
-const formatTimeRemaining = (seconds: bigint): string => {
-  const days = Number(seconds) / 86400
-  if (days >= 1) {
-    return `${Math.ceil(days)} day${Math.ceil(days) > 1 ? 's' : ''}`
-  }
-  const hours = Number(seconds) / 3600
-  if (hours >= 1) {
-    return `${Math.ceil(hours)} hour${Math.ceil(hours) > 1 ? 's' : ''}`
-  }
-  const minutes = Number(seconds) / 60
-  return `${Math.ceil(minutes)} minute${Math.ceil(minutes) > 1 ? 's' : ''}`
-}
 </script>
 
 <template>
@@ -108,16 +105,12 @@ const formatTimeRemaining = (seconds: bigint): string => {
             <template #label>
               <span class="flex items-center gap-4">
                 Liquidation LTV
-                <span
+                <SvgIcon
                   v-if="isLiquidationLTVRamping(pair)"
-                  @click.stop.prevent
-                >
-                  <UiFootnote
-                    title="LTV Ramping"
-                    :text="`The Liquidation LTV for this collateral is currently being reduced. Target Liquidation LTV: ${formatNumber(nanoToValue(pair.liquidationLTV, 2), 2)}%. Time remaining: ${formatTimeRemaining(getRampTimeRemaining(pair))}.`"
-                    class="[--ui-footnote-icon-color:var(--c-content-tertiary)]"
-                  />
-                </span>
+                  class="!w-20 !h-20 text-content-muted cursor-pointer hover:text-content-secondary"
+                  name="info-circle"
+                  @click.stop.prevent="onRampDownInfoIconClick($event, pair)"
+                />
               </span>
             </template>
             <div class="flex items-center gap-4">
@@ -128,16 +121,6 @@ const formatTimeRemaining = (seconds: bigint): string => {
                 title="Liquidation LTV ramping down"
               />
               <span>{{ `${formatNumber(nanoToValue(getCurrentLiquidationLTV(pair), 2), 2)}%` }}</span>
-              <span
-                v-if="isLiquidationLTVRamping(pair)"
-                @click.stop.prevent
-              >
-                <UiFootnote
-                  title="LTV Ramping"
-                  :text="`The Liquidation LTV for this pair is being reduced. Target: ${formatNumber(nanoToValue(pair.liquidationLTV, 2), 2)}%. Time remaining: ${formatTimeRemaining(getRampTimeRemaining(pair))}.`"
-                  class="[--ui-footnote-icon-color:var(--c-content-tertiary)]"
-                />
-              </span>
             </div>
           </VaultOverviewLabelValue>
         </div>

--- a/components/entities/vault/overview/VaultOverviewBlockBorrow.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockBorrow.vue
@@ -113,15 +113,16 @@ const allCollateralPairs = computed(() => {
                 />
               </span>
             </template>
-            <div class="flex items-center gap-4">
+            <span class="flex items-center gap-4">
               <SvgIcon
                 v-if="isLiquidationLTVRamping(pair)"
                 name="arrow-top-right"
-                class="!w-14 !h-14 text-warning-500 shrink-0 rotate-180"
+                class="!w-14 !h-14 text-warning-500 shrink-0 rotate-180 cursor-pointer"
                 title="Liquidation LTV ramping down"
+                @click.stop.prevent="onRampDownInfoIconClick($event, pair)"
               />
-              <span>{{ `${formatNumber(nanoToValue(getCurrentLiquidationLTV(pair), 2), 2)}%` }}</span>
-            </div>
+              {{ `${formatNumber(nanoToValue(getCurrentLiquidationLTV(pair), 2), 2)}%` }}
+            </span>
           </VaultOverviewLabelValue>
         </div>
       </div>

--- a/components/entities/vault/overview/VaultOverviewBlockBorrow.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockBorrow.vue
@@ -128,6 +128,16 @@ const formatTimeRemaining = (seconds: bigint): string => {
                 title="Liquidation LTV ramping down"
               />
               <span>{{ `${formatNumber(nanoToValue(getCurrentLiquidationLTV(pair), 2), 2)}%` }}</span>
+              <span
+                v-if="isLiquidationLTVRamping(pair)"
+                @click.stop.prevent
+              >
+                <UiFootnote
+                  title="LTV Ramping"
+                  :text="`The Liquidation LTV for this pair is being reduced. Target: ${formatNumber(nanoToValue(pair.liquidationLTV, 2), 2)}%. Time remaining: ${formatTimeRemaining(getRampTimeRemaining(pair))}.`"
+                  class="[--ui-footnote-icon-color:var(--c-content-tertiary)]"
+                />
+              </span>
             </div>
           </VaultOverviewLabelValue>
         </div>

--- a/components/entities/vault/overview/VaultOverviewPairBlockGeneral.vue
+++ b/components/entities/vault/overview/VaultOverviewPairBlockGeneral.vue
@@ -219,24 +219,28 @@ const onRampDownInfoIconClick = (event: MouseEvent, pair: LTVRampConfig) => {
         label="Max LTV"
         :value="`${formatNumber(nanoToValue(pair.borrowLTV, 2), 2)}%`"
       />
-      <VaultOverviewLabelValue
-        label="Liquidation LTV"
-      >
-        <div class="flex items-center gap-4">
+      <VaultOverviewLabelValue>
+        <template #label>
+          <span class="flex items-center gap-4">
+            Liquidation LTV
+            <SvgIcon
+              v-if="isRamping"
+              class="!w-20 !h-20 text-content-muted cursor-pointer hover:text-content-secondary"
+              name="info-circle"
+              @click.stop.prevent="onRampDownInfoIconClick($event, pair as AnyBorrowVaultPair)"
+            />
+          </span>
+        </template>
+        <span class="flex items-center gap-4">
           <SvgIcon
             v-if="isRamping"
             name="arrow-top-right"
-            class="!w-14 !h-14 text-warning-500 shrink-0 rotate-180"
+            class="!w-14 !h-14 text-warning-500 shrink-0 rotate-180 cursor-pointer"
             title="Liquidation LTV ramping down"
-          />
-          <span>{{ `${formatNumber(nanoToValue(currentLiquidationLTV, 2), 2)}%` }}</span>
-          <SvgIcon
-            v-if="isRamping"
-            class="!w-20 !h-20 text-content-muted cursor-pointer hover:text-content-secondary"
-            name="info-circle"
             @click.stop.prevent="onRampDownInfoIconClick($event, pair as AnyBorrowVaultPair)"
           />
-        </div>
+          {{ `${formatNumber(nanoToValue(currentLiquidationLTV, 2), 2)}%` }}
+        </span>
       </VaultOverviewLabelValue>
     </div>
   </div>

--- a/components/entities/vault/overview/VaultOverviewPairBlockGeneral.vue
+++ b/components/entities/vault/overview/VaultOverviewPairBlockGeneral.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { type AnyBorrowVaultPair, getCurrentLiquidationLTV, isLiquidationLTVRamping, getRampTimeRemaining } from '~/entities/vault'
+import { type AnyBorrowVaultPair, getCurrentLiquidationLTV, isLiquidationLTVRamping } from '~/entities/vault'
 import { isAnyVaultBlockedByCountry } from '~/composables/useGeoBlock'
 import { isVaultDeprecated } from '~/utils/eulerLabelsUtils'
 import { getCollateralOraclePrice, getAssetOraclePrice } from '~/services/pricing/priceProvider'
@@ -7,8 +7,9 @@ import { formatNumber, formatSignificant } from '~/utils/string-utils'
 import { nanoToValue } from '~/utils/crypto-utils'
 import { getMaxMultiplier, getMaxRoe } from '~/utils/leverage'
 import type { AccountBorrowPosition } from '~/entities/account'
+import type { LTVRampConfig } from '~/entities/vault/ltv'
 import { useModal } from '~/components/ui/composables/useModal'
-import { VaultNetApyPairModal, VaultMaxRoeModal } from '#components'
+import { VaultNetApyPairModal, VaultMaxRoeModal, VaultRampDownModal } from '#components'
 
 const { pair } = defineProps<{ pair: AnyBorrowVaultPair | AccountBorrowPosition }>()
 
@@ -19,15 +20,6 @@ const currentLiquidationLTV = computed(() =>
 const isRamping = computed(() =>
   hasRampConfig.value && isLiquidationLTVRamping(pair as AnyBorrowVaultPair),
 )
-
-const formatTimeRemaining = (seconds: bigint): string => {
-  const days = Number(seconds) / 86400
-  if (days >= 1) return `${Math.ceil(days)} day${Math.ceil(days) > 1 ? 's' : ''}`
-  const hours = Number(seconds) / 3600
-  if (hours >= 1) return `${Math.ceil(hours)} hour${Math.ceil(hours) > 1 ? 's' : ''}`
-  const minutes = Number(seconds) / 60
-  return `${Math.ceil(minutes)} minute${Math.ceil(minutes) > 1 ? 's' : ''}`
-}
 
 const modal = useModal()
 const { withIntrinsicBorrowApy, withIntrinsicSupplyApy, getIntrinsicApy } = useIntrinsicApy()
@@ -103,6 +95,12 @@ const onMaxRoeInfoIconClick = () => {
       borrowAPY: borrowApyWithRewards.value,
       borrowLTV: nanoToValue(pair.borrowLTV, 2),
     },
+  })
+}
+
+const onRampDownInfoIconClick = (event: MouseEvent, pair: LTVRampConfig) => {
+  modal.open(VaultRampDownModal, {
+    props: pair,
   })
 }
 </script>
@@ -232,16 +230,12 @@ const onMaxRoeInfoIconClick = () => {
             title="Liquidation LTV ramping down"
           />
           <span>{{ `${formatNumber(nanoToValue(currentLiquidationLTV, 2), 2)}%` }}</span>
-          <span
+          <SvgIcon
             v-if="isRamping"
-            @click.stop.prevent
-          >
-            <UiFootnote
-              title="LTV Ramping"
-              :text="`The Liquidation LTV for this pair is being reduced. Target: ${formatNumber(nanoToValue(pair.liquidationLTV, 2), 2)}%. Time remaining: ${formatTimeRemaining(getRampTimeRemaining(pair as AnyBorrowVaultPair))}.`"
-              class="[--ui-footnote-icon-color:var(--c-content-tertiary)]"
-            />
-          </span>
+            class="!w-20 !h-20 text-content-muted cursor-pointer hover:text-content-secondary"
+            name="info-circle"
+            @click.stop.prevent="onRampDownInfoIconClick($event, pair as AnyBorrowVaultPair)"
+          />
         </div>
       </VaultOverviewLabelValue>
     </div>

--- a/components/ui/UiFootnote.vue
+++ b/components/ui/UiFootnote.vue
@@ -106,6 +106,7 @@ onClickOutside(reference, () => {
     border-radius: 12px;
     background-color: var(--ui-footnote-floating-background-color);
     box-shadow: 0 8px 32px var(--ui-footnote-floating-box-shadow-color);
+    z-index: 1;
   }
 
   &__floating-content {

--- a/entities/vault/ltv.ts
+++ b/entities/vault/ltv.ts
@@ -1,7 +1,7 @@
 import type { VaultCollateralLTV } from './types'
 
 /** Shared LTV ramp config fields used by both VaultCollateralLTV and BorrowVaultPair */
-type LTVRampConfig = Pick<VaultCollateralLTV, 'liquidationLTV' | 'initialLiquidationLTV' | 'targetTimestamp' | 'rampDuration'>
+export type LTVRampConfig = Pick<VaultCollateralLTV, 'liquidationLTV' | 'initialLiquidationLTV' | 'targetTimestamp' | 'rampDuration'>
 
 /**
  * Calculate the current liquidation LTV, taking into account ramping.


### PR DESCRIPTION
# feat: add ramp down modal to liquidation LTV

Replaced LTV ramping down tooltip with modal.

[Tab-1772193299386.webm](https://github.com/user-attachments/assets/02418948-c0d9-4848-9255-13756f4e61e4)
