### PR TITLE
feat: add Securitize intrinsic yield provider

### DIFF
--- a/components/entities/vault/SecuritizeVaultItem.vue
+++ b/components/entities/vault/SecuritizeVaultItem.vue
@@ -7,6 +7,8 @@ import { useEulerProductOfVault, useEulerEntitiesOfVault } from '~/composables/u
 import { getEulerLabelEntityLogo } from '~/entities/euler/labels'
 import { formatNumber, formatCompactUsdValue } from '~/utils/string-utils'
 import { nanoToValue } from '~/utils/crypto-utils'
+import { useModal } from '~/components/ui/composables/useModal'
+import { VaultSupplyApyModal } from '#components'
 import BaseLoadableContent from '~/components/base/BaseLoadableContent.vue'
 
 const { isConnected } = useAccount()
@@ -35,8 +37,9 @@ const displayName = computed(() => product.name || vault.name)
 const isGeoBlocked = computed(() => isVaultBlockedByCountry(vault.address))
 
 const { getBalance, isLoading: isBalancesLoading } = useWallets()
-const { withIntrinsicSupplyApy } = useIntrinsicApy()
-const { getSupplyRewardApy, hasSupplyRewards } = useRewardsApy()
+const modal = useModal()
+const { withIntrinsicSupplyApy, getIntrinsicApy, getIntrinsicApyInfo } = useIntrinsicApy()
+const { getSupplyRewardApy, hasSupplyRewards, getSupplyRewardCampaigns } = useRewardsApy()
 
 const balance = computed(() =>
   getBalance(vault.asset.address as `0x${string}`),
@@ -52,6 +55,19 @@ const supplyApy = computed(() =>
 const supplyApyWithRewards = computed(
   () => supplyApy.value + totalRewardsAPY.value,
 )
+
+const onSupplyInfoIconClick = (event: MouseEvent) => {
+  event.preventDefault()
+  event.stopPropagation()
+  modal.open(VaultSupplyApyModal, {
+    props: {
+      lendingAPY: lendingAPY.value,
+      intrinsicAPY: getIntrinsicApy(vault.asset.address),
+      intrinsicApyInfo: getIntrinsicApyInfo(vault.asset.address),
+      campaigns: getSupplyRewardCampaigns(vault.address),
+    },
+  })
+}
 
 const statsGridCols = computed(() => {
   const cols: string[] = []
@@ -113,8 +129,13 @@ watchEffect(async () => {
         </div>
       </div>
       <div class="flex flex-col items-end">
-        <div class="text-content-tertiary text-p3 mb-4 text-right">
+        <div class="text-content-tertiary text-p3 mb-4 text-right flex items-center gap-4">
           Supply APY
+          <SvgIcon
+            class="!w-16 !h-16 text-content-muted hover:text-content-secondary transition-colors cursor-pointer"
+            name="info-circle"
+            @click="onSupplyInfoIconClick"
+          />
         </div>
         <div class="flex items-center">
           <div class="text-p2 flex items-center text-accent-600 font-semibold">

--- a/composables/useIntrinsicApy.ts
+++ b/composables/useIntrinsicApy.ts
@@ -3,6 +3,7 @@ import type { IntrinsicApyInfo, IntrinsicApyProvider, IntrinsicApyResult } from 
 import { EMPTY_INTRINSIC_APY } from '~/entities/intrinsic-apy'
 import { createDefiLlamaProvider } from '~/services/intrinsicApy/defillamaProvider'
 import { createPendleProvider } from '~/services/intrinsicApy/pendleProvider'
+import { createSecuritizeProvider } from '~/services/intrinsicApy/securitizeProvider'
 import { logWarn } from '~/utils/errorHandling'
 import { CACHE_TTL_5MIN_MS } from '~/entities/tuning-constants'
 
@@ -17,6 +18,7 @@ const normalize = (value?: string) => value?.toLowerCase() || ''
 const providers: IntrinsicApyProvider[] = [
   createDefiLlamaProvider(intrinsicApySources),
   createPendleProvider(intrinsicApySources),
+  createSecuritizeProvider(intrinsicApySources),
 ]
 
 const mergeResults = (allResults: IntrinsicApyResult[]): Record<string, IntrinsicApyInfo> => {

--- a/entities/constants.ts
+++ b/entities/constants.ts
@@ -132,6 +132,7 @@ export const MERKL_DISTRIBUTOR_ADDRESS = '0x3Ef3D8bA38EBe18DB133cEc108f4D14CE00D
 export const MERKL_API_BASE_URL = 'https://api.merkl.xyz/v4'
 export const EULER_INTERFACES_CHAINS_URL = 'https://raw.githubusercontent.com/euler-xyz/euler-interfaces/refs/heads/master/EulerChains.json'
 export const DEFILLAMA_YIELDS_URL = 'https://yields.llama.fi/pools'
+export const SECURITIZE_FEED_URL = 'https://public-feed.securitize.io/asset-stats'
 export const BREVIS_API_URL = 'https://incentra-prd.brevis.network/sdk/v1/eulerCampaigns'
 export const BREVIS_MERKLE_PROOF_URL = 'https://incentra-prd.brevis.network/v1/getMerkleProofsBatch'
 

--- a/entities/custom.ts
+++ b/entities/custom.ts
@@ -5,6 +5,7 @@ export const themeHue = 150
 export type IntrinsicApySourceConfig =
   | { provider: 'defillama', address: string, chainId: number, poolId: string, useSpotApy?: boolean }
   | { provider: 'pendle', address: string, chainId: number, pendleMarket: string, crossChainSourceChainId?: number }
+  | { provider: 'securitize', address: string, chainId: number, symbol: string, yieldField: 'nav_yield_30d' | 'distribution_yield' }
 
 export const intrinsicApySources: readonly IntrinsicApySourceConfig[] = [
   // DefiLlama pools — Ethereum (1)
@@ -172,4 +173,9 @@ export const intrinsicApySources: readonly IntrinsicApySourceConfig[] = [
   { provider: 'pendle', address: '0xFFaF49f320b8Ae1Bb9Ea596197040077a3666105', chainId: 9745, pendleMarket: '0x23180d15651FE6e4415ce27b212Cf8e5d2dEDa96' }, // PT-wstUSR-26FEB2026
   { provider: 'pendle', address: '0xD516188daf64EFa04a8d60872F891f2cC811A561', chainId: 9745, pendleMarket: '0x15735f2F53c5cd25A57dFf83B11C93EcEaf72073' }, // PT-USDai-19MAR2026
   { provider: 'pendle', address: '0xedac81b27790e0728f54dEa3B7718e5437E85353', chainId: 9745, pendleMarket: '0x0d7d9abEE602c7f0A242EA7e200e47C372aCba84' }, // PT-sUSDai-19MAR2026
+
+  // Securitize tokens — Ethereum (1)
+  { provider: 'securitize', chainId: 1, address: '0x17418038ecF73BA4026c4f428547BF099706F27B', symbol: 'ACRED', yieldField: 'nav_yield_30d' },
+  { provider: 'securitize', chainId: 1, address: '0x2255718832bC9fD3bE1CaF75084F4803DA14FF01', symbol: 'VBILL', yieldField: 'distribution_yield' },
+  { provider: 'securitize', chainId: 1, address: '0x51C2d74017390CbBd30550179A16A1c28F7210fc', symbol: 'STAC', yieldField: 'nav_yield_30d' },
 ]

--- a/entities/vault/factory.ts
+++ b/entities/vault/factory.ts
@@ -56,8 +56,12 @@ export const isSecuritizeVault = async (address: string): Promise<boolean> => {
       return registryType === 'securitize'
     }
 
-    // Fall back to subgraph query
-    const { eulerPeripheryAddresses } = useEulerAddresses()
+    // Fall back to subgraph query — wait for addresses to load
+    const { eulerPeripheryAddresses, isReady, loadEulerConfig } = useEulerAddresses()
+    if (!isReady.value) {
+      loadEulerConfig()
+      await until(computed(() => isReady.value)).toBeTruthy()
+    }
     const securitizeFactory = eulerPeripheryAddresses.value?.securitizeFactory
     if (!securitizeFactory) {
       return false

--- a/pages/lend/[vault]/index.vue
+++ b/pages/lend/[vault]/index.vue
@@ -31,7 +31,6 @@ interface VaultFeatures {
   hasPriceInfo: boolean
   hasVerifiedStatus: boolean
   hasPoints: boolean
-  hasApyBreakdown: boolean
   hasOverview: boolean
 }
 
@@ -42,7 +41,6 @@ const VAULT_FEATURES: Record<VaultType, VaultFeatures> = {
     hasPriceInfo: true,
     hasVerifiedStatus: true,
     hasPoints: true,
-    hasApyBreakdown: true,
     hasOverview: true,
   },
   securitize: {
@@ -51,7 +49,6 @@ const VAULT_FEATURES: Record<VaultType, VaultFeatures> = {
     hasPriceInfo: false,
     hasVerifiedStatus: false,
     hasPoints: false,
-    hasApyBreakdown: false,
     hasOverview: true,
   },
 }
@@ -685,7 +682,6 @@ watch(address, () => {
               <p class="mb-4 text-content-tertiary flex items-center gap-4">
                 Supply APY
                 <SvgIcon
-                  v-if="features.hasApyBreakdown"
                   class="!w-20 !h-20 text-content-muted cursor-pointer hover:text-content-secondary"
                   name="info-circle"
                   @click="onSupplyInfoIconClick"

--- a/server/plugins/csp.ts
+++ b/server/plugins/csp.ts
@@ -64,6 +64,7 @@ const CONNECT_SRC_BASE = [
   // External data APIs
   'https://yields.llama.fi',
   'https://api-v2.pendle.finance',
+  'https://public-feed.securitize.io',
   // Reown AppKit SDK version check
   'https://registry.npmjs.org',
   // RPC providers (wildcard — operators configure per chain)

--- a/services/intrinsicApy/securitizeProvider.ts
+++ b/services/intrinsicApy/securitizeProvider.ts
@@ -1,0 +1,95 @@
+import axios from 'axios'
+import { SECURITIZE_FEED_URL } from '~/entities/constants'
+import type { IntrinsicApySourceConfig } from '~/entities/custom'
+import type { IntrinsicApyProvider, IntrinsicApyResult } from '~/entities/intrinsic-apy'
+import { logWarn } from '~/utils/errorHandling'
+
+type SecuritizeSource = Extract<IntrinsicApySourceConfig, { provider: 'securitize' }>
+
+type SecuritizeResponse = {
+  data?: SecuritizeAssetStats[]
+}
+
+type SecuritizeAssetStats = {
+  token_address?: string
+  nav_yield_30d?: string | number
+  distribution_yield?: string | number
+}
+
+const normalize = (value?: string) => value?.toLowerCase() || ''
+
+const buildSourceUrl = (symbol: string) =>
+  `https://id.securitize.io/#/investment/${symbol}`
+
+const fetchBySymbol = async (
+  symbol: string,
+  sources: SecuritizeSource[],
+): Promise<IntrinsicApyResult[]> => {
+  const res = await axios.get<SecuritizeResponse>(SECURITIZE_FEED_URL, {
+    params: { symbol },
+    timeout: 10_000,
+  })
+
+  const entries = Array.isArray(res.data?.data) ? res.data.data : []
+  const results: IntrinsicApyResult[] = []
+
+  for (const source of sources) {
+    const match = entries.find(
+      e => normalize(e.token_address) === normalize(source.address),
+    )
+    if (!match) continue
+
+    const raw = match[source.yieldField]
+    const apy = typeof raw === 'string' ? parseFloat(raw) || 0 : (raw ?? 0)
+
+    results.push({
+      address: normalize(source.address),
+      info: {
+        apy,
+        provider: 'Securitize',
+        source: buildSourceUrl(source.symbol),
+      },
+    })
+  }
+
+  return results
+}
+
+export const createSecuritizeProvider = (sources: readonly IntrinsicApySourceConfig[]): IntrinsicApyProvider => {
+  const securitizeSources = sources.filter(
+    (s): s is SecuritizeSource => s.provider === 'securitize',
+  )
+
+  return {
+    name: 'Securitize',
+
+    async fetch(chainId: number): Promise<IntrinsicApyResult[]> {
+      const chainSources = securitizeSources.filter(s => s.chainId === chainId)
+      if (!chainSources.length) return []
+
+      const bySymbol = new Map<string, SecuritizeSource[]>()
+      for (const source of chainSources) {
+        const existing = bySymbol.get(source.symbol) ?? []
+        bySymbol.set(source.symbol, [...existing, source])
+      }
+
+      const settled = await Promise.allSettled(
+        [...bySymbol.entries()].map(([symbol, sources]) =>
+          fetchBySymbol(symbol, sources),
+        ),
+      )
+
+      const results: IntrinsicApyResult[] = []
+      for (const result of settled) {
+        if (result.status === 'fulfilled') {
+          results.push(...result.value)
+        }
+        else {
+          logWarn('intrinsicApy/securitize', result.reason)
+        }
+      }
+
+      return results
+    },
+  }
+}


### PR DESCRIPTION
## Summary

- Add new intrinsic APY provider fetching yield data from Securitize's public API (`public-feed.securitize.io/asset-stats`)
- Configure three Securitize tokens on Ethereum: ACRED (`nav_yield_30d`), VBILL (`distribution_yield`), STAC (`nav_yield_30d`)
- Add APY breakdown info icon + modal to `SecuritizeVaultItem` card (matching EVK vault pattern)
- Fix `isSecuritizeVault` race condition where periphery addresses weren't loaded yet, causing a noisy `getVaultInfoFull` revert on Securitize vault pages
- Remove unused `hasApyBreakdown` feature flag (now always true for both vault types)
- Add `public-feed.securitize.io` to CSP `connect-src`

## Test plan

- [ ] Navigate to a Securitize vault page (e.g. ACRED vault on Ethereum) — confirm supply APY shows Securitize yield (~1.14% ACRED, ~3.47% VBILL, ~3.82% STAC)
- [ ] Click the "i" icon next to Supply APY — verify modal shows "Intrinsic APY (Securitize)" row with source link
- [ ] Verify the "i" icon also appears on the Securitize vault card in the discovery list
- [ ] Confirm no `getVaultInfoFull` revert errors in console on Securitize vault pages
- [ ] Verify EVK vault pages are unaffected (info icon, sparkles, modal all work as before)
- [ ] Check browser console for no CSP violations from the Securitize API