### PR TITLE
fix: verify oracle router governor in risk manager check

### DIFF
--- a/composables/useVaults.ts
+++ b/composables/useVaults.ts
@@ -1,4 +1,4 @@
-import { getAddress } from 'viem'
+import { getAddress, zeroAddress } from 'viem'
 import { useVaultRegistry } from './useVaultRegistry'
 import { logWarn } from '~/utils/errorHandling'
 import {
@@ -18,6 +18,7 @@ import {
   type Vault,
 } from '~/entities/vault'
 import { getProductByVault } from '~/utils/eulerLabelsUtils'
+import { getEulerRouterGovernor } from '~/entities/oracle'
 
 const isReady = ref(false)
 const isLoading = ref(false)
@@ -578,14 +579,29 @@ export const useVaults = () => {
     }
 
     // Check if governorAdmin matches any address in any of the declared entities
-    for (const entityKey of declaredEntityKeys) {
+    const governorAdminVerified = declaredEntityKeys.some((entityKey) => {
       const entity = entities[entityKey]
-      if (entity && Object.keys(entity.addresses).includes(vault.governorAdmin)) {
-        return true
+      return entity && Object.keys(entity.addresses).includes(vault.governorAdmin)
+    })
+
+    if (!governorAdminVerified) {
+      return false
+    }
+
+    // Also verify oracle router governor if the oracle is an EulerRouter
+    const routerGovernor = getEulerRouterGovernor(vault.oracleDetailedInfo)
+    if (routerGovernor && routerGovernor !== zeroAddress) {
+      const routerGovernorVerified = declaredEntityKeys.some((entityKey) => {
+        const entity = entities[entityKey]
+        return entity && Object.keys(entity.addresses).includes(routerGovernor)
+      })
+
+      if (!routerGovernorVerified) {
+        return false
       }
     }
 
-    return false
+    return true
   }
 
   // Check if earn vault's on-chain owner matches any of the product's declared entities

--- a/entities/oracle.ts
+++ b/entities/oracle.ts
@@ -97,6 +97,14 @@ export const decodeEulerRouterInfo = (oracleInfo: Hex | string | Uint8Array): Eu
   }
 }
 
+export const getEulerRouterGovernor = (
+  oracleInfo: OracleDetailedInfo | null | undefined,
+): Address | null => {
+  if (!oracleInfo || oracleInfo.name !== 'EulerRouter') return null
+  const decoded = decodeEulerRouterInfo(oracleInfo.oracleInfo)
+  return decoded?.governor ?? null
+}
+
 export const decodeCrossAdapterInfo = (oracleInfo: Hex | string | Uint8Array): CrossAdapterInfo | null => {
   try {
     const [decoded] = decodeAbiParameters(


### PR DESCRIPTION
## Summary

- Adds `getEulerRouterGovernor()` helper in `entities/oracle.ts` to extract the governor from an EulerRouter oracle
- Extends `isVaultGovernorVerified()` to also verify the oracle router's governor against declared entity addresses
- Vaults with an EulerRouter whose governor is unrecognized now show "Unknown" risk manager, surfacing the risk to users
- Immutable routers (zero-address governor) pass automatically; non-EulerRouter oracles are unaffected

## Test plan

- [ ] `vue-tsc --noEmit` passes with no type errors
- [ ] Verify a vault with a known EulerRouter oracle still shows the correct risk manager
- [ ] Verify a vault whose router governor differs from entity addresses shows "Unknown" risk manager
- [ ] Verify escrow vaults, SecuritizeVaults, and non-EulerRouter vaults are unaffected