### PR TITLE
fix: route securitize vaults to correct lens in updateVault

### DIFF
--- a/composables/useVaults.ts
+++ b/composables/useVaults.ts
@@ -380,11 +380,17 @@ const getEarnVault = async (address: string): Promise<EarnVault> => {
   registrySet(normalizedAddress, vault, 'earn')
   return vault
 }
-const updateVault = async (vaultAddress: string): Promise<Vault> => {
-  const { set: registrySet, isKnownEscrowAddress } = useVaultRegistry()
+const updateVault = async (vaultAddress: string): Promise<Vault | SecuritizeVault> => {
+  const { set: registrySet, isKnownEscrowAddress, getType } = useVaultRegistry()
   const address = getAddress(vaultAddress)
 
-  // Use appropriate fetch function to preserve escrow status
+  // Use appropriate fetch function based on vault type
+  if (getType(address) === 'securitize') {
+    const vault = await fetchSecuritizeVault(address)
+    registrySet(address, vault, 'securitize')
+    return vault
+  }
+
   const vault = isKnownEscrowAddress(address)
     ? await fetchEscrowVault(address)
     : await fetchVault(address)


### PR DESCRIPTION
## Summary
- `updateVault()` did not check for securitize vault type before fetching, causing it to call `getVaultInfoFull` on the standard vault lens which reverts for securitize vaults
- Added a `getType(address) === 'securitize'` check that routes to `fetchSecuritizeVault` (uses `getVaultInfoERC4626` on utils lens), matching the pattern already used in the getters

## Test plan
- [ ] Navigate to a borrow page with a Securitize collateral vault
- [ ] Enter collateral and borrow amounts
- [ ] Verify no `getVaultInfoFull` revert errors in console
- [ ] Verify estimates (health factor, liquidation price, net APY) update correctly