### PR TITLE
feat: replace Best Net APY with Best Max ROE in explore table

### DIFF
--- a/components/entities/vault/VaultMaxRoeModal.vue
+++ b/components/entities/vault/VaultMaxRoeModal.vue
@@ -14,6 +14,7 @@ const {
   supplyAPY: number
   borrowAPY: number
   borrowLTV: number
+  isBestInMarket?: boolean
 }>()
 
 const handleClose = () => {
@@ -23,9 +24,15 @@ const handleClose = () => {
 
 <template>
   <BaseModalWrapper
-    title="Max ROE"
+    :title="isBestInMarket ? 'Best Max ROE' : 'Max ROE'"
     @close="handleClose"
   >
+    <p class="text-euler-dark-900 text-p3 mb-16">
+      ROE (Return on Equity) estimates the annualized return on your own capital in a multiplied position. A positive ROE means the supply yield exceeds borrowing costs at the given multiplier. A negative ROE means the position is gradually losing value to interest costs.
+      <template v-if="isBestInMarket">
+        The value shown is the best max ROE out of all possible collateral/borrow pairs in this market.
+      </template>
+    </p>
     <div class="mb-24">
       <div class="pb-16 mb-16 border-b border-euler-dark-600">
         <div class="flex justify-between items-center mb-16">
@@ -47,7 +54,7 @@ const handleClose = () => {
               Max multiplier
             </p>
             <p class="text-euler-dark-900">
-              Max multiplier at full LTV
+              Max multiplier at max LTV
             </p>
           </div>
           <div class="text-h5">
@@ -92,7 +99,7 @@ const handleClose = () => {
         </div>
       </div>
     </div>
-    <div class="bg-euler-dark-600 rounded-12 p-16 flex justify-between items-center">
+    <div class="bg-euler-dark-600 rounded-12 p-16 flex justify-between items-center mb-16">
       <div>
         <p>Max ROE</p>
         <p class="text-euler-dark-900 text-p3">

--- a/components/entities/vault/discovery/DiscoveryMarketCard.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketCard.vue
@@ -204,36 +204,28 @@ const onMaxRoeInfoIconClick = (event: MouseEvent, result: BestMaxRoeResult) => {
           :key="'max-roe-' + bestRoeIdx"
         >
           <div class="flex-1 min-w-0">
-            <div class="text-content-tertiary text-p3 mb-4 flex items-center gap-4">
-              Best max ROE
-              <SvgIcon
-                v-if="bestRoe.value > 0"
-                class="!w-14 !h-14 text-content-muted hover:text-content-secondary transition-colors cursor-pointer"
-                name="info-circle"
-                @click="onMaxRoeInfoIconClick($event, bestRoe)"
-              />
-            </div>
-            <div
-              v-if="bestRoe.value > 0"
-              class="text-p2 text-content-primary flex items-center gap-4 min-w-0 mobile:overflow-hidden"
-            >
-              <SvgIcon
-                v-if="bestRoe.hasRewards"
-                name="sparks"
-                class="!w-12 !h-12 text-accent-500 shrink-0"
-              />
-              <span class="shrink-0">{{ formatNumber(bestRoe.value, 2, 2) }}%</span>
-              <span
-                v-if="bestRoe.pair"
-                class="text-p4 text-content-muted min-w-0 truncate"
-              >{{ bestRoe.pair }}</span>
-            </div>
-            <div
-              v-else
-              class="text-p2 text-content-muted"
-            >
-              &mdash;
-            </div>
+            <template v-if="bestRoe.value > 0">
+              <div class="text-content-tertiary text-p3 mb-4 flex items-center gap-4">
+                Best max ROE
+                <SvgIcon
+                  class="!w-14 !h-14 text-content-muted hover:text-content-secondary transition-colors cursor-pointer"
+                  name="info-circle"
+                  @click="onMaxRoeInfoIconClick($event, bestRoe)"
+                />
+              </div>
+              <div class="text-p2 text-content-primary flex items-center gap-4 min-w-0 mobile:overflow-hidden">
+                <SvgIcon
+                  v-if="bestRoe.hasRewards"
+                  name="sparks"
+                  class="!w-12 !h-12 text-accent-500 shrink-0"
+                />
+                <span class="shrink-0">{{ formatNumber(bestRoe.value, 2, 2) }}%</span>
+                <span
+                  v-if="bestRoe.pair"
+                  class="text-p4 text-content-muted min-w-0 truncate"
+                >{{ bestRoe.pair }}</span>
+              </div>
+            </template>
           </div>
         </template>
       </div>

--- a/components/entities/vault/discovery/DiscoveryMarketCard.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketCard.vue
@@ -9,8 +9,11 @@ import {
   getMiniDiagram,
   getBorrowableVaults,
   findVault,
-  type BestNetApyResult,
+  type BestMaxRoeResult,
 } from '~/utils/discoveryCalculations'
+import { getMaxMultiplier, getMaxRoe } from '~/utils/leverage'
+import { useModal } from '~/components/ui/composables/useModal'
+import { VaultMaxRoeModal } from '#components'
 
 defineProps<{
   market: MarketGroup
@@ -24,17 +27,22 @@ defineEmits<{
 const { withIntrinsicSupplyApy, withIntrinsicBorrowApy } = useIntrinsicApy()
 const { getBorrowRewardApy, getSupplyRewardApy } = useRewardsApy()
 const { products } = useEulerLabels()
+const modal = useModal()
 
 const getProductDescription = (market: MarketGroup): string => {
   if (market.source !== 'product') return ''
   return products[market.id]?.description ?? ''
 }
 
-const getBestNetApy = (market: MarketGroup): BestNetApyResult => {
+const getBestMaxRoe = (market: MarketGroup): BestMaxRoeResult => {
   const borrowable = getBorrowableVaults(market)
   let best = -Infinity
   let bestHasRewards = false
   let bestPair = ''
+  let bestMultiplier = 1
+  let bestSupplyAPY = 0
+  let bestBorrowAPY = 0
+  let bestBorrowLTV = 0
 
   for (const liability of borrowable) {
     const borrowBase = nanoToValue(liability.interestRateInfo.borrowAPY, 25)
@@ -50,16 +58,48 @@ const getBestNetApy = (market: MarketGroup): BestNetApyResult => {
       const supplyRewards = getSupplyRewardApy(collateral.address)
       const borrowRewards = getBorrowRewardApy(liability.address, collateral.address)
 
-      const netApy = (supplyApy + supplyRewards) - (borrowApy - borrowRewards)
-      if (netApy > best) {
-        best = netApy
+      const supplyFinal = supplyApy + supplyRewards
+      const borrowFinal = borrowApy - borrowRewards
+      const multiplier = getMaxMultiplier(ltv.borrowLTV)
+      const roe = getMaxRoe(multiplier, supplyFinal, borrowFinal)
+
+      if (roe > best) {
+        best = roe
         bestHasRewards = supplyRewards > 0 || borrowRewards > 0
         bestPair = `${collateral.asset.symbol}/${liability.asset.symbol}`
+        bestMultiplier = multiplier
+        bestSupplyAPY = supplyFinal
+        bestBorrowAPY = borrowFinal
+        bestBorrowLTV = nanoToValue(ltv.borrowLTV, 2)
       }
     }
   }
 
-  return { value: Number.isFinite(best) && best > -Infinity ? best : 0, hasRewards: bestHasRewards, pair: bestPair }
+  const value = Number.isFinite(best) && best > -Infinity ? best : 0
+  return {
+    value,
+    hasRewards: bestHasRewards,
+    pair: bestPair,
+    maxMultiplier: bestMultiplier,
+    supplyAPY: bestSupplyAPY,
+    borrowAPY: bestBorrowAPY,
+    borrowLTV: bestBorrowLTV,
+  }
+}
+
+const onMaxRoeInfoIconClick = (event: MouseEvent, result: BestMaxRoeResult) => {
+  event.preventDefault()
+  event.stopPropagation()
+  modal.open(VaultMaxRoeModal, {
+    props: {
+      maxRoe: result.value,
+      maxMultiplier: result.maxMultiplier,
+      supplyAPY: result.supplyAPY,
+      borrowAPY: result.borrowAPY,
+      borrowLTV: result.borrowLTV,
+      isBestInMarket: true,
+    },
+  })
 }
 </script>
 
@@ -160,27 +200,39 @@ const getBestNetApy = (market: MarketGroup): BestNetApyResult => {
           </div>
         </div>
         <template
-          v-for="(bestNet, bestNetIdx) in [getBestNetApy(market)]"
-          :key="'net-apy-' + bestNetIdx"
+          v-for="(bestRoe, bestRoeIdx) in [getBestMaxRoe(market)]"
+          :key="'max-roe-' + bestRoeIdx"
         >
-          <div
-            v-if="bestNet.value !== 0"
-            class="flex-1 min-w-0"
-          >
-            <div class="text-content-tertiary text-p3 mb-4">
-              Best net APY
-            </div>
-            <div class="text-p2 text-content-primary flex items-center gap-4 min-w-0 mobile:overflow-hidden">
+          <div class="flex-1 min-w-0">
+            <div class="text-content-tertiary text-p3 mb-4 flex items-center gap-4">
+              Best max ROE
               <SvgIcon
-                v-if="bestNet.hasRewards"
+                v-if="bestRoe.value > 0"
+                class="!w-14 !h-14 text-content-muted hover:text-content-secondary transition-colors cursor-pointer"
+                name="info-circle"
+                @click="onMaxRoeInfoIconClick($event, bestRoe)"
+              />
+            </div>
+            <div
+              v-if="bestRoe.value > 0"
+              class="text-p2 text-content-primary flex items-center gap-4 min-w-0 mobile:overflow-hidden"
+            >
+              <SvgIcon
+                v-if="bestRoe.hasRewards"
                 name="sparks"
                 class="!w-12 !h-12 text-accent-500 shrink-0"
               />
-              <span class="shrink-0">{{ formatNumber(bestNet.value, 2, 2) }}%</span>
+              <span class="shrink-0">{{ formatNumber(bestRoe.value, 2, 2) }}%</span>
               <span
-                v-if="bestNet.pair"
+                v-if="bestRoe.pair"
                 class="text-p4 text-content-muted min-w-0 truncate"
-              >{{ bestNet.pair }}</span>
+              >{{ bestRoe.pair }}</span>
+            </div>
+            <div
+              v-else
+              class="text-p2 text-content-muted"
+            >
+              &mdash;
             </div>
           </div>
         </template>

--- a/composables/useBestMaxROE.ts
+++ b/composables/useBestMaxROE.ts
@@ -1,12 +1,7 @@
 import type { MarketGroup } from '~/entities/lend-discovery'
-import type { Vault } from '~/entities/vault'
-import type { BestMaxRoeResult } from '~/utils/discoveryCalculations'
-import type { AnyVault } from '~/composables/useVaultRegistry'
+import { type BestMaxRoeResult, getBorrowableVaults, isVaultType } from '~/utils/discoveryCalculations'
 import { nanoToValue } from '~/utils/crypto-utils'
 import { getMaxMultiplier, getMaxRoe } from '~/utils/leverage'
-
-const isVaultType = (vault: AnyVault): vault is Vault =>
-  !('type' in vault) || (vault as { type?: string }).type === undefined
 
 /**
  * Computes the best max ROE for each market group by iterating all actual
@@ -20,9 +15,7 @@ export const useBestMaxROE = (marketGroups: Ref<MarketGroup[]>) => {
   const { getSupplyRewardApy, getBorrowRewardApy, version: rewardsVersion } = useRewardsApy()
 
   const computeForGroup = (group: MarketGroup): BestMaxRoeResult => {
-    const borrowableVaults = group.vaults.filter(
-      v => isVaultType(v) && v.vaultCategory !== 'escrow',
-    ) as Vault[]
+    const borrowableVaults = getBorrowableVaults(group)
 
     const allVaults = [...group.vaults, ...group.externalCollateral]
     const knownAddresses = new Set(

--- a/composables/useBestMaxROE.ts
+++ b/composables/useBestMaxROE.ts
@@ -1,23 +1,25 @@
 import type { MarketGroup } from '~/entities/lend-discovery'
 import type { Vault } from '~/entities/vault'
-import { nanoToValue } from '~/utils/crypto-utils'
+import type { BestMaxRoeResult } from '~/utils/discoveryCalculations'
 import type { AnyVault } from '~/composables/useVaultRegistry'
+import { nanoToValue } from '~/utils/crypto-utils'
+import { getMaxMultiplier, getMaxRoe } from '~/utils/leverage'
 
 const isVaultType = (vault: AnyVault): vault is Vault =>
   !('type' in vault) || (vault as { type?: string }).type === undefined
 
 /**
- * Computes the best net APY for each market group by iterating all actual
- * collateral/liability pairs with LTV relationships. Accounts for intrinsic
- * APY and reward campaigns based on user settings.
+ * Computes the best max ROE for each market group by iterating all actual
+ * collateral/liability pairs with LTV relationships. Uses leveraged return
+ * (max ROE) instead of simple net APY spread.
  *
- * Returns a reactive map of marketGroupId → bestNetAPY (as a percentage, e.g. 5.2 for 5.2%).
+ * Returns a reactive map of marketGroupId -> BestMaxRoeResult.
  */
-export const useBestNetAPY = (marketGroups: Ref<MarketGroup[]>) => {
+export const useBestMaxROE = (marketGroups: Ref<MarketGroup[]>) => {
   const { withIntrinsicSupplyApy, withIntrinsicBorrowApy, version: intrinsicVersion } = useIntrinsicApy()
   const { getSupplyRewardApy, getBorrowRewardApy, version: rewardsVersion } = useRewardsApy()
 
-  const computeForGroup = (group: MarketGroup): number => {
+  const computeForGroup = (group: MarketGroup): BestMaxRoeResult => {
     const borrowableVaults = group.vaults.filter(
       v => isVaultType(v) && v.vaultCategory !== 'escrow',
     ) as Vault[]
@@ -28,6 +30,12 @@ export const useBestNetAPY = (marketGroups: Ref<MarketGroup[]>) => {
     )
 
     let best = -Infinity
+    let bestHasRewards = false
+    let bestPair = ''
+    let bestMultiplier = 1
+    let bestSupplyAPY = 0
+    let bestBorrowAPY = 0
+    let bestBorrowLTV = 0
 
     for (const liability of borrowableVaults) {
       const borrowBase = nanoToValue(liability.interestRateInfo.borrowAPY, 25)
@@ -50,33 +58,60 @@ export const useBestNetAPY = (marketGroups: Ref<MarketGroup[]>) => {
 
         const supplyFinal = supplyApy + supplyRewards
         const borrowFinal = borrowApy - borrowRewards
-        const netApy = supplyFinal - borrowFinal
+        const maxMultiplier = getMaxMultiplier(ltv.borrowLTV)
+        const roe = getMaxRoe(maxMultiplier, supplyFinal, borrowFinal)
 
-        if (netApy > best) best = netApy
+        if (roe > best) {
+          best = roe
+          bestHasRewards = supplyRewards > 0 || borrowRewards > 0
+          bestPair = `${collateral.asset.symbol}/${liability.asset.symbol}`
+          bestMultiplier = maxMultiplier
+          bestSupplyAPY = supplyFinal
+          bestBorrowAPY = borrowFinal
+          bestBorrowLTV = nanoToValue(ltv.borrowLTV, 2)
+        }
       }
     }
 
-    return Number.isFinite(best) && best > -Infinity ? best : 0
+    const value = Number.isFinite(best) && best > -Infinity ? best : 0
+    return {
+      value,
+      hasRewards: bestHasRewards,
+      pair: bestPair,
+      maxMultiplier: bestMultiplier,
+      supplyAPY: bestSupplyAPY,
+      borrowAPY: bestBorrowAPY,
+      borrowLTV: bestBorrowLTV,
+    }
   }
 
-  const bestNetAPYMap = computed((): Map<string, number> => {
-    // Read reactive dependencies so this recomputes when they change
+  const bestMaxROEMap = computed((): Map<string, BestMaxRoeResult> => {
     void intrinsicVersion.value
     void rewardsVersion.value
 
-    const result = new Map<string, number>()
+    const result = new Map<string, BestMaxRoeResult>()
     for (const group of marketGroups.value) {
       result.set(group.id, computeForGroup(group))
     }
     return result
   })
 
-  const getBestNetAPY = (groupId: string): number => {
-    return bestNetAPYMap.value.get(groupId) ?? 0
+  const defaultResult: BestMaxRoeResult = {
+    value: 0,
+    hasRewards: false,
+    pair: '',
+    maxMultiplier: 1,
+    supplyAPY: 0,
+    borrowAPY: 0,
+    borrowLTV: 0,
+  }
+
+  const getBestMaxROE = (groupId: string): BestMaxRoeResult => {
+    return bestMaxROEMap.value.get(groupId) ?? defaultResult
   }
 
   return {
-    bestNetAPYMap,
-    getBestNetAPY,
+    bestMaxROEMap,
+    getBestMaxROE,
   }
 }

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -115,7 +115,7 @@ composables/
 ├── useAccountPositions.ts          # Position loading and categorization
 ├── useAccountValues.ts             # Position USD value calculations
 ├── useAddressScreen.ts             # Address screening (compliance)
-├── useBestNetAPY.ts                # Best net APY calculations for sorting/filtering
+├── useBestMaxROE.ts                # Best max ROE calculations for sorting/filtering
 ├── useBrevis.ts                    # Brevis ZK proof rewards integration
 ├── useChainConfig.ts               # Dynamic chain derivation from RPC_URL_HTTP_* env vars
 ├── useCustomFilters.ts             # Generic custom metric filter system (gt/lt)

--- a/pages/explore/index.vue
+++ b/pages/explore/index.vue
@@ -5,7 +5,7 @@ import { getAssetLogoUrl } from '~/composables/useTokens'
 import { getProductByVault, getEntitiesByVault, isVaultDeprecated } from '~/utils/eulerLabelsUtils'
 import { getEulerLabelEntityLogo } from '~/entities/euler/labels'
 import { useCustomFilters } from '~/composables/useCustomFilters'
-import { useBestNetAPY } from '~/composables/useBestNetAPY'
+import { useBestMaxROE } from '~/composables/useBestMaxROE'
 import { useVaultSearch } from '~/composables/useVaultSearch'
 import type { MarketGroup } from '~/entities/lend-discovery'
 import type { Vault } from '~/entities/vault'
@@ -16,7 +16,7 @@ defineOptions({
 })
 
 const { marketGroups, isResolvingTVL } = useMarketGroups()
-const { getBestNetAPY } = useBestNetAPY(marketGroups)
+const { getBestMaxROE } = useBestMaxROE(marketGroups)
 const { isUpdating, isEarnUpdating, isEscrowUpdating } = useVaults()
 const { chainId } = useEulerAddresses()
 const { entities } = useEulerLabels()
@@ -61,13 +61,13 @@ const {
   matchesCustomFilters,
 } = useCustomFilters<MarketGroup>(
   [
-    { key: 'bestNetAPY', label: 'Best net APY', shortLabel: 'Best net APY', unit: 'percent' },
+    { key: 'bestMaxROE', label: 'Best max ROE', shortLabel: 'Best max ROE', unit: 'percent' },
     { key: 'totalTVL', label: 'Total supply', shortLabel: 'Total supply', unit: 'usd' },
     { key: 'totalBorrowed', label: 'Total borrowed', shortLabel: 'Total borrowed', unit: 'usd' },
     { key: 'totalAvailableLiquidity', label: 'Available liquidity', shortLabel: 'Avail. liquidity', unit: 'usd' },
   ],
   (group, metric) => {
-    if (metric === 'bestNetAPY') return getBestNetAPY(group.id)
+    if (metric === 'bestMaxROE') return getBestMaxROE(group.id).value
     const val = group.metrics[metric as keyof typeof group.metrics]
     return typeof val === 'number' ? val : 0
   },
@@ -235,9 +235,9 @@ const sortedMarkets = computed(() => {
       scored.sort((a, b) => b.compositeScore - a.compositeScore)
       return applyDeprecatedGroupSort(applyFeaturedSort(scored.map(s => s.group)))
     }
-    case 'Best Net APY':
+    case 'Best Max ROE':
       sorted = applyFeaturedSort([...filteredMarkets.value].sort((a, b) =>
-        getBestNetAPY(b.id) - getBestNetAPY(a.id),
+        getBestMaxROE(b.id).value - getBestMaxROE(a.id).value,
       ))
       break
     case 'Total Supply':
@@ -294,7 +294,7 @@ const isLoading = computed(() =>
         <VaultSortButton
           v-model="sortBy"
           v-model:dir="sortDir"
-          :options="['Recommended', 'Best Net APY', 'Total Supply', 'Total Borrowed', 'Available Liquidity']"
+          :options="['Recommended', 'Best Max ROE', 'Total Supply', 'Total Borrowed', 'Available Liquidity']"
           :disable-dir="sortBy === 'Recommended'"
           title="Sorting type"
         />

--- a/utils/discoveryCalculations.ts
+++ b/utils/discoveryCalculations.ts
@@ -117,11 +117,14 @@ export const getMarketEntities = (market: MarketGroup): { name: string, logos: s
   return { name, logos: all.map(e => getEulerLabelEntityLogo(e.logo)) }
 }
 
+const hasBorrowableLTV = (vault: Vault): boolean =>
+  vault.collateralLTVs.some(ltv => ltv.borrowLTV > 0n)
+
 export const getBorrowableVaults = (market: MarketGroup): Vault[] =>
-  market.vaults.filter(isVaultType).filter(v => v.vaultCategory !== 'escrow' && v.borrowCap > 0n)
+  market.vaults.filter(isVaultType).filter(hasBorrowableLTV)
 
 export const getNonBorrowableMemberVaults = (market: MarketGroup): Vault[] =>
-  market.vaults.filter(isVaultType).filter(v => v.vaultCategory === 'escrow' || v.borrowCap === 0n)
+  market.vaults.filter(isVaultType).filter(v => !hasBorrowableLTV(v))
 
 export const isExternalCollateral = (market: MarketGroup, address: string): boolean => {
   const normalized = address.toLowerCase()

--- a/utils/discoveryCalculations.ts
+++ b/utils/discoveryCalculations.ts
@@ -23,10 +23,14 @@ export interface CollateralMatrixData {
   pairCount: number
 }
 
-export interface BestNetApyResult {
+export interface BestMaxRoeResult {
   value: number
   hasRewards: boolean
   pair: string
+  maxMultiplier: number
+  supplyAPY: number
+  borrowAPY: number
+  borrowLTV: number
 }
 
 export interface EnhancedCellApys {


### PR DESCRIPTION
## Summary

- Replace "Best Net APY" (simple supply - borrow spread) with "Best Max ROE" (return at max multiplier) in the explore page market cards
- Add info icon on each card that opens the Max ROE modal with formula breakdown for the best collateral/borrow pair
- Show dash for markets with non-positive ROE
- Update sorting and custom filter options to use Best Max ROE
- Improve modal copy: accurate ROE description, contextual title and explanation for best-in-market view