### PR TITLE
feat: incentive providers improvements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,6 +65,11 @@ NUXT_PUBLIC_CONFIG_ENABLE_LEND_PAGE="true"
 NUXT_PUBLIC_CONFIG_ENABLE_EXPLORE_PAGE="true"
 NUXT_PUBLIC_CONFIG_ENABLE_APP_TITLE="true"
 
+# Incentives provider flags — all enabled by default
+NUXT_PUBLIC_CONFIG_ENABLE_MERKL="true"
+NUXT_PUBLIC_CONFIG_ENABLE_INCENTRA="true"
+NUXT_PUBLIC_CONFIG_ENABLE_FUUL="true"
+
 # Subgraph URIs per chain
 NUXT_PUBLIC_SUBGRAPH_URI_1="https://api.goldsky.com/api/public/project_cm4iagnemt1wp01xn4gh1agft/subgraphs/euler-simple-mainnet/latest/gn"
 NUXT_PUBLIC_SUBGRAPH_URI_130="https://api.goldsky.com/api/public/project_cm4iagnemt1wp01xn4gh1agft/subgraphs/euler-simple-unichain/latest/gn"

--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,10 @@ NUXT_PUBLIC_SWAP_API_URL="https://swap-dev.euler.finance"
 NUXT_PUBLIC_PRICE_API_URL="https://indexer.euler.finance"
 NUXT_PUBLIC_PYTH_HERMES_URL=https://hermes.pyth.network
 
+# Stablewatch intrinsic APY (server-side only, optional)
+# If not set, Stablewatch APY data will not be fetched even if tokens are configured.
+STABLEWATCH_API_KEY=
+
 # Tenderly simulation (server-side only, optional)
 TENDERLY_ACCESS_KEY=
 TENDERLY_ACCOUNT_SLUG=

--- a/.env.example
+++ b/.env.example
@@ -74,6 +74,9 @@ NUXT_PUBLIC_CONFIG_ENABLE_MERKL="true"
 NUXT_PUBLIC_CONFIG_ENABLE_INCENTRA="true"
 NUXT_PUBLIC_CONFIG_ENABLE_FUUL="true"
 
+# Fuul API key (server-side only, required for claim checks and reward totals)
+FUUL_API_KEY=
+
 # Subgraph URIs per chain
 NUXT_PUBLIC_SUBGRAPH_URI_1="https://api.goldsky.com/api/public/project_cm4iagnemt1wp01xn4gh1agft/subgraphs/euler-simple-mainnet/latest/gn"
 NUXT_PUBLIC_SUBGRAPH_URI_130="https://api.goldsky.com/api/public/project_cm4iagnemt1wp01xn4gh1agft/subgraphs/euler-simple-unichain/latest/gn"

--- a/abis/fuul.ts
+++ b/abis/fuul.ts
@@ -1,0 +1,50 @@
+export const fuulManagerABI = [
+  {
+    type: 'function',
+    name: 'claim',
+    inputs: [
+      {
+        name: 'claimChecks',
+        type: 'tuple[]',
+        internalType: 'struct ClaimCheck[]',
+        components: [
+          { name: 'projectAddress', type: 'address', internalType: 'address' },
+          { name: 'to', type: 'address', internalType: 'address' },
+          { name: 'currency', type: 'address', internalType: 'address' },
+          { name: 'currencyType', type: 'uint8', internalType: 'enum IFuulProject.TokenType' },
+          { name: 'amount', type: 'uint256', internalType: 'uint256' },
+          { name: 'reason', type: 'uint8', internalType: 'enum ClaimReason' },
+          { name: 'tokenId', type: 'uint256', internalType: 'uint256' },
+          { name: 'deadline', type: 'uint256', internalType: 'uint256' },
+          { name: 'proof', type: 'bytes32', internalType: 'bytes32' },
+          { name: 'signatures', type: 'bytes[]', internalType: 'bytes[]' },
+        ],
+      },
+    ],
+    outputs: [],
+    stateMutability: 'payable',
+  },
+] as const
+
+export const fuulFactoryABI = [
+  {
+    type: 'function',
+    name: 'getFeesInformation',
+    inputs: [
+      { name: 'projectAddress', type: 'address', internalType: 'address' },
+    ],
+    outputs: [
+      {
+        name: '',
+        type: 'tuple',
+        internalType: 'struct FeesInformation',
+        components: [
+          { name: 'projectOwnerClaimFee', type: 'uint256', internalType: 'uint256' },
+          { name: 'nativeUserClaimFee', type: 'uint256', internalType: 'uint256' },
+          { name: 'tokenUserClaimFee', type: 'uint256', internalType: 'uint256' },
+        ],
+      },
+    ],
+    stateMutability: 'view',
+  },
+] as const

--- a/components/entities/vault/overview/VaultOverviewBlockGeneral.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockGeneral.vue
@@ -51,13 +51,14 @@ const vaultGovernanceType = computed(() => {
   if (vault.vaultCategory === 'escrow') {
     return 'escrow'
   }
+  // Zero governorAdmin → ungoverned (check before entity match,
+  // since ungoverned vaults may have a label entity for display purposes)
+  if (!vault.governorAdmin || vault.governorAdmin === zeroAddress) {
+    return 'ungoverned'
+  }
   // Has matching entity → governed
   if (entities.length) {
     return 'governed'
-  }
-  // Zero governorAdmin → ungoverned
-  if (!vault.governorAdmin || vault.governorAdmin === zeroAddress) {
-    return 'ungoverned'
   }
   // Non-zero but no matching entity → unknown
   return 'unknown'

--- a/composables/useBrevis.ts
+++ b/composables/useBrevis.ts
@@ -67,6 +67,9 @@ const cacheState = {
   rewards: { timestamp: 0, address: '' },
 }
 
+let latestCampaignsRequestId = 0
+let latestRewardsRequestId = 0
+
 const getBrevisCampaignsForVault = (vaultAddress: string): RewardCampaign[] => {
   return brevisCampaigns.value.get(vaultAddress.toLowerCase()) || []
 }
@@ -93,14 +96,16 @@ export const useBrevis = () => {
   }
 
   const loadCampaigns = async (isInitialLoading = true, forceRefresh = false) => {
-    try {
-      const now = Date.now()
-      if (!forceRefresh
-        && brevisCampaigns.value.size > 0
-        && (now - cacheState.campaigns.timestamp) < CACHE_TTL_1MIN_MS) {
-        return
-      }
+    const now = Date.now()
+    if (!forceRefresh
+      && brevisCampaigns.value.size > 0
+      && (now - cacheState.campaigns.timestamp) < CACHE_TTL_1MIN_MS) {
+      return
+    }
 
+    const requestId = ++latestCampaignsRequestId
+
+    try {
       if (isInitialLoading) {
         isCampaignsLoading.value = true
       }
@@ -112,6 +117,8 @@ export const useBrevis = () => {
       }
 
       const res = await axios.post(BREVIS_API_URL, request)
+
+      if (requestId !== latestCampaignsRequestId) return
 
       if (res.data.err) {
         logWarn('brevis/campaigns', res.data.err)
@@ -148,36 +155,43 @@ export const useBrevis = () => {
       logWarn('brevis/campaigns', e)
     }
     finally {
-      isCampaignsLoading.value = false
+      if (requestId === latestCampaignsRequestId) {
+        isCampaignsLoading.value = false
+      }
     }
   }
 
   const loadRewards = async (isInitialLoading = true, forceRefresh = false) => {
+    if (!address.value) {
+      userRewards.value = []
+      return
+    }
+
+    const now = Date.now()
+    if (!forceRefresh
+      && cacheState.rewards.address === address.value
+      && userRewards.value.length > 0
+      && (now - cacheState.rewards.timestamp) < CACHE_TTL_1MIN_MS) {
+      return
+    }
+
+    const requestId = ++latestRewardsRequestId
+    const capturedAddress = address.value
+
     try {
-      if (!address.value) {
-        userRewards.value = []
-        return
-      }
-
-      const now = Date.now()
-      if (!forceRefresh
-        && cacheState.rewards.address === address.value
-        && userRewards.value.length > 0
-        && (now - cacheState.rewards.timestamp) < CACHE_TTL_1MIN_MS) {
-        return
-      }
-
       if (isInitialLoading) {
         isRewardsLoading.value = true
       }
 
       const request: CampaignsRequest = {
         chain_id: [1],
-        user_address: [address.value],
+        user_address: [capturedAddress],
         status: [3, 4],
       }
 
       const res = await axios.post(BREVIS_API_URL, request)
+
+      if (requestId !== latestRewardsRequestId) return
 
       if (res.data.err) {
         logWarn('brevis/rewards', res.data.err)
@@ -186,13 +200,15 @@ export const useBrevis = () => {
 
       userRewards.value = (res.data.campaigns || []).map(normalizeCampaign)
       cacheState.rewards.timestamp = Date.now()
-      cacheState.rewards.address = address.value
+      cacheState.rewards.address = capturedAddress
     }
     catch (e) {
       logWarn('brevis/allocations', e)
     }
     finally {
-      isRewardsLoading.value = false
+      if (requestId === latestRewardsRequestId) {
+        isRewardsLoading.value = false
+      }
     }
   }
 
@@ -290,7 +306,7 @@ export const useBrevis = () => {
       address.value = ''
     }
     // Force-refresh rewards when the connected wallet changes
-    if (oldVal && val && val !== oldVal) {
+    if (val !== oldVal) {
       loadRewards(true, true)
     }
   }, { immediate: true })

--- a/composables/useBrevis.ts
+++ b/composables/useBrevis.ts
@@ -164,6 +164,7 @@ export const useBrevis = () => {
   const loadRewards = async (isInitialLoading = true, forceRefresh = false) => {
     if (!address.value) {
       userRewards.value = []
+      isRewardsLoading.value = false
       return
     }
 
@@ -305,8 +306,8 @@ export const useBrevis = () => {
     else {
       address.value = ''
     }
-    // Force-refresh rewards when the connected wallet changes
-    if (val !== oldVal) {
+    // Force-refresh rewards when the connected wallet changes (skip initial mount)
+    if (oldVal && val && val !== oldVal) {
       loadRewards(true, true)
     }
   }, { immediate: true })

--- a/composables/useBrevis.ts
+++ b/composables/useBrevis.ts
@@ -96,6 +96,9 @@ export const useBrevis = () => {
   }
 
   const loadCampaigns = async (isInitialLoading = true, forceRefresh = false) => {
+    const currentChainId = chainId.value
+    if (!currentChainId) return
+
     const now = Date.now()
     if (!forceRefresh
       && brevisCampaigns.value.size > 0
@@ -111,7 +114,7 @@ export const useBrevis = () => {
       }
 
       const request: CampaignsRequest = {
-        chain_id: [1],
+        chain_id: [currentChainId],
         action: [CampaignAction.LEND, CampaignAction.BORROW],
         status: [3],
       }
@@ -162,6 +165,9 @@ export const useBrevis = () => {
   }
 
   const loadRewards = async (isInitialLoading = true, forceRefresh = false) => {
+    const currentChainId = chainId.value
+    if (!currentChainId) return
+
     if (!address.value) {
       userRewards.value = []
       isRewardsLoading.value = false
@@ -185,7 +191,7 @@ export const useBrevis = () => {
       }
 
       const request: CampaignsRequest = {
-        chain_id: [1],
+        chain_id: [currentChainId],
         user_address: [capturedAddress],
         status: [3, 4],
       }
@@ -311,6 +317,17 @@ export const useBrevis = () => {
       loadRewards(true, true)
     }
   }, { immediate: true })
+
+  watch(chainId, (val, oldVal) => {
+    if (oldVal && val !== oldVal) {
+      isLoaded.value = false
+      brevisCampaigns.value = new Map()
+      userRewards.value = []
+      cacheState.campaigns.timestamp = 0
+      cacheState.rewards.timestamp = 0
+      cacheState.rewards.address = ''
+    }
+  })
 
   watch(isConnected, (connected) => {
     if (connected) {

--- a/composables/useBrevis.ts
+++ b/composables/useBrevis.ts
@@ -282,12 +282,16 @@ export const useBrevis = () => {
     }
   }
 
-  watch(wagmiAddress, (val) => {
+  watch(wagmiAddress, (val, oldVal) => {
     if (val) {
       address.value = val
     }
     else {
       address.value = ''
+    }
+    // Force-refresh rewards when the connected wallet changes
+    if (oldVal && val && val !== oldVal) {
+      loadRewards(true, true)
     }
   }, { immediate: true })
 

--- a/composables/useBrevis.ts
+++ b/composables/useBrevis.ts
@@ -345,6 +345,10 @@ export const useBrevis = () => {
       }
     }
     else {
+      userRewards.value = []
+      isCampaignsLoading.value = false
+      isRewardsLoading.value = false
+      cacheState.rewards = { timestamp: 0, address: '' }
       if (interval) {
         clearInterval(interval)
         interval = null

--- a/composables/useDeployConfig.ts
+++ b/composables/useDeployConfig.ts
@@ -45,6 +45,9 @@ export const useDeployConfig = () => {
     enablePoweredByEuler: isEnabled(rc.configEnablePoweredByEuler),
     enableAppTitle: isEnabled(rc.configEnableAppTitle),
     enableSwapDeposit: isExplicitlyEnabled(rc.configEnableSwapDeposit),
+    enableMerkl: isEnabled(rc.configEnableMerkl),
+    enableIncentra: isEnabled(rc.configEnableIncentra),
+    enableFuul: isEnabled(rc.configEnableFuul),
 
     // Chains (derived from env vars at runtime via useChainConfig)
     ...useChainConfig(),

--- a/composables/useEulerConfig.ts
+++ b/composables/useEulerConfig.ts
@@ -3,6 +3,7 @@ import {
   BREVIS_API_URL,
   BREVIS_MERKLE_PROOF_URL,
   EULER_INTERFACES_CHAINS_URL,
+  FUUL_API_BASE_URL,
   MERKL_API_BASE_URL,
   MERKL_DISTRIBUTOR_ADDRESS,
 } from '~/entities/constants'
@@ -32,6 +33,7 @@ export const useEulerConfig = () => {
     BREVIS_API_URL,
     BREVIS_MERKLE_PROOF_URL,
     EULER_INTERFACES_CHAINS_URL,
+    FUUL_API_BASE_URL,
     MERKL_API_BASE_URL,
 
     // Labels (built from CONFIG_LABELS_REPO)

--- a/composables/useEulerConfig.ts
+++ b/composables/useEulerConfig.ts
@@ -4,6 +4,8 @@ import {
   BREVIS_MERKLE_PROOF_URL,
   EULER_INTERFACES_CHAINS_URL,
   FUUL_API_BASE_URL,
+  FUUL_FACTORY_ADDRESS,
+  FUUL_MANAGER_ADDRESS,
   MERKL_API_BASE_URL,
   MERKL_DISTRIBUTOR_ADDRESS,
 } from '~/entities/constants'
@@ -53,5 +55,7 @@ export const useEulerConfig = () => {
     EVM_PROVIDER_URL: computed(() => getRpcUrlByChainId(chainId.value, requestUrl.origin)).value,
     SUBGRAPH_URL: computed(() => subgraphUris[String(chainId.value)] || '').value,
     MERKL_ADDRESS: MERKL_DISTRIBUTOR_ADDRESS,
+    FUUL_MANAGER_ADDRESS,
+    FUUL_FACTORY_ADDRESS,
   }
 }

--- a/composables/useFuul.ts
+++ b/composables/useFuul.ts
@@ -259,6 +259,9 @@ export const useFuul = () => {
     }
     else {
       address.value = ''
+      fuulTotals.value = { claimed: [], unclaimed: [] }
+      isTotalsLoading.value = false
+      cacheState.totals = { timestamp: 0, address: '' }
     }
     if (oldVal && val && val !== oldVal) {
       loadTotals(true, true)

--- a/composables/useFuul.ts
+++ b/composables/useFuul.ts
@@ -103,6 +103,7 @@ export const useFuul = () => {
   const loadTotals = async (isInitialLoading = true, forceRefresh = false) => {
     if (!address.value) {
       fuulTotals.value = { claimed: [], unclaimed: [] }
+      isTotalsLoading.value = false
       return
     }
 

--- a/composables/useFuul.ts
+++ b/composables/useFuul.ts
@@ -1,0 +1,111 @@
+import axios from 'axios'
+
+import type { FuulIncentive } from '~/entities/fuul'
+import type { RewardCampaign } from '~/entities/reward-campaign'
+import { CACHE_TTL_1MIN_MS, POLL_INTERVAL_10S_MS } from '~/entities/tuning-constants'
+import { logWarn } from '~/utils/errorHandling'
+
+const isLoaded = ref(false)
+const fuulCampaigns: Ref<Map<string, RewardCampaign[]>> = shallowRef(new Map())
+const isCampaignsLoading = ref(true)
+
+let interval: NodeJS.Timeout | null = null
+
+const cacheState = {
+  campaigns: { chainId: 0, timestamp: 0 },
+}
+
+const getFuulCampaignsForVault = (vaultAddress: string): RewardCampaign[] => {
+  return fuulCampaigns.value.get(vaultAddress.toLowerCase()) || []
+}
+
+export const useFuul = () => {
+  const { FUUL_API_BASE_URL } = useEulerConfig()
+  const { chainId } = useEulerAddresses()
+
+  const loadIncentives = async (isInitialLoading = true, forceRefresh = false) => {
+    const currentChainId = chainId.value
+    if (!currentChainId) return
+
+    const now = Date.now()
+    if (!forceRefresh
+      && cacheState.campaigns.chainId === currentChainId
+      && fuulCampaigns.value.size > 0
+      && (now - cacheState.campaigns.timestamp) < CACHE_TTL_1MIN_MS) {
+      return
+    }
+
+    try {
+      if (isInitialLoading) {
+        isCampaignsLoading.value = true
+      }
+
+      const res = await axios.get(`${FUUL_API_BASE_URL}/incentives`, {
+        params: { protocol: 'euler', chain_id: currentChainId },
+      })
+
+      const data: FuulIncentive[] = Array.isArray(res.data) ? res.data : []
+      const campaignMap = new Map<string, RewardCampaign[]>()
+
+      for (const item of data) {
+        const vaultKey = item.trigger.context.token_address.toLowerCase()
+
+        const rewardCampaign: RewardCampaign = {
+          vault: vaultKey,
+          type: 'euler_lend',
+          apr: item.apr * 100,
+          provider: 'fuul',
+          endTimestamp: 0,
+          rewardToken: {
+            symbol: item.project,
+            icon: '',
+          },
+        }
+
+        const existing = campaignMap.get(vaultKey)
+        if (existing) existing.push(rewardCampaign)
+        else campaignMap.set(vaultKey, [rewardCampaign])
+      }
+
+      fuulCampaigns.value = campaignMap
+      cacheState.campaigns = { chainId: currentChainId, timestamp: Date.now() }
+    }
+    catch (e) {
+      logWarn('fuul/incentives', e)
+    }
+    finally {
+      isCampaignsLoading.value = false
+    }
+  }
+
+  watch(chainId, (val, oldVal) => {
+    if (oldVal && val !== oldVal) {
+      isLoaded.value = false
+    }
+
+    if (!isLoaded.value) {
+      loadIncentives()
+      isLoaded.value = true
+    }
+
+    if (!interval) {
+      interval = setInterval(() => {
+        loadIncentives(false)
+      }, POLL_INTERVAL_10S_MS)
+    }
+  }, { immediate: true })
+
+  onUnmounted(() => {
+    if (interval) {
+      clearInterval(interval)
+      interval = null
+    }
+  })
+
+  return {
+    fuulCampaigns,
+    isCampaignsLoading,
+    loadIncentives,
+    getFuulCampaignsForVault,
+  }
+}

--- a/composables/useFuul.ts
+++ b/composables/useFuul.ts
@@ -15,6 +15,8 @@ const cacheState = {
   campaigns: { chainId: 0, timestamp: 0 },
 }
 
+let latestRequestId = 0
+
 const getFuulCampaignsForVault = (vaultAddress: string): RewardCampaign[] => {
   return fuulCampaigns.value.get(vaultAddress.toLowerCase()) || []
 }
@@ -35,6 +37,8 @@ export const useFuul = () => {
       return
     }
 
+    const requestId = ++latestRequestId
+
     try {
       if (isInitialLoading) {
         isCampaignsLoading.value = true
@@ -43,6 +47,8 @@ export const useFuul = () => {
       const res = await axios.get(`${FUUL_API_BASE_URL}/incentives`, {
         params: { protocol: 'euler', chain_id: currentChainId },
       })
+
+      if (requestId !== latestRequestId || chainId.value !== currentChainId) return
 
       const data: FuulIncentive[] = Array.isArray(res.data) ? res.data : []
       const campaignMap = new Map<string, RewardCampaign[]>()
@@ -74,13 +80,18 @@ export const useFuul = () => {
       logWarn('fuul/incentives', e)
     }
     finally {
-      isCampaignsLoading.value = false
+      if (requestId === latestRequestId) {
+        isCampaignsLoading.value = false
+      }
     }
   }
 
   watch(chainId, (val, oldVal) => {
     if (oldVal && val !== oldVal) {
       isLoaded.value = false
+      fuulCampaigns.value = new Map()
+      cacheState.campaigns = { chainId: 0, timestamp: 0 }
+      isCampaignsLoading.value = true
     }
 
     if (!isLoaded.value) {

--- a/composables/useFuul.ts
+++ b/composables/useFuul.ts
@@ -259,6 +259,7 @@ export const useFuul = () => {
     }
     else {
       address.value = ''
+      latestTotalsRequestId++
       fuulTotals.value = { claimed: [], unclaimed: [] }
       isTotalsLoading.value = false
       cacheState.totals = { timestamp: 0, address: '' }

--- a/composables/useFuul.ts
+++ b/composables/useFuul.ts
@@ -19,6 +19,7 @@ const fuulTotals: Ref<FuulTotals> = ref({ claimed: [], unclaimed: [] })
 const isTotalsLoading = ref(true)
 
 let interval: NodeJS.Timeout | null = null
+let subscriberCount = 0
 let latestTotalsRequestId = 0
 
 const cacheState = {
@@ -178,9 +179,11 @@ export const useFuul = () => {
       throw new Error('No claimable rewards found')
     }
 
-    // Read fee from first check's project (all checks may share fee, but read per-project to be safe)
-    const feePerCheck = await readClaimFee(claimChecks[0].project_address)
-    const totalFee = feePerCheck * BigInt(claimChecks.length)
+    // Read fee per unique project and aggregate
+    const uniqueProjects = [...new Set(claimChecks.map(c => c.project_address))]
+    const fees = await Promise.all(uniqueProjects.map(addr => readClaimFee(addr)))
+    const feeMap = new Map(uniqueProjects.map((addr, i) => [addr, fees[i]]))
+    const totalFee = claimChecks.reduce((sum, c) => sum + (feeMap.get(c.project_address) ?? 0n), 0n)
 
     const contractChecks = claimChecks.map(check => ({
       projectAddress: check.project_address as Address,
@@ -216,8 +219,10 @@ export const useFuul = () => {
       throw new Error('No claimable rewards found')
     }
 
-    const feePerCheck = await readClaimFee(claimChecks[0].project_address)
-    const totalFee = feePerCheck * BigInt(claimChecks.length)
+    const uniqueProjects = [...new Set(claimChecks.map(c => c.project_address))]
+    const fees = await Promise.all(uniqueProjects.map(addr => readClaimFee(addr)))
+    const feeMap = new Map(uniqueProjects.map((addr, i) => [addr, fees[i]]))
+    const totalFee = claimChecks.reduce((sum, c) => sum + (feeMap.get(c.project_address) ?? 0n), 0n)
 
     const contractChecks = claimChecks.map(check => ({
       projectAddress: check.project_address as Address,
@@ -265,7 +270,7 @@ export const useFuul = () => {
       isLoaded.value = false
     }
 
-    if (!isLoaded.value) {
+    if (!isLoaded.value && val) {
       loadIncentives()
       loadTotals()
       isLoaded.value = true
@@ -279,8 +284,11 @@ export const useFuul = () => {
     }
   }, { immediate: true })
 
+  subscriberCount++
+
   onUnmounted(() => {
-    if (interval) {
+    subscriberCount--
+    if (subscriberCount === 0 && interval) {
       clearInterval(interval)
       interval = null
     }

--- a/composables/useFuul.ts
+++ b/composables/useFuul.ts
@@ -1,29 +1,49 @@
+import { useAccount, useSwitchChain, useWriteContract } from '@wagmi/vue'
+import type { Address } from 'viem'
 import axios from 'axios'
 
-import type { FuulIncentive } from '~/entities/fuul'
+import { fuulManagerABI, fuulFactoryABI } from '~/abis/fuul'
+import { getPublicClient } from '~/utils/public-client'
+import type { FuulClaimCheck, FuulIncentive, FuulTotals } from '~/entities/fuul'
 import type { RewardCampaign } from '~/entities/reward-campaign'
+import type { TxPlan } from '~/entities/txPlan'
 import { CACHE_TTL_1MIN_MS, POLL_INTERVAL_10S_MS } from '~/entities/tuning-constants'
 import { logWarn } from '~/utils/errorHandling'
+
+const address = ref('')
 
 const isLoaded = ref(false)
 const fuulCampaigns: Ref<Map<string, RewardCampaign[]>> = shallowRef(new Map())
 const isCampaignsLoading = ref(true)
+const fuulTotals: Ref<FuulTotals> = ref({ claimed: [], unclaimed: [] })
+const isTotalsLoading = ref(true)
 
 let interval: NodeJS.Timeout | null = null
+let latestTotalsRequestId = 0
 
 const cacheState = {
   campaigns: { chainId: 0, timestamp: 0 },
+  totals: { timestamp: 0, address: '' },
 }
-
-let latestRequestId = 0
 
 const getFuulCampaignsForVault = (vaultAddress: string): RewardCampaign[] => {
   return fuulCampaigns.value.get(vaultAddress.toLowerCase()) || []
 }
 
 export const useFuul = () => {
-  const { FUUL_API_BASE_URL } = useEulerConfig()
+  const { address: wagmiAddress, chain: wagmiChain } = useAccount()
+  const { switchChain } = useSwitchChain()
+  const { writeContractAsync } = useWriteContract()
+  const { FUUL_API_BASE_URL, FUUL_MANAGER_ADDRESS, FUUL_FACTORY_ADDRESS, EVM_PROVIDER_URL } = useEulerConfig()
   const { chainId } = useEulerAddresses()
+
+  const ensureWalletOnCurrentChain = async () => {
+    const targetChainId = chainId.value
+    if (!targetChainId) return
+
+    if (wagmiChain.value?.id === targetChainId) return
+    await switchChain({ chainId: targetChainId })
+  }
 
   const loadIncentives = async (isInitialLoading = true, forceRefresh = false) => {
     const currentChainId = chainId.value
@@ -37,8 +57,6 @@ export const useFuul = () => {
       return
     }
 
-    const requestId = ++latestRequestId
-
     try {
       if (isInitialLoading) {
         isCampaignsLoading.value = true
@@ -47,8 +65,6 @@ export const useFuul = () => {
       const res = await axios.get(`${FUUL_API_BASE_URL}/incentives`, {
         params: { protocol: 'euler', chain_id: currentChainId },
       })
-
-      if (requestId !== latestRequestId || chainId.value !== currentChainId) return
 
       const data: FuulIncentive[] = Array.isArray(res.data) ? res.data : []
       const campaignMap = new Map<string, RewardCampaign[]>()
@@ -80,28 +96,184 @@ export const useFuul = () => {
       logWarn('fuul/incentives', e)
     }
     finally {
-      if (requestId === latestRequestId) {
-        isCampaignsLoading.value = false
+      isCampaignsLoading.value = false
+    }
+  }
+
+  const loadTotals = async (isInitialLoading = true, forceRefresh = false) => {
+    if (!address.value) {
+      fuulTotals.value = { claimed: [], unclaimed: [] }
+      return
+    }
+
+    const now = Date.now()
+    if (!forceRefresh
+      && cacheState.totals.address === address.value
+      && (now - cacheState.totals.timestamp) < CACHE_TTL_1MIN_MS) {
+      return
+    }
+
+    const requestId = ++latestTotalsRequestId
+    const capturedAddress = address.value
+
+    try {
+      if (isInitialLoading) {
+        isTotalsLoading.value = true
+      }
+
+      const res = await axios.get('/api/fuul/totals', {
+        params: { user_identifier: capturedAddress },
+      })
+
+      if (requestId !== latestTotalsRequestId) return
+
+      fuulTotals.value = res.data || { claimed: [], unclaimed: [] }
+      cacheState.totals = { timestamp: Date.now(), address: capturedAddress }
+    }
+    catch (e) {
+      logWarn('fuul/totals', e)
+    }
+    finally {
+      if (requestId === latestTotalsRequestId) {
+        isTotalsLoading.value = false
       }
     }
   }
 
+  const fetchClaimChecks = async (): Promise<FuulClaimCheck[]> => {
+    if (!wagmiAddress.value) {
+      throw new Error('Wallet not connected')
+    }
+
+    const res = await axios.post('/api/fuul/claim-checks', {
+      userIdentifier: wagmiAddress.value,
+    })
+
+    return Array.isArray(res.data) ? res.data : []
+  }
+
+  const readClaimFee = async (projectAddress: string): Promise<bigint> => {
+    const client = getPublicClient(EVM_PROVIDER_URL)
+
+    const feesInfo = await client.readContract({
+      address: FUUL_FACTORY_ADDRESS as Address,
+      abi: fuulFactoryABI,
+      functionName: 'getFeesInformation',
+      args: [projectAddress as Address],
+    })
+
+    return (feesInfo as { nativeUserClaimFee: bigint }).nativeUserClaimFee
+  }
+
+  const claimRewards = async () => {
+    if (!wagmiAddress.value) {
+      throw new Error('Wallet not connected')
+    }
+
+    await ensureWalletOnCurrentChain()
+
+    const claimChecks = await fetchClaimChecks()
+    if (claimChecks.length === 0) {
+      throw new Error('No claimable rewards found')
+    }
+
+    // Read fee from first check's project (all checks may share fee, but read per-project to be safe)
+    const feePerCheck = await readClaimFee(claimChecks[0].project_address)
+    const totalFee = feePerCheck * BigInt(claimChecks.length)
+
+    const contractChecks = claimChecks.map(check => ({
+      projectAddress: check.project_address as Address,
+      to: check.to as Address,
+      currency: check.currency as Address,
+      currencyType: check.currency_type,
+      amount: BigInt(check.amount),
+      reason: check.reason,
+      tokenId: BigInt(check.token_id),
+      deadline: BigInt(check.deadline),
+      proof: check.proof as `0x${string}`,
+      signatures: check.signatures as `0x${string}`[],
+    }))
+
+    const hash = await writeContractAsync({
+      address: FUUL_MANAGER_ADDRESS as Address,
+      abi: fuulManagerABI,
+      functionName: 'claim',
+      args: [contractChecks],
+      value: totalFee,
+    })
+
+    return hash
+  }
+
+  const buildClaimRewardsPlan = async (): Promise<TxPlan> => {
+    if (!wagmiAddress.value) {
+      throw new Error('Wallet not connected')
+    }
+
+    const claimChecks = await fetchClaimChecks()
+    if (claimChecks.length === 0) {
+      throw new Error('No claimable rewards found')
+    }
+
+    const feePerCheck = await readClaimFee(claimChecks[0].project_address)
+    const totalFee = feePerCheck * BigInt(claimChecks.length)
+
+    const contractChecks = claimChecks.map(check => ({
+      projectAddress: check.project_address as Address,
+      to: check.to as Address,
+      currency: check.currency as Address,
+      currencyType: check.currency_type,
+      amount: BigInt(check.amount),
+      reason: check.reason,
+      tokenId: BigInt(check.token_id),
+      deadline: BigInt(check.deadline),
+      proof: check.proof as `0x${string}`,
+      signatures: check.signatures as `0x${string}`[],
+    }))
+
+    return {
+      kind: 'fuul-reward',
+      steps: [
+        {
+          type: 'other',
+          label: 'Claim Fuul rewards',
+          to: FUUL_MANAGER_ADDRESS as Address,
+          abi: fuulManagerABI,
+          functionName: 'claim',
+          args: [contractChecks],
+          value: totalFee,
+        },
+      ],
+    }
+  }
+
+  watch(wagmiAddress, (val, oldVal) => {
+    if (val) {
+      address.value = val
+    }
+    else {
+      address.value = ''
+    }
+    if (oldVal && val && val !== oldVal) {
+      loadTotals(true, true)
+    }
+  }, { immediate: true })
+
   watch(chainId, (val, oldVal) => {
     if (oldVal && val !== oldVal) {
       isLoaded.value = false
-      fuulCampaigns.value = new Map()
-      cacheState.campaigns = { chainId: 0, timestamp: 0 }
-      isCampaignsLoading.value = true
     }
 
     if (!isLoaded.value) {
       loadIncentives()
+      loadTotals()
       isLoaded.value = true
     }
 
     if (!interval) {
       interval = setInterval(() => {
         loadIncentives(false)
+        loadTotals(false)
       }, POLL_INTERVAL_10S_MS)
     }
   }, { immediate: true })
@@ -115,8 +287,13 @@ export const useFuul = () => {
 
   return {
     fuulCampaigns,
+    fuulTotals,
     isCampaignsLoading,
+    isTotalsLoading,
     loadIncentives,
+    loadTotals,
+    claimRewards,
+    buildClaimRewardsPlan,
     getFuulCampaignsForVault,
   }
 }

--- a/composables/useIntrinsicApy.ts
+++ b/composables/useIntrinsicApy.ts
@@ -4,6 +4,7 @@ import { EMPTY_INTRINSIC_APY } from '~/entities/intrinsic-apy'
 import { createDefiLlamaProvider } from '~/services/intrinsicApy/defillamaProvider'
 import { createPendleProvider } from '~/services/intrinsicApy/pendleProvider'
 import { createSecuritizeProvider } from '~/services/intrinsicApy/securitizeProvider'
+import { createStablewatchProvider } from '~/services/intrinsicApy/stablewatchProvider'
 import { logWarn } from '~/utils/errorHandling'
 import { CACHE_TTL_5MIN_MS } from '~/entities/tuning-constants'
 
@@ -19,11 +20,16 @@ const providers: IntrinsicApyProvider[] = [
   createDefiLlamaProvider(intrinsicApySources),
   createPendleProvider(intrinsicApySources),
   createSecuritizeProvider(intrinsicApySources),
+  createStablewatchProvider(intrinsicApySources),
 ]
 
 const mergeResults = (allResults: IntrinsicApyResult[]): Record<string, IntrinsicApyInfo> => {
   const byAddress: Record<string, IntrinsicApyInfo> = {}
   for (const result of allResults) {
+    const existing = byAddress[result.address]
+    if (existing) {
+      logWarn('intrinsicApy/merge', `Duplicate APY for ${result.address}: "${existing.provider}" (${existing.apy}%) overwritten by "${result.info.provider}" (${result.info.apy}%)`)
+    }
     byAddress[result.address] = result.info
   }
   return byAddress

--- a/composables/useMerkl.ts
+++ b/composables/useMerkl.ts
@@ -299,12 +299,16 @@ export const useMerkl = () => {
     }
   }
 
-  watch(wagmiAddress, (val) => {
+  watch(wagmiAddress, (val, oldVal) => {
     if (val) {
       address.value = val
     }
     else {
       address.value = ''
+    }
+    // Force-refresh rewards when the connected wallet changes
+    if (oldVal && val && val !== oldVal && chainId.value) {
+      loadRewards(chainId.value, true, true)
     }
   }, { immediate: true })
 

--- a/composables/useMerkl.ts
+++ b/composables/useMerkl.ts
@@ -329,11 +329,21 @@ export const useMerkl = () => {
   }, { immediate: true })
 
   watch([isConnected, chainId], (val, oldVal) => {
-    if (oldVal[1] && val[1] !== oldVal[1]) {
+    const [connected, currentChainId] = val
+    const [oldConnected, oldChainId] = oldVal ?? [undefined, undefined]
+
+    if (oldChainId && currentChainId !== oldChainId) {
       isLoaded.value = false
       merklCampaigns.value = new Map()
       rewards.value = []
       cacheState.opportunities = { chainId: 0, timestamp: 0 }
+      cacheState.rewards = { chainId: 0, address: '', timestamp: 0 }
+    }
+
+    // Clear user-specific data on disconnect
+    if (oldConnected && !connected) {
+      rewards.value = []
+      isRewardsLoading.value = false
       cacheState.rewards = { chainId: 0, address: '', timestamp: 0 }
     }
 
@@ -344,18 +354,16 @@ export const useMerkl = () => {
       isLoaded.value = true
     }
 
-    if (!interval) {
+    if (connected && !interval) {
       interval = setInterval(() => {
         loadRewards(chainId.value, false)
         loadOpportunities(chainId.value, false)
         loadTokens(chainId.value, false)
       }, POLL_INTERVAL_10S_MS)
     }
-    else {
-      if (interval) {
-        clearInterval(interval)
-        interval = null
-      }
+    else if (!connected && interval) {
+      clearInterval(interval)
+      interval = null
     }
   }, { immediate: true })
 

--- a/composables/useMerkl.ts
+++ b/composables/useMerkl.ts
@@ -40,6 +40,9 @@ const cacheState = {
   rewards: { chainId: 0, address: '', timestamp: 0 },
 }
 
+let latestOpportunitiesRequestId = 0
+let latestRewardsRequestId = 0
+
 const loadTokens = async (chainId: number, isInitialLoading = true, forceRefresh = false) => {
   const now = Date.now()
   // Skip if cached and not expired
@@ -136,6 +139,8 @@ const loadOpportunities = async (chainId: number, isInitialLoading = true, force
     return
   }
 
+  const requestId = ++latestOpportunitiesRequestId
+
   try {
     if (isInitialLoading) {
       isOpportunitiesLoading.value = true
@@ -161,6 +166,8 @@ const loadOpportunities = async (chainId: number, isInitialLoading = true, force
       }),
     )
 
+    if (requestId !== latestOpportunitiesRequestId) return
+
     const merged = new Map<string, RewardCampaign[]>()
 
     for (const { data, type } of results) {
@@ -179,7 +186,9 @@ const loadOpportunities = async (chainId: number, isInitialLoading = true, force
     logWarn('merkl/loadOpportunities', e)
   }
   finally {
-    isOpportunitiesLoading.value = false
+    if (requestId === latestOpportunitiesRequestId) {
+      isOpportunitiesLoading.value = false
+    }
   }
 }
 
@@ -198,6 +207,8 @@ const loadRewards = async (chainId: number, isInitialLoading = true, forceRefres
     return
   }
 
+  const requestId = ++latestRewardsRequestId
+
   try {
     if (isInitialLoading) {
       isRewardsLoading.value = true
@@ -207,6 +218,8 @@ const loadRewards = async (chainId: number, isInitialLoading = true, forceRefres
         chainId,
       },
     })
+
+    if (requestId !== latestRewardsRequestId) return
 
     const data = res.data
 
@@ -222,7 +235,9 @@ const loadRewards = async (chainId: number, isInitialLoading = true, forceRefres
     logWarn('merkl/loadRewards', e)
   }
   finally {
-    isRewardsLoading.value = false
+    if (requestId === latestRewardsRequestId) {
+      isRewardsLoading.value = false
+    }
   }
 }
 
@@ -307,7 +322,7 @@ export const useMerkl = () => {
       address.value = ''
     }
     // Force-refresh rewards when the connected wallet changes
-    if (oldVal && val && val !== oldVal && chainId.value) {
+    if (val !== oldVal && chainId.value) {
       loadRewards(chainId.value, true, true)
     }
   }, { immediate: true })
@@ -315,6 +330,10 @@ export const useMerkl = () => {
   watch([isConnected, chainId], (val, oldVal) => {
     if (oldVal[1] && val[1] !== oldVal[1]) {
       isLoaded.value = false
+      merklCampaigns.value = new Map()
+      rewards.value = []
+      cacheState.opportunities = { chainId: 0, timestamp: 0 }
+      cacheState.rewards = { chainId: 0, address: '', timestamp: 0 }
     }
 
     if (!isLoaded.value) {

--- a/composables/useMerkl.ts
+++ b/composables/useMerkl.ts
@@ -195,6 +195,7 @@ const loadOpportunities = async (chainId: number, isInitialLoading = true, force
 const loadRewards = async (chainId: number, isInitialLoading = true, forceRefresh = false) => {
   if (!address.value) {
     rewards.value = []
+    isRewardsLoading.value = false
     return
   }
 
@@ -321,8 +322,8 @@ export const useMerkl = () => {
     else {
       address.value = ''
     }
-    // Force-refresh rewards when the connected wallet changes
-    if (val !== oldVal && chainId.value) {
+    // Force-refresh rewards when the connected wallet changes (skip initial mount)
+    if (oldVal && val && val !== oldVal && chainId.value) {
       loadRewards(chainId.value, true, true)
     }
   }, { immediate: true })

--- a/composables/useREULLocks.ts
+++ b/composables/useREULLocks.ts
@@ -104,9 +104,13 @@ export const useREULLocks = () => {
         }
       }, POLL_INTERVAL_60S_MS)
     }
-    else if (!connected && interval) {
-      clearInterval(interval)
-      interval = null
+    else if (!connected) {
+      locks.value = []
+      isLocksLoading.value = false
+      if (interval) {
+        clearInterval(interval)
+        interval = null
+      }
     }
   }, { immediate: true })
 

--- a/composables/useRewardsApy.ts
+++ b/composables/useRewardsApy.ts
@@ -2,8 +2,10 @@ import type { RewardCampaign } from '~/entities/reward-campaign'
 
 export const useRewardsApy = () => {
   const { settings } = useUserSettings()
+  const { enableMerkl, enableIncentra, enableFuul } = useDeployConfig()
   const { merklCampaigns, getMerklCampaignsForVault } = useMerkl()
   const { brevisCampaigns, getBrevisCampaignsForVault } = useBrevis()
+  const { fuulCampaigns, getFuulCampaignsForVault } = useFuul()
 
   const isEnabled = computed(() => settings.value.enableRewardsApy)
 
@@ -12,7 +14,7 @@ export const useRewardsApy = () => {
   // to ensure they re-run when reward data updates.
   const _versionCounter = ref(0)
   watch(
-    [isEnabled, merklCampaigns, brevisCampaigns],
+    [isEnabled, merklCampaigns, brevisCampaigns, fuulCampaigns],
     () => { _versionCounter.value++ },
   )
   const version = computed(() => _versionCounter.value)
@@ -20,8 +22,9 @@ export const useRewardsApy = () => {
   const getCampaignsForVault = (vaultAddress: string): RewardCampaign[] => {
     if (!isEnabled.value) return []
     return [
-      ...getMerklCampaignsForVault(vaultAddress),
-      ...getBrevisCampaignsForVault(vaultAddress),
+      ...(enableMerkl ? getMerklCampaignsForVault(vaultAddress) : []),
+      ...(enableIncentra ? getBrevisCampaignsForVault(vaultAddress) : []),
+      ...(enableFuul ? getFuulCampaignsForVault(vaultAddress) : []),
     ]
   }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,7 +31,7 @@ Welcome to the documentation for the Euler Lite project. This documentation is d
 
 ### 🔌 [Data Flow and Integrations](./data-flow-and-integrations.md)
 
-- Unified rewards system (Merkl + Brevis)
+- Unified rewards system (Merkl + Brevis + Fuul)
 - Intrinsic APY (multi-provider yield data)
 - Chain switching and stale data prevention
 - Euler Finance protocol integration
@@ -92,7 +92,7 @@ Welcome to the documentation for the Euler Lite project. This documentation is d
 - **Repay from Savings**: Repay debt using savings positions (same or cross-asset)
 - **Explore Markets**: Discover and compare markets grouped by curator/product
 - **Manage Portfolio**: Track positions, rewards, and performance
-- **Access Rewards**: Participate in Merkl and Brevis reward programs
+- **Access Rewards**: Participate in Merkl, Brevis, and Fuul reward programs
 
 ## 🏛️ Key Technologies
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,7 +31,7 @@ Welcome to the documentation for the Euler Lite project. This documentation is d
 
 ### 🔌 [Data Flow and Integrations](./data-flow-and-integrations.md)
 
-- Unified rewards system (Merkl + Brevis + Fuul)
+- Unified rewards system (Merkl + Incentra + Fuul)
 - Intrinsic APY (multi-provider yield data)
 - Chain switching and stale data prevention
 - Euler Finance protocol integration
@@ -92,7 +92,7 @@ Welcome to the documentation for the Euler Lite project. This documentation is d
 - **Repay from Savings**: Repay debt using savings positions (same or cross-asset)
 - **Explore Markets**: Discover and compare markets grouped by curator/product
 - **Manage Portfolio**: Track positions, rewards, and performance
-- **Access Rewards**: Participate in Merkl, Brevis, and Fuul reward programs
+- **Access Rewards**: Participate in Merkl, Incentra, and Fuul reward programs
 
 ## 🏛️ Key Technologies
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -48,7 +48,7 @@ The application follows Vue 3's Composition API pattern, organizing code into lo
 ├─────────────────────────────────────────────────────────────────┤
 │                        Entities                                 │
 │  ┌─────────────┐ ┌─────────────┐ ┌─────────────┐                │
-│  │   Vault     │ │   Account   │ │   Merkl     │                │
+│  │   Vault     │ │   Account   │ │  Rewards    │                │
 │  └─────────────┘ └─────────────┘ └─────────────┘                │
 └─────────────────────────────────────────────────────────────────┘
 ```
@@ -183,8 +183,8 @@ The application follows Vue 3's Composition API pattern, organizing code into lo
 │                    External Services                            │
 │  ┌─────────────┐ ┌─────────────┐ ┌─────────────┐                │
 │  │ Euler       │ │ EVM RPC     │ │ Merkl /     │                │
-│  │ Finance     │ │ (multi-     │ │ Brevis      │                │
-│  │             │ │  chain)     │ │ Rewards     │                │
+│  │ Finance     │ │ (multi-     │ │ Brevis /    │                │
+│  │             │ │  chain)     │ │ Fuul        │                │
 │  └─────────────┘ └─────────────┘ └─────────────┘                │
 └─────────────────────────────────────────────────────────────────┘
 ```

--- a/docs/data-flow-and-integrations.md
+++ b/docs/data-flow-and-integrations.md
@@ -147,7 +147,7 @@ The rewards system was unified in a refactor that introduced the `RewardCampaign
 
 #### Architecture
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────────┐
 │                    Reward Providers                             │
 │  ┌─────────────┐ ┌─────────────┐ ┌─────────────┐                │
@@ -231,7 +231,7 @@ The system uses a **provider abstraction** with three implementations:
 - **Pendle** — per-market API fetch for PT implied yield, with maturity detection
 - **Securitize** — public feed fetch for tokenized RWA yield, symbol-based matching
 
-All lookups are by **token address** (not symbol). Results are cached for 5 minutes with automatic chain-switch invalidation. APY modals show provider name and source link for transparency.
+All lookups are by **token address** (except Securitize, which uses symbol-based matching). Results are cached for 5 minutes with automatic chain-switch invalidation. APY modals show provider name and source link for transparency.
 
 #### Key API
 

--- a/docs/data-flow-and-integrations.md
+++ b/docs/data-flow-and-integrations.md
@@ -33,6 +33,10 @@ The Euler Lite application integrates with multiple external systems to provide 
 │  │ DeFi Llama  │ │ Pendle API  │ │ Securitize  │                │
 │  │ (yields)    │ │ (PT yield)  │ │ (RWA yield) │                │
 │  └─────────────┘ └─────────────┘ └─────────────┘                │
+│  ┌─────────────┐                                                 │
+│  │ Stablewatch │                                                 │
+│  │ (APY, proxy)│                                                 │
+│  └─────────────┘                                                 │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
@@ -230,8 +234,9 @@ The system uses a **provider abstraction** with three implementations:
 - **DefiLlama** — bulk pool fetch, poolId-based matching, 30-day average APY
 - **Pendle** — per-market API fetch for PT implied yield, with maturity detection
 - **Securitize** — public feed fetch for tokenized RWA yield, symbol-based matching
+- **Stablewatch** — server-proxied API for stablecoin/yield-bearing token APY, chain+address matching (requires `STABLEWATCH_API_KEY`)
 
-All lookups are by **token address** (except Securitize, which uses symbol-based matching). Results are cached for 5 minutes with automatic chain-switch invalidation. APY modals show provider name and source link for transparency.
+All lookups are by **token address** (except Securitize, which uses symbol-based matching). Stablewatch uses a server proxy to keep the API key server-side. Results are cached for 5 minutes with automatic chain-switch invalidation. APY modals show provider name and source link for transparency.
 
 #### Key API
 

--- a/docs/data-flow-and-integrations.md
+++ b/docs/data-flow-and-integrations.md
@@ -210,7 +210,7 @@ interface RewardCampaign {
 
 - **useMerkl** — Fetches campaigns from the Merkl API, maps `subType` indices (0 = lend, 1 = borrow, 2 = borrow-collateral) to `RewardCampaignType`. Also handles user reward balances, claiming, and REUL lock management.
 - **useBrevis** — Fetches ZK-proof reward campaigns from the Brevis/Incentra backend, normalizes them to `RewardCampaign`.
-- **useFuul** — Fetches incentive campaigns from the Fuul API, normalizes them to `RewardCampaign`. Currently supports campaign APY aggregation only (claiming not yet available).
+- **useFuul** — Fetches incentive campaigns from the Fuul API, normalizes them to `RewardCampaign`. Supports campaign APY aggregation and reward claiming via FuulManager contract. User reward totals and claim checks are fetched through server-side proxy routes (`/api/fuul/totals`, `/api/fuul/claim-checks`) to keep the `FUUL_API_KEY` secret.
 
 #### Consuming Rewards in UI
 

--- a/docs/data-flow-and-integrations.md
+++ b/docs/data-flow-and-integrations.md
@@ -230,7 +230,7 @@ const borrowReward = getBorrowRewardApy(borrowVault.address, collateral.address)
 
 The `useIntrinsicApy` composable (`composables/useIntrinsicApy.ts`) adds yield intrinsic to the underlying asset (e.g., stETH staking yield, sDAI DSR, Pendle PT implied yield) on top of vault lending/borrowing APY.
 
-The system uses a **provider abstraction** with three implementations:
+The system uses a **provider abstraction** with four implementations:
 - **DefiLlama** — bulk pool fetch, poolId-based matching, 30-day average APY
 - **Pendle** — per-market API fetch for PT implied yield, with maturity detection
 - **Securitize** — public feed fetch for tokenized RWA yield, symbol-based matching

--- a/docs/data-flow-and-integrations.md
+++ b/docs/data-flow-and-integrations.md
@@ -164,9 +164,11 @@ The rewards system was unified in a refactor that introduced the `RewardCampaign
 │  ┌─────────────┐ ┌─────────────┐ ┌─────────────┐                │
 │  │ useMerkl    │ │ useBrevis   │ │ useFuul     │                │
 │  │ (campaigns, │ │ (campaigns, │ │ (campaigns) │                │
-│  │  claiming,  │ │  ZK proofs) │ │             │                │
-│  │  REUL locks)│ │             │ │             │                │
+│  │  claiming)  │ │  ZK proofs) │ │             │                │
 │  └─────────────┘ └─────────────┘ └─────────────┘                │
+│  ┌──────────────┐                                               │
+│  │ useREULLocks │ (separate composable, not part of Merkl)      │
+│  └──────────────┘                                               │
 │           │               │                                     │
 │           ▼               ▼                                     │
 ├─────────────────────────────────────────────────────────────────┤
@@ -208,7 +210,8 @@ interface RewardCampaign {
 
 #### Provider Details
 
-- **useMerkl** — Fetches campaigns from the Merkl API, maps `subType` indices (0 = lend, 1 = borrow, 2 = borrow-collateral) to `RewardCampaignType`. Also handles user reward balances, claiming, and REUL lock management.
+- **useMerkl** — Fetches campaigns from the Merkl API, maps `subType` indices (0 = lend, 1 = borrow, 2 = borrow-collateral) to `RewardCampaignType`. Also handles user reward balances and claiming.
+- **useREULLocks** — Reads locked rEUL positions directly from the rEUL contract on-chain (`getLockedAmounts`, `getWithdrawAmountsByLockTimestamp`) and handles unlocking via `withdrawToByLockTimestamp()`. This is independent from Merkl.
 - **useBrevis** — Fetches ZK-proof reward campaigns from the Brevis/Incentra backend, normalizes them to `RewardCampaign`.
 - **useFuul** — Fetches incentive campaigns from the Fuul API, normalizes them to `RewardCampaign`. Supports campaign APY aggregation and reward claiming via FuulManager contract. User reward totals and claim checks are fetched through server-side proxy routes (`/api/fuul/totals`, `/api/fuul/claim-checks`) to keep the `FUUL_API_KEY` secret.
 
@@ -2389,7 +2392,7 @@ const claim = async () => {
 
 - [Back to the top](#table-of-contents)
 
-#### Locks fetching, storing it in useMerkl composable
+#### Locks fetching, storing it in useREULLocks composable
 
 ```typescript
 const locks: Ref<REULLock[]> = ref([]);
@@ -2510,7 +2513,8 @@ const unlockREUL = async (lockTimestamps: bigint[]) => {
 
 ```vue
 <script setup lang="ts">
-const { rewards, isRewardsLoading, locks, isLocksLoading } = useMerkl();
+const { rewards, isRewardsLoading } = useMerkl();
+const { locks, isLocksLoading } = useREULLocks();
 </script>
 
 <template>

--- a/docs/data-flow-and-integrations.md
+++ b/docs/data-flow-and-integrations.md
@@ -16,7 +16,7 @@ The Euler Lite application integrates with multiple external systems to provide 
 │  ┌─────────────┐ ┌─────────────┐ ┌─────────────┐                │
 │  │ Wagmi/Viem  │ │ Euler       │ │ Rewards     │                │
 │  │ (EVM RPC)   │ │ Finance     │ │ (Merkl +    │                │
-│  │             │ │             │ │  Brevis)    │                │
+│  │             │ │             │ │ Brevis+Fuul)│                │
 │  └─────────────┘ └─────────────┘ └─────────────┘                │
 ├─────────────────────────────────────────────────────────────────┤
 │                    External Services                            │
@@ -26,8 +26,12 @@ The Euler Lite application integrates with multiple external systems to provide 
 │  │  chain)     │ │             │ │             │                │
 │  └─────────────┘ └─────────────┘ └─────────────┘                │
 │  ┌─────────────┐ ┌─────────────┐ ┌─────────────┐                │
-│  │ Merkl API   │ │ Brevis API  │ │ DeFi Llama  │                │
-│  │ (rewards)   │ │ (ZK proofs) │ │ (yields)    │                │
+│  │ Merkl API   │ │ Brevis API  │ │ Fuul API    │                │
+│  │ (rewards)   │ │ (ZK proofs) │ │ (incentives)│                │
+│  └─────────────┘ └─────────────┘ └─────────────┘                │
+│  ┌─────────────┐ ┌─────────────┐ ┌─────────────┐                │
+│  │ DeFi Llama  │ │ Pendle API  │ │ Securitize  │                │
+│  │ (yields)    │ │ (PT yield)  │ │ (RWA yield) │                │
 │  └─────────────┘ └─────────────┘ └─────────────┘                │
 └─────────────────────────────────────────────────────────────────┘
 ```
@@ -47,7 +51,7 @@ The Euler Lite application integrates with multiple external systems to provide 
 │                    Data Integration Layer                       │
 │  ┌─────────────┐ ┌─────────────┐ ┌─────────────┐                │
 │  │ Vault Lens  │ │ EVC Batch   │ │ Merkl/Brevis│                │
-│  │ Multicall   │ │ Simulation  │ │ Clients     │                │
+│  │ Multicall   │ │ Simulation  │ │ /Fuul       │                │
 │  └─────────────┘ └─────────────┘ └─────────────┘                │
 │           │               │               │                     │
 │           ▼               ▼               ▼                     │
@@ -139,26 +143,26 @@ The Euler Lite application integrates with multiple external systems to provide 
 
 - [Back to the top](#table-of-contents)
 
-The rewards system was unified in a refactor that introduced the `RewardCampaign` type, consolidating data from multiple reward providers into a single interface.
+The rewards system was unified in a refactor that introduced the `RewardCampaign` type, consolidating data from multiple reward providers into a single interface. Each provider can be independently toggled via environment variable feature flags (`NUXT_PUBLIC_CONFIG_ENABLE_MERKL`, `NUXT_PUBLIC_CONFIG_ENABLE_INCENTRA`, `NUXT_PUBLIC_CONFIG_ENABLE_FUUL`).
 
 #### Architecture
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
 │                    Reward Providers                             │
-│  ┌─────────────┐ ┌─────────────┐                                │
-│  │ Merkl API   │ │ Brevis API  │                                │
-│  └─────────────┘ └─────────────┘                                │
-│           │               │                                     │
-│           ▼               ▼                                     │
+│  ┌─────────────┐ ┌─────────────┐ ┌─────────────┐                │
+│  │ Merkl API   │ │ Brevis API  │ │ Fuul API    │                │
+│  └─────────────┘ └─────────────┘ └─────────────┘                │
+│           │               │               │                     │
+│           ▼               ▼               ▼                     │
 ├─────────────────────────────────────────────────────────────────┤
 │              Provider Composables                               │
-│  ┌─────────────┐ ┌─────────────┐                                │
-│  │ useMerkl    │ │ useBrevis   │                                │
-│  │ (campaigns, │ │ (campaigns, │                                │
-│  │  claiming,  │ │  ZK proofs) │                                │
-│  │  REUL locks)│ │             │                                │
-│  └─────────────┘ └─────────────┘                                │
+│  ┌─────────────┐ ┌─────────────┐ ┌─────────────┐                │
+│  │ useMerkl    │ │ useBrevis   │ │ useFuul     │                │
+│  │ (campaigns, │ │ (campaigns, │ │ (campaigns) │                │
+│  │  claiming,  │ │  ZK proofs) │ │             │                │
+│  │  REUL locks)│ │             │ │             │                │
+│  └─────────────┘ └─────────────┘ └─────────────┘                │
 │           │               │                                     │
 │           ▼               ▼                                     │
 ├─────────────────────────────────────────────────────────────────┤
@@ -192,7 +196,7 @@ interface RewardCampaign {
   collateral?: string               // For borrow-collateral campaigns
   type: RewardCampaignType          // 'euler_lend' | 'euler_borrow' | 'euler_borrow_collateral'
   apr: number                       // Annual percentage rate
-  provider: 'merkl' | 'brevis'     // Which provider sourced this campaign
+  provider: 'merkl' | 'brevis' | 'fuul'  // Which provider sourced this campaign
   endTimestamp: number              // Campaign expiry
   rewardToken?: { symbol: string; icon: string }
 }
@@ -201,7 +205,8 @@ interface RewardCampaign {
 #### Provider Details
 
 - **useMerkl** — Fetches campaigns from the Merkl API, maps `subType` indices (0 = lend, 1 = borrow, 2 = borrow-collateral) to `RewardCampaignType`. Also handles user reward balances, claiming, and REUL lock management.
-- **useBrevis** — Fetches ZK-proof reward campaigns from the Brevis backend, normalizes them to `RewardCampaign`.
+- **useBrevis** — Fetches ZK-proof reward campaigns from the Brevis/Incentra backend, normalizes them to `RewardCampaign`.
+- **useFuul** — Fetches incentive campaigns from the Fuul API, normalizes them to `RewardCampaign`. Currently supports campaign APY aggregation only (claiming not yet available).
 
 #### Consuming Rewards in UI
 
@@ -221,9 +226,10 @@ const borrowReward = getBorrowRewardApy(borrowVault.address, collateral.address)
 
 The `useIntrinsicApy` composable (`composables/useIntrinsicApy.ts`) adds yield intrinsic to the underlying asset (e.g., stETH staking yield, sDAI DSR, Pendle PT implied yield) on top of vault lending/borrowing APY.
 
-The system uses a **provider abstraction** with two implementations:
+The system uses a **provider abstraction** with three implementations:
 - **DefiLlama** — bulk pool fetch, poolId-based matching, 30-day average APY
 - **Pendle** — per-market API fetch for PT implied yield, with maturity detection
+- **Securitize** — public feed fetch for tokenized RWA yield, symbol-based matching
 
 All lookups are by **token address** (not symbol). Results are cached for 5 minutes with automatic chain-switch invalidation. APY modals show provider name and source link for transparency.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -11,7 +11,7 @@ Welcome to the Euler Lite project! This guide will help you get up and running w
 - **Lending**: Users can deposit assets to earn yield
 - **Borrowing**: Users can borrow assets using collateral
 - **Portfolio Management**: Track positions and performance
-- **Rewards**: Participate in Merkl reward programs
+- **Rewards**: Participate in Merkl, Incentra, and Fuul reward programs
 - **Multi-chain**: Connect to any EVM-compatible network
 
 ## 🏗️ Technology Stack
@@ -132,6 +132,12 @@ NUXT_PUBLIC_SUBGRAPH_URI_1=https://your-subgraph.com
 - **Purpose**: Reward distribution and management
 - **Integration**: API for opportunities and rewards
 - **Data Source**: Campaign information, user rewards
+
+### Fuul
+
+- **Purpose**: Incentive campaign distribution
+- **Integration**: API for incentive campaigns
+- **Data Source**: Campaign APR data (claiming not yet available)
 
 ## 🆘 Common Issues
 

--- a/docs/intrinsic-apy.md
+++ b/docs/intrinsic-apy.md
@@ -16,15 +16,16 @@ The system uses a **provider abstraction** to support multiple APY data sources.
 │  - chain-switch invalidation│
 └──────────┬──────────────────┘
            │ Promise.allSettled
-    ┌──────┴──────┐
-    ▼             ▼
-┌─────────┐  ┌─────────┐
-│DefiLlama│  │ Pendle  │     Providers
-│Provider │  │Provider │
-└────┬────┘  └────┬────┘
-     │            │
-     ▼            ▼
-  yields API   Pendle V2 API
+    ┌──────┼──────────────┐
+    ▼      ▼              ▼
+┌─────────┐ ┌─────────┐ ┌──────────┐
+│DefiLlama│ │ Pendle  │ │Securitize│  Providers
+│Provider │ │Provider │ │Provider  │
+└────┬────┘ └────┬────┘ └────┬─────┘
+     │           │           │
+     ▼           ▼           ▼
+  yields API  Pendle V2   Securitize
+              API         public feed
 ```
 
 ### Types (`entities/intrinsic-apy.ts`)
@@ -55,9 +56,10 @@ All intrinsic APY sources are configured as a static array with discriminated un
 type IntrinsicApySourceConfig =
   | { provider: 'defillama'; address: string; chainId: number; poolId: string; useSpotApy?: boolean }
   | { provider: 'pendle'; address: string; chainId: number; pendleMarket: string; crossChainSourceChainId?: number }
+  | { provider: 'securitize'; address: string; chainId: number; symbol: string; yieldField: 'nav_yield_30d' | 'distribution_yield' }
 ```
 
-Each entry maps a token address on a specific chain to its data source. DefiLlama entries reference a pool UUID; Pendle entries reference a Pendle market address.
+Each entry maps a token address on a specific chain to its data source. DefiLlama entries reference a pool UUID; Pendle entries reference a Pendle market address; Securitize entries reference a token symbol and which yield field to read.
 
 ## Providers
 
@@ -81,6 +83,16 @@ Covers Pendle Principal Tokens (PTs) which earn implied yield from Pendle's fixe
 - **Maturity detection**: If the market's `timestamp` is older than 2 hours, the PT has matured and APY is set to 0
 - **Cross-chain**: Use `crossChainSourceChainId` for PTs whose Pendle market lives on a different chain than the token
 - **Source URL**: `https://app.pendle.finance/trade/markets`
+
+### Securitize (`services/intrinsicApy/securitizeProvider.ts`)
+
+Covers tokenized real-world assets (RWAs) with native yield from Securitize's public feed.
+
+- **API**: Fetch from `https://public-feed.securitize.io/asset-stats?symbol={symbol}`
+- **Matching**: Groups config entries by symbol, fetches per-symbol, matches by token address
+- **APY value**: Reads the configured `yieldField` — either `nav_yield_30d` (30-day NAV yield) or `distribution_yield`
+- **Source URL**: `https://public-feed.securitize.io/asset-stats?symbol={symbol}`
+- **Provider name**: "Securitize"
 
 ## Composable (`composables/useIntrinsicApy.ts`)
 
@@ -148,6 +160,7 @@ modal.open(VaultSupplyApyModal, {
    const providers: IntrinsicApyProvider[] = [
      createDefiLlamaProvider(intrinsicApySources),
      createPendleProvider(intrinsicApySources),
+     createSecuritizeProvider(intrinsicApySources),
      createMyProvider(intrinsicApySources),  // new
    ]
    ```
@@ -172,6 +185,15 @@ modal.open(VaultSupplyApyModal, {
    ```
 3. Pendle PTs mature — periodically remove expired entries and add new ones
 
+### Securitize
+
+1. Find the token symbol and address on Securitize's public feed
+2. Determine which yield field to use (`nav_yield_30d` for NAV-based yield, `distribution_yield` for distribution-based)
+3. Add an entry:
+   ```typescript
+   { provider: 'securitize', address: '0x...token', chainId: 1, symbol: 'BUIDL', yieldField: 'nav_yield_30d' }
+   ```
+
 ## Files
 
 | File | Purpose |
@@ -180,6 +202,7 @@ modal.open(VaultSupplyApyModal, {
 | `entities/custom.ts` | Config array mapping tokens to providers (`intrinsicApySources`) |
 | `services/intrinsicApy/defillamaProvider.ts` | DefiLlama provider (bulk pool fetch, poolId matching) |
 | `services/intrinsicApy/pendleProvider.ts` | Pendle provider (per-market API, batch concurrency, maturity detection) |
+| `services/intrinsicApy/securitizeProvider.ts` | Securitize provider (public feed, symbol-based batching) |
 | `composables/useIntrinsicApy.ts` | Orchestrator composable (TTL cache, multi-provider, address lookup) |
 | `components/entities/vault/VaultSupplyApyModal.vue` | Supply APY modal with source attribution |
 | `components/entities/vault/VaultBorrowApyModal.vue` | Borrow APY modal with source attribution |

--- a/docs/intrinsic-apy.md
+++ b/docs/intrinsic-apy.md
@@ -18,14 +18,14 @@ The system uses a **provider abstraction** to support multiple APY data sources.
            │ Promise.allSettled
     ┌──────┼──────────────┐
     ▼      ▼              ▼
-┌─────────┐ ┌─────────┐ ┌──────────┐
-│DefiLlama│ │ Pendle  │ │Securitize│  Providers
-│Provider │ │Provider │ │Provider  │
-└────┬────┘ └────┬────┘ └────┬─────┘
-     │           │           │
-     ▼           ▼           ▼
-  yields API  Pendle V2   Securitize
-              API         public feed
+┌─────────┐ ┌─────────┐ ┌──────────┐ ┌───────────┐
+│DefiLlama│ │ Pendle  │ │Securitize│ │Stablewatch│  Providers
+│Provider │ │Provider │ │Provider  │ │Provider   │
+└────┬────┘ └────┬────┘ └────┬─────┘ └─────┬─────┘
+     │           │           │              │
+     ▼           ▼           ▼              ▼
+  yields API  Pendle V2   Securitize   /api/stablewatch-pools
+              API         public feed  (server proxy)
 ```
 
 ### Types (`entities/intrinsic-apy.ts`)
@@ -57,9 +57,10 @@ type IntrinsicApySourceConfig =
   | { provider: 'defillama'; address: string; chainId: number; poolId: string; useSpotApy?: boolean }
   | { provider: 'pendle'; address: string; chainId: number; pendleMarket: string; crossChainSourceChainId?: number }
   | { provider: 'securitize'; address: string; chainId: number; symbol: string; yieldField: 'nav_yield_30d' | 'distribution_yield' }
+  | { provider: 'stablewatch'; address: string; chainId: number }
 ```
 
-Each entry maps a token address on a specific chain to its data source. DefiLlama entries reference a pool UUID; Pendle entries reference a Pendle market address; Securitize entries reference a token symbol and which yield field to read.
+Each entry maps a token address on a specific chain to its data source. DefiLlama entries reference a pool UUID; Pendle entries reference a Pendle market address; Securitize entries reference a token symbol and which yield field to read; Stablewatch entries only need the address and chain ID (matching is done automatically via the API response).
 
 ## Providers
 
@@ -93,6 +94,17 @@ Covers tokenized real-world assets (RWAs) with native yield from Securitize's pu
 - **APY value**: Reads the configured `yieldField` — either `nav_yield_30d` (30-day NAV yield) or `distribution_yield`
 - **Source URL**: `https://public-feed.securitize.io/asset-stats?symbol={symbol}`
 - **Provider name**: "Securitize"
+
+### Stablewatch (`services/intrinsicApy/stablewatchProvider.ts`)
+
+Covers stablecoins and yield-bearing tokens tracked by Stablewatch. Unlike the other providers, Stablewatch requires an API key, so requests go through a server-side proxy.
+
+- **API**: Server proxy at `/api/stablewatch-pools` (proxies `https://api.stablewatch.io/api/pools`)
+- **API key**: `STABLEWATCH_API_KEY` env var (server-side only). If not set, the proxy returns empty data and the provider produces zero results.
+- **Matching**: Converts `chainId` to a chain name (e.g. 1 → "ethereum", 42161 → "arbitrumone"), then matches by `chainName:address` against the pool's token list
+- **APY value**: `metrics.apy.avg7d` (7-day average)
+- **Source URL**: `https://stablewatch.io`
+- **Provider name**: "Stablewatch"
 
 ## Composable (`composables/useIntrinsicApy.ts`)
 
@@ -164,7 +176,7 @@ modal.open(VaultSupplyApyModal, {
      createMyProvider(intrinsicApySources),  // new
    ]
    ```
-5. Add the API domain to the CSP `connect-src` in `nuxt.config.ts`
+5. Add the API domain to the CSP `connect-src` in `nuxt.config.ts` (not needed for server-proxied providers)
 
 ## Adding New Tokens
 
@@ -194,6 +206,15 @@ modal.open(VaultSupplyApyModal, {
    { provider: 'securitize', address: '0x...token', chainId: 1, symbol: 'BUIDL', yieldField: 'nav_yield_30d' }
    ```
 
+### Stablewatch
+
+1. Find the token address and chain ID
+2. Ensure `STABLEWATCH_API_KEY` is set in the server environment
+3. Add an entry:
+   ```typescript
+   { provider: 'stablewatch', address: '0x...token', chainId: 1 }
+   ```
+
 ## Files
 
 | File | Purpose |
@@ -203,6 +224,8 @@ modal.open(VaultSupplyApyModal, {
 | `services/intrinsicApy/defillamaProvider.ts` | DefiLlama provider (bulk pool fetch, poolId matching) |
 | `services/intrinsicApy/pendleProvider.ts` | Pendle provider (per-market API, batch concurrency, maturity detection) |
 | `services/intrinsicApy/securitizeProvider.ts` | Securitize provider (public feed, symbol-based batching) |
+| `services/intrinsicApy/stablewatchProvider.ts` | Stablewatch provider (server-proxied, chain+address matching) |
+| `server/api/stablewatch-pools.get.ts` | Nitro server proxy for Stablewatch API (keeps API key server-side) |
 | `composables/useIntrinsicApy.ts` | Orchestrator composable (TTL cache, multi-provider, address lookup) |
 | `components/entities/vault/VaultSupplyApyModal.vue` | Supply APY modal with source attribution |
 | `components/entities/vault/VaultBorrowApyModal.vue` | Borrow APY modal with source attribution |

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -117,6 +117,7 @@ composables/
 ├── useAddressScreen.ts             # Address screening (compliance)
 ├── useBestMaxROE.ts                # Best max ROE calculations for sorting/filtering
 ├── useBrevis.ts                    # Brevis ZK proof rewards integration
+├── useFuul.ts                     # Fuul incentive campaign integration
 ├── useChainConfig.ts               # Dynamic chain derivation from RPC_URL_HTTP_* env vars
 ├── useCustomFilters.ts             # Generic custom metric filter system (gt/lt)
 ├── useCustomTokenResolver.ts       # Custom token metadata resolution
@@ -140,7 +141,7 @@ composables/
 ├── useReactiveMap.ts               # Race-guarded async watchEffect pattern
 ├── useREULLocks.ts                 # REUL token lock management
 ├── useRepaySavingsOptions.ts       # Savings position selection for repay-from-savings
-├── useRewardsApy.ts                # Unified reward APY aggregation (Merkl + Brevis)
+├── useRewardsApy.ts                # Unified reward APY aggregation (Merkl + Brevis + Fuul)
 ├── useSlippage.ts                  # Swap slippage settings (with save button)
 ├── useSwapApi.ts                   # Swap API integration
 ├── useSwapCollateralOptions.ts     # Swap collateral selection
@@ -178,6 +179,7 @@ entities/
 ├── account.ts               # Account-related data models
 ├── brevis.ts                # Brevis ZK proof types
 ├── chainRegistry.ts         # Chain registry and multi-chain config
+├── fuul.ts                  # Fuul incentive API types
 ├── constants.ts             # Shared constants
 ├── country-constants.ts     # Country codes and group aliases (EU, EEA, EFTA)
 ├── custom.ts                # Theme hue and intrinsic APY source config (DefiLlama pools + Pendle PTs)
@@ -193,7 +195,7 @@ entities/
 ├── oracle-providers.ts      # Oracle provider type definitions
 ├── permit2.ts               # Permit2 approval types
 ├── reul.ts                  # REUL token types
-├── reward-campaign.ts       # Unified RewardCampaign type (Merkl + Brevis)
+├── reward-campaign.ts       # Unified RewardCampaign type (Merkl + Brevis + Fuul)
 ├── saHooksSDK.ts            # Smart account hooks builder
 ├── swap.ts                  # Swap types and utilities
 ├── token.ts                 # Token data models

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -116,7 +116,7 @@ composables/
 ├── useAccountValues.ts             # Position USD value calculations
 ├── useAddressScreen.ts             # Address screening (compliance)
 ├── useBestMaxROE.ts                # Best max ROE calculations for sorting/filtering
-├── useBrevis.ts                    # Brevis ZK proof rewards integration
+├── useBrevis.ts                    # Incentra (Brevis) rewards integration
 ├── useFuul.ts                     # Fuul incentive campaign integration
 ├── useChainConfig.ts               # Dynamic chain derivation from RPC_URL_HTTP_* env vars
 ├── useCustomFilters.ts             # Generic custom metric filter system (gt/lt)
@@ -141,7 +141,7 @@ composables/
 ├── useReactiveMap.ts               # Race-guarded async watchEffect pattern
 ├── useREULLocks.ts                 # REUL token lock management
 ├── useRepaySavingsOptions.ts       # Savings position selection for repay-from-savings
-├── useRewardsApy.ts                # Unified reward APY aggregation (Merkl + Brevis + Fuul)
+├── useRewardsApy.ts                # Unified reward APY aggregation (Merkl + Incentra + Fuul)
 ├── useSlippage.ts                  # Swap slippage settings (with save button)
 ├── useSwapApi.ts                   # Swap API integration
 ├── useSwapCollateralOptions.ts     # Swap collateral selection
@@ -177,7 +177,7 @@ composables/
 ```
 entities/
 ├── account.ts               # Account-related data models
-├── brevis.ts                # Brevis ZK proof types
+├── brevis.ts                # Incentra (Brevis) types
 ├── chainRegistry.ts         # Chain registry and multi-chain config
 ├── fuul.ts                  # Fuul incentive API types
 ├── constants.ts             # Shared constants
@@ -195,7 +195,7 @@ entities/
 ├── oracle-providers.ts      # Oracle provider type definitions
 ├── permit2.ts               # Permit2 approval types
 ├── reul.ts                  # REUL token types
-├── reward-campaign.ts       # Unified RewardCampaign type (Merkl + Brevis + Fuul)
+├── reward-campaign.ts       # Unified RewardCampaign type (Merkl + Incentra + Fuul)
 ├── saHooksSDK.ts            # Smart account hooks builder
 ├── swap.ts                  # Swap types and utilities
 ├── token.ts                 # Token data models

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -368,6 +368,7 @@ abis/
 ├── brevis.ts                # Brevis contract ABI
 ├── erc20.ts                 # ERC-20 token ABI
 ├── evc.ts                   # EVC (Ethereum Vault Connector) ABI
+├── fuul.ts                  # Fuul Manager + Factory ABIs
 ├── merkl.ts                 # Merkl distributor ABI
 ├── pyth.ts                  # Pyth oracle contract ABI
 ├── reul.ts                  # REUL token ABI

--- a/docs/transaction-building.md
+++ b/docs/transaction-building.md
@@ -17,7 +17,7 @@ interface TxPlan {
   kind: 'supply' | 'withdraw' | 'borrow' | 'repay' | 'full-repay'
       | 'savings-repay' | 'savings-full-repay' | 'swap-collateral-full-repay'
       | 'swap-savings-full-repay' | 'disable-collateral' | 'reward'
-      | 'brevis-reward' | 'reul-unlock' | string
+      | 'brevis-reward' | 'fuul-reward' | 'reul-unlock' | string
   steps: TxStep[]
 }
 ```

--- a/entities/constants.ts
+++ b/entities/constants.ts
@@ -136,6 +136,8 @@ export const SECURITIZE_FEED_URL = 'https://public-feed.securitize.io/asset-stat
 export const BREVIS_API_URL = 'https://incentra-prd.brevis.network/sdk/v1/eulerCampaigns'
 export const BREVIS_MERKLE_PROOF_URL = 'https://incentra-prd.brevis.network/v1/getMerkleProofsBatch'
 export const FUUL_API_BASE_URL = 'https://api.fuul.xyz/api/v1'
+export const FUUL_MANAGER_ADDRESS = '0x8a0836dA623ea1083c85acB958DeEa3716b39dc6'
+export const FUUL_FACTORY_ADDRESS = '0xa0080A60EE9f1985151161Fa6b09652Dc46afdEF'
 export const STABLEWATCH_POOLS_URL = 'https://api.stablewatch.io/api/pools'
 export const STABLEWATCH_SOURCE_URL = 'https://stablewatch.io'
 

--- a/entities/constants.ts
+++ b/entities/constants.ts
@@ -135,6 +135,7 @@ export const DEFILLAMA_YIELDS_URL = 'https://yields.llama.fi/pools'
 export const SECURITIZE_FEED_URL = 'https://public-feed.securitize.io/asset-stats'
 export const BREVIS_API_URL = 'https://incentra-prd.brevis.network/sdk/v1/eulerCampaigns'
 export const BREVIS_MERKLE_PROOF_URL = 'https://incentra-prd.brevis.network/v1/getMerkleProofsBatch'
+export const FUUL_API_BASE_URL = 'https://api.fuul.xyz/api/v1'
 
 // Re-export geo-blocking constants (separated to avoid pulling BigInt into server builds)
 export { SANCTIONED_COUNTRIES, EU_COUNTRIES, EEA_COUNTRIES, EFTA_COUNTRIES, COUNTRY_GROUPS } from './country-constants'

--- a/entities/constants.ts
+++ b/entities/constants.ts
@@ -136,6 +136,8 @@ export const SECURITIZE_FEED_URL = 'https://public-feed.securitize.io/asset-stat
 export const BREVIS_API_URL = 'https://incentra-prd.brevis.network/sdk/v1/eulerCampaigns'
 export const BREVIS_MERKLE_PROOF_URL = 'https://incentra-prd.brevis.network/v1/getMerkleProofsBatch'
 export const FUUL_API_BASE_URL = 'https://api.fuul.xyz/api/v1'
+export const STABLEWATCH_POOLS_URL = 'https://api.stablewatch.io/api/pools'
+export const STABLEWATCH_SOURCE_URL = 'https://stablewatch.io'
 
 // Re-export geo-blocking constants (separated to avoid pulling BigInt into server builds)
 export { SANCTIONED_COUNTRIES, EU_COUNTRIES, EEA_COUNTRIES, EFTA_COUNTRIES, COUNTRY_GROUPS } from './country-constants'

--- a/entities/custom.ts
+++ b/entities/custom.ts
@@ -6,6 +6,7 @@ export type IntrinsicApySourceConfig =
   | { provider: 'defillama', address: string, chainId: number, poolId: string, useSpotApy?: boolean }
   | { provider: 'pendle', address: string, chainId: number, pendleMarket: string, crossChainSourceChainId?: number }
   | { provider: 'securitize', address: string, chainId: number, symbol: string, yieldField: 'nav_yield_30d' | 'distribution_yield' }
+  | { provider: 'stablewatch', address: string, chainId: number }
 
 export const intrinsicApySources: readonly IntrinsicApySourceConfig[] = [
   // DefiLlama pools — Ethereum (1)
@@ -178,4 +179,35 @@ export const intrinsicApySources: readonly IntrinsicApySourceConfig[] = [
   { provider: 'securitize', chainId: 1, address: '0x17418038ecF73BA4026c4f428547BF099706F27B', symbol: 'ACRED', yieldField: 'nav_yield_30d' },
   { provider: 'securitize', chainId: 1, address: '0x2255718832bC9fD3bE1CaF75084F4803DA14FF01', symbol: 'VBILL', yieldField: 'distribution_yield' },
   { provider: 'securitize', chainId: 1, address: '0x51C2d74017390CbBd30550179A16A1c28F7210fc', symbol: 'STAC', yieldField: 'nav_yield_30d' },
+
+  // Stablewatch tokens — Ethereum (1)
+  { provider: 'stablewatch', chainId: 1, address: '0x89E93172AEF8261Db8437b90c3dCb61545a05317' },
+  { provider: 'stablewatch', chainId: 1, address: '0x1CE7D9942ff78c328A4181b9F3826fEE6D845A97' },
+  { provider: 'stablewatch', chainId: 1, address: '0x0aBd93dA8387B5Ef0511a2859d85D84fe4519e94' },
+
+  // Stablewatch tokens — BSC (56)
+  { provider: 'stablewatch', chainId: 56, address: '0x7788A3538C5fc7F9c7C8A74EAC4c898fC8d87d92' },
+
+  // Stablewatch tokens — Sonic (146)
+  { provider: 'stablewatch', chainId: 146, address: '0x3D75F2BB8aBcDBd1e27443cB5CBCE8A668046C81' },
+  { provider: 'stablewatch', chainId: 146, address: '0x9fb76f7ce5FCeAA2C42887ff441D46095E494206' },
+
+  // Stablewatch tokens — TAC (239)
+  { provider: 'stablewatch', chainId: 239, address: '0x2a52B289bA68bBd02676640aA9F605700c9e5699' },
+  { provider: 'stablewatch', chainId: 239, address: '0x35533f54740F1F1aA4179E57bA37039dfa16868B' },
+  { provider: 'stablewatch', chainId: 239, address: '0x5Ced7F73B76A555CCB372cc0F0137bEc5665F81E' },
+
+  // Stablewatch tokens — Plasma (9745)
+  { provider: 'stablewatch', chainId: 9745, address: '0x211Cc4DD073734dA055fbF44a2b4667d5E5fE5d2' },
+  { provider: 'stablewatch', chainId: 9745, address: '0x0B2b2B2076d95dda7817e785989fE353fe955ef9' },
+  { provider: 'stablewatch', chainId: 9745, address: '0x35533f54740F1F1aA4179E57bA37039dfa16868B' },
+  { provider: 'stablewatch', chainId: 9745, address: '0x616185600989Bf8339b58aC9e539d49536598343' },
+  { provider: 'stablewatch', chainId: 9745, address: '0xC8A8DF9B210243c55D31c73090F06787aD0A1Bf6' },
+  { provider: 'stablewatch', chainId: 9745, address: '0xEbFC8C2Fe73C431Ef2A371AeA9132110aaB50DCa' },
+  { provider: 'stablewatch', chainId: 9745, address: '0xfDD22Ce6D1F66bc0Ec89b20BF16CcB6670F55A5a' },
+
+  // Stablewatch tokens — Arbitrum (42161)
+  { provider: 'stablewatch', chainId: 42161, address: '0xfDD22Ce6D1F66bc0Ec89b20BF16CcB6670F55A5a' },
+  { provider: 'stablewatch', chainId: 42161, address: '0x0B2b2B2076d95dda7817e785989fE353fe955ef9' },
+  { provider: 'stablewatch', chainId: 42161, address: '0x62dDf301B21970e7Cc12c34cAAc9CE9bC975c0a9' },
 ]

--- a/entities/fuul.ts
+++ b/entities/fuul.ts
@@ -1,0 +1,25 @@
+export interface FuulPool {
+  name: string
+  token0_symbol: string
+  token0_address: string
+}
+
+export interface FuulTrigger {
+  type: string
+  context: {
+    chain_id: number
+    token_address: string
+  }
+}
+
+export interface FuulIncentive {
+  conversion: string
+  project: string
+  protocol: string
+  chain_id: number
+  pool: FuulPool
+  trigger: FuulTrigger
+  apr: number
+  tvl: number
+  refreshed_at: string
+}

--- a/entities/fuul.ts
+++ b/entities/fuul.ts
@@ -23,3 +23,28 @@ export interface FuulIncentive {
   tvl: number
   refreshed_at: string
 }
+
+export interface FuulClaimCheck {
+  project_address: string
+  to: string
+  currency: string
+  currency_type: number
+  amount: string
+  reason: number
+  token_id: string
+  deadline: string
+  proof: string
+  signatures: string[]
+}
+
+export interface FuulTotalEntry {
+  currency: string
+  currency_type: number
+  amount: string
+  chain_id: number
+}
+
+export interface FuulTotals {
+  claimed: FuulTotalEntry[]
+  unclaimed: FuulTotalEntry[]
+}

--- a/entities/reward-campaign.ts
+++ b/entities/reward-campaign.ts
@@ -5,7 +5,7 @@ export interface RewardCampaign {
   collateral?: string
   type: RewardCampaignType
   apr: number
-  provider: 'merkl' | 'brevis'
+  provider: 'merkl' | 'brevis' | 'fuul'
   endTimestamp: number
   rewardToken?: {
     symbol: string

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -114,6 +114,10 @@ export default defineNuxtConfig({
       configEnableAppTitle: '',
       // Feature flags: disabled by default. Set to 'true' to enable.
       configEnableSwapDeposit: '',
+      // Incentives provider flags: enabled by default. Set to 'false' to disable.
+      configEnableMerkl: '',
+      configEnableIncentra: '',
+      configEnableFuul: '',
       // Env config fallbacks (Doppler: NUXT_PUBLIC_*)
       // Prefer window.__APP_CONFIG__ at runtime; these are build-time fallbacks.
       appKitProjectId: '',

--- a/pages/lend/[vault]/index.vue
+++ b/pages/lend/[vault]/index.vue
@@ -219,7 +219,7 @@ const needsRefresh = (v: Vault | undefined): boolean => {
 // Pyth prices are only valid for ~2 minutes, so always refresh when Pyth is detected
 if (evkVault.value && needsRefresh(evkVault.value)) {
   const refreshedVault = await updateVault(vaultAddress)
-  evkVault.value = refreshedVault
+  evkVault.value = refreshedVault as Vault
 }
 
 const features = computed(() => VAULT_FEATURES[vaultType.value])

--- a/pages/lend/[vault]/index.vue
+++ b/pages/lend/[vault]/index.vue
@@ -219,7 +219,9 @@ const needsRefresh = (v: Vault | undefined): boolean => {
 // Pyth prices are only valid for ~2 minutes, so always refresh when Pyth is detected
 if (evkVault.value && needsRefresh(evkVault.value)) {
   const refreshedVault = await updateVault(vaultAddress)
-  evkVault.value = refreshedVault as Vault
+  if (!('type' in refreshedVault && refreshedVault.type === 'securitize')) {
+    evkVault.value = refreshedVault as Vault
+  }
 }
 
 const features = computed(() => VAULT_FEATURES[vaultType.value])

--- a/pages/portfolio/rewards.vue
+++ b/pages/portfolio/rewards.vue
@@ -6,7 +6,10 @@ const { isConnected } = useAccount()
 const { enableMerkl, enableIncentra, enableFuul } = useDeployConfig()
 const { rewards, isRewardsLoading } = useMerkl()
 const { userRewards: brevisRewards, isRewardsLoading: isBrevisRewardsLoading } = useBrevis()
+const { fuulTotals, isTotalsLoading: isFuulTotalsLoading } = useFuul()
 const { locks, isLocksLoading } = useREULLocks()
+
+const hasUnclaimedFuul = computed(() => fuulTotals.value.unclaimed.length > 0)
 
 const sortedRewards = computed(() => {
   return [...rewards.value].sort((a, b) => {
@@ -120,12 +123,43 @@ const sortedBrevisRewards = computed(() => {
           </h3>
         </div>
         <div class="flex flex-1 rounded-12 p-8 mb-16 border border-line-default bg-card">
-          <div class="flex flex-1 min-h-[100px] justify-center items-center py-32">
+          <div
+            v-if="isFuulTotalsLoading"
+            class="flex flex-1 min-h-[100px] justify-center items-center"
+          >
+            <UiLoader class="text-neutral-500" />
+          </div>
+          <div
+            v-else-if="!hasUnclaimedFuul"
+            class="flex flex-1 min-h-[100px] justify-center items-center py-32"
+          >
             <div class="flex flex-col gap-8 items-center text-neutral-500 text-p2">
               <div class="flex w-48 h-48 justify-center items-center rounded-12 bg-neutral-100">
                 <SvgIcon name="search" />
               </div>
-              Fuul rewards claiming coming soon
+              <template v-if="isConnected">
+                You don't have rewards yet
+              </template>
+              <template v-else>
+                Connect your wallet to see your rewards
+              </template>
+            </div>
+          </div>
+          <div
+            v-else
+            class="flex-1 min-h-[100px]"
+          >
+            <div
+              v-for="entry in fuulTotals.unclaimed"
+              :key="entry.currency"
+              class="flex items-center justify-between p-12 rounded-8"
+            >
+              <span class="text-p2 text-neutral-800 font-mono">
+                {{ entry.currency }}
+              </span>
+              <span class="text-p2 text-neutral-800 font-mono">
+                {{ entry.amount }}
+              </span>
             </div>
           </div>
         </div>

--- a/pages/portfolio/rewards.vue
+++ b/pages/portfolio/rewards.vue
@@ -3,6 +3,7 @@ import { useAccount } from '@wagmi/vue'
 import { nanoToValue } from '~/utils/crypto-utils'
 
 const { isConnected } = useAccount()
+const { enableMerkl, enableIncentra, enableFuul } = useDeployConfig()
 const { rewards, isRewardsLoading } = useMerkl()
 const { userRewards: brevisRewards, isRewardsLoading: isBrevisRewardsLoading } = useBrevis()
 const { locks, isLocksLoading } = useREULLocks()
@@ -27,89 +28,108 @@ const sortedBrevisRewards = computed(() => {
 <template>
   <div class="flex flex-col flex-1 mx-16 rounded-12">
     <div>
-      <div class="flex justify-between items-center mb-8">
-        <h3 class="text-h3 font-normal text-neutral-800">
-          Rewards via Merkl
-        </h3>
-      </div>
-      <p class="text-p2 text-neutral-500 mb-16">
-        Rewards distributed via Merkl, with updates every 8-12 hours
-      </p>
-      <div class="flex flex-1 rounded-12 p-8 mb-16 border border-line-default bg-card">
-        <div
-          v-if="isRewardsLoading"
-          class="flex flex-1 min-h-[100px] justify-center items-center"
-        >
-          <UiLoader class="text-neutral-500" />
+      <template v-if="enableMerkl">
+        <div class="flex justify-between items-center mb-8">
+          <h3 class="text-h3 font-normal text-neutral-800">
+            Rewards via Merkl
+          </h3>
         </div>
-        <div
-          v-else-if="rewards.length === 0"
-          class="flex flex-1 min-h-[100px] justify-center items-center py-32"
-        >
-          <div class="flex flex-col gap-8 items-center text-neutral-500 text-p2">
-            <div class="flex w-48 h-48 justify-center items-center rounded-12 bg-neutral-100">
-              <SvgIcon name="search" />
+        <p class="text-p2 text-neutral-500 mb-16">
+          Updated every 8-12 hours
+        </p>
+        <div class="flex flex-1 rounded-12 p-8 mb-16 border border-line-default bg-card">
+          <div
+            v-if="isRewardsLoading"
+            class="flex flex-1 min-h-[100px] justify-center items-center"
+          >
+            <UiLoader class="text-neutral-500" />
+          </div>
+          <div
+            v-else-if="rewards.length === 0"
+            class="flex flex-1 min-h-[100px] justify-center items-center py-32"
+          >
+            <div class="flex flex-col gap-8 items-center text-neutral-500 text-p2">
+              <div class="flex w-48 h-48 justify-center items-center rounded-12 bg-neutral-100">
+                <SvgIcon name="search" />
+              </div>
+              <template v-if="isConnected">
+                You don't have rewards yet
+              </template>
+              <template v-else>
+                Connect your wallet to see your rewards
+              </template>
             </div>
-            <template v-if="isConnected">
-              You don't have rewards yet
-            </template>
-            <template v-else>
-              Connect your wallet to see your rewards
-            </template>
+          </div>
+          <div
+            v-else
+            class="flex-1 min-h-[100px]"
+          >
+            <PortfolioList
+              :items="sortedRewards"
+              type="rewards"
+            />
           </div>
         </div>
-        <div
-          v-else
-          class="flex-1 min-h-[100px]"
-        >
-          <PortfolioList
-            :items="sortedRewards"
-            type="rewards"
-          />
-        </div>
-      </div>
+      </template>
 
-      <div class="flex justify-between items-center mb-8">
-        <h3 class="text-h3 font-normal text-neutral-800">
-          Rewards via Incentra
-        </h3>
-      </div>
-      <p class="text-p2 text-neutral-500 mb-16">
-        Rewards distributed via Incentra incentive campaigns
-      </p>
-      <div class="flex flex-1 rounded-12 p-8 mb-16 border border-line-default bg-card">
-        <div
-          v-if="isBrevisRewardsLoading"
-          class="flex flex-1 min-h-[100px] justify-center items-center"
-        >
-          <UiLoader class="text-neutral-500" />
+      <template v-if="enableIncentra">
+        <div class="flex justify-between items-center mb-8">
+          <h3 class="text-h3 font-normal text-neutral-800">
+            Rewards via Incentra
+          </h3>
         </div>
-        <div
-          v-else-if="brevisRewards.length === 0"
-          class="flex flex-1 min-h-[100px] justify-center items-center py-32"
-        >
-          <div class="flex flex-col gap-8 items-center text-neutral-500 text-p2">
-            <div class="flex w-48 h-48 justify-center items-center rounded-12 bg-neutral-100">
-              <SvgIcon name="search" />
+        <div class="flex flex-1 rounded-12 p-8 mb-16 border border-line-default bg-card">
+          <div
+            v-if="isBrevisRewardsLoading"
+            class="flex flex-1 min-h-[100px] justify-center items-center"
+          >
+            <UiLoader class="text-neutral-500" />
+          </div>
+          <div
+            v-else-if="brevisRewards.length === 0"
+            class="flex flex-1 min-h-[100px] justify-center items-center py-32"
+          >
+            <div class="flex flex-col gap-8 items-center text-neutral-500 text-p2">
+              <div class="flex w-48 h-48 justify-center items-center rounded-12 bg-neutral-100">
+                <SvgIcon name="search" />
+              </div>
+              <template v-if="isConnected">
+                You don't have rewards yet
+              </template>
+              <template v-else>
+                Connect your wallet to see your rewards
+              </template>
             </div>
-            <template v-if="isConnected">
-              You don't have rewards yet
-            </template>
-            <template v-else>
-              Connect your wallet to see your rewards
-            </template>
+          </div>
+          <div
+            v-else
+            class="flex-1 min-h-[100px]"
+          >
+            <PortfolioList
+              :items="sortedBrevisRewards"
+              type="brevis-rewards"
+            />
           </div>
         </div>
-        <div
-          v-else
-          class="flex-1 min-h-[100px]"
-        >
-          <PortfolioList
-            :items="sortedBrevisRewards"
-            type="brevis-rewards"
-          />
+      </template>
+
+      <template v-if="enableFuul">
+        <div class="flex justify-between items-center mb-8">
+          <h3 class="text-h3 font-normal text-neutral-800">
+            Rewards via Fuul
+          </h3>
         </div>
-      </div>
+        <div class="flex flex-1 rounded-12 p-8 mb-16 border border-line-default bg-card">
+          <div class="flex flex-1 min-h-[100px] justify-center items-center py-32">
+            <div class="flex flex-col gap-8 items-center text-neutral-500 text-p2">
+              <div class="flex w-48 h-48 justify-center items-center rounded-12 bg-neutral-100">
+                <SvgIcon name="search" />
+              </div>
+              Fuul rewards claiming coming soon
+            </div>
+          </div>
+        </div>
+      </template>
 
       <h3 class="text-h3 font-normal mb-8 text-neutral-800">
         Rewards in EUL (rEUL)

--- a/pages/position/[number]/borrow/swap.vue
+++ b/pages/position/[number]/borrow/swap.vue
@@ -36,7 +36,7 @@ const { borrowOptions, borrowVaults } = useSwapDebtOptions({
 const currentDebt = computed(() => position.value?.borrowed || 0n)
 const balance = computed(() => currentDebt.value)
 const targetVaultAddress = computed(() => typeof route.query.to === 'string' ? route.query.to : '')
-const hasBorrowSwapOptions = computed(() => borrowVaults.value.length > 0)
+const _hasBorrowSwapOptions = computed(() => borrowVaults.value.length > 0)
 
 const setFromAmountToMax = () => {
   if (!fromVault.value) {

--- a/server/api/fuul/claim-checks.post.ts
+++ b/server/api/fuul/claim-checks.post.ts
@@ -1,8 +1,10 @@
 import { createError, readBody } from 'h3'
 import { createRateLimiter } from '~/server/utils/rate-limit'
+import { logWarn } from '~/server/utils/log'
 import { FUUL_API_BASE_URL } from '~/entities/constants'
 
 const TIMEOUT_MS = 10_000
+let keyWarningLogged = false
 
 const rateLimiter = createRateLimiter({
   max: 30,
@@ -15,7 +17,11 @@ export default defineEventHandler(async (event) => {
 
   const apiKey = process.env.FUUL_API_KEY
   if (!apiKey) {
-    throw createError({ statusCode: 503, statusMessage: 'Fuul API key not configured' })
+    if (!keyWarningLogged) {
+      logWarn('fuul/claim-checks', 'FUUL_API_KEY not configured')
+      keyWarningLogged = true
+    }
+    return []
   }
 
   const body = await readBody(event)

--- a/server/api/fuul/claim-checks.post.ts
+++ b/server/api/fuul/claim-checks.post.ts
@@ -1,0 +1,58 @@
+import { createError, readBody } from 'h3'
+import { createRateLimiter } from '~/server/utils/rate-limit'
+import { FUUL_API_BASE_URL } from '~/entities/constants'
+
+const TIMEOUT_MS = 10_000
+
+const rateLimiter = createRateLimiter({
+  max: 30,
+  windowMs: 60_000,
+  label: 'fuul-claim-checks',
+})
+
+export default defineEventHandler(async (event) => {
+  rateLimiter.consume(event)
+
+  const apiKey = process.env.FUUL_API_KEY
+  if (!apiKey) {
+    throw createError({ statusCode: 503, statusMessage: 'Fuul API key not configured' })
+  }
+
+  const body = await readBody(event)
+  if (!body?.userIdentifier) {
+    throw createError({ statusCode: 400, statusMessage: 'userIdentifier is required' })
+  }
+
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS)
+
+  try {
+    const resp = await fetch(`${FUUL_API_BASE_URL}/claim-checks/claim`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        userIdentifier: body.userIdentifier,
+        userIdentifierType: 'evm_address',
+      }),
+      signal: controller.signal,
+    })
+
+    if (!resp.ok) {
+      throw createError({ statusCode: 502, statusMessage: 'Upstream error' })
+    }
+
+    return await resp.json()
+  }
+  catch (error) {
+    if (error && typeof error === 'object' && 'statusCode' in error) {
+      throw error
+    }
+    throw createError({ statusCode: 502, statusMessage: 'Upstream error' })
+  }
+  finally {
+    clearTimeout(timeout)
+  }
+})

--- a/server/api/fuul/totals.get.ts
+++ b/server/api/fuul/totals.get.ts
@@ -1,0 +1,55 @@
+import { createError, getQuery } from 'h3'
+import { createRateLimiter } from '~/server/utils/rate-limit'
+import { FUUL_API_BASE_URL } from '~/entities/constants'
+
+const TIMEOUT_MS = 10_000
+
+const rateLimiter = createRateLimiter({
+  max: 30,
+  windowMs: 60_000,
+  label: 'fuul-totals',
+})
+
+export default defineEventHandler(async (event) => {
+  rateLimiter.consume(event)
+
+  const apiKey = process.env.FUUL_API_KEY
+  if (!apiKey) {
+    throw createError({ statusCode: 503, statusMessage: 'Fuul API key not configured' })
+  }
+
+  const query = getQuery(event)
+  if (!query.user_identifier) {
+    throw createError({ statusCode: 400, statusMessage: 'user_identifier is required' })
+  }
+
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS)
+
+  try {
+    const params = new URLSearchParams({
+      user_identifier: String(query.user_identifier),
+      user_identifier_type: 'evm_address',
+    })
+
+    const resp = await fetch(`${FUUL_API_BASE_URL}/claim-checks/totals?${params}`, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+      signal: controller.signal,
+    })
+
+    if (!resp.ok) {
+      throw createError({ statusCode: 502, statusMessage: 'Upstream error' })
+    }
+
+    return await resp.json()
+  }
+  catch (error) {
+    if (error && typeof error === 'object' && 'statusCode' in error) {
+      throw error
+    }
+    throw createError({ statusCode: 502, statusMessage: 'Upstream error' })
+  }
+  finally {
+    clearTimeout(timeout)
+  }
+})

--- a/server/api/fuul/totals.get.ts
+++ b/server/api/fuul/totals.get.ts
@@ -1,8 +1,10 @@
 import { createError, getQuery } from 'h3'
 import { createRateLimiter } from '~/server/utils/rate-limit'
+import { logWarn } from '~/server/utils/log'
 import { FUUL_API_BASE_URL } from '~/entities/constants'
 
 const TIMEOUT_MS = 10_000
+let keyWarningLogged = false
 
 const rateLimiter = createRateLimiter({
   max: 30,
@@ -15,7 +17,11 @@ export default defineEventHandler(async (event) => {
 
   const apiKey = process.env.FUUL_API_KEY
   if (!apiKey) {
-    throw createError({ statusCode: 503, statusMessage: 'Fuul API key not configured' })
+    if (!keyWarningLogged) {
+      logWarn('fuul/totals', 'FUUL_API_KEY not configured')
+      keyWarningLogged = true
+    }
+    return { claimed: [], unclaimed: [] }
   }
 
   const query = getQuery(event)

--- a/server/api/stablewatch-pools.get.ts
+++ b/server/api/stablewatch-pools.get.ts
@@ -1,0 +1,47 @@
+import { createError } from 'h3'
+import { createRateLimiter } from '~/server/utils/rate-limit'
+import { STABLEWATCH_POOLS_URL } from '~/entities/constants'
+
+const TIMEOUT_MS = 10_000
+
+const rateLimiter = createRateLimiter({
+  max: 100,
+  windowMs: 60_000,
+  label: 'stablewatch-pools',
+})
+
+export default defineEventHandler(async (event) => {
+  rateLimiter.consume(event)
+
+  const apiKey = process.env.STABLEWATCH_API_KEY
+
+  if (!apiKey) {
+    return { pools: [] }
+  }
+
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS)
+
+  try {
+    const url = `${STABLEWATCH_POOLS_URL}?api_key=${encodeURIComponent(apiKey)}`
+    const resp = await fetch(url, { signal: controller.signal })
+
+    if (!resp.ok) {
+      console.warn('[stablewatch-pools] API returned', resp.status)
+      throw createError({ statusCode: 502, statusMessage: 'Upstream error' })
+    }
+
+    const data = await resp.json()
+    return data
+  }
+  catch (error) {
+    if (error && typeof error === 'object' && 'statusCode' in error) {
+      throw error
+    }
+    console.warn('[stablewatch-pools] API error:', error)
+    throw createError({ statusCode: 502, statusMessage: 'Upstream error' })
+  }
+  finally {
+    clearTimeout(timeout)
+  }
+})

--- a/server/api/stablewatch-pools.get.ts
+++ b/server/api/stablewatch-pools.get.ts
@@ -23,7 +23,8 @@ export default defineEventHandler(async (event) => {
   const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS)
 
   try {
-    const url = `${STABLEWATCH_POOLS_URL}?api_key=${encodeURIComponent(apiKey)}`
+    const url = new URL(STABLEWATCH_POOLS_URL)
+    url.searchParams.set('api_key', apiKey)
     const resp = await fetch(url, { signal: controller.signal })
 
     if (!resp.ok) {
@@ -38,7 +39,8 @@ export default defineEventHandler(async (event) => {
     if (error && typeof error === 'object' && 'statusCode' in error) {
       throw error
     }
-    console.warn('[stablewatch-pools] API error:', error)
+    const message = error instanceof Error ? error.message : 'Unknown error'
+    console.warn('[stablewatch-pools] API error:', message)
     throw createError({ statusCode: 502, statusMessage: 'Upstream error' })
   }
   finally {

--- a/server/plugins/csp.ts
+++ b/server/plugins/csp.ts
@@ -62,6 +62,7 @@ const CONNECT_SRC_BASE = [
   'https://chain-proxy.wallet.coinbase.com',
   'https://cca-lite.coinbase.com',
   // External data APIs
+  'https://api.fuul.xyz',
   'https://yields.llama.fi',
   'https://api-v2.pendle.finance',
   'https://public-feed.securitize.io',

--- a/services/intrinsicApy/defillamaProvider.ts
+++ b/services/intrinsicApy/defillamaProvider.ts
@@ -28,7 +28,10 @@ export const createDefiLlamaProvider = (sources: readonly IntrinsicApySourceConf
   return {
     name: 'DefiLlama',
 
-    async fetch(): Promise<IntrinsicApyResult[]> {
+    async fetch(chainId: number): Promise<IntrinsicApyResult[]> {
+      const chainSources = defillamaSources.filter(s => s.chainId === chainId)
+      if (chainSources.length === 0) return []
+
       const res = await axios.get(DEFILLAMA_YIELDS_URL)
       const rawPools = (res.data?.data || []) as DefiLlamaPool[]
 
@@ -41,7 +44,7 @@ export const createDefiLlamaProvider = (sources: readonly IntrinsicApySourceConf
 
       const results: IntrinsicApyResult[] = []
 
-      for (const source of defillamaSources) {
+      for (const source of chainSources) {
         const pool = poolsById.get(source.poolId)
         if (!pool) continue
 

--- a/services/intrinsicApy/stablewatchProvider.ts
+++ b/services/intrinsicApy/stablewatchProvider.ts
@@ -1,0 +1,107 @@
+import type { IntrinsicApySourceConfig } from '~/entities/custom'
+import type { IntrinsicApyProvider, IntrinsicApyResult } from '~/entities/intrinsic-apy'
+import { STABLEWATCH_SOURCE_URL } from '~/entities/constants'
+import { logWarn } from '~/utils/errorHandling'
+
+type StablewatchSource = Extract<IntrinsicApySourceConfig, { provider: 'stablewatch' }>
+
+type StablewatchResponse = {
+  data?: StablewatchPool[]
+}
+
+type StablewatchPool = {
+  metrics?: {
+    apy?: {
+      avg7d?: number | string
+    }
+  }
+  token?: {
+    chains?: Record<string, string[]>
+  }
+}
+
+const CHAIN_ID_TO_NAME: Record<number, string> = {
+  1: 'ethereum',
+  56: 'bnbsmartchain',
+  146: 'sonic',
+  239: 'tac',
+  8453: 'base',
+  9745: 'plasma',
+  42161: 'arbitrumone',
+  43114: 'avalanche',
+  59144: 'lineamainnet',
+}
+
+const normalize = (value?: string) => value?.toLowerCase() || ''
+
+const normalizeChainName = (raw: string): string => {
+  const trimmed = raw.toLowerCase().replace(/\s+/g, '')
+  if (trimmed === 'binance-smart-chain') return 'bnbsmartchain'
+  if (trimmed === 'linea') return 'lineamainnet'
+  if (trimmed === 'arbitrum') return 'arbitrumone'
+  return trimmed
+}
+
+const buildLookupKey = (chain: string, address: string) =>
+  `${chain.toLowerCase()}:${address.toLowerCase()}`
+
+export const createStablewatchProvider = (sources: readonly IntrinsicApySourceConfig[]): IntrinsicApyProvider => {
+  const stablewatchSources = sources.filter(
+    (s): s is StablewatchSource => s.provider === 'stablewatch',
+  )
+
+  return {
+    name: 'Stablewatch',
+
+    async fetch(chainId: number): Promise<IntrinsicApyResult[]> {
+      const chainSources = stablewatchSources.filter(s => s.chainId === chainId)
+      if (!chainSources.length) return []
+
+      const chainName = CHAIN_ID_TO_NAME[chainId]
+      if (!chainName) return []
+
+      try {
+        const resp = await $fetch<StablewatchResponse>('/api/stablewatch-pools')
+        const pools = Array.isArray(resp?.data) ? resp.data : []
+
+        const lookup = new Map<string, number>()
+        for (const pool of pools) {
+          const apyRaw = pool.metrics?.apy?.avg7d
+          const apy = typeof apyRaw === 'number' ? apyRaw : Number(apyRaw)
+          if (!Number.isFinite(apy) || !pool.token?.chains) continue
+
+          for (const [rawChainName, addresses] of Object.entries(pool.token.chains)) {
+            if (!Array.isArray(addresses)) continue
+            const normalizedChain = normalizeChainName(rawChainName)
+            for (const addr of addresses) {
+              if (typeof addr !== 'string') continue
+              lookup.set(buildLookupKey(normalizedChain, addr), Math.max(0, apy))
+            }
+          }
+        }
+
+        const results: IntrinsicApyResult[] = []
+        for (const source of chainSources) {
+          const key = buildLookupKey(chainName, source.address)
+          const apy = lookup.get(key)
+          if (apy === undefined) continue
+
+          results.push({
+            address: normalize(source.address),
+            info: {
+              apy,
+              provider: 'Stablewatch',
+              source: STABLEWATCH_SOURCE_URL,
+            },
+          })
+        }
+
+        return results
+      }
+      catch (err) {
+        logWarn('intrinsicApy/stablewatch', err)
+        return []
+      }
+    },
+  }
+}


### PR DESCRIPTION
## Summary

### Incentive Provider Feature Flags
- Add env var feature flags (`NUXT_PUBLIC_CONFIG_ENABLE_MERKL`, `ENABLE_INCENTRA`, `ENABLE_FUUL`) to independently toggle each incentive provider for both APY calculations and portfolio rewards UI
- All flags enabled by default for backwards compatibility

### Fuul Provider Integration
- New `useFuul` composable fetching incentive campaigns from the Fuul public API
- Full claiming support: server-side proxy routes (`/api/fuul/totals`, `/api/fuul/claim-checks`) to keep `FUUL_API_KEY` secret, ABIs for FuulManager/FuulFactory contracts, claim transaction building via TxPlan
- Fuul rewards section in portfolio rewards page with unclaimed totals display
- CSP: add `api.fuul.xyz` to connect-src allowlist

### Stablewatch Intrinsic APY Provider
- New server-proxied Stablewatch APY provider for stablecoins and yield-bearing tokens
- API key stays server-side via Nitro endpoint (`/api/stablewatch-pools`)
- 23 token entries across 6 chains

### Bug Fixes
- Fix wallet address change not refreshing rewards until page reload (Merkl, Brevis, Fuul)
- Fix infinite loading state when wallet is disconnected (missing `isRewardsLoading` reset)
- Fix DefiLlama intrinsic APY provider ignoring `chainId` parameter, causing duplicate entries for vaults deployed on multiple chains
- Add race guards to all reward providers to prevent stale async responses from overwriting newer data on chain/address switch
- Clear cached campaigns immediately on chain switch (Merkl, Fuul)
- Avoid potential API key leak in stablewatch proxy error logs
- Fix type error in vault refresh assertion
- Fix zero address check in vault governance type

### Docs
- Update data-flow, architecture, project-structure, getting-started, intrinsic-apy, transaction-building docs
- Add Fuul to all reward system descriptions
- Add Stablewatch and Securitize as intrinsic APY providers in docs
- Normalize Incentra/Brevis naming (Incentra user-facing, Brevis in code)

## Test plan
- [x] Set `NUXT_PUBLIC_CONFIG_ENABLE_MERKL=false` — verify Merkl campaigns disappear from APYs and portfolio rewards
- [x] Set `NUXT_PUBLIC_CONFIG_ENABLE_FUUL=false` — verify Fuul campaigns disappear
- [x] Leave all flags unset — verify all providers enabled (backwards compatible)
- [x] Verify Fuul APR appears in vault supply APY when Fuul API returns data
- [x] Switch connected wallet on /portfolio/rewards — verify rewards refresh immediately for all providers
- [x] Disconnect wallet — verify loading states resolve (no infinite spinners)
- [x] Switch chains — verify stale campaigns are cleared and new ones load
- [x] Verify Stablewatch APY appears for configured tokens when `STABLEWATCH_API_KEY` is set
- [x] Verify no duplicate intrinsic APY warnings in console
- [x] Run `npx nuxi typecheck` — no new errors