### PR TITLE
fix: filter inactive collateral pairs

### DIFF
--- a/components/entities/vault/overview/VaultOverviewBlockBorrow.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockBorrow.vue
@@ -26,8 +26,8 @@ const onRampDownInfoIconClick = (event: MouseEvent, pair: LTVRampConfig) => {
   })
 }
 
-// Build collateral pairs from ALL collateralLTVs where currentLiquidationLTV > 0
-// This includes collaterals that are ramping down (borrowLTV == 0 but currentLiquidationLTV > 0)
+// Build collateral pairs from collateralLTVs where currentLiquidationLTV > 0
+// Excludes fully ramped-down collaterals (borrowLTV == 0) with no remaining supply
 const allCollateralPairs = computed(() => {
   const pairs: Array<{
     collateral: Vault | SecuritizeVault

--- a/components/entities/vault/overview/VaultOverviewBlockBorrow.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockBorrow.vue
@@ -39,21 +39,22 @@ const allCollateralPairs = computed(() => {
   }> = []
 
   vault.collateralLTVs.forEach((ltv) => {
-    // Check if current liquidation LTV > 0 (not yet fully ramped down)
     if (getCurrentLiquidationLTV(ltv) <= 0n) return
-
-    const pairData = {
-      borrowLTV: ltv.borrowLTV,
-      liquidationLTV: ltv.liquidationLTV,
-      initialLiquidationLTV: ltv.initialLiquidationLTV,
-      targetTimestamp: ltv.targetTimestamp,
-      rampDuration: ltv.rampDuration,
-    }
 
     // Try to find the collateral vault from registry
     const collateralEntry = registryGet(ltv.collateral)
     if (collateralEntry) {
-      pairs.push({ collateral: collateralEntry.vault as Vault | SecuritizeVault, ...pairData })
+      const collateral = collateralEntry.vault as Vault | SecuritizeVault
+      if (ltv.borrowLTV <= 0n && collateral.totalAssets <= 0n) return
+
+      pairs.push({
+        collateral,
+        borrowLTV: ltv.borrowLTV,
+        liquidationLTV: ltv.liquidationLTV,
+        initialLiquidationLTV: ltv.initialLiquidationLTV,
+        targetTimestamp: ltv.targetTimestamp,
+        rampDuration: ltv.rampDuration,
+      })
     }
   })
 

--- a/pages/lend/[vault]/index.vue
+++ b/pages/lend/[vault]/index.vue
@@ -157,18 +157,10 @@ else {
 
     // Load any collateral vaults that aren't already in registry
     if (evkVault.value) {
-      const { get: registryGet, has: registryHas } = useVaultRegistry()
+      const { has: registryHas } = useVaultRegistry()
 
       const collateralAddresses = evkVault.value.collateralLTVs
-        .filter((ltv) => {
-          if (getCurrentLiquidationLTV(ltv) <= 0n) return false
-          if (ltv.borrowLTV > 0n) return true
-
-          const collateralEntry = registryGet(ltv.collateral)
-          if (!collateralEntry) return true
-
-          return collateralEntry.vault.totalAssets > 0n
-        })
+        .filter(ltv => getCurrentLiquidationLTV(ltv) > 0n)
         .map(ltv => ltv.collateral)
 
       // Check and load missing collaterals in parallel

--- a/pages/lend/[vault]/index.vue
+++ b/pages/lend/[vault]/index.vue
@@ -157,10 +157,18 @@ else {
 
     // Load any collateral vaults that aren't already in registry
     if (evkVault.value) {
-      const { has: registryHas } = useVaultRegistry()
+      const { get: registryGet, has: registryHas } = useVaultRegistry()
 
       const collateralAddresses = evkVault.value.collateralLTVs
-        .filter(ltv => getCurrentLiquidationLTV(ltv) > 0n)
+        .filter((ltv) => {
+          if (getCurrentLiquidationLTV(ltv) <= 0n) return false
+          if (ltv.borrowLTV > 0n) return true
+
+          const collateralEntry = registryGet(ltv.collateral)
+          if (!collateralEntry) return true
+
+          return collateralEntry.vault.totalAssets > 0n
+        })
         .map(ltv => ltv.collateral)
 
       // Check and load missing collaterals in parallel


### PR DESCRIPTION
# Hide Zero-Supply Ramped-Down Collaterals From Vault Exposure

## Summary

This updates the collateral exposure list on the vault overview page to use a stricter filter.

Before, collaterals were shown whenever `currentLiquidationLTV > 0`, which included ramped-down collaterals with `borrowLTV == 0` even when the collateral vault had no remaining supply.

Now, a collateral is shown only when:

```ts
currentLiquidationLTV > 0 && (borrowLTV > 0 || totalAssets > 0)
```

## Why

This keeps:

- active borrowable collaterals visible
- legacy ramp-down collaterals visible only while there is still on-chain supply that could back existing positions

This hides:

- ramped-down collaterals with `borrowLTV == 0` and zero supply, since they cannot affect any live position

## Changes

- Updated [`components/entities/vault/overview/VaultOverviewBlockBorrow.vue`](/Users/dariusz/Euler/euler-lite/components/entities/vault/overview/VaultOverviewBlockBorrow.vue) to apply the new exposure filter in the rendered collateral list.
- Updated [`pages/lend/[vault]/index.vue`](/Users/dariusz/Euler/euler-lite/pages/lend/[vault]/index.vue) to match the same filter in the collateral preload path.

## Notes

- The preload logic now stays consistent with the UI, so hidden collaterals are not eagerly loaded when already known in the registry.

