### PR TITLE
improve searching quotes message

### DIFF
--- a/composables/useSwapQuotesParallel.ts
+++ b/composables/useSwapQuotesParallel.ts
@@ -55,9 +55,10 @@ export const useSwapQuotesParallel = (options: SwapQuotesParallelOptions) => {
     }
     const current = Math.min(providersFetchedCount.value, providersCount.value)
     const total = providersCount.value
+    const progress = Math.round((current / total) * 100)
     return current < total
-      ? `Fetching quotes ${current}/${total}`
-      : `Quotes returned ${current}/${total}`
+      ? `Fetching quotes ${progress}%`
+      : 'Quotes fetched'
   })
 
   const getQuoteDiffPctFor = (quote: SwapApiQuote) => {


### PR DESCRIPTION
Improves "fetching quotes" message. The requests to the swap api are not always equal to quotes getting fetched, there are some technicalities and there almost never is one quote per query and in some instance there's only 1 quote expected. Showing progress in percentage is cleaner