### PR TITLE
feat: price impact warnings & multiplied price impact

### DIFF
--- a/components/entities/operation/HighPriceImpactModal.vue
+++ b/components/entities/operation/HighPriceImpactModal.vue
@@ -4,20 +4,27 @@ import { formatNumber } from '~/utils/string-utils'
 const props = defineProps<{
   directPriceImpact: number
   multipliedPriceImpact?: number | null
-  onConfirm: () => void
+  onConfirm: () => void | Promise<void>
 }>()
 const emits = defineEmits(['close'])
 
 const confirmText = ref('')
+const isSubmitting = ref(false)
 const isConfirmed = computed(() => confirmText.value.trim().toLowerCase() === 'i understand')
 
 const onCancel = () => {
   emits('close')
 }
 
-const onSubmit = () => {
-  if (!isConfirmed.value) return
-  props.onConfirm()
+const onSubmit = async () => {
+  if (!isConfirmed.value || isSubmitting.value) return
+  isSubmitting.value = true
+  try {
+    await props.onConfirm()
+  }
+  finally {
+    isSubmitting.value = false
+  }
 }
 </script>
 
@@ -74,7 +81,7 @@ const onSubmit = () => {
           variant="primary"
           size="xlarge"
           rounded
-          :disabled="!isConfirmed"
+          :disabled="!isConfirmed || isSubmitting"
           @click="onSubmit"
         >
           Confirm

--- a/components/entities/operation/HighPriceImpactModal.vue
+++ b/components/entities/operation/HighPriceImpactModal.vue
@@ -1,0 +1,85 @@
+<script setup lang="ts">
+import { formatNumber } from '~/utils/string-utils'
+
+const props = defineProps<{
+  directPriceImpact: number
+  multipliedPriceImpact?: number | null
+  onConfirm: () => void
+}>()
+const emits = defineEmits(['close'])
+
+const confirmText = ref('')
+const isConfirmed = computed(() => confirmText.value.trim().toLowerCase() === 'i understand')
+
+const onCancel = () => {
+  emits('close')
+}
+
+const onSubmit = () => {
+  if (!isConfirmed.value) return
+  props.onConfirm()
+}
+</script>
+
+<template>
+  <BaseModalWrapper
+    warning
+    title="High Price Impact"
+    @close="onCancel"
+  >
+    <div class="flex flex-col gap-24 flex-grow">
+      <div class="text-p3 text-content-secondary">
+        This transaction has a very high price impact. You may receive significantly less value than expected.
+      </div>
+
+      <div class="bg-surface-secondary rounded-12 p-16 flex flex-col gap-8">
+        <div class="flex justify-between">
+          <span class="text-p3 text-content-tertiary">Price impact</span>
+          <span class="text-p2 text-error-500">{{ formatNumber(directPriceImpact, 2, 2) }}%</span>
+        </div>
+        <div
+          v-if="multipliedPriceImpact !== undefined && multipliedPriceImpact !== null"
+          class="flex justify-between"
+        >
+          <span class="text-p3 text-content-tertiary">Multiplied price impact</span>
+          <span class="text-p2 text-error-500">{{ formatNumber(multipliedPriceImpact, 2, 2) }}%</span>
+        </div>
+      </div>
+
+      <div class="flex flex-col gap-8">
+        <label
+          for="confirm-input"
+          class="text-p3 text-content-secondary"
+        >
+          Type "I understand" to continue
+        </label>
+        <UiInput
+          id="confirm-input"
+          v-model="confirmText"
+          placeholder="I understand"
+          @keydown.enter="onSubmit"
+        />
+      </div>
+
+      <div class="flex gap-8">
+        <UiButton
+          variant="primary-stroke"
+          size="xlarge"
+          rounded
+          @click="onCancel"
+        >
+          Cancel
+        </UiButton>
+        <UiButton
+          variant="primary"
+          size="xlarge"
+          rounded
+          :disabled="!isConfirmed"
+          @click="onSubmit"
+        >
+          Confirm
+        </UiButton>
+      </div>
+    </div>
+  </BaseModalWrapper>
+</template>

--- a/components/entities/swap/SlippageSettings.vue
+++ b/components/entities/swap/SlippageSettings.vue
@@ -1,6 +1,12 @@
 <script setup lang="ts">
 import { formatNumber } from '~/utils/string-utils'
 
+const _props = withDefaults(defineProps<{
+  deferSave?: boolean
+}>(), {
+  deferSave: false,
+})
+
 const { slippage, setSlippage, minSlippage, maxSlippage } = useSlippage()
 
 const slippagePresets = [
@@ -73,6 +79,17 @@ watch(customInput, () => {
     customInputError.value = ''
   }
 })
+
+const savePending = () => {
+  if (!isCustomInputVisible.value) return
+  const parsed = parsedCustomSlippage.value
+  if (parsed === null) return
+  setSlippage(parsed)
+  slippageSelection.value = 'custom'
+  isCustomInputVisible.value = false
+}
+
+defineExpose({ savePending })
 </script>
 
 <template>
@@ -122,6 +139,7 @@ watch(customInput, () => {
           @keyup.enter="onSaveCustom"
         />
         <UiButton
+          v-if="!deferSave"
           size="medium"
           @click="onSaveCustom"
         >

--- a/components/entities/swap/SlippageSettings.vue
+++ b/components/entities/swap/SlippageSettings.vue
@@ -80,13 +80,18 @@ watch(customInput, () => {
   }
 })
 
-const savePending = () => {
-  if (!isCustomInputVisible.value) return
+const savePending = (): boolean => {
+  if (!isCustomInputVisible.value) return true
   const parsed = parsedCustomSlippage.value
-  if (parsed === null) return
+  if (parsed === null) {
+    customInputError.value = `Enter a value between ${minSlippage} and ${maxSlippage}`
+    return false
+  }
+  customInputError.value = ''
   setSlippage(parsed)
   slippageSelection.value = 'custom'
   isCustomInputVisible.value = false
+  return true
 }
 
 defineExpose({ savePending })

--- a/components/entities/swap/SlippageSettingsModal.vue
+++ b/components/entities/swap/SlippageSettingsModal.vue
@@ -3,7 +3,7 @@ const emit = defineEmits(['close'])
 const slippageRef = ref<InstanceType<typeof SlippageSettings> | null>(null)
 
 const onSave = () => {
-  slippageRef.value?.savePending()
+  if (slippageRef.value?.savePending() === false) return
   emit('close')
 }
 </script>

--- a/components/entities/swap/SlippageSettingsModal.vue
+++ b/components/entities/swap/SlippageSettingsModal.vue
@@ -1,16 +1,25 @@
 <script setup lang="ts">
 const emit = defineEmits(['close'])
+const slippageRef = ref<InstanceType<typeof SlippageSettings> | null>(null)
+
+const onSave = () => {
+  slippageRef.value?.savePending()
+  emit('close')
+}
 </script>
 
 <template>
   <BaseModalWrapper
     @close="emit('close')"
   >
-    <SlippageSettings />
+    <SlippageSettings
+      ref="slippageRef"
+      defer-save
+    />
     <UiButton
       variant="primary"
       size="xlarge"
-      @click="emit('close')"
+      @click="onSave"
     >
       Save
     </UiButton>

--- a/composables/borrow/useBorrowForm.ts
+++ b/composables/borrow/useBorrowForm.ts
@@ -22,6 +22,7 @@ import {
 } from '~/services/pricing/priceProvider'
 import { fetchBackendPrice } from '~/services/pricing/backendClient'
 import { type SwapApiQuote, SwapperMode } from '~/entities/swap'
+import { useSwapPriceImpact } from '~/composables/useSwapPriceImpact'
 import { buildSwapRouteItems } from '~/utils/swapRouteItems'
 import { formatSmartAmount, trimTrailingZeros } from '~/utils/string-utils'
 import { nanoToValue } from '~/utils/crypto-utils'
@@ -232,6 +233,11 @@ export const useBorrowForm = (options: UseBorrowFormOptions) => {
     const amountOut = BigInt(borrowSwapEffectiveQuote.value.amountOut || 0)
     if (amountOut <= 0n) return ''
     return formatUnits(amountOut, Number(collateralVault.value.asset.decimals))
+  })
+
+  const { priceImpact: borrowSwapPriceImpact } = useSwapPriceImpact({
+    quote: borrowSwapEffectiveQuote,
+    toVault: collateralVault,
   })
 
   const borrowSwapRouteItems = computed(() => {
@@ -774,6 +780,7 @@ export const useBorrowForm = (options: UseBorrowFormOptions) => {
 
     // Computed: swap
     borrowSwapEstimatedCollateral,
+    borrowSwapPriceImpact,
     borrowSwapRouteItems,
 
     // Swap state

--- a/composables/borrow/useMultiplyForm.ts
+++ b/composables/borrow/useMultiplyForm.ts
@@ -23,6 +23,7 @@ import { type SwapApiQuote, SwapperMode } from '~/entities/swap'
 import { buildSwapRouteItems } from '~/utils/swapRouteItems'
 import { formatNumber, formatSmartAmount, trimTrailingZeros } from '~/utils/string-utils'
 import { nanoToValue } from '~/utils/crypto-utils'
+import { computeMultipliedPriceImpact } from '~/utils/priceImpact'
 import type { TxPlan } from '~/entities/txPlan'
 import { getUtilisationWarning, getBorrowCapWarning } from '~/composables/useVaultWarnings'
 import { useMultiplyCollateralOptions } from '~/composables/useMultiplyCollateralOptions'
@@ -468,6 +469,10 @@ export const useMultiplyForm = (options: UseMultiplyFormOptions) => {
     }
     multiplyPriceImpact.value = impact
   })
+
+  const multipliedPriceImpact = computed(() =>
+    computeMultipliedPriceImpact(multiplyPriceImpact.value, multiplier.value),
+  )
 
   const multiplyRoutedVia = computed(() => {
     if (isMultiplyQuoteLoading.value) return null
@@ -955,6 +960,7 @@ export const useMultiplyForm = (options: UseMultiplyFormOptions) => {
     // Display
     multiplySwapSummary,
     multiplyPriceImpact,
+    multipliedPriceImpact,
     multiplyRoutedVia,
     multiplyRouteItems,
     multiplyRouteEmptyMessage,

--- a/composables/position/useCollateralForm.ts
+++ b/composables/position/useCollateralForm.ts
@@ -26,6 +26,8 @@ import { useSwapQuotesParallel } from '~/composables/useSwapQuotesParallel'
 import type { SwapApiQuote } from '~/entities/swap'
 import type { SwapApiRequestInput } from '~/composables/useSwapApi'
 import { buildSwapRouteItems } from '~/utils/swapRouteItems'
+import { useSwapPriceImpact } from '~/composables/useSwapPriceImpact'
+import { usePriceImpactGate } from '~/composables/usePriceImpactGate'
 import { formatSmartAmount } from '~/utils/string-utils'
 import { nanoToValue } from '~/utils/crypto-utils'
 import { normalizeAddressOrEmpty } from '~/utils/accountPositionHelpers'
@@ -278,6 +280,16 @@ export const useCollateralForm = (options: UseCollateralFormOptions) => {
     return formatUnits(amountOut, Number(outputAsset.decimals))
   })
 
+  const { priceImpact: swapPriceImpact } = useSwapPriceImpact({
+    quote: swapEffectiveQuote,
+    fromVault: computed(() => options.mode === 'withdraw' ? collateralVault.value : null),
+    toVault: computed(() => options.mode === 'supply' ? collateralVault.value : null),
+  })
+
+  const { guardWithPriceImpact } = usePriceImpactGate({
+    directPriceImpact: swapPriceImpact,
+  })
+
   const swapRouteItems = computed(() => {
     const outputAsset = options.getSwapOutputAsset()
     if (!outputAsset) return []
@@ -474,55 +486,57 @@ export const useCollateralForm = (options: UseCollateralFormOptions) => {
     isPreparing.value = true
     try {
       await guardWithTerms(async () => {
-        if (!collateralVault.value?.address || !asset.value?.address) return
+        await guardWithPriceImpact(async () => {
+          if (!collateralVault.value?.address || !asset.value?.address) return
 
-        try {
-          if (options.needsSwap.value && swapEffectiveQuote.value) {
-            plan.value = await options.buildSwapPlan(swapEffectiveQuote.value, {
-              vaultAddress: collateralVault.value.address,
-              amountNano: valueToNano(amount.value || '0', asset.value.decimals),
-              subAccount: position.value?.subAccount,
-              includePermit2Call: false,
-            })
+          try {
+            if (options.needsSwap.value && swapEffectiveQuote.value) {
+              plan.value = await options.buildSwapPlan(swapEffectiveQuote.value, {
+                vaultAddress: collateralVault.value.address,
+                amountNano: valueToNano(amount.value || '0', asset.value.decimals),
+                subAccount: position.value?.subAccount,
+                includePermit2Call: false,
+              })
+            }
+            else {
+              plan.value = await options.buildDirectPlan({
+                vaultAddress: collateralVault.value.address,
+                assetAddress: asset.value.address,
+                amountNano: valueToNano(amount.value || '0', asset.value.decimals),
+                subAccount: position.value?.subAccount,
+                includePermit2Call: false,
+              })
+            }
           }
-          else {
-            plan.value = await options.buildDirectPlan({
-              vaultAddress: collateralVault.value.address,
-              assetAddress: asset.value.address,
-              amountNano: valueToNano(amount.value || '0', asset.value.decimals),
-              subAccount: position.value?.subAccount,
-              includePermit2Call: false,
-            })
+          catch (e) {
+            logWarn(`collateral/${options.mode}/buildPlan`, e)
+            plan.value = null
           }
-        }
-        catch (e) {
-          logWarn(`collateral/${options.mode}/buildPlan`, e)
-          plan.value = null
-        }
 
-        if (plan.value) {
-          const ok = await runSimulation(plan.value)
-          if (!ok) return
-        }
+          if (plan.value) {
+            const ok = await runSimulation(plan.value)
+            if (!ok) return
+          }
 
-        const reviewAsset = options.getReviewAsset(options.needsSwap.value)
-        const reviewType = options.needsSwap.value ? options.swapReviewType : options.reviewType
-        modal.open(OperationReviewModal, {
-          props: {
-            type: reviewType,
-            asset: reviewAsset,
-            amount: amount.value,
-            plan: plan.value || undefined,
-            subAccount: position.value?.subAccount,
-            hasBorrows: (position.value?.borrowed || 0n) > 0n,
-            swapToAsset: options.needsSwap.value ? options.getSwapToAsset() : undefined,
-            swapToAmount: options.needsSwap.value ? swapEstimatedOutput.value : undefined,
-            onConfirm: () => {
-              setTimeout(() => {
-                send()
-              }, 400)
+          const reviewAsset = options.getReviewAsset(options.needsSwap.value)
+          const reviewType = options.needsSwap.value ? options.swapReviewType : options.reviewType
+          modal.open(OperationReviewModal, {
+            props: {
+              type: reviewType,
+              asset: reviewAsset,
+              amount: amount.value,
+              plan: plan.value || undefined,
+              subAccount: position.value?.subAccount,
+              hasBorrows: (position.value?.borrowed || 0n) > 0n,
+              swapToAsset: options.needsSwap.value ? options.getSwapToAsset() : undefined,
+              swapToAmount: options.needsSwap.value ? swapEstimatedOutput.value : undefined,
+              onConfirm: () => {
+                setTimeout(() => {
+                  send()
+                }, 400)
+              },
             },
-          },
+          })
         })
       })
     }
@@ -661,6 +675,7 @@ export const useCollateralForm = (options: UseCollateralFormOptions) => {
     swapQuoteError,
     swapQuotesStatusLabel,
     swapEstimatedOutput,
+    swapPriceImpact,
     swapRouteItems,
     selectSwapQuote,
     resetSwapQuoteState,

--- a/composables/usePriceImpactGate.ts
+++ b/composables/usePriceImpactGate.ts
@@ -1,0 +1,36 @@
+import { unref } from 'vue'
+import type { Ref, ComputedRef } from 'vue'
+import { useModal } from '~/components/ui/composables/useModal'
+import { HighPriceImpactModal } from '#components'
+import { isPriceImpactDanger } from '~/utils/priceImpact'
+
+export const usePriceImpactGate = (options: {
+  directPriceImpact: Ref<number | null> | ComputedRef<number | null>
+  multipliedPriceImpact?: Ref<number | null> | ComputedRef<number | null>
+}) => {
+  const modal = useModal()
+
+  const needsConfirmation = computed(() =>
+    isPriceImpactDanger(unref(options.directPriceImpact))
+    || isPriceImpactDanger(unref(options.multipliedPriceImpact) ?? null),
+  )
+
+  const guardWithPriceImpact = async (onProceed: () => void | Promise<void>) => {
+    if (!needsConfirmation.value) {
+      await onProceed()
+      return
+    }
+    modal.open(HighPriceImpactModal, {
+      props: {
+        directPriceImpact: unref(options.directPriceImpact) ?? 0,
+        multipliedPriceImpact: unref(options.multipliedPriceImpact) ?? null,
+        onConfirm: async () => {
+          modal.close()
+          await onProceed()
+        },
+      },
+    })
+  }
+
+  return { needsConfirmation, guardWithPriceImpact }
+}

--- a/composables/useSwapPageLogic.ts
+++ b/composables/useSwapPageLogic.ts
@@ -3,6 +3,7 @@ import { useAccount } from '@wagmi/vue'
 import { logWarn } from '~/utils/errorHandling'
 import { OperationReviewModal, SlippageSettingsModal } from '#components'
 import { useTermsOfUseGate } from '~/composables/useTermsOfUseGate'
+import { usePriceImpactGate } from '~/composables/usePriceImpactGate'
 import type { Vault, SecuritizeVault } from '~/entities/vault'
 import type { SwapApiQuote } from '~/entities/swap'
 import { getAssetUsdValue } from '~/services/pricing/priceProvider'
@@ -377,6 +378,7 @@ export const useSwapPageLogic = (options: UseSwapPageLogicOptions) => {
 
   // ── Price impact ───────────────────────────────────────────────────────
   const priceImpact = ref<number | null>(null)
+  const { guardWithPriceImpact } = usePriceImpactGate({ directPriceImpact: priceImpact })
 
   watchEffect(async () => {
     if (!quote.value || !fromVault.value || !toVault.value) {
@@ -437,39 +439,41 @@ export const useSwapPageLogic = (options: UseSwapPageLogicOptions) => {
     isPreparing.value = true
     try {
       await guardWithTerms(async () => {
-        if (isSubmitting.value || !fromVault.value) return
-        if (!isSameAsset.value && !selectedQuote.value) return
+        await guardWithPriceImpact(async () => {
+          if (isSubmitting.value || !fromVault.value) return
+          if (!isSameAsset.value && !selectedQuote.value) return
 
-        try {
-          plan.value = await buildPlan()
-        }
-        catch (e) {
-          logWarn('swap/buildPlan', e)
-          showError('Failed to build transaction')
-          plan.value = null
-          return
-        }
+          try {
+            plan.value = await buildPlan()
+          }
+          catch (e) {
+            logWarn('swap/buildPlan', e)
+            showError('Failed to build transaction')
+            plan.value = null
+            return
+          }
 
-        if (plan.value) {
-          const ok = await runSimulation(plan.value)
-          if (!ok) return
-        }
+          if (plan.value) {
+            const ok = await runSimulation(plan.value)
+            if (!ok) return
+          }
 
-        const showSwapAmounts = sameAssetModalType === 'transfer' || !isSameAsset.value
-        modal.open(OperationReviewModal, {
-          props: {
-            type: isSameAsset.value ? sameAssetModalType : 'swap',
-            asset: fromVault.value.asset,
-            amount: fromAmount.value,
-            swapToAsset: showSwapAmounts ? toVault.value?.asset : undefined,
-            swapToAmount: showSwapAmounts ? toAmount.value : undefined,
-            plan: plan.value || undefined,
-            onConfirm: () => {
-              setTimeout(() => {
-                send()
-              }, 400)
+          const showSwapAmounts = sameAssetModalType === 'transfer' || !isSameAsset.value
+          modal.open(OperationReviewModal, {
+            props: {
+              type: isSameAsset.value ? sameAssetModalType : 'swap',
+              asset: fromVault.value.asset,
+              amount: fromAmount.value,
+              swapToAsset: showSwapAmounts ? toVault.value?.asset : undefined,
+              swapToAmount: showSwapAmounts ? toAmount.value : undefined,
+              plan: plan.value || undefined,
+              onConfirm: () => {
+                setTimeout(() => {
+                  send()
+                }, 400)
+              },
             },
-          },
+          })
         })
       })
     }

--- a/composables/useSwapPriceImpact.ts
+++ b/composables/useSwapPriceImpact.ts
@@ -1,0 +1,71 @@
+import { type Address, formatUnits } from 'viem'
+import type { Ref } from 'vue'
+import type { SwapApiQuote } from '~/entities/swap'
+import type { Vault, SecuritizeVault, EarnVault } from '~/entities/vault'
+import { getAssetUsdValue } from '~/services/pricing/priceProvider'
+import { fetchBackendPrice } from '~/services/pricing/backendClient'
+import { createRaceGuard } from '~/utils/race-guard'
+
+type AnyVault = Vault | SecuritizeVault | EarnVault
+
+const getTokenUsdValue = async (
+  amount: bigint,
+  decimals: number,
+  tokenAddress: string,
+  vault: AnyVault | null | undefined,
+): Promise<number | undefined> => {
+  if (vault) {
+    return getAssetUsdValue(amount, vault, 'off-chain')
+  }
+  const priceData = await fetchBackendPrice(tokenAddress as Address)
+  if (!priceData?.price) return undefined
+  const tokenAmount = Number(formatUnits(amount, decimals))
+  return tokenAmount * priceData.price
+}
+
+export const useSwapPriceImpact = (options: {
+  quote: Ref<SwapApiQuote | null>
+  fromVault?: Ref<AnyVault | null | undefined>
+  toVault?: Ref<AnyVault | null | undefined>
+}) => {
+  const priceImpact = ref<number | null>(null)
+  const guard = createRaceGuard()
+
+  watchEffect(async () => {
+    const q = options.quote.value
+    if (!q) {
+      priceImpact.value = null
+      return
+    }
+
+    const amountIn = BigInt(q.amountIn || 0)
+    const amountOut = BigInt(q.amountOut || 0)
+    if (amountIn <= 0n || amountOut <= 0n) {
+      priceImpact.value = null
+      return
+    }
+
+    const tokenInAddr = q.tokenIn.address || q.tokenIn.addressInfo
+    const tokenOutAddr = q.tokenOut.address || q.tokenOut.addressInfo
+    if (!tokenInAddr || !tokenOutAddr) {
+      priceImpact.value = null
+      return
+    }
+
+    const gen = guard.next()
+    const [inUsd, outUsd] = await Promise.all([
+      getTokenUsdValue(amountIn, q.tokenIn.decimals, tokenInAddr, options.fromVault?.value),
+      getTokenUsdValue(amountOut, q.tokenOut.decimals, tokenOutAddr, options.toVault?.value),
+    ])
+    if (guard.isStale(gen)) return
+
+    if (!inUsd || !outUsd) {
+      priceImpact.value = null
+      return
+    }
+    const impact = (outUsd / inUsd - 1) * 100
+    priceImpact.value = Number.isFinite(impact) ? impact : null
+  })
+
+  return { priceImpact }
+}

--- a/pages/borrow/[collateral]/[borrow]/index.vue
+++ b/pages/borrow/[collateral]/[borrow]/index.vue
@@ -11,6 +11,8 @@ import { getNewSubAccount } from '~/entities/account'
 import { useEulerProductOfVault } from '~/composables/useEulerLabels'
 import { isAnyVaultBlockedByCountry, isVaultRestrictedByCountry } from '~/composables/useGeoBlock'
 import { formatNumber, formatSmartAmount, formatHealthScore } from '~/utils/string-utils'
+import { isPriceImpactWarning, isSlippageWarning } from '~/utils/priceImpact'
+import { usePriceImpactGate } from '~/composables/usePriceImpactGate'
 import { nanoToValue } from '~/utils/crypto-utils'
 import { useBorrowForm } from '~/composables/borrow/useBorrowForm'
 import { useMultiplyForm } from '~/composables/borrow/useMultiplyForm'
@@ -145,6 +147,11 @@ const multiply = useMultiplyForm({
   isMultiplyRestricted,
 })
 
+const { guardWithPriceImpact: guardWithMultiplyPriceImpact } = usePriceImpactGate({
+  directPriceImpact: multiply.multiplyPriceImpact,
+  multipliedPriceImpact: multiply.multipliedPriceImpact,
+})
+
 // --- Submit disabled ---
 const reviewBorrowDisabled = getSubmitDisabled(computed(() => isGeoBlocked.value || isBorrowRestricted.value || borrow.isBorrowSwapRestricted.value || borrow.isSubmitDisabled.value))
 const reviewMultiplyDisabled = getSubmitDisabled(computed(() => isGeoBlocked.value || isMultiplyRestricted.value || multiply.isMultiplySubmitDisabled.value))
@@ -230,12 +237,12 @@ const updateBalance = async () => {
 }
 
 // --- Submit dispatcher ---
-const onSubmit = () => {
+const onSubmit = async () => {
   if (formTab.value === 'borrow') {
     borrow.submit()
   }
   else if (formTab.value === 'multiply') {
-    multiply.submitMultiply()
+    await guardWithMultiplyPriceImpact(() => multiply.submitMultiply())
   }
 }
 
@@ -503,7 +510,7 @@ watch(formTab, () => {
                       class="flex items-center gap-6 text-p2"
                       @click="openSlippageSettings"
                     >
-                      <span>{{ formatNumber(borrow.borrowSwapSlippage.value, 2, 0) }}%</span>
+                      <span :class="{ 'text-error-500': isSlippageWarning(borrow.borrowSwapSlippage.value) }">{{ formatNumber(borrow.borrowSwapSlippage.value, 2, 0) }}%</span>
                       <SvgIcon
                         name="edit"
                         class="!w-16 !h-16 text-accent-600"
@@ -791,8 +798,22 @@ watch(formTab, () => {
                       </p>
                     </SummaryRow>
                     <SummaryRow label="Price impact">
-                      <p class="text-p2">
+                      <p
+                        class="text-p2"
+                        :class="{ 'text-error-500': isPriceImpactWarning(multiply.multiplyPriceImpact.value) }"
+                      >
                         {{ multiply.multiplyPriceImpact.value !== null ? `${formatNumber(multiply.multiplyPriceImpact.value, 2, 2)}%` : '-' }}
+                      </p>
+                    </SummaryRow>
+                    <SummaryRow
+                      v-if="multiply.multipliedPriceImpact.value !== null"
+                      label="Multiplied price impact"
+                    >
+                      <p
+                        class="text-p2"
+                        :class="{ 'text-error-500': isPriceImpactWarning(multiply.multipliedPriceImpact.value) }"
+                      >
+                        {{ formatNumber(multiply.multipliedPriceImpact.value, 2, 2) }}%
                       </p>
                     </SummaryRow>
                     <SummaryRow label="Slippage tolerance">
@@ -801,7 +822,7 @@ watch(formTab, () => {
                         class="flex items-center gap-6 text-p2"
                         @click="openSlippageSettings"
                       >
-                        <span>{{ formatNumber(multiply.multiplySlippage.value, 2, 0) }}%</span>
+                        <span :class="{ 'text-error-500': isSlippageWarning(multiply.multiplySlippage.value) }">{{ formatNumber(multiply.multiplySlippage.value, 2, 0) }}%</span>
                         <SvgIcon
                           name="edit"
                           class="!w-16 !h-16 text-accent-600"

--- a/pages/borrow/[collateral]/[borrow]/index.vue
+++ b/pages/borrow/[collateral]/[borrow]/index.vue
@@ -152,6 +152,10 @@ const { guardWithPriceImpact: guardWithMultiplyPriceImpact } = usePriceImpactGat
   multipliedPriceImpact: multiply.multipliedPriceImpact,
 })
 
+const { guardWithPriceImpact: guardWithBorrowSwapPriceImpact } = usePriceImpactGate({
+  directPriceImpact: borrow.borrowSwapPriceImpact,
+})
+
 // --- Submit disabled ---
 const reviewBorrowDisabled = getSubmitDisabled(computed(() => isGeoBlocked.value || isBorrowRestricted.value || borrow.isBorrowSwapRestricted.value || borrow.isSubmitDisabled.value))
 const reviewMultiplyDisabled = getSubmitDisabled(computed(() => isGeoBlocked.value || isMultiplyRestricted.value || multiply.isMultiplySubmitDisabled.value))
@@ -239,7 +243,7 @@ const updateBalance = async () => {
 // --- Submit dispatcher ---
 const onSubmit = async () => {
   if (formTab.value === 'borrow') {
-    borrow.submit()
+    await guardWithBorrowSwapPriceImpact(() => borrow.submit())
   }
   else if (formTab.value === 'multiply') {
     await guardWithMultiplyPriceImpact(() => multiply.submitMultiply())
@@ -503,6 +507,17 @@ watch(formTab, () => {
                     <p class="text-p2">
                       ~{{ formatSmartAmount(borrow.borrowSwapEstimatedCollateral.value) }} {{ collateralVault.asset.symbol }}
                     </p>
+                  </SummaryRow>
+                  <SummaryRow
+                    v-if="borrow.borrowSwapPriceImpact.value !== null"
+                    label="Price impact"
+                  >
+                    <span
+                      class="text-p2"
+                      :class="{ 'text-error-500': isPriceImpactWarning(borrow.borrowSwapPriceImpact.value) }"
+                    >
+                      {{ formatNumber(borrow.borrowSwapPriceImpact.value, 2) }}%
+                    </span>
                   </SummaryRow>
                   <SummaryRow label="Slippage tolerance">
                     <button

--- a/pages/lend/[vault]/[subAccount]/swap.vue
+++ b/pages/lend/[vault]/[subAccount]/swap.vue
@@ -8,6 +8,7 @@ import { SwapperMode } from '~/entities/swap'
 import type { TxPlan } from '~/entities/txPlan'
 import { useIntrinsicApy } from '~/composables/useIntrinsicApy'
 import { formatNumber, formatSmartAmount } from '~/utils/string-utils'
+import { isPriceImpactWarning, isSlippageWarning } from '~/utils/priceImpact'
 import { nanoToValue } from '~/utils/crypto-utils'
 import { useSwapPageLogic } from '~/composables/useSwapPageLogic'
 import { normalizeAddress } from '~/utils/normalizeAddress'
@@ -317,7 +318,10 @@ watch([() => route.params.vault, () => route.query.to], () => {
                 </p>
               </SummaryRow>
               <SummaryRow label="Price impact">
-                <p class="text-p2">
+                <p
+                  class="text-p2"
+                  :class="{ 'text-error-500': isPriceImpactWarning(priceImpact) }"
+                >
                   {{ priceImpact !== null ? `${formatNumber(priceImpact, 2, 2)}%` : '-' }}
                 </p>
               </SummaryRow>
@@ -327,7 +331,7 @@ watch([() => route.params.vault, () => route.query.to], () => {
                   class="flex items-center gap-6 text-p2"
                   @click="openSlippageSettings"
                 >
-                  <span>{{ formatNumber(slippage, 2, 0) }}%</span>
+                  <span :class="{ 'text-error-500': isSlippageWarning(slippage) }">{{ formatNumber(slippage, 2, 0) }}%</span>
                   <SvgIcon
                     name="edit"
                     class="!w-16 !h-16 text-accent-600"

--- a/pages/lend/[vault]/[subAccount]/withdraw.vue
+++ b/pages/lend/[vault]/[subAccount]/withdraw.vue
@@ -22,6 +22,9 @@ import { useSwapQuotesParallel } from '~/composables/useSwapQuotesParallel'
 import { SwapperMode } from '~/entities/swap'
 import { buildSwapRouteItems } from '~/utils/swapRouteItems'
 import { formatNumber, formatSmartAmount } from '~/utils/string-utils'
+import { isPriceImpactWarning, isSlippageWarning } from '~/utils/priceImpact'
+import { useSwapPriceImpact } from '~/composables/useSwapPriceImpact'
+import { usePriceImpactGate } from '~/composables/usePriceImpactGate'
 import { nanoToValue } from '~/utils/crypto-utils'
 
 const router = useRouter()
@@ -140,6 +143,15 @@ const swapEstimatedOutput = computed(() => {
   const amountOut = BigInt(swapEffectiveQuote.value.amountOut || 0)
   if (amountOut <= 0n) return ''
   return formatUnits(amountOut, Number(selectedOutputAsset.value.decimals))
+})
+
+const { priceImpact: swapPriceImpact } = useSwapPriceImpact({
+  quote: swapEffectiveQuote,
+  fromVault: vault,
+})
+
+const { guardWithPriceImpact } = usePriceImpactGate({
+  directPriceImpact: swapPriceImpact,
 })
 
 const swapRouteItems = computed(() => {
@@ -274,64 +286,66 @@ const submit = async () => {
   isPreparing.value = true
   try {
     await guardWithTerms(async () => {
-      if (!asset.value?.address) {
-        return
-      }
-
-      const isMax = FixedPoint.fromValue(assetsBalance.value, asset.value?.decimals).lte(amountFixed.value)
-
-      try {
-        if (needsSwap.value && swapEffectiveQuote.value) {
-          if (isMax) {
-            plan.value = await buildRedeemAndSwapPlan({
-              vaultAddress: vaultAddress as Address,
-              sharesAmount: sharesBalance.value,
-              quote: swapEffectiveQuote.value,
-              subAccount: subAccount.value,
-            })
-          }
-          else {
-            plan.value = await buildWithdrawAndSwapPlan({
-              vaultAddress: vaultAddress as Address,
-              assetsAmount: amountFixed.value.value,
-              quote: swapEffectiveQuote.value,
-              subAccount: subAccount.value,
-            })
-          }
-        }
-        else {
-          plan.value = isMax
-            ? await buildRedeemPlan(vaultAddress, amountFixed.value.value, sharesBalance.value, isMax, subAccount.value)
-            : await buildWithdrawPlan(vaultAddress, amountFixed.value.value, subAccount.value)
-        }
-      }
-      catch (e) {
-        console.warn('[lend/withdraw] failed to build plan', e)
-        plan.value = null
-      }
-
-      if (plan.value) {
-        const ok = await runSimulation(plan.value)
-        if (!ok) {
+      await guardWithPriceImpact(async () => {
+        if (!asset.value?.address) {
           return
         }
-      }
 
-      const reviewType = needsSwap.value ? 'swap-withdraw' as const : 'withdraw' as const
-      modal.open(OperationReviewModal, {
-        props: {
-          type: reviewType,
-          asset: asset.value,
-          amount: amount.value,
-          plan: plan.value || undefined,
-          swapToAsset: needsSwap.value ? selectedOutputAsset.value : undefined,
-          swapToAmount: needsSwap.value ? swapEstimatedOutput.value : undefined,
-          onConfirm: () => {
-            setTimeout(() => {
-              send()
-            }, 400)
+        const isMax = FixedPoint.fromValue(assetsBalance.value, asset.value?.decimals).lte(amountFixed.value)
+
+        try {
+          if (needsSwap.value && swapEffectiveQuote.value) {
+            if (isMax) {
+              plan.value = await buildRedeemAndSwapPlan({
+                vaultAddress: vaultAddress as Address,
+                sharesAmount: sharesBalance.value,
+                quote: swapEffectiveQuote.value,
+                subAccount: subAccount.value,
+              })
+            }
+            else {
+              plan.value = await buildWithdrawAndSwapPlan({
+                vaultAddress: vaultAddress as Address,
+                assetsAmount: amountFixed.value.value,
+                quote: swapEffectiveQuote.value,
+                subAccount: subAccount.value,
+              })
+            }
+          }
+          else {
+            plan.value = isMax
+              ? await buildRedeemPlan(vaultAddress, amountFixed.value.value, sharesBalance.value, isMax, subAccount.value)
+              : await buildWithdrawPlan(vaultAddress, amountFixed.value.value, subAccount.value)
+          }
+        }
+        catch (e) {
+          console.warn('[lend/withdraw] failed to build plan', e)
+          plan.value = null
+        }
+
+        if (plan.value) {
+          const ok = await runSimulation(plan.value)
+          if (!ok) {
+            return
+          }
+        }
+
+        const reviewType = needsSwap.value ? 'swap-withdraw' as const : 'withdraw' as const
+        modal.open(OperationReviewModal, {
+          props: {
+            type: reviewType,
+            asset: asset.value,
+            amount: amount.value,
+            plan: plan.value || undefined,
+            swapToAsset: needsSwap.value ? selectedOutputAsset.value : undefined,
+            swapToAmount: needsSwap.value ? swapEstimatedOutput.value : undefined,
+            onConfirm: () => {
+              setTimeout(() => {
+                send()
+              }, 400)
+            },
           },
-        },
+        })
       })
     })
   }
@@ -545,13 +559,24 @@ watch(swapSelectedQuote, () => {
                   ~{{ formatSmartAmount(swapEstimatedOutput) }} {{ selectedOutputAsset.symbol }}
                 </p>
               </SummaryRow>
+              <SummaryRow
+                v-if="swapPriceImpact !== null"
+                label="Price impact"
+              >
+                <span
+                  class="text-p2"
+                  :class="{ 'text-error-500': isPriceImpactWarning(swapPriceImpact) }"
+                >
+                  {{ formatNumber(swapPriceImpact, 2) }}%
+                </span>
+              </SummaryRow>
               <SummaryRow label="Slippage tolerance">
                 <button
                   type="button"
                   class="flex items-center gap-6 text-p2"
                   @click="openSlippageSettings"
                 >
-                  <span>{{ formatNumber(swapSlippage, 2, 0) }}%</span>
+                  <span :class="{ 'text-error-500': isSlippageWarning(swapSlippage) }">{{ formatNumber(swapSlippage, 2, 0) }}%</span>
                   <SvgIcon
                     name="edit"
                     class="!w-16 !h-16 text-accent-600"

--- a/pages/lend/[vault]/index.vue
+++ b/pages/lend/[vault]/index.vue
@@ -21,6 +21,9 @@ import VaultFormInfoBlock from '~/components/entities/vault/form/VaultFormInfoBl
 import VaultFormSubmit from '~/components/entities/vault/form/VaultFormSubmit.vue'
 import SecuritizeVaultOverview from '~/components/entities/vault/overview/SecuritizeVaultOverview.vue'
 import { formatNumber, compactNumber, formatSmartAmount } from '~/utils/string-utils'
+import { isPriceImpactWarning, isSlippageWarning } from '~/utils/priceImpact'
+import { useSwapPriceImpact } from '~/composables/useSwapPriceImpact'
+import { usePriceImpactGate } from '~/composables/usePriceImpactGate'
 
 // Type definitions for vault display
 type VaultType = 'evk' | 'securitize'
@@ -356,52 +359,54 @@ const submit = async () => {
   isPreparing.value = true
   try {
     await guardWithTerms(async () => {
-      if (!asset.value?.address) {
-        return
-      }
-
-      try {
-        if (needsSwap.value && swapEffectiveQuote.value) {
-          plan.value = await buildSwapSupplyPlanFromQuote(swapEffectiveQuote.value, { includePermit2Call: false })
-        }
-        else {
-          plan.value = await buildSupplyPlan(
-            vaultAddress,
-            asset.value.address,
-            valueToNano(amount.value || '0', asset.value.decimals),
-            undefined,
-            { includePermit2Call: false },
-          )
-        }
-      }
-      catch (e) {
-        console.warn('[OperationReviewModal] failed to build plan', e)
-        plan.value = null
-      }
-
-      if (plan.value) {
-        const ok = await runSimulation(plan.value)
-        if (!ok) {
+      await guardWithPriceImpact(async () => {
+        if (!asset.value?.address) {
           return
         }
-      }
 
-      const reviewAsset = needsSwap.value && selectedAsset.value ? selectedAsset.value : asset.value
-      const reviewType = needsSwap.value ? 'swap-supply' as const : 'supply' as const
-      modal.open(OperationReviewModal, {
-        props: {
-          type: reviewType,
-          asset: reviewAsset,
-          amount: amount.value,
-          plan: plan.value || undefined,
-          swapToAsset: needsSwap.value ? asset.value : undefined,
-          swapToAmount: needsSwap.value ? swapEstimatedOutput.value : undefined,
-          onConfirm: () => {
-            setTimeout(() => {
-              send()
-            }, 400)
+        try {
+          if (needsSwap.value && swapEffectiveQuote.value) {
+            plan.value = await buildSwapSupplyPlanFromQuote(swapEffectiveQuote.value, { includePermit2Call: false })
+          }
+          else {
+            plan.value = await buildSupplyPlan(
+              vaultAddress,
+              asset.value.address,
+              valueToNano(amount.value || '0', asset.value.decimals),
+              undefined,
+              { includePermit2Call: false },
+            )
+          }
+        }
+        catch (e) {
+          console.warn('[OperationReviewModal] failed to build plan', e)
+          plan.value = null
+        }
+
+        if (plan.value) {
+          const ok = await runSimulation(plan.value)
+          if (!ok) {
+            return
+          }
+        }
+
+        const reviewAsset = needsSwap.value && selectedAsset.value ? selectedAsset.value : asset.value
+        const reviewType = needsSwap.value ? 'swap-supply' as const : 'supply' as const
+        modal.open(OperationReviewModal, {
+          props: {
+            type: reviewType,
+            asset: reviewAsset,
+            amount: amount.value,
+            plan: plan.value || undefined,
+            swapToAsset: needsSwap.value ? asset.value : undefined,
+            swapToAmount: needsSwap.value ? swapEstimatedOutput.value : undefined,
+            onConfirm: () => {
+              setTimeout(() => {
+                send()
+              }, 400)
+            },
           },
-        },
+        })
       })
     })
   }
@@ -500,6 +505,15 @@ const swapEstimatedOutput = computed(() => {
   const amountOut = BigInt(swapEffectiveQuote.value.amountOut || 0)
   if (amountOut <= 0n) return ''
   return formatUnits(amountOut, Number(asset.value.decimals))
+})
+
+const { priceImpact: swapPriceImpact } = useSwapPriceImpact({
+  quote: swapEffectiveQuote,
+  toVault: evkVault,
+})
+
+const { guardWithPriceImpact } = usePriceImpactGate({
+  directPriceImpact: swapPriceImpact,
 })
 
 const swapRouteItems = computed(() => {
@@ -768,13 +782,24 @@ watch(address, () => {
                   ~{{ formatSmartAmount(swapEstimatedOutput) }} {{ asset.symbol }}
                 </p>
               </SummaryRow>
+              <SummaryRow
+                v-if="swapPriceImpact !== null"
+                label="Price impact"
+              >
+                <span
+                  class="text-p2"
+                  :class="{ 'text-error-500': isPriceImpactWarning(swapPriceImpact) }"
+                >
+                  {{ formatNumber(swapPriceImpact, 2) }}%
+                </span>
+              </SummaryRow>
               <SummaryRow label="Slippage tolerance">
                 <button
                   type="button"
                   class="flex items-center gap-6 text-p2"
                   @click="openSlippageSettings"
                 >
-                  <span>{{ formatNumber(swapSlippage, 2, 0) }}%</span>
+                  <span :class="{ 'text-error-500': isSlippageWarning(swapSlippage) }">{{ formatNumber(swapSlippage, 2, 0) }}%</span>
                   <SvgIcon
                     name="edit"
                     class="!w-16 !h-16 text-accent-600"

--- a/pages/position/[number]/borrow/swap.vue
+++ b/pages/position/[number]/borrow/swap.vue
@@ -9,6 +9,7 @@ import { SwapperMode } from '~/entities/swap'
 import type { TxPlan } from '~/entities/txPlan'
 import { useIntrinsicApy } from '~/composables/useIntrinsicApy'
 import { formatNumber, formatSmartAmount, formatHealthScore } from '~/utils/string-utils'
+import { isPriceImpactWarning, isSlippageWarning } from '~/utils/priceImpact'
 import { nanoToValue } from '~/utils/crypto-utils'
 import { useSwapPageLogic } from '~/composables/useSwapPageLogic'
 
@@ -36,7 +37,7 @@ const { borrowOptions, borrowVaults } = useSwapDebtOptions({
 const currentDebt = computed(() => position.value?.borrowed || 0n)
 const balance = computed(() => currentDebt.value)
 const targetVaultAddress = computed(() => typeof route.query.to === 'string' ? route.query.to : '')
-const hasBorrowSwapOptions = computed(() => borrowVaults.value.length > 0)
+const _hasBorrowSwapOptions = computed(() => borrowVaults.value.length > 0)
 
 const setFromAmountToMax = () => {
   if (!fromVault.value) {
@@ -546,7 +547,10 @@ const onToVaultChange = (selectedIndex: number) => {
                 </p>
               </SummaryRow>
               <SummaryRow label="Price impact">
-                <p class="text-p2">
+                <p
+                  class="text-p2"
+                  :class="{ 'text-error-500': isPriceImpactWarning(priceImpact) }"
+                >
                   {{ priceImpact !== null ? `${formatNumber(priceImpact, 2, 2)}%` : '-' }}
                 </p>
               </SummaryRow>
@@ -556,7 +560,7 @@ const onToVaultChange = (selectedIndex: number) => {
                   class="flex items-center gap-6 text-p2"
                   @click="openSlippageSettings"
                 >
-                  <span>{{ formatNumber(slippage, 2, 0) }}%</span>
+                  <span :class="{ 'text-error-500': isSlippageWarning(slippage) }">{{ formatNumber(slippage, 2, 0) }}%</span>
                   <SvgIcon
                     name="edit"
                     class="!w-16 !h-16 text-accent-600"

--- a/pages/position/[number]/collateral/swap.vue
+++ b/pages/position/[number]/collateral/swap.vue
@@ -9,6 +9,7 @@ import type {
   SecuritizeVault,
   VaultAsset,
 } from '~/entities/vault'
+import { isPriceImpactWarning, isSlippageWarning } from '~/utils/priceImpact'
 import {
   getAssetUsdValue,
   getAssetOraclePrice,
@@ -661,7 +662,10 @@ const nextLiquidationPrice = computed(() => {
                 </p>
               </SummaryRow>
               <SummaryRow label="Price impact">
-                <p class="text-p2">
+                <p
+                  class="text-p2"
+                  :class="{ 'text-error-500': isPriceImpactWarning(priceImpact) }"
+                >
                   {{ priceImpact !== null ? `${formatNumber(priceImpact, 2, 2)}%` : '-' }}
                 </p>
               </SummaryRow>
@@ -671,7 +675,7 @@ const nextLiquidationPrice = computed(() => {
                   class="flex items-center gap-6 text-p2"
                   @click="openSlippageSettings"
                 >
-                  <span>{{ formatNumber(slippage, 2, 0) }}%</span>
+                  <span :class="{ 'text-error-500': isSlippageWarning(slippage) }">{{ formatNumber(slippage, 2, 0) }}%</span>
                   <SvgIcon
                     name="edit"
                     class="!w-16 !h-16 text-accent-600"

--- a/pages/position/[number]/multiply.vue
+++ b/pages/position/[number]/multiply.vue
@@ -9,6 +9,8 @@ import { useToast } from '~/components/ui/composables/useToast'
 import type { AccountBorrowPosition } from '~/entities/account'
 import type { Vault, VaultAsset } from '~/entities/vault'
 import { getAssetUsdValue, getAssetOraclePrice, getCollateralOraclePrice, conservativePriceRatioNumber } from '~/services/pricing/priceProvider'
+import { computeMultipliedPriceImpact, isPriceImpactWarning, isSlippageWarning } from '~/utils/priceImpact'
+import { usePriceImpactGate } from '~/composables/usePriceImpactGate'
 import { useEulerProductOfVault } from '~/composables/useEulerLabels'
 import { isAnyVaultBlockedByCountry, isVaultRestrictedByCountry } from '~/composables/useGeoBlock'
 import { useSwapQuotesParallel } from '~/composables/useSwapQuotesParallel'
@@ -465,6 +467,13 @@ watchEffect(async () => {
   }
   multiplyPriceImpact.value = impact
 })
+const multipliedPriceImpact = computed(() =>
+  computeMultipliedPriceImpact(multiplyPriceImpact.value, multiplier.value),
+)
+const { guardWithPriceImpact } = usePriceImpactGate({
+  directPriceImpact: multiplyPriceImpact,
+  multipliedPriceImpact,
+})
 const multiplyRoutedVia = computed(() => {
   if (isMultiplyQuoteLoading.value) {
     return null
@@ -595,79 +604,81 @@ const submitMultiply = async () => {
   isPreparing.value = true
   try {
     await guardWithTerms(async () => {
-      if (isSubmitting.value || !isConnected.value) {
-        return
-      }
-      if (!multiplySupplyVault.value || !multiplyLongVault.value || !multiplyShortVault.value) {
-        return
-      }
-      const debtAmount = multiplyDebtAmountNano.value
-      if (debtAmount <= 0n) {
-        return
-      }
-      if (multiplyErrorText.value) {
-        return
-      }
-      const subAccount = multiplySubAccount.value
-      if (!subAccount) {
-        error('Unable to resolve position')
-        return
-      }
-
-      const isSameAsset = normalizeAddress(multiplyLongVault.value.asset.address) === normalizeAddress(multiplyShortVault.value.asset.address)
-      const quote = isSameAsset ? null : multiplySelectedQuote.value
-      if (!isSameAsset && !quote) {
-        return
-      }
-
-      const nextPlanParams: MultiplyPlanParams = {
-        supplyVaultAddress: multiplySupplyVault.value.address,
-        supplyAssetAddress: multiplySupplyVault.value.asset.address,
-        supplyAmount: 0n,
-        longVaultAddress: multiplyLongVault.value.address,
-        longAssetAddress: multiplyLongVault.value.asset.address,
-        borrowVaultAddress: multiplyShortVault.value.address,
-        debtAmount,
-        quote: quote || undefined,
-        swapperMode: SwapperMode.EXACT_IN,
-        subAccount,
-      }
-      planParams.value = nextPlanParams
-
-      try {
-        plan.value = await buildMultiplyPlan({
-          ...nextPlanParams,
-          includePermit2Call: false,
-          enabledCollaterals: position.value?.collaterals,
-        })
-      }
-      catch (e) {
-        console.warn('[Multiply] failed to build plan', e)
-        plan.value = null
-      }
-
-      if (plan.value) {
-        const ok = await runMultiplySimulation(plan.value)
-        if (!ok) {
+      await guardWithPriceImpact(async () => {
+        if (isSubmitting.value || !isConnected.value) {
           return
         }
-      }
+        if (!multiplySupplyVault.value || !multiplyLongVault.value || !multiplyShortVault.value) {
+          return
+        }
+        const debtAmount = multiplyDebtAmountNano.value
+        if (debtAmount <= 0n) {
+          return
+        }
+        if (multiplyErrorText.value) {
+          return
+        }
+        const subAccount = multiplySubAccount.value
+        if (!subAccount) {
+          error('Unable to resolve position')
+          return
+        }
 
-      modal.open(OperationReviewModal, {
-        props: {
-          type: 'borrow',
-          asset: multiplyShortVault.value.asset,
-          amount: multiplyShortAmount.value || formatUnits(debtAmount, Number(multiplyShortVault.value.asset.decimals)),
-          plan: plan.value || undefined,
-          swapToAsset: quote ? multiplyLongVault.value.asset : undefined,
-          swapToAmount: quote ? multiplyLongAmount.value : undefined,
+        const isSameAsset = normalizeAddress(multiplyLongVault.value.asset.address) === normalizeAddress(multiplyShortVault.value.asset.address)
+        const quote = isSameAsset ? null : multiplySelectedQuote.value
+        if (!isSameAsset && !quote) {
+          return
+        }
+
+        const nextPlanParams: MultiplyPlanParams = {
+          supplyVaultAddress: multiplySupplyVault.value.address,
+          supplyAssetAddress: multiplySupplyVault.value.asset.address,
+          supplyAmount: 0n,
+          longVaultAddress: multiplyLongVault.value.address,
+          longAssetAddress: multiplyLongVault.value.asset.address,
+          borrowVaultAddress: multiplyShortVault.value.address,
+          debtAmount,
+          quote: quote || undefined,
+          swapperMode: SwapperMode.EXACT_IN,
           subAccount,
-          onConfirm: () => {
-            setTimeout(() => {
-              sendMultiply()
-            }, 400)
+        }
+        planParams.value = nextPlanParams
+
+        try {
+          plan.value = await buildMultiplyPlan({
+            ...nextPlanParams,
+            includePermit2Call: false,
+            enabledCollaterals: position.value?.collaterals,
+          })
+        }
+        catch (e) {
+          console.warn('[Multiply] failed to build plan', e)
+          plan.value = null
+        }
+
+        if (plan.value) {
+          const ok = await runMultiplySimulation(plan.value)
+          if (!ok) {
+            return
+          }
+        }
+
+        modal.open(OperationReviewModal, {
+          props: {
+            type: 'borrow',
+            asset: multiplyShortVault.value.asset,
+            amount: multiplyShortAmount.value || formatUnits(debtAmount, Number(multiplyShortVault.value.asset.decimals)),
+            plan: plan.value || undefined,
+            swapToAsset: quote ? multiplyLongVault.value.asset : undefined,
+            swapToAmount: quote ? multiplyLongAmount.value : undefined,
+            subAccount,
+            onConfirm: () => {
+              setTimeout(() => {
+                sendMultiply()
+              }, 400)
+            },
           },
-        },
+        })
       })
     })
   }
@@ -959,8 +970,22 @@ watch([multiplyMinMultiplier, multiplyMaxMultiplier], ([min, max]) => {
             </p>
           </SummaryRow>
           <SummaryRow label="Price impact">
-            <p class="text-p2">
+            <p
+              class="text-p2"
+              :class="{ 'text-error-500': isPriceImpactWarning(multiplyPriceImpact) }"
+            >
               {{ multiplyPriceImpact !== null ? `${formatNumber(multiplyPriceImpact, 2, 2)}%` : '-' }}
+            </p>
+          </SummaryRow>
+          <SummaryRow
+            v-if="multipliedPriceImpact !== null"
+            label="Multiplied price impact"
+          >
+            <p
+              class="text-p2"
+              :class="{ 'text-error-500': isPriceImpactWarning(multipliedPriceImpact) }"
+            >
+              {{ formatNumber(multipliedPriceImpact, 2, 2) }}%
             </p>
           </SummaryRow>
           <SummaryRow label="Slippage tolerance">
@@ -969,7 +994,7 @@ watch([multiplyMinMultiplier, multiplyMaxMultiplier], ([min, max]) => {
               class="flex items-center gap-6 text-p2"
               @click="openSlippageSettings"
             >
-              <span>{{ formatNumber(multiplySlippage, 2, 0) }}%</span>
+              <span :class="{ 'text-error-500': isSlippageWarning(multiplySlippage) }">{{ formatNumber(multiplySlippage, 2, 0) }}%</span>
               <SvgIcon
                 name="edit"
                 class="!w-16 !h-16 text-accent-600"

--- a/pages/position/[number]/repay.vue
+++ b/pages/position/[number]/repay.vue
@@ -12,6 +12,8 @@ import { POLL_INTERVAL_5S_MS } from '~/entities/tuning-constants'
 import { nanoToValue } from '~/utils/crypto-utils'
 import { createRaceGuard } from '~/utils/race-guard'
 import { formatNumber, formatSmartAmount, formatHealthScore } from '~/utils/string-utils'
+import { isPriceImpactWarning, isSlippageWarning } from '~/utils/priceImpact'
+import { usePriceImpactGate } from '~/composables/usePriceImpactGate'
 import { useWalletRepay } from '~/composables/repay/useWalletRepay'
 import { useCollateralSwapRepay } from '~/composables/repay/useCollateralSwapRepay'
 import { useSavingsRepay } from '~/composables/repay/useSavingsRepay'
@@ -152,6 +154,13 @@ const savings = useSavingsRepay({
   borrowApy,
 })
 
+const { guardWithPriceImpact: guardWithCollateralPriceImpact } = usePriceImpactGate({
+  directPriceImpact: collateral.priceImpact,
+})
+const { guardWithPriceImpact: guardWithSavingsPriceImpact } = usePriceImpactGate({
+  directPriceImpact: savings.priceImpact,
+})
+
 // --- Form tabs ---
 const formTabs = computed(() => {
   const tabs = [
@@ -178,10 +187,10 @@ const onSubmitForm = async () => {
       await wallet.submit()
     }
     else if (formTab.value === 'savings') {
-      await savings.submit()
+      await guardWithSavingsPriceImpact(() => savings.submit())
     }
     else {
-      await collateral.submit()
+      await guardWithCollateralPriceImpact(() => collateral.submit())
     }
   })
 }
@@ -547,13 +556,11 @@ onUnmounted(() => {
                 </p>
               </SummaryRow>
               <SummaryRow label="Price impact">
-                <p class="text-p2">
+                <p
+                  class="text-p2"
+                  :class="{ 'text-error-500': isPriceImpactWarning(collateral.priceImpact.value) }"
+                >
                   {{ collateral.priceImpact.value !== null ? `${formatNumber(collateral.priceImpact.value, 2, 2)}%` : '-' }}
-                </p>
-              </SummaryRow>
-              <SummaryRow label="Leveraged price impact">
-                <p class="text-p2">
-                  {{ collateral.leveragedPriceImpact.value !== null ? `${formatNumber(collateral.leveragedPriceImpact.value, 2, 2)}%` : '-' }}
                 </p>
               </SummaryRow>
               <SummaryRow label="Slippage tolerance">
@@ -562,7 +569,7 @@ onUnmounted(() => {
                   class="flex items-center gap-6 text-p2"
                   @click="openSlippageSettings"
                 >
-                  <span>{{ formatNumber(slippage, 2, 0) }}%</span>
+                  <span :class="{ 'text-error-500': isSlippageWarning(slippage) }">{{ formatNumber(slippage, 2, 0) }}%</span>
                   <SvgIcon
                     name="edit"
                     class="!w-16 !h-16 text-accent-600"
@@ -736,13 +743,11 @@ onUnmounted(() => {
                 </p>
               </SummaryRow>
               <SummaryRow label="Price impact">
-                <p class="text-p2">
+                <p
+                  class="text-p2"
+                  :class="{ 'text-error-500': isPriceImpactWarning(savings.priceImpact.value) }"
+                >
                   {{ savings.priceImpact.value !== null ? `${formatNumber(savings.priceImpact.value, 2, 2)}%` : '-' }}
-                </p>
-              </SummaryRow>
-              <SummaryRow label="Leveraged price impact">
-                <p class="text-p2">
-                  {{ savings.leveragedPriceImpact.value !== null ? `${formatNumber(savings.leveragedPriceImpact.value, 2, 2)}%` : '-' }}
                 </p>
               </SummaryRow>
               <SummaryRow label="Slippage tolerance">
@@ -751,7 +756,7 @@ onUnmounted(() => {
                   class="flex items-center gap-6 text-p2"
                   @click="openSlippageSettings"
                 >
-                  <span>{{ formatNumber(slippage, 2, 0) }}%</span>
+                  <span :class="{ 'text-error-500': isSlippageWarning(slippage) }">{{ formatNumber(slippage, 2, 0) }}%</span>
                   <SvgIcon
                     name="edit"
                     class="!w-16 !h-16 text-accent-600"

--- a/pages/position/[number]/supply.vue
+++ b/pages/position/[number]/supply.vue
@@ -11,6 +11,7 @@ import type { SwapApiQuote } from '~/entities/swap'
 import { SwapperMode } from '~/entities/swap'
 import { formatNumber, formatSmartAmount, formatHealthScore } from '~/utils/string-utils'
 import { nanoToValue } from '~/utils/crypto-utils'
+import { isPriceImpactWarning, isSlippageWarning } from '~/utils/priceImpact'
 import { useCollateralForm } from '~/composables/position/useCollateralForm'
 
 const { isConnected, address } = useAccount()
@@ -251,13 +252,24 @@ onUnmounted(() => {
                   ~{{ formatSmartAmount(form.swapEstimatedOutput.value) }} {{ form.asset.value.symbol }}
                 </p>
               </SummaryRow>
+              <SummaryRow
+                v-if="form.swapPriceImpact.value !== null"
+                label="Price impact"
+              >
+                <span
+                  class="text-p2"
+                  :class="{ 'text-error-500': isPriceImpactWarning(form.swapPriceImpact.value) }"
+                >
+                  {{ formatNumber(form.swapPriceImpact.value, 2) }}%
+                </span>
+              </SummaryRow>
               <SummaryRow label="Slippage tolerance">
                 <button
                   type="button"
                   class="flex items-center gap-6 text-p2"
                   @click="form.openSlippageSettings"
                 >
-                  <span>{{ formatNumber(form.swapSlippage.value, 2, 0) }}%</span>
+                  <span :class="{ 'text-error-500': isSlippageWarning(form.swapSlippage.value) }">{{ formatNumber(form.swapSlippage.value, 2, 0) }}%</span>
                   <SvgIcon
                     name="edit"
                     class="!w-16 !h-16 text-accent-600"

--- a/pages/position/[number]/withdraw.vue
+++ b/pages/position/[number]/withdraw.vue
@@ -13,6 +13,7 @@ import type { SwapApiQuote } from '~/entities/swap'
 import { SwapperMode } from '~/entities/swap'
 import { formatNumber, formatSmartAmount, formatHealthScore } from '~/utils/string-utils'
 import { nanoToValue } from '~/utils/crypto-utils'
+import { isPriceImpactWarning, isSlippageWarning } from '~/utils/priceImpact'
 import { useCollateralForm } from '~/composables/position/useCollateralForm'
 
 const { address } = useAccount()
@@ -231,13 +232,24 @@ watch(selectedOutputAsset, () => {
                   ~{{ formatSmartAmount(form.swapEstimatedOutput.value) }} {{ selectedOutputAsset.symbol }}
                 </p>
               </SummaryRow>
+              <SummaryRow
+                v-if="form.swapPriceImpact.value !== null"
+                label="Price impact"
+              >
+                <span
+                  class="text-p2"
+                  :class="{ 'text-error-500': isPriceImpactWarning(form.swapPriceImpact.value) }"
+                >
+                  {{ formatNumber(form.swapPriceImpact.value, 2) }}%
+                </span>
+              </SummaryRow>
               <SummaryRow label="Slippage tolerance">
                 <button
                   type="button"
                   class="flex items-center gap-6 text-p2"
                   @click="form.openSlippageSettings"
                 >
-                  <span>{{ formatNumber(form.swapSlippage.value, 2, 0) }}%</span>
+                  <span :class="{ 'text-error-500': isSlippageWarning(form.swapSlippage.value) }">{{ formatNumber(form.swapSlippage.value, 2, 0) }}%</span>
                   <SvgIcon
                     name="edit"
                     class="!w-16 !h-16 text-accent-600"

--- a/utils/priceImpact.ts
+++ b/utils/priceImpact.ts
@@ -1,0 +1,21 @@
+export const PRICE_IMPACT_WARNING_THRESHOLD = -5
+export const PRICE_IMPACT_DANGER_THRESHOLD = -10
+export const SLIPPAGE_WARNING_THRESHOLD = 1
+
+export const isPriceImpactWarning = (impact: number | null): boolean =>
+  impact !== null && impact <= PRICE_IMPACT_WARNING_THRESHOLD
+
+export const isPriceImpactDanger = (impact: number | null): boolean =>
+  impact !== null && impact <= PRICE_IMPACT_DANGER_THRESHOLD
+
+export const isSlippageWarning = (slippage: number): boolean =>
+  slippage > SLIPPAGE_WARNING_THRESHOLD
+
+export const computeMultipliedPriceImpact = (
+  directImpact: number | null,
+  multiplier: number | null,
+): number | null => {
+  if (directImpact === null || multiplier === null || multiplier <= 1) return null
+  const result = directImpact * multiplier
+  return Number.isFinite(result) ? result : null
+}


### PR DESCRIPTION
## Summary
- Add red text warnings for high price impact (>5% loss) and high slippage (>1%) across all swap, multiply, and repay pages
- Add "Multiplied price impact" row on multiply pages showing `directImpact × multiplier`
- Add confirmation modal (type "I understand") when price impact exceeds 10% loss, gating all submit flows
- Fix SlippageSettingsModal UX: custom slippage now applies live as you type, only one Save button needed

## Changes
- **New**: `utils/priceImpact.ts` — thresholds and helper functions
- **New**: `composables/usePriceImpactGate.ts` — gate composable with modal trigger
- **New**: `HighPriceImpactModal.vue` — confirmation modal for dangerous price impact
- **Edit**: `useMultiplyForm.ts` — adds `multipliedPriceImpact` computed
- **Edit**: `useSwapPageLogic.ts` — wires price impact gate into generic swap submit flow
- **Edit**: All swap/multiply/repay page templates — red styling on price impact and slippage values
- **Edit**: `SlippageSettings.vue` / `SlippageSettingsModal.vue` — defer custom save, remove inner Save in modal context

## Test plan
- [ ] Set slippage > 1% → verify red text on all swap/multiply/repay pages
- [ ] Find a swap pair with > 5% negative price impact → verify red price impact text
- [ ] Positive price impact should NOT show red
- [ ] Multiply page: set multiplier > 1x → "Multiplied price impact" row appears
- [ ] Multiply page: multiplier = 1x → row hidden
- [ ] Borrow page multiply tab: same multiplied impact behavior
- [ ] Trigger > 10% negative price impact → modal appears requiring "I understand"
- [ ] Modal Cancel → does not proceed; Confirm → proceeds to review
- [ ] SlippageSettingsModal: type custom value, click Save → value applies and modal closes
- [ ] SettingsModal: inner Save button still present and works