### PR TITLE
add 1h tag for earn apy

### DIFF
--- a/components/entities/portfolio/PortfolioEarnItem.vue
+++ b/components/entities/portfolio/PortfolioEarnItem.vue
@@ -82,6 +82,7 @@ const onSupplyInfoIconClick = (event: MouseEvent) => {
       intrinsicAPY: getIntrinsicApy(vault.value.asset.address),
       intrinsicApyInfo: getIntrinsicApyInfo(vault.value.asset.address),
       campaigns: getSupplyRewardCampaigns(vault.value.address),
+      baseApyAverageLabel: '1h',
     },
   })
 }
@@ -145,6 +146,9 @@ const onClick = () => {
         <div class="flex flex-col items-end">
           <div class="text-content-tertiary text-p3 mb-4 flex items-center gap-4">
             Supply APY
+            <span class="inline-flex h-20 items-center rounded-full border border-accent-200 bg-accent-100 px-7 text-[10px] font-semibold tracking-[0.08em] text-accent-700 shadow-[inset_0_1px_0_rgba(255,255,255,0.55)]">
+              1h
+            </span>
             <SvgIcon
               class="!w-16 !h-16 text-content-muted hover:text-content-secondary transition-colors cursor-pointer"
               name="info-circle"

--- a/components/entities/vault/VaultEarnItem.vue
+++ b/components/entities/vault/VaultEarnItem.vue
@@ -84,6 +84,7 @@ const onSupplyInfoIconClick = (event: MouseEvent) => {
       intrinsicAPY: getIntrinsicApy(vault.asset.address),
       intrinsicApyInfo: getIntrinsicApyInfo(vault.asset.address),
       campaigns: getSupplyRewardCampaigns(vault.address),
+      baseApyAverageLabel: '1h',
     },
   })
 }
@@ -142,6 +143,9 @@ const onSupplyInfoIconClick = (event: MouseEvent) => {
       <div class="flex flex-col items-end">
         <div class="text-content-tertiary text-p3 mb-4 text-right flex items-center gap-4">
           Supply APY
+          <span class="inline-flex h-20 items-center rounded-full border border-accent-200 bg-accent-100 px-7 text-[10px] font-semibold tracking-[0.08em] text-accent-700 shadow-[inset_0_1px_0_rgba(255,255,255,0.55)]">
+            1h
+          </span>
           <SvgIcon
             class="!w-16 !h-16 shrink-0 text-content-muted hover:text-content-secondary transition-colors cursor-pointer"
             name="info-circle"

--- a/components/entities/vault/VaultSupplyApyModal.vue
+++ b/components/entities/vault/VaultSupplyApyModal.vue
@@ -5,11 +5,12 @@ import type { RewardCampaign } from '~/entities/reward-campaign'
 import type { IntrinsicApyInfo } from '~/entities/intrinsic-apy'
 
 const emits = defineEmits(['close'])
-const { lendingAPY, intrinsicAPY, intrinsicApyInfo, campaigns } = defineProps<{
+const { lendingAPY, intrinsicAPY, intrinsicApyInfo, campaigns, baseApyAverageLabel } = defineProps<{
   lendingAPY: number
   intrinsicAPY?: number
   intrinsicApyInfo?: IntrinsicApyInfo
   campaigns?: RewardCampaign[]
+  baseApyAverageLabel?: string
 }>()
 
 const rewardsTotalAPY = computed(() => {
@@ -59,8 +60,14 @@ const handleClose = () => {
       >
         <div class="flex justify-between items-center">
           <div>
-            <p class="mb-4">
+            <p class="mb-4 flex items-center gap-6">
               Lending APY
+              <span
+                v-if="baseApyAverageLabel"
+                class="inline-flex h-20 items-center rounded-full border border-accent-200 bg-accent-100 px-7 text-[10px] font-semibold tracking-[0.08em] text-accent-700 shadow-[inset_0_1px_0_rgba(255,255,255,0.55)]"
+              >
+                {{ baseApyAverageLabel }}
+              </span>
             </p>
             <p class="text-euler-dark-900">
               Yield from lending on Euler

--- a/components/entities/vault/overview/earn/VaultOverviewEarnBlockStats.vue
+++ b/components/entities/vault/overview/earn/VaultOverviewEarnBlockStats.vue
@@ -48,6 +48,7 @@ const onSupplyInfoIconClick = () => {
       intrinsicAPY: getIntrinsicApy(vault.asset.address),
       intrinsicApyInfo: getIntrinsicApyInfo(vault.asset.address),
       campaigns: getSupplyRewardCampaigns(vault.address),
+      baseApyAverageLabel: '1h',
     },
   })
 }
@@ -73,7 +74,12 @@ const onSupplyInfoIconClick = () => {
         orientation="horizontal"
       >
         <template #label>
-          Supply APY
+          <span class="flex items-center gap-6">
+            Supply APY
+            <span class="inline-flex h-20 items-center rounded-full border border-accent-200 bg-accent-100 px-7 text-[10px] font-semibold tracking-[0.08em] text-accent-700 shadow-[inset_0_1px_0_rgba(255,255,255,0.55)]">
+              1h
+            </span>
+          </span>
         </template>
         <span class="flex items-center gap-4">
           <SvgIcon

--- a/pages/earn/[vault]/index.vue
+++ b/pages/earn/[vault]/index.vue
@@ -197,6 +197,7 @@ const onSupplyInfoIconClick = () => {
       intrinsicAPY: intrinsicApy.value,
       intrinsicApyInfo: getIntrinsicApyInfo(vault.value?.asset.address),
       campaigns: getSupplyRewardCampaigns(vaultAddress),
+      baseApyAverageLabel: '1h',
     },
   })
 }
@@ -262,6 +263,9 @@ watch(address, () => {
             <div class="flex flex-col items-end justify-end">
               <p class="mb-4 text-content-tertiary flex items-center gap-4">
                 Supply APY
+                <span class="inline-flex h-20 items-center rounded-full border border-accent-200 bg-accent-100 px-7 text-[10px] font-semibold tracking-[0.08em] text-accent-700 shadow-[inset_0_1px_0_rgba(255,255,255,0.55)]">
+                  1h
+                </span>
                 <SvgIcon
                   class="!w-20 !h-20 text-content-muted cursor-pointer hover:text-content-secondary"
                   name="info-circle"


### PR DESCRIPTION
## Summary

  Add a `1h` APY tag to Euler Earn APY surfaces in `euler-lite`, matching the behavior used in `euler-protocol-monorepo` where the earn vault base APY represents a 1-hour
  annualized window.

  ## Changes

  - Added an optional `baseApyAverageLabel` prop to the shared supply APY modal
  - Passed `baseApyAverageLabel: '1h'` from earn-only callers
  - Displayed a visible `1h` tag next to `Supply APY` in earn views:
    - earn vault card
    - earn portfolio card
    - earn vault stats block
    - earn vault supply page
  - Updated the tag styling to look like a proper chip/tag
  - Fixed the rendered label casing so it shows `1h` instead of `1H`

  ## Scope

  This is a presentation-only change for Euler Earn APY surfaces.
  It does not change the APY calculation itself.

  Regular lend and securitize APY displays were left unchanged.

  ## Verification

  - `npm run typecheck`