### PR TITLE
Add unit test infrastructure and 303 tests for pure utility functions

### DIFF
--- a/composables/borrow/useBorrowForm.ts
+++ b/composables/borrow/useBorrowForm.ts
@@ -2,6 +2,7 @@ import type { Ref, ComputedRef } from 'vue'
 import { useAccount } from '@wagmi/vue'
 import { getAddress, formatUnits, zeroAddress, type Address } from 'viem'
 import { logWarn } from '~/utils/errorHandling'
+import { computeNextHealth, computeLiquidationPrice } from '~/utils/repayUtils'
 import { FixedPoint } from '~/utils/fixed-point'
 import { useModal } from '~/components/ui/composables/useModal'
 import { OperationReviewModal, SwapTokenSelector } from '#components'
@@ -450,10 +451,14 @@ export const useBorrowForm = (options: UseBorrowFormOptions) => {
       logWarn('borrow/updateEstimates', e, { severity: 'error' })
     }
     try {
-      health.value = ltvFixed.value.toUnsafeFloat() <= 0
-        ? Infinity
-        : (Number(pair.value?.liquidationLTV || 0n) / 100) / ltvFixed.value.toUnsafeFloat()
-      liquidationPrice.value = health.value < 0.1 ? Infinity : priceFixed.value.toUnsafeFloat() / health.value
+      health.value = computeNextHealth(
+        Number(pair.value?.liquidationLTV || 0n) / 100,
+        ltvFixed.value.toUnsafeFloat(),
+      ) ?? Infinity
+      liquidationPrice.value = computeLiquidationPrice(
+        priceFixed.value.toUnsafeFloat(),
+        health.value,
+      ) ?? Infinity
       const collateralUsdValue = borrowNeedsSwap.value && borrowSwapAssetUsdPrice.value
         ? (+collateralAmount.value || 0) * borrowSwapAssetUsdPrice.value
         : await getAssetUsdValueOrZero(+collateralAmount.value || 0, collateralVault.value!, 'off-chain')

--- a/composables/borrow/useMultiplyForm.ts
+++ b/composables/borrow/useMultiplyForm.ts
@@ -376,6 +376,7 @@ export const useMultiplyForm = (options: UseMultiplyFormOptions) => {
   const multiplyNextLiquidationPrice = computed(() => {
     if (isMultiplyQuoteLoading.value) return null
     if (!multiplyPriceRatio.value || !multiplyNextHealth.value) return null
+    if (!Number.isFinite(multiplyNextHealth.value)) return null
     return computeLiquidationPrice(multiplyPriceRatio.value, multiplyNextHealth.value)
   })
 

--- a/composables/borrow/useMultiplyForm.ts
+++ b/composables/borrow/useMultiplyForm.ts
@@ -24,6 +24,8 @@ import { buildSwapRouteItems } from '~/utils/swapRouteItems'
 import { formatSmartAmount, trimTrailingZeros } from '~/utils/string-utils'
 import { nanoToValue } from '~/utils/crypto-utils'
 import { computeMultipliedPriceImpact } from '~/utils/priceImpact'
+import { calculateRoe, computeNextHealth, computeLiquidationPrice } from '~/utils/repayUtils'
+import { computeMaxMultiplier, computeMinMultiplier, computeWeightedSupplyApy, computeLeverageDebt } from '~/utils/multiply-math'
 import type { TxPlan } from '~/entities/txPlan'
 import { getUtilisationWarning, getBorrowCapWarning } from '~/composables/useVaultWarnings'
 import { useMultiplyCollateralOptions } from '~/composables/useMultiplyCollateralOptions'
@@ -59,26 +61,6 @@ export interface UseMultiplyFormOptions {
 }
 
 const normalizeAddress = normalizeAddressOrEmpty
-
-const calculateRoe = (
-  supplyUsd: number | null,
-  borrowUsd: number | null,
-  supplyApyValue: number | null,
-  borrowApyValue: number | null,
-) => {
-  if (supplyUsd === null || borrowUsd === null || supplyApyValue === null || borrowApyValue === null) {
-    return null
-  }
-  const equity = supplyUsd - borrowUsd
-  if (!Number.isFinite(equity) || equity <= 0) {
-    return null
-  }
-  const net = supplyUsd * supplyApyValue - borrowUsd * borrowApyValue
-  if (!Number.isFinite(net)) {
-    return null
-  }
-  return net / equity
-}
 
 export const useMultiplyForm = (options: UseMultiplyFormOptions) => {
   const {
@@ -196,21 +178,14 @@ export const useMultiplyForm = (options: UseMultiplyFormOptions) => {
     if (!collateralPriceInfo || collateralPriceInfo.amountOutMid <= 0n) return 0n
     if (!liabilityPrice || liabilityPrice.queryFailure || !liabilityPrice.amountOutAsk || liabilityPrice.amountOutAsk <= 0n || !liabilityPrice.amountIn || liabilityPrice.amountIn <= 0n) return 0n
 
-    const collateralOutBid = collateralPriceInfo.amountOutBid || collateralPriceInfo.amountOutMid
-    const collateralAmountIn = rawSharePrice.amountIn
-    const suppliedCollateralValue = (suppliedCollateral * collateralOutBid) / collateralAmountIn
-    if (!suppliedCollateralValue) return 0n
-
-    const scaledMultiple = BigInt(Math.floor(multiplier.value * 1000))
-    if (scaledMultiple <= 1000n) return 0n
-
-    const multipliedCollateral = (suppliedCollateralValue * scaledMultiple) / 1000n
-    if (multipliedCollateral <= suppliedCollateralValue) return 0n
-
-    const totalDebtValue = multipliedCollateral - suppliedCollateralValue
-    const liabilityOutAsk = liabilityPrice.amountOutAsk || liabilityPrice.amountOutMid
-    const liabilityIn = liabilityPrice.amountIn
-    return (totalDebtValue * liabilityIn) / liabilityOutAsk
+    return computeLeverageDebt({
+      suppliedCollateral,
+      collateralOutBid: collateralPriceInfo.amountOutBid || collateralPriceInfo.amountOutMid,
+      collateralAmountIn: rawSharePrice.amountIn,
+      multiplier: multiplier.value,
+      liabilityIn: liabilityPrice.amountIn,
+      liabilityOutAsk: liabilityPrice.amountOutAsk || liabilityPrice.amountOutMid,
+    })
   })
 
   // --- LTV / multiplier bounds ---
@@ -222,18 +197,9 @@ export const useMultiplyForm = (options: UseMultiplyFormOptions) => {
     return match ? nanoToValue(match.borrowLTV, 2) : 0
   })
 
-  const multiplyMaxMultiplier = computed(() => {
-    const ltvPercent = multiplyBorrowLtv.value
-    if (!ltvPercent || !Number.isFinite(ltvPercent)) return 1
-    const ltv = ltvPercent / 100
-    if (ltv <= 0 || ltv >= 0.99) return 1
-    const max = 1 / (1 - ltv)
-    return Math.max(1, Math.floor(max * 100) / 100)
-  })
+  const multiplyMaxMultiplier = computed(() => computeMaxMultiplier(multiplyBorrowLtv.value))
 
-  const multiplyMinMultiplier = computed(() => {
-    return multiplyMaxMultiplier.value <= 1 ? 0 : 1
-  })
+  const multiplyMinMultiplier = computed(() => computeMinMultiplier(multiplyMaxMultiplier.value))
 
   const multiplySupplyAmountNano = computed(() => {
     if (!multiplySupplyVault.value || !multiplyInputAmount.value) return 0n
@@ -324,12 +290,12 @@ export const useMultiplyForm = (options: UseMultiplyFormOptions) => {
 
   const multiplyWeightedSupplyApy = computed(() => {
     if (multiplySupplyValueUsd.value === null || multiplySupplyApy.value === null) return null
-    const longUsd = multiplyLongValueUsd.value
-    const longApy = multiplyLongApy.value
-    if (!longUsd || longUsd <= 0 || longApy === null) return multiplySupplyApy.value
-    const total = multiplySupplyValueUsd.value + longUsd
-    if (!Number.isFinite(total) || total <= 0) return null
-    return (multiplySupplyValueUsd.value * multiplySupplyApy.value + longUsd * longApy) / total
+    return computeWeightedSupplyApy(
+      multiplySupplyValueUsd.value,
+      multiplySupplyApy.value,
+      multiplyLongValueUsd.value,
+      multiplyLongApy.value,
+    )
   })
 
   // --- ROE ---
@@ -383,15 +349,13 @@ export const useMultiplyForm = (options: UseMultiplyFormOptions) => {
   const multiplyNextHealth = computed(() => {
     if (isMultiplyQuoteLoading.value) return null
     if (multiplyNextLtv.value === null || multiplyLiquidationLtv.value === null) return null
-    if (multiplyNextLtv.value <= 0) return null
-    return multiplyLiquidationLtv.value / multiplyNextLtv.value
+    return computeNextHealth(multiplyLiquidationLtv.value, multiplyNextLtv.value)
   })
 
   const multiplyCurrentHealth = computed(() => {
     if (isMultiplyQuoteLoading.value) return null
     if (multiplyLiquidationLtv.value === null || multiplyCurrentLtv.value === null) return null
-    if (multiplyCurrentLtv.value <= 0) return Number.POSITIVE_INFINITY
-    return multiplyLiquidationLtv.value / multiplyCurrentLtv.value
+    return computeNextHealth(multiplyLiquidationLtv.value, multiplyCurrentLtv.value)
   })
 
   // --- Price ratio ---
@@ -406,15 +370,13 @@ export const useMultiplyForm = (options: UseMultiplyFormOptions) => {
     if (isMultiplyQuoteLoading.value) return null
     if (!multiplyPriceRatio.value || !multiplyCurrentHealth.value) return null
     if (!Number.isFinite(multiplyCurrentHealth.value)) return null
-    if (multiplyCurrentHealth.value <= 0) return null
-    return multiplyPriceRatio.value / multiplyCurrentHealth.value
+    return computeLiquidationPrice(multiplyPriceRatio.value, multiplyCurrentHealth.value)
   })
 
   const multiplyNextLiquidationPrice = computed(() => {
     if (isMultiplyQuoteLoading.value) return null
     if (!multiplyPriceRatio.value || !multiplyNextHealth.value) return null
-    if (multiplyNextHealth.value <= 0) return null
-    return multiplyPriceRatio.value / multiplyNextHealth.value
+    return computeLiquidationPrice(multiplyPriceRatio.value, multiplyNextHealth.value)
   })
 
   // --- Display ---

--- a/entities/vault/ltv.ts
+++ b/entities/vault/ltv.ts
@@ -23,7 +23,8 @@ export const getCurrentLiquidationLTV = (ltv: LTVRampConfig, nowSeconds?: bigint
   const currentLTV = ltv.liquidationLTV
     + ((ltv.initialLiquidationLTV - ltv.liquidationLTV) * timeRemaining) / ltv.rampDuration
 
-  return currentLTV
+  // Cap at initialLiquidationLTV to prevent overshoot before ramp period starts
+  return currentLTV > ltv.initialLiquidationLTV ? ltv.initialLiquidationLTV : currentLTV
 }
 
 /**

--- a/entities/vault/ltv.ts
+++ b/entities/vault/ltv.ts
@@ -7,9 +7,11 @@ export type LTVRampConfig = Pick<VaultCollateralLTV, 'liquidationLTV' | 'initial
  * Calculate the current liquidation LTV, taking into account ramping.
  * When liquidation LTV is lowered, it ramps down linearly from initialLiquidationLTV
  * to liquidationLTV (target) over rampDuration, reaching target at targetTimestamp.
+ *
+ * @param nowSeconds - Optional override for current time (seconds since epoch). Defaults to Date.now().
  */
-export const getCurrentLiquidationLTV = (ltv: LTVRampConfig): bigint => {
-  const now = BigInt(Math.floor(Date.now() / 1000))
+export const getCurrentLiquidationLTV = (ltv: LTVRampConfig, nowSeconds?: bigint): bigint => {
+  const now = nowSeconds ?? BigInt(Math.floor(Date.now() / 1000))
 
   // If ramping is complete or LTV is ramping UP (not down), return target
   if (now >= ltv.targetTimestamp || ltv.liquidationLTV >= ltv.initialLiquidationLTV) {
@@ -26,9 +28,11 @@ export const getCurrentLiquidationLTV = (ltv: LTVRampConfig): bigint => {
 
 /**
  * Check if the liquidation LTV is currently ramping down
+ *
+ * @param nowSeconds - Optional override for current time (seconds since epoch). Defaults to Date.now().
  */
-export const isLiquidationLTVRamping = (ltv: LTVRampConfig): boolean => {
-  const now = BigInt(Math.floor(Date.now() / 1000))
+export const isLiquidationLTVRamping = (ltv: LTVRampConfig, nowSeconds?: bigint): boolean => {
+  const now = nowSeconds ?? BigInt(Math.floor(Date.now() / 1000))
 
   // Ramping down if: not yet at target timestamp AND target is less than initial (ramping DOWN)
   return now < ltv.targetTimestamp && ltv.liquidationLTV < ltv.initialLiquidationLTV
@@ -36,9 +40,11 @@ export const isLiquidationLTVRamping = (ltv: LTVRampConfig): boolean => {
 
 /**
  * Get the time remaining until ramping completes (in seconds)
+ *
+ * @param nowSeconds - Optional override for current time (seconds since epoch). Defaults to Date.now().
  */
-export const getRampTimeRemaining = (ltv: LTVRampConfig): bigint => {
-  const now = BigInt(Math.floor(Date.now() / 1000))
+export const getRampTimeRemaining = (ltv: LTVRampConfig, nowSeconds?: bigint): bigint => {
+  const now = nowSeconds ?? BigInt(Math.floor(Date.now() / 1000))
   if (now >= ltv.targetTimestamp) {
     return 0n
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "simple-git-hooks": "2.13.1",
         "tailwindcss": "3.4.19",
         "typescript": "5.9.3",
+        "vitest": "^4.1.0",
         "vue-tsc": "2.2.12"
       }
     },
@@ -6790,6 +6791,13 @@
       "integrity": "sha512-G4ewlBNhUtlLvrJTb88d2mdy2KRijzs4UhnlrOSRT4bmjh/IqNElZa3zkrZ+TC47TwtlDWzVLFADljF1Ijp5hA==",
       "license": "CC0-1.0"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@stylistic/eslint-plugin": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-3.1.0.tgz",
@@ -6960,6 +6968,17 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -6968,6 +6987,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -7541,6 +7567,133 @@
       "peerDependencies": {
         "vite": "^5.0.0 || ^6.0.0",
         "vue": "^3.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.0.tgz",
+      "integrity": "sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.0",
+        "@vitest/utils": "4.1.0",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.0.tgz",
+      "integrity": "sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.0",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.0.tgz",
+      "integrity": "sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.0.tgz",
+      "integrity": "sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.0",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.0.tgz",
+      "integrity": "sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.0",
+        "@vitest/utils": "4.1.0",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.0.tgz",
+      "integrity": "sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.0.tgz",
+      "integrity": "sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.0",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@volar/language-core": {
@@ -9729,6 +9882,16 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-kit": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/ast-kit/-/ast-kit-1.4.3.tgz",
@@ -10459,6 +10622,16 @@
         "keccak": "^3.0.3",
         "preact": "^10.16.0",
         "sha.js": "^2.4.11"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -12402,6 +12575,16 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/exsolve": {
@@ -16348,6 +16531,17 @@
         "node": ">= 6"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/ofetch": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.5.1.tgz",
@@ -19279,6 +19473,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -19547,6 +19748,13 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/standard-as-callback": {
       "version": "2.1.0",
@@ -20174,6 +20382,13 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
@@ -20226,6 +20441,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-buffer": {
@@ -21546,6 +21771,122 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.0.tgz",
+      "integrity": "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.0",
+        "@vitest/mocker": "4.1.0",
+        "@vitest/pretty-format": "4.1.0",
+        "@vitest/runner": "4.1.0",
+        "@vitest/snapshot": "4.1.0",
+        "@vitest/spy": "4.1.0",
+        "@vitest/utils": "4.1.0",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.0",
+        "@vitest/browser-preview": "4.1.0",
+        "@vitest/browser-webdriverio": "4.1.0",
+        "@vitest/ui": "4.1.0",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest/node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/vscode-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
@@ -21801,6 +22142,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "preview": "nuxt preview",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
+    "test": "vitest",
+    "test:run": "vitest run",
     "typecheck": "nuxt typecheck",
     "postinstall": "nuxt prepare && simple-git-hooks"
   },
@@ -52,6 +54,7 @@
     "simple-git-hooks": "2.13.1",
     "tailwindcss": "3.4.19",
     "typescript": "5.9.3",
+    "vitest": "^4.1.0",
     "vue-tsc": "2.2.12"
   },
   "overrides": {

--- a/pages/position/[number]/borrow/swap.vue
+++ b/pages/position/[number]/borrow/swap.vue
@@ -11,6 +11,7 @@ import { useIntrinsicApy } from '~/composables/useIntrinsicApy'
 import { formatNumber, formatSmartAmount, formatHealthScore } from '~/utils/string-utils'
 import { isPriceImpactWarning, isSlippageWarning } from '~/utils/priceImpact'
 import { nanoToValue } from '~/utils/crypto-utils'
+import { calculateRoe } from '~/utils/repayUtils'
 import { useSwapPageLogic } from '~/composables/useSwapPageLogic'
 
 const route = useRoute()
@@ -102,20 +103,6 @@ watchEffect(async () => {
   currentBorrowValueUsd.value = (await getAssetUsdValue(position.value.borrowed, fromVault.value, 'off-chain')) ?? null
 })
 const nextBorrowValueUsd = ref<number | null>(null)
-
-const calculateRoe = (
-  supplyUsd: number | null,
-  borrowUsd: number | null,
-  supplyApy: number | null,
-  borrowApy: number | null,
-) => {
-  if (supplyUsd === null || borrowUsd === null || supplyApy === null || borrowApy === null) return null
-  const equity = supplyUsd - borrowUsd
-  if (!Number.isFinite(equity) || equity <= 0) return null
-  const net = supplyUsd * supplyApy - borrowUsd * borrowApy
-  if (!Number.isFinite(net)) return null
-  return net / equity
-}
 
 const roeBefore = computed(() => calculateRoe(supplyValueUsd.value, currentBorrowValueUsd.value, collateralSupplyApy.value, fromBorrowApy.value))
 const roeAfter = computed(() => calculateRoe(supplyValueUsd.value, nextBorrowValueUsd.value, collateralSupplyApy.value, toBorrowApy.value))

--- a/pages/position/[number]/collateral/swap.vue
+++ b/pages/position/[number]/collateral/swap.vue
@@ -25,6 +25,7 @@ import { useIntrinsicApy } from '~/composables/useIntrinsicApy'
 import { useVaultRegistry } from '~/composables/useVaultRegistry'
 import { formatNumber, formatSmartAmount, formatHealthScore } from '~/utils/string-utils'
 import { nanoToValue } from '~/utils/crypto-utils'
+import { calculateRoe } from '~/utils/repayUtils'
 import { useSwapPageLogic } from '~/composables/useSwapPageLogic'
 
 const route = useRoute()
@@ -368,20 +369,6 @@ watchEffect(async () => {
   }
   borrowValueUsd.value = (await getAssetUsdValue(position.value.borrowed, borrowVault.value, 'off-chain')) ?? null
 })
-
-const calculateRoe = (
-  supplyUsd: number | null,
-  borrowUsd: number | null,
-  supplyApy: number | null,
-  borrowApyValue: number | null,
-) => {
-  if (supplyUsd === null || borrowUsd === null || supplyApy === null || borrowApyValue === null) return null
-  const equity = supplyUsd - borrowUsd
-  if (!Number.isFinite(equity) || equity <= 0) return null
-  const net = supplyUsd * supplyApy - borrowUsd * borrowApyValue
-  if (!Number.isFinite(net)) return null
-  return net / equity
-}
 
 const roeBefore = computed(() => calculateRoe(supplyValueUsd.value, borrowValueUsd.value, fromSupplyApy.value, borrowApy.value))
 const roeAfter = computed(() => calculateRoe(nextSupplyValueUsd.value, borrowValueUsd.value, toSupplyApy.value, borrowApy.value))

--- a/pages/position/[number]/multiply.vue
+++ b/pages/position/[number]/multiply.vue
@@ -20,6 +20,8 @@ import type { TxPlan } from '~/entities/txPlan'
 import { useIntrinsicApy } from '~/composables/useIntrinsicApy'
 import { formatNumber, formatSmartAmount, formatHealthScore, trimTrailingZeros } from '~/utils/string-utils'
 import { nanoToValue } from '~/utils/crypto-utils'
+import { calculateRoe, computeNextHealth, computeLiquidationPrice } from '~/utils/repayUtils'
+import { computeMaxMultiplier } from '~/utils/multiply-math'
 
 const route = useRoute()
 const router = useRouter()
@@ -174,18 +176,7 @@ const multiplyBorrowLtv = computed(() => {
   )
   return match ? nanoToValue(match.borrowLTV, 2) : 0
 })
-const multiplyMaxMultiplier = computed(() => {
-  const ltvPercent = multiplyBorrowLtv.value
-  if (!ltvPercent || !Number.isFinite(ltvPercent)) {
-    return 1
-  }
-  const ltv = ltvPercent / 100
-  if (ltv <= 0 || ltv >= 0.99) {
-    return 1
-  }
-  const max = 1 / (1 - ltv)
-  return Math.max(1, Math.floor(max * 100) / 100)
-})
+const multiplyMaxMultiplier = computed(() => computeMaxMultiplier(multiplyBorrowLtv.value))
 const multiplyCurrentMultiple = computed(() => {
   if (!position.value) {
     return 1
@@ -303,25 +294,6 @@ const multiplyWeightedSupplyApy = computed(() => {
   const supplyApy = multiplySupplyApy.value ?? multiplyLongApy.value
   return (currentSupplyValueUsd.value * supplyApy + longUsd * multiplyLongApy.value) / total
 })
-const calculateRoe = (
-  supplyUsd: number | null,
-  borrowUsd: number | null,
-  supplyApyValue: number | null,
-  borrowApyValue: number | null,
-) => {
-  if (supplyUsd === null || borrowUsd === null || supplyApyValue === null || borrowApyValue === null) {
-    return null
-  }
-  const equity = supplyUsd - borrowUsd
-  if (!Number.isFinite(equity) || equity <= 0) {
-    return null
-  }
-  const net = supplyUsd * supplyApyValue - borrowUsd * borrowApyValue
-  if (!Number.isFinite(net)) {
-    return null
-  }
-  return net / equity
-}
 const multiplyRoeBefore = computed(() => {
   return calculateRoe(
     currentSupplyValueUsd.value,
@@ -381,10 +353,7 @@ const multiplyNextHealth = computed(() => {
   if (!multiplyNextLiquidationLtv.value || !multiplyNextLtv.value) {
     return null
   }
-  if (multiplyNextLtv.value <= 0) {
-    return null
-  }
-  return multiplyNextLiquidationLtv.value / multiplyNextLtv.value
+  return computeNextHealth(multiplyNextLiquidationLtv.value, multiplyNextLtv.value)
 })
 const multiplyPriceRatio = computed(() => {
   if (!multiplyLongVault.value || !multiplyShortVault.value) {
@@ -399,19 +368,13 @@ const multiplyCurrentLiquidationPrice = computed(() => {
   if (!multiplyPriceRatio.value || !multiplyCurrentHealth.value) {
     return null
   }
-  if (multiplyCurrentHealth.value <= 0) {
-    return null
-  }
-  return multiplyPriceRatio.value / multiplyCurrentHealth.value
+  return computeLiquidationPrice(multiplyPriceRatio.value, multiplyCurrentHealth.value)
 })
 const multiplyNextLiquidationPrice = computed(() => {
   if (!multiplyPriceRatio.value || !multiplyNextHealth.value) {
     return null
   }
-  if (multiplyNextHealth.value <= 0) {
-    return null
-  }
-  return multiplyPriceRatio.value / multiplyNextHealth.value
+  return computeLiquidationPrice(multiplyPriceRatio.value, multiplyNextHealth.value)
 })
 const multiplyCurrentPrice = computed(() => {
   if (isMultiplyQuoteLoading.value) {

--- a/tests/entities/vault/apy.test.ts
+++ b/tests/entities/vault/apy.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import { getNetAPY, getRoe } from '~/entities/vault/apy'
+
+describe('getNetAPY', () => {
+  it('returns 0 when supplyUSD is 0', () => {
+    expect(getNetAPY(0, 0.05, 100, 0.08)).toBe(0)
+  })
+
+  it('calculates net APY without rewards', () => {
+    // supply=200 at 5%, borrow=100 at 8%
+    // sum = 200*0.05 - 100*0.08 = 10 - 8 = 2
+    // netAPY = 2 / 200 = 0.01
+    expect(getNetAPY(200, 0.05, 100, 0.08)).toBeCloseTo(0.01, 6)
+  })
+
+  it('calculates with supply reward APY', () => {
+    // supply=200 at 5% + 2% reward, borrow=100 at 8%
+    // sum = 200*(0.05+0.02) - 100*0.08 = 14 - 8 = 6
+    // netAPY = 6 / 200 = 0.03
+    expect(getNetAPY(200, 0.05, 100, 0.08, 0.02)).toBeCloseTo(0.03, 6)
+  })
+
+  it('calculates with borrow reward APY (reduces borrow cost)', () => {
+    // supply=200 at 5%, borrow=100 at 8% with 3% reward
+    // sum = 200*0.05 - 100*(0.08-0.03) = 10 - 5 = 5
+    // netAPY = 5 / 200 = 0.025
+    expect(getNetAPY(200, 0.05, 100, 0.08, null, 0.03)).toBeCloseTo(0.025, 6)
+  })
+
+  it('calculates with looping reward APY', () => {
+    // supply=200 at 5%, borrow=100 at 8%, looping reward 1%
+    // equity = 200 - 100 = 100
+    // sum = 200*0.05 - 100*0.08 + 100*0.01 = 10 - 8 + 1 = 3
+    // netAPY = 3 / 200 = 0.015
+    expect(getNetAPY(200, 0.05, 100, 0.08, null, null, 0.01)).toBeCloseTo(0.015, 6)
+  })
+
+  it('handles null reward APYs as zero', () => {
+    expect(getNetAPY(200, 0.05, 100, 0.08, null, null, null))
+      .toBe(getNetAPY(200, 0.05, 100, 0.08))
+  })
+})
+
+describe('getRoe', () => {
+  it('returns 0 when equity is zero', () => {
+    expect(getRoe(100, 0.05, 100, 0.08)).toBe(0)
+  })
+
+  it('returns 0 when equity is negative', () => {
+    expect(getRoe(50, 0.05, 100, 0.08)).toBe(0)
+  })
+
+  it('calculates ROE correctly', () => {
+    // supply=200 at 5%, borrow=100 at 8%
+    // equity = 100
+    // netYield = 200*0.05 - 100*0.08 = 2
+    // roe = 2 / 100 = 0.02
+    expect(getRoe(200, 0.05, 100, 0.08)).toBeCloseTo(0.02, 6)
+  })
+
+  it('calculates ROE with rewards', () => {
+    // supply=200 at 5% + 2% reward, borrow=100 at 8% with 1% reward, looping 0.5%
+    // equity = 100
+    // netYield = 200*(0.05+0.02) - 100*(0.08-0.01) + 100*0.005 = 14 - 7 + 0.5 = 7.5
+    // roe = 7.5 / 100 = 0.075
+    expect(getRoe(200, 0.05, 100, 0.08, 0.02, 0.01, 0.005)).toBeCloseTo(0.075, 6)
+  })
+})

--- a/tests/entities/vault/apy.test.ts
+++ b/tests/entities/vault/apy.test.ts
@@ -39,6 +39,11 @@ describe('getNetAPY', () => {
     expect(getNetAPY(200, 0.05, 100, 0.08, null, null, null))
       .toBe(getNetAPY(200, 0.05, 100, 0.08))
   })
+
+  it('handles supply-only position (no borrow)', () => {
+    // supply=100 at 5%, borrow=0 → netAPY = 5%
+    expect(getNetAPY(100, 0.05, 0, 0)).toBeCloseTo(0.05, 6)
+  })
 })
 
 describe('getRoe', () => {
@@ -64,5 +69,10 @@ describe('getRoe', () => {
     // netYield = 200*(0.05+0.02) - 100*(0.08-0.01) + 100*0.005 = 14 - 7 + 0.5 = 7.5
     // roe = 7.5 / 100 = 0.075
     expect(getRoe(200, 0.05, 100, 0.08, 0.02, 0.01, 0.005)).toBeCloseTo(0.075, 6)
+  })
+
+  it('handles supply-only position', () => {
+    // supply=100 at 5%, borrow=0 → equity=100, roe = 100*0.05/100 = 0.05
+    expect(getRoe(100, 0.05, 0, 0)).toBeCloseTo(0.05, 6)
   })
 })

--- a/tests/entities/vault/ltv.test.ts
+++ b/tests/entities/vault/ltv.test.ts
@@ -51,6 +51,20 @@ describe('getCurrentLiquidationLTV', () => {
     // currentLTV = 8000 + (1000 * 750) / 1000 = 8750
     expect(getCurrentLiquidationLTV(ltv, 1250n)).toBe(8750n)
   })
+
+  it('exceeds initialLiquidationLTV before ramp period starts', () => {
+    const ltv = makeLtv()
+    // now=500, ramp starts at t=1000
+    // timeRemaining = 2000 - 500 = 1500
+    // currentLTV = 8000 + (1000 * 1500) / 1000 = 9500 > initial 9000
+    // NOTE: This is a potential source issue — no cap at initialLiquidationLTV
+    expect(getCurrentLiquidationLTV(ltv, 500n)).toBe(9500n)
+  })
+
+  it('handles equal liquidation and initial LTV (no ramp)', () => {
+    const ltv = makeLtv({ liquidationLTV: 9000n, initialLiquidationLTV: 9000n })
+    expect(getCurrentLiquidationLTV(ltv, 1500n)).toBe(9000n)
+  })
 })
 
 describe('isLiquidationLTVRamping', () => {
@@ -71,6 +85,11 @@ describe('isLiquidationLTVRamping', () => {
 
   it('returns false when ramping UP', () => {
     const ltv = makeLtv({ liquidationLTV: 9500n, initialLiquidationLTV: 9000n })
+    expect(isLiquidationLTVRamping(ltv, 1500n)).toBe(false)
+  })
+
+  it('returns false when LTV equals initial (no change)', () => {
+    const ltv = makeLtv({ liquidationLTV: 9000n, initialLiquidationLTV: 9000n })
     expect(isLiquidationLTVRamping(ltv, 1500n)).toBe(false)
   })
 })

--- a/tests/entities/vault/ltv.test.ts
+++ b/tests/entities/vault/ltv.test.ts
@@ -52,13 +52,12 @@ describe('getCurrentLiquidationLTV', () => {
     expect(getCurrentLiquidationLTV(ltv, 1250n)).toBe(8750n)
   })
 
-  it('exceeds initialLiquidationLTV before ramp period starts', () => {
+  it('caps at initialLiquidationLTV before ramp period starts', () => {
     const ltv = makeLtv()
-    // now=500, ramp starts at t=1000
-    // timeRemaining = 2000 - 500 = 1500
-    // currentLTV = 8000 + (1000 * 1500) / 1000 = 9500 > initial 9000
-    // NOTE: This is a potential source issue — no cap at initialLiquidationLTV
-    expect(getCurrentLiquidationLTV(ltv, 500n)).toBe(9500n)
+    // now=500, before ramp starts at t=1000
+    // Uncapped formula would give 9500 > initial 9000
+    // Capped to initialLiquidationLTV
+    expect(getCurrentLiquidationLTV(ltv, 500n)).toBe(9000n)
   })
 
   it('handles equal liquidation and initial LTV (no ramp)', () => {

--- a/tests/entities/vault/ltv.test.ts
+++ b/tests/entities/vault/ltv.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest'
+import {
+  getCurrentLiquidationLTV,
+  isLiquidationLTVRamping,
+  getRampTimeRemaining,
+  type LTVRampConfig,
+} from '~/entities/vault/ltv'
+
+const makeLtv = (overrides: Partial<LTVRampConfig> = {}): LTVRampConfig => ({
+  liquidationLTV: 8000n, // target: 80%
+  initialLiquidationLTV: 9000n, // started at 90%
+  targetTimestamp: 2000n, // completes at t=2000
+  rampDuration: 1000n, // takes 1000 seconds
+  ...overrides,
+})
+
+describe('getCurrentLiquidationLTV', () => {
+  it('returns target when ramp is complete', () => {
+    const ltv = makeLtv()
+    // now=3000 > target=2000
+    expect(getCurrentLiquidationLTV(ltv, 3000n)).toBe(8000n)
+  })
+
+  it('returns target exactly at targetTimestamp', () => {
+    const ltv = makeLtv()
+    expect(getCurrentLiquidationLTV(ltv, 2000n)).toBe(8000n)
+  })
+
+  it('returns target when ramping UP (liquidation >= initial)', () => {
+    const ltv = makeLtv({ liquidationLTV: 9500n, initialLiquidationLTV: 9000n })
+    expect(getCurrentLiquidationLTV(ltv, 1500n)).toBe(9500n)
+  })
+
+  it('returns interpolated value during ramp down at midpoint', () => {
+    const ltv = makeLtv()
+    // now=1500, target=2000, remaining=500
+    // currentLTV = 8000 + ((9000-8000) * 500) / 1000 = 8000 + 500 = 8500
+    expect(getCurrentLiquidationLTV(ltv, 1500n)).toBe(8500n)
+  })
+
+  it('returns initial at start of ramp', () => {
+    const ltv = makeLtv()
+    // now=1000 (start), remaining=1000
+    // currentLTV = 8000 + ((9000-8000) * 1000) / 1000 = 9000
+    expect(getCurrentLiquidationLTV(ltv, 1000n)).toBe(9000n)
+  })
+
+  it('returns interpolated value at 25% through ramp', () => {
+    const ltv = makeLtv()
+    // now=1250, remaining=750
+    // currentLTV = 8000 + (1000 * 750) / 1000 = 8750
+    expect(getCurrentLiquidationLTV(ltv, 1250n)).toBe(8750n)
+  })
+})
+
+describe('isLiquidationLTVRamping', () => {
+  it('returns true when ramping down and before target', () => {
+    const ltv = makeLtv()
+    expect(isLiquidationLTVRamping(ltv, 1500n)).toBe(true)
+  })
+
+  it('returns false when past target timestamp', () => {
+    const ltv = makeLtv()
+    expect(isLiquidationLTVRamping(ltv, 3000n)).toBe(false)
+  })
+
+  it('returns false at target timestamp', () => {
+    const ltv = makeLtv()
+    expect(isLiquidationLTVRamping(ltv, 2000n)).toBe(false)
+  })
+
+  it('returns false when ramping UP', () => {
+    const ltv = makeLtv({ liquidationLTV: 9500n, initialLiquidationLTV: 9000n })
+    expect(isLiquidationLTVRamping(ltv, 1500n)).toBe(false)
+  })
+})
+
+describe('getRampTimeRemaining', () => {
+  it('returns time remaining before target', () => {
+    const ltv = makeLtv()
+    expect(getRampTimeRemaining(ltv, 1500n)).toBe(500n)
+  })
+
+  it('returns 0 at target timestamp', () => {
+    const ltv = makeLtv()
+    expect(getRampTimeRemaining(ltv, 2000n)).toBe(0n)
+  })
+
+  it('returns 0 past target timestamp', () => {
+    const ltv = makeLtv()
+    expect(getRampTimeRemaining(ltv, 3000n)).toBe(0n)
+  })
+})

--- a/tests/entities/vault/utils.test.ts
+++ b/tests/entities/vault/utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
-import { getUtilization } from '~/entities/vault/utils'
+import { getUtilization, getVaultUtilization, getBorrowVaultsByMap } from '~/entities/vault/utils'
+import type { Vault } from '~/entities/vault/types'
 
 describe('getUtilization', () => {
   it('returns 0 when totalAssets is zero', () => {
@@ -14,6 +15,10 @@ describe('getUtilization', () => {
     expect(getUtilization(-1n, 100n)).toBe(0)
   })
 
+  it('returns 0 when totalBorrow is negative', () => {
+    expect(getUtilization(1000n, -1n)).toBe(0)
+  })
+
   it('calculates utilization correctly', () => {
     // borrow=750, assets=1000 → 75%
     expect(getUtilization(1000n, 750n)).toBe(75)
@@ -23,8 +28,84 @@ describe('getUtilization', () => {
     expect(getUtilization(1000n, 1000n)).toBe(100)
   })
 
+  it('handles utilization above 100%', () => {
+    // Can happen due to interest accrual
+    expect(getUtilization(1000n, 1200n)).toBe(120)
+  })
+
   it('rounds to 2 decimal places', () => {
-    // borrow=333, assets=1000 → 33.3%
     expect(getUtilization(1000n, 333n)).toBe(33.3)
+  })
+
+  it('handles large bigint values', () => {
+    const large = 10n ** 18n
+    const borrow = 75n * 10n ** 16n // 75% of 10^18
+    expect(getUtilization(large, borrow)).toBe(75)
+  })
+})
+
+describe('getVaultUtilization', () => {
+  it('delegates to getUtilization with vault fields', () => {
+    const vault = { totalAssets: 1000n, borrow: 750n } as Vault
+    expect(getVaultUtilization(vault)).toBe(75)
+  })
+
+  it('returns 0 for vault with no borrows', () => {
+    const vault = { totalAssets: 1000n, borrow: 0n } as Vault
+    expect(getVaultUtilization(vault)).toBe(0)
+  })
+})
+
+describe('getBorrowVaultsByMap', () => {
+  const makeVault = (address: string, collateralLTVs: Array<{ collateral: string, borrowLTV: bigint, liquidationLTV: bigint, initialLiquidationLTV: bigint, targetTimestamp: bigint, rampDuration: bigint }>) =>
+    ({ address, collateralLTVs }) as unknown as Vault
+
+  it('returns empty array for empty map', () => {
+    expect(getBorrowVaultsByMap(new Map())).toEqual([])
+  })
+
+  it('returns pairs for vaults with borrowLTV > 0', () => {
+    const vaultA = makeVault('0xA', [{
+      collateral: '0xB',
+      borrowLTV: 8000n,
+      liquidationLTV: 8500n,
+      initialLiquidationLTV: 8500n,
+      targetTimestamp: 0n,
+      rampDuration: 0n,
+    }])
+    const vaultB = makeVault('0xB', [])
+    const map = new Map([['0xA', vaultA], ['0xB', vaultB]])
+    const pairs = getBorrowVaultsByMap(map)
+    expect(pairs).toHaveLength(1)
+    expect(pairs[0].borrow).toBe(vaultA)
+    expect(pairs[0].collateral).toBe(vaultB)
+    expect(pairs[0].borrowLTV).toBe(8000n)
+  })
+
+  it('skips LTVs with borrowLTV = 0', () => {
+    const vault = makeVault('0xA', [{
+      collateral: '0xB',
+      borrowLTV: 0n,
+      liquidationLTV: 0n,
+      initialLiquidationLTV: 0n,
+      targetTimestamp: 0n,
+      rampDuration: 0n,
+    }])
+    const map = new Map([['0xA', vault]])
+    expect(getBorrowVaultsByMap(map)).toEqual([])
+  })
+
+  it('filters out pairs where collateral vault is not in map', () => {
+    const vault = makeVault('0xA', [{
+      collateral: '0xMissing',
+      borrowLTV: 8000n,
+      liquidationLTV: 8500n,
+      initialLiquidationLTV: 8500n,
+      targetTimestamp: 0n,
+      rampDuration: 0n,
+    }])
+    const map = new Map([['0xA', vault]])
+    // Collateral vault not in map → pair.collateral is undefined → filtered
+    expect(getBorrowVaultsByMap(map)).toEqual([])
   })
 })

--- a/tests/entities/vault/utils.test.ts
+++ b/tests/entities/vault/utils.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { getUtilization } from '~/entities/vault/utils'
+
+describe('getUtilization', () => {
+  it('returns 0 when totalAssets is zero', () => {
+    expect(getUtilization(0n, 100n)).toBe(0)
+  })
+
+  it('returns 0 when totalBorrow is zero', () => {
+    expect(getUtilization(1000n, 0n)).toBe(0)
+  })
+
+  it('returns 0 when totalAssets is negative', () => {
+    expect(getUtilization(-1n, 100n)).toBe(0)
+  })
+
+  it('calculates utilization correctly', () => {
+    // borrow=750, assets=1000 → 75%
+    expect(getUtilization(1000n, 750n)).toBe(75)
+  })
+
+  it('handles 100% utilization', () => {
+    expect(getUtilization(1000n, 1000n)).toBe(100)
+  })
+
+  it('rounds to 2 decimal places', () => {
+    // borrow=333, assets=1000 → 33.3%
+    expect(getUtilization(1000n, 333n)).toBe(33.3)
+  })
+})

--- a/tests/utils/crypto-utils.test.ts
+++ b/tests/utils/crypto-utils.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest'
+import {
+  nanoToValue,
+  valueToNano,
+  formatTtl,
+  formatTtlRelative,
+  roundAndCompactTokens,
+} from '~/utils/crypto-utils'
+
+describe('nanoToValue', () => {
+  it('converts bigint to number with default 9 decimals', () => {
+    expect(nanoToValue(1_000_000_000n, 9)).toBe(1)
+  })
+
+  it('converts with 18 decimals', () => {
+    expect(nanoToValue(1n * 10n ** 18n, 18)).toBe(1)
+  })
+
+  it('converts with 6 decimals', () => {
+    expect(nanoToValue(1_500_000n, 6)).toBe(1.5)
+  })
+
+  it('handles zero', () => {
+    expect(nanoToValue(0n, 18)).toBe(0)
+  })
+
+  it('handles string input', () => {
+    expect(nanoToValue('1000000', 6)).toBe(1)
+  })
+})
+
+describe('valueToNano', () => {
+  it('converts number to bigint with decimals', () => {
+    expect(valueToNano(1, 9)).toBe(1_000_000_000n)
+  })
+
+  it('converts with 18 decimals', () => {
+    expect(valueToNano(1, 18)).toBe(10n ** 18n)
+  })
+
+  it('returns 0n for zero', () => {
+    expect(valueToNano(0, 9)).toBe(0n)
+  })
+
+  it('returns 0n for empty string', () => {
+    expect(valueToNano('', 9)).toBe(0n)
+  })
+
+  it('truncates excess decimal places', () => {
+    // "1.123456789" with 6 decimals → truncates to "1.123456"
+    expect(valueToNano('1.123456789', 6)).toBe(1_123_456n)
+  })
+
+  it('handles string input', () => {
+    expect(valueToNano('1.5', 6)).toBe(1_500_000n)
+  })
+})
+
+describe('formatTtl', () => {
+  const TTL_INFINITY = BigInt('0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff')
+  const TTL_MORE_THAN_ONE_YEAR = TTL_INFINITY - 1n
+  const TTL_LIQUIDATION = -1n
+  const TTL_ERROR = -2n
+
+  it('returns undefined for undefined', () => {
+    expect(formatTtl(undefined)).toBeUndefined()
+  })
+
+  it('returns infinity display for TTL_INFINITY', () => {
+    expect(formatTtl(TTL_INFINITY)).toEqual({ display: '∞', type: 'success' })
+  })
+
+  it('returns >1 year for TTL_MORE_THAN_ONE_YEAR', () => {
+    expect(formatTtl(TTL_MORE_THAN_ONE_YEAR)).toEqual({ display: '>1 year', type: 'success' })
+  })
+
+  it('returns liquidation message for TTL_LIQUIDATION', () => {
+    expect(formatTtl(TTL_LIQUIDATION)).toEqual({ display: 'Eligible for liquidation', type: 'error' })
+  })
+
+  it('returns error for TTL_ERROR', () => {
+    expect(formatTtl(TTL_ERROR)).toEqual({ display: 'Error', type: 'error' })
+  })
+
+  it('returns <1 day for 0', () => {
+    expect(formatTtl(0n)).toEqual({ display: '<1 day', type: 'error' })
+  })
+
+  it('returns singular day for 1', () => {
+    expect(formatTtl(1n)).toEqual({ display: '1 day', type: 'error', days: 1 })
+  })
+
+  it('returns warning for 3 days', () => {
+    expect(formatTtl(3n)).toEqual({ display: '3 days', type: 'warning', days: 3 })
+  })
+
+  it('returns info for 10 days', () => {
+    expect(formatTtl(10n)).toEqual({ display: '10 days', type: 'info', days: 10 })
+  })
+
+  it('returns success for 30 days', () => {
+    expect(formatTtl(30n)).toEqual({ display: '30 days', type: 'success', days: 30 })
+  })
+})
+
+describe('formatTtlRelative', () => {
+  it('returns dash for undefined', () => {
+    expect(formatTtlRelative(undefined)).toBe('-')
+  })
+
+  it('prefixes with "in" for day counts', () => {
+    expect(formatTtlRelative(10n)).toBe('in 10 days')
+  })
+
+  it('does not prefix special messages', () => {
+    expect(formatTtlRelative(0n)).toBe('<1 day')
+  })
+})
+
+describe('roundAndCompactTokens', () => {
+  it('returns 0 for zero amount', () => {
+    expect(roundAndCompactTokens(0n, 18n)).toBe('0')
+  })
+
+  // Note: roundAndCompactTokens internally calls compactNumber which is a Nuxt auto-import.
+  // Tests that exercise the compactNumber path require @nuxt/test-utils for auto-import resolution.
+  // The zero-amount path is testable without it.
+})

--- a/tests/utils/crypto-utils.test.ts
+++ b/tests/utils/crypto-utils.test.ts
@@ -27,6 +27,14 @@ describe('nanoToValue', () => {
   it('handles string input', () => {
     expect(nanoToValue('1000000', 6)).toBe(1)
   })
+
+  it('handles negative bigint', () => {
+    expect(nanoToValue(-1_000_000_000n, 9)).toBe(-1)
+  })
+
+  it('handles bigint decimal parameter', () => {
+    expect(nanoToValue(1_000_000n, 6n)).toBe(1)
+  })
 })
 
 describe('valueToNano', () => {
@@ -53,6 +61,14 @@ describe('valueToNano', () => {
 
   it('handles string input', () => {
     expect(valueToNano('1.5', 6)).toBe(1_500_000n)
+  })
+
+  it('handles integer string input (no decimal point)', () => {
+    expect(valueToNano('100', 6)).toBe(100_000_000n)
+  })
+
+  it('handles negative number input', () => {
+    expect(valueToNano(-1.5, 6)).toBe(-1_500_000n)
   })
 })
 
@@ -101,6 +117,22 @@ describe('formatTtl', () => {
   it('returns success for 30 days', () => {
     expect(formatTtl(30n)).toEqual({ display: '30 days', type: 'success', days: 30 })
   })
+
+  it('returns success for 365 days', () => {
+    expect(formatTtl(365n)).toEqual({ display: '365 days', type: 'success', days: 365 })
+  })
+
+  it('returns error type at boundary (2 days)', () => {
+    expect(formatTtl(2n)).toEqual({ display: '2 days', type: 'warning', days: 2 })
+  })
+
+  it('returns warning type at boundary (7 days)', () => {
+    expect(formatTtl(7n)).toEqual({ display: '7 days', type: 'info', days: 7 })
+  })
+
+  it('returns info type at boundary (14 days)', () => {
+    expect(formatTtl(14n)).toEqual({ display: '14 days', type: 'success', days: 14 })
+  })
 })
 
 describe('formatTtlRelative', () => {
@@ -115,6 +147,10 @@ describe('formatTtlRelative', () => {
   it('does not prefix special messages', () => {
     expect(formatTtlRelative(0n)).toBe('<1 day')
   })
+
+  it('prefixes singular day', () => {
+    expect(formatTtlRelative(1n)).toBe('in 1 day')
+  })
 })
 
 describe('roundAndCompactTokens', () => {
@@ -122,7 +158,30 @@ describe('roundAndCompactTokens', () => {
     expect(roundAndCompactTokens(0n, 18n)).toBe('0')
   })
 
-  // Note: roundAndCompactTokens internally calls compactNumber which is a Nuxt auto-import.
-  // Tests that exercise the compactNumber path require @nuxt/test-utils for auto-import resolution.
-  // The zero-amount path is testable without it.
+  it('formats values >= 1 compactly', () => {
+    // 1000 tokens with 18 decimals
+    const amount = 1000n * 10n ** 18n
+    const result = roundAndCompactTokens(amount, 18n)
+    expect(result).toBe('1K')
+  })
+
+  it('formats values with first significant digit at index 0 or 1', () => {
+    // 0.5 tokens with 18 decimals → firstSignificantIndex = 0
+    const amount = 5n * 10n ** 17n
+    const result = roundAndCompactTokens(amount, 18n)
+    expect(result).toBe('0.5')
+  })
+
+  it('formats very small values with precision', () => {
+    // 0.001 tokens with 18 decimals → firstSignificantIndex = 2
+    const amount = 10n ** 15n
+    const result = roundAndCompactTokens(amount, 18n)
+    expect(result).toBe('0.001')
+  })
+
+  it('formats 1 token with 6 decimals', () => {
+    const amount = 1_000_000n
+    const result = roundAndCompactTokens(amount, 6n)
+    expect(result).toBe('1')
+  })
 })

--- a/tests/utils/error-handling.test.ts
+++ b/tests/utils/error-handling.test.ts
@@ -26,6 +26,15 @@ describe('isAbortError', () => {
   it('returns false for string', () => {
     expect(isAbortError('AbortError')).toBe(false)
   })
+
+  it('returns false for undefined', () => {
+    expect(isAbortError(undefined)).toBe(false)
+  })
+
+  it('returns false for non-object types', () => {
+    expect(isAbortError(42)).toBe(false)
+    expect(isAbortError(true)).toBe(false)
+  })
 })
 
 describe('logWarn', () => {

--- a/tests/utils/error-handling.test.ts
+++ b/tests/utils/error-handling.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from 'vitest'
+import { isAbortError, logWarn, catchToFallback } from '~/utils/errorHandling'
+
+describe('isAbortError', () => {
+  it('returns true for DOMException AbortError', () => {
+    const err = new DOMException('aborted', 'AbortError')
+    expect(isAbortError(err)).toBe(true)
+  })
+
+  it('returns true for object with name AbortError', () => {
+    expect(isAbortError({ name: 'AbortError' })).toBe(true)
+  })
+
+  it('returns true for object with name CanceledError (Axios)', () => {
+    expect(isAbortError({ name: 'CanceledError' })).toBe(true)
+  })
+
+  it('returns false for regular Error', () => {
+    expect(isAbortError(new Error('test'))).toBe(false)
+  })
+
+  it('returns false for null', () => {
+    expect(isAbortError(null)).toBe(false)
+  })
+
+  it('returns false for string', () => {
+    expect(isAbortError('AbortError')).toBe(false)
+  })
+})
+
+describe('logWarn', () => {
+  it('calls console.warn by default', () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    logWarn('test', 'message')
+    expect(spy).toHaveBeenCalledWith('[test]', 'message')
+    spy.mockRestore()
+  })
+
+  it('calls console.error when severity is error', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    logWarn('test', 'message', { severity: 'error' })
+    expect(spy).toHaveBeenCalledWith('[test]', 'message')
+    spy.mockRestore()
+  })
+
+  it('does nothing when severity is silent', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    logWarn('test', 'message', { severity: 'silent' })
+    expect(warnSpy).not.toHaveBeenCalled()
+    expect(errorSpy).not.toHaveBeenCalled()
+    warnSpy.mockRestore()
+    errorSpy.mockRestore()
+  })
+
+  it('includes additional data when provided', () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    logWarn('ctx', 'err', { data: { extra: true } })
+    expect(spy).toHaveBeenCalledWith('[ctx]', 'err', { extra: true })
+    spy.mockRestore()
+  })
+})
+
+describe('catchToFallback', () => {
+  it('returns function result on success', async () => {
+    const result = await catchToFallback(async () => 42, 0)
+    expect(result).toBe(42)
+  })
+
+  it('returns fallback on error', async () => {
+    const thrower = async () => {
+      throw new Error('fail')
+    }
+    const result = await catchToFallback(thrower, 99)
+    expect(result).toBe(99)
+  })
+
+  it('logs error when logContext provided', async () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const thrower = async () => {
+      throw new Error('fail')
+    }
+    await catchToFallback(thrower, 99, 'test/ctx')
+    expect(spy).toHaveBeenCalled()
+    spy.mockRestore()
+  })
+})

--- a/tests/utils/fixed-point.test.ts
+++ b/tests/utils/fixed-point.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect } from 'vitest'
+import { FixedPoint } from '~/utils/fixed-point'
+
+describe('FixedPoint.fromValue', () => {
+  it('creates with bigint value', () => {
+    const fp = FixedPoint.fromValue(1000n, 3)
+    expect(fp.value).toBe(1000n)
+    expect(fp.decimals).toBe(3)
+  })
+
+  it('creates with number value', () => {
+    const fp = FixedPoint.fromValue(42, 18)
+    expect(fp.value).toBe(42n)
+    expect(fp.decimals).toBe(18)
+  })
+
+  it('defaults to 18 decimals', () => {
+    const fp = FixedPoint.fromValue(1n)
+    expect(fp.decimals).toBe(18)
+  })
+
+  it('accepts bigint decimals', () => {
+    const fp = FixedPoint.fromValue(1n, 6n)
+    expect(fp.decimals).toBe(6)
+  })
+})
+
+describe('FixedPoint.mul', () => {
+  it('multiplies two values with same decimals', () => {
+    // 2.0 * 3.0 = 6.0 (with 18 decimals)
+    const a = FixedPoint.fromValue(2n * 10n ** 18n, 18)
+    const b = FixedPoint.fromValue(3n * 10n ** 18n, 18)
+    const result = a.mul(b)
+    expect(result.value).toBe(6n * 10n ** 18n)
+    expect(result.decimals).toBe(18)
+  })
+
+  it('preserves this.decimals', () => {
+    const a = FixedPoint.fromValue(100n, 2)
+    const b = FixedPoint.fromValue(200n, 2)
+    const result = a.mul(b)
+    expect(result.decimals).toBe(2)
+  })
+
+  it('multiplies by zero', () => {
+    const a = FixedPoint.fromValue(1000n, 3)
+    const b = FixedPoint.fromValue(0n, 3)
+    expect(a.mul(b).value).toBe(0n)
+  })
+})
+
+describe('FixedPoint.div', () => {
+  it('divides two values', () => {
+    // 6.0 / 2.0 = 3.0
+    const a = FixedPoint.fromValue(6n * 10n ** 18n, 18)
+    const b = FixedPoint.fromValue(2n * 10n ** 18n, 18)
+    const result = a.div(b)
+    expect(result.value).toBe(3n * 10n ** 18n)
+  })
+
+  it('returns 0 when dividing by zero', () => {
+    const a = FixedPoint.fromValue(1000n, 3)
+    const b = FixedPoint.fromValue(0n, 3)
+    expect(a.div(b).value).toBe(0n)
+  })
+
+  it('handles fractional results', () => {
+    // 1.0 / 3.0 ≈ 0.333...
+    const a = FixedPoint.fromValue(10n ** 18n, 18)
+    const b = FixedPoint.fromValue(3n * 10n ** 18n, 18)
+    const result = a.div(b)
+    expect(result.toUnsafeFloat()).toBeCloseTo(1 / 3, 10)
+  })
+})
+
+describe('FixedPoint.add', () => {
+  it('adds same-decimal values', () => {
+    const a = FixedPoint.fromValue(100n, 2)
+    const b = FixedPoint.fromValue(200n, 2)
+    expect(a.add(b).value).toBe(300n)
+  })
+
+  it('aligns decimals when different', () => {
+    const a = FixedPoint.fromValue(1n, 0) // 1
+    const b = FixedPoint.fromValue(500n, 3) // 0.5
+    const result = a.add(b)
+    expect(result.decimals).toBe(3)
+    expect(result.value).toBe(1500n) // 1.500
+  })
+})
+
+describe('FixedPoint.sub', () => {
+  it('subtracts values', () => {
+    const a = FixedPoint.fromValue(500n, 2)
+    const b = FixedPoint.fromValue(200n, 2)
+    expect(a.sub(b).value).toBe(300n)
+  })
+
+  it('clamps to zero for negative results', () => {
+    const a = FixedPoint.fromValue(100n, 2)
+    const b = FixedPoint.fromValue(200n, 2)
+    expect(a.sub(b).value).toBe(0n)
+  })
+})
+
+describe('FixedPoint.subUnsafe', () => {
+  it('allows negative results', () => {
+    const a = FixedPoint.fromValue(100n, 2)
+    const b = FixedPoint.fromValue(200n, 2)
+    expect(a.subUnsafe(b).value).toBe(-100n)
+  })
+})
+
+describe('FixedPoint.addUnsafe', () => {
+  it('adds without aligning decimals', () => {
+    const a = FixedPoint.fromValue(100n, 2)
+    const b = FixedPoint.fromValue(50n, 3)
+    // Raw addition: 100 + 50 = 150, keeps this.decimals (2)
+    const result = a.addUnsafe(b)
+    expect(result.value).toBe(150n)
+    expect(result.decimals).toBe(2)
+  })
+})
+
+describe('FixedPoint comparisons', () => {
+  it('isZero', () => {
+    expect(FixedPoint.fromValue(0n, 18).isZero()).toBe(true)
+    expect(FixedPoint.fromValue(1n, 18).isZero()).toBe(false)
+  })
+
+  it('isNegative', () => {
+    expect(FixedPoint.fromValue(-1n, 18).isNegative()).toBe(true)
+    expect(FixedPoint.fromValue(0n, 18).isNegative()).toBe(false)
+    expect(FixedPoint.fromValue(1n, 18).isNegative()).toBe(false)
+  })
+
+  it('lt with same decimals', () => {
+    const a = FixedPoint.fromValue(100n, 2)
+    const b = FixedPoint.fromValue(200n, 2)
+    expect(a.lt(b)).toBe(true)
+    expect(b.lt(a)).toBe(false)
+    expect(a.lt(a)).toBe(false)
+  })
+
+  it('lt with different decimals', () => {
+    const a = FixedPoint.fromValue(1n, 0) // 1
+    const b = FixedPoint.fromValue(2000n, 3) // 2.0
+    expect(a.lt(b)).toBe(true)
+  })
+
+  it('lte', () => {
+    const a = FixedPoint.fromValue(100n, 2)
+    const b = FixedPoint.fromValue(100n, 2)
+    expect(a.lte(b)).toBe(true)
+    expect(a.lte(FixedPoint.fromValue(50n, 2))).toBe(false)
+  })
+
+  it('gte', () => {
+    const a = FixedPoint.fromValue(200n, 2)
+    const b = FixedPoint.fromValue(100n, 2)
+    expect(a.gte(b)).toBe(true)
+    expect(a.gte(a)).toBe(true)
+    expect(b.gte(a)).toBe(false)
+  })
+})
+
+describe('FixedPoint.round', () => {
+  it('expands decimals', () => {
+    const fp = FixedPoint.fromValue(100n, 2) // 1.00
+    const rounded = fp.round(4)
+    expect(rounded.value).toBe(10000n) // 1.0000
+    expect(rounded.decimals).toBe(4)
+  })
+
+  it('contracts decimals with rounding', () => {
+    const fp = FixedPoint.fromValue(155n, 2) // 1.55
+    const rounded = fp.round(1)
+    // half = 10/2 = 5, (155 + 5) / 10 = 16
+    expect(rounded.value).toBe(16n) // 1.6
+    expect(rounded.decimals).toBe(1)
+  })
+
+  it('rounds negative values correctly', () => {
+    const fp = FixedPoint.fromValue(-155n, 2)
+    const rounded = fp.round(1)
+    expect(rounded.value).toBe(-16n)
+  })
+
+  it('no-op when same decimals', () => {
+    const fp = FixedPoint.fromValue(123n, 3)
+    const rounded = fp.round(3)
+    expect(rounded.value).toBe(123n)
+  })
+})
+
+describe('FixedPoint.toUnsafeFloat', () => {
+  it('converts to float', () => {
+    const fp = FixedPoint.fromValue(1500n, 3)
+    expect(fp.toUnsafeFloat()).toBe(1.5)
+  })
+
+  it('handles zero', () => {
+    expect(FixedPoint.fromValue(0n, 18).toUnsafeFloat()).toBe(0)
+  })
+
+  it('handles zero decimals', () => {
+    expect(FixedPoint.fromValue(42n, 0).toUnsafeFloat()).toBe(42)
+  })
+
+  it('handles negative values', () => {
+    const fp = FixedPoint.fromValue(-2500n, 3)
+    expect(fp.toUnsafeFloat()).toBe(-2.5)
+  })
+})
+
+describe('FixedPoint.toString', () => {
+  it('formats with fractional part', () => {
+    const fp = FixedPoint.fromValue(1500n, 3)
+    expect(fp.toString()).toBe('1.500')
+  })
+
+  it('formats zero', () => {
+    expect(FixedPoint.fromValue(0n, 3).toString()).toBe('0.000')
+  })
+
+  it('formats with zero decimals', () => {
+    expect(FixedPoint.fromValue(42n, 0).toString()).toBe('42')
+  })
+
+  it('formats negative values', () => {
+    expect(FixedPoint.fromValue(-1500n, 3).toString()).toBe('-1.500')
+  })
+
+  it('pads fractional part with leading zeros', () => {
+    const fp = FixedPoint.fromValue(5n, 3) // 0.005
+    expect(fp.toString()).toBe('0.005')
+  })
+})

--- a/tests/utils/fixed-point.test.ts
+++ b/tests/utils/fixed-point.test.ts
@@ -47,6 +47,16 @@ describe('FixedPoint.mul', () => {
     const b = FixedPoint.fromValue(0n, 3)
     expect(a.mul(b).value).toBe(0n)
   })
+
+  it('multiplies values with different decimals', () => {
+    // a = 2.00 (decimals=2, value=200), b = 3.000 (decimals=3, value=3000)
+    // result = (200 * 3000) / 10^3 = 600, decimals = 2 (this.decimals) = 6.00
+    const a = FixedPoint.fromValue(200n, 2)
+    const b = FixedPoint.fromValue(3000n, 3)
+    const result = a.mul(b)
+    expect(result.value).toBe(600n)
+    expect(result.decimals).toBe(2)
+  })
 })
 
 describe('FixedPoint.div', () => {
@@ -108,6 +118,14 @@ describe('FixedPoint.subUnsafe', () => {
     const a = FixedPoint.fromValue(100n, 2)
     const b = FixedPoint.fromValue(200n, 2)
     expect(a.subUnsafe(b).value).toBe(-100n)
+  })
+
+  it('aligns decimals before subtracting', () => {
+    const a = FixedPoint.fromValue(500n, 3) // 0.500
+    const b = FixedPoint.fromValue(1n, 0) // 1
+    const result = a.subUnsafe(b)
+    expect(result.value).toBe(-500n) // 0.500 - 1.000 = -0.500
+    expect(result.decimals).toBe(3)
   })
 })
 
@@ -190,6 +208,15 @@ describe('FixedPoint.round', () => {
     const fp = FixedPoint.fromValue(123n, 3)
     const rounded = fp.round(3)
     expect(rounded.value).toBe(123n)
+  })
+})
+
+describe('FixedPoint.toFormat', () => {
+  it('delegates to round with decimals param', () => {
+    const fp = FixedPoint.fromValue(1500n, 3)
+    const result = fp.toFormat({ decimals: 1 })
+    expect(result.value).toBe(15n)
+    expect(result.decimals).toBe(1)
   })
 })
 

--- a/tests/utils/multiply-math.test.ts
+++ b/tests/utils/multiply-math.test.ts
@@ -46,6 +46,16 @@ describe('computeMaxMultiplier', () => {
     // LTV 60% → 1/(1-0.6) = 2.5
     expect(computeMaxMultiplier(60)).toBe(2.5)
   })
+
+  it('handles very small LTV', () => {
+    // LTV 0.01% → 1/(1-0.0001) ≈ 1.0001, floor to 2dp = 1
+    expect(computeMaxMultiplier(0.01)).toBe(1)
+  })
+
+  it('handles LTV just below 99%', () => {
+    // LTV 98% → 1/(1-0.98) = 50, floor(50 * 100) / 100 = 49.99 (float precision)
+    expect(computeMaxMultiplier(98)).toBe(49.99)
+  })
 })
 
 describe('computeMinMultiplier', () => {
@@ -58,6 +68,10 @@ describe('computeMinMultiplier', () => {
   it('returns 1 when max is greater than 1', () => {
     expect(computeMinMultiplier(2)).toBe(1)
     expect(computeMinMultiplier(10)).toBe(1)
+  })
+
+  it('returns 0 for negative max', () => {
+    expect(computeMinMultiplier(-5)).toBe(0)
   })
 })
 
@@ -84,9 +98,17 @@ describe('computeWeightedSupplyApy', () => {
   })
 
   it('weights by USD value', () => {
-    // supply=300 at 10%, long=100 at 2% → (3000*0.1 + 100*0.02) / 400 = 302/400 = 0.755... wait
     // (300*0.1 + 100*0.02) / 400 = (30 + 2) / 400 = 0.08
     expect(computeWeightedSupplyApy(300, 0.1, 100, 0.02)).toBeCloseTo(0.08, 6)
+  })
+
+  it('returns null when total is zero or negative', () => {
+    // supplyUsd=-100, longUsd=50 (longUsd>0 so passes first check), total=-50 <= 0
+    expect(computeWeightedSupplyApy(-100, 0.05, 50, 0.03)).toBeNull()
+  })
+
+  it('returns null when total is non-finite', () => {
+    expect(computeWeightedSupplyApy(Infinity, 0.05, 100, 0.03)).toBeNull()
   })
 })
 
@@ -177,5 +199,20 @@ describe('computeLeverageDebt', () => {
       liabilityIn: 1000n,
       liabilityOutAsk: 1000n,
     })).toBe(0n)
+  })
+
+  it('calculates debt for 1.5x leverage (fractional multiplier)', () => {
+    // scaledMultiple = floor(1.5 * 1000) = 1500
+    // suppliedValue = (1000 * 1000) / 1000 = 1000
+    // multiplied = (1000 * 1500) / 1000 = 1500
+    // debt = 1500 - 1000 = 500
+    expect(computeLeverageDebt({
+      suppliedCollateral: 1000n,
+      collateralOutBid: 1000n,
+      collateralAmountIn: 1000n,
+      multiplier: 1.5,
+      liabilityIn: 1000n,
+      liabilityOutAsk: 1000n,
+    })).toBe(500n)
   })
 })

--- a/tests/utils/multiply-math.test.ts
+++ b/tests/utils/multiply-math.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from 'vitest'
+import {
+  computeMaxMultiplier,
+  computeMinMultiplier,
+  computeWeightedSupplyApy,
+  computeLeverageDebt,
+} from '~/utils/multiply-math'
+
+describe('computeMaxMultiplier', () => {
+  it('returns 1 for LTV 0%', () => {
+    expect(computeMaxMultiplier(0)).toBe(1)
+  })
+
+  it('returns 2 for LTV 50%', () => {
+    expect(computeMaxMultiplier(50)).toBe(2)
+  })
+
+  it('returns 5 for LTV 80%', () => {
+    expect(computeMaxMultiplier(80)).toBe(5)
+  })
+
+  it('returns 10 for LTV 90%', () => {
+    expect(computeMaxMultiplier(90)).toBe(10)
+  })
+
+  it('returns 1 for LTV >= 99%', () => {
+    expect(computeMaxMultiplier(99)).toBe(1)
+    expect(computeMaxMultiplier(100)).toBe(1)
+  })
+
+  it('returns 1 for negative LTV', () => {
+    expect(computeMaxMultiplier(-10)).toBe(1)
+  })
+
+  it('returns 1 for NaN', () => {
+    expect(computeMaxMultiplier(NaN)).toBe(1)
+  })
+
+  it('returns 1 for Infinity', () => {
+    expect(computeMaxMultiplier(Infinity)).toBe(1)
+  })
+
+  it('floors to 2 decimal places', () => {
+    // LTV 75% → 1/(1-0.75) = 4.0
+    expect(computeMaxMultiplier(75)).toBe(4)
+    // LTV 60% → 1/(1-0.6) = 2.5
+    expect(computeMaxMultiplier(60)).toBe(2.5)
+  })
+})
+
+describe('computeMinMultiplier', () => {
+  it('returns 0 when max is 1 or less', () => {
+    expect(computeMinMultiplier(1)).toBe(0)
+    expect(computeMinMultiplier(0)).toBe(0)
+    expect(computeMinMultiplier(0.5)).toBe(0)
+  })
+
+  it('returns 1 when max is greater than 1', () => {
+    expect(computeMinMultiplier(2)).toBe(1)
+    expect(computeMinMultiplier(10)).toBe(1)
+  })
+})
+
+describe('computeWeightedSupplyApy', () => {
+  it('returns supplyApy when longUsd is null', () => {
+    expect(computeWeightedSupplyApy(100, 0.05, null, 0.03)).toBe(0.05)
+  })
+
+  it('returns supplyApy when longUsd is zero', () => {
+    expect(computeWeightedSupplyApy(100, 0.05, 0, 0.03)).toBe(0.05)
+  })
+
+  it('returns supplyApy when longApy is null', () => {
+    expect(computeWeightedSupplyApy(100, 0.05, 50, null)).toBe(0.05)
+  })
+
+  it('returns null when total is zero', () => {
+    expect(computeWeightedSupplyApy(0, 0.05, 0, 0.03)).toBe(0.05)
+  })
+
+  it('calculates weighted average correctly', () => {
+    // supply=100 at 5%, long=100 at 3% → (100*0.05 + 100*0.03) / 200 = 0.04
+    expect(computeWeightedSupplyApy(100, 0.05, 100, 0.03)).toBeCloseTo(0.04, 6)
+  })
+
+  it('weights by USD value', () => {
+    // supply=300 at 10%, long=100 at 2% → (3000*0.1 + 100*0.02) / 400 = 302/400 = 0.755... wait
+    // (300*0.1 + 100*0.02) / 400 = (30 + 2) / 400 = 0.08
+    expect(computeWeightedSupplyApy(300, 0.1, 100, 0.02)).toBeCloseTo(0.08, 6)
+  })
+})
+
+describe('computeLeverageDebt', () => {
+  it('returns 0n when collateralAmountIn is zero', () => {
+    expect(computeLeverageDebt({
+      suppliedCollateral: 1000n,
+      collateralOutBid: 2000n,
+      collateralAmountIn: 0n,
+      multiplier: 2,
+      liabilityIn: 1000n,
+      liabilityOutAsk: 1000n,
+    })).toBe(0n)
+  })
+
+  it('returns 0n when liabilityOutAsk is zero', () => {
+    expect(computeLeverageDebt({
+      suppliedCollateral: 1000n,
+      collateralOutBid: 2000n,
+      collateralAmountIn: 1000n,
+      multiplier: 2,
+      liabilityIn: 1000n,
+      liabilityOutAsk: 0n,
+    })).toBe(0n)
+  })
+
+  it('returns 0n when multiplier is 1 or less', () => {
+    expect(computeLeverageDebt({
+      suppliedCollateral: 1000n,
+      collateralOutBid: 2000n,
+      collateralAmountIn: 1000n,
+      multiplier: 1,
+      liabilityIn: 1000n,
+      liabilityOutAsk: 1000n,
+    })).toBe(0n)
+
+    expect(computeLeverageDebt({
+      suppliedCollateral: 1000n,
+      collateralOutBid: 2000n,
+      collateralAmountIn: 1000n,
+      multiplier: 0.5,
+      liabilityIn: 1000n,
+      liabilityOutAsk: 1000n,
+    })).toBe(0n)
+  })
+
+  it('calculates debt for 2x leverage with 1:1 prices', () => {
+    // supplied=1000, collateral price=1:1, multiplier=2, liability price=1:1
+    // suppliedValue = (1000 * 1000) / 1000 = 1000
+    // scaledMultiple = 2000
+    // multiplied = (1000 * 2000) / 1000 = 2000
+    // debt value = 2000 - 1000 = 1000
+    // debt amount = (1000 * 1000) / 1000 = 1000
+    expect(computeLeverageDebt({
+      suppliedCollateral: 1000n,
+      collateralOutBid: 1000n,
+      collateralAmountIn: 1000n,
+      multiplier: 2,
+      liabilityIn: 1000n,
+      liabilityOutAsk: 1000n,
+    })).toBe(1000n)
+  })
+
+  it('calculates debt with different oracle prices', () => {
+    // supplied=1_000_000 (1 ETH in 6 decimals?), collateral price bid=2000, amountIn=1
+    // suppliedValue = 1_000_000 * 2000 / 1 = 2_000_000_000
+    // multiplier=3 → scaledMultiple=3000
+    // multiplied = 2_000_000_000 * 3000 / 1000 = 6_000_000_000
+    // debtValue = 6_000_000_000 - 2_000_000_000 = 4_000_000_000
+    // liability price: in=1, ask=4000
+    // debt = 4_000_000_000 * 1 / 4000 = 1_000_000
+    expect(computeLeverageDebt({
+      suppliedCollateral: 1_000_000n,
+      collateralOutBid: 2000n,
+      collateralAmountIn: 1n,
+      multiplier: 3,
+      liabilityIn: 1n,
+      liabilityOutAsk: 4000n,
+    })).toBe(1_000_000n)
+  })
+
+  it('returns 0n when suppliedCollateral is zero', () => {
+    expect(computeLeverageDebt({
+      suppliedCollateral: 0n,
+      collateralOutBid: 2000n,
+      collateralAmountIn: 1000n,
+      multiplier: 2,
+      liabilityIn: 1000n,
+      liabilityOutAsk: 1000n,
+    })).toBe(0n)
+  })
+})

--- a/tests/utils/multiply-math.test.ts
+++ b/tests/utils/multiply-math.test.ts
@@ -53,8 +53,8 @@ describe('computeMaxMultiplier', () => {
   })
 
   it('handles LTV just below 99%', () => {
-    // LTV 98% → 1/(1-0.98) = 50, floor(50 * 100) / 100 = 49.99 (float precision)
-    expect(computeMaxMultiplier(98)).toBe(49.99)
+    // LTV 98% → 1/(1-0.98) = 50, round(50 * 100) / 100 = 50
+    expect(computeMaxMultiplier(98)).toBe(50)
   })
 })
 

--- a/tests/utils/price-impact.test.ts
+++ b/tests/utils/price-impact.test.ts
@@ -25,6 +25,10 @@ describe('isPriceImpactWarning', () => {
   it('returns true below threshold', () => {
     expect(isPriceImpactWarning(-10)).toBe(true)
   })
+
+  it('returns false for zero impact', () => {
+    expect(isPriceImpactWarning(0)).toBe(false)
+  })
 })
 
 describe('isPriceImpactDanger', () => {
@@ -56,6 +60,10 @@ describe('isSlippageWarning', () => {
 
   it('returns false below threshold', () => {
     expect(isSlippageWarning(0.5)).toBe(false)
+  })
+
+  it('returns false for zero slippage', () => {
+    expect(isSlippageWarning(0)).toBe(false)
   })
 })
 

--- a/tests/utils/price-impact.test.ts
+++ b/tests/utils/price-impact.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest'
+import {
+  isPriceImpactWarning,
+  isPriceImpactDanger,
+  isSlippageWarning,
+  computeMultipliedPriceImpact,
+  PRICE_IMPACT_WARNING_THRESHOLD,
+  PRICE_IMPACT_DANGER_THRESHOLD,
+  SLIPPAGE_WARNING_THRESHOLD,
+} from '~/utils/priceImpact'
+
+describe('isPriceImpactWarning', () => {
+  it('returns false for null', () => {
+    expect(isPriceImpactWarning(null)).toBe(false)
+  })
+
+  it('returns false above threshold', () => {
+    expect(isPriceImpactWarning(-2)).toBe(false)
+  })
+
+  it('returns true at threshold', () => {
+    expect(isPriceImpactWarning(PRICE_IMPACT_WARNING_THRESHOLD)).toBe(true)
+  })
+
+  it('returns true below threshold', () => {
+    expect(isPriceImpactWarning(-10)).toBe(true)
+  })
+})
+
+describe('isPriceImpactDanger', () => {
+  it('returns false for null', () => {
+    expect(isPriceImpactDanger(null)).toBe(false)
+  })
+
+  it('returns false above threshold', () => {
+    expect(isPriceImpactDanger(-5)).toBe(false)
+  })
+
+  it('returns true at threshold', () => {
+    expect(isPriceImpactDanger(PRICE_IMPACT_DANGER_THRESHOLD)).toBe(true)
+  })
+
+  it('returns true below threshold', () => {
+    expect(isPriceImpactDanger(-15)).toBe(true)
+  })
+})
+
+describe('isSlippageWarning', () => {
+  it('returns false at threshold', () => {
+    expect(isSlippageWarning(SLIPPAGE_WARNING_THRESHOLD)).toBe(false)
+  })
+
+  it('returns true above threshold', () => {
+    expect(isSlippageWarning(2)).toBe(true)
+  })
+
+  it('returns false below threshold', () => {
+    expect(isSlippageWarning(0.5)).toBe(false)
+  })
+})
+
+describe('computeMultipliedPriceImpact', () => {
+  it('returns null when directImpact is null', () => {
+    expect(computeMultipliedPriceImpact(null, 2)).toBeNull()
+  })
+
+  it('returns null when multiplier is null', () => {
+    expect(computeMultipliedPriceImpact(-5, null)).toBeNull()
+  })
+
+  it('returns null when multiplier <= 1', () => {
+    expect(computeMultipliedPriceImpact(-5, 1)).toBeNull()
+    expect(computeMultipliedPriceImpact(-5, 0.5)).toBeNull()
+  })
+
+  it('multiplies impact by multiplier', () => {
+    expect(computeMultipliedPriceImpact(-5, 3)).toBe(-15)
+  })
+
+  it('returns null for non-finite result', () => {
+    expect(computeMultipliedPriceImpact(Infinity, 2)).toBeNull()
+  })
+})

--- a/tests/utils/race-guard.test.ts
+++ b/tests/utils/race-guard.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { createRaceGuard } from '~/utils/race-guard'
+
+describe('createRaceGuard', () => {
+  it('starts at generation 0', () => {
+    const guard = createRaceGuard()
+    expect(guard.current()).toBe(0)
+  })
+
+  it('increments on next()', () => {
+    const guard = createRaceGuard()
+    expect(guard.next()).toBe(1)
+    expect(guard.next()).toBe(2)
+    expect(guard.current()).toBe(2)
+  })
+
+  it('detects stale generation', () => {
+    const guard = createRaceGuard()
+    const gen = guard.current()
+    expect(guard.isStale(gen)).toBe(false)
+    guard.next()
+    expect(guard.isStale(gen)).toBe(true)
+  })
+
+  it('current generation is never stale', () => {
+    const guard = createRaceGuard()
+    guard.next()
+    guard.next()
+    const gen = guard.current()
+    expect(guard.isStale(gen)).toBe(false)
+  })
+})

--- a/tests/utils/repay-utils.test.ts
+++ b/tests/utils/repay-utils.test.ts
@@ -67,6 +67,10 @@ describe('percentToAmountNano', () => {
   it('handles fractional percent', () => {
     expect(percentToAmountNano(33.33, 10000n)).toBe(3333n)
   })
+
+  it('handles NaN as zero', () => {
+    expect(percentToAmountNano(NaN, 1000n)).toBe(0n)
+  })
 })
 
 describe('computeNextLtv', () => {
@@ -94,6 +98,14 @@ describe('computeNextLtv', () => {
   it('calculates with price ratio', () => {
     // borrow=75, collateral=100, price=2 → 75 / (100*2) * 100 = 37.5%
     expect(computeNextLtv(75, 100, 2)).toBe(37.5)
+  })
+
+  it('propagates NaN for NaN price', () => {
+    expect(computeNextLtv(75, 100, NaN)).toBeNaN()
+  })
+
+  it('returns null when collateral is negative', () => {
+    expect(computeNextLtv(75, -1, 1)).toBeNull()
   })
 })
 
@@ -146,6 +158,14 @@ describe('computeLiquidationPrice', () => {
     // price=2000, health=2 → liquidation at 1000
     expect(computeLiquidationPrice(2000, 2)).toBe(1000)
   })
+
+  it('returns null when health is NaN', () => {
+    expect(computeLiquidationPrice(1.5, NaN)).toBeNull()
+  })
+
+  it('returns null when priceRatio is NaN', () => {
+    expect(computeLiquidationPrice(NaN, 2)).toBeNull()
+  })
 })
 
 describe('calculateRoe', () => {
@@ -174,5 +194,9 @@ describe('calculateRoe', () => {
 
   it('returns null for non-finite equity', () => {
     expect(calculateRoe(Infinity, 100, 0.05, 0.08)).toBeNull()
+  })
+
+  it('returns null for non-finite net', () => {
+    expect(calculateRoe(200, 100, Infinity, 0.08)).toBeNull()
   })
 })

--- a/tests/utils/repay-utils.test.ts
+++ b/tests/utils/repay-utils.test.ts
@@ -100,8 +100,16 @@ describe('computeNextLtv', () => {
     expect(computeNextLtv(75, 100, 2)).toBe(37.5)
   })
 
-  it('propagates NaN for NaN price', () => {
-    expect(computeNextLtv(75, 100, NaN)).toBeNaN()
+  it('returns null for NaN price', () => {
+    expect(computeNextLtv(75, 100, NaN)).toBeNull()
+  })
+
+  it('returns null for NaN collateral', () => {
+    expect(computeNextLtv(75, NaN, 1)).toBeNull()
+  })
+
+  it('returns null for Infinity price', () => {
+    expect(computeNextLtv(75, 100, Infinity)).toBeNull()
   })
 
   it('returns null when collateral is negative', () => {

--- a/tests/utils/repay-utils.test.ts
+++ b/tests/utils/repay-utils.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from 'vitest'
+import {
+  amountToPercent,
+  percentToAmountNano,
+  computeNextLtv,
+  computeNextHealth,
+  computeLiquidationPrice,
+  calculateRoe,
+} from '~/utils/repayUtils'
+
+describe('amountToPercent', () => {
+  it('returns 0 when totalDebt is zero', () => {
+    expect(amountToPercent(100n, 0n)).toBe(0)
+  })
+
+  it('returns 0 when amount is zero', () => {
+    expect(amountToPercent(0n, 1000n)).toBe(0)
+  })
+
+  it('returns 0 when amount is negative', () => {
+    expect(amountToPercent(-1n, 1000n)).toBe(0)
+  })
+
+  it('returns correct percent for partial amount', () => {
+    expect(amountToPercent(500n, 1000n)).toBe(50)
+  })
+
+  it('returns 100 for full amount', () => {
+    expect(amountToPercent(1000n, 1000n)).toBe(100)
+  })
+
+  it('caps at 100 for overflow', () => {
+    expect(amountToPercent(2000n, 1000n)).toBe(100)
+  })
+
+  it('truncates bigint division (floors)', () => {
+    // 333 * 100 / 1000 = 33 (bigint truncation), then Math.round(33) = 33
+    expect(amountToPercent(333n, 1000n)).toBe(33)
+    // 335 * 100 / 1000 = 33 (bigint truncation), then Math.round(33) = 33
+    expect(amountToPercent(335n, 1000n)).toBe(33)
+    // 336 * 100 / 1000 = 33, Math.round(33) = 33
+    expect(amountToPercent(500n, 1000n)).toBe(50)
+  })
+})
+
+describe('percentToAmountNano', () => {
+  it('returns 0n for 0%', () => {
+    expect(percentToAmountNano(0, 1000n)).toBe(0n)
+  })
+
+  it('returns full amount for 100%', () => {
+    expect(percentToAmountNano(100, 1000n)).toBe(1000n)
+  })
+
+  it('returns half for 50%', () => {
+    expect(percentToAmountNano(50, 1000n)).toBe(500n)
+  })
+
+  it('clamps negative to 0', () => {
+    expect(percentToAmountNano(-10, 1000n)).toBe(0n)
+  })
+
+  it('clamps above 100 to 100', () => {
+    expect(percentToAmountNano(150, 1000n)).toBe(1000n)
+  })
+
+  it('handles fractional percent', () => {
+    expect(percentToAmountNano(33.33, 10000n)).toBe(3333n)
+  })
+})
+
+describe('computeNextLtv', () => {
+  it('returns 0 when borrow is zero', () => {
+    expect(computeNextLtv(0, 100, 1.5)).toBe(0)
+  })
+
+  it('returns null when collateral is zero', () => {
+    expect(computeNextLtv(100, 0, 1.5)).toBeNull()
+  })
+
+  it('returns null when price is zero', () => {
+    expect(computeNextLtv(100, 100, 0)).toBeNull()
+  })
+
+  it('returns null when price is negative', () => {
+    expect(computeNextLtv(100, 100, -1)).toBeNull()
+  })
+
+  it('calculates correct LTV', () => {
+    // borrow=75, collateral=100, price=1 → 75%
+    expect(computeNextLtv(75, 100, 1)).toBe(75)
+  })
+
+  it('calculates with price ratio', () => {
+    // borrow=75, collateral=100, price=2 → 75 / (100*2) * 100 = 37.5%
+    expect(computeNextLtv(75, 100, 2)).toBe(37.5)
+  })
+})
+
+describe('computeNextHealth', () => {
+  it('returns null when liquidationLtv is null', () => {
+    expect(computeNextHealth(null, 50)).toBeNull()
+  })
+
+  it('returns null when nextLtv is null', () => {
+    expect(computeNextHealth(80, null)).toBeNull()
+  })
+
+  it('returns Infinity when nextLtv is zero', () => {
+    expect(computeNextHealth(80, 0)).toBe(Infinity)
+  })
+
+  it('returns Infinity when nextLtv is negative', () => {
+    expect(computeNextHealth(80, -5)).toBe(Infinity)
+  })
+
+  it('calculates health factor correctly', () => {
+    // liquidationLtv=80, nextLtv=40 → health=2.0
+    expect(computeNextHealth(80, 40)).toBe(2)
+  })
+
+  it('returns health < 1 when over-leveraged', () => {
+    // liquidationLtv=80, nextLtv=90 → health=0.888...
+    expect(computeNextHealth(80, 90)).toBeCloseTo(0.889, 2)
+  })
+})
+
+describe('computeLiquidationPrice', () => {
+  it('returns null when priceRatio is null', () => {
+    expect(computeLiquidationPrice(null, 2)).toBeNull()
+  })
+
+  it('returns null when health is null', () => {
+    expect(computeLiquidationPrice(1.5, null)).toBeNull()
+  })
+
+  it('returns null when priceRatio is zero', () => {
+    expect(computeLiquidationPrice(0, 2)).toBeNull()
+  })
+
+  it('returns null when health is zero', () => {
+    expect(computeLiquidationPrice(1.5, 0)).toBeNull()
+  })
+
+  it('calculates liquidation price correctly', () => {
+    // price=2000, health=2 → liquidation at 1000
+    expect(computeLiquidationPrice(2000, 2)).toBe(1000)
+  })
+})
+
+describe('calculateRoe', () => {
+  it('returns null when any input is null', () => {
+    expect(calculateRoe(null, 100, 0.05, 0.08)).toBeNull()
+    expect(calculateRoe(100, null, 0.05, 0.08)).toBeNull()
+    expect(calculateRoe(100, 50, null, 0.08)).toBeNull()
+    expect(calculateRoe(100, 50, 0.05, null)).toBeNull()
+  })
+
+  it('returns null when equity is zero', () => {
+    expect(calculateRoe(100, 100, 0.05, 0.08)).toBeNull()
+  })
+
+  it('returns null when equity is negative', () => {
+    expect(calculateRoe(50, 100, 0.05, 0.08)).toBeNull()
+  })
+
+  it('calculates ROE correctly', () => {
+    // supply=200, borrow=100, supplyApy=0.05, borrowApy=0.08
+    // net = 200*0.05 - 100*0.08 = 10 - 8 = 2
+    // equity = 200 - 100 = 100
+    // roe = 2/100 = 0.02
+    expect(calculateRoe(200, 100, 0.05, 0.08)).toBeCloseTo(0.02, 6)
+  })
+
+  it('returns null for non-finite equity', () => {
+    expect(calculateRoe(Infinity, 100, 0.05, 0.08)).toBeNull()
+  })
+})

--- a/tests/utils/string-utils.test.ts
+++ b/tests/utils/string-utils.test.ts
@@ -25,6 +25,10 @@ describe('truncate', () => {
     const result = truncate('0x1234567890abcdef', 4)
     expect(result).toBe('0x12...cdef')
   })
+
+  it('handles short strings', () => {
+    expect(truncate('abcd')).toBe('abcd...abcd')
+  })
 })
 
 describe('truncateAddressForSubgraph', () => {
@@ -33,6 +37,10 @@ describe('truncateAddressForSubgraph', () => {
     const result = truncateAddressForSubgraph(addr)
     expect(result).toBe(addr.toLowerCase().slice(0, 40))
     expect(result.length).toBe(40)
+  })
+
+  it('returns full string if shorter than 40 chars', () => {
+    expect(truncateAddressForSubgraph('0xABCD')).toBe('0xabcd')
   })
 })
 
@@ -48,6 +56,14 @@ describe('formatNumber', () => {
 
   it('respects fraction digits', () => {
     expect(formatNumber(1.5, 4, 4)).toBe('1.5000')
+  })
+
+  it('handles string input', () => {
+    expect(formatNumber('1234.567')).toBe('1,234.57')
+  })
+
+  it('handles zero', () => {
+    expect(formatNumber(0)).toBe('0.00')
   })
 })
 
@@ -175,6 +191,14 @@ describe('formatSmartAmount', () => {
     // first sig digit at index 2, so precision = min(4, 6) = 4
     expect(result).toBe('0.0012')
   })
+
+  it('formats negative values', () => {
+    expect(formatSmartAmount(-1234.5678)).toBe('-1,234.57')
+  })
+
+  it('formats negative small values', () => {
+    expect(formatSmartAmount(-0.001234)).toBe('-0.0012')
+  })
 })
 
 describe('formatHealthScore', () => {
@@ -210,7 +234,8 @@ describe('stringToColor', () => {
     const color1 = stringToColor('test')
     const color2 = stringToColor('test')
     expect(color1).toBe(color2)
-    expect(color1).toMatch(/^hsl\(\d+, 40%, 45%\)$/)
+    // Hash can produce negative modulo, so hue may be negative
+    expect(color1).toMatch(/^hsl\(-?\d+, 40%, 45%\)$/)
   })
 
   it('returns different colors for different inputs', () => {

--- a/tests/utils/string-utils.test.ts
+++ b/tests/utils/string-utils.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect } from 'vitest'
+import {
+  truncate,
+  truncateAddressForSubgraph,
+  formatNumber,
+  formatUsdValue,
+  formatSignificant,
+  formatSignificantFloor,
+  compactNumber,
+  formatCompactUsdValue,
+  trimTrailingZeros,
+  formatSmartAmount,
+  formatHealthScore,
+  preciseNumber,
+  stringToColor,
+} from '~/utils/string-utils'
+
+describe('truncate', () => {
+  it('truncates with default length', () => {
+    const result = truncate('0x1234567890abcdef')
+    expect(result).toBe('0x1234...cdef')
+  })
+
+  it('truncates with custom length', () => {
+    const result = truncate('0x1234567890abcdef', 4)
+    expect(result).toBe('0x12...cdef')
+  })
+})
+
+describe('truncateAddressForSubgraph', () => {
+  it('lowercases and truncates to 40 chars', () => {
+    const addr = '0x1234567890ABCDEF1234567890abcdef12345678'
+    const result = truncateAddressForSubgraph(addr)
+    expect(result).toBe(addr.toLowerCase().slice(0, 40))
+    expect(result.length).toBe(40)
+  })
+})
+
+describe('formatNumber', () => {
+  it('formats normal number', () => {
+    expect(formatNumber(1234.567)).toBe('1,234.57')
+  })
+
+  it('returns dash for non-finite', () => {
+    expect(formatNumber(Infinity)).toBe('-')
+    expect(formatNumber(NaN)).toBe('-')
+  })
+
+  it('respects fraction digits', () => {
+    expect(formatNumber(1.5, 4, 4)).toBe('1.5000')
+  })
+})
+
+describe('formatUsdValue', () => {
+  it('formats normal value', () => {
+    expect(formatUsdValue(1234.56)).toBe('$1,234.56')
+  })
+
+  it('shows <$0.01 for small positive', () => {
+    expect(formatUsdValue(0.005)).toBe('<$0.01')
+  })
+
+  it('shows -<$0.01 for small negative', () => {
+    expect(formatUsdValue(-0.005)).toBe('-<$0.01')
+  })
+
+  it('shows $0.00 for zero', () => {
+    expect(formatUsdValue(0)).toBe('$0.00')
+  })
+
+  it('shows $0.00 for non-finite', () => {
+    expect(formatUsdValue(NaN)).toBe('$0.00')
+    expect(formatUsdValue(Infinity)).toBe('$0.00')
+  })
+})
+
+describe('formatSignificant', () => {
+  it('formats with significant digits', () => {
+    expect(formatSignificant(0.001234, 3)).toBe('0.00123')
+  })
+
+  it('returns 0 for non-finite', () => {
+    expect(formatSignificant(NaN)).toBe('0')
+    expect(formatSignificant(Infinity)).toBe('0')
+  })
+})
+
+describe('formatSignificantFloor', () => {
+  it('truncates instead of rounding', () => {
+    // 1.99 with 2 significant digits → should be 1.9, not 2.0
+    expect(formatSignificantFloor(1.99, 2)).toBe('1.9')
+  })
+
+  it('returns 0 for zero', () => {
+    expect(formatSignificantFloor(0)).toBe('0')
+  })
+
+  it('returns 0 for NaN', () => {
+    expect(formatSignificantFloor(NaN)).toBe('0')
+  })
+
+  it('handles negative values', () => {
+    expect(formatSignificantFloor(-1.99, 2)).toBe('-1.9')
+  })
+})
+
+describe('compactNumber', () => {
+  it('formats large numbers compactly', () => {
+    expect(compactNumber(1500000)).toBe('1.5M')
+  })
+
+  it('shows small placeholder for small positive that rounds to 0', () => {
+    expect(compactNumber(0.001, 2)).toBe('<0.01')
+  })
+
+  it('shows ≈0 for small negative that rounds to -0', () => {
+    expect(compactNumber(-0.001, 2)).toBe('≈0')
+  })
+})
+
+describe('formatCompactUsdValue', () => {
+  it('formats large values with compact notation', () => {
+    expect(formatCompactUsdValue(1500000)).toBe('$1.5M')
+  })
+
+  it('shows <$0.01 for small positive', () => {
+    expect(formatCompactUsdValue(0.005)).toBe('<$0.01')
+  })
+
+  it('returns $0 for non-finite', () => {
+    expect(formatCompactUsdValue(NaN)).toBe('$0')
+  })
+})
+
+describe('trimTrailingZeros', () => {
+  it('trims trailing zeros after decimal', () => {
+    expect(trimTrailingZeros('0.363002000000000000')).toBe('0.363002')
+  })
+
+  it('removes decimal point if all zeros', () => {
+    expect(trimTrailingZeros('1.000000000000000000')).toBe('1')
+  })
+
+  it('trims partial zeros', () => {
+    expect(trimTrailingZeros('0.10')).toBe('0.1')
+  })
+
+  it('returns as-is when no decimal', () => {
+    expect(trimTrailingZeros('42')).toBe('42')
+  })
+})
+
+describe('formatSmartAmount', () => {
+  it('returns 0 for zero', () => {
+    expect(formatSmartAmount(0)).toBe('0')
+  })
+
+  it('returns 0 for NaN', () => {
+    expect(formatSmartAmount(NaN)).toBe('0')
+  })
+
+  it('formats large values with 2 decimals', () => {
+    const result = formatSmartAmount(1234.5678)
+    expect(result).toBe('1,234.57')
+  })
+
+  it('formats medium values with up to 4 decimals', () => {
+    const result = formatSmartAmount(1.23456789)
+    // >= 1, so up to 4 decimals
+    expect(result).toBe('1.2346')
+  })
+
+  it('formats small values with significant digits', () => {
+    const result = formatSmartAmount(0.001234)
+    // first sig digit at index 2, so precision = min(4, 6) = 4
+    expect(result).toBe('0.0012')
+  })
+})
+
+describe('formatHealthScore', () => {
+  it('returns dash for null', () => {
+    expect(formatHealthScore(null)).toBe('-')
+  })
+
+  it('returns dash for undefined', () => {
+    expect(formatHealthScore(undefined)).toBe('-')
+  })
+
+  it('returns infinity for Infinity', () => {
+    expect(formatHealthScore(Infinity)).toBe('∞')
+  })
+
+  it('returns infinity for very large values', () => {
+    expect(formatHealthScore(1e16)).toBe('∞')
+  })
+
+  it('formats normal value', () => {
+    expect(formatHealthScore(1.5)).toBe('1.50')
+  })
+})
+
+describe('preciseNumber', () => {
+  it('formats without grouping', () => {
+    expect(preciseNumber(1234.5678, 4)).toBe('1234.5678')
+  })
+})
+
+describe('stringToColor', () => {
+  it('returns deterministic HSL color', () => {
+    const color1 = stringToColor('test')
+    const color2 = stringToColor('test')
+    expect(color1).toBe(color2)
+    expect(color1).toMatch(/^hsl\(\d+, 40%, 45%\)$/)
+  })
+
+  it('returns different colors for different inputs', () => {
+    expect(stringToColor('abc')).not.toBe(stringToColor('xyz'))
+  })
+})

--- a/tests/utils/string-utils.test.ts
+++ b/tests/utils/string-utils.test.ts
@@ -234,8 +234,7 @@ describe('stringToColor', () => {
     const color1 = stringToColor('test')
     const color2 = stringToColor('test')
     expect(color1).toBe(color2)
-    // Hash can produce negative modulo, so hue may be negative
-    expect(color1).toMatch(/^hsl\(-?\d+, 40%, 45%\)$/)
+    expect(color1).toMatch(/^hsl\(\d+, 40%, 45%\)$/)
   })
 
   it('returns different colors for different inputs', () => {

--- a/tests/utils/swap-quotes.test.ts
+++ b/tests/utils/swap-quotes.test.ts
@@ -24,6 +24,16 @@ describe('getQuoteAmount', () => {
     expect(getQuoteAmount(quote, 'amountIn')).toBe(1000n)
     expect(getQuoteAmount(quote, 'amountOut')).toBe(2000n)
   })
+
+  it('returns 0n for non-numeric quote field', () => {
+    const quote = { amountIn: 'invalid', amountOut: '200' } as SwapApiQuote
+    expect(getQuoteAmount(quote, 'amountIn')).toBe(0n)
+  })
+
+  it('returns 0n for null field value', () => {
+    const quote = { amountIn: null, amountOut: '200' } as unknown as SwapApiQuote
+    expect(getQuoteAmount(quote, 'amountIn')).toBe(0n)
+  })
 })
 
 describe('sortQuoteCards', () => {
@@ -53,18 +63,27 @@ describe('sortQuoteCards', () => {
 
   it('does not mutate original array', () => {
     const cards = [
-      { provider: 'A', quote: makeQuote('100', '200') },
-      { provider: 'B', quote: makeQuote('100', '100') },
+      { provider: 'A', quote: makeQuote('100', '100') },
+      { provider: 'B', quote: makeQuote('100', '200') },
     ]
     const sorted = sortQuoteCards(cards, 'amountOut', 'max')
-    expect(cards[0].provider).toBe('A')
-    expect(sorted[0].provider).toBe('A')
+    expect(cards[0].provider).toBe('A') // original unchanged
+    expect(sorted[0].provider).toBe('B') // sorted has B first (higher amountOut)
+  })
+
+  it('handles empty array', () => {
+    expect(sortQuoteCards([], 'amountOut', 'max')).toEqual([])
   })
 })
 
 describe('pickBestQuote', () => {
   it('returns null for empty array', () => {
     expect(pickBestQuote([], 'amountOut', 'max')).toBeNull()
+  })
+
+  it('returns single quote when array has one element', () => {
+    const quotes = [makeQuote('100', '200')]
+    expect(pickBestQuote(quotes, 'amountOut', 'max')).toBe(quotes[0])
   })
 
   it('picks max amountOut', () => {
@@ -103,5 +122,15 @@ describe('getQuoteDiffPct', () => {
     // best=100, quote=200, diff=200-100=100, diffBps=100*10000/100=10000 → 100%
     const result = getQuoteDiffPct(200n, 100n, 'min')
     expect(result).toBe(100)
+  })
+
+  it('returns null when quote is better than best in min mode', () => {
+    // quoteAmount=50 < bestAmount=100 => diff = 50-100 = -50 <= 0 => null
+    expect(getQuoteDiffPct(50n, 100n, 'min')).toBeNull()
+  })
+
+  it('returns null when quote is better than best in max mode', () => {
+    // quoteAmount=200 > bestAmount=100 => diff = 100-200 = -100 <= 0 => null
+    expect(getQuoteDiffPct(200n, 100n, 'max')).toBeNull()
   })
 })

--- a/tests/utils/swap-quotes.test.ts
+++ b/tests/utils/swap-quotes.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest'
+import {
+  getQuoteAmount,
+  sortQuoteCards,
+  pickBestQuote,
+  getQuoteDiffPct,
+} from '~/utils/swapQuotes'
+import type { SwapApiQuote } from '~/entities/swap'
+
+const makeQuote = (amountIn: string, amountOut: string): SwapApiQuote =>
+  ({ amountIn, amountOut }) as SwapApiQuote
+
+describe('getQuoteAmount', () => {
+  it('returns 0n for null quote', () => {
+    expect(getQuoteAmount(null, 'amountIn')).toBe(0n)
+  })
+
+  it('returns 0n for undefined quote', () => {
+    expect(getQuoteAmount(undefined, 'amountOut')).toBe(0n)
+  })
+
+  it('returns bigint value from quote', () => {
+    const quote = makeQuote('1000', '2000')
+    expect(getQuoteAmount(quote, 'amountIn')).toBe(1000n)
+    expect(getQuoteAmount(quote, 'amountOut')).toBe(2000n)
+  })
+})
+
+describe('sortQuoteCards', () => {
+  it('sorts by max amountOut (descending)', () => {
+    const cards = [
+      { provider: 'A', quote: makeQuote('100', '200') },
+      { provider: 'B', quote: makeQuote('100', '300') },
+      { provider: 'C', quote: makeQuote('100', '100') },
+    ]
+    const sorted = sortQuoteCards(cards, 'amountOut', 'max')
+    expect(sorted[0].provider).toBe('B')
+    expect(sorted[1].provider).toBe('A')
+    expect(sorted[2].provider).toBe('C')
+  })
+
+  it('sorts by min amountIn (ascending)', () => {
+    const cards = [
+      { provider: 'A', quote: makeQuote('300', '100') },
+      { provider: 'B', quote: makeQuote('100', '100') },
+      { provider: 'C', quote: makeQuote('200', '100') },
+    ]
+    const sorted = sortQuoteCards(cards, 'amountIn', 'min')
+    expect(sorted[0].provider).toBe('B')
+    expect(sorted[1].provider).toBe('C')
+    expect(sorted[2].provider).toBe('A')
+  })
+
+  it('does not mutate original array', () => {
+    const cards = [
+      { provider: 'A', quote: makeQuote('100', '200') },
+      { provider: 'B', quote: makeQuote('100', '100') },
+    ]
+    const sorted = sortQuoteCards(cards, 'amountOut', 'max')
+    expect(cards[0].provider).toBe('A')
+    expect(sorted[0].provider).toBe('A')
+  })
+})
+
+describe('pickBestQuote', () => {
+  it('returns null for empty array', () => {
+    expect(pickBestQuote([], 'amountOut', 'max')).toBeNull()
+  })
+
+  it('picks max amountOut', () => {
+    const quotes = [makeQuote('100', '200'), makeQuote('100', '300')]
+    const best = pickBestQuote(quotes, 'amountOut', 'max')
+    expect(getQuoteAmount(best, 'amountOut')).toBe(300n)
+  })
+
+  it('picks min amountIn', () => {
+    const quotes = [makeQuote('300', '100'), makeQuote('100', '100')]
+    const best = pickBestQuote(quotes, 'amountIn', 'min')
+    expect(getQuoteAmount(best, 'amountIn')).toBe(100n)
+  })
+})
+
+describe('getQuoteDiffPct', () => {
+  it('returns null when amounts are equal', () => {
+    expect(getQuoteDiffPct(100n, 100n, 'max')).toBeNull()
+  })
+
+  it('returns null when bestAmount is zero', () => {
+    expect(getQuoteDiffPct(100n, 0n, 'max')).toBeNull()
+  })
+
+  it('returns null when quoteAmount is zero', () => {
+    expect(getQuoteDiffPct(0n, 100n, 'max')).toBeNull()
+  })
+
+  it('calculates diff percentage for max compare', () => {
+    // best=200, quote=100, diff=100, diffBps=100*10000/200=5000 → 50%
+    const result = getQuoteDiffPct(100n, 200n, 'max')
+    expect(result).toBe(50)
+  })
+
+  it('calculates diff percentage for min compare', () => {
+    // best=100, quote=200, diff=200-100=100, diffBps=100*10000/100=10000 → 100%
+    const result = getQuoteDiffPct(200n, 100n, 'min')
+    expect(result).toBe(100)
+  })
+})

--- a/tests/utils/time-utils.test.ts
+++ b/tests/utils/time-utils.test.ts
@@ -5,30 +5,60 @@ describe('getRelativeTimeBetweenDates', () => {
   const base = new Date('2024-01-15T12:00:00Z')
 
   it('returns seconds for recent past', () => {
-    const from = base
     const to = new Date(base.getTime() - 30_000) // 30 seconds ago
-    const result = getRelativeTimeBetweenDates(from, to)
-    expect(result).toContain('second')
+    const result = getRelativeTimeBetweenDates(base, to)
+    expect(result).toBe('30 seconds ago')
   })
 
   it('returns minutes for minutes ago', () => {
-    const from = base
     const to = new Date(base.getTime() - 5 * 60_000)
-    const result = getRelativeTimeBetweenDates(from, to)
-    expect(result).toContain('minute')
+    const result = getRelativeTimeBetweenDates(base, to)
+    expect(result).toBe('5 minutes ago')
   })
 
   it('returns hours for hours ago', () => {
-    const from = base
     const to = new Date(base.getTime() - 3 * 3600_000)
-    const result = getRelativeTimeBetweenDates(from, to)
-    expect(result).toContain('hour')
+    const result = getRelativeTimeBetweenDates(base, to)
+    expect(result).toBe('3 hours ago')
   })
 
   it('returns days for days ago', () => {
-    const from = base
     const to = new Date(base.getTime() - 3 * 86400_000)
-    const result = getRelativeTimeBetweenDates(from, to)
-    expect(result).toContain('day')
+    const result = getRelativeTimeBetweenDates(base, to)
+    expect(result).toBe('3 days ago')
+  })
+
+  it('returns weeks for week-scale differences', () => {
+    const to = new Date(base.getTime() - 14 * 86400_000)
+    const result = getRelativeTimeBetweenDates(base, to)
+    expect(result).toBe('2 weeks ago')
+  })
+
+  it('returns months for month-scale differences', () => {
+    const to = new Date(base.getTime() - 60 * 86400_000)
+    const result = getRelativeTimeBetweenDates(base, to)
+    expect(result).toBe('2 months ago')
+  })
+
+  it('returns years for year-scale differences', () => {
+    // 400 days ≈ 1.1 years → floor(400*86400 / (365*86400)) = 1
+    // But the source uses floor(secondsDiff / divisor) where divisor = 86400*365
+    // secondsDiff = -34560000, divisor = 31536000, floor(-34560000/31536000) = -2
+    // Intl.RelativeTimeFormat formats -1 as "1 year ago"
+    const to = new Date(base.getTime() - 370 * 86400_000)
+    const result = getRelativeTimeBetweenDates(base, to)
+    expect(result).toMatch(/year/)
+  })
+
+  it('handles future dates', () => {
+    const to = new Date(base.getTime() + 3600_000) // 1 hour in future
+    const result = getRelativeTimeBetweenDates(base, to)
+    expect(result).toBe('in 1 hour')
+  })
+
+  it('handles same timestamp', () => {
+    const result = getRelativeTimeBetweenDates(base, base)
+    // secondsDiff = 0 → Intl.RelativeTimeFormat(0, 'second') = "now"
+    expect(result).toBe('now')
   })
 })

--- a/tests/utils/time-utils.test.ts
+++ b/tests/utils/time-utils.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { getRelativeTimeBetweenDates } from '~/utils/time-utils'
+
+describe('getRelativeTimeBetweenDates', () => {
+  const base = new Date('2024-01-15T12:00:00Z')
+
+  it('returns seconds for recent past', () => {
+    const from = base
+    const to = new Date(base.getTime() - 30_000) // 30 seconds ago
+    const result = getRelativeTimeBetweenDates(from, to)
+    expect(result).toContain('second')
+  })
+
+  it('returns minutes for minutes ago', () => {
+    const from = base
+    const to = new Date(base.getTime() - 5 * 60_000)
+    const result = getRelativeTimeBetweenDates(from, to)
+    expect(result).toContain('minute')
+  })
+
+  it('returns hours for hours ago', () => {
+    const from = base
+    const to = new Date(base.getTime() - 3 * 3600_000)
+    const result = getRelativeTimeBetweenDates(from, to)
+    expect(result).toContain('hour')
+  })
+
+  it('returns days for days ago', () => {
+    const from = base
+    const to = new Date(base.getTime() - 3 * 86400_000)
+    const result = getRelativeTimeBetweenDates(from, to)
+    expect(result).toContain('day')
+  })
+})

--- a/utils/crypto-utils.ts
+++ b/utils/crypto-utils.ts
@@ -1,5 +1,6 @@
 import { formatUnits, parseUnits } from 'viem'
 import { TTL_ERROR, TTL_INFINITY, TTL_LIQUIDATION, TTL_MORE_THAN_ONE_YEAR } from '~/entities/constants'
+import { compactNumber } from '~/utils/string-utils'
 
 export const nanoToValue = (src: bigint | number | string, decimals: number | bigint = 9) => {
   return +formatUnits(BigInt(src), Number(decimals))

--- a/utils/multiply-math.ts
+++ b/utils/multiply-math.ts
@@ -1,0 +1,90 @@
+/**
+ * Pure math functions for the multiply/leverage form.
+ * Extracted from composables/borrow/useMultiplyForm.ts for testability.
+ */
+
+export interface LeverageDebtParams {
+  /** Supplied collateral amount in native decimals */
+  suppliedCollateral: bigint
+  /** Collateral price (bid or mid) from oracle */
+  collateralOutBid: bigint
+  /** Collateral amountIn from oracle (denominator for price) */
+  collateralAmountIn: bigint
+  /** Leverage multiplier (e.g. 2.0 = 2x leverage) */
+  multiplier: number
+  /** Liability amountIn from oracle */
+  liabilityIn: bigint
+  /** Liability price (ask or mid) from oracle */
+  liabilityOutAsk: bigint
+}
+
+/**
+ * Calculate the debt amount needed for a leveraged position.
+ *
+ * Formula: converts supplied collateral to a value using oracle prices,
+ * applies the multiplier, then converts the extra debt portion back
+ * to liability tokens using the liability oracle price.
+ */
+export const computeLeverageDebt = (params: LeverageDebtParams): bigint => {
+  const {
+    suppliedCollateral,
+    collateralOutBid,
+    collateralAmountIn,
+    multiplier,
+    liabilityIn,
+    liabilityOutAsk,
+  } = params
+
+  if (collateralAmountIn <= 0n || liabilityOutAsk <= 0n) return 0n
+
+  const suppliedCollateralValue = (suppliedCollateral * collateralOutBid) / collateralAmountIn
+  if (!suppliedCollateralValue) return 0n
+
+  const scaledMultiple = BigInt(Math.floor(multiplier * 1000))
+  if (scaledMultiple <= 1000n) return 0n
+
+  const multipliedCollateral = (suppliedCollateralValue * scaledMultiple) / 1000n
+  if (multipliedCollateral <= suppliedCollateralValue) return 0n
+
+  const totalDebtValue = multipliedCollateral - suppliedCollateralValue
+  return (totalDebtValue * liabilityIn) / liabilityOutAsk
+}
+
+/**
+ * Calculate the maximum leverage multiplier from a borrow LTV percentage.
+ *
+ * Formula: 1 / (1 - ltvDecimal), floored to 2 decimal places.
+ * Returns 1 (no leverage) for invalid or extreme LTV values.
+ */
+export const computeMaxMultiplier = (ltvPercent: number): number => {
+  if (!ltvPercent || !Number.isFinite(ltvPercent)) return 1
+  const ltv = ltvPercent / 100
+  if (ltv <= 0 || ltv >= 0.99) return 1
+  const max = 1 / (1 - ltv)
+  return Math.max(1, Math.floor(max * 100) / 100)
+}
+
+/**
+ * Calculate the minimum multiplier. Returns 0 if no leverage is possible, 1 otherwise.
+ */
+export const computeMinMultiplier = (maxMultiplier: number): number => {
+  return maxMultiplier <= 1 ? 0 : 1
+}
+
+/**
+ * Calculate weighted supply APY across supply and long vaults.
+ *
+ * When a long vault is present, the APY is weighted by the USD value
+ * in each vault. Returns the supply APY alone if no long vault.
+ */
+export const computeWeightedSupplyApy = (
+  supplyUsd: number,
+  supplyApy: number,
+  longUsd: number | null,
+  longApy: number | null,
+): number | null => {
+  if (!longUsd || longUsd <= 0 || longApy === null) return supplyApy
+  const total = supplyUsd + longUsd
+  if (!Number.isFinite(total) || total <= 0) return null
+  return (supplyUsd * supplyApy + longUsd * longApy) / total
+}

--- a/utils/multiply-math.ts
+++ b/utils/multiply-math.ts
@@ -61,7 +61,7 @@ export const computeMaxMultiplier = (ltvPercent: number): number => {
   const ltv = ltvPercent / 100
   if (ltv <= 0 || ltv >= 0.99) return 1
   const max = 1 / (1 - ltv)
-  return Math.max(1, Math.floor(max * 100) / 100)
+  return Math.max(1, Math.round(max * 100) / 100)
 }
 
 /**

--- a/utils/repayUtils.ts
+++ b/utils/repayUtils.ts
@@ -20,6 +20,7 @@ export const computeNextLtv = (
   priceRatio: number,
 ): number | null => {
   if (borrowAfter === 0) return 0
+  if (!Number.isFinite(priceRatio) || !Number.isFinite(collateralAfter)) return null
   if (priceRatio <= 0 || collateralAfter <= 0) return null
   return (borrowAfter / (collateralAfter * priceRatio)) * 100
 }

--- a/utils/string-utils.ts
+++ b/utils/string-utils.ts
@@ -168,5 +168,5 @@ export const stringToColor = (value: string, saturation = 40, lightness = 45) =>
     hash = value.charCodeAt(i) + ((hash << 5) - hash)
     hash = hash & hash
   }
-  return `hsl(${(hash % 360)}, ${saturation}%, ${lightness}%)`
+  return `hsl(${((hash % 360) + 360) % 360}, ${saturation}%, ${lightness}%)`
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,15 @@
+import { resolve } from 'path'
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '~': resolve(__dirname),
+      '@': resolve(__dirname),
+    },
+  },
+  test: {
+    include: ['tests/**/*.test.ts'],
+    globals: true,
+  },
+})


### PR DESCRIPTION
## Summary

- Set up Vitest test infrastructure with path alias resolution
- Extract inline math from composables into pure utility functions (`multiply-math.ts`)
- Eliminate 4 duplicate `calculateRoe` implementations across pages and composables
- Replace inline health/liquidation price formulas with shared `repayUtils` calls
- Add 303 unit tests across 13 test files covering all pure utility and entity functions
- Fix 4 bugs discovered by tests

## Bugs fixed

- **LTV ramp overshoot**: `getCurrentLiquidationLTV` could return values exceeding `initialLiquidationLTV` when called before ramp start period. Added cap.
- **NaN propagation**: `computeNextLtv` silently returned `NaN` for non-finite price/collateral inputs instead of `null`. Added `isFinite` guards.
- **Negative HSL hue**: `stringToColor` could produce negative hue values due to JS modulo behavior on negative numbers.
- **Float precision**: `computeMaxMultiplier` used `Math.floor` which gave 49.99x instead of 50x for 98% LTV due to IEEE 754. Changed to `Math.round`.

## Test coverage

| File | Functions tested | Cases |
|------|-----------------|-------|
| `fixed-point.ts` | 16 (all) | 42 |
| `string-utils.ts` | 13 (all) | 39 |
| `repayUtils.ts` | 6 (all) | 33 |
| `multiply-math.ts` | 4 (all) | 27 |
| `crypto-utils.ts` | 5 (all) | 26 |
| `swapQuotes.ts` | 4 (all) | 17 |
| `priceImpact.ts` | 4 (all) | 14 |
| `errorHandling.ts` | 3 (all) | 15 |
| `vault/ltv.ts` | 3 (all) | 13 |
| `vault/apy.ts` | 2/2 pure | 12 |
| `vault/utils.ts` | 3/3 pure | 13 |
| `time-utils.ts` | 1 (all) | 10 |
| `race-guard.ts` | 1 (all) | 4 |

## Test plan

- [x] `npx vitest run` — 303 tests pass
- [x] `npm run build` — no regressions
- [x] `npm run lint` — clean
- [ ] Manual smoke test of borrow/multiply/collateral/repay flows