### PR TITLE
fix: spy mode coverage, console cleanup, and estimate corrections

### DIFF
--- a/components/entities/portfolio/PortfolioBrevisRewardItem.vue
+++ b/components/entities/portfolio/PortfolioBrevisRewardItem.vue
@@ -11,6 +11,7 @@ const { campaign } = defineProps<{ campaign: Campaign }>()
 
 const { getVault } = useVaults()
 const { claimReward, loadRewards, buildClaimRewardPlan } = useBrevis()
+const { isSpyMode } = useSpyMode()
 const modal = useModal()
 const { error } = useToast()
 const { chainId: siteChainId } = useEulerAddresses()
@@ -140,6 +141,7 @@ const onClaimClick = async () => {
       <UiButton
         rounded
         :loading="isClaiming || isPreparing"
+        :disabled="isSpyMode"
         @click="onClaimClick"
       >
         Claim

--- a/components/entities/portfolio/PortfolioFuulRewardItem.vue
+++ b/components/entities/portfolio/PortfolioFuulRewardItem.vue
@@ -11,6 +11,7 @@ import { nanoToValue } from '~/utils/crypto-utils'
 const { reward } = defineProps<{ reward: FuulClaimableReward }>()
 
 const { claimReward, loadClaimableRewards, buildClaimRewardPlan } = useFuul()
+const { isSpyMode } = useSpyMode()
 const modal = useModal()
 const { error } = useToast()
 const { chainId: siteChainId } = useEulerAddresses()
@@ -122,6 +123,7 @@ const onClaimClick = async () => {
       <UiButton
         rounded
         :loading="isClaiming || isPreparing"
+        :disabled="isSpyMode"
         @click="onClaimClick"
       >
         Claim

--- a/components/entities/portfolio/PortfolioRewardItem.vue
+++ b/components/entities/portfolio/PortfolioRewardItem.vue
@@ -11,6 +11,7 @@ import { nanoToValue } from '~/utils/crypto-utils'
 const { reward } = defineProps<{ reward: Reward }>()
 
 const { isTokensLoading, rewardTokens, claimReward, loadRewards, buildClaimRewardPlan } = useMerkl()
+const { isSpyMode } = useSpyMode()
 const modal = useModal()
 const { error } = useToast()
 const { chainId: siteChainId } = useEulerAddresses()
@@ -148,6 +149,7 @@ const onClaimClick = async () => {
       <UiButton
         rounded
         :loading="isClaiming || isPreparing"
+        :disabled="isSpyMode"
         @click="onClaimClick"
       >
         Claim

--- a/components/entities/reward/RewardUnlockItem.vue
+++ b/components/entities/reward/RewardUnlockItem.vue
@@ -11,6 +11,7 @@ import { nanoToValue } from '~/utils/crypto-utils'
 
 const modal = useModal()
 const { error } = useToast()
+const { isSpyMode } = useSpyMode()
 const { rewardTokens, isTokensLoading } = useMerkl()
 const { unlockREUL, buildUnlockREULPlan, reulTokenContractAddress, loadREULLocksInfo } = useREULLocks()
 const { chainId: siteChainId } = useEulerAddresses()
@@ -179,6 +180,7 @@ const onUnlockClick = async () => {
         variant="primary-stroke"
         rounded
         :loading="isUnlocking || isPreparing"
+        :disabled="isSpyMode"
         @click="onUnlockClick"
       >
         Unlock

--- a/components/entities/vault/VaultEarnItem.vue
+++ b/components/entities/vault/VaultEarnItem.vue
@@ -92,11 +92,11 @@ const onSupplyInfoIconClick = (event: MouseEvent) => {
 
 <template>
   <NuxtLink
-    class="block no-underline bg-surface rounded-xl border border-line-subtle shadow-card transition-all duration-default ease-default hover:shadow-card-hover hover:border-line-emphasis"
+    class="block no-underline bg-surface rounded-xl border border-line-default shadow-card transition-all duration-default ease-default hover:shadow-card-hover hover:border-line-emphasis"
     :class="isGeoBlocked ? 'opacity-50' : ''"
     :to="{ path: `/earn/${vault.address}`, query: { network: $route.query.network } }"
   >
-    <div class="flex py-16 px-16 pb-12 border-b border-line-default">
+    <div class="flex py-16 px-16 pb-12 border-b border-line-subtle">
       <AssetAvatar
         :asset="vault.asset"
         size="40"

--- a/composables/position/useCollateralForm.ts
+++ b/composables/position/useCollateralForm.ts
@@ -104,6 +104,7 @@ export const useCollateralForm = (options: UseCollateralFormOptions) => {
   const submitLabel = getSubmitLabel(options.reviewLabel)
   const { executeTxPlan } = useEulerOperations()
   const { isConnected, address } = useAccount()
+  const { isSpyMode } = useSpyMode()
   const positionIndex = usePositionIndex()
   const { isPositionsLoaded, getPositionBySubAccountIndex } = useEulerAccount()
   const { getSupplyRewardApy, getBorrowRewardApy } = useRewardsApy()
@@ -462,7 +463,7 @@ export const useCollateralForm = (options: UseCollateralFormOptions) => {
 
   // --- Load ---
   const load = async () => {
-    if (!isConnected.value) return
+    if (!isConnected.value && !isSpyMode.value) return
     isLoading.value = true
     await until(isPositionLoaded).toBe(true)
     try {

--- a/composables/repay/useWalletRepay.ts
+++ b/composables/repay/useWalletRepay.ts
@@ -62,9 +62,13 @@ export const useWalletRepay = (options: UseWalletRepayOptions) => {
   const amount = ref('')
   const walletRepayPercent = ref(0)
   const balance = ref(0n)
-  const estimateNetAPY = ref(0)
-  const estimateUserLTV = ref(0n)
-  const estimateHealth = ref(0n)
+  const hasEstimate = ref(false)
+  const _estimateNetAPY = ref(0)
+  const _estimateUserLTV = ref(0n)
+  const _estimateHealth = ref(0n)
+  const estimateNetAPY = computed(() => hasEstimate.value ? _estimateNetAPY.value : netAPY.value)
+  const estimateUserLTV = computed(() => hasEstimate.value ? _estimateUserLTV.value : (position.value?.userLTV ?? 0n))
+  const estimateHealth = computed(() => hasEstimate.value ? _estimateHealth.value : (position.value?.health ?? 0n))
   const estimatesError = ref('')
   const isEstimatesLoading = ref(false)
 
@@ -209,7 +213,7 @@ export const useWalletRepay = (options: UseWalletRepayOptions) => {
         getAssetUsdValueOrZero((position.value.supplied || 0n), collateralVault.value, 'off-chain'),
         getAssetUsdValueOrZero((position.value.borrowed || 0n) - valueToNano(amount.value, borrowVault.value.decimals), borrowVault.value, 'off-chain'),
       ])
-      estimateNetAPY.value = getNetAPY(
+      _estimateNetAPY.value = getNetAPY(
         supplyUsd,
         collateralSupplyApy.value,
         borrowUsd,
@@ -223,10 +227,11 @@ export const useWalletRepay = (options: UseWalletRepayOptions) => {
         : (borrowedFixed.value.sub(amountFixed.value))
             .div(collateralValue)
             .mul(FixedPoint.fromValue(100n, 0))
-      estimateUserLTV.value = userLtvFixed.value
-      estimateHealth.value = (userLtvFixed.isZero() || userLtvFixed.isNegative())
+      _estimateUserLTV.value = userLtvFixed.value
+      _estimateHealth.value = (userLtvFixed.isZero() || userLtvFixed.isNegative())
         ? 0n
         : FixedPoint.fromValue(position.value!.liquidationLTV, 2).div(userLtvFixed).value
+      hasEstimate.value = true
 
       if (userLtvFixed.gte(FixedPoint.fromValue(position.value!.liquidationLTV, 2))) {
         throw new Error('Not enough liquidity for the vault, LTV is too large')
@@ -234,9 +239,7 @@ export const useWalletRepay = (options: UseWalletRepayOptions) => {
     }
     catch (e: unknown) {
       logWarn('walletRepay/estimates', e)
-      estimateNetAPY.value = netAPY.value
-      estimateUserLTV.value = position.value!.userLTV
-      estimateHealth.value = position.value!.health
+      hasEstimate.value = false
       estimatesError.value = (e as { message: string }).message
     }
     finally {
@@ -288,15 +291,14 @@ export const useWalletRepay = (options: UseWalletRepayOptions) => {
     updateEstimates()
   })
 
-  const initEstimates = (currentNetAPY: number, currentUserLTV: bigint, currentHealth: bigint) => {
-    estimateNetAPY.value = currentNetAPY
-    estimateUserLTV.value = currentUserLTV
-    estimateHealth.value = currentHealth
+  const initEstimates = () => {
+    hasEstimate.value = false
   }
 
   const resetOnTabSwitch = () => {
     amount.value = ''
     walletRepayPercent.value = 0
+    hasEstimate.value = false
   }
 
   return {

--- a/composables/useSpyMode.ts
+++ b/composables/useSpyMode.ts
@@ -18,6 +18,12 @@ let watchersInitialized = false
 let ownerResolved = false
 let explicitlyCleared = false
 
+/** Lightweight accessor for middleware — avoids useRoute() */
+export const getSpyModeState = () => ({
+  spyAddress: computed(() => spyAddress.value),
+  isSpyMode: computed(() => Boolean(spyAddress.value)),
+})
+
 export const useSpyMode = () => {
   const route = useRoute()
   const router = useRouter()

--- a/composables/useWallets.ts
+++ b/composables/useWallets.ts
@@ -156,6 +156,10 @@ export const useWallets = () => {
     finally {
       isFetching.value = false
       fetchPromise = null
+      // If dependencies changed while we were fetching, schedule a follow-up run
+      if (needsFetch()) {
+        fetchPromise = updateBalances()
+      }
     }
   }
 

--- a/composables/useWallets.ts
+++ b/composables/useWallets.ts
@@ -174,6 +174,13 @@ export const useWallets = () => {
     fetchPromise = updateBalances()
   }
 
+  // Retry when dependencies become ready (e.g. vaults load after cold start)
+  watch([isReady, () => balanceAddress.value, () => eulerLensAddresses.value?.utilsLens], () => {
+    if (needsFetch() && !fetchPromise) {
+      fetchPromise = updateBalances()
+    }
+  })
+
   const resetBalances = () => {
     balances.value = new Map()
     isLoaded.value = false

--- a/middleware/02.spy-param.global.ts
+++ b/middleware/02.spy-param.global.ts
@@ -1,14 +1,11 @@
 export default defineNuxtRouteMiddleware((to) => {
   if (import.meta.server) return
 
-  // Read spy address directly from module-level ref (avoid calling useSpyMode in middleware)
   const spyParam = to.query.spy
 
   // If spy mode is active (address in memory) but ?spy missing from target route — re-add it
-  // We check the existing query first; if it already has spy, nothing to do
   if (!spyParam) {
-    // Access the singleton spy address by calling the composable
-    const { spyAddress, isSpyMode } = useSpyMode()
+    const { spyAddress, isSpyMode } = getSpyModeState()
     if (isSpyMode.value) {
       return navigateTo({
         path: to.path,

--- a/middleware/ensure-vault.global.ts
+++ b/middleware/ensure-vault.global.ts
@@ -22,8 +22,9 @@ const getDefaultRoute = () => {
 }
 
 const scheduleVaultCheck = (vaultParam: string, path: string, expectedChainId: number | null) => {
+  const router = useRouter()
+
   setTimeout(async () => {
-    const route = useRoute()
     const { info } = useToast()
     const { getVault, getSecuritizeVault, isSecuritizeVault } = useVaults()
     const { chainId } = useEulerAddresses()
@@ -31,6 +32,8 @@ const scheduleVaultCheck = (vaultParam: string, path: string, expectedChainId: n
     if (path.includes('earn')) {
       return
     }
+
+    const route = router.currentRoute.value
 
     const currentVault = normalizeParam(route.params?.vault)
     if (!currentVault || String(currentVault) !== vaultParam) {
@@ -55,7 +58,9 @@ const scheduleVaultCheck = (vaultParam: string, path: string, expectedChainId: n
       }
     }
     catch {
-      if (route.path !== path) {
+      const latestRoute = router.currentRoute.value
+
+      if (latestRoute.path !== path) {
         return
       }
 
@@ -66,8 +71,8 @@ const scheduleVaultCheck = (vaultParam: string, path: string, expectedChainId: n
       info('This vault could not be found on this chain!')
       void navigateTo({
         name: getDefaultRoute(),
-        query: { ...route.query },
-        hash: route.hash,
+        query: { ...latestRoute.query },
+        hash: latestRoute.hash,
       }, { replace: true })
     }
   }, 0)

--- a/pages/earn/[vault]/[subAccount]/withdraw.vue
+++ b/pages/earn/[vault]/[subAccount]/withdraw.vue
@@ -25,14 +25,17 @@ const reviewWithdrawLabel = getSubmitLabel('Review Withdraw')
 const { buildWithdrawPlan, buildRedeemPlan, executeTxPlan } = useEulerOperations()
 const { getEarnVault } = useVaults()
 const { isConnected, address } = useAccount()
+const { isSpyMode, spyAddress } = useSpyMode()
+const effectiveAddress = computed(() => isSpyMode.value ? spyAddress.value : address.value)
 const { fetchVaultShareBalance } = useWallets()
 const { runSimulation, simulationError, clearSimulationError } = useTxPlanSimulation()
 const { getSupplyRewardApy } = useRewardsApy()
 const vaultAddress = route.params.vault as string
 const subAccountIndex = Number(route.params.subAccount)
 const subAccount = computed(() => {
-  if (!address.value || isNaN(subAccountIndex)) return undefined
-  return getSubAccountAddress(address.value, subAccountIndex)
+  const addr = effectiveAddress.value
+  if (!addr || isNaN(subAccountIndex)) return undefined
+  return getSubAccountAddress(addr, subAccountIndex)
 })
 
 const isLoading = ref(false)
@@ -105,7 +108,7 @@ const fetchShareBalance = async () => {
 }
 
 const updateBalance = async () => {
-  if (!isConnected.value || sharesBalance.value === 0n) {
+  if ((!isConnected.value && !isSpyMode.value) || sharesBalance.value === 0n) {
     assetsBalance.value = 0n
     delta.value = 0n
     return
@@ -229,13 +232,7 @@ watchEffect(async () => {
   deltaUsd.value = await getAssetUsdValueOrZero(delta.value, vault.value, 'off-chain')
 })
 
-watch(isConnected, async () => {
-  if (vault.value) {
-    await fetchShareBalance()
-    await updateBalance()
-  }
-})
-watch(address, async () => {
+watch([isConnected, effectiveAddress], async () => {
   if (vault.value) {
     await fetchShareBalance()
     await updateBalance()

--- a/pages/lend/[vault]/[subAccount]/withdraw.vue
+++ b/pages/lend/[vault]/[subAccount]/withdraw.vue
@@ -36,6 +36,8 @@ const reviewWithdrawLabel = getSubmitLabel('Review Withdraw')
 const { buildWithdrawPlan, buildRedeemPlan, buildWithdrawAndSwapPlan, buildRedeemAndSwapPlan, executeTxPlan } = useEulerOperations()
 const { getVault, getSecuritizeVault: _getSecuritizeVault, getEscrowVault: _getEscrowVault } = useVaults()
 const { isConnected, address } = useAccount()
+const { isSpyMode, spyAddress } = useSpyMode()
+const effectiveAddress = computed(() => isSpyMode.value ? spyAddress.value : address.value)
 const { fetchVaultShareBalance } = useWallets()
 const { runSimulation, simulationError, clearSimulationError } = useTxPlanSimulation()
 const { getSupplyRewardApy } = useRewardsApy()
@@ -43,8 +45,9 @@ const { withIntrinsicSupplyApy } = useIntrinsicApy()
 const vaultAddress = route.params.vault as string
 const subAccountIndex = Number(route.params.subAccount)
 const subAccount = computed(() => {
-  if (!address.value || isNaN(subAccountIndex)) return undefined
-  return getSubAccountAddress(address.value, subAccountIndex)
+  const addr = effectiveAddress.value
+  if (!addr || isNaN(subAccountIndex)) return undefined
+  return getSubAccountAddress(addr, subAccountIndex)
 })
 
 const isLoading = ref(false)
@@ -270,7 +273,7 @@ const fetchShareBalance = async () => {
   sharesBalance.value = await fetchVaultShareBalance(vault.value.address, subAccount.value)
 }
 const updateBalance = async () => {
-  if (!isConnected.value || sharesBalance.value === 0n) {
+  if ((!isConnected.value && !isSpyMode.value) || sharesBalance.value === 0n) {
     assetsBalance.value = 0n
     delta.value = 0n
     return
@@ -438,13 +441,7 @@ const updateEstimates = useDebounceFn(async () => {
 
 load()
 
-watch(isConnected, async () => {
-  if (vault.value) {
-    await fetchShareBalance()
-    await updateBalance()
-  }
-})
-watch(address, async () => {
+watch([isConnected, effectiveAddress], async () => {
   if (vault.value) {
     await fetchShareBalance()
     await updateBalance()

--- a/pages/portfolio/rewards.vue
+++ b/pages/portfolio/rewards.vue
@@ -3,6 +3,7 @@ import { useAccount } from '@wagmi/vue'
 import { nanoToValue } from '~/utils/crypto-utils'
 
 const { isConnected } = useAccount()
+const { isSpyMode } = useSpyMode()
 const { enableMerkl, enableIncentra, enableFuul } = useDeployConfig()
 const { rewards, isRewardsLoading } = useMerkl()
 const { userRewards: brevisRewards, isRewardsLoading: isBrevisRewardsLoading } = useBrevis()
@@ -55,7 +56,7 @@ const sortedBrevisRewards = computed(() => {
               <div class="flex w-48 h-48 justify-center items-center rounded-12 bg-neutral-100">
                 <SvgIcon name="search" />
               </div>
-              <template v-if="isConnected">
+              <template v-if="isConnected || isSpyMode">
                 You don't have rewards yet
               </template>
               <template v-else>
@@ -96,7 +97,7 @@ const sortedBrevisRewards = computed(() => {
               <div class="flex w-48 h-48 justify-center items-center rounded-12 bg-neutral-100">
                 <SvgIcon name="search" />
               </div>
-              <template v-if="isConnected">
+              <template v-if="isConnected || isSpyMode">
                 You don't have rewards yet
               </template>
               <template v-else>
@@ -137,7 +138,7 @@ const sortedBrevisRewards = computed(() => {
               <div class="flex w-48 h-48 justify-center items-center rounded-12 bg-neutral-100">
                 <SvgIcon name="search" />
               </div>
-              <template v-if="isConnected">
+              <template v-if="isConnected || isSpyMode">
                 You don't have rewards yet
               </template>
               <template v-else>
@@ -178,7 +179,7 @@ const sortedBrevisRewards = computed(() => {
           <div class="flex w-48 h-48 justify-center items-center rounded-12 bg-neutral-100">
             <SvgIcon name="search" />
           </div>
-          <template v-if="isConnected">
+          <template v-if="isConnected || isSpyMode">
             You don't have locks yet
           </template>
           <template v-else>

--- a/pages/position/[number]/borrow/index.vue
+++ b/pages/position/[number]/borrow/index.vue
@@ -328,9 +328,12 @@ const updateEstimates = useDebounceFn(async () => {
       ? Infinity
       : (Number(pair.value?.liquidationLTV || 0n) / 100) / ltvFixed.value.toUnsafeFloat()
     liquidationPrice.value = health.value < 0.1 ? Infinity : priceFixed.value.toUnsafeFloat() / health.value
+    // borrowAmount is the ADDITIONAL borrow; estimate Net APY using total borrow
+    const existingBorrow = nanoToValue(position.value?.borrowed || 0n, borrowVault.value!.decimals)
+    const totalBorrow = existingBorrow + (+borrowAmount.value || 0)
     const [collateralUsd, borrowUsd] = await Promise.all([
       getAssetUsdValueOrZero(+collateralAmount.value || 0, collateralVault.value!, 'off-chain'),
-      getAssetUsdValueOrZero(+borrowAmount.value || 0, borrowVault.value!, 'off-chain'),
+      getAssetUsdValueOrZero(totalBorrow, borrowVault.value!, 'off-chain'),
     ])
     netAPY.value = getNetAPY(
       collateralUsd,

--- a/pages/position/[number]/borrow/index.vue
+++ b/pages/position/[number]/borrow/index.vue
@@ -25,6 +25,7 @@ const reviewBorrowLabel = getSubmitLabel('Review Borrow')
 const { buildBorrowPlan, executeTxPlan } = useEulerOperations()
 const { getBorrowVaultPair, updateVault } = useVaults()
 const { isConnected, address } = useAccount()
+const { isSpyMode } = useSpyMode()
 const { isPositionsLoading, isPositionsLoaded, getPositionBySubAccountIndex } = useEulerAccount()
 const positionIndex = usePositionIndex()
 const { fetchSingleBalance } = useWallets()
@@ -146,7 +147,7 @@ const borrowApy = computed(() => withIntrinsicBorrowApy(
 ))
 
 const load = async () => {
-  if (!isConnected.value) {
+  if (!isConnected.value && !isSpyMode.value) {
     position.value = undefined
     return
   }

--- a/pages/position/[number]/borrow/swap.vue
+++ b/pages/position/[number]/borrow/swap.vue
@@ -15,6 +15,7 @@ import { useSwapPageLogic } from '~/composables/useSwapPageLogic'
 
 const route = useRoute()
 const { isConnected, address } = useAccount()
+const { isSpyMode } = useSpyMode()
 const { isPositionsLoaded, isPositionsLoading, getPositionBySubAccountIndex } = useEulerAccount()
 const { buildSwapPlan, buildSameAssetDebtSwapPlan } = useEulerOperations()
 const { withIntrinsicBorrowApy, withIntrinsicSupplyApy } = useIntrinsicApy()
@@ -285,7 +286,7 @@ watchEffect(async () => {
 
 // ── Position loading ─────────────────────────────────────────────────────
 const loadPosition = async () => {
-  if (!isConnected.value) {
+  if (!isConnected.value && !isSpyMode.value) {
     position.value = null
     return
   }

--- a/pages/position/[number]/collateral/swap.vue
+++ b/pages/position/[number]/collateral/swap.vue
@@ -29,6 +29,7 @@ import { useSwapPageLogic } from '~/composables/useSwapPageLogic'
 
 const route = useRoute()
 const { isConnected, address } = useAccount()
+const { isSpyMode } = useSpyMode()
 const { isPositionsLoaded, isPositionsLoading, getPositionBySubAccountIndex } = useEulerAccount()
 const { buildSwapPlan, buildSameAssetSwapPlan } = useEulerOperations()
 const { withIntrinsicBorrowApy, withIntrinsicSupplyApy } = useIntrinsicApy()
@@ -249,7 +250,7 @@ const loadSelectedCollateral = async () => {
 }
 
 const loadPosition = async () => {
-  if (!isConnected.value) {
+  if (!isConnected.value && !isSpyMode.value) {
     position.value = null
     return
   }

--- a/pages/position/[number]/index.vue
+++ b/pages/position/[number]/index.vue
@@ -35,6 +35,7 @@ const router = useRouter()
 const modal = useModal()
 const { error } = useToast()
 const { isConnected } = useAccount()
+const { isSpyMode } = useSpyMode()
 const { isPositionsLoaded, isPositionsLoading, getPositionBySubAccountIndex } = useEulerAccount()
 const { withIntrinsicBorrowApy, withIntrinsicSupplyApy, getIntrinsicApy, getIntrinsicApyInfo } = useIntrinsicApy()
 const { getSupplyRewardApy, getBorrowRewardApy, hasSupplyRewards, hasBorrowRewards, getSupplyRewardCampaigns, getBorrowRewardCampaigns } = useRewardsApy()
@@ -617,8 +618,8 @@ const send = async (collateralAddress: string) => {
   }
 }
 const load = async () => {
-  // Redirect to portfolio if not connected
-  if (!isConnected.value) {
+  // Redirect to portfolio if not connected and not in spy mode
+  if (!isConnected.value && !isSpyMode.value) {
     router.replace('/portfolio')
     return
   }

--- a/pages/position/[number]/multiply.vue
+++ b/pages/position/[number]/multiply.vue
@@ -28,6 +28,7 @@ const { error } = useToast()
 const { getSubmitLabel, getSubmitDisabled, guardWithTerms } = useTermsOfUseGate()
 const reviewMultiplyLabel = getSubmitLabel('Review Multiply')
 const { address, isConnected } = useAccount()
+const { isSpyMode } = useSpyMode()
 const { isPositionsLoading, isPositionsLoaded, refreshAllPositions, getPositionBySubAccountIndex } = useEulerAccount()
 const { buildMultiplyPlan, executeTxPlan } = useEulerOperations()
 const { eulerLensAddresses } = useEulerAddresses()
@@ -748,7 +749,7 @@ const isMultiplyRestricted = computed(() => {
 const reviewMultiplyDisabled = getSubmitDisabled(computed(() => isGeoBlocked.value || isMultiplyRestricted.value || isMultiplySubmitDisabled.value))
 
 const loadPosition = async () => {
-  if (!isConnected.value) {
+  if (!isConnected.value && !isSpyMode.value) {
     position.value = null
     return
   }

--- a/pages/position/[number]/repay.vue
+++ b/pages/position/[number]/repay.vue
@@ -22,6 +22,7 @@ const _route = useRoute()
 const _router = useRouter()
 const modal = useModal()
 const { isConnected, address } = useAccount()
+const { isSpyMode } = useSpyMode()
 const positionIndex = usePositionIndex()
 const { isPositionsLoading, isPositionsLoaded, isDepositsLoaded, refreshAllPositions: _refreshAllPositions, getPositionBySubAccountIndex } = useEulerAccount()
 const { getSupplyRewardApy, getBorrowRewardApy } = useRewardsApy()
@@ -209,7 +210,7 @@ const fetchWalletBalance = async () => {
 }
 
 const load = async () => {
-  if (!isConnected.value) {
+  if (!isConnected.value && !isSpyMode.value) {
     position.value = undefined
     return
   }
@@ -271,7 +272,7 @@ onUnmounted(() => {
     title="Repay position"
     @submit.prevent="onSubmitForm"
   >
-    <div v-if="!isConnected">
+    <div v-if="!isConnected && !isSpyMode">
       Connect your wallet to see your positions
     </div>
 

--- a/pages/position/[number]/repay.vue
+++ b/pages/position/[number]/repay.vue
@@ -222,7 +222,7 @@ const load = async () => {
     position.value = getPositionBySubAccountIndex(+positionIndex)
     await fetchWalletBalance()
     await wallet.updateBalance()
-    wallet.initEstimates(netAPY.value, position.value?.userLTV || 0n, position.value?.health || 0n)
+    wallet.initEstimates()
     collateral.initVault(position.value?.collateral as Vault | undefined)
     savings.initVault()
   }

--- a/pages/position/[number]/supply.vue
+++ b/pages/position/[number]/supply.vue
@@ -16,6 +16,7 @@ import { isPriceImpactWarning, isSlippageWarning } from '~/utils/priceImpact'
 import { useCollateralForm } from '~/composables/position/useCollateralForm'
 
 const { isConnected, address } = useAccount()
+const { isSpyMode } = useSpyMode()
 const { fetchSingleBalance } = useWallets()
 const { buildSupplyPlan, buildSwapAndSupplyPlan } = useEulerOperations()
 
@@ -112,7 +113,7 @@ const { name } = useEulerProductOfVault(computed(() => form.collateralVault.valu
 
 // Supply-specific: balance management
 const updateBalance = async () => {
-  if (!isConnected.value || !form.collateralVault.value?.asset.address) {
+  if ((!isConnected.value && !isSpyMode.value) || !form.collateralVault.value?.asset.address) {
     balance.value = 0n
     return
   }
@@ -183,7 +184,7 @@ onUnmounted(() => {
     :loading="form.isLoading.value"
     @submit.prevent="form.submit"
   >
-    <div v-if="!isConnected">
+    <div v-if="!isConnected && !isSpyMode">
       Connect your wallet to see your positions
     </div>
 

--- a/plugins/00.wagmi.ts
+++ b/plugins/00.wagmi.ts
@@ -52,6 +52,9 @@ export default defineNuxtPlugin((nuxtApp) => {
     networks,
     projectId: projectId || '',
     metadata,
+    themeVariables: {
+      '--w3m-font-family': 'inherit',
+    },
   })
 
   nuxtApp.vueApp.use(WagmiPlugin, { config: wagmiAdapter.wagmiConfig })


### PR DESCRIPTION
## Summary

- **Spy mode**: Enable all position sub-pages (multiply, borrow, repay, supply, withdraw, debt swap, collateral swap), rewards tab, and earn/lend withdraw pages in spy mode
- **Spy mode safety**: Disable claim/unlock buttons across all reward components when in spy mode
- **Console cleanup**: Fix `useRoute` in middleware warning, suppress AppKit font preload noise
- **UI**: Align Earn card border colors with Explore/Lend/Borrow pages
- **Bug fix**: Correct borrow page Net APY estimate to use total debt (existing + additional) instead of only additional amount
- **Bug fix**: Fix supply/withdraw pages showing "→ 0.00" estimates when no amount entered
- **Infra**: Add `useWallets` watcher to retry balance fetch when dependencies become ready (fixes forever-spinner on cold navigation to position pages)

## Test plan

- [ ] Navigate directly to `/position/1?spy=<address>` — should load without spinner
- [ ] Test all position operations (multiply, borrow, repay, supply, withdraw, debt swap, collateral swap) in spy mode
- [ ] Verify claim/unlock buttons are disabled in spy mode on rewards tab
- [ ] Verify earn/lend withdraw pages show correct balance in spy mode
- [ ] Verify supply/withdraw estimate values match current position when no amount entered
- [ ] Verify borrow page Net APY shows correct before/after when LTV unchanged
- [ ] Check browser console — no more `useRoute` middleware warning or `KHTeka` font preload warning