### PR TITLE
feat: swap + repay from wallet

### DIFF
--- a/composables/borrow/useBorrowForm.ts
+++ b/composables/borrow/useBorrowForm.ts
@@ -305,8 +305,8 @@ export const useBorrowForm = (options: UseBorrowFormOptions) => {
     else if ((borrowVault.value?.supply || 0n) < valueToNano(borrowAmount.value, borrowVault.value?.decimals)) {
       return 'Not enough liquidity in the vault'
     }
-    if (borrowNeedsSwap.value && !borrowSwapEffectiveQuote.value && !isBorrowSwapQuoteLoading.value && +collateralAmount.value > 0) {
-      return 'No swap quote available'
+    if (borrowNeedsSwap.value && !borrowSwapSelectedQuote.value && +collateralAmount.value > 0) {
+      return isBorrowSwapQuoteLoading.value ? null : 'No swap quote available'
     }
     return null
   })
@@ -320,7 +320,7 @@ export const useBorrowForm = (options: UseBorrowFormOptions) => {
     if (!(+collateralAmount.value)) return true
     if ((borrowVault.value?.supply || 0n) < valueToNano(borrowAmount.value, borrowVault.value?.decimals)) return true
     if (!valueToNano(borrowAmount.value, borrowVault.value?.decimals)) return true
-    if (borrowNeedsSwap.value && !borrowSwapEffectiveQuote.value && !isBorrowSwapQuoteLoading.value) return true
+    if (borrowNeedsSwap.value && !borrowSwapSelectedQuote.value) return true
     if (isSupplyCapReached.value || isBorrowCapReached.value) return true
     return false
   })

--- a/composables/position/useCollateralForm.ts
+++ b/composables/position/useCollateralForm.ts
@@ -388,7 +388,7 @@ export const useCollateralForm = (options: UseCollateralFormOptions) => {
     if (!isConnected.value) return false
     if (options.effectiveBalance.value < valueToNano(amount.value, asset.value?.decimals)) return true
     if (isLoading.value || !(+amount.value) || !!estimatesError.value || isEstimatesLoading.value) return true
-    if (options.needsSwap.value && !swapEffectiveQuote.value && !isSwapQuoteLoading.value) return true
+    if (options.needsSwap.value && !swapSelectedQuote.value) return true
     return false
   })
 

--- a/composables/repay/useWalletSwapRepay.ts
+++ b/composables/repay/useWalletSwapRepay.ts
@@ -374,12 +374,21 @@ export const useWalletSwapRepay = (options: UseWalletSwapRepayOptions) => {
     }
   }, 500)
 
+  // --- Helpers ---
+  const resetDerivedState = () => {
+    hasEstimate.value = false
+    estimatesError.value = ''
+    isEstimatesLoading.value = false
+  }
+
   // --- Input handlers ---
   const onAmountInput = () => {
     clearSimulationError()
     debtAmount.value = ''
+    debtPercent.value = 0
     direction.value = SwapperMode.EXACT_IN
     quotes.reset()
+    resetDerivedState()
     requestQuote()
   }
 
@@ -388,6 +397,7 @@ export const useWalletSwapRepay = (options: UseWalletSwapRepayOptions) => {
     amount.value = ''
     direction.value = SwapperMode.TARGET_DEBT
     quotes.reset()
+    resetDerivedState()
     const currentDebt = getCurrentDebt()
     let amountNano = 0n
     try {
@@ -405,11 +415,11 @@ export const useWalletSwapRepay = (options: UseWalletSwapRepayOptions) => {
     amount.value = ''
     direction.value = SwapperMode.TARGET_DEBT
     quotes.reset()
+    resetDerivedState()
     const currentDebt = getCurrentDebt()
     if (!borrowVault.value || currentDebt <= 0n) {
       debtAmount.value = ''
       debtPercent.value = 0
-      quotes.reset()
       return
     }
     const amountNano = percentToAmountNano(debtPercent.value, currentDebt)
@@ -426,8 +436,7 @@ export const useWalletSwapRepay = (options: UseWalletSwapRepayOptions) => {
     direction.value = SwapperMode.EXACT_IN
     clearSimulationError()
     quotes.reset()
-    hasEstimate.value = false
-    estimatesError.value = ''
+    resetDerivedState()
 
     if (newAsset.address) {
       selectedAssetBalance.value = await fetchSingleBalance(newAsset.address)
@@ -436,13 +445,17 @@ export const useWalletSwapRepay = (options: UseWalletSwapRepayOptions) => {
 
   const onRefreshSwapQuotes = () => {
     quotes.reset()
+    resetDerivedState()
     requestQuote()
   }
 
-  // Refresh selected asset balance when wallet address changes
+  // Refresh selected asset balance and re-validate when wallet address changes
   watch(address, async () => {
-    if (selectedAsset.value?.address && needsSwap.value) {
+    if (selectedAsset.value?.address) {
       selectedAssetBalance.value = await fetchSingleBalance(selectedAsset.value.address)
+      if (needsSwap.value) {
+        updateEstimates()
+      }
     }
   })
 

--- a/composables/repay/useWalletSwapRepay.ts
+++ b/composables/repay/useWalletSwapRepay.ts
@@ -103,6 +103,11 @@ export const useWalletSwapRepay = (options: UseWalletSwapRepayOptions) => {
     return BigInt(quotes.effectiveQuote.value.amountOut || 0)
   })
 
+  const guaranteedDebtRepaid = computed(() => {
+    if (!quotes.effectiveQuote.value) return 0n
+    return BigInt(quotes.effectiveQuote.value.amountOutMin || 0)
+  })
+
   const computedTargetDebt = computed(() => {
     if (direction.value !== SwapperMode.TARGET_DEBT || !borrowVault.value || !debtAmount.value) return 0n
     try {
@@ -119,7 +124,7 @@ export const useWalletSwapRepay = (options: UseWalletSwapRepayOptions) => {
       return computedTargetDebt.value === 0n && !!debtAmount.value
     }
     const currentDebt = getCurrentDebt()
-    return currentDebt > 0n && estimatedDebtRepaid.value >= currentDebt
+    return currentDebt > 0n && guaranteedDebtRepaid.value >= currentDebt
   })
 
   const { priceImpact: swapPriceImpact } = useSwapPriceImpact({
@@ -366,6 +371,7 @@ export const useWalletSwapRepay = (options: UseWalletSwapRepayOptions) => {
     clearSimulationError()
     debtAmount.value = ''
     direction.value = SwapperMode.EXACT_IN
+    quotes.reset()
     requestQuote()
   }
 
@@ -373,6 +379,7 @@ export const useWalletSwapRepay = (options: UseWalletSwapRepayOptions) => {
     clearSimulationError()
     amount.value = ''
     direction.value = SwapperMode.TARGET_DEBT
+    quotes.reset()
     const currentDebt = getCurrentDebt()
     let amountNano = 0n
     try {
@@ -389,6 +396,7 @@ export const useWalletSwapRepay = (options: UseWalletSwapRepayOptions) => {
     clearSimulationError()
     amount.value = ''
     direction.value = SwapperMode.TARGET_DEBT
+    quotes.reset()
     const currentDebt = getCurrentDebt()
     if (!borrowVault.value || currentDebt <= 0n) {
       debtAmount.value = ''

--- a/composables/repay/useWalletSwapRepay.ts
+++ b/composables/repay/useWalletSwapRepay.ts
@@ -1,0 +1,615 @@
+import type { Ref, ComputedRef } from 'vue'
+import { useAccount } from '@wagmi/vue'
+import { formatUnits, getAddress, zeroAddress, type Address } from 'viem'
+import { FixedPoint } from '~/utils/fixed-point'
+import { logWarn } from '~/utils/errorHandling'
+import { useModal } from '~/components/ui/composables/useModal'
+import { OperationReviewModal } from '#components'
+import { useToast } from '~/components/ui/composables/useToast'
+import { getNetAPY, type VaultAsset } from '~/entities/vault'
+import { getAssetUsdValueOrZero } from '~/services/pricing/priceProvider'
+import type { AccountBorrowPosition } from '~/entities/account'
+import type { TxPlan } from '~/entities/txPlan'
+import { valueToNano } from '~/utils/crypto-utils'
+import { formatSmartAmount, trimTrailingZeros } from '~/utils/string-utils'
+import { amountToPercent, percentToAmountNano } from '~/utils/repayUtils'
+import { SwapperMode } from '~/entities/swap'
+import { buildSwapRouteItems } from '~/utils/swapRouteItems'
+import { useSwapPriceImpact } from '~/composables/useSwapPriceImpact'
+import { useSwapRepayQuotes } from '~/composables/repay/useSwapRepayQuotes'
+import { getSwapInputAmount } from '~/composables/useEulerOperations/swaps/verify'
+
+interface UseWalletSwapRepayOptions {
+  position: Ref<AccountBorrowPosition | undefined>
+  borrowVault: ComputedRef<AccountBorrowPosition['borrow'] | undefined>
+  collateralVault: ComputedRef<AccountBorrowPosition['collateral'] | undefined>
+  formTab: Ref<string>
+  plan: Ref<TxPlan | null>
+  isSubmitting: Ref<boolean>
+  isPreparing: Ref<boolean>
+  clearSimulationError: () => void
+  runSimulation: (plan: TxPlan) => Promise<boolean>
+  netAPY: Ref<number>
+  collateralSupplyApy: ComputedRef<number>
+  borrowApy: ComputedRef<number>
+  collateralSupplyRewardApy: ComputedRef<number>
+  borrowRewardApy: ComputedRef<number>
+  oraclePriceRatio: ComputedRef<number | null>
+}
+
+export const useWalletSwapRepay = (options: UseWalletSwapRepayOptions) => {
+  const {
+    position,
+    borrowVault,
+    collateralVault,
+    formTab,
+    plan,
+    isSubmitting,
+    isPreparing,
+    clearSimulationError,
+    runSimulation,
+    netAPY,
+    collateralSupplyApy,
+    borrowApy,
+    collateralSupplyRewardApy,
+    borrowRewardApy,
+    oraclePriceRatio,
+  } = options
+
+  const router = useRouter()
+  const modal = useModal()
+  const { error } = useToast()
+  const { buildSwapAndRepayPlan, executeTxPlan } = useEulerOperations()
+  const { refreshAllPositions } = useEulerAccount()
+  const { eulerLensAddresses } = useEulerAddresses()
+  const { isConnected, address } = useAccount()
+  const { fetchSingleBalance } = useWallets()
+  const { slippage } = useSlippage()
+
+  // --- State ---
+  const selectedAsset = ref<VaultAsset | undefined>()
+  const selectedAssetBalance = ref(0n)
+  const isUnknownSwapToken = ref(false)
+  const amount = ref('')
+  const debtAmount = ref('')
+  const direction = ref(SwapperMode.EXACT_IN)
+  const debtPercent = ref(0)
+
+  // --- Swap quotes (dual-direction) ---
+  const quotes = useSwapRepayQuotes({ direction })
+
+  // --- Derived ---
+  const needsSwap = computed(() => {
+    if (!selectedAsset.value || !borrowVault.value) return false
+    try {
+      return getAddress(selectedAsset.value.address) !== getAddress(borrowVault.value.asset.address)
+    }
+    catch {
+      return false
+    }
+  })
+
+  const getCurrentDebt = () => position.value?.borrowed || 0n
+
+  const swapEstimatedOutput = computed(() => {
+    if (!quotes.effectiveQuote.value || !borrowVault.value) return ''
+    const amountOut = BigInt(quotes.effectiveQuote.value.amountOutMin || 0)
+    if (amountOut <= 0n) return ''
+    return formatUnits(amountOut, Number(borrowVault.value.asset.decimals))
+  })
+
+  const estimatedDebtRepaid = computed(() => {
+    if (!quotes.effectiveQuote.value) return 0n
+    return BigInt(quotes.effectiveQuote.value.amountOut || 0)
+  })
+
+  const computedTargetDebt = computed(() => {
+    if (direction.value !== SwapperMode.TARGET_DEBT || !borrowVault.value || !debtAmount.value) return 0n
+    try {
+      const parsed = valueToNano(debtAmount.value, borrowVault.value.asset.decimals)
+      const currentDebt = getCurrentDebt()
+      return parsed >= currentDebt ? 0n : currentDebt - parsed
+    }
+    catch { return 0n }
+  })
+
+  const isFullRepay = computed(() => {
+    if (!position.value) return false
+    if (direction.value === SwapperMode.TARGET_DEBT) {
+      return computedTargetDebt.value === 0n && !!debtAmount.value
+    }
+    const currentDebt = getCurrentDebt()
+    return currentDebt > 0n && estimatedDebtRepaid.value >= currentDebt
+  })
+
+  const { priceImpact: swapPriceImpact } = useSwapPriceImpact({
+    quote: quotes.effectiveQuote,
+    toVault: computed(() => {
+      if (!borrowVault.value) return undefined
+      return borrowVault.value as Parameters<typeof useSwapPriceImpact>[0]['toVault']['value']
+    }),
+  })
+
+  const swapRouteItems = computed(() => {
+    if (!borrowVault.value) return []
+    return buildSwapRouteItems({
+      quoteCards: quotes.sortedQuoteCards.value,
+      getQuoteDiffPct: quotes.getQuoteDiffPct,
+      decimals: Number(borrowVault.value.asset.decimals),
+      symbol: borrowVault.value.asset.symbol,
+      formatAmount: formatSmartAmount,
+    })
+  })
+
+  // --- Health estimates ---
+  const hasEstimate = ref(false)
+  const _estimateNetAPY = ref(0)
+  const _estimateUserLTV = ref(0n)
+  const _estimateHealth = ref(0n)
+  const estimateNetAPY = computed(() => hasEstimate.value ? _estimateNetAPY.value : netAPY.value)
+  const estimateUserLTV = computed(() => hasEstimate.value ? _estimateUserLTV.value : (position.value?.userLTV ?? 0n))
+  const estimateHealth = computed(() => hasEstimate.value ? _estimateHealth.value : (position.value?.health ?? 0n))
+  const estimatesError = ref('')
+  const isEstimatesLoading = ref(false)
+
+  const borrowedFixed = computed(() => FixedPoint.fromValue(position.value?.borrowed || 0n, position.value?.borrow.decimals || 18))
+  const suppliedFixed = computed(() => FixedPoint.fromValue(position.value?.supplied || 0n, position.value?.collateral.decimals || 18))
+  const priceFixed = computed(() => {
+    const ratio = oraclePriceRatio.value
+    if (ratio && Number.isFinite(ratio) && ratio > 0) {
+      return FixedPoint.fromValue(BigInt(Math.round(ratio * 1e18)), 18)
+    }
+    return FixedPoint.fromValue(0n, 18)
+  })
+
+  // --- Validation ---
+  const isRepayExceedsDebt = computed(() => {
+    if (!position.value || position.value.borrowed <= 0n) return false
+    if (direction.value === SwapperMode.EXACT_IN) {
+      if (estimatedDebtRepaid.value === 0n) return false
+      return estimatedDebtRepaid.value > position.value.borrowed
+    }
+    if (direction.value === SwapperMode.TARGET_DEBT && debtAmount.value && borrowVault.value) {
+      try {
+        const inputNano = valueToNano(debtAmount.value, borrowVault.value.asset.decimals)
+        return inputNano > position.value.borrowed
+      }
+      catch { return false }
+    }
+    return false
+  })
+
+  const disabledReason = computed(() => {
+    if (isRepayExceedsDebt.value) {
+      return 'You repaying more than required'
+    }
+    return undefined
+  })
+
+  const isSubmitDisabled = computed(() => {
+    if (!isConnected.value) return false
+    if (direction.value === SwapperMode.EXACT_IN && !(+amount.value)) return true
+    if (direction.value === SwapperMode.TARGET_DEBT && !(+debtAmount.value)) return true
+    if (isRepayExceedsDebt.value) return true
+    if (needsSwap.value && !quotes.selectedQuote.value) return true
+    if (direction.value === SwapperMode.EXACT_IN && selectedAssetBalance.value < valueToNano(amount.value, selectedAsset.value?.decimals)) return true
+    if (!!estimatesError.value || isEstimatesLoading.value) return true
+    return false
+  })
+
+  // --- Quote requests ---
+  const requestQuote = useDebounceFn(async () => {
+    if (!selectedAsset.value || !borrowVault.value || !needsSwap.value || !position.value) {
+      quotes.reset()
+      return
+    }
+
+    const currentDebt = getCurrentDebt()
+    const userAddr = (address.value || zeroAddress) as Address
+    const subAccount = (position.value.subAccount || address.value || zeroAddress) as Address
+
+    if (direction.value === SwapperMode.EXACT_IN) {
+      if (!amount.value) {
+        quotes.reset()
+        return
+      }
+      let parsedAmount: bigint
+      try {
+        parsedAmount = valueToNano(amount.value, selectedAsset.value.decimals)
+      }
+      catch {
+        quotes.reset()
+        return
+      }
+      if (parsedAmount <= 0n) {
+        quotes.reset()
+        return
+      }
+      await quotes.exactInQuotes.requestQuotes({
+        tokenIn: selectedAsset.value.address as Address,
+        tokenOut: borrowVault.value.asset.address as Address,
+        accountIn: zeroAddress as Address,
+        accountOut: subAccount,
+        amount: parsedAmount,
+        vaultIn: zeroAddress as Address,
+        receiver: borrowVault.value.address as Address,
+        unusedInputReceiver: userAddr,
+        slippage: slippage.value,
+        swapperMode: SwapperMode.EXACT_IN,
+        isRepay: true,
+        targetDebt: 0n,
+        currentDebt,
+      })
+      return
+    }
+
+    // TARGET_DEBT
+    if (!debtAmount.value) {
+      quotes.reset()
+      return
+    }
+    let parsedAmount: bigint
+    try {
+      parsedAmount = valueToNano(debtAmount.value, borrowVault.value.asset.decimals)
+    }
+    catch {
+      quotes.reset()
+      return
+    }
+    if (parsedAmount <= 0n) {
+      quotes.reset()
+      return
+    }
+    const targetDebt = parsedAmount >= currentDebt ? 0n : currentDebt - parsedAmount
+    await quotes.targetDebtQuotes.requestQuotes({
+      tokenIn: selectedAsset.value.address as Address,
+      tokenOut: borrowVault.value.asset.address as Address,
+      accountIn: zeroAddress as Address,
+      accountOut: subAccount,
+      amount: parsedAmount,
+      vaultIn: zeroAddress as Address,
+      receiver: borrowVault.value.address as Address,
+      unusedInputReceiver: userAddr,
+      slippage: slippage.value,
+      swapperMode: SwapperMode.TARGET_DEBT,
+      isRepay: true,
+      targetDebt,
+      currentDebt,
+    })
+  }, 500)
+
+  // --- Estimates ---
+  const updateEstimates = useDebounceFn(async () => {
+    clearSimulationError()
+    estimatesError.value = ''
+    if (!position.value || !collateralVault.value || !borrowVault.value) return
+
+    try {
+      // Balance check only for EXACT_IN (for TARGET_DEBT, the needed amount comes from the quote)
+      if (direction.value === SwapperMode.EXACT_IN) {
+        if (selectedAssetBalance.value < valueToNano(amount.value, selectedAsset.value?.decimals)) {
+          throw new Error('Not enough balance')
+        }
+      }
+
+      if (needsSwap.value && !quotes.effectiveQuote.value && !quotes.isLoading.value) {
+        throw new Error('No swap quote available')
+      }
+
+      let debtRepaidNano: bigint
+      if (direction.value === SwapperMode.TARGET_DEBT && debtAmount.value) {
+        debtRepaidNano = valueToNano(debtAmount.value, borrowVault.value.asset.decimals)
+      }
+      else {
+        debtRepaidNano = estimatedDebtRepaid.value
+      }
+
+      const currentDebt = getCurrentDebt()
+      if (debtRepaidNano > currentDebt) {
+        debtRepaidNano = currentDebt
+      }
+
+      // Balance check for TARGET_DEBT after quote
+      if (direction.value === SwapperMode.TARGET_DEBT && quotes.effectiveQuote.value) {
+        const neededInput = BigInt(quotes.effectiveQuote.value.amountInMax || quotes.effectiveQuote.value.amountIn || 0)
+        if (selectedAssetBalance.value < neededInput) {
+          throw new Error('Not enough balance')
+        }
+      }
+
+      const nextBorrowed = currentDebt - debtRepaidNano
+      const [supplyUsd, borrowUsd] = await Promise.all([
+        getAssetUsdValueOrZero(position.value.supplied || 0n, collateralVault.value, 'off-chain'),
+        getAssetUsdValueOrZero(nextBorrowed > 0n ? nextBorrowed : 0n, borrowVault.value, 'off-chain'),
+      ])
+
+      _estimateNetAPY.value = getNetAPY(
+        supplyUsd,
+        collateralSupplyApy.value,
+        borrowUsd,
+        borrowApy.value,
+        collateralSupplyRewardApy.value || null,
+        borrowRewardApy.value || null,
+      )
+
+      const debtRepaidFixed = FixedPoint.fromValue(debtRepaidNano, Number(borrowVault.value.decimals))
+      const collateralValue = suppliedFixed.value.mul(priceFixed.value)
+      const userLtvFixed = collateralValue.isZero()
+        ? FixedPoint.fromValue(0n, 18)
+        : (borrowedFixed.value.sub(debtRepaidFixed))
+            .div(collateralValue)
+            .mul(FixedPoint.fromValue(100n, 0))
+      const healthFixed = (userLtvFixed.isZero() || userLtvFixed.isNegative())
+        ? null
+        : FixedPoint.fromValue(position.value!.liquidationLTV, 2).div(userLtvFixed)
+
+      _estimateUserLTV.value = userLtvFixed.toScaledBigint(18)
+      _estimateHealth.value = healthFixed ? healthFixed.toScaledBigint(18) : 10n ** 36n
+      hasEstimate.value = true
+
+      if (userLtvFixed.gte(FixedPoint.fromValue(position.value!.liquidationLTV, 2))) {
+        throw new Error('Not enough liquidity for the vault, LTV is too large')
+      }
+    }
+    catch (e: unknown) {
+      logWarn('walletSwapRepay/estimates', e)
+      hasEstimate.value = false
+      estimatesError.value = (e as { message: string }).message
+    }
+    finally {
+      isEstimatesLoading.value = false
+    }
+  }, 500)
+
+  // --- Input handlers ---
+  const onAmountInput = () => {
+    clearSimulationError()
+    debtAmount.value = ''
+    direction.value = SwapperMode.EXACT_IN
+    requestQuote()
+  }
+
+  const onDebtInput = () => {
+    clearSimulationError()
+    amount.value = ''
+    direction.value = SwapperMode.TARGET_DEBT
+    const currentDebt = getCurrentDebt()
+    let amountNano = 0n
+    try {
+      amountNano = valueToNano(debtAmount.value || '0', borrowVault.value?.asset.decimals)
+    }
+    catch {
+      amountNano = 0n
+    }
+    debtPercent.value = amountToPercent(amountNano, currentDebt)
+    requestQuote()
+  }
+
+  const onPercentInput = () => {
+    clearSimulationError()
+    amount.value = ''
+    direction.value = SwapperMode.TARGET_DEBT
+    const currentDebt = getCurrentDebt()
+    if (!borrowVault.value || currentDebt <= 0n) {
+      debtAmount.value = ''
+      debtPercent.value = 0
+      quotes.reset()
+      return
+    }
+    const amountNano = percentToAmountNano(debtPercent.value, currentDebt)
+    debtAmount.value = trimTrailingZeros(formatUnits(amountNano, Number(borrowVault.value.asset.decimals)))
+    requestQuote()
+  }
+
+  const onSelectSwapAsset = async (newAsset: VaultAsset, meta?: { isUnknownToken?: boolean }) => {
+    selectedAsset.value = newAsset
+    isUnknownSwapToken.value = meta?.isUnknownToken ?? false
+    amount.value = ''
+    debtAmount.value = ''
+    debtPercent.value = 0
+    direction.value = SwapperMode.EXACT_IN
+    clearSimulationError()
+    quotes.reset()
+    hasEstimate.value = false
+    estimatesError.value = ''
+
+    if (newAsset.address) {
+      selectedAssetBalance.value = await fetchSingleBalance(newAsset.address)
+    }
+  }
+
+  const onRefreshSwapQuotes = () => {
+    quotes.reset()
+    requestQuote()
+  }
+
+  // --- Watch quote changes → sync opposite field + estimates ---
+  watch([quotes.effectiveQuote, direction], () => {
+    if (formTab.value !== 'wallet' || !needsSwap.value) return
+    if (!quotes.effectiveQuote.value || !selectedAsset.value || !borrowVault.value) return
+
+    // Sync the opposite input field
+    if (direction.value === SwapperMode.TARGET_DEBT) {
+      const amountIn = BigInt(quotes.effectiveQuote.value.amountIn || 0)
+      if (amountIn > 0n) {
+        amount.value = trimTrailingZeros(formatUnits(amountIn, Number(selectedAsset.value.decimals)))
+      }
+    }
+    else {
+      // EXACT_IN: sync debt amount from quote output
+      const amountOut = BigInt(quotes.effectiveQuote.value.amountOut || 0)
+      if (amountOut > 0n) {
+        debtAmount.value = trimTrailingZeros(formatUnits(amountOut, Number(borrowVault.value.asset.decimals)))
+        const currentDebt = getCurrentDebt()
+        debtPercent.value = amountToPercent(amountOut, currentDebt)
+      }
+    }
+
+    if (!isEstimatesLoading.value) {
+      isEstimatesLoading.value = true
+    }
+    updateEstimates()
+  })
+
+  // --- Build plan ---
+  const buildRepayPlan = async (includePermit2Call: boolean): Promise<TxPlan> => {
+    if (!position.value || !borrowVault.value || !collateralVault.value || !quotes.selectedQuote.value || !selectedAsset.value) {
+      throw new Error('Missing data for swap repay plan')
+    }
+
+    const currentDebt = getCurrentDebt()
+    const swapMode = direction.value
+    let targetDebt = 0n
+
+    if (swapMode === SwapperMode.TARGET_DEBT && debtAmount.value) {
+      const debtAmountNano = valueToNano(debtAmount.value, borrowVault.value.asset.decimals)
+      targetDebt = debtAmountNano >= currentDebt ? 0n : currentDebt - debtAmountNano
+    }
+
+    const inputAmount = getSwapInputAmount(quotes.selectedQuote.value, swapMode)
+
+    return buildSwapAndRepayPlan({
+      inputTokenAddress: selectedAsset.value.address as Address,
+      inputAmount,
+      quote: quotes.selectedQuote.value,
+      borrowVaultAddress: borrowVault.value.address as Address,
+      subAccount: (position.value.subAccount || address.value || zeroAddress) as Address,
+      enabledCollaterals: position.value.collaterals ?? [collateralVault.value.address],
+      isFullRepay: isFullRepay.value,
+      swapperMode: swapMode,
+      targetDebt,
+      currentDebt,
+      includePermit2Call,
+    })
+  }
+
+  // --- Submit ---
+  const submit = async () => {
+    if (isPreparing.value || isSubmitting.value || !position.value || !borrowVault.value || !collateralVault.value) {
+      return
+    }
+    if (!needsSwap.value || !quotes.selectedQuote.value || !selectedAsset.value) return
+
+    isPreparing.value = true
+    try {
+      try {
+        plan.value = await buildRepayPlan(false)
+      }
+      catch (e) {
+        logWarn('walletSwapRepay/buildPlan', e)
+        plan.value = null
+      }
+
+      if (plan.value) {
+        const ok = await runSimulation(plan.value)
+        if (!ok) return
+      }
+
+      // For review modal: show input token as primary asset, borrow asset as swap target
+      const inputDisplay = direction.value === SwapperMode.TARGET_DEBT && amount.value
+        ? amount.value
+        : (amount.value || '0')
+
+      modal.open(OperationReviewModal, {
+        props: {
+          type: 'repay',
+          asset: selectedAsset.value,
+          amount: inputDisplay,
+          swapToAsset: borrowVault.value.asset,
+          swapToAmount: swapEstimatedOutput.value,
+          plan: plan.value || undefined,
+          subAccount: position.value?.subAccount,
+          hasBorrows: (position.value?.borrowed || 0n) > 0n,
+          onConfirm: () => {
+            setTimeout(() => {
+              send()
+            }, 400)
+          },
+        },
+      })
+    }
+    finally {
+      isPreparing.value = false
+    }
+  }
+
+  const send = async () => {
+    try {
+      isSubmitting.value = true
+      if (!position.value || !borrowVault.value || !collateralVault.value || !quotes.selectedQuote.value || !selectedAsset.value) return
+
+      const txPlan = await buildRepayPlan(true)
+      await executeTxPlan(txPlan)
+
+      modal.close()
+      refreshAllPositions(eulerLensAddresses.value, address.value as string)
+      setTimeout(() => {
+        router.replace('/portfolio')
+      }, 400)
+    }
+    catch (e) {
+      error('Transaction failed')
+      logWarn('walletSwapRepay/send', e)
+    }
+    finally {
+      isSubmitting.value = false
+    }
+  }
+
+  const resetOnTabSwitch = () => {
+    amount.value = ''
+    debtAmount.value = ''
+    debtPercent.value = 0
+    direction.value = SwapperMode.EXACT_IN
+    hasEstimate.value = false
+    estimatesError.value = ''
+    isEstimatesLoading.value = false
+    quotes.reset()
+  }
+
+  const initEstimates = () => {
+    hasEstimate.value = false
+    estimatesError.value = ''
+    isEstimatesLoading.value = false
+  }
+
+  return {
+    // State
+    selectedAsset,
+    selectedAssetBalance,
+    isUnknownSwapToken,
+    amount,
+    debtAmount,
+    direction,
+    debtPercent,
+    needsSwap,
+
+    // Swap quotes
+    quotes,
+    swapEstimatedOutput,
+    swapPriceImpact,
+    swapRouteItems,
+    isFullRepay,
+
+    // Health estimates
+    estimateNetAPY,
+    estimateUserLTV,
+    estimateHealth,
+    estimatesError,
+    isEstimatesLoading,
+    isSubmitDisabled,
+    isRepayExceedsDebt,
+    disabledReason,
+
+    // Actions
+    onAmountInput,
+    onDebtInput,
+    onPercentInput,
+    onSelectSwapAsset,
+    onRefreshSwapQuotes,
+    submit,
+    send,
+    resetOnTabSwitch,
+    initEstimates,
+  }
+}

--- a/composables/repay/useWalletSwapRepay.ts
+++ b/composables/repay/useWalletSwapRepay.ts
@@ -294,6 +294,10 @@ export const useWalletSwapRepay = (options: UseWalletSwapRepayOptions) => {
     const gen = estimatesGuard.next()
 
     try {
+      if (!oraclePriceRatio.value || !Number.isFinite(oraclePriceRatio.value) || oraclePriceRatio.value <= 0) {
+        throw new Error('Price data unavailable')
+      }
+
       // Balance check only for EXACT_IN (for TARGET_DEBT, the needed amount comes from the quote)
       if (direction.value === SwapperMode.EXACT_IN) {
         if (selectedAssetBalance.value < valueToNano(amount.value, selectedAsset.value?.decimals)) {
@@ -376,6 +380,7 @@ export const useWalletSwapRepay = (options: UseWalletSwapRepayOptions) => {
 
   // --- Helpers ---
   const resetDerivedState = () => {
+    estimatesGuard.next()
     hasEstimate.value = false
     estimatesError.value = ''
     isEstimatesLoading.value = false
@@ -599,10 +604,8 @@ export const useWalletSwapRepay = (options: UseWalletSwapRepayOptions) => {
     debtAmount.value = ''
     debtPercent.value = 0
     direction.value = SwapperMode.EXACT_IN
-    hasEstimate.value = false
-    estimatesError.value = ''
-    isEstimatesLoading.value = false
     quotes.reset()
+    resetDerivedState()
   }
 
   const initEstimates = () => {

--- a/composables/repay/useWalletSwapRepay.ts
+++ b/composables/repay/useWalletSwapRepay.ts
@@ -14,6 +14,7 @@ import { valueToNano } from '~/utils/crypto-utils'
 import { formatSmartAmount, trimTrailingZeros } from '~/utils/string-utils'
 import { amountToPercent, percentToAmountNano } from '~/utils/repayUtils'
 import { SwapperMode } from '~/entities/swap'
+import { createRaceGuard } from '~/utils/race-guard'
 import { buildSwapRouteItems } from '~/utils/swapRouteItems'
 import { useSwapPriceImpact } from '~/composables/useSwapPriceImpact'
 import { useSwapRepayQuotes } from '~/composables/repay/useSwapRepayQuotes'
@@ -284,10 +285,13 @@ export const useWalletSwapRepay = (options: UseWalletSwapRepayOptions) => {
   }, 500)
 
   // --- Estimates ---
+  const estimatesGuard = createRaceGuard()
+
   const updateEstimates = useDebounceFn(async () => {
     clearSimulationError()
     estimatesError.value = ''
     if (!position.value || !collateralVault.value || !borrowVault.value) return
+    const gen = estimatesGuard.next()
 
     try {
       // Balance check only for EXACT_IN (for TARGET_DEBT, the needed amount comes from the quote)
@@ -327,6 +331,7 @@ export const useWalletSwapRepay = (options: UseWalletSwapRepayOptions) => {
         getAssetUsdValueOrZero(position.value.supplied || 0n, collateralVault.value, 'off-chain'),
         getAssetUsdValueOrZero(nextBorrowed > 0n ? nextBorrowed : 0n, borrowVault.value, 'off-chain'),
       ])
+      if (estimatesGuard.isStale(gen)) return
 
       _estimateNetAPY.value = getNetAPY(
         supplyUsd,
@@ -357,12 +362,15 @@ export const useWalletSwapRepay = (options: UseWalletSwapRepayOptions) => {
       }
     }
     catch (e: unknown) {
+      if (estimatesGuard.isStale(gen)) return
       logWarn('walletSwapRepay/estimates', e)
       hasEstimate.value = false
       estimatesError.value = (e as { message: string }).message
     }
     finally {
-      isEstimatesLoading.value = false
+      if (!estimatesGuard.isStale(gen)) {
+        isEstimatesLoading.value = false
+      }
     }
   }, 500)
 
@@ -430,6 +438,13 @@ export const useWalletSwapRepay = (options: UseWalletSwapRepayOptions) => {
     quotes.reset()
     requestQuote()
   }
+
+  // Refresh selected asset balance when wallet address changes
+  watch(address, async () => {
+    if (selectedAsset.value?.address && needsSwap.value) {
+      selectedAssetBalance.value = await fetchSingleBalance(selectedAsset.value.address)
+    }
+  })
 
   // --- Watch quote changes → sync opposite field + estimates ---
   watch([quotes.effectiveQuote, direction], () => {
@@ -506,12 +521,14 @@ export const useWalletSwapRepay = (options: UseWalletSwapRepayOptions) => {
       catch (e) {
         logWarn('walletSwapRepay/buildPlan', e)
         plan.value = null
+        error('Unable to prepare transaction')
+        return
       }
 
-      if (plan.value) {
-        const ok = await runSimulation(plan.value)
-        if (!ok) return
-      }
+      if (!plan.value) return
+
+      const ok = await runSimulation(plan.value)
+      if (!ok) return
 
       // For review modal: show input token as primary asset, borrow asset as swap target
       const inputDisplay = direction.value === SwapperMode.TARGET_DEBT && amount.value

--- a/composables/useEulerOperations/swaps/supply-borrow.ts
+++ b/composables/useEulerOperations/swaps/supply-borrow.ts
@@ -2,8 +2,8 @@ import type { Address, Hash } from 'viem'
 import { encodeFunctionData } from 'viem'
 import type { OperationsContext, OperationHelpers } from '../types'
 import { buildSwapVerifierData } from './verify'
-import { evcEnableCollateralAbi, evcEnableControllerAbi } from '~/abis/evc'
-import { vaultBorrowAbi, vaultRedeemAbi, vaultWithdrawAbi } from '~/abis/vault'
+import { evcDisableCollateralAbi, evcDisableControllerAbi, evcEnableCollateralAbi, evcEnableControllerAbi } from '~/abis/evc'
+import { vaultBorrowAbi, vaultRedeemAbi, vaultTransferFromMaxAbi, vaultWithdrawAbi } from '~/abis/vault'
 import { SaHooksBuilder } from '~/entities/saHooksSDK'
 import { swapperAbi, swapVerifierAbi, transferFromSenderAbi } from '~/entities/euler/abis'
 import { convertSaHooksToEVCCalls, type EVCCall } from '~/utils/evc-converter'
@@ -447,9 +447,172 @@ export const createSupplyBorrowSwapBuilders = (
     }
   }
 
+  /**
+   * Swap an arbitrary token from the user's wallet and repay debt via verifyDebtMax.
+   * Supports both EXACT_IN and TARGET_DEBT modes. Optionally cleans up the position on full repay.
+   */
+  const buildSwapAndRepayPlan = async ({
+    inputTokenAddress,
+    inputAmount,
+    quote,
+    borrowVaultAddress,
+    subAccount,
+    enabledCollaterals,
+    isFullRepay = false,
+    swapperMode = SwapperMode.EXACT_IN,
+    targetDebt = 0n,
+    currentDebt = 0n,
+    includePermit2Call = true,
+  }: {
+    inputTokenAddress: Address
+    inputAmount: bigint
+    quote: SwapApiQuote
+    borrowVaultAddress: Address
+    subAccount: Address
+    enabledCollaterals?: string[]
+    isFullRepay?: boolean
+    swapperMode?: SwapperMode
+    targetDebt?: bigint
+    currentDebt?: bigint
+    includePermit2Call?: boolean
+  }): Promise<TxPlan> => {
+    if (!ctx.address.value || !ctx.eulerCoreAddresses.value || !ctx.eulerPeripheryAddresses.value) {
+      throw new Error('Wallet not connected or addresses not available')
+    }
+
+    const userAddr = ctx.address.value as Address
+    const evcAddress = ctx.eulerCoreAddresses.value.evc as Address
+    const swapVerifierAddress = ctx.eulerPeripheryAddresses.value.swapVerifier as Address
+    const borrowVaultAddr = borrowVaultAddress
+
+    assertSwapperVerifierAllowed(quote.verify.verifierAddress, ctx.eulerPeripheryAddresses.value.swapVerifier)
+
+    if (quote.verify.type !== SwapVerificationType.DebtMax) {
+      throw new Error('Swap verifier type mismatch')
+    }
+
+    const verifierData = buildSwapVerifierData({ quote, swapperMode, isRepay: true, targetDebt, currentDebt })
+    if (verifierData.toLowerCase() !== quote.verify.verifierData.toLowerCase()) {
+      logWarn('swap-repay', 'SwapVerifier data mismatch')
+      throw new Error('SwapVerifier data mismatch')
+    }
+
+    const { steps, permitCall, usesPermit2 } = await helpers.prepareTokenApproval({
+      assetAddr: inputTokenAddress,
+      spenderAddr: swapVerifierAddress,
+      userAddr,
+      amount: inputAmount,
+      includePermit2Call,
+    })
+
+    const tos = await helpers.prepareTos(userAddr)
+
+    const hooks = new SaHooksBuilder()
+    hooks.addContractInterface(swapVerifierAddress, [...transferFromSenderAbi, ...swapVerifierAbi])
+    hooks.addContractInterface(quote.swap.swapperAddress, swapperAbi)
+
+    if (isFullRepay) {
+      hooks.addContractInterface(borrowVaultAddr, evcDisableControllerAbi)
+      hooks.addContractInterface(evcAddress, evcDisableCollateralAbi)
+      const collateralAddresses = enabledCollaterals || []
+      for (const collateralAddr of collateralAddresses) {
+        hooks.addContractInterface(collateralAddr as Address, vaultTransferFromMaxAbi)
+      }
+    }
+
+    tos.addTosInterface(hooks)
+
+    const evcCalls: EVCCall[] = []
+
+    if (permitCall) {
+      evcCalls.push(permitCall)
+    }
+
+    tos.injectTosCall(evcCalls, hooks)
+
+    // transferFromSender: pull tokens from wallet to swapper
+    evcCalls.push({
+      targetContract: swapVerifierAddress,
+      onBehalfOfAccount: userAddr,
+      value: 0n,
+      data: hooks.getDataForCall(swapVerifierAddress, 'transferFromSender', [inputTokenAddress, inputAmount, quote.swap.swapperAddress]) as Hash,
+    })
+
+    // Swapper multicall
+    evcCalls.push({
+      targetContract: quote.swap.swapperAddress,
+      onBehalfOfAccount: userAddr,
+      value: 0n,
+      data: encodeFunctionData({
+        abi: swapperAbi,
+        functionName: 'multicall',
+        args: [quote.swap.multicallItems.map(item => item.data)],
+      }),
+    })
+
+    // Verify debt max — handles skim + repay internally
+    evcCalls.push({
+      targetContract: quote.verify.verifierAddress,
+      onBehalfOfAccount: quote.verify.account,
+      value: 0n,
+      data: verifierData,
+    })
+
+    if (isFullRepay) {
+      // Disable controller
+      evcCalls.push({
+        targetContract: borrowVaultAddr,
+        onBehalfOfAccount: subAccount,
+        value: 0n,
+        data: hooks.getDataForCall(borrowVaultAddr, 'disableController', []) as Hash,
+      })
+
+      // Disable collateral
+      const collateralAddresses = enabledCollaterals || []
+      for (const collateralAddr of collateralAddresses) {
+        evcCalls.push({
+          targetContract: evcAddress,
+          onBehalfOfAccount: '0x0000000000000000000000000000000000000000' as Address,
+          value: 0n,
+          data: hooks.getDataForCall(evcAddress, 'disableCollateral', [subAccount, collateralAddr as Address]) as Hash,
+        })
+      }
+
+      // Transfer collateral shares back to main account
+      const isMainAccount = subAccount.toLowerCase() === userAddr.toLowerCase()
+      if (!isMainAccount) {
+        for (const collateralAddr of collateralAddresses) {
+          evcCalls.push({
+            targetContract: collateralAddr as Address,
+            onBehalfOfAccount: subAccount,
+            value: 0n,
+            data: hooks.getDataForCall(collateralAddr as Address, 'transferFromMax', [subAccount, userAddr]) as Hash,
+          })
+        }
+      }
+    }
+    else {
+      // Partial repay: prepend Pyth updates for health check
+      await helpers.injectPythHealthCheckUpdates({
+        evcCalls,
+        liabilityVaultAddr: borrowVaultAddr,
+        enabledCollaterals,
+        userAddr,
+      })
+    }
+
+    const kind = isFullRepay ? 'swap-wallet-full-repay' : 'swap-wallet-repay'
+    const label = usesPermit2 ? 'Permit2 swap & repay via EVC' : 'Swap & repay via EVC'
+
+    steps.push(helpers.buildEvcBatchStep({ evcCalls, label }))
+
+    return { kind, steps }
+  }
+
   return {
     buildSwapAndSupplyPlan,
     buildSwapAndBorrowPlan,
+    buildSwapAndRepayPlan,
     buildWithdrawAndSwapPlan,
     buildRedeemAndSwapPlan,
   }

--- a/pages/lend/[vault]/index.vue
+++ b/pages/lend/[vault]/index.vue
@@ -268,7 +268,7 @@ const isSubmitDisabled = computed(() => {
   if (!isConnected.value) return false
   if (activeBalance.value < valueToNano(amount.value, activeAsset.value?.decimals)) return true
   if (isLoading.value || !(+amount.value)) return true
-  if (needsSwap.value && !swapEffectiveQuote.value && !isSwapQuoteLoading.value) return true
+  if (needsSwap.value && !swapSelectedQuote.value) return true
   if (isSupplyCapReached.value) return true
   return false
 })

--- a/pages/position/[number]/repay.vue
+++ b/pages/position/[number]/repay.vue
@@ -7,7 +7,7 @@ import type { TxPlan } from '~/entities/txPlan'
 import { useTermsOfUseGate } from '~/composables/useTermsOfUseGate'
 import { useEulerProductOfVault } from '~/composables/useEulerLabels'
 import { useModal } from '~/components/ui/composables/useModal'
-import { SlippageSettingsModal } from '#components'
+import { SlippageSettingsModal, SwapTokenSelector } from '#components'
 import { nanoToValue } from '~/utils/crypto-utils'
 import { createRaceGuard } from '~/utils/race-guard'
 import { formatNumber, formatSmartAmount, formatHealthScore } from '~/utils/string-utils'
@@ -15,6 +15,7 @@ import { formatLiquidationBuffer as formatLiqBuffer } from '~/utils/repayUtils'
 import { isPriceImpactWarning, isSlippageWarning } from '~/utils/priceImpact'
 import { usePriceImpactGate } from '~/composables/usePriceImpactGate'
 import { useWalletRepay } from '~/composables/repay/useWalletRepay'
+import { useWalletSwapRepay } from '~/composables/repay/useWalletSwapRepay'
 import { useCollateralSwapRepay } from '~/composables/repay/useCollateralSwapRepay'
 import { useSavingsRepay } from '~/composables/repay/useSavingsRepay'
 
@@ -128,6 +129,28 @@ const wallet = useWalletRepay({
   oraclePriceRatio,
 })
 
+const walletSwap = useWalletSwapRepay({
+  position,
+  borrowVault,
+  collateralVault,
+  formTab,
+  plan,
+  isSubmitting,
+  isPreparing,
+  clearSimulationError,
+  runSimulation,
+  netAPY,
+  collateralSupplyApy,
+  borrowApy,
+  collateralSupplyRewardApy,
+  borrowRewardApy,
+  oraclePriceRatio,
+})
+
+const { guardWithPriceImpact: guardWithWalletSwapPriceImpact } = usePriceImpactGate({
+  directPriceImpact: walletSwap.swapPriceImpact,
+})
+
 const collateral = useCollateralSwapRepay({
   position,
   borrowVault,
@@ -182,7 +205,11 @@ const formTabs = computed(() => {
 // --- Submit ---
 const reviewRepayLabel = getSubmitLabel('Review Repay')
 const reviewRepayDisabled = getSubmitDisabled(computed(() => {
-  if (formTab.value === 'wallet') return wallet.isSubmitDisabled.value
+  if (formTab.value === 'wallet') {
+    return walletSwap.needsSwap.value
+      ? walletSwap.isSubmitDisabled.value
+      : wallet.isSubmitDisabled.value
+  }
   if (formTab.value === 'savings') return savings.isSubmitDisabled.value
   return collateral.isSubmitDisabled.value
 }))
@@ -190,7 +217,12 @@ const reviewRepayDisabled = getSubmitDisabled(computed(() => {
 const onSubmitForm = async () => {
   await guardWithTerms(async () => {
     if (formTab.value === 'wallet') {
-      await wallet.submit()
+      if (walletSwap.needsSwap.value) {
+        await guardWithWalletSwapPriceImpact(() => walletSwap.submit())
+      }
+      else {
+        await wallet.submit()
+      }
     }
     else if (formTab.value === 'savings') {
       await guardWithSavingsPriceImpact(() => savings.submit())
@@ -203,6 +235,15 @@ const onSubmitForm = async () => {
 
 const openSlippageSettings = () => {
   modal.open(SlippageSettingsModal)
+}
+
+const openWalletSwapTokenSelector = () => {
+  modal.open(SwapTokenSelector, {
+    props: {
+      currentAssetAddress: walletSwap.selectedAsset.value?.address || borrowVault.value?.asset.address,
+      onSelect: walletSwap.onSelectSwapAsset,
+    },
+  })
 }
 
 // --- Load / Fetch ---
@@ -255,6 +296,7 @@ watch(address, () => {
 watch(formTab, () => {
   clearSimulationError()
   wallet.resetOnTabSwitch()
+  walletSwap.resetOnTabSwitch()
   collateral.resetOnTabSwitch()
   savings.resetOnTabSwitch()
 })
@@ -293,43 +335,125 @@ watch(formTab, () => {
       <template v-if="formTab === 'wallet'">
         <div class="grid gap-16 laptop:grid-cols-[minmax(0,1fr)_360px] laptop:items-start">
           <div class="flex flex-col gap-16 w-full">
-            <AssetInput
-              v-if="position.borrow.asset"
-              v-model="wallet.amount.value"
-              label="Pay from wallet"
-              :desc="name"
-              :asset="position.borrow.asset"
-              :vault="position.borrow"
-              :balance="walletBalance"
-              maxable
-            />
+            <!-- Direct repay (no swap) -->
+            <template v-if="!walletSwap.needsSwap.value">
+              <AssetInput
+                v-if="position.borrow.asset"
+                v-model="wallet.amount.value"
+                label="Pay from wallet"
+                :desc="name"
+                :asset="position.borrow.asset"
+                :vault="position.borrow"
+                :balance="walletBalance"
+                maxable
+              />
 
-            <AssetInput
-              v-if="position.borrow.asset"
-              v-model="wallet.amount.value"
-              label="Debt to repay"
-              :asset="position.borrow.asset"
-              :vault="position.borrow"
-              :balance="position.borrowed"
-              maxable
-            />
+              <AssetInput
+                v-if="position.borrow.asset"
+                v-model="wallet.amount.value"
+                label="Debt to repay"
+                :asset="position.borrow.asset"
+                :vault="position.borrow"
+                :balance="position.borrowed"
+                maxable
+              />
 
-            <UiRange
-              v-if="borrowVault"
-              v-model="wallet.walletRepayPercent.value"
-              label="Percent of debt to repay"
-              :min="0"
-              :max="100"
-              :step="1"
-              :number-filter="(n: number) => `${n}%`"
-              @update:model-value="wallet.onWalletRepayPercentInput"
-            />
+              <UiRange
+                v-if="borrowVault"
+                v-model="wallet.walletRepayPercent.value"
+                label="Percent of debt to repay"
+                :min="0"
+                :max="100"
+                :step="1"
+                :number-filter="(n: number) => `${n}%`"
+                @update:model-value="wallet.onWalletRepayPercentInput"
+              />
+            </template>
+
+            <!-- Swap + repay -->
+            <template v-else>
+              <AssetInput
+                v-if="walletSwap.selectedAsset.value"
+                v-model="walletSwap.amount.value"
+                label="Pay from wallet"
+                :asset="walletSwap.selectedAsset.value"
+                :balance="walletSwap.selectedAssetBalance.value"
+                maxable
+                @update:model-value="walletSwap.onAmountInput"
+              />
+
+              <AssetInput
+                v-if="position.borrow.asset"
+                v-model="walletSwap.debtAmount.value"
+                label="Debt to repay"
+                :asset="position.borrow.asset"
+                :vault="position.borrow"
+                :balance="position.borrowed"
+                maxable
+                @update:model-value="walletSwap.onDebtInput"
+              />
+
+              <UiRange
+                v-if="borrowVault"
+                v-model="walletSwap.debtPercent.value"
+                label="Percent of debt to repay"
+                :min="0"
+                :max="100"
+                :step="1"
+                :number-filter="(n: number) => `${n}%`"
+                @update:model-value="walletSwap.onPercentInput"
+              />
+
+              <SwapRouteSelector
+                :items="walletSwap.swapRouteItems.value"
+                :selected-provider="walletSwap.quotes.selectedProvider.value"
+                :status-label="walletSwap.quotes.statusLabel.value"
+                :is-loading="walletSwap.quotes.isLoading.value"
+                empty-message="Enter amount to fetch quotes"
+                @select="walletSwap.quotes.selectProvider"
+                @refresh="walletSwap.onRefreshSwapQuotes"
+              />
+            </template>
+
+            <!-- Pay with token selector -->
+            <div class="flex items-center gap-8">
+              <span class="text-p3 text-content-tertiary">Pay with</span>
+              <button
+                type="button"
+                class="flex items-center gap-6 bg-card text-p3 font-semibold px-12 h-36 rounded-[40px] whitespace-nowrap"
+                @click="openWalletSwapTokenSelector"
+              >
+                <AssetAvatar
+                  :asset="{ address: walletSwap.selectedAsset.value?.address || position.borrow.asset?.address || '', symbol: walletSwap.selectedAsset.value?.symbol || position.borrow.asset?.symbol || '' }"
+                  size="20"
+                />
+                {{ walletSwap.selectedAsset.value?.symbol || position.borrow.asset?.symbol }}
+                <SvgIcon
+                  class="text-content-tertiary !w-16 !h-16"
+                  name="arrow-down"
+                />
+              </button>
+            </div>
 
             <UiToast
-              v-show="wallet.estimatesError.value"
+              v-if="walletSwap.needsSwap.value && walletSwap.disabledReason.value"
               title="Error"
               variant="error"
-              :description="wallet.estimatesError.value"
+              :description="walletSwap.disabledReason.value"
+              size="compact"
+            />
+            <UiToast
+              v-show="walletSwap.needsSwap.value ? walletSwap.estimatesError.value : wallet.estimatesError.value"
+              title="Error"
+              variant="error"
+              :description="walletSwap.needsSwap.value ? walletSwap.estimatesError.value : wallet.estimatesError.value"
+              size="compact"
+            />
+            <UiToast
+              v-if="walletSwap.needsSwap.value && walletSwap.quotes.quoteError.value"
+              title="Swap quote"
+              variant="warning"
+              :description="walletSwap.quotes.quoteError.value"
               size="compact"
             />
             <UiToast
@@ -343,14 +467,42 @@ watch(formTab, () => {
 
           <VaultFormInfoBlock
             v-if="collateralVault && borrowVault"
-            :loading="wallet.isEstimatesLoading.value"
+            :loading="walletSwap.needsSwap.value ? walletSwap.isEstimatesLoading.value : wallet.isEstimatesLoading.value"
             variant="card"
             class="w-full laptop:max-w-[360px]"
           >
+            <!-- Swap details (when swapping) -->
+            <template v-if="walletSwap.needsSwap.value && walletSwap.swapEstimatedOutput.value">
+              <SummaryRow
+                v-if="walletSwap.swapPriceImpact.value !== null"
+                label="Price impact"
+              >
+                <span
+                  class="text-p2"
+                  :class="{ 'text-error-500': isPriceImpactWarning(walletSwap.swapPriceImpact.value) }"
+                >
+                  {{ formatNumber(walletSwap.swapPriceImpact.value, 2) }}%
+                </span>
+              </SummaryRow>
+              <SummaryRow label="Slippage tolerance">
+                <button
+                  type="button"
+                  class="flex items-center gap-6 text-p2"
+                  @click="openSlippageSettings"
+                >
+                  <span :class="{ 'text-error-500': isSlippageWarning(slippage) }">{{ formatNumber(slippage, 2, 0) }}%</span>
+                  <SvgIcon
+                    name="edit"
+                    class="!w-16 !h-16 text-accent-600"
+                  />
+                </button>
+              </SummaryRow>
+            </template>
+
             <SummaryRow label="Net APY">
               <SummaryValue
                 :before="formatNumber(netAPY)"
-                :after="formatNumber(wallet.estimateNetAPY.value)"
+                :after="formatNumber(walletSwap.needsSwap.value ? walletSwap.estimateNetAPY.value : wallet.estimateNetAPY.value)"
                 suffix="%"
               />
             </SummaryRow>
@@ -365,8 +517,8 @@ watch(formTab, () => {
             <SummaryRow label="Liq. price">
               <SummaryPriceValue
                 :before="walletPriceInvert.invertValue(liquidationPrice) != null ? formatSmartAmount(walletPriceInvert.invertValue(liquidationPrice)!) : undefined"
-                :after="walletPriceInvert.invertValue(liqPriceFromHealth(nanoToValue(wallet.estimateHealth.value, 18))) != null
-                  ? formatSmartAmount(walletPriceInvert.invertValue(liqPriceFromHealth(nanoToValue(wallet.estimateHealth.value, 18)))!)
+                :after="walletPriceInvert.invertValue(liqPriceFromHealth(nanoToValue((walletSwap.needsSwap.value ? walletSwap.estimateHealth.value : wallet.estimateHealth.value), 18))) != null
+                  ? formatSmartAmount(walletPriceInvert.invertValue(liqPriceFromHealth(nanoToValue((walletSwap.needsSwap.value ? walletSwap.estimateHealth.value : wallet.estimateHealth.value), 18)))!)
                   : undefined"
                 :symbol="walletPriceInvert.displaySymbol"
                 invertible
@@ -378,7 +530,7 @@ watch(formTab, () => {
                 :before="formatLiqBuffer(walletPriceInvert.invertValue(oraclePriceRatio), walletPriceInvert.invertValue(liquidationPrice))"
                 :after="formatLiqBuffer(
                   walletPriceInvert.invertValue(oraclePriceRatio),
-                  walletPriceInvert.invertValue(liqPriceFromHealth(nanoToValue(wallet.estimateHealth.value, 18))),
+                  walletPriceInvert.invertValue(liqPriceFromHealth(nanoToValue((walletSwap.needsSwap.value ? walletSwap.estimateHealth.value : wallet.estimateHealth.value), 18))),
                 )"
                 suffix="%"
               />
@@ -386,14 +538,14 @@ watch(formTab, () => {
             <SummaryRow label="LTV">
               <SummaryValue
                 :before="formatNumber(nanoToValue(position.userLTV, 18))"
-                :after="formatNumber(nanoToValue(wallet.estimateUserLTV.value, 18))"
+                :after="formatNumber(nanoToValue(walletSwap.needsSwap.value ? walletSwap.estimateUserLTV.value : wallet.estimateUserLTV.value, 18))"
                 suffix="%"
               />
             </SummaryRow>
             <SummaryRow label="Health score">
               <SummaryValue
                 :before="formatHealthScore(nanoToValue(position.health, 18))"
-                :after="formatHealthScore(nanoToValue(wallet.estimateHealth.value, 18))"
+                :after="formatHealthScore(nanoToValue(walletSwap.needsSwap.value ? walletSwap.estimateHealth.value : wallet.estimateHealth.value, 18))"
               />
             </SummaryRow>
           </VaultFormInfoBlock>

--- a/pages/position/[number]/repay.vue
+++ b/pages/position/[number]/repay.vue
@@ -409,16 +409,6 @@ watch(formTab, () => {
                 :number-filter="(n: number) => `${n}%`"
                 @update:model-value="walletSwap.onPercentInput"
               />
-
-              <SwapRouteSelector
-                :items="walletSwap.swapRouteItems.value"
-                :selected-provider="walletSwap.quotes.selectedProvider.value"
-                :status-label="walletSwap.quotes.statusLabel.value"
-                :is-loading="walletSwap.quotes.isLoading.value"
-                empty-message="Enter amount to fetch quotes"
-                @select="walletSwap.quotes.selectProvider"
-                @refresh="walletSwap.onRefreshSwapQuotes"
-              />
             </template>
 
             <!-- Pay with token selector -->
@@ -440,6 +430,18 @@ watch(formTab, () => {
                 />
               </button>
             </div>
+
+            <!-- Swap route selector (only when swapping) -->
+            <SwapRouteSelector
+              v-if="walletSwap.needsSwap.value"
+              :items="walletSwap.swapRouteItems.value"
+              :selected-provider="walletSwap.quotes.selectedProvider.value"
+              :status-label="walletSwap.quotes.statusLabel.value"
+              :is-loading="walletSwap.quotes.isLoading.value"
+              empty-message="Enter amount to fetch quotes"
+              @select="walletSwap.quotes.selectProvider"
+              @refresh="walletSwap.onRefreshSwapQuotes"
+            />
 
             <UiToast
               v-if="isWalletSwapRestricted"

--- a/pages/position/[number]/repay.vue
+++ b/pages/position/[number]/repay.vue
@@ -14,6 +14,7 @@ import { formatNumber, formatSmartAmount, formatHealthScore } from '~/utils/stri
 import { formatLiquidationBuffer as formatLiqBuffer } from '~/utils/repayUtils'
 import { isPriceImpactWarning, isSlippageWarning } from '~/utils/priceImpact'
 import { usePriceImpactGate } from '~/composables/usePriceImpactGate'
+import { isVaultRestrictedByCountry } from '~/composables/useGeoBlock'
 import { useWalletRepay } from '~/composables/repay/useWalletRepay'
 import { useWalletSwapRepay } from '~/composables/repay/useWalletSwapRepay'
 import { useCollateralSwapRepay } from '~/composables/repay/useCollateralSwapRepay'
@@ -151,6 +152,10 @@ const { guardWithPriceImpact: guardWithWalletSwapPriceImpact } = usePriceImpactG
   directPriceImpact: walletSwap.swapPriceImpact,
 })
 
+const isWalletSwapRestricted = computed(() =>
+  walletSwap.needsSwap.value && isVaultRestrictedByCountry(borrowVault.value?.address || ''),
+)
+
 const collateral = useCollateralSwapRepay({
   position,
   borrowVault,
@@ -207,7 +212,7 @@ const reviewRepayLabel = getSubmitLabel('Review Repay')
 const reviewRepayDisabled = getSubmitDisabled(computed(() => {
   if (formTab.value === 'wallet') {
     return walletSwap.needsSwap.value
-      ? walletSwap.isSubmitDisabled.value
+      ? (isWalletSwapRestricted.value || walletSwap.isSubmitDisabled.value)
       : wallet.isSubmitDisabled.value
   }
   if (formTab.value === 'savings') return savings.isSubmitDisabled.value
@@ -218,6 +223,7 @@ const onSubmitForm = async () => {
   await guardWithTerms(async () => {
     if (formTab.value === 'wallet') {
       if (walletSwap.needsSwap.value) {
+        if (isWalletSwapRestricted.value) return
         await guardWithWalletSwapPriceImpact(() => walletSwap.submit())
       }
       else {
@@ -436,7 +442,14 @@ watch(formTab, () => {
             </div>
 
             <UiToast
-              v-if="walletSwap.needsSwap.value && walletSwap.disabledReason.value"
+              v-if="isWalletSwapRestricted"
+              title="Swap restricted"
+              description="Swapping into this vault is not available in your region. You can repay with the vault's underlying asset directly."
+              variant="warning"
+              size="compact"
+            />
+            <UiToast
+              v-if="walletSwap.needsSwap.value && !isWalletSwapRestricted && walletSwap.disabledReason.value"
               title="Error"
               variant="error"
               :description="walletSwap.disabledReason.value"


### PR DESCRIPTION
## Summary

- Add swap + repay from wallet on the repay page's "From wallet" tab. Users can now select any wallet token via "Pay with" selector, swap it to the borrow asset, and repay debt in a single transaction.
- Supports dual-direction: EXACT_IN (enter wallet token amount) and TARGET_DEBT (enter debt amount or use percent slider), matching the UX of collateral swap and savings repay tabs.
- Plan builder uses `verifyDebtMax` for debt-targeting verification, consistent with existing cross-asset repay flows. Full repay includes position cleanup (disable controller/collateral/transfer).
- Enforce explicit swap quote selection across all swap flows (lend supply, borrow, position supply/withdraw). Submit button now requires user to select a quote provider.
- Show "You repaying more than required" error when estimated swap output exceeds current debt.

## Key files
- `composables/useEulerOperations/swaps/supply-borrow.ts` — new `buildSwapAndRepayPlan`
- `composables/repay/useWalletSwapRepay.ts` — new dual-direction composable
- `pages/position/[number]/repay.vue` — wallet tab UI with token selector, debt input, slider

## Test plan
- [ ] Select non-borrow token on wallet tab → swap quotes appear
- [ ] EXACT_IN: enter wallet token amount → estimated debt repaid shown
- [ ] TARGET_DEBT: enter debt amount → wallet token amount shown
- [ ] Percent slider: slide to 50% → debt and wallet amounts update
- [ ] Full repay: slide to 100% → position cleaned up after execution
- [ ] Same-asset fallback: select borrow asset → direct repay (no swap)
- [ ] Explicit quote selection required before submit across all swap flows
- [ ] "You repaying more than required" error shown when applicable
- [ ] Geoblocking: swap blocked when borrow vault is restricted