### PR TITLE
fix: reduce RPC call volume and add periodic vault refresh

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
-import { POLL_INTERVAL_30S_MS } from '~/entities/tuning-constants'
+import { POLL_INTERVAL_60S_MS } from '~/entities/tuning-constants'
 
 const route = useRoute()
 const router = useRouter()
 const { loadEulerConfig, chainId } = useEulerAddresses()
-const { loadVaults, isReady: isVaultsReady, resetVaultsState } = useVaults()
+const { loadVaults, isReady: isVaultsReady, resetVaultsState, refreshVaults } = useVaults()
 const { loadTokens } = useTokens()
 const { loadTokenList, isLoaded: isTokenListLoaded } = useTokenList()
 const { loadLabels } = useEulerLabels()
@@ -107,7 +107,8 @@ watch([isConnected, isVaultsReady], ([val]) => {
     updateBalances()
     interval = setInterval(async () => {
       updateBalances()
-    }, POLL_INTERVAL_30S_MS)
+      refreshVaults()
+    }, POLL_INTERVAL_60S_MS)
   }
 }, { immediate: true })
 

--- a/composables/useVaults.ts
+++ b/composables/useVaults.ts
@@ -20,12 +20,15 @@ import { getProductByVault, isVaultNotExplorable } from '~/utils/eulerLabelsUtil
 import { getEulerRouterGovernor } from '~/entities/oracle'
 
 const isReady = ref(false)
-const isLoading = ref(false)
-const isUpdating = ref(false)
+const isEVKLoading = ref(false)
+const isEVKUpdating = ref(false)
 const loadedChainId = ref<number | null>(null)
 
 const isEarnLoading = ref(false)
 const isEarnUpdating = ref(false)
+
+const isSecuritizeLoading = ref(false)
+const isSecuritizeUpdating = ref(false)
 
 const isEscrowLoading = ref(false)
 const isEscrowUpdating = ref(false)
@@ -70,10 +73,12 @@ const resetVaultsState = () => {
 
   loadGeneration.value++
   isReady.value = false
-  isLoading.value = true
-  isUpdating.value = true
+  isEVKLoading.value = true
+  isEVKUpdating.value = true
   isEarnLoading.value = true
   isEarnUpdating.value = true
+  isSecuritizeLoading.value = true
+  isSecuritizeUpdating.value = true
   isEscrowUpdating.value = true
   isEscrowLoadedOnce.value = false
   loadedChainId.value = null
@@ -81,13 +86,15 @@ const resetVaultsState = () => {
   clearPriceCaches()
 }
 
-const updateVaults = async (vaultAddresses?: string[], generation?: number) => {
+const updateEVKVaults = async (vaultAddresses: string[], generation?: number, silent = false) => {
   const { set: registrySet } = useVaultRegistry()
   const gen = generation ?? loadGeneration.value
 
   try {
-    isUpdating.value = true
-    isLoading.value = true
+    if (!silent) {
+      isEVKUpdating.value = true
+      isEVKLoading.value = true
+    }
 
     for await (const result of fetchVaults(vaultAddresses)) {
       if (loadGeneration.value !== gen) return
@@ -96,35 +103,44 @@ const updateVaults = async (vaultAddresses?: string[], generation?: number) => {
         registrySet(vault.address, vault, 'evk')
       })
 
-      isLoading.value = false
+      if (!silent) {
+        isEVKLoading.value = false
+      }
 
       if (result.isFinished) {
         break
       }
     }
   }
+  catch (e) {
+    logWarn('useVaults/updateEVKVaults', e)
+  }
   finally {
-    if (loadGeneration.value === gen) {
-      isUpdating.value = false
+    if (!silent && loadGeneration.value === gen) {
+      isEVKUpdating.value = false
     }
   }
 }
-const updateEarnVaults = async (generation?: number) => {
+const updateEarnVaults = async (vaultAddresses: string[], generation?: number, silent = false) => {
   const { set: registrySet } = useVaultRegistry()
   const gen = generation ?? loadGeneration.value
 
   try {
-    isEarnUpdating.value = true
-    isEarnLoading.value = true
+    if (!silent) {
+      isEarnUpdating.value = true
+      isEarnLoading.value = true
+    }
 
-    for await (const result of fetchEarnVaults()) {
+    for await (const result of fetchEarnVaults(vaultAddresses)) {
       if (loadGeneration.value !== gen) return
 
       result.vaults.forEach((vault) => {
         registrySet(vault.address, vault, 'earn')
       })
 
-      isEarnLoading.value = false
+      if (!silent) {
+        isEarnLoading.value = false
+      }
 
       if (result.isFinished) {
         break
@@ -133,7 +149,7 @@ const updateEarnVaults = async (generation?: number) => {
   }
   catch (e) {
     logWarn('useVaults/updateEarnVaults', e)
-    if (loadGeneration.value === gen) {
+    if (!silent && loadGeneration.value === gen) {
       isEarnUpdating.value = false
     }
   }
@@ -196,30 +212,45 @@ const fetchNeededEscrowVaults = async (addresses: string[], generation: number):
   })
 }
 
-const updateSecuritizeVaults = async (securitizeAddresses: string[], generation: number) => {
+const updateSecuritizeVaults = async (securitizeAddresses: string[], generation: number, silent = false) => {
   const { set: registrySet } = useVaultRegistry()
 
   if (!securitizeAddresses.length || loadGeneration.value !== generation) {
     return
   }
 
-  // Fetch securitize vault details
-  const results = await Promise.allSettled(
-    securitizeAddresses.map(addr => fetchSecuritizeVault(addr)),
-  )
-
-  if (loadGeneration.value !== generation) return
-
-  results.forEach((result) => {
-    if (result.status === 'fulfilled') {
-      registrySet(result.value.address, result.value, 'securitize')
+  try {
+    if (!silent) {
+      isSecuritizeUpdating.value = true
+      isSecuritizeLoading.value = true
     }
-  })
+
+    const results = await Promise.allSettled(
+      securitizeAddresses.map(addr => fetchSecuritizeVault(addr)),
+    )
+
+    if (loadGeneration.value !== generation) return
+
+    results.forEach((result) => {
+      if (result.status === 'fulfilled') {
+        registrySet(result.value.address, result.value, 'securitize')
+      }
+    })
+  }
+  catch (e) {
+    logWarn('useVaults/updateSecuritizeVaults', e)
+  }
+  finally {
+    if (!silent && loadGeneration.value === generation) {
+      isSecuritizeUpdating.value = false
+      isSecuritizeLoading.value = false
+    }
+  }
 }
 
 const loadVaults = async () => {
   const { chainId, eulerPeripheryAddresses } = useEulerAddresses()
-  const { verifiedVaultAddresses } = useEulerLabels()
+  const { verifiedVaultAddresses, earnVaults: earnVaultAddresses } = useEulerLabels()
   const { setEscrowAddresses } = useVaultRegistry()
 
   resetVaultsState()
@@ -271,11 +302,11 @@ const loadVaults = async () => {
 
     await Promise.all([
       (async () => {
-        await updateEarnVaults(generation)
+        await updateEarnVaults(earnVaultAddresses.value, generation)
         earnResolve()
       })(),
       (async () => {
-        await updateVaults(evkAddresses, generation)
+        await updateEVKVaults(evkAddresses, generation)
         evkResolve()
       })(),
       updateSecuritizeVaults(securitizeAddresses, generation),
@@ -300,6 +331,8 @@ const loadVaults = async () => {
 
     // Set loading flags AFTER all needed escrow vaults are loaded
     isEarnUpdating.value = false
+    isSecuritizeUpdating.value = false
+    isSecuritizeLoading.value = false
     isEscrowUpdating.value = false
     isEscrowLoading.value = false
     isEscrowLoadedOnce.value = true
@@ -307,10 +340,12 @@ const loadVaults = async () => {
   catch (e) {
     logWarn('useVaults/loadVaults', e)
     if (loadGeneration.value === generation) {
-      isLoading.value = false
-      isUpdating.value = false
+      isEVKLoading.value = false
+      isEVKUpdating.value = false
       isEarnLoading.value = false
       isEarnUpdating.value = false
+      isSecuritizeLoading.value = false
+      isSecuritizeUpdating.value = false
       isEscrowLoading.value = false
       isEscrowUpdating.value = false
     }
@@ -413,6 +448,23 @@ const updateVault = async (vaultAddress: string): Promise<Vault | SecuritizeVaul
   registrySet(address, vault, 'evk')
   return vault
 }
+/**
+ * Silent vault data refresh — updates registry in-place without resetting loading flags.
+ * Used for periodic polling to keep interest rates, supply/borrow totals, and prices fresh.
+ */
+const refreshVaults = async () => {
+  const { getEvkVaults, getEarnVaults, getSecuritizeVaults } = useVaultRegistry()
+  const gen = loadGeneration.value
+
+  await updateEVKVaults(getEvkVaults().map(v => v.address), gen, true)
+  if (loadGeneration.value !== gen) return
+
+  await updateEarnVaults(getEarnVaults().map(v => v.address), gen, true)
+  if (loadGeneration.value !== gen) return
+
+  await updateSecuritizeVaults(getSecuritizeVaults().map(v => v.address), gen, true)
+}
+
 const updateEarnVault = async (vaultAddress: string): Promise<EarnVault> => {
   const { set: registrySet } = useVaultRegistry()
   const address = getAddress(vaultAddress)
@@ -653,10 +705,12 @@ export const useVaults = () => {
     // State
     isReady,
     loadedChainId,
-    isLoading,
-    isUpdating,
+    isEVKLoading,
+    isEVKUpdating,
     isEarnLoading,
     isEarnUpdating,
+    isSecuritizeLoading,
+    isSecuritizeUpdating,
     isEscrowLoading,
     isEscrowUpdating,
     isEscrowLoadedOnce,
@@ -676,9 +730,10 @@ export const useVaults = () => {
     updateVault,
     updateEarnVault,
     updateEscrowVault,
+    refreshVaults,
 
     // Bulk updates (internal use)
-    updateVaults,
+    updateEVKVaults,
     updateEarnVaults,
 
     // Verification

--- a/composables/useVaults.ts
+++ b/composables/useVaults.ts
@@ -231,9 +231,12 @@ const updateSecuritizeVaults = async (securitizeAddresses: string[], generation:
 
     if (loadGeneration.value !== generation) return
 
-    results.forEach((result) => {
+    results.forEach((result, index) => {
       if (result.status === 'fulfilled') {
         registrySet(result.value.address, result.value, 'securitize')
+      }
+      else {
+        logWarn(`useVaults/updateSecuritizeVaults/${securitizeAddresses[index]}`, result.reason)
       }
     })
   }

--- a/composables/useWallets.ts
+++ b/composables/useWallets.ts
@@ -91,7 +91,7 @@ export const useWallets = () => {
       const client = getPublicClient(rpcUrl.value)
 
       // Fetch balances via lens in chunks to stay within gas limits
-      const LENS_BATCH_SIZE = 200
+      const LENS_BATCH_SIZE = 250
       const result: bigint[] = []
       for (let i = 0; i < tokenAddresses.length; i += LENS_BATCH_SIZE) {
         const batch = tokenAddresses.slice(i, i + LENS_BATCH_SIZE)
@@ -104,24 +104,12 @@ export const useWallets = () => {
           }) as bigint[]
           result.push(...batchResult)
         }
-        catch {
-          // Fallback: individual balanceOf calls for this chunk
-          const fallbackResult = await Promise.all(
-            batch.map(async (tokenAddr) => {
-              try {
-                return await client.readContract({
-                  address: tokenAddr,
-                  abi: erc20BalanceOfAbi,
-                  functionName: 'balanceOf',
-                  args: [targetAddress],
-                }) as bigint
-              }
-              catch {
-                return 0n
-              }
-            }),
-          )
-          result.push(...fallbackResult)
+        catch (e) {
+          // Zero fallback: if the lens batch fails it's typically an RPC-level issue,
+          // firing 200 individual balanceOf calls would make rate limiting worse.
+          // Balances will be retried on the next polling tick.
+          logWarn('wallets/batchFetch', `Lens tokenBalances failed for chunk of ${batch.length}, using zero fallback`, e)
+          result.push(...batch.map(() => 0n))
         }
       }
 

--- a/composables/useWallets.ts
+++ b/composables/useWallets.ts
@@ -104,11 +104,11 @@ export const useWallets = () => {
           }) as bigint[]
           result.push(...batchResult)
         }
-        catch (e) {
+        catch {
           // Zero fallback: if the lens batch fails it's typically an RPC-level issue,
           // firing 200 individual balanceOf calls would make rate limiting worse.
           // Balances will be retried on the next polling tick.
-          logWarn('wallets/batchFetch', `Lens tokenBalances failed for chunk of ${batch.length}, using zero fallback`, e)
+          logWarn('wallets/batchFetch', `Lens tokenBalances failed for chunk of ${batch.length}, using zero fallback`)
           result.push(...batch.map(() => 0n))
         }
       }

--- a/docs/portfolio-logic.md
+++ b/docs/portfolio-logic.md
@@ -313,11 +313,16 @@ This is a `staticCall` - no transaction is sent, no gas is spent, and the state 
 
 ### Where Pyth Simulation Is Used
 
-**Vault fetching** (`entities/vault/fetcher.ts: fetchVault`):
+**Bulk vault fetching** (`entities/vault/fetcher.ts: fetchVaults`):
+1. Batch-fetch vaults via `batchLensCalls()` (fast path).
+2. Collect all Pyth-enabled vaults via `collectPythFeedIds()`.
+3. Batch re-fetch all Pyth vaults in a single `batchSimulation` via `executeBatchLensWithPythSimulation()`.
+4. Replace vault data with simulation results (contains fresh prices in `liabilityPriceInfo` and `collateralPrices[]`).
+
+**Single vault fetching** (`entities/vault/fetcher.ts: fetchVault`):
 1. Call `vaultLens.getVaultInfoFull()` normally (fast path).
-2. Check `collectPythFeedIds(vault.oracleDetailedInfo)`.
-3. If Pyth detected: re-query with `fetchVaultWithPythSimulation()`.
-4. Replace vault data with simulation result (contains fresh prices in `liabilityPriceInfo` and `collateralPrices[]`).
+2. If Pyth detected: re-query with `fetchVaultWithPythSimulation()` → `executeLensWithPythSimulation()`.
+3. Replace vault data with simulation result.
 
 **Borrow position loading** (`composables/useEulerAccount.ts: updateBorrowPositions`):
 1. Pre-fetch the borrow vault to check for Pyth oracles.

--- a/docs/pricing-system.md
+++ b/docs/pricing-system.md
@@ -300,10 +300,13 @@ fetchVaults() generator called
         └───────┬───────┘
            No   │   → Keep vault as-is
                 ↓ Yes
-    Re-fetch with fetchVaultWithPythSimulation()
-    to get fresh Pyth prices
+    Collect all Pyth vaults, then batch re-fetch
+    via executeBatchLensWithPythSimulation():
+    1. Merge + deduplicate all feeds across vaults
+    2. Build Pyth updates + all lens calls
+    3. Execute single EVC batchSimulation
                 ↓
-    Replace original vault with refreshed version
+    Replace original vaults with refreshed versions
                 ↓
     Yield batch (with fresh Pyth prices)
 ```

--- a/entities/vault/fetcher.ts
+++ b/entities/vault/fetcher.ts
@@ -17,7 +17,7 @@ import {
   eulerUtilsLensABI,
   eulerVaultLensABI,
 } from '~/entities/euler/abis'
-import { executeLensWithPythSimulation } from '~/utils/pyth'
+import { executeLensWithPythSimulation, executeBatchLensWithPythSimulation } from '~/utils/pyth'
 import { valueToNano } from '~/utils/crypto-utils'
 import { batchLensCalls } from '~/utils/multicall'
 
@@ -526,33 +526,37 @@ export const fetchVaults = async function* (
     // Re-fetch Pyth-powered vaults with simulation to get fresh prices
     // Pyth prices are only valid for ~2 minutes after on-chain update
     if (eulerCoreAddresses.value?.evc && PYTH_HERMES_URL) {
-      const pythVaultsToRefresh = validVaults.filter((vault) => {
-        const feeds = collectPythFeedIds(vault.oracleDetailedInfo)
-        return feeds.length > 0
-      })
+      const pythVaultEntries = validVaults
+        .map((vault) => {
+          const feeds = collectPythFeedIds(vault.oracleDetailedInfo)
+          return feeds.length > 0 ? { vaultAddress: vault.address, feeds } : null
+        })
+        .filter((entry): entry is NonNullable<typeof entry> => entry !== null)
 
-      if (pythVaultsToRefresh.length > 0) {
-        const refreshedVaults = await Promise.all(
-          pythVaultsToRefresh.map(async (vault) => {
-            const feeds = collectPythFeedIds(vault.oracleDetailedInfo)
-            const refreshed = await fetchVaultWithPythSimulation(
-              vault.address,
-              feeds,
-              rpcUrl.value,
-              eulerLensAddresses.value!.vaultLens,
-              eulerCoreAddresses.value!.evc,
-              PYTH_HERMES_URL,
-              verifiedVaultAddresses.value,
-            )
-            return refreshed || vault // Fall back to original if simulation fails
-          }),
+      if (pythVaultEntries.length > 0) {
+        const refreshedMap = await executeBatchLensWithPythSimulation<Record<string, unknown>>(
+          pythVaultEntries,
+          eulerLensAddresses.value!.vaultLens as Address,
+          eulerVaultLensABI,
+          'getVaultInfoFull',
+          eulerCoreAddresses.value!.evc,
+          rpcUrl.value,
+          PYTH_HERMES_URL,
         )
 
         if (chainId.value !== startChainId) return
 
-        // Replace original vaults with refreshed versions
-        const refreshedMap = new Map(refreshedVaults.map(v => [v.address, v]))
-        validVaults = validVaults.map(v => refreshedMap.get(v.address) || v)
+        validVaults = validVaults.map((vault) => {
+          const raw = refreshedMap.get(vault.address)
+          if (!raw) return vault
+          try {
+            return processRawVaultData(raw, vault.address, undefined, { verified: true })
+          }
+          catch (e) {
+            logWarn('vault/pythRefresh', e, { severity: 'error' })
+            return vault
+          }
+        })
       }
     }
 
@@ -581,7 +585,7 @@ export const fetchVaults = async function* (
   }
 }
 
-export const fetchEarnVaults = async function* (): AsyncGenerator<
+export const fetchEarnVaults = async function* (vaultAddresses?: string[]): AsyncGenerator<
   VaultIteratorResult<EarnVault>,
   void,
   unknown
@@ -611,7 +615,7 @@ export const fetchEarnVaults = async function* (): AsyncGenerator<
 
   const client = rpcClient.value!
 
-  const verifiedVaults = earnVaults.value
+  const verifiedVaults = vaultAddresses || earnVaults.value
 
   // Start block prefetch in parallel - will be awaited when needed for APY calculation
   const blockCachePromise = fetchBlockDataForAPY()

--- a/pages/borrow/index.vue
+++ b/pages/borrow/index.vue
@@ -41,11 +41,11 @@ defineOptions({
   name: 'BorrowPage',
 })
 
-const { borrowList, isUpdating, isEscrowUpdating } = useVaults()
+const { borrowList, isEVKUpdating, isEscrowUpdating } = useVaults()
 const { chainId } = useEulerAddresses()
 
 const isPricesReady = ref(false)
-const isLoading = computed(() => isUpdating.value || isEscrowUpdating.value || !isPricesReady.value)
+const isLoading = computed(() => isEVKUpdating.value || isEscrowUpdating.value || !isPricesReady.value)
 const { isSlow } = useSlowLoading(isLoading)
 const { enableEntityBranding } = useDeployConfig()
 const { entities } = useEulerLabels()

--- a/pages/explore/[market].vue
+++ b/pages/explore/[market].vue
@@ -9,10 +9,10 @@ const route = useRoute()
 const marketKey = computed(() => route.params.market as string)
 
 const { marketGroups, isResolvingTVL } = useMarketGroups()
-const { isUpdating, isEarnUpdating, isEscrowUpdating } = useVaults()
+const { isEVKUpdating, isEarnUpdating, isSecuritizeUpdating, isEscrowUpdating } = useVaults()
 
 const isLoading = computed(() =>
-  isUpdating.value || isEarnUpdating.value || isEscrowUpdating.value
+  isEVKUpdating.value || isEarnUpdating.value || isSecuritizeUpdating.value || isEscrowUpdating.value
   || isResolvingTVL.value || marketGroups.value.length === 0,
 )
 

--- a/pages/explore/index.vue
+++ b/pages/explore/index.vue
@@ -17,7 +17,7 @@ defineOptions({
 
 const { marketGroups, isResolvingTVL } = useMarketGroups()
 const { getBestMaxROE } = useBestMaxROE(marketGroups)
-const { isUpdating, isEarnUpdating, isEscrowUpdating } = useVaults()
+const { isEVKUpdating, isEarnUpdating, isSecuritizeUpdating, isEscrowUpdating } = useVaults()
 const { chainId } = useEulerAddresses()
 const { entities } = useEulerLabels()
 const { enableEntityBranding } = useDeployConfig()
@@ -263,7 +263,7 @@ const sortedMarkets = computed(() => {
 })
 
 const isLoading = computed(() =>
-  isUpdating.value || isEarnUpdating.value || isEscrowUpdating.value
+  isEVKUpdating.value || isEarnUpdating.value || isSecuritizeUpdating.value || isEscrowUpdating.value
   || (isResolvingTVL.value && marketGroups.value.length === 0)
   || marketGroups.value.length === 0,
 )

--- a/pages/lend/index.vue
+++ b/pages/lend/index.vue
@@ -16,13 +16,13 @@ defineOptions({
   name: 'LendPage',
 })
 
-const { borrowList, isUpdating } = useVaults()
+const { borrowList, isEVKUpdating } = useVaults()
 const { getVerifiedEvkVaults } = useVaultRegistry()
 const { chainId } = useEulerAddresses()
 const list = computed(() => getVerifiedEvkVaults())
 
 const isPricesReady = ref(false)
-const isLoading = computed(() => isUpdating.value || !isPricesReady.value)
+const isLoading = computed(() => isEVKUpdating.value || !isPricesReady.value)
 const { isSlow } = useSlowLoading(isLoading)
 const { entities } = useEulerLabels()
 const { withIntrinsicSupplyApy } = useIntrinsicApy()

--- a/utils/multicall.ts
+++ b/utils/multicall.ts
@@ -12,6 +12,9 @@ export type MulticallResult<T = unknown> = {
  * Execute multiple contract calls in a single RPC request using EVC batchSimulation.
  * This is more reliable than Multicall3 as EVC is guaranteed to exist on all Euler chains.
  *
+ * When batch items carry value (e.g. Pyth update fees), the total is automatically
+ * summed for msg.value and a balance state override is added for the caller.
+ *
  * @param evcAddress - EVC contract address
  * @param items - Array of batch items (target, data, value)
  * @param rpcUrl - JSON-RPC URL
@@ -27,6 +30,7 @@ export const evcBatchCall = async (
   }
 
   const client = getPublicClient(rpcUrl)
+  const totalValue = items.reduce((sum, item) => sum + item.value, 0n)
 
   try {
     const callData = encodeFunctionData({
@@ -38,7 +42,8 @@ export const evcBatchCall = async (
     const result = await client.call({
       to: evcAddress as Address,
       data: callData,
-      value: 0n,
+      value: totalValue,
+      ...(totalValue > 0n ? { stateOverride: [{ address: zeroAddress as `0x${string}`, balance: totalValue }] } : {}),
     })
 
     if (!result.data) {

--- a/utils/pyth.ts
+++ b/utils/pyth.ts
@@ -2,12 +2,14 @@ import { PriceServiceConnection } from '@pythnetwork/price-service-client'
 import { encodeFunctionData, decodeFunctionResult, zeroAddress, type Address, type Hex, type Abi } from 'viem'
 import type { EVCCall } from './evc-converter'
 import { PYTH_ABI } from '~/abis/pyth'
-import { EVC_ABI, type BatchItem, type BatchItemResult } from '~/abis/evc'
+import type { BatchItem } from '~/abis/evc'
 import { DEFAULT_PRICE_CACHE_TTL_MS } from '~/entities/constants'
 import { CACHE_TTL_15S_MS, BATCH_DELAY_COLLECT_MS } from '~/entities/tuning-constants'
 import { collectPythFeedIds, collectPythFeedIdsForPair, type PythFeed } from '~/entities/oracle'
 import type { Vault } from '~/entities/vault'
 import { getPublicClient } from '~/utils/public-client'
+import { evcBatchCall } from '~/utils/multicall'
+import { logWarn } from '~/utils/errorHandling'
 
 const normalizeHex = (value: string): Hex => (value.startsWith('0x') ? value as Hex : (`0x${value}` as Hex))
 const normalizeFeedId = (value: string): Hex => normalizeHex(value).toLowerCase() as Hex
@@ -551,77 +553,152 @@ export const executeLensWithPythSimulation = async <T>(
   hermesEndpoint: string,
 ): Promise<T | undefined> => {
   try {
-    // Build Pyth update batch items
-    const { items: pythItems, totalFee } = await buildPythBatchItemsFromFeeds(
+    const { items: pythItems } = await buildPythBatchItemsFromFeeds(
       feeds,
       providerUrl,
       hermesEndpoint,
     )
 
-    // Build lens batch item
-    const lensCallData = encodeFunctionData({
-      abi: lensAbi as Abi,
-      functionName: lensMethod,
-      args: lensArgs,
-    })
     const lensBatchItem: BatchItem = {
       targetContract: lensAddress as `0x${string}`,
       onBehalfOfAccount: zeroAddress,
       value: 0n,
-      data: lensCallData as `0x${string}`,
+      data: encodeFunctionData({
+        abi: lensAbi as Abi,
+        functionName: lensMethod,
+        args: lensArgs,
+      }) as `0x${string}`,
     }
 
-    // Combine: Pyth updates first, then lens call
     const batchItems = [...pythItems, lensBatchItem]
 
-    // Execute batch simulation via low-level call
-    const client = getPublicClient(providerUrl)
-    const batchCallData = encodeFunctionData({
-      abi: EVC_ABI,
-      functionName: 'batchSimulation',
-      args: [batchItems],
-    })
-
-    const callResult = await client.call({
-      to: evcAddress as Address,
-      data: batchCallData,
-      value: totalFee,
-    })
-
-    if (!callResult.data) {
-      return undefined
-    }
-
-    const decoded = decodeFunctionResult({
-      abi: EVC_ABI,
-      functionName: 'batchSimulation',
-      data: callResult.data,
-    })
-
-    const batchResults = decoded[0] as unknown as BatchItemResult[]
-
-    // Validate and get the last result (lens call)
-    if (!batchResults || batchResults.length === 0) {
-      return undefined
-    }
+    const batchResults = await evcBatchCall(evcAddress, batchItems, providerUrl)
 
     const lensResult = batchResults[batchResults.length - 1]
-    if (!lensResult || !lensResult.success) {
+    if (!lensResult?.success) {
       return undefined
     }
 
-    // Decode the lens result
-    const decodedResult = decodeFunctionResult({
+    return decodeFunctionResult({
       abi: lensAbi as Abi,
       functionName: lensMethod,
       data: lensResult.result as Hex,
-    })
-    return decodedResult as T
+    }) as T
   }
   catch (err) {
-    console.warn('[executeLensWithPythSimulation] Error:', err)
+    logWarn('pyth/executeLensWithPythSimulation', err)
     return undefined
   }
+}
+
+/**
+ * Execute lens calls for multiple vaults in a single batchSimulation with Pyth updates.
+ * Combines all Pyth feed updates + all vault lens calls into one RPC request.
+ *
+ * @param vaultEntries - Array of { vaultAddress, feeds } for each vault to refresh
+ * @param lensAddress - Address of the lens contract
+ * @param lensAbi - ABI of the lens contract
+ * @param lensMethod - Method name to call on the lens (e.g. 'getVaultInfoFull')
+ * @param evcAddress - EVC contract address
+ * @param providerUrl - Provider URL for Pyth batch building and RPC calls
+ * @param hermesEndpoint - Pyth Hermes endpoint
+ * @param batchSize - Max lens calls per batchSimulation (default 25)
+ * @returns Map of vault address → decoded result (undefined for failed entries)
+ */
+export const executeBatchLensWithPythSimulation = async <T>(
+  vaultEntries: Array<{ vaultAddress: string, feeds: PythFeed[] }>,
+  lensAddress: Address,
+  lensAbi: Abi | readonly unknown[],
+  lensMethod: string,
+  evcAddress: string,
+  providerUrl: string,
+  hermesEndpoint: string,
+  batchSize = 25,
+): Promise<Map<string, T | undefined>> => {
+  const results = new Map<string, T | undefined>()
+
+  if (vaultEntries.length === 0) {
+    return results
+  }
+
+  try {
+    // Merge and deduplicate all Pyth feeds across all vaults
+    const uniqueFeeds = new Map<string, PythFeed>()
+    for (const entry of vaultEntries) {
+      for (const feed of entry.feeds) {
+        const key = `${feed.pythAddress.toLowerCase()}:${feed.feedId.toLowerCase()}`
+        if (!uniqueFeeds.has(key)) {
+          uniqueFeeds.set(key, feed)
+        }
+      }
+    }
+
+    // Build Pyth update items once (shared across all sub-batches)
+    const { items: pythItems } = await buildPythBatchItemsFromFeeds(
+      [...uniqueFeeds.values()],
+      providerUrl,
+      hermesEndpoint,
+    )
+
+    // Build lens items for each vault
+    const lensEntries = vaultEntries.map(entry => ({
+      vaultAddress: entry.vaultAddress,
+      item: {
+        targetContract: lensAddress as `0x${string}`,
+        onBehalfOfAccount: zeroAddress,
+        value: 0n,
+        data: encodeFunctionData({
+          abi: lensAbi as Abi,
+          functionName: lensMethod,
+          args: [entry.vaultAddress],
+        }) as `0x${string}`,
+      } satisfies BatchItem,
+    }))
+
+    // Split lens items into sub-batches, each prepended with full Pyth updates
+    const chunks: typeof lensEntries[] = []
+    for (let i = 0; i < lensEntries.length; i += batchSize) {
+      chunks.push(lensEntries.slice(i, i + batchSize))
+    }
+
+    const chunkResults = await Promise.all(
+      chunks.map(async (chunk) => {
+        const batchItems = [...pythItems, ...chunk.map(c => c.item)]
+
+        const batchResults = await evcBatchCall(evcAddress, batchItems, providerUrl)
+
+        return chunk.map((entry, i) => {
+          const lensResult = batchResults[pythItems.length + i]
+          if (!lensResult?.success) {
+            return { vaultAddress: entry.vaultAddress, result: undefined as T | undefined }
+          }
+
+          try {
+            const decoded = decodeFunctionResult({
+              abi: lensAbi as Abi,
+              functionName: lensMethod,
+              data: lensResult.result as Hex,
+            })
+            return { vaultAddress: entry.vaultAddress, result: decoded as T }
+          }
+          catch {
+            return { vaultAddress: entry.vaultAddress, result: undefined as T | undefined }
+          }
+        })
+      }),
+    )
+
+    for (const chunk of chunkResults) {
+      for (const entry of chunk) {
+        results.set(entry.vaultAddress, entry.result)
+      }
+    }
+  }
+  catch (err) {
+    logWarn('pyth/executeBatchLensWithPythSimulation', err)
+  }
+
+  return results
 }
 
 export const pythAbi = PYTH_ABI


### PR DESCRIPTION
## Summary

- **Batch Pyth vault re-fetches** into single `batchSimulation` call (~24 individual RPC calls → 1). New `executeBatchLensWithPythSimulation()` merges all Pyth feeds across vaults and executes all lens calls in one request.
- **Auto-derive `msg.value` and balance state override** in `evcBatchCall` from batch item values — no need for callers to calculate fees manually.
- **Remove `balanceOf` fallback storm** — when `tokenBalances` lens fails, use zero fallback instead of firing 200 individual `balanceOf` calls that worsen rate limiting.
- **Add periodic vault data refresh** via `refreshVaults()` using silent mode (no UI loading flash). Vault interest rates, supply/borrow totals, and prices now stay fresh.
- **Add securitize vault loading flags** (`isSecuritizeLoading`/`isSecuritizeUpdating`) for consistency with EVK/Earn, wired into explore pages.
- **Rename vault functions/flags** for consistency: `isEVKLoading`, `isEVKUpdating`, `updateEVKVaults`, etc.
- **Make `fetchEarnVaults` accept address array** for consistency with EVK/Securitize fetchers.
- Increase balance lens batch size from 200 to 250.
- Change polling interval from 30s to 60s.

## Test plan

- [ ] Initial load: verify vault data loads correctly across all pages (lend, borrow, explore, earn)
- [ ] Network tab: confirm ~5-7 RPC calls per load instead of ~30
- [ ] Wait 60s+: vault APYs and supply/borrow totals should update without page reload
- [ ] Switch chains: verify vault data reloads cleanly, no stale data from previous chain
- [ ] Simulate lens failure (e.g. disconnect network briefly): confirm no 200-call fallback storm, balances recover on next poll
- [ ] Pyth-enabled vaults: verify prices display correctly (not stale/zero)
- [ ] Explore page: loading spinner shows during initial load, not during background refresh