### PR TITLE
feat: add 11 intrinsic APY providers with unified server proxy

### DIFF
--- a/composables/useIntrinsicApy.ts
+++ b/composables/useIntrinsicApy.ts
@@ -5,6 +5,17 @@ import { createDefiLlamaProvider } from '~/services/intrinsicApy/defillamaProvid
 import { createPendleProvider } from '~/services/intrinsicApy/pendleProvider'
 import { createSecuritizeProvider } from '~/services/intrinsicApy/securitizeProvider'
 import { createStablewatchProvider } from '~/services/intrinsicApy/stablewatchProvider'
+import { createEtherfiProvider } from '~/services/intrinsicApy/etherfiProvider'
+import { createRenzoProvider } from '~/services/intrinsicApy/renzoProvider'
+import { createMidasProvider } from '~/services/intrinsicApy/midasProvider'
+import { createYoProvider } from '~/services/intrinsicApy/yoProvider'
+import { createSparkProvider } from '~/services/intrinsicApy/sparkProvider'
+import { createPufferProvider } from '~/services/intrinsicApy/pufferProvider'
+import { createTreehouseProvider } from '~/services/intrinsicApy/treehouseProvider'
+import { createOndoProvider } from '~/services/intrinsicApy/ondoProvider'
+import { createOpenEdenProvider } from '~/services/intrinsicApy/openEdenProvider'
+import { createBenqiProvider } from '~/services/intrinsicApy/benqiProvider'
+import { createAvantProvider } from '~/services/intrinsicApy/avantProvider'
 import { logWarn } from '~/utils/errorHandling'
 import { CACHE_TTL_5MIN_MS } from '~/entities/tuning-constants'
 
@@ -21,6 +32,17 @@ const providers: IntrinsicApyProvider[] = [
   createPendleProvider(intrinsicApySources),
   createSecuritizeProvider(intrinsicApySources),
   createStablewatchProvider(intrinsicApySources),
+  createEtherfiProvider(intrinsicApySources),
+  createRenzoProvider(intrinsicApySources),
+  createMidasProvider(intrinsicApySources),
+  createYoProvider(intrinsicApySources),
+  createSparkProvider(intrinsicApySources),
+  createPufferProvider(intrinsicApySources),
+  createTreehouseProvider(intrinsicApySources),
+  createOndoProvider(intrinsicApySources),
+  createOpenEdenProvider(intrinsicApySources),
+  createBenqiProvider(intrinsicApySources),
+  createAvantProvider(intrinsicApySources),
 ]
 
 const mergeResults = (allResults: IntrinsicApyResult[]): Record<string, IntrinsicApyInfo> => {

--- a/entities/custom.ts
+++ b/entities/custom.ts
@@ -7,31 +7,33 @@ export type IntrinsicApySourceConfig =
   | { provider: 'pendle', address: string, chainId: number, pendleMarket: string, crossChainSourceChainId?: number }
   | { provider: 'securitize', address: string, chainId: number, symbol: string, yieldField: 'nav_yield_30d' | 'distribution_yield' }
   | { provider: 'stablewatch', address: string, chainId: number }
+  | { provider: 'etherfi', address: string, chainId: number }
+  | { provider: 'renzo', address: string, chainId: number, renzoVariant: 'ezETH' | 'pzETH' }
+  | { provider: 'midas', address: string, chainId: number, midasKey: string }
+  | { provider: 'yo', address: string, chainId: number }
+  | { provider: 'spark', address: string, chainId: number }
+  | { provider: 'puffer', address: string, chainId: number }
+  | { provider: 'treehouse', address: string, chainId: number }
+  | { provider: 'ondo', address: string, chainId: number }
+  | { provider: 'openeden', address: string, chainId: number }
+  | { provider: 'benqi', address: string, chainId: number }
+  | { provider: 'avant', address: string, chainId: number }
 
 export const intrinsicApySources: readonly IntrinsicApySourceConfig[] = [
   // DefiLlama pools — Ethereum (1)
-  { provider: 'defillama', chainId: 1, address: '0x0022228a2cc5E7eF0274A7Baa600d44da5aB5776', poolId: '01e33a85-8bb6-4f30-a11b-7b2a8166e6b7' },
-  { provider: 'defillama', chainId: 1, address: '0x007115416AB6c266329a03B09a8aa39aC2eF7d9d', poolId: '37bdb634-87d4-4eca-8b73-343653bd9a25' },
-  { provider: 'defillama', chainId: 1, address: '0x030b69280892c888670EDCDCD8B69Fd8026A0BF3', poolId: '0ffd2dc2-72d2-449f-8cac-34a09ce6f323' },
-  { provider: 'defillama', chainId: 1, address: '0x04C154b66CB340F3Ae24111CC767e0184Ed00Cc6', poolId: 'acee1e4d-a73c-4e20-98f7-e87c13d446e4' },
   { provider: 'defillama', chainId: 1, address: '0x0655977FEb2f289A4aB78af67BAB0d17aAb84367', poolId: '5fd328af-4203-471b-bd16-1705c726d926' },
   { provider: 'defillama', chainId: 1, address: '0x09db87A538BD693E9d08544577d5cCfAA6373A48', poolId: '44dd4153-aa9f-4616-9a88-e6803c86b995' },
   { provider: 'defillama', chainId: 1, address: '0x0d86883FAf4FfD7aEb116390af37746F45b6f378', poolId: '9c4e675e-7615-4d60-90ef-03d58c66b476' },
   { provider: 'defillama', chainId: 1, address: '0x1202F5C7b4B9E47a1A484E8B270be34dbbC75055', poolId: '0aedb3f6-9298-49de-8bb0-2f611a4df784' },
   { provider: 'defillama', chainId: 1, address: '0x12b004719fb632f1E7c010c6F5D6009Fb4258442', poolId: 'fef01bce-008a-43b0-85f9-5377a56411c4' },
-  { provider: 'defillama', chainId: 1, address: '0x12fd502e2052CaFB41eccC5B596023d9978057d6', poolId: '69021e5e-7cae-4df4-915e-08a6b349f456' },
-  { provider: 'defillama', chainId: 1, address: '0x19Ebd191f7A24ECE672ba13A302212b5eF7F35cb', poolId: '7c43e890-cefc-48d1-bf80-203cdb7dfe4f' },
-  { provider: 'defillama', chainId: 1, address: '0x2a8c22E3b10036f3AEF5875d04f8441d4188b656', poolId: 'b50e0e37-2256-466b-9030-168c515a2ca4' },
   { provider: 'defillama', chainId: 1, address: '0x35D8949372D46B7a3D5A56006AE77B215fc69bC0', poolId: '55b0893b-1dbb-47fd-9912-5e439cd3d511' },
   { provider: 'defillama', chainId: 1, address: '0x3d7d6fdf07EE548B939A80edbc9B2256d0cdc003', poolId: '843be062-d836-43ef-9670-c78d6ecb60bf' },
   { provider: 'defillama', chainId: 1, address: '0x3eE841F47947FEFbE510366E4bbb49e145484195', poolId: '6258d8cc-e618-4165-9385-7775168369b2' },
   { provider: 'defillama', chainId: 1, address: '0x4956b52aE2fF65D74CA2d61207523288e4528f96', poolId: '2ad8497d-c855-4840-85ad-cdc536b92ced' },
-  { provider: 'defillama', chainId: 1, address: '0x5E8422345238F34275888049021821E8E08CAa1f', poolId: '77020688-e1f9-443c-9388-e51ace15cc32' },
   { provider: 'defillama', chainId: 1, address: '0x5fD13359Ba15A84B76f7F87568309040176167cd', poolId: '747c1d2a-c668-4682-b9f9-296708a3dd90' },
   { provider: 'defillama', chainId: 1, address: '0x657d9ABA1DBb59e53f9F3eCAA878447dCfC96dCb', poolId: 'e3c59895-d6ad-4634-b257-f599f1a1a4a0' },
   { provider: 'defillama', chainId: 1, address: '0x738d1115B90efa71AE468F1287fc864775e23a31', poolId: '402b0554-9525-40af-8703-3c59b0aa863c' },
   { provider: 'defillama', chainId: 1, address: '0x7a4EffD87C2f3C55CA251080b1343b605f327E3a', poolId: '747c1d2a-c668-4682-b9f9-296708a3dd90' },
-  { provider: 'defillama', chainId: 1, address: '0x7E586fBaF3084C0be7aB5C82C04FfD7592723153', poolId: '24b3096a-488d-4a61-afa6-e5e9be2ce4bf' },
   { provider: 'defillama', chainId: 1, address: '0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0', poolId: '747c1d2a-c668-4682-b9f9-296708a3dd90' },
   { provider: 'defillama', chainId: 1, address: '0x80ac24aA929eaF5013f6436cdA2a7ba190f5Cc0b', poolId: '43641cf5-a92e-416b-bce9-27113d3c0db6' },
   { provider: 'defillama', chainId: 1, address: '0x83F20F44975D03b1b09e64809B757c47f942BEeA', poolId: 'c8a24fee-ec00-4f38-86c0-9f6daebc4225' },
@@ -42,9 +44,7 @@ export const intrinsicApySources: readonly IntrinsicApySourceConfig[] = [
   { provider: 'defillama', chainId: 1, address: '0xA1290d69c65A6Fe4DF752f95823fae25cB99e5A7', poolId: '33c732f6-a78d-41da-af5b-ccd9fa5e52d5' },
   { provider: 'defillama', chainId: 1, address: '0xA35b1B31Ce002FBF2058D22F30f95D405200A15b', poolId: '90bfb3c2-5d35-4959-a275-ba5085b08aa3' },
   { provider: 'defillama', chainId: 1, address: '0xae78736Cd615f374D3085123A210448E74Fc6393', poolId: 'd4b3c522-6127-4b89-bedf-83641cdcd2eb' },
-  { provider: 'defillama', chainId: 1, address: '0xB33f4B9C6f0624EdeAE8881c97381837760D52CB', poolId: '104b3467-bba3-4923-851d-aa9e6ff47611' },
   { provider: 'defillama', chainId: 1, address: '0xb45ad160634c528Cc3D2926d9807104FA3157305', poolId: 'bf0f95c9-bc46-467d-9762-1d80ff50cd74' },
-  { provider: 'defillama', chainId: 1, address: '0xbB51E2a15A9158EBE2b0Ceb8678511e063AB7a55', poolId: 'd48e9c5a-7c28-4192-ab3d-795b5fbed7be' },
   { provider: 'defillama', chainId: 1, address: '0xBe9895146f7AF43049ca1c1AE358B0541Ea49704', poolId: '0f45d730-b279-4629-8e11-ccb5cc3038b4' },
   { provider: 'defillama', chainId: 1, address: '0xBEEF69Ac7870777598A04B2bd4771c71212E6aBc', poolId: '747c1d2a-c668-4682-b9f9-296708a3dd90' },
   { provider: 'defillama', chainId: 1, address: '0xC58D044404d8B14e953C115E67823784dEA53d8F', poolId: '8352355c-5ad7-45c5-aca2-628de224f8d8' },
@@ -54,7 +54,6 @@ export const intrinsicApySources: readonly IntrinsicApySourceConfig[] = [
   { provider: 'defillama', chainId: 1, address: '0xd5F7838F5C461fefF7FE49ea5ebaF7728bB0ADfa', poolId: 'b9f2f00a-ba96-4589-a171-dde979a23d87' },
   { provider: 'defillama', chainId: 1, address: '0xDBDC1Ef57537E34680B898E1FEBD3D68c7389bCB', poolId: '8fa2e60e-365a-41fc-8d50-fadde5041f94' },
   { provider: 'defillama', chainId: 1, address: '0xDcEe70654261AF21C44c093C300eD3Bb97b78192', poolId: '423681e3-4787-40ce-ae43-e9f67c5269b3' },
-  { provider: 'defillama', chainId: 1, address: '0xE2Fc85BfB48C4cF147921fBE110cf92Ef9f26F94', poolId: 'b7daea94-6378-4eeb-8d10-52beebadf77b' },
   { provider: 'defillama', chainId: 1, address: '0xE72B141DF173b999AE7c1aDcbF60Cc9833Ce56a8', poolId: '4e6cd326-72d5-4680-8d2f-3481d50e8bb1' },
   { provider: 'defillama', chainId: 1, address: '0xf1C9acDc66974dFB6dEcB12aA385b9cD01190E38', poolId: '4d01599c-69ae-41a3-bae1-5fab896f04c8' },
   { provider: 'defillama', chainId: 1, address: '0xf951E335afb289353dc249e82926178EaC7DEd78', poolId: 'ca2acc2d-6246-44aa-ae91-8725b2c62c7c' },
@@ -66,8 +65,17 @@ export const intrinsicApySources: readonly IntrinsicApySourceConfig[] = [
   { provider: 'defillama', chainId: 1, address: '0x7743e50F534a7f9F1791DdE7dCD89F7783Eefc39', poolId: 'ee0b7069-f8f3-4aa2-a415-728f13e6cc3d' },
   { provider: 'defillama', chainId: 1, address: '0x3db228fe836d99ccb25ec4dfdc80ed6d2cddcb4b', poolId: 'bc8b5474-015a-4af5-8d88-3b4b6155b56e' },
   { provider: 'defillama', chainId: 1, address: '0x01ba69727e2860b37bc1a2bd56999c1afb4c15d8', poolId: '21617aef-e012-49dd-bb8f-a624d8bcd469' },
+  { provider: 'defillama', chainId: 1, address: '0x9D39A5DE30e57443BfF2A8307A4256c8797A3497', poolId: '66985a81-9c51-46ca-9977-42b4fe7bc6df' },
+  { provider: 'defillama', chainId: 1, address: '0x007115416AB6c266329a03B09a8aa39aC2eF7d9d', poolId: '37bdb634-87d4-4eca-8b73-343653bd9a25' },
+  { provider: 'defillama', chainId: 1, address: '0x030b69280892c888670EDCDCD8B69Fd8026A0BF3', poolId: '0ffd2dc2-72d2-449f-8cac-34a09ce6f323' },
+  { provider: 'defillama', chainId: 1, address: '0x12fd502e2052CaFB41eccC5B596023d9978057d6', poolId: '69021e5e-7cae-4df4-915e-08a6b349f456' },
+  { provider: 'defillama', chainId: 1, address: '0x2a8c22E3b10036f3AEF5875d04f8441d4188b656', poolId: 'b50e0e37-2256-466b-9030-168c515a2ca4' },
+  { provider: 'defillama', chainId: 1, address: '0x7E586fBaF3084C0be7aB5C82C04FfD7592723153', poolId: '24b3096a-488d-4a61-afa6-e5e9be2ce4bf' },
+  { provider: 'defillama', chainId: 1, address: '0xE2Fc85BfB48C4cF147921fBE110cf92Ef9f26F94', poolId: 'b7daea94-6378-4eeb-8d10-52beebadf77b' },
+  { provider: 'defillama', chainId: 1, address: '0xbB51E2a15A9158EBE2b0Ceb8678511e063AB7a55', poolId: 'd48e9c5a-7c28-4192-ab3d-795b5fbed7be' },
 
   // DefiLlama pools — BSC (56)
+  { provider: 'defillama', chainId: 56, address: '0x211Cc4DD073734DA055fbF44a2b4667d5E5fE5d2', poolId: '66985a81-9c51-46ca-9977-42b4fe7bc6df' },
   { provider: 'defillama', chainId: 56, address: '0x32C830f5c34122C6afB8aE87ABA541B7900a2C5F', poolId: '89818a06-3414-4d9d-a8a6-7c8686a40d2a' },
 
   // DefiLlama pools — Unichain (130)
@@ -81,19 +89,16 @@ export const intrinsicApySources: readonly IntrinsicApySourceConfig[] = [
 
   // DefiLlama pools — Sonic (146)
   { provider: 'defillama', chainId: 146, address: '0x16af6b1315471Dc306D47e9CcEfEd6e5996285B6', poolId: '24b3096a-488d-4a61-afa6-e5e9be2ce4bf' },
-  { provider: 'defillama', chainId: 146, address: '0x4772D2e014F9fC3a820C444e3313968e9a5C8121', poolId: '7c43e890-cefc-48d1-bf80-203cdb7dfe4f' },
   { provider: 'defillama', chainId: 146, address: '0x6202B9f02E30E5e1c62Cc01E4305450E5d83b926', poolId: 'b7daea94-6378-4eeb-8d10-52beebadf77b' },
-  { provider: 'defillama', chainId: 146, address: '0x67A298e5B65dB2b4616E05C3b455E017275f53cB', poolId: '104b3467-bba3-4923-851d-aa9e6ff47611' },
   { provider: 'defillama', chainId: 146, address: '0xB88fF15ae5f82c791e637b27337909BcF8065270', poolId: '69021e5e-7cae-4df4-915e-08a6b349f456' },
-  { provider: 'defillama', chainId: 146, address: '0xE8a41c62BB4d5863C6eadC96792cFE90A1f37C47', poolId: '505e1ca5-9986-45e1-b013-ff6b902678fc' },
 
-  // DefiLlama pools — Ink (239)
+  // DefiLlama pools — TAC (239)
   { provider: 'defillama', chainId: 239, address: '0x1791BAff6a5e2F2A1340e8B7C1EA2B0c1E2DD1ea', poolId: '55b0893b-1dbb-47fd-9912-5e439cd3d511' },
-  { provider: 'defillama', chainId: 239, address: '0x4772D2e014F9fC3a820C444e3313968e9a5C8121', poolId: '7c43e890-cefc-48d1-bf80-203cdb7dfe4f' },
   { provider: 'defillama', chainId: 239, address: '0x5448BBf60Ee2edBCd32F032f3294982f4ad1119e', poolId: '33c732f6-a78d-41da-af5b-ccd9fa5e52d5' },
   { provider: 'defillama', chainId: 239, address: '0xAf368c91793CB22739386DFCbBb2F1A9e4bCBeBf', poolId: '747c1d2a-c668-4682-b9f9-296708a3dd90' },
 
   // DefiLlama pools — Swell (1923)
+  { provider: 'defillama', chainId: 1923, address: '0x211Cc4DD073734DA055fbF44a2b4667d5E5fE5d2', poolId: '66985a81-9c51-46ca-9977-42b4fe7bc6df' },
   { provider: 'defillama', chainId: 1923, address: '0x09341022ea237a4DB1644DE7CCf8FA0e489D85B7', poolId: 'ca2acc2d-6246-44aa-ae91-8725b2c62c7c' },
   { provider: 'defillama', chainId: 1923, address: '0x18d33689AE5d02649a859A1CF16c9f0563975258', poolId: 'eff9b43c-a80d-4bfc-9f9e-55e02a8ef619' },
   { provider: 'defillama', chainId: 1923, address: '0x7c98E0779EB5924b3ba8cE3B17648539ed5b0Ecc', poolId: '747c1d2a-c668-4682-b9f9-296708a3dd90' },
@@ -108,17 +113,13 @@ export const intrinsicApySources: readonly IntrinsicApySourceConfig[] = [
   { provider: 'defillama', chainId: 8453, address: '0xEDfa23602D0EC14714057867A78d01e94176BEA0', poolId: '33c732f6-a78d-41da-af5b-ccd9fa5e52d5' },
 
   // DefiLlama pools — Plasma (9745)
-  { provider: 'defillama', chainId: 9745, address: '0x2a52B289bA68bBd02676640aA9F605700c9e5699', poolId: '0aedb3f6-9298-49de-8bb0-2f611a4df784' },
-  { provider: 'defillama', chainId: 9745, address: '0x4772D2e014F9fC3a820C444e3313968e9a5C8121', poolId: '7c43e890-cefc-48d1-bf80-203cdb7dfe4f' },
-  { provider: 'defillama', chainId: 9745, address: '0x4809010926aec940b550D34a46A52739f996D75D', poolId: '402b0554-9525-40af-8703-3c59b0aa863c' },
   { provider: 'defillama', chainId: 9745, address: '0x6eAf19b2FC24552925dB245F9Ff613157a7dbb4C', poolId: 'b7daea94-6378-4eeb-8d10-52beebadf77b' },
+  { provider: 'defillama', chainId: 9745, address: '0x4809010926aec940b550D34a46A52739f996D75D', poolId: '402b0554-9525-40af-8703-3c59b0aa863c' },
   { provider: 'defillama', chainId: 9745, address: '0x9eCaf80c1303CCA8791aFBc0AD405c8a35e8d9f1', poolId: '33c732f6-a78d-41da-af5b-ccd9fa5e52d5' },
   { provider: 'defillama', chainId: 9745, address: '0xC4374775489CB9C56003BF2C9b12495fC64F0771', poolId: '8edfdf02-cdbb-43f7-bca6-954e5fe56813' },
   { provider: 'defillama', chainId: 9745, address: '0xe561FE05C39075312Aa9Bc6af79DdaE981461359', poolId: '33c732f6-a78d-41da-af5b-ccd9fa5e52d5' },
-  { provider: 'defillama', chainId: 9745, address: '0xF4F447E6AFa04c9D11Ef0e2fC0d7f19C24Ee55de', poolId: 'aba6b15d-8554-4b9b-9489-88b8d2035fc9' },
 
   // DefiLlama pools — Arbitrum (42161)
-  { provider: 'defillama', chainId: 42161, address: '0x004626A008B1aCdC4c74ab51644093b155e59A23', poolId: '789970a7-7ddd-4580-b86b-fe0c3844881e' },
   { provider: 'defillama', chainId: 42161, address: '0x211Cc4DD073734dA055fbF44a2b4667d5E5fE5d2', poolId: '66985a81-9c51-46ca-9977-42b4fe7bc6df' },
   { provider: 'defillama', chainId: 42161, address: '0x35E5dB674D8e93a03d814FA0ADa70731efe8a4b9', poolId: '2ad8497d-c855-4840-85ad-cdc536b92ced' },
   { provider: 'defillama', chainId: 42161, address: '0x4186BFC76E2E237523CBC30FD220FE055156b41F', poolId: '33c732f6-a78d-41da-af5b-ccd9fa5e52d5' },
@@ -129,22 +130,23 @@ export const intrinsicApySources: readonly IntrinsicApySourceConfig[] = [
   { provider: 'defillama', chainId: 42161, address: '0xEC70Dcb4A1EFa46b8F2D97C310C9c4790ba5ffA8', poolId: 'd4b3c522-6127-4b89-bedf-83641cdcd2eb' },
 
   // DefiLlama pools — Avalanche (43114)
+  { provider: 'defillama', chainId: 43114, address: '0x211Cc4DD073734DA055fbF44a2b4667d5E5fE5d2', poolId: '66985a81-9c51-46ca-9977-42b4fe7bc6df' },
   { provider: 'defillama', chainId: 43114, address: '0x7bFd4CA2a6Cf3A3fDDd645D10B323031afe47FF0', poolId: '33c732f6-a78d-41da-af5b-ccd9fa5e52d5' },
   { provider: 'defillama', chainId: 43114, address: '0xA25EaF2906FA1a3a13EdAc9B9657108Af7B703e3', poolId: '3efc0d84-53c6-4c6a-b1c3-c140502c7f26' },
 
   // DefiLlama pools — Linea (59144)
+  { provider: 'defillama', chainId: 59144, address: '0x211Cc4DD073734DA055fbF44a2b4667d5E5fE5d2', poolId: '66985a81-9c51-46ca-9977-42b4fe7bc6df' },
   { provider: 'defillama', chainId: 59144, address: '0x4809010926aec940b550D34a46A52739f996D75D', poolId: '402b0554-9525-40af-8703-3c59b0aa863c' },
-  { provider: 'defillama', chainId: 59144, address: '0x4e559dBCCbe87De66c6a9F3f25231096F24c2e28', poolId: '7c43e890-cefc-48d1-bf80-203cdb7dfe4f' },
   { provider: 'defillama', chainId: 59144, address: '0xB5beDd42000b71FddE22D3eE8a79Bd49A568fC8F', poolId: '747c1d2a-c668-4682-b9f9-296708a3dd90' },
   { provider: 'defillama', chainId: 59144, address: '0xD2671165570f41BBB3B0097893300b6EB6101E6C', poolId: '33c732f6-a78d-41da-af5b-ccd9fa5e52d5' },
 
   // DefiLlama pools — BOB (60808)
-  { provider: 'defillama', chainId: 60808, address: '0x4124CBBDE250a1a4bF94740491E79AB6a2eC0321', poolId: '77020688-e1f9-443c-9388-e51ace15cc32' },
   { provider: 'defillama', chainId: 60808, address: '0x85008aE6198BC91aC0735CB5497CF125ddAAc528', poolId: 'e28e32b5-e356-41d9-8dc7-a376ece56619' },
   { provider: 'defillama', chainId: 60808, address: '0x96147A9Ae9a42d7Da551fD2322ca15B71032F342', poolId: 'e28e32b5-e356-41d9-8dc7-a376ece56619' },
   { provider: 'defillama', chainId: 60808, address: '0xB5686c4f60904Ec2BDA6277d6FE1F7cAa8D1b41a', poolId: 'd4b3c522-6127-4b89-bedf-83641cdcd2eb' },
 
   // DefiLlama pools — Berachain (80094)
+  { provider: 'defillama', chainId: 80094, address: '0x211Cc4DD073734DA055fbF44a2b4667d5E5fE5d2', poolId: '66985a81-9c51-46ca-9977-42b4fe7bc6df' },
   { provider: 'defillama', chainId: 80094, address: '0x1d22592F66Fc92e0a64eE9300eAeca548cd466c5', poolId: '30dd2264-82da-40d1-b28d-87e94fc9c2e7' },
   { provider: 'defillama', chainId: 80094, address: '0x5475611Dffb8ef4d697Ae39df9395513b6E947d7', poolId: '402b0554-9525-40af-8703-3c59b0aa863c' },
   { provider: 'defillama', chainId: 80094, address: '0x69f1E971257419B1E9C405A553f252c64A29A30a', poolId: '9b8da01e-a2d6-427b-95ef-96df8de8d32f' },
@@ -159,21 +161,18 @@ export const intrinsicApySources: readonly IntrinsicApySourceConfig[] = [
   { provider: 'pendle', address: '0x5b1578E2604B91bd7b24F86F0E5EF6C024bB3a14', chainId: 1, pendleMarket: '0x7da97FbFAA3020f856C60EB4EF068079A9023Aca' }, // PT-hgETH-25JUN2026
   { provider: 'pendle', address: '0x928FB6ED39100a92B2480f5cbB93453f98D9F4cE', chainId: 1, pendleMarket: '0x9EaAedA23177B7168c55a3A0F937f67919733449' }, // PT-cUSD-23JUL2026
   { provider: 'pendle', address: '0x2d3C279E5FcDF5b793c0a75ed90738D7369B0b83', chainId: 1, pendleMarket: '0xaC24A6f0068d9701EAEa76AB0B418021017F8D59' }, // PT-stcUSD-23JUL2026
+  { provider: 'pendle', address: '0x3de0ff76E8b528C092d47b9DaC775931cef80F49', chainId: 1, pendleMarket: '0x8dAe8ECe668cf80d348873F23D456448E8694883' }, // PT-sUSDE-7MAY2026
 
   // Pendle PTs — Arbitrum (42161)
-  { provider: 'pendle', address: '0x5B2C615E22272234AACF187632a0531cA1243279', chainId: 42161, pendleMarket: '0x3308574370f19eA639f4671838e01Cfb77d8db70' }, // PT-USDai-19FEB2026
-  { provider: 'pendle', address: '0x1BF1311FCF914A69Dd5805C9B06b72F80539cB3f', chainId: 42161, pendleMarket: '0x2092Fa5d02276B3136A50F3C2C3a6Ed45413183E' }, // PT-sUSDai-19FEB2026
-  { provider: 'pendle', address: '0x9b3924f9652cabf3Db48B7B4C92E474c571B3Ab4', chainId: 42161, pendleMarket: '0xfAD63f0a2Ff618EdDE23561dfF212EDfeddBE89d' }, // PT-thBILL-19FEB2026
-
-  // Pendle PTs — Base (8453)
-  { provider: 'pendle', address: '0x0177055f7429D3bd6B19f2dd591127DB871A510e', chainId: 8453, pendleMarket: '0xA679ce6D07cbe579252F0f9742Fc73884b1c611c' }, // PT-yoUSD-26MAR2026
-  { provider: 'pendle', address: '0x1A5c5eA50717a2ea0e4F7036FB289349DEaAB58b', chainId: 8453, pendleMarket: '0x5d6E67FcE4aD099363D062815B784d281460C49b' }, // PT-yoETH-26MAR2026
+  { provider: 'pendle', address: '0x1cdDE40e29dA213f42a7fa109ccadca372d9ee1b', chainId: 42161, pendleMarket: '0x8A8A557b90eC79496a18a1f9C9DA8Bbd7DB86Fd3' }, // PT-USDai-18JUN2026
+  { provider: 'pendle', address: '0x07bc5bD6cE9A17f0e7aa91e0adbc9070dcb1d1de', chainId: 42161, pendleMarket: '0x299674F6Da858f903D77486FBA50Bc9F2e0Db24D' }, // PT-sUSDai-18JUN2026
+  { provider: 'pendle', address: '0xE46271ecb1d5c7c5134868760f10c18b03021ef1', chainId: 42161, pendleMarket: '0x22d95cEC2b962C142FfF9BE88CfC7eF15043419F' }, // PT-thBILL-18JUN2026
+  { provider: 'pendle', address: '0xC9d24aD0bB25f34098e226a8c5192dea7bacccae', chainId: 42161, pendleMarket: '0xA8a0DEA40174CfC30fEA9e3A77f182aB33f46E25' }, // PT-USDai-15OCT2026
+  { provider: 'pendle', address: '0xB459dB106f645d698e74027eef6019a26a0675cc', chainId: 42161, pendleMarket: '0xcbF629C8d396b1261F81F55175Afa010E94787d8' }, // PT-sUSDai-15OCT2026
 
   // Pendle PTs — Plasma (9745)
-  { provider: 'pendle', address: '0x48F119b3fCA8244274531f2e06B74AC4B1F5fe58', chainId: 9745, pendleMarket: '0x23280356de3a7aEc0B0710CD9b902AC8f431368C' }, // PT-RLP-26FEB2026
-  { provider: 'pendle', address: '0xFFaF49f320b8Ae1Bb9Ea596197040077a3666105', chainId: 9745, pendleMarket: '0x23180d15651FE6e4415ce27b212Cf8e5d2dEDa96' }, // PT-wstUSR-26FEB2026
-  { provider: 'pendle', address: '0xD516188daf64EFa04a8d60872F891f2cC811A561', chainId: 9745, pendleMarket: '0x15735f2F53c5cd25A57dFf83B11C93EcEaf72073' }, // PT-USDai-19MAR2026
-  { provider: 'pendle', address: '0xedac81b27790e0728f54dEa3B7718e5437E85353', chainId: 9745, pendleMarket: '0x0d7d9abEE602c7f0A242EA7e200e47C372aCba84' }, // PT-sUSDai-19MAR2026
+  { provider: 'pendle', address: '0xab509448ad489e2e1341e25cc500f2596464cc82', chainId: 9745, pendleMarket: '0x5Fa69163085efd4767f24639eB1fB87Ed34bBB12' }, // PT-sUSDE-9APR2026
+  { provider: 'pendle', address: '0x34C772F9B78590f5AB324be11d87885e36878eee', chainId: 9745, pendleMarket: '0x5F6b7F7105340Ce6e7c8844279f33776262B5180' }, // PT-syrupUSDT-30APR2026
 
   // Securitize tokens — Ethereum (1)
   { provider: 'securitize', chainId: 1, address: '0x17418038ecF73BA4026c4f428547BF099706F27B', symbol: 'ACRED', yieldField: 'nav_yield_30d' },
@@ -182,26 +181,20 @@ export const intrinsicApySources: readonly IntrinsicApySourceConfig[] = [
 
   // Stablewatch tokens — Ethereum (1)
   { provider: 'stablewatch', chainId: 1, address: '0x89E93172AEF8261Db8437b90c3dCb61545a05317' },
-  { provider: 'stablewatch', chainId: 1, address: '0x1CE7D9942ff78c328A4181b9F3826fEE6D845A97' },
-  { provider: 'stablewatch', chainId: 1, address: '0x0aBd93dA8387B5Ef0511a2859d85D84fe4519e94' },
-
-  // Stablewatch tokens — BSC (56)
-  { provider: 'stablewatch', chainId: 56, address: '0x7788A3538C5fc7F9c7C8A74EAC4c898fC8d87d92' },
 
   // Stablewatch tokens — Sonic (146)
   { provider: 'stablewatch', chainId: 146, address: '0x3D75F2BB8aBcDBd1e27443cB5CBCE8A668046C81' },
   { provider: 'stablewatch', chainId: 146, address: '0x9fb76f7ce5FCeAA2C42887ff441D46095E494206' },
 
   // Stablewatch tokens — TAC (239)
-  { provider: 'stablewatch', chainId: 239, address: '0x2a52B289bA68bBd02676640aA9F605700c9e5699' },
   { provider: 'stablewatch', chainId: 239, address: '0x35533f54740F1F1aA4179E57bA37039dfa16868B' },
   { provider: 'stablewatch', chainId: 239, address: '0x5Ced7F73B76A555CCB372cc0F0137bEc5665F81E' },
 
   // Stablewatch tokens — Plasma (9745)
+  { provider: 'stablewatch', chainId: 9745, address: '0x2a52B289bA68bBd02676640aA9F605700c9e5699' },
   { provider: 'stablewatch', chainId: 9745, address: '0x211Cc4DD073734dA055fbF44a2b4667d5E5fE5d2' },
   { provider: 'stablewatch', chainId: 9745, address: '0x0B2b2B2076d95dda7817e785989fE353fe955ef9' },
   { provider: 'stablewatch', chainId: 9745, address: '0x35533f54740F1F1aA4179E57bA37039dfa16868B' },
-  { provider: 'stablewatch', chainId: 9745, address: '0x616185600989Bf8339b58aC9e539d49536598343' },
   { provider: 'stablewatch', chainId: 9745, address: '0xC8A8DF9B210243c55D31c73090F06787aD0A1Bf6' },
   { provider: 'stablewatch', chainId: 9745, address: '0xEbFC8C2Fe73C431Ef2A371AeA9132110aaB50DCa' },
   { provider: 'stablewatch', chainId: 9745, address: '0xfDD22Ce6D1F66bc0Ec89b20BF16CcB6670F55A5a' },
@@ -209,5 +202,67 @@ export const intrinsicApySources: readonly IntrinsicApySourceConfig[] = [
   // Stablewatch tokens — Arbitrum (42161)
   { provider: 'stablewatch', chainId: 42161, address: '0xfDD22Ce6D1F66bc0Ec89b20BF16CcB6670F55A5a' },
   { provider: 'stablewatch', chainId: 42161, address: '0x0B2b2B2076d95dda7817e785989fE353fe955ef9' },
-  { provider: 'stablewatch', chainId: 42161, address: '0x62dDf301B21970e7Cc12c34cAAc9CE9bC975c0a9' },
+
+  // Ether.fi — weETH
+  { provider: 'etherfi', chainId: 1, address: '0xCd5fE23C85820F7B72D0926FC9b05b43E359b7ee' },
+  { provider: 'etherfi', chainId: 130, address: '0x7DCC39B4d1C53CB31e1aBc0e358b43987FEF80f7' },
+  { provider: 'etherfi', chainId: 1923, address: '0xA6cB988942610f6731e664379D15fFcfBf282b44' },
+  { provider: 'etherfi', chainId: 8453, address: '0x04C0599Ae5A44757c0af6F9eC3b93da8976c150A' },
+  { provider: 'etherfi', chainId: 9745, address: '0xA3D68b74bF0528fdD07263c60d6488749044914b' },
+  { provider: 'etherfi', chainId: 42161, address: '0x35751007a407ca6FEFfE80b3cB397736D2cf4dbe' },
+  { provider: 'etherfi', chainId: 43114, address: '0xA3D68b74bF0528fdD07263c60d6488749044914b' },
+  { provider: 'etherfi', chainId: 59144, address: '0x1Bf74C010E6320bab11e2e5A532b5AC15e0b8aA6' },
+
+  // Renzo — ezETH / pzETH
+  { provider: 'renzo', chainId: 1, address: '0xbf5495Efe5DB9ce00f80364C8B423567e58d2110', renzoVariant: 'ezETH' },
+  { provider: 'renzo', chainId: 1, address: '0x8c9532a60E0E7C6BbD2B2c1303F63aCE1c3E9811', renzoVariant: 'pzETH' },
+  { provider: 'renzo', chainId: 130, address: '0x2416092f143378750bb29b79eD961ab195CcEea5', renzoVariant: 'ezETH' },
+  { provider: 'renzo', chainId: 1923, address: '0x2416092f143378750bb29b79eD961ab195CcEea5', renzoVariant: 'ezETH' },
+  { provider: 'renzo', chainId: 1923, address: '0x9cb41CD74D01ae4b4f640EC40f7A60cA1bCF83E7', renzoVariant: 'pzETH' },
+  { provider: 'renzo', chainId: 8453, address: '0x2416092f143378750bb29b79eD961ab195CcEea5', renzoVariant: 'ezETH' },
+  { provider: 'renzo', chainId: 42161, address: '0x2416092f143378750bb29b79eD961ab195CcEea5', renzoVariant: 'ezETH' },
+  { provider: 'renzo', chainId: 59144, address: '0x2416092f143378750bb29b79eD961ab195CcEea5', renzoVariant: 'ezETH' },
+
+  // Midas — mTBILL, mRe7, mHYPER, mAPOLLO, mFONE, mevBTC
+  { provider: 'midas', chainId: 1, address: '0xDD629E5241CbC5919847783e6C96B2De4754e438', midasKey: 'mtbill' },
+  { provider: 'midas', chainId: 1, address: '0x87C9053C819bB28e0D73d33059E1b3DA80AFb0cf', midasKey: 'mre7' },
+  { provider: 'midas', chainId: 1, address: '0x9b5528528656DBC094765E2abB79F293c21191B9', midasKey: 'mhyper' },
+  { provider: 'midas', chainId: 1, address: '0x7CF9DEC92ca9FD46f8d86e7798B72624Bc116C05', midasKey: 'mapollo' },
+  { provider: 'midas', chainId: 1, address: '0x238a700eD6165261Cf8b2e544ba797BC11e466Ba', midasKey: 'mfone' },
+  { provider: 'midas', chainId: 1, address: '0xb64C014307622eB15046C66fF71D04258F5963DC', midasKey: 'mevbtc' },
+  { provider: 'midas', chainId: 9745, address: '0xb31BeA5c2a43f942a3800558B1aa25978da75F8a', midasKey: 'mhyper' },
+
+  // YO — yoUSD, yoETH, yoBTC
+  { provider: 'yo', chainId: 1, address: '0x0000000f2eB9f69274678c76222B35eEc7588a65' },
+  { provider: 'yo', chainId: 1, address: '0x3A43AEC53490CB9Fa922847385D82fe25d0E9De7' },
+  { provider: 'yo', chainId: 1, address: '0xbCbc8cb4D1e8ED048a6276a5E94A3e952660BcbC' },
+  { provider: 'yo', chainId: 8453, address: '0x0000000f2eB9f69274678c76222B35eEc7588a65' },
+  { provider: 'yo', chainId: 8453, address: '0x3A43AEC53490CB9Fa922847385D82fe25d0E9De7' },
+  { provider: 'yo', chainId: 8453, address: '0xbCbc8cb4D1e8ED048a6276a5E94A3e952660BcbC' },
+
+  // Spark — sUSDS / sUSDC
+  { provider: 'spark', chainId: 1, address: '0xa3931d71877C0E7a3148CB7Eb4463524FEc27fbD' },
+  { provider: 'spark', chainId: 130, address: '0x14d9143BEcC348920b68D123687045db49a016C6' },
+  { provider: 'spark', chainId: 8453, address: '0x5875eEE11Cf8398102FdAd704C9E96607675467a' },
+  { provider: 'spark', chainId: 42161, address: '0x940098b108fB7D0a7E374f6eDED7760787464609' },
+
+  // Puffer — pufETH / xPufETH
+  { provider: 'puffer', chainId: 1, address: '0xD7D2802f6b19843ac4DfE25022771FD83b5A7464' },
+  { provider: 'puffer', chainId: 1, address: '0xD9A442856C234a39a81a089C06451EBAa4306a72' },
+
+  // Treehouse — tETH
+  { provider: 'treehouse', chainId: 1, address: '0xD11c452fc99cF405034ee446803b6F6c1F6d5ED8' },
+  { provider: 'treehouse', chainId: 42161, address: '0xd09ACb80C1E8f2291862c4978A008791c9167003' },
+
+  // Ondo — USDY
+  { provider: 'ondo', chainId: 1, address: '0x96F6eF951840721AdBF46Ac996b59E0235CB985C' },
+
+  // OpenEden — cUSDO
+  { provider: 'openeden', chainId: 1, address: '0xaD55aebc9b8c03FC43cd9f62260391c13c23e7c0' },
+
+  // Benqi — sAVAX
+  { provider: 'benqi', chainId: 43114, address: '0x2b2C81e08f1Af8835a78Bb2A90AE924ACE0eA4bE' },
+
+  // Avant — savUSD
+  { provider: 'avant', chainId: 43114, address: '0x06d47F3fb376649c3A9Dafe069B3D6E35572219E' },
 ]

--- a/server/api/intrinsic-apy/[provider].get.ts
+++ b/server/api/intrinsic-apy/[provider].get.ts
@@ -1,0 +1,119 @@
+import { createError, getRouterParam, getQuery } from 'h3'
+import { createRateLimiter } from '~/server/utils/rate-limit'
+
+const TIMEOUT_MS = 10_000
+const CACHE_TTL_MS = 5 * 60 * 1000
+
+const rateLimiter = createRateLimiter({
+  max: 200,
+  windowMs: 60_000,
+  label: 'intrinsic-apy-proxy',
+})
+
+const PROVIDER_URLS: Record<string, string> = {
+  defillama: 'https://yields.llama.fi/pools',
+  etherfi: 'https://app.ether.fi/api/protocol/protocol-detail',
+  puffer: 'https://api-v2.puffer.fi/backend-for-frontend/tvl/all',
+  treehouse: 'https://api.treehouse.finance/apy',
+  spark: 'https://info-sky.blockanalitica.com/api/v1/overall/?format=json',
+  openeden: 'https://prod-gw.openeden.com/sys/apy',
+  benqi: 'https://api.benqi.fi/liquidstaking/apr',
+  avant: 'https://app.avantprotocol.com/api/savusdApy',
+  ondo: 'https://ondo.finance/api/v1/assets',
+  renzo: 'https://app.renzoprotocol.com/api/stats',
+  midas: 'https://api-prod.midas.app/api/data/apys',
+  yo: 'https://api.yo.xyz/api/v1/vault/stats',
+  securitize: 'https://public-feed.securitize.io/asset-stats',
+}
+
+const PENDLE_API_BASE = 'https://api-v2.pendle.finance/core/v2'
+
+interface CacheEntry {
+  data: unknown
+  expiresAt: number
+}
+
+const cache = new Map<string, CacheEntry>()
+
+const getCached = (key: string): unknown | undefined => {
+  const entry = cache.get(key)
+  if (!entry) return undefined
+  if (Date.now() > entry.expiresAt) {
+    cache.delete(key)
+    return undefined
+  }
+  return entry.data
+}
+
+const setCache = (key: string, data: unknown) => {
+  cache.set(key, { data, expiresAt: Date.now() + CACHE_TTL_MS })
+}
+
+export default defineEventHandler(async (event) => {
+  rateLimiter.consume(event)
+
+  const provider = getRouterParam(event, 'provider')
+  if (!provider) {
+    throw createError({ statusCode: 400, statusMessage: 'Missing provider' })
+  }
+
+  const query = getQuery(event)
+
+  let url: string
+  let cacheKey: string
+
+  if (provider === 'pendle') {
+    const chainId = query.chainId as string
+    const market = query.market as string
+    if (!chainId || !market || !/^0x[a-fA-F0-9]{40}$/.test(market)) {
+      throw createError({ statusCode: 400, statusMessage: 'Invalid pendle params' })
+    }
+    url = `${PENDLE_API_BASE}/${chainId}/markets/${market}/data`
+    cacheKey = `pendle:${chainId}:${market.toLowerCase()}`
+  }
+  else if (provider === 'securitize') {
+    const symbol = query.symbol as string
+    if (!symbol) {
+      throw createError({ statusCode: 400, statusMessage: 'Missing symbol param' })
+    }
+    url = `${PROVIDER_URLS.securitize}?symbol=${encodeURIComponent(symbol)}`
+    cacheKey = `securitize:${symbol}`
+  }
+  else {
+    const baseUrl = PROVIDER_URLS[provider]
+    if (!baseUrl) {
+      throw createError({ statusCode: 404, statusMessage: 'Unknown provider' })
+    }
+    url = baseUrl
+    cacheKey = provider
+  }
+
+  const cached = getCached(cacheKey)
+  if (cached !== undefined) return cached
+
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS)
+
+  try {
+    const resp = await fetch(url, { signal: controller.signal })
+
+    if (!resp.ok) {
+      throw createError({ statusCode: 502, statusMessage: `Upstream ${provider} returned ${resp.status}` })
+    }
+
+    const data = await resp.json()
+    setCache(cacheKey, data)
+    return data
+  }
+  catch (error) {
+    if (error && typeof error === 'object' && 'statusCode' in error) {
+      throw error
+    }
+    const message = error instanceof Error ? error.message : 'Unknown error'
+    console.warn(`[intrinsic-apy/${provider}] error:`, message)
+    throw createError({ statusCode: 502, statusMessage: 'Upstream error' })
+  }
+  finally {
+    clearTimeout(timeout)
+  }
+})

--- a/server/api/intrinsic-apy/[provider].get.ts
+++ b/server/api/intrinsic-apy/[provider].get.ts
@@ -33,7 +33,15 @@ interface CacheEntry {
   expiresAt: number
 }
 
+const MAX_CACHE_ENTRIES = 200
 const cache = new Map<string, CacheEntry>()
+
+const pruneExpired = () => {
+  const now = Date.now()
+  for (const [key, entry] of cache) {
+    if (now > entry.expiresAt) cache.delete(key)
+  }
+}
 
 const getCached = (key: string): unknown | undefined => {
   const entry = cache.get(key)
@@ -46,6 +54,11 @@ const getCached = (key: string): unknown | undefined => {
 }
 
 const setCache = (key: string, data: unknown) => {
+  if (cache.size >= MAX_CACHE_ENTRIES) pruneExpired()
+  if (cache.size >= MAX_CACHE_ENTRIES) {
+    const oldest = cache.keys().next().value
+    if (oldest) cache.delete(oldest)
+  }
   cache.set(key, { data, expiresAt: Date.now() + CACHE_TTL_MS })
 }
 

--- a/server/api/intrinsic-apy/[provider].get.ts
+++ b/server/api/intrinsic-apy/[provider].get.ts
@@ -85,12 +85,13 @@ export default defineEventHandler(async (event) => {
     cacheKey = `pendle:${chainId}:${market.toLowerCase()}`
   }
   else if (provider === 'securitize') {
-    const symbol = query.symbol as string
+    const symbol = typeof query.symbol === 'string' ? query.symbol.trim() : undefined
     if (!symbol) {
       throw createError({ statusCode: 400, statusMessage: 'Missing symbol param' })
     }
-    url = `${PROVIDER_URLS.securitize}?symbol=${encodeURIComponent(symbol)}`
-    cacheKey = `securitize:${symbol}`
+    const normalizedSymbol = symbol.toUpperCase()
+    url = `${PROVIDER_URLS.securitize}?symbol=${encodeURIComponent(normalizedSymbol)}`
+    cacheKey = `securitize:${normalizedSymbol}`
   }
   else {
     const baseUrl = PROVIDER_URLS[provider]

--- a/server/api/intrinsic-apy/[provider].get.ts
+++ b/server/api/intrinsic-apy/[provider].get.ts
@@ -76,9 +76,9 @@ export default defineEventHandler(async (event) => {
   let cacheKey: string
 
   if (provider === 'pendle') {
-    const chainId = query.chainId as string
-    const market = query.market as string
-    if (!chainId || !market || !/^0x[a-fA-F0-9]{40}$/.test(market)) {
+    const chainId = typeof query.chainId === 'string' ? query.chainId : undefined
+    const market = typeof query.market === 'string' ? query.market : undefined
+    if (!chainId || !/^\d+$/.test(chainId) || !market || !/^0x[a-fA-F0-9]{40}$/.test(market)) {
       throw createError({ statusCode: 400, statusMessage: 'Invalid pendle params' })
     }
     url = `${PENDLE_API_BASE}/${chainId}/markets/${market}/data`

--- a/server/plugins/csp.ts
+++ b/server/plugins/csp.ts
@@ -114,9 +114,6 @@ const CONNECT_SRC_BASE = [
   'https://cca-lite.coinbase.com',
   // External data APIs
   'https://api.fuul.xyz',
-  'https://yields.llama.fi',
-  'https://api-v2.pendle.finance',
-  'https://public-feed.securitize.io',
   // Reown AppKit SDK version check
   'https://registry.npmjs.org',
   // RPC providers (wildcard — operators configure per chain)

--- a/services/intrinsicApy/avantProvider.ts
+++ b/services/intrinsicApy/avantProvider.ts
@@ -1,0 +1,11 @@
+import { createSimpleProvider } from './createSimpleProvider'
+import type { IntrinsicApySourceConfig } from '~/entities/custom'
+import type { IntrinsicApyProvider } from '~/entities/intrinsic-apy'
+
+export const createAvantProvider = (sources: readonly IntrinsicApySourceConfig[]): IntrinsicApyProvider =>
+  createSimpleProvider({
+    providerName: 'Avant',
+    providerKey: 'avant',
+    extractApy: data => Number((data as { savusdApy?: number }).savusdApy ?? 0),
+    sourceUrl: 'https://avantprotocol.com',
+  }, sources)

--- a/services/intrinsicApy/benqiProvider.ts
+++ b/services/intrinsicApy/benqiProvider.ts
@@ -1,0 +1,11 @@
+import { createSimpleProvider } from './createSimpleProvider'
+import type { IntrinsicApySourceConfig } from '~/entities/custom'
+import type { IntrinsicApyProvider } from '~/entities/intrinsic-apy'
+
+export const createBenqiProvider = (sources: readonly IntrinsicApySourceConfig[]): IntrinsicApyProvider =>
+  createSimpleProvider({
+    providerName: 'Benqi',
+    providerKey: 'benqi',
+    extractApy: data => Number((data as { apr?: number }).apr ?? 0) * 100,
+    sourceUrl: 'https://benqi.fi',
+  }, sources)

--- a/services/intrinsicApy/createSimpleProvider.ts
+++ b/services/intrinsicApy/createSimpleProvider.ts
@@ -1,0 +1,41 @@
+import type { IntrinsicApySourceConfig } from '~/entities/custom'
+import type { IntrinsicApyProvider, IntrinsicApyResult } from '~/entities/intrinsic-apy'
+
+interface SimpleProviderConfig {
+  readonly providerName: string
+  readonly providerKey: string
+  readonly extractApy: (data: unknown) => number
+  readonly sourceUrl?: string
+}
+
+const normalize = (value?: string) => value?.toLowerCase() || ''
+
+export const createSimpleProvider = (
+  config: SimpleProviderConfig,
+  sources: readonly IntrinsicApySourceConfig[],
+): IntrinsicApyProvider => {
+  const filtered = sources.filter(s => s.provider === config.providerKey)
+
+  return {
+    name: config.providerName,
+
+    async fetch(chainId: number): Promise<IntrinsicApyResult[]> {
+      const chainSources = filtered.filter(s => s.chainId === chainId)
+      if (!chainSources.length) return []
+
+      const data = await $fetch(`/api/intrinsic-apy/${config.providerKey}`)
+      const apy = config.extractApy(data)
+
+      if (!Number.isFinite(apy) || apy <= 0) return []
+
+      return chainSources.map(source => ({
+        address: normalize(source.address),
+        info: {
+          apy,
+          provider: config.providerName,
+          ...(config.sourceUrl && { source: config.sourceUrl }),
+        },
+      }))
+    },
+  }
+}

--- a/services/intrinsicApy/defillamaProvider.ts
+++ b/services/intrinsicApy/defillamaProvider.ts
@@ -1,5 +1,3 @@
-import axios from 'axios'
-import { DEFILLAMA_YIELDS_URL } from '~/entities/constants'
 import type { IntrinsicApySourceConfig } from '~/entities/custom'
 import type { IntrinsicApyProvider, IntrinsicApyResult } from '~/entities/intrinsic-apy'
 
@@ -32,8 +30,8 @@ export const createDefiLlamaProvider = (sources: readonly IntrinsicApySourceConf
       const chainSources = defillamaSources.filter(s => s.chainId === chainId)
       if (chainSources.length === 0) return []
 
-      const res = await axios.get(DEFILLAMA_YIELDS_URL)
-      const rawPools = (res.data?.data || []) as DefiLlamaPool[]
+      const res = await $fetch<{ data?: DefiLlamaPool[] }>('/api/intrinsic-apy/defillama')
+      const rawPools = (res?.data || []) as DefiLlamaPool[]
 
       const poolsById = new Map<string, DefiLlamaPool>()
       for (const pool of rawPools) {

--- a/services/intrinsicApy/etherfiProvider.ts
+++ b/services/intrinsicApy/etherfiProvider.ts
@@ -1,0 +1,14 @@
+import { createSimpleProvider } from './createSimpleProvider'
+import type { IntrinsicApySourceConfig } from '~/entities/custom'
+import type { IntrinsicApyProvider } from '~/entities/intrinsic-apy'
+
+export const createEtherfiProvider = (sources: readonly IntrinsicApySourceConfig[]): IntrinsicApyProvider =>
+  createSimpleProvider({
+    providerName: 'Ether.fi',
+    providerKey: 'etherfi',
+    extractApy: (data) => {
+      const d = data as { '7_day_apr'?: number, '7_day_restaking_apr'?: number }
+      return ((d['7_day_apr'] ?? 0) / 0.9) + (d['7_day_restaking_apr'] ?? 0)
+    },
+    sourceUrl: 'https://app.ether.fi',
+  }, sources)

--- a/services/intrinsicApy/midasProvider.ts
+++ b/services/intrinsicApy/midasProvider.ts
@@ -1,0 +1,34 @@
+import type { IntrinsicApySourceConfig } from '~/entities/custom'
+import type { IntrinsicApyProvider, IntrinsicApyResult } from '~/entities/intrinsic-apy'
+
+type MidasSource = Extract<IntrinsicApySourceConfig, { provider: 'midas' }>
+
+const normalize = (value?: string) => value?.toLowerCase() || ''
+
+export const createMidasProvider = (sources: readonly IntrinsicApySourceConfig[]): IntrinsicApyProvider => {
+  const midasSources = sources.filter(
+    (s): s is MidasSource => s.provider === 'midas',
+  )
+
+  return {
+    name: 'Midas',
+
+    async fetch(chainId: number): Promise<IntrinsicApyResult[]> {
+      const chainSources = midasSources.filter(s => s.chainId === chainId)
+      if (!chainSources.length) return []
+
+      const data = await $fetch<Record<string, number>>('/api/intrinsic-apy/midas')
+
+      return chainSources
+        .filter(source => data[source.midasKey] !== undefined)
+        .map(source => ({
+          address: normalize(source.address),
+          info: {
+            apy: Number(data[source.midasKey]) * 100,
+            provider: 'Midas',
+            source: 'https://midas.app',
+          },
+        }))
+    },
+  }
+}

--- a/services/intrinsicApy/ondoProvider.ts
+++ b/services/intrinsicApy/ondoProvider.ts
@@ -1,0 +1,15 @@
+import { createSimpleProvider } from './createSimpleProvider'
+import type { IntrinsicApySourceConfig } from '~/entities/custom'
+import type { IntrinsicApyProvider } from '~/entities/intrinsic-apy'
+
+export const createOndoProvider = (sources: readonly IntrinsicApySourceConfig[]): IntrinsicApyProvider =>
+  createSimpleProvider({
+    providerName: 'Ondo',
+    providerKey: 'ondo',
+    extractApy: (data) => {
+      const assets = (data as { assets?: Array<{ symbol?: string, apy?: number }> }).assets ?? []
+      const usdy = assets.find(a => a.symbol?.toLowerCase() === 'usdy')
+      return Number(usdy?.apy ?? 0)
+    },
+    sourceUrl: 'https://ondo.finance',
+  }, sources)

--- a/services/intrinsicApy/openEdenProvider.ts
+++ b/services/intrinsicApy/openEdenProvider.ts
@@ -1,0 +1,11 @@
+import { createSimpleProvider } from './createSimpleProvider'
+import type { IntrinsicApySourceConfig } from '~/entities/custom'
+import type { IntrinsicApyProvider } from '~/entities/intrinsic-apy'
+
+export const createOpenEdenProvider = (sources: readonly IntrinsicApySourceConfig[]): IntrinsicApyProvider =>
+  createSimpleProvider({
+    providerName: 'OpenEden',
+    providerKey: 'openeden',
+    extractApy: data => Number((data as { apy?: number }).apy ?? 0),
+    sourceUrl: 'https://openeden.com',
+  }, sources)

--- a/services/intrinsicApy/pendleProvider.ts
+++ b/services/intrinsicApy/pendleProvider.ts
@@ -1,8 +1,6 @@
-import axios from 'axios'
 import type { IntrinsicApySourceConfig } from '~/entities/custom'
 import type { IntrinsicApyProvider, IntrinsicApyResult } from '~/entities/intrinsic-apy'
 
-const PENDLE_API_BASE = 'https://api-v2.pendle.finance/core/v2'
 const CONCURRENCY = 10
 const MATURITY_STALE_THRESHOLD_MS = 2 * 60 * 60 * 1000
 
@@ -27,9 +25,9 @@ const fetchMarketData = async (
   const apiChainId = source.crossChainSourceChainId ?? source.chainId
 
   try {
-    const url = `${PENDLE_API_BASE}/${apiChainId}/markets/${source.pendleMarket}/data`
-    const res = await axios.get<PendleMarketData>(url, { timeout: 10_000 })
-    const data = res.data
+    const data = await $fetch<PendleMarketData>('/api/intrinsic-apy/pendle', {
+      query: { chainId: apiChainId, market: source.pendleMarket },
+    })
 
     if (!data || isMatured(data.timestamp)) {
       return {

--- a/services/intrinsicApy/pufferProvider.ts
+++ b/services/intrinsicApy/pufferProvider.ts
@@ -1,0 +1,11 @@
+import { createSimpleProvider } from './createSimpleProvider'
+import type { IntrinsicApySourceConfig } from '~/entities/custom'
+import type { IntrinsicApyProvider } from '~/entities/intrinsic-apy'
+
+export const createPufferProvider = (sources: readonly IntrinsicApySourceConfig[]): IntrinsicApyProvider =>
+  createSimpleProvider({
+    providerName: 'Puffer',
+    providerKey: 'puffer',
+    extractApy: data => Number((data as { apy?: number }).apy ?? 0),
+    sourceUrl: 'https://www.puffer.fi',
+  }, sources)

--- a/services/intrinsicApy/renzoProvider.ts
+++ b/services/intrinsicApy/renzoProvider.ts
@@ -1,0 +1,44 @@
+import type { IntrinsicApySourceConfig } from '~/entities/custom'
+import type { IntrinsicApyProvider, IntrinsicApyResult } from '~/entities/intrinsic-apy'
+
+type RenzoSource = Extract<IntrinsicApySourceConfig, { provider: 'renzo' }>
+
+type RenzoStatsResponse = {
+  data?: {
+    apr?: {
+      data?: { rate?: number }
+      pzETHAPR?: { rate?: number }
+    }
+  }
+}
+
+const normalize = (value?: string) => value?.toLowerCase() || ''
+
+export const createRenzoProvider = (sources: readonly IntrinsicApySourceConfig[]): IntrinsicApyProvider => {
+  const renzoSources = sources.filter(
+    (s): s is RenzoSource => s.provider === 'renzo',
+  )
+
+  return {
+    name: 'Renzo',
+
+    async fetch(chainId: number): Promise<IntrinsicApyResult[]> {
+      const chainSources = renzoSources.filter(s => s.chainId === chainId)
+      if (!chainSources.length) return []
+
+      const data = await $fetch<RenzoStatsResponse>('/api/intrinsic-apy/renzo')
+      const apr = data?.data?.apr
+
+      return chainSources.map(source => ({
+        address: normalize(source.address),
+        info: {
+          apy: source.renzoVariant === 'pzETH'
+            ? Number(apr?.pzETHAPR?.rate ?? 0)
+            : Number(apr?.data?.rate ?? 0),
+          provider: 'Renzo',
+          source: 'https://app.renzoprotocol.com',
+        },
+      }))
+    },
+  }
+}

--- a/services/intrinsicApy/securitizeProvider.ts
+++ b/services/intrinsicApy/securitizeProvider.ts
@@ -1,5 +1,3 @@
-import axios from 'axios'
-import { SECURITIZE_FEED_URL } from '~/entities/constants'
 import type { IntrinsicApySourceConfig } from '~/entities/custom'
 import type { IntrinsicApyProvider, IntrinsicApyResult } from '~/entities/intrinsic-apy'
 import { logWarn } from '~/utils/errorHandling'
@@ -19,18 +17,17 @@ type SecuritizeAssetStats = {
 const normalize = (value?: string) => value?.toLowerCase() || ''
 
 const buildSourceUrl = (symbol: string) =>
-  `${SECURITIZE_FEED_URL}?symbol=${symbol}`
+  `https://public-feed.securitize.io/asset-stats?symbol=${symbol}`
 
 const fetchBySymbol = async (
   symbol: string,
   sources: SecuritizeSource[],
 ): Promise<IntrinsicApyResult[]> => {
-  const res = await axios.get<SecuritizeResponse>(SECURITIZE_FEED_URL, {
-    params: { symbol },
-    timeout: 10_000,
+  const res = await $fetch<SecuritizeResponse>('/api/intrinsic-apy/securitize', {
+    query: { symbol },
   })
 
-  const entries = Array.isArray(res.data?.data) ? res.data.data : []
+  const entries = Array.isArray(res?.data) ? res.data : []
   const results: IntrinsicApyResult[] = []
 
   for (const source of sources) {

--- a/services/intrinsicApy/sparkProvider.ts
+++ b/services/intrinsicApy/sparkProvider.ts
@@ -1,0 +1,14 @@
+import { createSimpleProvider } from './createSimpleProvider'
+import type { IntrinsicApySourceConfig } from '~/entities/custom'
+import type { IntrinsicApyProvider } from '~/entities/intrinsic-apy'
+
+export const createSparkProvider = (sources: readonly IntrinsicApySourceConfig[]): IntrinsicApyProvider =>
+  createSimpleProvider({
+    providerName: 'Spark',
+    providerKey: 'spark',
+    extractApy: (data) => {
+      const arr = data as Array<{ sky_savings_rate_apy?: string }>
+      return Number(arr[0]?.sky_savings_rate_apy ?? 0) * 100
+    },
+    sourceUrl: 'https://info-sky.blockanalitica.com',
+  }, sources)

--- a/services/intrinsicApy/treehouseProvider.ts
+++ b/services/intrinsicApy/treehouseProvider.ts
@@ -1,0 +1,11 @@
+import { createSimpleProvider } from './createSimpleProvider'
+import type { IntrinsicApySourceConfig } from '~/entities/custom'
+import type { IntrinsicApyProvider } from '~/entities/intrinsic-apy'
+
+export const createTreehouseProvider = (sources: readonly IntrinsicApySourceConfig[]): IntrinsicApyProvider =>
+  createSimpleProvider({
+    providerName: 'Treehouse',
+    providerKey: 'treehouse',
+    extractApy: data => Number((data as { total_apr_teth?: number }).total_apr_teth ?? 0),
+    sourceUrl: 'https://www.treehouse.finance',
+  }, sources)

--- a/services/intrinsicApy/yoProvider.ts
+++ b/services/intrinsicApy/yoProvider.ts
@@ -1,0 +1,50 @@
+import type { IntrinsicApySourceConfig } from '~/entities/custom'
+import type { IntrinsicApyProvider, IntrinsicApyResult } from '~/entities/intrinsic-apy'
+
+type YoSource = Extract<IntrinsicApySourceConfig, { provider: 'yo' }>
+
+type YoVaultStats = {
+  data?: Array<{
+    contracts?: { vaultAddress?: string }
+    yield?: { '7d'?: number }
+  }>
+}
+
+const normalize = (value?: string) => value?.toLowerCase() || ''
+
+export const createYoProvider = (sources: readonly IntrinsicApySourceConfig[]): IntrinsicApyProvider => {
+  const yoSources = sources.filter(
+    (s): s is YoSource => s.provider === 'yo',
+  )
+
+  return {
+    name: 'YO',
+
+    async fetch(chainId: number): Promise<IntrinsicApyResult[]> {
+      const chainSources = yoSources.filter(s => s.chainId === chainId)
+      if (!chainSources.length) return []
+
+      const resp = await $fetch<YoVaultStats>('/api/intrinsic-apy/yo')
+      const vaults = resp?.data ?? []
+
+      const apyByAddress = new Map<string, number>()
+      for (const vault of vaults) {
+        const addr = vault.contracts?.vaultAddress
+        if (addr) {
+          apyByAddress.set(addr.toLowerCase(), vault.yield?.['7d'] ?? 0)
+        }
+      }
+
+      return chainSources
+        .filter(source => apyByAddress.has(normalize(source.address)))
+        .map(source => ({
+          address: normalize(source.address),
+          info: {
+            apy: apyByAddress.get(normalize(source.address))!,
+            provider: 'YO',
+            source: 'https://yo.xyz',
+          },
+        }))
+    },
+  }
+}


### PR DESCRIPTION
## Summary

- Add intrinsic APY providers for **Ether.fi, Renzo, Midas, YO, Spark, Puffer, Treehouse, Ondo, OpenEden, Benqi, Avant** — covering 42 additional assets across 8+ chains
- Unify all external API calls through a server-side proxy (`/api/intrinsic-apy/[provider]`) with 5-minute response caching and rate limiting
- Migrate existing providers (DefiLlama, Pendle, Securitize) from direct `axios` calls to the same server proxy, eliminating CORS concerns
- Sync intrinsic APY source entries: remove 29 stale entries (expired Pendle PTs, delisted DefiLlama pools), add 26 new entries
- Restore Securitize tokens (ACRED, VBILL, STAC) where lite is ahead of the backend

## Architecture

```
Browser                    Server                     External APIs
  |                          |                            |
  |  $fetch(/api/intrinsic-  |                            |
  |  apy/etherfi)            |                            |
  |------------------------->|  5min cache hit?           |
  |                          |  yes -> return cached      |
  |                          |  no  -> fetch upstream --->|
  |                          |       <- JSON response ----|
  |                          |  cache + return            |
  |<-------------------------|                            |
```

8 simple providers use a `createSimpleProvider` factory. 3 bespoke providers (Renzo, Midas, YO) have custom address-mapping logic.

## Test plan

- [ ] `npx nuxi typecheck` passes (no new errors)
- [ ] Dev server: vault list shows intrinsic APY for weETH, sUSDS, pufETH, tETH, USDY, sAVAX, savUSD vaults
- [ ] Network tab: no direct external API calls, all go through `/api/intrinsic-apy/*`
- [ ] Existing intrinsic APY (sUSDe via DefiLlama, PTs via Pendle) still works after proxy migration
- [ ] Toggle "Enable Intrinsic APY" off/on — values disappear/reappear
- [ ] Switch chains — only relevant providers fire