### PR TITLE
fix: batch account position RPC calls to avoid Cloudflare rate limiting

### DIFF
--- a/composables/useAccountPositions.ts
+++ b/composables/useAccountPositions.ts
@@ -7,7 +7,7 @@ import type { SubgraphPositionEntry } from '~/utils/subgraph'
 import { eulerAccountLensABI } from '~/entities/euler/abis'
 import type { EulerLensAddresses } from '~/composables/useEulerAddresses'
 import { createRaceGuard } from '~/utils/race-guard'
-import { BATCH_SIZE_RPC_CALLS, BPS_BASE } from '~/entities/tuning-constants'
+import { BPS_BASE } from '~/entities/tuning-constants'
 import type {
   AccountBorrowPosition, AccountDepositPosition,
 } from '~/entities/account'
@@ -18,7 +18,8 @@ import {
 } from '~/entities/vault'
 import { getCollateralUsdPrice } from '~/services/pricing/priceProvider'
 import { collectPythFeedIds } from '~/entities/oracle'
-import { executeLensWithPythSimulation } from '~/utils/pyth'
+import { executeBatchLensWithPythSimulation } from '~/utils/pyth'
+import { batchLensCalls } from '~/utils/multicall'
 import {
   type LensAccountInfo,
   type LensVaultAccountInfo,
@@ -70,7 +71,7 @@ const updateBorrowPositions = async (
   }
 
   const { PYTH_HERMES_URL } = useEulerConfig()
-  const { client: rpcClient, rpcUrl } = useRpcClient()
+  const { rpcUrl } = useRpcClient()
   const { getOrFetch } = useVaultRegistry()
   const { eulerCoreAddresses } = useEulerAddresses()
   const shouldShowAllPositions = options.forceAllPositions ?? isShowAllPositions.value
@@ -80,278 +81,323 @@ const updateBorrowPositions = async (
     throw new Error('Euler addresses not loaded yet')
   }
 
-  const client = rpcClient.value!
-
-  let borrows: AccountBorrowPosition[] = []
-  let hiddenBorrows = 0
-  const batchSize = BATCH_SIZE_RPC_CALLS
-  const pythRefreshCache = new Map<string, Promise<Vault | undefined>>()
-
-  for (let i = 0; i < borrowEntries.length; i += batchSize) {
-    if (positionGuard.isStale(gen)) return
-
-    const batch = borrowEntries
-      .slice(i, i + batchSize)
-      .map(async (entry) => {
-        const vaultAddress = entry.vault
-        const subAccount = entry.subAccount
-
-        // Pre-fetch borrow vault to check for Pyth oracles
-        const borrowVault = await getOrFetch(vaultAddress) as Vault | undefined
-
-        let res: LensAccountInfo | undefined
-        try {
-          // Check if vault uses Pyth oracles and we can use simulation
-          const pythFeeds = borrowVault ? collectPythFeedIds(borrowVault.oracleDetailedInfo) : []
-          const canUsePythSimulation = pythFeeds.length > 0
-            && PYTH_HERMES_URL
-            && eulerCoreAddresses.value?.evc
-
-          if (canUsePythSimulation) {
-            // Use batchSimulation with Pyth updates for fresh oracle prices
-            const result = await executeLensWithPythSimulation(
-              pythFeeds,
-              eulerLensAddresses.accountLens as Address,
-              eulerAccountLensABI as Abi,
-              'getAccountInfo',
-              [subAccount, vaultAddress],
-              eulerCoreAddresses.value!.evc,
-              rpcUrl.value,
-              PYTH_HERMES_URL!,
-            ) as LensAccountInfo | undefined
-            if (result) {
-              res = result
-            }
-          }
-
-          // Direct call: either non-Pyth vault, or Pyth simulation failed/returned nothing
-          if (!res) {
-            res = await client.readContract({
-              address: eulerLensAddresses.accountLens as Address,
-              abi: eulerAccountLensABI as Abi,
-              functionName: 'getAccountInfo',
-              args: [subAccount, vaultAddress],
-            }) as LensAccountInfo
-          }
-        }
-        catch (err) {
-          logWarn('updateBorrowPositions', err)
-          return undefined
-        }
-
-        if (!res || !res.evcAccountInfo.enabledControllers.length || !res.evcAccountInfo.enabledCollaterals.length || res.vaultAccountInfo.borrowed === 0n) {
-          return undefined
-        }
-
-        const enabledCollateralsList = res.evcAccountInfo.enabledCollaterals.map(collateral => getAddress(collateral))
-        const collaterals = resolvePositionCollaterals(res.vaultAccountInfo?.liquidityInfo, enabledCollateralsList)
-
-        const borrowAddress = getAddress(res.evcAccountInfo.enabledControllers[0])
-        // Use pre-fetched vault if it matches, otherwise fetch
-        let borrow = borrowVault && borrowVault.address.toLowerCase() === borrowAddress.toLowerCase()
-          ? borrowVault
-          : await getOrFetch(borrowAddress) as Vault | undefined
-        if (!borrow) {
-          return undefined
-        }
-
-        // If borrow vault uses Pyth oracles, always fetch fresh prices
-        // (Pyth prices are only valid for ~2 minutes and require continuous updates)
-        if (hasPythOracles(borrow)) {
-          const key = getAddress(borrowAddress)
-          let freshPromise = pythRefreshCache.get(key)
-          if (!freshPromise) {
-            freshPromise = fetchVault(key).catch(() => {
-              pythRefreshCache.delete(key)
-              return undefined
-            })
-            pythRefreshCache.set(key, freshPromise)
-          }
-          const freshBorrow = await freshPromise
-          if (freshBorrow) {
-            borrow = freshBorrow
-          }
-        }
-
-        let collateralAddress: string | undefined
-        const collateralCandidates = collaterals.length ? collaterals : enabledCollateralsList
-        for (const addr of collateralCandidates) {
-          if (borrow.collateralLTVs.some(ltv => getAddress(ltv.collateral) === addr)) {
-            collateralAddress = addr
-            break
-          }
-        }
-
-        if (!collateralAddress) {
-          collateralAddress = collateralCandidates[0]
-        }
-
-        if (!collateralAddress) {
-          return undefined
-        }
-
-        // Use unified resolution for collateral vault (handles EVK, escrow, and securitize)
-        // Note: Collateral PRICES come from borrow.collateralPrices[], which are already
-        // refreshed when we fetch the borrow vault with Pyth simulation above.
-        // The collateral vault only provides totalAssets/totalShares for share→asset conversion.
-        const collateral = await getOrFetch(collateralAddress) as Vault | SecuritizeVault | undefined
-
-        if (!collateral) {
-          return undefined
-        }
-
-        // Skip positions where either vault is unverified (unless showing all positions)
-        if (!shouldShowAllPositions && (!borrow.verified || !collateral.verified)) {
-          hiddenBorrows++
-          return undefined
-        }
-
-        // Fetch actual collateral balance — doesn't depend on the oracle
-        let suppliedAssets = 0n
-        try {
-          const collateralRes = await client.readContract({
-            address: eulerLensAddresses.accountLens as Address,
-            abi: eulerAccountLensABI as Abi,
-            functionName: 'getVaultAccountInfo',
-            args: [subAccount, collateralAddress],
-          }) as LensVaultAccountInfo
-          suppliedAssets = toBigInt(collateralRes.assets)
-        }
-        catch {
-          // Collateral amount unavailable
-        }
-
-        const liquidityInfo = res.vaultAccountInfo.liquidityInfo
-        const hasQueryFailure = Boolean(liquidityInfo.queryFailure)
-
-        if (hasQueryFailure) {
-          // LTV config comes from vault governance, not oracle
-          const ltvConfig = borrow.collateralLTVs.find(ltv =>
-            getAddress(ltv.collateral) === getAddress(collateral.address),
-          )
-
-          return {
-            borrow,
-            collateral,
-            collaterals,
-            subAccount,
-            borrowed: res.vaultAccountInfo.borrowed,
-            supplied: suppliedAssets,
-            borrowLTV: ltvConfig?.borrowLTV ?? 0n,
-            liquidationLTV: ltvConfig?.liquidationLTV ?? 0n,
-            // Oracle-dependent fields — genuinely unavailable
-            health: 0n,
-            userLTV: 0n,
-            price: 0n,
-            liabilityValueBorrowing: 0n,
-            liabilityValueLiquidation: 0n,
-            timeToLiquidation: 0n,
-            collateralValueLiquidation: 0n,
-            liquidityQueryFailure: true,
-          } as AccountBorrowPosition
-        }
-
-        const collateralValueLiquidation = liquidityInfo.collateralValueLiquidation
-        const collateralValueRaw = liquidityInfo.collateralValueRaw
-        let liabilityValueBorrowing = liquidityInfo.liabilityValueBorrowing
-
-        // Compute effective LTVs from aggregates (handles multi-collateral correctly)
-        const liquidationLTV = collateralValueRaw > 0n
-          ? collateralValueLiquidation * BPS_BASE / collateralValueRaw
-          : 0n
-        const effectiveBorrowLTV = collateralValueRaw > 0n
-          ? liquidityInfo.collateralValueBorrowing * BPS_BASE / collateralValueRaw
-          : 0n
-
-        if (liabilityValueBorrowing === 0n && res.vaultAccountInfo.borrowed > 0n) {
-          logWarn('updateBorrowPositions', 'liabilityValueBorrowing is 0 but borrowed amount exists, calculating manually')
-          const borrowedInUnitOfAccount = FixedPoint.fromValue(res.vaultAccountInfo.borrowed, borrow.decimals)
-            .mul(FixedPoint.fromValue(borrow.liabilityPriceInfo.amountOutMid, 18))
-            .div(FixedPoint.fromValue(borrow.liabilityPriceInfo.amountIn, 0))
-          liabilityValueBorrowing = borrowedInUnitOfAccount.value
-        }
-        const healthFixed = liabilityValueBorrowing === 0n
-          ? FixedPoint.fromValue(0n, 18)
-          : FixedPoint.fromValue(collateralValueLiquidation, 18).div(FixedPoint.fromValue(liabilityValueBorrowing, 18))
-
-        const userLTVFixed = healthFixed.isZero()
-          ? FixedPoint.fromValue(0n, 18)
-          : FixedPoint.fromValue(liquidationLTV * (10n ** 16n), 18).div(healthFixed)
-        const userLTV = userLTVFixed.value
-
-        // Get collateral price in USD for liquidation price calculation
-        const collateralPriceUsd = await getCollateralUsdPrice(borrow, collateral, 'off-chain')
-
-        // Missing price — return position with degraded state (same pattern as oracle query failure)
-        if (!collateralPriceUsd) {
-          return {
-            borrow,
-            collateral,
-            collaterals,
-            subAccount,
-            borrowed: res.vaultAccountInfo.borrowed,
-            supplied: suppliedAssets,
-            borrowLTV: effectiveBorrowLTV,
-            liquidationLTV,
-            health: healthFixed.value,
-            userLTV,
-            price: 0n,
-            liabilityValueBorrowing,
-            liabilityValueLiquidation: liquidityInfo.liabilityValueLiquidation,
-            timeToLiquidation: liquidityInfo.timeToLiquidation,
-            collateralValueLiquidation,
-            liquidityQueryFailure: true,
-          } as AccountBorrowPosition
-        }
-
-        const supplyLiquidationPriceRatio = collateralValueLiquidation === 0n
-          ? FixedPoint.fromValue(0n, 18)
-          : FixedPoint.fromValue(liabilityValueBorrowing, 18)
-              .div(FixedPoint.fromValue(collateralValueLiquidation, 18))
-
-        // Use USD price for display (already converted from UoA)
-        const currentCollateralPriceUsd = FixedPoint.fromValue(collateralPriceUsd.amountOutMid, 18)
-
-        const price = currentCollateralPriceUsd.mul(supplyLiquidationPriceRatio).value
-
-        return {
-          borrow,
-          collateral,
-          collaterals,
-          subAccount,
-          borrowLTV: effectiveBorrowLTV,
-          timeToLiquidation: liquidityInfo.timeToLiquidation,
-          health: healthFixed.value,
-          borrowed: res.vaultAccountInfo.borrowed,
-          price,
-          userLTV,
-          supplied: suppliedAssets,
-          liabilityValueBorrowing,
-          liabilityValueLiquidation: liquidityInfo.liabilityValueLiquidation,
-          liquidationLTV,
-          collateralValueLiquidation,
-        } as AccountBorrowPosition
-      })
-
-    const batchResults = await Promise.all(batch)
-    const validResults = batchResults.filter(o => !!o) as AccountBorrowPosition[]
-    borrows = [...borrows, ...validResults]
+  const evcAddress = eulerCoreAddresses.value?.evc
+  if (!evcAddress) {
+    throw new Error('EVC address not loaded yet')
   }
-  // Discard results if chain switched during fetch
+
+  // ── Phase A: Batch all getAccountInfo calls ─────────────────────────
+  // Pre-resolve vaults from registry (should be cache hits) to classify Pyth vs non-Pyth
+  const entryVaults = await Promise.all(
+    borrowEntries.map(async entry => ({
+      entry,
+      vault: await getOrFetch(entry.vault) as Vault | undefined,
+    })),
+  )
+
   if (positionGuard.isStale(gen)) return
 
-  const collateralPositions: AccountBorrowPosition[] = []
+  // Split into Pyth and non-Pyth groups
+  type PythEntry = { key: string, entry: SubgraphPositionEntry, vault: Vault, feeds: ReturnType<typeof collectPythFeedIds> }
+  type NonPythEntry = { key: string, entry: SubgraphPositionEntry, vault: Vault | undefined }
+
+  const pythEntries: PythEntry[] = []
+  const nonPythEntries: NonPythEntry[] = []
+
+  for (const { entry, vault } of entryVaults) {
+    const key = `${entry.subAccount}:${entry.vault}`
+    const feeds = vault ? collectPythFeedIds(vault.oracleDetailedInfo) : []
+    const canUsePyth = feeds.length > 0 && PYTH_HERMES_URL && evcAddress
+
+    if (canUsePyth && vault) {
+      pythEntries.push({ key, entry, vault, feeds })
+    }
+    else {
+      nonPythEntries.push({ key, entry, vault })
+    }
+  }
+
+  // Batch non-Pyth getAccountInfo calls via EVC batchSimulation
+  const accountInfoMap = new Map<string, LensAccountInfo>()
+
+  if (nonPythEntries.length > 0) {
+    const calls = nonPythEntries.map(({ entry }) => ({
+      functionName: 'getAccountInfo',
+      args: [entry.subAccount, entry.vault],
+    }))
+
+    const results = await batchLensCalls<LensAccountInfo>(
+      evcAddress,
+      eulerLensAddresses.accountLens,
+      eulerAccountLensABI as Abi,
+      calls,
+      rpcUrl.value,
+    )
+
+    for (let i = 0; i < results.length; i++) {
+      if (results[i].success && results[i].result) {
+        accountInfoMap.set(nonPythEntries[i].key, results[i].result!)
+      }
+    }
+  }
+
+  if (positionGuard.isStale(gen)) return
+
+  // Batch Pyth getAccountInfo calls with simulation
+  if (pythEntries.length > 0 && PYTH_HERMES_URL) {
+    const batchEntries = pythEntries.map(({ key, entry, feeds }) => ({
+      key,
+      feeds,
+      args: [entry.subAccount, entry.vault],
+    }))
+
+    const pythResults = await executeBatchLensWithPythSimulation<LensAccountInfo>(
+      batchEntries,
+      eulerLensAddresses.accountLens as Address,
+      eulerAccountLensABI as Abi,
+      'getAccountInfo',
+      evcAddress,
+      rpcUrl.value,
+      PYTH_HERMES_URL,
+    )
+
+    for (const [key, result] of pythResults) {
+      if (result) {
+        accountInfoMap.set(key, result)
+      }
+    }
+  }
+
+  if (positionGuard.isStale(gen)) return
+
+  // ── Phase B: Process results, batch getVaultAccountInfo calls ───────
+  // First pass: process getAccountInfo results and collect collateral lookups needed
+  type ProcessedEntry = {
+    entry: SubgraphPositionEntry
+    res: LensAccountInfo
+    borrowVault: Vault
+    collateral: Vault | SecuritizeVault
+    collaterals: string[]
+    collateralAddress: string
+  }
+  const processed: ProcessedEntry[] = []
+  let hiddenBorrows = 0
+  const pythRefreshCache = new Map<string, Promise<Vault | undefined>>()
+
+  for (const { entry, vault: prefetchedVault } of entryVaults) {
+    const key = `${entry.subAccount}:${entry.vault}`
+    const res = accountInfoMap.get(key)
+
+    if (!res || !res.evcAccountInfo.enabledControllers.length || !res.evcAccountInfo.enabledCollaterals.length || res.vaultAccountInfo.borrowed === 0n) {
+      continue
+    }
+
+    const enabledCollateralsList = res.evcAccountInfo.enabledCollaterals.map(c => getAddress(c))
+    const collaterals = resolvePositionCollaterals(res.vaultAccountInfo?.liquidityInfo, enabledCollateralsList)
+
+    const borrowAddress = getAddress(res.evcAccountInfo.enabledControllers[0])
+    let borrow = prefetchedVault && prefetchedVault.address.toLowerCase() === borrowAddress.toLowerCase()
+      ? prefetchedVault
+      : await getOrFetch(borrowAddress) as Vault | undefined
+    if (!borrow) continue
+
+    // If borrow vault uses Pyth oracles, always fetch fresh prices
+    if (hasPythOracles(borrow)) {
+      const refreshKey = getAddress(borrowAddress)
+      let freshPromise = pythRefreshCache.get(refreshKey)
+      if (!freshPromise) {
+        freshPromise = fetchVault(refreshKey).catch(() => {
+          pythRefreshCache.delete(refreshKey)
+          return undefined
+        })
+        pythRefreshCache.set(refreshKey, freshPromise)
+      }
+      const freshBorrow = await freshPromise
+      if (freshBorrow) {
+        borrow = freshBorrow
+      }
+    }
+
+    let collateralAddress: string | undefined
+    const collateralCandidates = collaterals.length ? collaterals : enabledCollateralsList
+    for (const addr of collateralCandidates) {
+      if (borrow.collateralLTVs.some(ltv => getAddress(ltv.collateral) === addr)) {
+        collateralAddress = addr
+        break
+      }
+    }
+    if (!collateralAddress) collateralAddress = collateralCandidates[0]
+    if (!collateralAddress) continue
+
+    const collateral = await getOrFetch(collateralAddress) as Vault | SecuritizeVault | undefined
+    if (!collateral) continue
+
+    if (!shouldShowAllPositions && (!borrow.verified || !collateral.verified)) {
+      hiddenBorrows++
+      continue
+    }
+
+    processed.push({
+      entry,
+      res,
+      borrowVault: borrow,
+      collateral,
+      collaterals,
+      collateralAddress,
+    })
+  }
+
+  if (positionGuard.isStale(gen)) return
+
+  // Batch all getVaultAccountInfo calls for collateral balances
+  const collateralAssets = new Map<string, bigint>()
+
+  if (processed.length > 0) {
+    const collateralCalls = processed.map(p => ({
+      functionName: 'getVaultAccountInfo',
+      args: [p.entry.subAccount, p.collateralAddress],
+    }))
+
+    const collateralResults = await batchLensCalls<LensVaultAccountInfo>(
+      evcAddress,
+      eulerLensAddresses.accountLens,
+      eulerAccountLensABI as Abi,
+      collateralCalls,
+      rpcUrl.value,
+    )
+
+    for (let i = 0; i < collateralResults.length; i++) {
+      const r = collateralResults[i]
+      if (r.success && r.result) {
+        const key = `${processed[i].entry.subAccount}:${processed[i].collateralAddress}`
+        collateralAssets.set(key, toBigInt(r.result.assets))
+      }
+    }
+  }
+
+  if (positionGuard.isStale(gen)) return
+
+  // ── Build final positions ───────────────────────────────────────────
+  const borrowResults = await Promise.all(processed.map(async (p) => {
+    const suppliedAssets = collateralAssets.get(`${p.entry.subAccount}:${p.collateralAddress}`) ?? 0n
+
+    const liquidityInfo = p.res.vaultAccountInfo.liquidityInfo
+    const hasQueryFailure = Boolean(liquidityInfo.queryFailure)
+
+    if (hasQueryFailure) {
+      const ltvConfig = p.borrowVault.collateralLTVs.find(ltv =>
+        getAddress(ltv.collateral) === getAddress(p.collateral.address),
+      )
+      return {
+        borrow: p.borrowVault,
+        collateral: p.collateral,
+        collaterals: p.collaterals,
+        subAccount: p.entry.subAccount,
+        borrowed: p.res.vaultAccountInfo.borrowed,
+        supplied: suppliedAssets,
+        borrowLTV: ltvConfig?.borrowLTV ?? 0n,
+        liquidationLTV: ltvConfig?.liquidationLTV ?? 0n,
+        health: 0n,
+        userLTV: 0n,
+        price: 0n,
+        liabilityValueBorrowing: 0n,
+        liabilityValueLiquidation: 0n,
+        timeToLiquidation: 0n,
+        collateralValueLiquidation: 0n,
+        liquidityQueryFailure: true,
+      } as AccountBorrowPosition
+    }
+
+    const collateralValueLiquidation = liquidityInfo.collateralValueLiquidation
+    const collateralValueRaw = liquidityInfo.collateralValueRaw
+    let liabilityValueBorrowing = liquidityInfo.liabilityValueBorrowing
+
+    const liquidationLTV = collateralValueRaw > 0n
+      ? collateralValueLiquidation * BPS_BASE / collateralValueRaw
+      : 0n
+    const effectiveBorrowLTV = collateralValueRaw > 0n
+      ? liquidityInfo.collateralValueBorrowing * BPS_BASE / collateralValueRaw
+      : 0n
+
+    if (liabilityValueBorrowing === 0n && p.res.vaultAccountInfo.borrowed > 0n) {
+      logWarn('updateBorrowPositions', 'liabilityValueBorrowing is 0 but borrowed amount exists, calculating manually')
+      const borrowedInUnitOfAccount = FixedPoint.fromValue(p.res.vaultAccountInfo.borrowed, p.borrowVault.decimals)
+        .mul(FixedPoint.fromValue(p.borrowVault.liabilityPriceInfo.amountOutMid, 18))
+        .div(FixedPoint.fromValue(p.borrowVault.liabilityPriceInfo.amountIn, 0))
+      liabilityValueBorrowing = borrowedInUnitOfAccount.value
+    }
+
+    const healthFixed = liabilityValueBorrowing === 0n
+      ? FixedPoint.fromValue(0n, 18)
+      : FixedPoint.fromValue(collateralValueLiquidation, 18).div(FixedPoint.fromValue(liabilityValueBorrowing, 18))
+
+    const userLTVFixed = healthFixed.isZero()
+      ? FixedPoint.fromValue(0n, 18)
+      : FixedPoint.fromValue(liquidationLTV * (10n ** 16n), 18).div(healthFixed)
+    const userLTV = userLTVFixed.value
+
+    const collateralPriceUsd = await getCollateralUsdPrice(p.borrowVault, p.collateral, 'off-chain')
+
+    if (!collateralPriceUsd) {
+      return {
+        borrow: p.borrowVault,
+        collateral: p.collateral,
+        collaterals: p.collaterals,
+        subAccount: p.entry.subAccount,
+        borrowed: p.res.vaultAccountInfo.borrowed,
+        supplied: suppliedAssets,
+        borrowLTV: effectiveBorrowLTV,
+        liquidationLTV,
+        health: healthFixed.value,
+        userLTV,
+        price: 0n,
+        liabilityValueBorrowing,
+        liabilityValueLiquidation: liquidityInfo.liabilityValueLiquidation,
+        timeToLiquidation: liquidityInfo.timeToLiquidation,
+        collateralValueLiquidation,
+        liquidityQueryFailure: true,
+      } as AccountBorrowPosition
+    }
+
+    const supplyLiquidationPriceRatio = collateralValueLiquidation === 0n
+      ? FixedPoint.fromValue(0n, 18)
+      : FixedPoint.fromValue(liabilityValueBorrowing, 18)
+          .div(FixedPoint.fromValue(collateralValueLiquidation, 18))
+
+    const currentCollateralPriceUsd = FixedPoint.fromValue(collateralPriceUsd.amountOutMid, 18)
+    const price = currentCollateralPriceUsd.mul(supplyLiquidationPriceRatio).value
+
+    return {
+      borrow: p.borrowVault,
+      collateral: p.collateral,
+      collaterals: p.collaterals,
+      subAccount: p.entry.subAccount,
+      borrowLTV: effectiveBorrowLTV,
+      timeToLiquidation: liquidityInfo.timeToLiquidation,
+      health: healthFixed.value,
+      borrowed: p.res.vaultAccountInfo.borrowed,
+      price,
+      userLTV,
+      supplied: suppliedAssets,
+      liabilityValueBorrowing,
+      liabilityValueLiquidation: liquidityInfo.liabilityValueLiquidation,
+      liquidationLTV,
+      collateralValueLiquidation,
+    } as AccountBorrowPosition
+  }))
+
+  if (positionGuard.isStale(gen)) return
+
+  const borrows = borrowResults.filter((o): o is AccountBorrowPosition => !!o)
   const shouldUpdate = options.forceAllPositions !== undefined
     ? true
     : isShowAllPositions.value === isAllPositionsAtStart
   if (shouldUpdate) {
-    const allPositions = [...borrows, ...collateralPositions]
-    borrowPositions.value = allPositions
+    borrowPositions.value = borrows
 
     // Build set of (subAccount, collateralVault) pairs used as collateral
-    // Must include ALL enabled collateral vaults, not just the primary one
     const usageSet = new Set<string>()
-    for (const pos of allPositions) {
+    for (const pos of borrows) {
       const subAccount = getAddress(pos.subAccount)
       for (const addr of pos.collaterals ?? [pos.collateral.address]) {
         usageSet.add(`${subAccount}:${getAddress(addr)}`)
@@ -390,7 +436,8 @@ const updateSavingsPositions = async (
   }
 
   const { getOrFetch } = useVaultRegistry()
-  const { client: rpcClient } = useRpcClient()
+  const { rpcUrl } = useRpcClient()
+  const { eulerCoreAddresses } = useEulerAddresses()
 
   const shouldShowAllPositions = options.forceAllPositions ?? isShowAllPositions.value
   const isAllPositionsAtStart = shouldShowAllPositions
@@ -399,67 +446,67 @@ const updateSavingsPositions = async (
     throw new Error('Euler addresses not loaded yet')
   }
 
-  const client = rpcClient.value!
-
-  let deposits: AccountDepositPosition[] = []
-  let hiddenDeposits = 0
-
-  const batchSize = BATCH_SIZE_RPC_CALLS
-  for (let i = 0; i < depositEntries.length; i += batchSize) {
-    if (positionGuard.isStale(gen)) return
-
-    const batch = depositEntries
-      .slice(i, i + batchSize)
-      .map(async (entry) => {
-        const vaultAddress = entry.vault
-        const subAccount = entry.subAccount
-
-        // Check if this deposit is being used as collateral
-        const collateralKey = `${subAccount}:${vaultAddress}`
-        if (collateralUsageSet.value.has(collateralKey)) {
-          return undefined
-        }
-
-        // Resolve vault from registry
-        const vault = await getOrFetch(vaultAddress)
-        if (!vault) return undefined
-
-        // Skip unverified vaults unless showing all positions
-        if (!shouldShowAllPositions && !vault.verified) {
-          hiddenDeposits++
-          return undefined
-        }
-
-        try {
-          const res = await client.readContract({
-            address: eulerLensAddresses.accountLens as Address,
-            abi: eulerAccountLensABI as Abi,
-            functionName: 'getAccountInfo',
-            args: [subAccount, vaultAddress],
-          }) as LensAccountInfo
-
-          // Only include if there are shares
-          if (res.vaultAccountInfo.shares === 0n) {
-            return undefined
-          }
-
-          return {
-            vault,
-            subAccount,
-            shares: res.vaultAccountInfo.shares,
-            assets: res.vaultAccountInfo.assets,
-          } as AccountDepositPosition
-        }
-        catch (e) {
-          logWarn('updateSavingsPositions', e)
-          return undefined
-        }
-      })
-    const results = (await Promise.all(batch)).filter((o): o is AccountDepositPosition => !!o)
-    deposits = [...deposits, ...results]
+  const evcAddress = eulerCoreAddresses.value?.evc
+  if (!evcAddress) {
+    throw new Error('EVC address not loaded yet')
   }
 
-  // Discard results if chain switched during fetch
+  let hiddenDeposits = 0
+
+  // Pre-filter: resolve vaults and exclude collateral-used entries
+  type ValidEntry = { entry: SubgraphPositionEntry, vault: NonNullable<Awaited<ReturnType<typeof getOrFetch>>> }
+  const validEntries: ValidEntry[] = []
+
+  for (const entry of depositEntries) {
+    const collateralKey = `${entry.subAccount}:${entry.vault}`
+    if (collateralUsageSet.value.has(collateralKey)) continue
+
+    const vault = await getOrFetch(entry.vault)
+    if (!vault) continue
+
+    if (!shouldShowAllPositions && !vault.verified) {
+      hiddenDeposits++
+      continue
+    }
+
+    validEntries.push({ entry, vault })
+  }
+
+  if (positionGuard.isStale(gen)) return
+
+  // Batch all getAccountInfo calls in one RPC request
+  const deposits: AccountDepositPosition[] = []
+
+  if (validEntries.length > 0) {
+    const calls = validEntries.map(({ entry }) => ({
+      functionName: 'getAccountInfo',
+      args: [entry.subAccount, entry.vault],
+    }))
+
+    const results = await batchLensCalls<LensAccountInfo>(
+      evcAddress,
+      eulerLensAddresses.accountLens,
+      eulerAccountLensABI as Abi,
+      calls,
+      rpcUrl.value,
+    )
+
+    for (let i = 0; i < results.length; i++) {
+      const r = results[i]
+      if (!r.success || !r.result) continue
+
+      const res = r.result
+      if (res.vaultAccountInfo.shares === 0n) continue
+
+      deposits.push({
+        vault: validEntries[i].vault,
+        subAccount: validEntries[i].entry.subAccount,
+        shares: res.vaultAccountInfo.shares,
+        assets: res.vaultAccountInfo.assets,
+      } as AccountDepositPosition)
+    }
+  }
+
   if (positionGuard.isStale(gen)) return
 
   const shouldUpdate = options.forceAllPositions !== undefined

--- a/entities/vault/fetcher.ts
+++ b/entities/vault/fetcher.ts
@@ -529,7 +529,7 @@ export const fetchVaults = async function* (
       const pythVaultEntries = validVaults
         .map((vault) => {
           const feeds = collectPythFeedIds(vault.oracleDetailedInfo)
-          return feeds.length > 0 ? { vaultAddress: vault.address, feeds } : null
+          return feeds.length > 0 ? { key: vault.address, feeds, args: [vault.address] } : null
         })
         .filter((entry): entry is NonNullable<typeof entry> => entry !== null)
 

--- a/utils/multicall.ts
+++ b/utils/multicall.ts
@@ -86,28 +86,15 @@ export const buildBatchItem = (
 })
 
 /**
- * Batch multiple lens calls using EVC batchSimulation.
- * Encodes calls, executes batch, and returns raw results for decoding.
- *
- * @param evcAddress - EVC contract address
- * @param lensAddress - Lens contract address
- * @param lensAbi - ABI for the lens contract
- * @param calls - Array of { functionName, args } to call
- * @param rpcUrl - JSON-RPC URL
- * @returns Array of decoded results (or null for failed calls)
+ * Execute a single chunk of lens calls via EVC batchSimulation.
  */
-export const batchLensCalls = async <T>(
+const executeLensChunk = async <T>(
   evcAddress: string,
   lensAddress: string,
   lensAbi: Abi | readonly unknown[],
   calls: Array<{ functionName: string, args: unknown[] }>,
   rpcUrl: string,
 ): Promise<Array<{ success: boolean, result: T | null }>> => {
-  if (calls.length === 0) {
-    return []
-  }
-
-  // Build batch items
   const items: BatchItem[] = calls.map((call) => {
     const callData = encodeFunctionData({
       abi: lensAbi as Abi,
@@ -117,10 +104,8 @@ export const batchLensCalls = async <T>(
     return buildBatchItem(lensAddress, callData)
   })
 
-  // Execute batch
   const batchResults = await evcBatchCall(evcAddress, items, rpcUrl)
 
-  // Decode results
   return batchResults.map((result, index) => {
     if (!result.success) {
       return { success: false, result: null }
@@ -139,4 +124,41 @@ export const batchLensCalls = async <T>(
       return { success: false, result: null }
     }
   })
+}
+
+/**
+ * Batch multiple lens calls using EVC batchSimulation.
+ * Automatically chunks into sub-batches to stay within gas limits.
+ *
+ * @param evcAddress - EVC contract address
+ * @param lensAddress - Lens contract address
+ * @param lensAbi - ABI for the lens contract
+ * @param calls - Array of { functionName, args } to call
+ * @param rpcUrl - JSON-RPC URL
+ * @param batchSize - Max calls per batchSimulation (default 25)
+ * @returns Array of decoded results (or null for failed calls)
+ */
+export const batchLensCalls = async <T>(
+  evcAddress: string,
+  lensAddress: string,
+  lensAbi: Abi | readonly unknown[],
+  calls: Array<{ functionName: string, args: unknown[] }>,
+  rpcUrl: string,
+  batchSize = 25,
+): Promise<Array<{ success: boolean, result: T | null }>> => {
+  if (calls.length === 0) {
+    return []
+  }
+
+  if (calls.length <= batchSize) {
+    return executeLensChunk<T>(evcAddress, lensAddress, lensAbi, calls, rpcUrl)
+  }
+
+  const allResults: Array<{ success: boolean, result: T | null }> = []
+  for (let i = 0; i < calls.length; i += batchSize) {
+    const chunk = calls.slice(i, i + batchSize)
+    const chunkResults = await executeLensChunk<T>(evcAddress, lensAddress, lensAbi, chunk, rpcUrl)
+    allResults.push(...chunkResults)
+  }
+  return allResults
 }

--- a/utils/public-client.ts
+++ b/utils/public-client.ts
@@ -12,7 +12,7 @@ export const getPublicClient = (rpcUrl: string): PublicClient => {
     transport: http(rpcUrl, {
       batch: {
         batchSize: 100,
-        wait: 50,
+        wait: 100,
       },
     }),
   })

--- a/utils/pyth.ts
+++ b/utils/pyth.ts
@@ -592,10 +592,10 @@ export const executeLensWithPythSimulation = async <T>(
 }
 
 /**
- * Execute lens calls for multiple vaults in a single batchSimulation with Pyth updates.
- * Combines all Pyth feed updates + all vault lens calls into one RPC request.
+ * Execute lens calls for multiple entries in a single batchSimulation with Pyth updates.
+ * Combines all Pyth feed updates + all lens calls into one RPC request.
  *
- * @param vaultEntries - Array of { vaultAddress, feeds } for each vault to refresh
+ * @param entries - Array of { key, feeds, args } for each lens call
  * @param lensAddress - Address of the lens contract
  * @param lensAbi - ABI of the lens contract
  * @param lensMethod - Method name to call on the lens (e.g. 'getVaultInfoFull')
@@ -603,10 +603,10 @@ export const executeLensWithPythSimulation = async <T>(
  * @param providerUrl - Provider URL for Pyth batch building and RPC calls
  * @param hermesEndpoint - Pyth Hermes endpoint
  * @param batchSize - Max lens calls per batchSimulation (default 25)
- * @returns Map of vault address → decoded result (undefined for failed entries)
+ * @returns Map of key → decoded result (undefined for failed entries)
  */
 export const executeBatchLensWithPythSimulation = async <T>(
-  vaultEntries: Array<{ vaultAddress: string, feeds: PythFeed[] }>,
+  entries: Array<{ key: string, feeds: PythFeed[], args: unknown[] }>,
   lensAddress: Address,
   lensAbi: Abi | readonly unknown[],
   lensMethod: string,
@@ -617,18 +617,18 @@ export const executeBatchLensWithPythSimulation = async <T>(
 ): Promise<Map<string, T | undefined>> => {
   const results = new Map<string, T | undefined>()
 
-  if (vaultEntries.length === 0) {
+  if (entries.length === 0) {
     return results
   }
 
   try {
-    // Merge and deduplicate all Pyth feeds across all vaults
+    // Merge and deduplicate all Pyth feeds across all entries
     const uniqueFeeds = new Map<string, PythFeed>()
-    for (const entry of vaultEntries) {
+    for (const entry of entries) {
       for (const feed of entry.feeds) {
-        const key = `${feed.pythAddress.toLowerCase()}:${feed.feedId.toLowerCase()}`
-        if (!uniqueFeeds.has(key)) {
-          uniqueFeeds.set(key, feed)
+        const feedKey = `${feed.pythAddress.toLowerCase()}:${feed.feedId.toLowerCase()}`
+        if (!uniqueFeeds.has(feedKey)) {
+          uniqueFeeds.set(feedKey, feed)
         }
       }
     }
@@ -640,9 +640,9 @@ export const executeBatchLensWithPythSimulation = async <T>(
       hermesEndpoint,
     )
 
-    // Build lens items for each vault
-    const lensEntries = vaultEntries.map(entry => ({
-      vaultAddress: entry.vaultAddress,
+    // Build lens items for each entry
+    const lensEntries = entries.map(entry => ({
+      key: entry.key,
       item: {
         targetContract: lensAddress as `0x${string}`,
         onBehalfOfAccount: zeroAddress,
@@ -650,7 +650,7 @@ export const executeBatchLensWithPythSimulation = async <T>(
         data: encodeFunctionData({
           abi: lensAbi as Abi,
           functionName: lensMethod,
-          args: [entry.vaultAddress],
+          args: entry.args,
         }) as `0x${string}`,
       } satisfies BatchItem,
     }))
@@ -670,7 +670,7 @@ export const executeBatchLensWithPythSimulation = async <T>(
         return chunk.map((entry, i) => {
           const lensResult = batchResults[pythItems.length + i]
           if (!lensResult?.success) {
-            return { vaultAddress: entry.vaultAddress, result: undefined as T | undefined }
+            return { key: entry.key, result: undefined as T | undefined }
           }
 
           try {
@@ -679,10 +679,10 @@ export const executeBatchLensWithPythSimulation = async <T>(
               functionName: lensMethod,
               data: lensResult.result as Hex,
             })
-            return { vaultAddress: entry.vaultAddress, result: decoded as T }
+            return { key: entry.key, result: decoded as T }
           }
           catch {
-            return { vaultAddress: entry.vaultAddress, result: undefined as T | undefined }
+            return { key: entry.key, result: undefined as T | undefined }
           }
         })
       }),
@@ -690,7 +690,7 @@ export const executeBatchLensWithPythSimulation = async <T>(
 
     for (const chunk of chunkResults) {
       for (const entry of chunk) {
-        results.set(entry.vaultAddress, entry.result)
+        results.set(entry.key, entry.result)
       }
     }
   }


### PR DESCRIPTION
## Summary

- Account position fetching was making ~3N individual HTTP requests for N borrow positions (getAccountInfo + getVaultAccountInfo each), triggering Cloudflare rate limiting (~75 req threshold, 10min lockout)
- Restructured into batched phases using existing EVC batchSimulation infrastructure: all getAccountInfo calls in one batch, all getVaultAccountInfo calls in another batch
- Savings positions also batched into a single RPC call
- Increased viem HTTP batch window from 50ms to 100ms for better accumulation of remaining individual calls
- Added auto-chunking to `batchLensCalls` (25 per chunk) and generalized `executeBatchLensWithPythSimulation` to accept custom args per entry

## Test plan

- [ ] Deploy preview, connect wallet with borrow + deposit positions
- [ ] Open devtools Network tab, filter `/api/rpc/` — verify no 429s and reduced request count
- [ ] Verify borrow positions load correctly (health, LTV, collateral amounts, liquidation price)
- [ ] Verify deposit positions load correctly (shares, assets)
- [ ] Test with Pyth-oracle vaults (liquidation prices should update with fresh prices)
- [ ] Test chain switching (positions should reset and reload cleanly)