### PR TITLE
fix: multi-collateral position pages and redundant tx steps

### DIFF
--- a/components/base/BaseModalWrapper.vue
+++ b/components/base/BaseModalWrapper.vue
@@ -28,7 +28,7 @@ defineEmits(['close'])
       />
       <p
         v-if="title"
-        class="flex text-center text-p2 items-center gap-8"
+        class="flex text-center text-h4 items-center gap-8"
       >
         <SvgIcon
           v-if="warning"

--- a/components/entities/operation/OperationReviewModal.vue
+++ b/components/entities/operation/OperationReviewModal.vue
@@ -212,9 +212,6 @@ const permit2DisclaimerText = 'You are granting the permit2 contract unlimited a
         v-if="displaySteps.length"
         class="flex flex-col gap-8"
       >
-        <p class="text-p3 text-content-primary">
-          Transaction steps
-        </p>
         <div class="bg-surface-secondary rounded-12 p-12 flex flex-col gap-8">
           <OperationStepsList :steps="displaySteps" />
         </div>

--- a/components/entities/vault/overview/VaultOverviewModal.vue
+++ b/components/entities/vault/overview/VaultOverviewModal.vue
@@ -96,6 +96,8 @@ const navigateToBorrow = (collateralAddress: string, borrowVaultAddress: string)
       v-if="tabs.length"
       v-model="tab"
       class="mb-12 mx-[-16px]"
+      rounded
+      pills
       :list="tabs"
     >
       <template #default="{ tab: slotTab }">

--- a/composables/position/useCollateralForm.ts
+++ b/composables/position/useCollateralForm.ts
@@ -434,10 +434,15 @@ export const useCollateralForm = (options: UseCollateralFormOptions) => {
       const priceFl = priceFixed.value.toUnsafeFloat()
       const amountFl = amount18.toUnsafeFloat()
 
+      // Only apply delta if this collateral is accepted by the controller (BLTV > 0)
+      const affectsLtv = borrowVault.value?.collateralLTVs.some(
+        ltv => ltv.collateral.toLowerCase() === collateralVault.value!.address.toLowerCase() && ltv.borrowLTV > 0n,
+      ) ?? false
+
       const collateralValueFl = totalValue !== null && priceFl > 0
         ? (options.mode === 'supply'
-            ? totalValue + amountFl * priceFl
-            : totalValue - amountFl * priceFl)
+            ? totalValue + (affectsLtv ? amountFl * priceFl : 0)
+            : totalValue - (affectsLtv ? amountFl * priceFl : 0))
         : (options.mode === 'supply'
             ? supplied18.add(amount18).mul(priceFixed.value).toUnsafeFloat()
             : supplied18.sub(amount18).mul(priceFixed.value).toUnsafeFloat())

--- a/composables/position/useCollateralForm.ts
+++ b/composables/position/useCollateralForm.ts
@@ -3,6 +3,7 @@ import { useAccount } from '@wagmi/vue'
 import { formatUnits, type Address, type Abi, zeroAddress } from 'viem'
 import { logWarn } from '~/utils/errorHandling'
 import { FixedPoint } from '~/utils/fixed-point'
+import { getTotalCollateralValue } from '~/utils/position-estimates'
 import { useModal } from '~/components/ui/composables/useModal'
 import { OperationReviewModal, SwapTokenSelector, SlippageSettingsModal } from '#components'
 import { useToast } from '~/components/ui/composables/useToast'
@@ -424,17 +425,27 @@ export const useCollateralForm = (options: UseCollateralFormOptions) => {
     try {
       const amountNano = valueToNano(amount.value, collateralVault.value.decimals)
 
-      // Normalize all FixedPoints to 18 decimals for consistent LTV/health math.
-      // borrowedFixed may have different decimals (e.g. 6 for USDC) than collateral (e.g. 18 for WETH),
-      // and FixedPoint.div inherits this.decimals — so without normalizing, the result would have
-      // wrong decimal scale vs what nanoToValue(..., 18) expects in the template.
-      const supplied18 = suppliedFixed.value.round(18)
-      const amount18 = amountFixed.value.round(18)
+      // Derive total collateral value from position's on-chain LTV (multi-collateral aware),
+      // then adjust for the collateral delta using the single collateral's price.
+      const totalValue = getTotalCollateralValue(position.value!)
       const borrowed18 = borrowedFixed.value.round(18)
+      const amount18 = amountFixed.value.round(18)
+      const supplied18 = suppliedFixed.value.round(18)
+      const priceFl = priceFixed.value.toUnsafeFloat()
+      const amountFl = amount18.toUnsafeFloat()
 
-      const collateralValue = options.mode === 'supply'
-        ? supplied18.add(amount18).mul(priceFixed.value)
-        : supplied18.sub(amount18).mul(priceFixed.value)
+      const collateralValueFl = totalValue !== null && priceFl > 0
+        ? (options.mode === 'supply'
+            ? totalValue + amountFl * priceFl
+            : totalValue - amountFl * priceFl)
+        : (options.mode === 'supply'
+            ? supplied18.add(amount18).mul(priceFixed.value).toUnsafeFloat()
+            : supplied18.sub(amount18).mul(priceFixed.value).toUnsafeFloat())
+
+      const collateralValue = FixedPoint.fromValue(
+        BigInt(Math.round(collateralValueFl * 1e18)),
+        18,
+      )
 
       const userLtvFixed = collateralValue.isZero()
         ? FixedPoint.fromValue(0n, 18)

--- a/composables/repay/useWalletRepay.ts
+++ b/composables/repay/useWalletRepay.ts
@@ -3,6 +3,7 @@ import { useAccount } from '@wagmi/vue'
 import { formatUnits } from 'viem'
 import { FixedPoint } from '~/utils/fixed-point'
 import { logWarn } from '~/utils/errorHandling'
+import { getTotalCollateralValue } from '~/utils/position-estimates'
 import { useModal } from '~/components/ui/composables/useModal'
 import { OperationReviewModal } from '#components'
 import { useToast } from '~/components/ui/composables/useToast'
@@ -215,7 +216,15 @@ export const useWalletRepay = (options: UseWalletRepayOptions) => {
         collateralSupplyRewardApy.value || null,
         borrowRewardApy.value || null,
       )
-      const collateralValue = suppliedFixed.value.mul(priceFixed.value)
+      // Use on-chain LTV to derive total collateral value (multi-collateral aware)
+      const totalValue = getTotalCollateralValue(position.value!)
+      const collateralValueFl = totalValue !== null
+        ? totalValue
+        : suppliedFixed.value.mul(priceFixed.value).toUnsafeFloat()
+      const collateralValue = FixedPoint.fromValue(
+        BigInt(Math.round(collateralValueFl * 1e18)),
+        18,
+      )
       const userLtvFixed = collateralValue.isZero()
         ? FixedPoint.fromValue(0n, 18)
         : (borrowedFixed.value.sub(amountFixed.value))

--- a/composables/repay/useWalletSwapRepay.ts
+++ b/composables/repay/useWalletSwapRepay.ts
@@ -4,6 +4,7 @@ import { formatUnits, getAddress, zeroAddress, type Address } from 'viem'
 import { isNativeCurrencyAddress, resolveWrappedNativeAddress, resolveWrappedNativeAsset } from '~/utils/native-currency'
 import { FixedPoint } from '~/utils/fixed-point'
 import { logWarn } from '~/utils/errorHandling'
+import { getTotalCollateralValue } from '~/utils/position-estimates'
 import { useModal } from '~/components/ui/composables/useModal'
 import { OperationReviewModal } from '#components'
 import { useToast } from '~/components/ui/composables/useToast'
@@ -372,7 +373,15 @@ export const useWalletSwapRepay = (options: UseWalletSwapRepayOptions) => {
       )
 
       const debtRepaidFixed = FixedPoint.fromValue(debtRepaidNano, Number(borrowVault.value.decimals))
-      const collateralValue = suppliedFixed.value.mul(priceFixed.value)
+      // Use on-chain LTV to derive total collateral value (multi-collateral aware)
+      const totalValue = getTotalCollateralValue(position.value!)
+      const collateralValueFl = totalValue !== null
+        ? totalValue
+        : suppliedFixed.value.mul(priceFixed.value).toUnsafeFloat()
+      const collateralValue = FixedPoint.fromValue(
+        BigInt(Math.round(collateralValueFl * 1e18)),
+        18,
+      )
       const userLtvFixed = collateralValue.isZero()
         ? FixedPoint.fromValue(0n, 18)
         : (borrowedFixed.value.sub(debtRepaidFixed))

--- a/composables/useEulerOperations/vault.ts
+++ b/composables/useEulerOperations/vault.ts
@@ -15,6 +15,9 @@ import { SwapperMode, SwapVerificationType } from '~/entities/swap'
 import { logWarn } from '~/utils/errorHandling'
 import { assertSwapperVerifierAllowed } from '~/utils/swap-validation'
 
+const isAlreadyEnabled = (list: string[] | undefined, address: string): boolean =>
+  !!list?.some(c => c.toLowerCase() === address.toLowerCase())
+
 export const createVaultBuilders = (
   ctx: OperationsContext,
   helpers: OperationHelpers,
@@ -172,7 +175,7 @@ export const createVaultBuilders = (
     borrowVaultAddress: string,
     borrowAmount: bigint,
     subAccount?: string,
-    options: { includePermit2Call?: boolean, enabledCollaterals?: string[], wrappedNativeInfo?: { wrappedTokenAddress: Address, nativeAmount: bigint } } = {},
+    options: { includePermit2Call?: boolean, enabledCollaterals?: string[], enabledController?: string, acceptedCollaterals?: string[], wrappedNativeInfo?: { wrappedTokenAddress: Address, nativeAmount: bigint } } = {},
   ): Promise<TxPlan> => {
     if (!ctx.address.value || !ctx.eulerCoreAddresses.value || !ctx.eulerPeripheryAddresses.value) {
       throw new Error('Wallet not connected or addresses not available')
@@ -221,6 +224,7 @@ export const createVaultBuilders = (
       subAccount: subAccountAddr as Address,
       providerUrl: ctx.rpcUrl,
       subgraphUrl: ctx.SUBGRAPH_URL,
+      acceptedCollaterals: options.acceptedCollaterals,
     })
     if (cleanupCalls.length) {
       evcCalls.push(...cleanupCalls)
@@ -263,7 +267,16 @@ export const createVaultBuilders = (
       data: hooks.getDataForCall(borrowVaultAddr, 'borrow', [borrowAmount, userAddr]) as Hash,
     }
 
-    evcCalls.push(depositCall, enableControllerCall, enableCollateralCall, borrowCall)
+    if (amount > 0n) {
+      evcCalls.push(depositCall)
+    }
+    if (!options.enabledController || options.enabledController.toLowerCase() !== borrowVaultAddr.toLowerCase()) {
+      evcCalls.push(enableControllerCall)
+    }
+    if (!isAlreadyEnabled(options.enabledCollaterals, vaultAddr)) {
+      evcCalls.push(enableCollateralCall)
+    }
+    evcCalls.push(borrowCall)
 
     await helpers.injectPythHealthCheckUpdates({
       evcCalls,
@@ -289,6 +302,7 @@ export const createVaultBuilders = (
     subAccount?: string,
     enabledCollaterals?: string[],
     savingsSubAccount?: string,
+    enabledController?: string,
   ): Promise<TxPlan> => {
     if (!ctx.address.value || !ctx.eulerCoreAddresses.value || !ctx.eulerPeripheryAddresses.value) {
       throw new Error('Wallet not connected or addresses not available')
@@ -358,7 +372,13 @@ export const createVaultBuilders = (
       data: hooks.getDataForCall(borrowVaultAddr, 'borrow', [borrowAmount, userAddr]) as Hash,
     }
 
-    evcCalls.push(enableControllerCall, enableCollateralCall, borrowCall)
+    if (!enabledController || enabledController.toLowerCase() !== borrowVaultAddr.toLowerCase()) {
+      evcCalls.push(enableControllerCall)
+    }
+    if (!isAlreadyEnabled(enabledCollaterals, vaultAddr)) {
+      evcCalls.push(enableCollateralCall)
+    }
+    evcCalls.push(borrowCall)
 
     await helpers.injectPythHealthCheckUpdates({
       evcCalls,
@@ -389,6 +409,7 @@ export const createVaultBuilders = (
     subAccount,
     includePermit2Call = true,
     enabledCollaterals,
+    enabledController,
   }: {
     supplyVaultAddress: string
     supplyAssetAddress: string
@@ -404,6 +425,7 @@ export const createVaultBuilders = (
     subAccount?: string
     includePermit2Call?: boolean
     enabledCollaterals?: string[]
+    enabledController?: string
   }): Promise<TxPlan> => {
     if (!ctx.address.value || !ctx.eulerCoreAddresses.value || !ctx.eulerPeripheryAddresses.value) {
       throw new Error('Wallet not connected or addresses not available')
@@ -550,7 +572,13 @@ export const createVaultBuilders = (
       data: hooks.getDataForCall(borrowVaultAddr, 'borrow', [borrowAmount, borrowRecipient]) as Hash,
     }
 
-    evcCalls.push(enableControllerCall, enableSupplyCollateralCall, borrowCall)
+    if (!enabledController || enabledController.toLowerCase() !== borrowVaultAddr.toLowerCase()) {
+      evcCalls.push(enableControllerCall)
+    }
+    if (!isAlreadyEnabled(enabledCollaterals, supplyVaultAddr)) {
+      evcCalls.push(enableSupplyCollateralCall)
+    }
+    evcCalls.push(borrowCall)
 
     if (hasSwap) {
       if (quote!.verify.type !== SwapVerificationType.SkimMin) {
@@ -637,7 +665,7 @@ export const createVaultBuilders = (
       evcCalls.push(depositBorrowedCall)
     }
 
-    if (!isSameVault) {
+    if (!isSameVault && !isAlreadyEnabled(enabledCollaterals, longVaultAddr)) {
       const enableLongCollateralCall: EVCCall = {
         targetContract: evcAddress,
         onBehalfOfAccount: '0x0000000000000000000000000000000000000000' as Address,

--- a/composables/usePositionPairLabel.ts
+++ b/composables/usePositionPairLabel.ts
@@ -1,0 +1,16 @@
+import type { AccountBorrowPosition } from '~/entities/account'
+
+/**
+ * Builds a pair assets label like "BOLD/USDC" or "BOLD & others/USDC"
+ * based on whether the position has multiple collaterals.
+ */
+export function usePositionPairLabel(position: Ref<AccountBorrowPosition | undefined | null>) {
+  return computed(() => {
+    if (!position.value) return undefined
+    const collateralSymbol = position.value.collateral.asset.symbol
+    const borrowSymbol = position.value.borrow.asset.symbol
+    const hasMultiple = (position.value.collaterals?.length || 0) > 1
+    const label = hasMultiple ? `${collateralSymbol} & others` : collateralSymbol
+    return `${label}/${borrowSymbol}`
+  })
+}

--- a/pages/borrow/[collateral]/[borrow]/index.vue
+++ b/pages/borrow/[collateral]/[borrow]/index.vue
@@ -364,6 +364,16 @@ watch(formTab, () => {
 <template>
   <div>
     <BaseBackButton class="laptop:!hidden mb-16" />
+
+    <VaultLabelsAndAssets
+      v-if="collateralVault && borrowVault"
+      class="mb-24"
+      :vault="collateralVault"
+      :pair-vault="borrowVault"
+      :assets="pairAssets as VaultAsset[]"
+      size="large"
+    />
+
     <div class="flex gap-32">
       <div
         v-if="pair"
@@ -373,6 +383,8 @@ watch(formTab, () => {
           v-if="tabs.length"
           v-model="tab"
           class="mb-12 min-w-0"
+          rounded
+          pills
           :list="tabs"
         >
           <template #default="{ tab: slotTab }">
@@ -430,14 +442,6 @@ watch(formTab, () => {
               rounded
               pills
               :list="formTabs"
-            />
-
-            <VaultLabelsAndAssets
-              v-if="collateralVault && borrowVault"
-              :vault="collateralVault"
-              :pair-vault="borrowVault"
-              :assets="pairAssets as VaultAsset[]"
-              size="large"
             />
 
             <template v-if="formTab === 'borrow'">

--- a/pages/earn/[vault]/index.vue
+++ b/pages/earn/[vault]/index.vue
@@ -231,6 +231,15 @@ watch(address, () => {
 <template>
   <div>
     <BaseBackButton class="laptop:!hidden mb-16" />
+
+    <VaultLabelsAndAssets
+      v-if="vault && asset"
+      class="mb-24"
+      :vault="vault"
+      :assets="assets"
+      size="large"
+    />
+
     <div class="flex gap-32">
       <div class="hidden laptop:!block laptop:flex-[55] min-w-0">
         <VaultOverviewEarn
@@ -247,42 +256,34 @@ watch(address, () => {
         >
           <div
             v-if="vault && asset"
-            class="flex justify-between"
+            class="flex items-center justify-between"
           >
-            <VaultLabelsAndAssets
-              :vault="vault"
-              :assets="assets"
-              size="large"
-            />
+            <p class="text-h3 text-content-tertiary flex items-center gap-4">
+              Supply APY
+              <span class="inline-flex items-center rounded-8 px-8 py-2 bg-accent-100 text-accent-600 text-p5">
+                1h
+              </span>
+              <SvgIcon
+                class="!w-20 !h-20 text-content-muted cursor-pointer hover:text-content-secondary"
+                name="info-circle"
+                @click="onSupplyInfoIconClick"
+              />
+            </p>
 
-            <div class="flex flex-col items-end justify-end">
-              <p class="mb-4 text-content-tertiary flex items-center gap-4">
-                Supply APY
-                <span class="inline-flex items-center rounded-8 px-8 py-2 bg-accent-100 text-accent-600 text-p5">
-                  1h
-                </span>
-                <SvgIcon
-                  class="!w-20 !h-20 text-content-muted cursor-pointer hover:text-content-secondary"
-                  name="info-circle"
-                  @click="onSupplyInfoIconClick"
-                />
-              </p>
-
-              <p class="flex justify-end gap-4 text-h3">
-                <VaultPoints
-                  :vault="vault"
-                />
-                <SvgIcon
-                  v-if="hasRewards"
-                  class="!w-24 !h-24 text-accent-500 cursor-pointer"
-                  name="sparks"
-                  @click="onSupplyInfoIconClick"
-                />
-                <span>
-                  {{ supplyAPYDisplay }}%
-                </span>
-              </p>
-            </div>
+            <p class="flex items-center gap-4 text-h3">
+              <VaultPoints
+                :vault="vault"
+              />
+              <SvgIcon
+                v-if="hasRewards"
+                class="!w-24 !h-24 text-accent-500 cursor-pointer"
+                name="sparks"
+                @click="onSupplyInfoIconClick"
+              />
+              <span>
+                {{ supplyAPYDisplay }}%
+              </span>
+            </p>
           </div>
 
           <AssetInput

--- a/pages/lend/[vault]/index.vue
+++ b/pages/lend/[vault]/index.vue
@@ -718,6 +718,16 @@ watch(address, () => {
 <template>
   <div>
     <BaseBackButton class="laptop:!hidden mb-16" />
+
+    <!-- Vault header -->
+    <VaultLabelsAndAssets
+      v-if="isVaultLoaded && asset && (vault || securitizeVault)"
+      class="mb-24"
+      :vault="(vault || securitizeVault)!"
+      :assets="assets"
+      size="large"
+    />
+
     <div class="flex gap-32">
       <div class="hidden laptop:!block laptop:flex-[55] min-w-0">
         <!-- EVK Vault Overview -->
@@ -739,46 +749,35 @@ watch(address, () => {
           class="w-full"
           @submit.prevent="submit"
         >
-          <!-- Vault header -->
           <div
             v-if="isVaultLoaded && asset"
-            class="flex justify-between"
+            class="flex items-center justify-between"
           >
-            <!-- Use VaultLabelsAndAssets for both EVK and Securitize vaults -->
-            <VaultLabelsAndAssets
-              v-if="vault || securitizeVault"
-              :vault="(vault || securitizeVault)!"
-              :assets="assets"
-              size="large"
-            />
+            <p class="text-h3 text-content-tertiary flex items-center gap-4">
+              Supply APY
+              <SvgIcon
+                class="!w-20 !h-20 text-content-muted cursor-pointer hover:text-content-secondary"
+                name="info-circle"
+                @click="onSupplyInfoIconClick"
+              />
+            </p>
 
-            <div class="flex flex-col items-end justify-end">
-              <p class="mb-4 text-content-tertiary flex items-center gap-4">
-                Supply APY
-                <SvgIcon
-                  class="!w-20 !h-20 text-content-muted cursor-pointer hover:text-content-secondary"
-                  name="info-circle"
-                  @click="onSupplyInfoIconClick"
-                />
-              </p>
-
-              <p class="flex justify-end gap-4 text-h3">
-                <VaultPoints
-                  v-if="features.hasPoints && vault"
-                  class="mr-4"
-                  :vault="vault"
-                />
-                <SvgIcon
-                  v-if="hasRewards"
-                  class="!w-24 !h-24 text-accent-600 cursor-pointer"
-                  name="sparks"
-                  @click="onSupplyInfoIconClick"
-                />
-                <span>
-                  {{ supplyAPYDisplay }}%
-                </span>
-              </p>
-            </div>
+            <p class="flex items-center gap-4 text-h3">
+              <VaultPoints
+                v-if="features.hasPoints && vault"
+                class="mr-4"
+                :vault="vault"
+              />
+              <SvgIcon
+                v-if="hasRewards"
+                class="!w-24 !h-24 text-accent-600 cursor-pointer"
+                name="sparks"
+                @click="onSupplyInfoIconClick"
+              />
+              <span>
+                {{ supplyAPYDisplay }}%
+              </span>
+            </p>
           </div>
 
           <AssetInput

--- a/pages/position/[number]/borrow/index.vue
+++ b/pages/position/[number]/borrow/index.vue
@@ -7,6 +7,7 @@ import { useToast } from '~/components/ui/composables/useToast'
 import { type BorrowVaultPair, getNetAPY, type VaultAsset } from '~/entities/vault'
 import { getUtilisationWarning, getBorrowCapWarning } from '~/composables/useVaultWarnings'
 import { getAssetUsdValueOrZero, getAssetOraclePrice, getCollateralOraclePrice, conservativePriceRatio } from '~/services/pricing/priceProvider'
+import { getTotalCollateralValue } from '~/utils/position-estimates'
 import { useEulerProductOfVault } from '~/composables/useEulerLabels'
 import { isAnyVaultBlockedByCountry, isVaultRestrictedByCountry } from '~/composables/useGeoBlock'
 import type { AccountBorrowPosition } from '~/entities/account'
@@ -109,6 +110,7 @@ const borrowWarnings = computed(() => {
   ]
 })
 const pairAssets = computed(() => [collateralVault.value?.asset, borrowVault.value?.asset])
+const pairAssetsLabel = usePositionPairLabel(position)
 const priceFixed = computed(() => {
   const collateralPrice = borrowVault.value && collateralVault.value
     ? getCollateralOraclePrice(borrowVault.value, collateralVault.value)
@@ -117,10 +119,6 @@ const priceFixed = computed(() => {
   return FixedPoint.fromValue(conservativePriceRatio(collateralPrice, borrowPrice), 18)
 })
 priceInvert.autoInvert(() => priceFixed.value.toUnsafeFloat())
-const collateralAmountFixed = computed(() => FixedPoint.fromValue(
-  valueToNano(collateralAmount.value || '0', collateralVault.value?.decimals),
-  Number(collateralVault.value?.decimals),
-))
 const borrowAmountFixed = computed(() => FixedPoint.fromValue(
   valueToNano(borrowAmount.value || '0', borrowVault.value?.decimals),
   Number(borrowVault.value?.decimals),
@@ -226,7 +224,12 @@ const submit = async () => {
         borrowVault.value.address,
         valueToNano(borrowAmount.value || '0', borrowVault.value.decimals),
         position.value?.subAccount,
-        { includePermit2Call: false, enabledCollaterals: position.value?.collaterals },
+        {
+          includePermit2Call: false,
+          enabledCollaterals: position.value?.collaterals,
+          enabledController: position.value?.borrow.address,
+          acceptedCollaterals: borrowVault.value.collateralLTVs.filter(c => c.borrowLTV > 0n).map(c => c.collateral),
+        },
       )
     }
     catch (e) {
@@ -274,7 +277,12 @@ const send = async () => {
       borrowVault.value.address,
       borrowAmountFixed.value.toFormat({ decimals: Number(borrowVault.value.decimals) }).value,
       position.value.subAccount,
-      { includePermit2Call: true, enabledCollaterals: position.value?.collaterals },
+      {
+        includePermit2Call: true,
+        enabledCollaterals: position.value?.collaterals,
+        enabledController: position.value?.borrow.address,
+        acceptedCollaterals: borrowVault.value.collateralLTVs.filter(c => c.borrowLTV > 0n).map(c => c.collateral),
+      },
     )
     await executeTxPlan(txPlan)
 
@@ -292,30 +300,41 @@ const send = async () => {
     isSubmitting.value = false
   }
 }
-const onCollateralInput = async () => {
-  await nextTick()
-  const result = collateralAmountFixed.value
-    .mul(priceFixed.value)
-    .mul(ltvFixed.value)
-    .div(FixedPoint.fromValue(100n, 0)).round(Number(borrowVault.value?.decimals || 18))
-    .subUnsafe(FixedPoint.fromValue(position.value?.borrowed || 0n, position.value?.borrow.decimals || 18))
-  const zero = FixedPoint.fromValue(0n, Number(borrowVault.value?.decimals || 18))
-  borrowAmount.value = result.lt(zero) ? zero.toString() : trimTrailingZeros(result.toString())
-}
-const onBorrowInput = async () => {
-  await nextTick()
-  if (!collateralAmount.value) {
-    return
+const isLtvDriven = ref(true)
+
+const computedBorrowAmount = computed(() => {
+  if (!pair.value || !borrowVault.value) return null
+  const borrowed = position.value?.borrowed || 0n
+  if (borrowed === 0n || currentUserLTV.value <= 0) return null
+
+  const newLtv = ltvFixed.value.toUnsafeFloat()
+  if (newLtv <= currentUserLTV.value) return '0'
+
+  const ratio = (newLtv / currentUserLTV.value) - 1
+  const additionalNano = BigInt(Math.floor(Number(borrowed) * ratio))
+  if (additionalNano <= 0n) return '0'
+
+  const result = FixedPoint.fromValue(additionalNano, Number(borrowVault.value.decimals))
+  return trimTrailingZeros(result.toString())
+})
+
+watch(computedBorrowAmount, (val) => {
+  if (isLtvDriven.value && val !== null) {
+    borrowAmount.value = val
   }
-  ltv.value = +borrowAmountFixed.value
-    .addUnsafe(FixedPoint.fromValue(position.value?.borrowed || 0n, position.value?.borrow.decimals || 18))
-    .div(collateralAmountFixed.value.mul(priceFixed.value))
-    .mul(FixedPoint.fromValue(100n, 0))
-    .toUnsafeFloat().toFixed(2)
-}
-const onLtvInput = async () => {
+})
+
+const onBorrowInput = async () => {
+  isLtvDriven.value = false
   await nextTick()
-  onCollateralInput()
+  if (!position.value) return
+  const totalCollateral = getTotalCollateralValue(position.value)
+  if (!totalCollateral || totalCollateral <= 0) return
+  const totalBorrow = nanoToValue(position.value.borrowed, position.value.borrow.decimals || 18) + (+borrowAmount.value || 0)
+  ltv.value = +((totalBorrow / totalCollateral) * 100).toFixed(2)
+}
+const onLtvInput = () => {
+  isLtvDriven.value = true
 }
 const updateEstimates = useDebounceFn(async () => {
   if (!pair.value) {
@@ -323,9 +342,11 @@ const updateEstimates = useDebounceFn(async () => {
   }
   await Promise.all([updateVault(collateralVault.value!.address), updateVault(borrowVault.value!.address)])
   try {
-    health.value = ltvFixed.value.toUnsafeFloat() <= 0
+    // Use LTV from the ratio-based slider (accounts for all collaterals)
+    const newLtvFloat = ltvFixed.value.toUnsafeFloat()
+    health.value = newLtvFloat <= 0
       ? Infinity
-      : (Number(pair.value?.liquidationLTV || 0n) / 100) / ltvFixed.value.toUnsafeFloat()
+      : (Number(pair.value?.liquidationLTV || 0n) / 100) / newLtvFloat
     liquidationPrice.value = health.value < 0.1 ? Infinity : priceFixed.value.toUnsafeFloat() / health.value
     // borrowAmount is the ADDITIONAL borrow; estimate Net APY using total borrow
     const existingBorrow = nanoToValue(position.value?.borrowed || 0n, borrowVault.value!.decimals)
@@ -391,6 +412,7 @@ watch([collateralAmount, borrowAmount], async () => {
         :vault="collateralVault"
         :pair-vault="borrowVault"
         :assets="pairAssets as VaultAsset[]"
+        :assets-label="pairAssetsLabel"
         size="large"
       />
 

--- a/pages/position/[number]/borrow/index.vue
+++ b/pages/position/[number]/borrow/index.vue
@@ -302,20 +302,22 @@ const send = async () => {
 }
 const isLtvDriven = ref(true)
 
+// Reactive borrow amount: uses FixedPoint throughout to avoid precision loss on large bigints.
+// Formula: additionalBorrow = borrowed * (newLtv - currentLtv) / currentLtv
 const computedBorrowAmount = computed(() => {
   if (!pair.value || !borrowVault.value) return null
   const borrowed = position.value?.borrowed || 0n
   if (borrowed === 0n || currentUserLTV.value <= 0) return null
 
-  const newLtv = ltvFixed.value.toUnsafeFloat()
-  if (newLtv <= currentUserLTV.value) return '0'
+  const newLtvFP = ltvFixed.value
+  const currentLtvFP = FixedPoint.fromValue(valueToNano(currentUserLTV.value, 4), 4)
+  if (currentLtvFP.isZero() || newLtvFP.lte(currentLtvFP)) return '0'
 
-  const ratio = (newLtv / currentUserLTV.value) - 1
-  const additionalNano = BigInt(Math.floor(Number(borrowed) * ratio))
-  if (additionalNano <= 0n) return '0'
-
-  const result = FixedPoint.fromValue(additionalNano, Number(borrowVault.value.decimals))
-  return trimTrailingZeros(result.toString())
+  const borrowedFP = FixedPoint.fromValue(borrowed, Number(borrowVault.value.decimals))
+  const delta = newLtvFP.subUnsafe(currentLtvFP)
+  const additional = borrowedFP.mul(delta).div(currentLtvFP)
+  if (additional.isZero() || additional.isNegative()) return '0'
+  return trimTrailingZeros(additional.toString())
 })
 
 watch(computedBorrowAmount, (val) => {

--- a/pages/position/[number]/borrow/swap.vue
+++ b/pages/position/[number]/borrow/swap.vue
@@ -26,6 +26,7 @@ const positionIndex = usePositionIndex()
 // ── Position & vaults ────────────────────────────────────────────────────
 const position: Ref<AccountBorrowPosition | null> = ref(null)
 
+const pairAssetsLabel = usePositionPairLabel(position)
 const fromVault = computed(() => position.value?.borrow)
 const collateralVault = computed(() => position.value?.collateral)
 const toVault: Ref<Vault | undefined> = ref()
@@ -331,6 +332,7 @@ const onToVaultChange = (selectedIndex: number) => {
         <VaultLabelsAndAssets
           :vault="fromVault"
           :assets="[fromVault.asset] as VaultAsset[]"
+          :assets-label="pairAssetsLabel"
           size="large"
         />
         <div class="grid gap-16 laptop:grid-cols-[minmax(0,1fr)_360px] laptop:items-start">

--- a/pages/position/[number]/collateral/swap.vue
+++ b/pages/position/[number]/collateral/swap.vue
@@ -42,6 +42,7 @@ const positionIndex = usePositionIndex()
 
 // ── Vaults & position ────────────────────────────────────────────────────
 const position: Ref<AccountBorrowPosition | null> = ref(null)
+const pairAssetsLabel = usePositionPairLabel(position)
 const selectedCollateral = ref<Vault | SecuritizeVault | null>(null)
 const selectedCollateralAssets = ref(0n)
 const lastCollateralAddress = ref('')
@@ -481,6 +482,7 @@ const nextLiquidationPrice = computed(() => {
         <VaultLabelsAndAssets
           :vault="fromVault"
           :assets="[fromVault.asset] as VaultAsset[]"
+          :assets-label="pairAssetsLabel"
           size="large"
         />
         <div class="grid gap-16 laptop:grid-cols-[minmax(0,1fr)_360px] laptop:items-start">

--- a/pages/position/[number]/index.vue
+++ b/pages/position/[number]/index.vue
@@ -703,6 +703,10 @@ watch([isConnected, isSpyMode], () => {
       </div>
     </template>
     <template v-else-if="position">
+      <div class="text-h6 text-content-secondary bg-surface-elevated py-4 px-12 rounded-8 border border-line-default self-start">
+        Position {{ positionIndex }}
+      </div>
+
       <VaultLabelsAndAssets
         :vault="position.collateral"
         :assets="pairAssets"
@@ -778,12 +782,8 @@ watch([isConnected, isSpyMode], () => {
         v-if="!hasNoBorrow"
         class="rounded-12 bg-card border border-line-default shadow-card p-16"
       >
-        <div class="text-h4 text-neutral-800 flex items-center flex-wrap gap-12 mb-16">
+        <div class="text-h4 text-neutral-800 mb-16">
           Position risk
-
-          <div class="text-h6 text-content-secondary bg-surface-elevated py-4 px-12 rounded-8 border border-line-default">
-            Position {{ positionIndex }}
-          </div>
         </div>
         <div class="flex justify-between gap-8 flex-wrap mb-16">
           <div class="text-neutral-500 text-p3">

--- a/pages/position/[number]/multiply.vue
+++ b/pages/position/[number]/multiply.vue
@@ -104,6 +104,7 @@ const pairAssets = computed(() => {
   }
   return [multiplyLongVault.value.asset, multiplyShortVault.value.asset]
 })
+const pairAssetsLabel = usePositionPairLabel(position)
 
 const multiplyLongProduct = useEulerProductOfVault(computed(() => multiplyLongVault.value?.address || ''))
 const multiplyShortProduct = useEulerProductOfVault(computed(() => multiplyShortVault.value?.address || ''))
@@ -614,6 +615,7 @@ const submitMultiply = async () => {
           ...nextPlanParams,
           includePermit2Call: false,
           enabledCollaterals: position.value?.collaterals,
+          enabledController: position.value?.borrow.address,
         })
       }
       catch (e) {
@@ -661,6 +663,7 @@ const sendMultiply = async () => {
       ...planParams.value,
       includePermit2Call: true,
       enabledCollaterals: position.value?.collaterals,
+      enabledController: position.value?.borrow.address,
     })
     plan.value = nextPlan
     await executeTxPlan(nextPlan)
@@ -787,6 +790,7 @@ watch([multiplyMinMultiplier, multiplyMaxMultiplier], ([min, max]) => {
       <VaultLabelsAndAssets
         :vault="multiplyLongVault"
         :assets="pairAssets as VaultAsset[]"
+        :assets-label="pairAssetsLabel"
         size="large"
       />
 

--- a/pages/position/[number]/repay.vue
+++ b/pages/position/[number]/repay.vue
@@ -46,6 +46,7 @@ const borrowVault = computed(() => position.value?.borrow)
 const collateralVault = computed(() => position.value?.collateral)
 useOperationGuard(computed(() => [borrowVault.value?.address].filter(Boolean)))
 const assets = computed(() => [collateralVault.value?.asset, borrowVault.value?.asset])
+const assetsLabel = usePositionPairLabel(position)
 const isEligibleForLiquidation = computed(() => isPositionEligibleForLiquidation(position.value))
 const getCurrentDebt = () => position.value?.borrowed || 0n
 
@@ -325,6 +326,7 @@ watch(formTab, () => {
       <VaultLabelsAndAssets
         :vault="position.borrow"
         :assets="assets as VaultAsset[]"
+        :assets-label="assetsLabel"
         size="large"
       />
 

--- a/pages/position/[number]/supply.vue
+++ b/pages/position/[number]/supply.vue
@@ -158,6 +158,7 @@ useOperationGuard(computed(() => [form.collateralVault.value?.address].filter(Bo
 
 const balanceFixed = computed(() => FixedPoint.fromValue(balance.value, form.collateralVault.value?.decimals || 18))
 const assets = computed(() => [form.asset.value].filter((v): v is VaultAsset => !!v))
+const pairAssetsLabel = usePositionPairLabel(form.position)
 const { name } = useEulerProductOfVault(computed(() => form.collateralVault.value?.address || ''))
 
 // Supply-specific: balance management
@@ -236,6 +237,7 @@ watch(selectedAsset, async () => {
       <VaultLabelsAndAssets
         :vault="form.collateralVault.value"
         :assets="assets"
+        :assets-label="pairAssetsLabel"
         size="large"
       />
 

--- a/pages/position/[number]/withdraw.vue
+++ b/pages/position/[number]/withdraw.vue
@@ -130,6 +130,7 @@ const form = useCollateralForm({
   },
 })
 useOperationGuard(computed(() => [form.collateralVault.value?.address, form.borrowVault.value?.address].filter(Boolean)))
+const pairAssetsLabel = usePositionPairLabel(form.position)
 
 // Withdraw-specific computeds
 const withdrawWarnings = computed(() => {
@@ -179,6 +180,7 @@ watch(selectedOutputAsset, () => {
       <VaultLabelsAndAssets
         :vault="form.collateralVault.value"
         :assets="[form.asset.value]"
+        :assets-label="pairAssetsLabel"
         size="large"
       />
 

--- a/utils/collateral-cleanup.ts
+++ b/utils/collateral-cleanup.ts
@@ -13,6 +13,9 @@ interface CleanupParams {
   subAccount: Address
   providerUrl: string
   subgraphUrl: string
+  /** Collateral addresses accepted by the controller (BLTV > 0). Collaterals in
+   *  this list are only disabled when they have zero balance (no deposit). */
+  acceptedCollaterals?: string[]
 }
 
 interface EVCAccountInfo {
@@ -21,7 +24,7 @@ interface EVCAccountInfo {
 }
 
 export async function buildCollateralCleanupCalls(params: CleanupParams): Promise<EVCCall[]> {
-  const { evcAddress, accountLensAddress, subAccount, providerUrl, subgraphUrl } = params
+  const { evcAddress, accountLensAddress, subAccount, providerUrl, subgraphUrl, acceptedCollaterals } = params
 
   try {
     const client = getPublicClient(providerUrl)
@@ -87,23 +90,31 @@ export async function buildCollateralCleanupCalls(params: CleanupParams): Promis
       return evcCalls
     }
 
-    // Branch 3: Active borrows exist — only disable collaterals not backing deposits
+    // Branch 3: Active borrows exist — only disable collaterals that don't
+    // contribute to the health score
     const depositSet = new Set(
       deposits
         .filter(d => d.subAccount === normalizedSubAccount)
-        .map(d => d.vault),
+        .map(d => getAddress(d.vault)),
+    )
+
+    const acceptedSet = new Set(
+      (acceptedCollaterals || []).map(a => getAddress(a)),
     )
 
     for (const collateral of collaterals) {
       const normalized = getAddress(collateral)
-      if (!depositSet.has(normalized)) {
-        evcCalls.push({
-          targetContract: evcAddress,
-          onBehalfOfAccount: zeroAddress,
-          value: 0n,
-          data: hooks.getDataForCall(evcAddress, 'disableCollateral', [subAccount, collateral]) as Hash,
-        })
-      }
+      // Keep collaterals that are accepted by the controller and have balance —
+      // they contribute to the health score
+      if (acceptedSet.has(normalized) && depositSet.has(normalized)) continue
+      // Also keep collaterals with deposits even if not accepted (safe default)
+      if (depositSet.has(normalized)) continue
+      evcCalls.push({
+        targetContract: evcAddress,
+        onBehalfOfAccount: zeroAddress,
+        value: 0n,
+        data: hooks.getDataForCall(evcAddress, 'disableCollateral', [subAccount, collateral]) as Hash,
+      })
     }
 
     return evcCalls

--- a/utils/position-estimates.ts
+++ b/utils/position-estimates.ts
@@ -1,0 +1,87 @@
+import { nanoToValue } from '~/utils/crypto-utils'
+import type { AccountBorrowPosition } from '~/entities/account'
+import { getAssetOraclePrice, getCollateralOraclePrice, conservativePriceRatioNumber } from '~/services/pricing/priceProvider'
+import type { Vault, SecuritizeVault } from '~/entities/vault'
+
+/**
+ * Derives the total collateral value (in borrow-asset terms) from the position's
+ * on-chain userLTV and borrowed amount. This accounts for ALL collaterals, not
+ * just the primary one.
+ *
+ * Returns null if the position has no borrow or LTV is zero.
+ */
+export function getTotalCollateralValue(position: AccountBorrowPosition): number | null {
+  const borrowed = nanoToValue(position.borrowed, position.borrow.decimals || 18)
+  const userLtv = nanoToValue(position.userLTV, 18)
+  if (userLtv <= 0 || borrowed <= 0) return null
+  return borrowed / userLtv * 100
+}
+
+/**
+ * Gets the conservative price ratio for a single collateral relative to a borrow vault.
+ * Returns the value of 1 unit of collateral in borrow-asset terms.
+ */
+export function getCollateralPriceRatio(
+  borrowVault: Vault,
+  collateralVault: Vault | SecuritizeVault,
+): number | null {
+  const collateralPrice = getCollateralOraclePrice(borrowVault, collateralVault)
+  const borrowPrice = getAssetOraclePrice(borrowVault)
+  return conservativePriceRatioNumber(collateralPrice, borrowPrice)
+}
+
+interface EstimateParams {
+  position: AccountBorrowPosition
+  /** Change in collateral amount (in collateral asset units). Positive = supply, negative = withdraw. */
+  collateralDelta?: number
+  /** Change in borrow amount (in borrow asset units). Positive = borrow more, negative = repay. */
+  borrowDelta?: number
+  /** Price ratio for the collateral being changed (from getCollateralPriceRatio). Only needed if collateralDelta != 0. */
+  collateralPriceRatio?: number | null
+}
+
+export interface PositionEstimate {
+  newLtv: number
+  newHealth: number
+  newLiquidationPrice: number | null
+}
+
+/**
+ * Estimates new LTV, health score, and liquidation price after a position change.
+ * Uses the on-chain userLTV to derive total collateral value (multi-collateral aware),
+ * then adjusts for the specific operation.
+ */
+export function estimatePositionAfterChange(params: EstimateParams): PositionEstimate | null {
+  const { position, collateralDelta = 0, borrowDelta = 0, collateralPriceRatio } = params
+
+  const totalCollateralValue = getTotalCollateralValue(position)
+  if (totalCollateralValue === null) return null
+
+  const borrowed = nanoToValue(position.borrowed, position.borrow.decimals || 18)
+  const liquidationLtv = Number(position.liquidationLTV) / 100
+
+  // Adjust collateral value
+  let newCollateralValue = totalCollateralValue
+  if (collateralDelta !== 0 && collateralPriceRatio) {
+    newCollateralValue += collateralDelta * collateralPriceRatio
+  }
+
+  // Adjust borrowed amount
+  const newBorrowed = borrowed + borrowDelta
+
+  if (newCollateralValue <= 0 || newBorrowed <= 0) {
+    return { newLtv: 0, newHealth: Infinity, newLiquidationPrice: null }
+  }
+
+  const newLtv = (newBorrowed / newCollateralValue) * 100
+  const newHealth = newLtv > 0 ? liquidationLtv / newLtv : Infinity
+
+  // Liquidation price: derived from the oracle price and health
+  // liqPrice = oraclePrice / health
+  const oraclePrice = collateralPriceRatio
+  const newLiquidationPrice = oraclePrice && newHealth > 0 && newHealth < Infinity
+    ? oraclePrice / newHealth
+    : null
+
+  return { newLtv, newHealth, newLiquidationPrice }
+}


### PR DESCRIPTION
## Summary

- **Redundant transaction steps**: Skip unnecessary `enableController`, `enableCollateral`, and `deposit(0)` calls when operating on existing positions (borrow-more, multiply). Uses `enabledController` and `enabledCollaterals` from position data to determine what's already enabled.
- **Borrow-more slider stuck at 0**: Replace price-based formula with ratio-based (`borrowed × (newLTV/currentLTV − 1)`) that's oracle-independent and works correctly with multi-collateral positions. Made reactive via `computed` + `watch` instead of event-driven double-nextTick chain.
- **Multi-collateral estimate fixes**: LTV, health score, and liquidation price estimates now derive total collateral value from on-chain `userLTV` instead of single collateral price. Affects supply, withdraw, repay, and borrow-more pages.
- **Smart collateral cleanup**: Preserves collaterals accepted by the controller (BLTV > 0) that have deposits. Only disables truly stale collaterals.
- **Position pair labels**: All sub-pages (borrow, multiply, repay, supply, withdraw, swaps) now show "X & others/Y" when position has multiple collaterals via shared `usePositionPairLabel` composable.
- **UI**: Remove "Transaction steps" header from transaction review modal.

## Test plan

- [ ] Borrow-more on a multi-collateral position (e.g., BOLD+sBOLD/USDC): slider updates borrow amount immediately, no stuck-at-0
- [ ] Borrow-more on a single-collateral position: slider still works correctly
- [ ] Transaction review for borrow-more: no Supply, Enable controller, or Enable collateral steps
- [ ] Transaction review for multiply: no redundant Enable steps
- [ ] Withdraw/supply/repay on multi-collateral position: LTV/health estimates are reasonable (not jumping to 74%+ for tiny amounts)
- [ ] All position sub-pages show "X & others/Y" label for multi-collateral positions
- [ ] Single-collateral positions show normal "X/Y" label
- [ ] Collateral cleanup only disables stale collaterals (not accepted ones with deposits)