### PR TITLE
fix: prevent transition crash on direct navigation

### DIFF
--- a/pages/borrow/[collateral]/[borrow]/index.vue
+++ b/pages/borrow/[collateral]/[borrow]/index.vue
@@ -45,9 +45,11 @@ const pendingSubAccount = ref<string | null>(null)
 const isPendingSubAccountLoading = ref(false)
 let pendingSubAccountPromise: Promise<string> | null = null
 
-// Load vault pair
-const initialPair = await getBorrowVaultPair(collateralAddress, borrowAddress)
-const pair: Ref<AnyBorrowVaultPair | undefined> = ref(initialPair)
+// Load vault pair (non-blocking to avoid Suspense + pageTransition crash on direct navigation)
+const pair: Ref<AnyBorrowVaultPair | undefined> = ref()
+getBorrowVaultPair(collateralAddress, borrowAddress).then((p) => {
+  pair.value = p
+})
 
 const borrowVault = computed(() => pair.value?.borrow)
 const collateralVault = computed(() => pair.value?.collateral)

--- a/pages/borrow/[collateral]/[borrow]/index.vue
+++ b/pages/borrow/[collateral]/[borrow]/index.vue
@@ -49,6 +49,8 @@ let pendingSubAccountPromise: Promise<string> | null = null
 const pair: Ref<AnyBorrowVaultPair | undefined> = ref()
 getBorrowVaultPair(collateralAddress, borrowAddress).then((p) => {
   pair.value = p
+}).catch((e) => {
+  logWarn('[borrow] failed to load vault pair', e)
 })
 
 const borrowVault = computed(() => pair.value?.borrow)

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -5,7 +5,8 @@ const { enableEarnPage, enableLendPage, enableExplorePage } = useDeployConfig()
 const defaultPageRoute = getDefaultPageRoute(enableEarnPage, enableLendPage, enableExplorePage)
 
 const route = useRoute()
-await navigateTo(
+// Non-blocking to avoid Suspense + pageTransition crash on direct navigation
+navigateTo(
   { name: defaultPageRoute, query: route.query, hash: route.hash },
   { replace: true },
 )

--- a/pages/lend/[vault]/[subAccount]/swap.vue
+++ b/pages/lend/[vault]/[subAccount]/swap.vue
@@ -178,7 +178,8 @@ const loadVaults = async () => {
   }
 }
 
-await loadVaults()
+// Non-blocking to avoid Suspense + pageTransition crash on direct navigation
+loadVaults()
 
 watch([() => route.params.vault, () => route.query.to], () => {
   loadVaults()

--- a/pages/lend/[vault]/index.vue
+++ b/pages/lend/[vault]/index.vue
@@ -126,83 +126,6 @@ const evkVault: Ref<Vault | undefined> = ref(undefined)
 const securitizeVault: Ref<SecuritizeVault | undefined> = ref(undefined)
 const balance = ref(0n)
 
-// Check if securitize vault first
-const isSecuritize = await isSecuritizeVault(vaultAddress)
-
-// Load vault data based on type
-if (isSecuritize) {
-  securitizeVault.value = await getSecuritizeVault(vaultAddress)
-}
-else {
-  try {
-    const normalizedAddress = getAddress(vaultAddress)
-
-    // Fast path: vault already in registry
-    const registryEntry = registryGet(normalizedAddress)
-    if (registryEntry?.type === 'evk') {
-      evkVault.value = registryEntry.vault as Vault
-    }
-    // Escrow vaults haven't loaded yet - wait for them
-    else if (!isEscrowLoadedOnce.value) {
-      await until(isEscrowLoadedOnce).toBe(true)
-      const entryAfterLoad = registryGet(normalizedAddress)
-      if (entryAfterLoad?.type === 'evk') {
-        evkVault.value = entryAfterLoad.vault as Vault
-      }
-      else if (isKnownEscrowAddress(normalizedAddress)) {
-        evkVault.value = await getEscrowVault(vaultAddress) as Vault
-      }
-      else {
-        evkVault.value = await getVault(vaultAddress)
-      }
-    }
-    // Escrow vaults loaded - check if known escrow address
-    else if (isKnownEscrowAddress(normalizedAddress)) {
-      evkVault.value = await getEscrowVault(vaultAddress) as Vault
-    }
-    // Regular vault
-    else {
-      evkVault.value = await getVault(vaultAddress)
-    }
-
-    // Load any collateral vaults that aren't already in registry
-    if (evkVault.value) {
-      const { has: registryHas } = useVaultRegistry()
-
-      const collateralAddresses = evkVault.value.collateralLTVs
-        .filter(ltv => getCurrentLiquidationLTV(ltv) > 0n)
-        .map(ltv => ltv.collateral)
-
-      // Check and load missing collaterals in parallel
-      await Promise.all(
-        collateralAddresses.map(async (collateralAddr) => {
-          // Skip if already loaded in registry
-          if (registryHas(collateralAddr)) return
-
-          try {
-            // Try regular vault first, then securitize
-            await getVault(collateralAddr)
-          }
-          catch {
-            // If regular vault fails, try securitize
-            try {
-              await getSecuritizeVault(collateralAddr)
-            }
-            catch {
-              // Ignore - collateral vault might not be accessible
-            }
-          }
-        }),
-      )
-    }
-  }
-  catch (e) {
-    // If EVK vault load fails, try as securitize vault
-    console.warn('[lend] EVK vault load failed, trying securitize:', e)
-    securitizeVault.value = await getSecuritizeVault(vaultAddress)
-  }
-}
-
 // Check if vault uses Pyth oracles (requires fresh prices)
 const hasPythOracles = (v: Vault | undefined): boolean => {
   if (!v) return false
@@ -225,14 +148,92 @@ const needsRefresh = (v: Vault | undefined): boolean => {
   return hasPythOracles(v) || hasPriceFailure(v)
 }
 
-// Refresh EVK vault if it uses Pyth oracles or has price failure
-// Pyth prices are only valid for ~2 minutes, so always refresh when Pyth is detected
-if (evkVault.value && needsRefresh(evkVault.value)) {
-  const refreshedVault = await updateVault(vaultAddress)
-  if (!('type' in refreshedVault && refreshedVault.type === 'securitize')) {
-    evkVault.value = refreshedVault as Vault
+// Non-blocking IIFE to avoid Suspense + pageTransition crash on direct navigation
+;(async () => {
+  const isSecuritize = await isSecuritizeVault(vaultAddress)
+
+  if (isSecuritize) {
+    securitizeVault.value = await getSecuritizeVault(vaultAddress)
   }
-}
+  else {
+    try {
+      const normalizedAddress = getAddress(vaultAddress)
+
+      // Fast path: vault already in registry
+      const registryEntry = registryGet(normalizedAddress)
+      if (registryEntry?.type === 'evk') {
+        evkVault.value = registryEntry.vault as Vault
+      }
+      // Escrow vaults haven't loaded yet - wait for them
+      else if (!isEscrowLoadedOnce.value) {
+        await until(isEscrowLoadedOnce).toBe(true)
+        const entryAfterLoad = registryGet(normalizedAddress)
+        if (entryAfterLoad?.type === 'evk') {
+          evkVault.value = entryAfterLoad.vault as Vault
+        }
+        else if (isKnownEscrowAddress(normalizedAddress)) {
+          evkVault.value = await getEscrowVault(vaultAddress) as Vault
+        }
+        else {
+          evkVault.value = await getVault(vaultAddress)
+        }
+      }
+      // Escrow vaults loaded - check if known escrow address
+      else if (isKnownEscrowAddress(normalizedAddress)) {
+        evkVault.value = await getEscrowVault(vaultAddress) as Vault
+      }
+      // Regular vault
+      else {
+        evkVault.value = await getVault(vaultAddress)
+      }
+
+      // Load any collateral vaults that aren't already in registry
+      if (evkVault.value) {
+        const { has: registryHas } = useVaultRegistry()
+
+        const collateralAddresses = evkVault.value.collateralLTVs
+          .filter(ltv => getCurrentLiquidationLTV(ltv) > 0n)
+          .map(ltv => ltv.collateral)
+
+        // Check and load missing collaterals in parallel
+        await Promise.all(
+          collateralAddresses.map(async (collateralAddr) => {
+            // Skip if already loaded in registry
+            if (registryHas(collateralAddr)) return
+
+            try {
+              // Try regular vault first, then securitize
+              await getVault(collateralAddr)
+            }
+            catch {
+              // If regular vault fails, try securitize
+              try {
+                await getSecuritizeVault(collateralAddr)
+              }
+              catch {
+                // Ignore - collateral vault might not be accessible
+              }
+            }
+          }),
+        )
+      }
+    }
+    catch (e) {
+      // If EVK vault load fails, try as securitize vault
+      console.warn('[lend] EVK vault load failed, trying securitize:', e)
+      securitizeVault.value = await getSecuritizeVault(vaultAddress)
+    }
+  }
+
+  // Refresh EVK vault if it uses Pyth oracles or has price failure
+  // Pyth prices are only valid for ~2 minutes, so always refresh when Pyth is detected
+  if (evkVault.value && needsRefresh(evkVault.value)) {
+    const refreshedVault = await updateVault(vaultAddress)
+    if (!('type' in refreshedVault && refreshedVault.type === 'securitize')) {
+      evkVault.value = refreshedVault as Vault
+    }
+  }
+})()
 
 const features = computed(() => VAULT_FEATURES[vaultType.value])
 

--- a/pages/lend/[vault]/index.vue
+++ b/pages/lend/[vault]/index.vue
@@ -233,6 +233,8 @@ const needsRefresh = (v: Vault | undefined): boolean => {
       evkVault.value = refreshedVault as Vault
     }
   }
+
+  load()
 })()
 
 const features = computed(() => VAULT_FEATURES[vaultType.value])
@@ -531,8 +533,6 @@ const onSupplyInfoIconClick = () => {
     },
   })
 }
-
-load()
 
 // Swap quote helpers
 const swapEstimatedOutput = computed(() => {


### PR DESCRIPTION
## Summary
- Remove top-level `await` in page `<script setup>` blocks that trigger Vue Suspense
- Suspense conflicts with Nuxt `pageTransition: { mode: 'out-in' }` on direct URL navigation (no previous page to transition from), causing "Cannot read properties of null (reading 'transition')"
- Affected pages: borrow pair, lend vault, lend swap, index redirect

## Test plan
- [ ] Direct-navigate to a borrow pair URL (e.g. `/borrow/0x.../0x...?network=1`) — no crash
- [ ] Direct-navigate to a lend vault URL — no crash
- [ ] Direct-navigate to `/` — redirects correctly
- [ ] In-app navigation between pages still works with transitions