### PR TITLE
feat: project post-action interest rates and instant health updates

### DIFF
--- a/composables/borrow/useBorrowForm.ts
+++ b/composables/borrow/useBorrowForm.ts
@@ -3,6 +3,7 @@ import { useAccount } from '@wagmi/vue'
 import { getAddress, formatUnits, zeroAddress, type Address } from 'viem'
 import { isNativeCurrencyAddress, isNativeOfWrapped, resolveWrappedNativeAddress, resolveWrappedNativeAsset } from '~/utils/native-currency'
 import { logWarn } from '~/utils/errorHandling'
+import { createRaceGuard } from '~/utils/race-guard'
 import { computeNextHealth, computeLiquidationPrice } from '~/utils/repayUtils'
 import { FixedPoint } from '~/utils/fixed-point'
 import { useModal } from '~/components/ui/composables/useModal'
@@ -495,8 +496,10 @@ export const useBorrowForm = (options: UseBorrowFormOptions) => {
   }
 
   // Async estimates (projected rates, USD prices, net APY) are debounced
+  const asyncEstimatesGuard = createRaceGuard()
   const updateAsyncEstimates = useDebounceFn(async () => {
     if (!pair.value || !collateralVault.value || !borrowVault.value) return
+    const gen = asyncEstimatesGuard.next()
     try {
       const collateralAmountNano = valueToNano(collateralAmount.value || '0', collateralVault.value.decimals)
       const borrowAmountNano = valueToNano(borrowAmount.value || '0', borrowVault.value.decimals)
@@ -522,6 +525,8 @@ export const useBorrowForm = (options: UseBorrowFormOptions) => {
         getAssetUsdValueOrZero(borrowAmountNano, borrowVault.value!, 'off-chain'),
       ])
 
+      if (asyncEstimatesGuard.isStale(gen)) return
+
       // Apply projected rate deltas on top of current APYs (which include intrinsic APY)
       const projectedSupplyApy = collateralProjected
         ? collateralSupplyApy.value + (nanoToValue(collateralProjected.supplyAPY, 25) - nanoToValue(collateralVault.value.interestRateInfo.supplyAPY, 25))
@@ -541,11 +546,14 @@ export const useBorrowForm = (options: UseBorrowFormOptions) => {
       )
     }
     catch (e) {
+      if (asyncEstimatesGuard.isStale(gen)) return
       logWarn('borrow/asyncEstimates', e)
       netAPY.value = undefined
     }
     finally {
-      isEstimatesLoading.value = false
+      if (!asyncEstimatesGuard.isStale(gen)) {
+        isEstimatesLoading.value = false
+      }
     }
   }, 500)
 

--- a/composables/borrow/useBorrowForm.ts
+++ b/composables/borrow/useBorrowForm.ts
@@ -518,18 +518,18 @@ export const useBorrowForm = (options: UseBorrowFormOptions) => {
         ),
         borrowNeedsSwap.value && borrowSwapAssetUsdPrice.value
           ? Promise.resolve((+collateralAmount.value || 0) * borrowSwapAssetUsdPrice.value)
-          : getAssetUsdValueOrZero(+collateralAmount.value || 0, collateralVault.value!, 'off-chain'),
-        getAssetUsdValueOrZero(+borrowAmount.value || 0, borrowVault.value!, 'off-chain'),
+          : getAssetUsdValueOrZero(collateralAmountNano, collateralVault.value!, 'off-chain'),
+        getAssetUsdValueOrZero(borrowAmountNano, borrowVault.value!, 'off-chain'),
       ])
 
       // Apply projected rate deltas on top of current APYs (which include intrinsic APY)
-      const currentRawSupplyApy = nanoToValue(collateralVault.value.interestRateInfo.supplyAPY, 25)
-      const projectedRawSupplyApy = nanoToValue(collateralProjected.supplyAPY, 25)
-      const projectedSupplyApy = collateralSupplyApy.value + (projectedRawSupplyApy - currentRawSupplyApy)
+      const projectedSupplyApy = collateralProjected
+        ? collateralSupplyApy.value + (nanoToValue(collateralProjected.supplyAPY, 25) - nanoToValue(collateralVault.value.interestRateInfo.supplyAPY, 25))
+        : collateralSupplyApy.value
 
-      const currentRawBorrowApy = nanoToValue(borrowVault.value.interestRateInfo.borrowAPY, 25)
-      const projectedRawBorrowApy = nanoToValue(borrowProjected.borrowAPY, 25)
-      const projectedBorrowApy = borrowApy.value + (projectedRawBorrowApy - currentRawBorrowApy)
+      const projectedBorrowApy = borrowProjected
+        ? borrowApy.value + (nanoToValue(borrowProjected.borrowAPY, 25) - nanoToValue(borrowVault.value.interestRateInfo.borrowAPY, 25))
+        : borrowApy.value
 
       netAPY.value = getNetAPY(
         collateralUsdValue,

--- a/composables/borrow/useBorrowForm.ts
+++ b/composables/borrow/useBorrowForm.ts
@@ -501,7 +501,10 @@ export const useBorrowForm = (options: UseBorrowFormOptions) => {
     if (!pair.value || !collateralVault.value || !borrowVault.value) return
     const gen = asyncEstimatesGuard.next()
     try {
-      const collateralAmountNano = valueToNano(collateralAmount.value || '0', collateralVault.value.decimals)
+      // When swapping, use the quote output amount (collateral-vault-asset denominated)
+      const collateralAmountNano = borrowNeedsSwap.value
+        ? borrowSwapEffectiveQuote.value ? BigInt(borrowSwapEffectiveQuote.value.amountOut || 0) : 0n
+        : valueToNano(collateralAmount.value || '0', collateralVault.value.decimals)
       const borrowAmountNano = valueToNano(borrowAmount.value || '0', borrowVault.value.decimals)
 
       const [collateralProjected, borrowProjected, collateralUsdValue, borrowUsdValue] = await Promise.all([
@@ -862,6 +865,17 @@ export const useBorrowForm = (options: UseBorrowFormOptions) => {
   watch(borrowSwapEffectiveQuote, () => {
     if (borrowNeedsSwap.value && collateralAmount.value && +ltv.value > 0) {
       onCollateralInput()
+    }
+    // Re-run projected rate estimates when quote resolves — collateralAmountNano depends on amountOut
+    if (borrowNeedsSwap.value) {
+      if (borrowSwapEffectiveQuote.value) {
+        if (!isEstimatesLoading.value) isEstimatesLoading.value = true
+        updateAsyncEstimates()
+      }
+      else {
+        isEstimatesLoading.value = true
+        updateAsyncEstimates()
+      }
     }
   })
 

--- a/composables/borrow/useBorrowForm.ts
+++ b/composables/borrow/useBorrowForm.ts
@@ -33,7 +33,7 @@ import type { TxPlan } from '~/entities/txPlan'
 import { getUtilisationWarning, getBorrowCapWarning, getSupplyCapWarning } from '~/composables/useVaultWarnings'
 import { getVaultTags, isVaultRestrictedByCountry } from '~/composables/useGeoBlock'
 import { useSwapQuotesParallel } from '~/composables/useSwapQuotesParallel'
-import { getNetAPY } from '~/entities/vault'
+import { getNetAPY, getProjectedRates } from '~/entities/vault'
 
 export interface UseBorrowFormOptions {
   pair: Ref<AnyBorrowVaultPair | undefined>
@@ -92,7 +92,6 @@ export const useBorrowForm = (options: UseBorrowFormOptions) => {
   const { address, isConnected } = useAccount()
   const { refreshAllPositions } = useEulerAccount()
   const { eulerLensAddresses, chainId } = useEulerAddresses()
-  const { updateVault } = useVaults()
   const { fetchSingleBalance } = useWallets()
 
   const {
@@ -474,16 +473,10 @@ export const useBorrowForm = (options: UseBorrowFormOptions) => {
   }
 
   // --- Actions: estimates ---
-  const updateEstimates = useDebounceFn(async () => {
-    if (!pair.value) {
-      return
-    }
-    try {
-      await Promise.all([updateVault(collateralVault.value!.address), updateVault(borrowVault.value!.address)])
-    }
-    catch (e) {
-      logWarn('borrow/updateEstimates', e, { severity: 'error' })
-    }
+
+  // Synchronous estimates (health, liq price) update instantly on every input
+  const updateSyncEstimates = () => {
+    if (!pair.value) return
     try {
       health.value = computeNextHealth(
         Number(pair.value?.liquidationLTV || 0n) / 100,
@@ -493,29 +486,68 @@ export const useBorrowForm = (options: UseBorrowFormOptions) => {
         priceFixed.value.toUnsafeFloat(),
         health.value,
       ) ?? undefined
-      const collateralUsdValue = borrowNeedsSwap.value && borrowSwapAssetUsdPrice.value
-        ? (+collateralAmount.value || 0) * borrowSwapAssetUsdPrice.value
-        : await getAssetUsdValueOrZero(+collateralAmount.value || 0, collateralVault.value!, 'off-chain')
-      const borrowUsdValue = await getAssetUsdValueOrZero(+borrowAmount.value || 0, borrowVault.value!, 'off-chain')
+    }
+    catch (e) {
+      logWarn('borrow/syncEstimates', e)
+      health.value = undefined
+      liquidationPrice.value = undefined
+    }
+  }
+
+  // Async estimates (projected rates, USD prices, net APY) are debounced
+  const updateAsyncEstimates = useDebounceFn(async () => {
+    if (!pair.value || !collateralVault.value || !borrowVault.value) return
+    try {
+      const collateralAmountNano = valueToNano(collateralAmount.value || '0', collateralVault.value.decimals)
+      const borrowAmountNano = valueToNano(borrowAmount.value || '0', borrowVault.value.decimals)
+
+      const [collateralProjected, borrowProjected, collateralUsdValue, borrowUsdValue] = await Promise.all([
+        getProjectedRates(
+          collateralVault.value.address,
+          collateralVault.value.interestRateInfo.cash,
+          collateralVault.value.interestRateInfo.borrows,
+          collateralAmountNano,
+          0n,
+        ),
+        getProjectedRates(
+          borrowVault.value.address,
+          borrowVault.value.interestRateInfo.cash,
+          borrowVault.value.interestRateInfo.borrows,
+          -borrowAmountNano,
+          borrowAmountNano,
+        ),
+        borrowNeedsSwap.value && borrowSwapAssetUsdPrice.value
+          ? Promise.resolve((+collateralAmount.value || 0) * borrowSwapAssetUsdPrice.value)
+          : getAssetUsdValueOrZero(+collateralAmount.value || 0, collateralVault.value!, 'off-chain'),
+        getAssetUsdValueOrZero(+borrowAmount.value || 0, borrowVault.value!, 'off-chain'),
+      ])
+
+      // Apply projected rate deltas on top of current APYs (which include intrinsic APY)
+      const currentRawSupplyApy = nanoToValue(collateralVault.value.interestRateInfo.supplyAPY, 25)
+      const projectedRawSupplyApy = nanoToValue(collateralProjected.supplyAPY, 25)
+      const projectedSupplyApy = collateralSupplyApy.value + (projectedRawSupplyApy - currentRawSupplyApy)
+
+      const currentRawBorrowApy = nanoToValue(borrowVault.value.interestRateInfo.borrowAPY, 25)
+      const projectedRawBorrowApy = nanoToValue(borrowProjected.borrowAPY, 25)
+      const projectedBorrowApy = borrowApy.value + (projectedRawBorrowApy - currentRawBorrowApy)
+
       netAPY.value = getNetAPY(
         collateralUsdValue,
-        collateralSupplyApy.value,
+        projectedSupplyApy,
         borrowUsdValue,
-        borrowApy.value,
+        projectedBorrowApy,
         collateralSupplyRewardApy.value || null,
         borrowRewardApy.value || null,
       )
     }
     catch (e) {
-      logWarn('borrow/estimates', e)
-      health.value = undefined
-      liquidationPrice.value = undefined
+      logWarn('borrow/asyncEstimates', e)
       netAPY.value = undefined
     }
     finally {
       isEstimatesLoading.value = false
     }
-  }, 1000)
+  }, 500)
 
   // --- Actions: submit & send ---
   const buildSwapBorrowPlanFromQuote = async (quote: SwapApiQuote, planOptions: { includePermit2Call?: boolean } = {}): Promise<TxPlan> => {
@@ -759,10 +791,11 @@ export const useBorrowForm = (options: UseBorrowFormOptions) => {
     if (!pair.value) {
       return
     }
+    updateSyncEstimates()
     if (!isEstimatesLoading.value) {
       isEstimatesLoading.value = true
     }
-    updateEstimates()
+    updateAsyncEstimates()
   })
 
   watch(savingCollateral, (val) => {
@@ -911,7 +944,10 @@ export const useBorrowForm = (options: UseBorrowFormOptions) => {
     onRefreshBorrowSwapQuotes,
     submit,
     send,
-    updateEstimates,
+    updateEstimates: () => {
+      updateSyncEstimates()
+      updateAsyncEstimates()
+    },
     updateBorrowSwapAssetBalance,
     resetOnTabSwitch,
   }

--- a/composables/borrow/useMultiplyForm.ts
+++ b/composables/borrow/useMultiplyForm.ts
@@ -9,7 +9,9 @@ import { useToast } from '~/components/ui/composables/useToast'
 import {
   type AnyBorrowVaultPair,
   type Vault,
+  type ProjectedRates,
   convertAssetsToShares,
+  getProjectedRates,
 } from '~/entities/vault'
 import {
   getAssetUsdValue,
@@ -271,23 +273,84 @@ export const useMultiplyForm = (options: UseMultiplyFormOptions) => {
     return multiplySupplyValueUsd.value + (multiplyLongValueUsd.value || 0)
   })
 
+  // --- Projected rates ---
+  const projectedSupplyRates = ref<ProjectedRates | null>(null)
+  const projectedLongRates = ref<ProjectedRates | null>(null)
+  const projectedBorrowRates = ref<ProjectedRates | null>(null)
+
+  watchEffect(async () => {
+    const supply = multiplySupplyVault.value
+    const short = multiplyShortVault.value
+    const long = multiplyLongVault.value
+    const supplyNano = multiplySupplyAmountNano.value
+    const debtNano = multiplyDebtAmountNano.value
+    const swapOut = multiplySwapAmountOut.value
+
+    if (!supply || !short || !long || !supplyNano || !debtNano) {
+      projectedSupplyRates.value = null
+      projectedLongRates.value = null
+      projectedBorrowRates.value = null
+      return
+    }
+
+    try {
+      const supplyAndLongSameVault = normalizeAddress(supply.address) === normalizeAddress(long.address)
+
+      if (supplyAndLongSameVault) {
+        // Combined delta for supply + long vault
+        const [combined, shortResult] = await Promise.all([
+          getProjectedRates(supply.address, supply.interestRateInfo.cash, supply.interestRateInfo.borrows, supplyNano + swapOut, 0n),
+          getProjectedRates(short.address, short.interestRateInfo.cash, short.interestRateInfo.borrows, -debtNano, debtNano),
+        ])
+        projectedSupplyRates.value = combined
+        projectedLongRates.value = combined
+        projectedBorrowRates.value = shortResult
+      }
+      else {
+        const [supplyResult, shortResult, longResult] = await Promise.all([
+          getProjectedRates(supply.address, supply.interestRateInfo.cash, supply.interestRateInfo.borrows, supplyNano, 0n),
+          getProjectedRates(short.address, short.interestRateInfo.cash, short.interestRateInfo.borrows, -debtNano, debtNano),
+          getProjectedRates(long.address, long.interestRateInfo.cash, long.interestRateInfo.borrows, swapOut, 0n),
+        ])
+        projectedSupplyRates.value = supplyResult
+        projectedLongRates.value = longResult
+        projectedBorrowRates.value = shortResult
+      }
+    }
+    catch (e) {
+      logWarn('multiply/projectedRates', e)
+      projectedSupplyRates.value = null
+      projectedLongRates.value = null
+      projectedBorrowRates.value = null
+    }
+  })
+
   // --- APYs ---
   const multiplySupplyApy = computed(() => {
     if (!multiplySupplyVault.value) return null
-    const base = nanoToValue(multiplySupplyVault.value.interestRateInfo.supplyAPY || 0n, 25)
-    return withIntrinsicSupplyApy(base, multiplySupplyVault.value.asset.address) + getSupplyRewardApy(multiplySupplyVault.value.address)
+    const currentRaw = nanoToValue(multiplySupplyVault.value.interestRateInfo.supplyAPY || 0n, 25)
+    const base = withIntrinsicSupplyApy(currentRaw, multiplySupplyVault.value.asset.address) + getSupplyRewardApy(multiplySupplyVault.value.address)
+    if (!projectedSupplyRates.value) return base
+    const projectedRaw = nanoToValue(projectedSupplyRates.value.supplyAPY, 25)
+    return base + (projectedRaw - currentRaw)
   })
 
   const multiplyLongApy = computed(() => {
     if (!multiplyLongVault.value) return null
-    const base = nanoToValue(multiplyLongVault.value.interestRateInfo.supplyAPY || 0n, 25)
-    return withIntrinsicSupplyApy(base, multiplyLongVault.value.asset.address) + getSupplyRewardApy(multiplyLongVault.value.address)
+    const currentRaw = nanoToValue(multiplyLongVault.value.interestRateInfo.supplyAPY || 0n, 25)
+    const base = withIntrinsicSupplyApy(currentRaw, multiplyLongVault.value.asset.address) + getSupplyRewardApy(multiplyLongVault.value.address)
+    if (!projectedLongRates.value) return base
+    const projectedRaw = nanoToValue(projectedLongRates.value.supplyAPY, 25)
+    return base + (projectedRaw - currentRaw)
   })
 
   const multiplyBorrowApy = computed(() => {
     if (!multiplyShortVault.value) return null
-    const base = nanoToValue(multiplyShortVault.value.interestRateInfo.borrowAPY || 0n, 25)
-    return withIntrinsicBorrowApy(base, multiplyShortVault.value.asset.address) - getBorrowRewardApy(multiplyShortVault.value.address, multiplySupplyVault.value?.address)
+    const currentRaw = nanoToValue(multiplyShortVault.value.interestRateInfo.borrowAPY || 0n, 25)
+    const base = withIntrinsicBorrowApy(currentRaw, multiplyShortVault.value.asset.address) - getBorrowRewardApy(multiplyShortVault.value.address, multiplySupplyVault.value?.address)
+    if (!projectedBorrowRates.value) return base
+    const projectedRaw = nanoToValue(projectedBorrowRates.value.borrowAPY, 25)
+    return base + (projectedRaw - currentRaw)
   })
 
   const multiplyWeightedSupplyApy = computed(() => {

--- a/composables/borrow/useMultiplyForm.ts
+++ b/composables/borrow/useMultiplyForm.ts
@@ -2,6 +2,7 @@ import type { Ref, ComputedRef } from 'vue'
 import { useAccount } from '@wagmi/vue'
 import { formatUnits, type Address } from 'viem'
 import { logWarn } from '~/utils/errorHandling'
+import { createRaceGuard } from '~/utils/race-guard'
 import { normalizeAddressOrEmpty } from '~/utils/accountPositionHelpers'
 import { useModal } from '~/components/ui/composables/useModal'
 import { OperationReviewModal } from '#components'
@@ -277,6 +278,7 @@ export const useMultiplyForm = (options: UseMultiplyFormOptions) => {
   const projectedSupplyRates = ref<ProjectedRates | null>(null)
   const projectedLongRates = ref<ProjectedRates | null>(null)
   const projectedBorrowRates = ref<ProjectedRates | null>(null)
+  const projectedRatesGuard = createRaceGuard()
 
   watchEffect(async () => {
     const supply = multiplySupplyVault.value
@@ -285,6 +287,7 @@ export const useMultiplyForm = (options: UseMultiplyFormOptions) => {
     const supplyNano = multiplySupplyAmountNano.value
     const debtNano = multiplyDebtAmountNano.value
     const swapOut = multiplySwapAmountOut.value
+    const gen = projectedRatesGuard.next()
 
     if (!supply || !short || !long || !supplyNano || !debtNano) {
       projectedSupplyRates.value = null
@@ -302,6 +305,7 @@ export const useMultiplyForm = (options: UseMultiplyFormOptions) => {
           getProjectedRates(supply.address, supply.interestRateInfo.cash, supply.interestRateInfo.borrows, supplyNano + swapOut, 0n),
           getProjectedRates(short.address, short.interestRateInfo.cash, short.interestRateInfo.borrows, -debtNano, debtNano),
         ])
+        if (projectedRatesGuard.isStale(gen)) return
         projectedSupplyRates.value = combined
         projectedLongRates.value = combined
         projectedBorrowRates.value = shortResult
@@ -312,12 +316,14 @@ export const useMultiplyForm = (options: UseMultiplyFormOptions) => {
           getProjectedRates(short.address, short.interestRateInfo.cash, short.interestRateInfo.borrows, -debtNano, debtNano),
           getProjectedRates(long.address, long.interestRateInfo.cash, long.interestRateInfo.borrows, swapOut, 0n),
         ])
+        if (projectedRatesGuard.isStale(gen)) return
         projectedSupplyRates.value = supplyResult
         projectedLongRates.value = longResult
         projectedBorrowRates.value = shortResult
       }
     }
     catch (e) {
+      if (projectedRatesGuard.isStale(gen)) return
       logWarn('multiply/projectedRates', e)
       projectedSupplyRates.value = null
       projectedLongRates.value = null

--- a/composables/position/useCollateralForm.ts
+++ b/composables/position/useCollateralForm.ts
@@ -2,6 +2,7 @@ import type { ComputedRef } from 'vue'
 import { useAccount } from '@wagmi/vue'
 import { formatUnits, type Address, type Abi, zeroAddress } from 'viem'
 import { logWarn } from '~/utils/errorHandling'
+import { createRaceGuard } from '~/utils/race-guard'
 import { FixedPoint } from '~/utils/fixed-point'
 import { getTotalCollateralValue } from '~/utils/position-estimates'
 import { useModal } from '~/components/ui/composables/useModal'
@@ -482,11 +483,13 @@ export const useCollateralForm = (options: UseCollateralFormOptions) => {
     }
   }
 
+  const asyncEstimatesGuard = createRaceGuard()
   const updateAsyncEstimates = useDebounceFn(async () => {
     if (!collateralVault.value || !borrowVault.value) {
       isEstimatesLoading.value = false
       return
     }
+    const gen = asyncEstimatesGuard.next()
     try {
       const amountNano = valueToNano(amount.value, collateralVault.value.decimals)
       const cashDelta = options.mode === 'supply' ? amountNano : -amountNano
@@ -507,6 +510,8 @@ export const useCollateralForm = (options: UseCollateralFormOptions) => {
         getAssetUsdValueOrZero(position.value!.borrowed || 0n, borrowVault.value!, 'off-chain'),
       ])
 
+      if (asyncEstimatesGuard.isStale(gen)) return
+
       const projectedSupplyApy = projected
         ? withIntrinsicSupplyApy(nanoToValue(projected.supplyAPY, 25), collateralVault.value?.asset.address)
         : collateralSupplyApy.value
@@ -521,11 +526,14 @@ export const useCollateralForm = (options: UseCollateralFormOptions) => {
       )
     }
     catch (e) {
+      if (asyncEstimatesGuard.isStale(gen)) return
       logWarn('collateral/asyncEstimates', e)
       estimateNetAPY.value = netAPY.value
     }
     finally {
-      isEstimatesLoading.value = false
+      if (!asyncEstimatesGuard.isStale(gen)) {
+        isEstimatesLoading.value = false
+      }
     }
   }, 500)
 

--- a/composables/position/useCollateralForm.ts
+++ b/composables/position/useCollateralForm.ts
@@ -507,10 +507,9 @@ export const useCollateralForm = (options: UseCollateralFormOptions) => {
         getAssetUsdValueOrZero(position.value!.borrowed || 0n, borrowVault.value!, 'off-chain'),
       ])
 
-      const projectedSupplyApy = withIntrinsicSupplyApy(
-        nanoToValue(projected.supplyAPY, 25),
-        collateralVault.value?.asset.address,
-      )
+      const projectedSupplyApy = projected
+        ? withIntrinsicSupplyApy(nanoToValue(projected.supplyAPY, 25), collateralVault.value?.asset.address)
+        : collateralSupplyApy.value
 
       estimateNetAPY.value = getNetAPY(
         collateralUsd,

--- a/composables/position/useCollateralForm.ts
+++ b/composables/position/useCollateralForm.ts
@@ -10,6 +10,7 @@ import { useToast } from '~/components/ui/composables/useToast'
 import { eulerAccountLensABI } from '~/entities/euler/abis'
 import {
   getNetAPY,
+  getProjectedRates,
   type Vault,
   type SecuritizeVault,
   type VaultAsset,
@@ -417,14 +418,12 @@ export const useCollateralForm = (options: UseCollateralFormOptions) => {
   )
 
   // --- Estimates ---
-  const updateEstimates = useDebounceFn(async () => {
+  const updateSyncEstimates = () => {
     clearSimulationError()
     estimatesError.value = ''
     if (!collateralVault.value) return
 
     try {
-      const amountNano = valueToNano(amount.value, collateralVault.value.decimals)
-
       // Derive total collateral value from position's on-chain LTV (multi-collateral aware),
       // then adjust for the collateral delta using the single collateral's price.
       const totalValue = getTotalCollateralValue(position.value!)
@@ -468,24 +467,6 @@ export const useCollateralForm = (options: UseCollateralFormOptions) => {
         needsSwap: options.needsSwap.value,
       })
 
-      const adjustedCollateral = options.mode === 'supply'
-        ? collateralAssets.value + amountNano
-        : collateralAssets.value - amountNano
-
-      const [collateralUsd, borrowedUsd] = await Promise.all([
-        getCollateralValueUsdLocal(adjustedCollateral),
-        getAssetUsdValueOrZero(position.value!.borrowed || 0n, borrowVault.value!, 'off-chain'),
-      ])
-
-      estimateNetAPY.value = getNetAPY(
-        collateralUsd,
-        collateralSupplyApy.value,
-        borrowedUsd,
-        borrowApy.value,
-        collateralSupplyRewardApy.value || null,
-        borrowRewardApy.value || null,
-      )
-
       estimateUserLTV.value = userLtvFixed.value
       // liquidationLTV is in basis points (e.g. 8600 = 86%). Convert to 18-decimal
       // percentage (8600 * 10^16 = 86 * 10^18) to match userLtvFixed's 18 decimals.
@@ -494,11 +475,55 @@ export const useCollateralForm = (options: UseCollateralFormOptions) => {
         : FixedPoint.fromValue(position.value!.liquidationLTV * (10n ** 16n), 18).div(userLtvFixed).value
     }
     catch (e: unknown) {
-      logWarn('collateral/estimates', e)
-      estimateNetAPY.value = netAPY.value
+      logWarn('collateral/syncEstimates', e)
       estimateUserLTV.value = position.value!.userLTV
       estimateHealth.value = position.value!.health
       estimatesError.value = (e as { message: string }).message
+    }
+  }
+
+  const updateAsyncEstimates = useDebounceFn(async () => {
+    if (!collateralVault.value || !borrowVault.value) {
+      isEstimatesLoading.value = false
+      return
+    }
+    try {
+      const amountNano = valueToNano(amount.value, collateralVault.value.decimals)
+      const cashDelta = options.mode === 'supply' ? amountNano : -amountNano
+
+      const [projected, collateralUsd, borrowedUsd] = await Promise.all([
+        getProjectedRates(
+          collateralVault.value.address,
+          collateralVault.value.interestRateInfo.cash,
+          collateralVault.value.interestRateInfo.borrows,
+          cashDelta,
+          0n,
+        ),
+        getCollateralValueUsdLocal(
+          options.mode === 'supply'
+            ? collateralAssets.value + amountNano
+            : collateralAssets.value - amountNano,
+        ),
+        getAssetUsdValueOrZero(position.value!.borrowed || 0n, borrowVault.value!, 'off-chain'),
+      ])
+
+      const projectedSupplyApy = withIntrinsicSupplyApy(
+        nanoToValue(projected.supplyAPY, 25),
+        collateralVault.value?.asset.address,
+      )
+
+      estimateNetAPY.value = getNetAPY(
+        collateralUsd,
+        projectedSupplyApy,
+        borrowedUsd,
+        borrowApy.value,
+        collateralSupplyRewardApy.value || null,
+        borrowRewardApy.value || null,
+      )
+    }
+    catch (e) {
+      logWarn('collateral/asyncEstimates', e)
+      estimateNetAPY.value = netAPY.value
     }
     finally {
       isEstimatesLoading.value = false
@@ -648,10 +673,11 @@ export const useCollateralForm = (options: UseCollateralFormOptions) => {
 
   watch(amount, async () => {
     if (!collateralVault.value) return
+    updateSyncEstimates()
     if (!isEstimatesLoading.value) {
       isEstimatesLoading.value = true
     }
-    updateEstimates()
+    updateAsyncEstimates()
     if (options.needsSwap.value) {
       resetSwapQuoteState()
       requestSwapQuote()
@@ -745,6 +771,9 @@ export const useCollateralForm = (options: UseCollateralFormOptions) => {
     loadSelectedCollateral,
     submit,
     send,
-    updateEstimates,
+    updateEstimates: () => {
+      updateSyncEstimates()
+      updateAsyncEstimates()
+    },
   }
 }

--- a/composables/repay/useWalletRepay.ts
+++ b/composables/repay/useWalletRepay.ts
@@ -7,7 +7,7 @@ import { getTotalCollateralValue } from '~/utils/position-estimates'
 import { useModal } from '~/components/ui/composables/useModal'
 import { OperationReviewModal } from '#components'
 import { useToast } from '~/components/ui/composables/useToast'
-import { getNetAPY } from '~/entities/vault'
+import { getNetAPY, getProjectedRates } from '~/entities/vault'
 import { getAssetUsdValueOrZero } from '~/services/pricing/priceProvider'
 import type { AccountBorrowPosition } from '~/entities/account'
 import type { TxPlan } from '~/entities/txPlan'
@@ -193,7 +193,7 @@ export const useWalletRepay = (options: UseWalletRepayOptions) => {
     }
   }
 
-  const updateEstimates = useDebounceFn(async () => {
+  const updateSyncEstimates = () => {
     clearSimulationError()
     estimatesError.value = ''
     if (!position.value || !collateralVault.value || !borrowVault.value) return
@@ -204,18 +204,6 @@ export const useWalletRepay = (options: UseWalletRepayOptions) => {
       if (borrowedFixed.value.lt(amountFixed.value)) {
         throw new Error('You repaying more than required')
       }
-      const [supplyUsd, borrowUsd] = await Promise.all([
-        getAssetUsdValueOrZero((position.value.supplied || 0n), collateralVault.value, 'off-chain'),
-        getAssetUsdValueOrZero((position.value.borrowed || 0n) - valueToNano(amount.value, borrowVault.value.decimals), borrowVault.value, 'off-chain'),
-      ])
-      _estimateNetAPY.value = getNetAPY(
-        supplyUsd,
-        collateralSupplyApy.value,
-        borrowUsd,
-        borrowApy.value,
-        collateralSupplyRewardApy.value || null,
-        borrowRewardApy.value || null,
-      )
       // Use on-chain LTV to derive total collateral value (multi-collateral aware)
       const totalValue = getTotalCollateralValue(position.value!)
       const collateralValueFl = totalValue !== null
@@ -242,9 +230,48 @@ export const useWalletRepay = (options: UseWalletRepayOptions) => {
       }
     }
     catch (e: unknown) {
-      logWarn('walletRepay/estimates', e)
+      logWarn('walletRepay/syncEstimates', e)
       hasEstimate.value = false
       estimatesError.value = (e as { message: string }).message
+    }
+  }
+
+  const updateAsyncEstimates = useDebounceFn(async () => {
+    if (!position.value || !collateralVault.value || !borrowVault.value) {
+      isEstimatesLoading.value = false
+      return
+    }
+    try {
+      const repayNano = valueToNano(amount.value, borrowVault.value.decimals)
+      const remainingBorrow = (position.value.borrowed || 0n) - repayNano
+
+      const [projected, supplyUsd, borrowUsd] = await Promise.all([
+        getProjectedRates(
+          borrowVault.value.address,
+          borrowVault.value.interestRateInfo.cash,
+          borrowVault.value.interestRateInfo.borrows,
+          repayNano,
+          -repayNano,
+        ),
+        getAssetUsdValueOrZero(position.value.supplied || 0n, collateralVault.value, 'off-chain'),
+        getAssetUsdValueOrZero(remainingBorrow > 0n ? remainingBorrow : 0n, borrowVault.value, 'off-chain'),
+      ])
+
+      const currentRawBorrowApy = nanoToValue(borrowVault.value.interestRateInfo.borrowAPY, 25)
+      const projectedRawBorrowApy = nanoToValue(projected.borrowAPY, 25)
+      const projectedBorrowApy = borrowApy.value + (projectedRawBorrowApy - currentRawBorrowApy)
+
+      _estimateNetAPY.value = getNetAPY(
+        supplyUsd,
+        collateralSupplyApy.value,
+        borrowUsd,
+        projectedBorrowApy,
+        collateralSupplyRewardApy.value || null,
+        borrowRewardApy.value || null,
+      )
+    }
+    catch (e) {
+      logWarn('walletRepay/asyncEstimates', e)
     }
     finally {
       isEstimatesLoading.value = false
@@ -289,10 +316,11 @@ export const useWalletRepay = (options: UseWalletRepayOptions) => {
       }
     }
     if (!collateralVault.value) return
+    updateSyncEstimates()
     if (!isEstimatesLoading.value) {
       isEstimatesLoading.value = true
     }
-    updateEstimates()
+    updateAsyncEstimates()
   })
 
   const initEstimates = () => {

--- a/composables/repay/useWalletRepay.ts
+++ b/composables/repay/useWalletRepay.ts
@@ -3,6 +3,7 @@ import { useAccount } from '@wagmi/vue'
 import { formatUnits } from 'viem'
 import { FixedPoint } from '~/utils/fixed-point'
 import { logWarn } from '~/utils/errorHandling'
+import { createRaceGuard } from '~/utils/race-guard'
 import { getTotalCollateralValue } from '~/utils/position-estimates'
 import { useModal } from '~/components/ui/composables/useModal'
 import { OperationReviewModal } from '#components'
@@ -236,11 +237,13 @@ export const useWalletRepay = (options: UseWalletRepayOptions) => {
     }
   }
 
+  const asyncEstimatesGuard = createRaceGuard()
   const updateAsyncEstimates = useDebounceFn(async () => {
     if (!position.value || !collateralVault.value || !borrowVault.value) {
       isEstimatesLoading.value = false
       return
     }
+    const gen = asyncEstimatesGuard.next()
     try {
       const repayNano = valueToNano(amount.value, borrowVault.value.decimals)
       const remainingBorrow = (position.value.borrowed || 0n) - repayNano
@@ -257,6 +260,8 @@ export const useWalletRepay = (options: UseWalletRepayOptions) => {
         getAssetUsdValueOrZero(remainingBorrow > 0n ? remainingBorrow : 0n, borrowVault.value, 'off-chain'),
       ])
 
+      if (asyncEstimatesGuard.isStale(gen)) return
+
       const projectedBorrowApy = projected
         ? borrowApy.value + (nanoToValue(projected.borrowAPY, 25) - nanoToValue(borrowVault.value.interestRateInfo.borrowAPY, 25))
         : borrowApy.value
@@ -271,10 +276,13 @@ export const useWalletRepay = (options: UseWalletRepayOptions) => {
       )
     }
     catch (e) {
+      if (asyncEstimatesGuard.isStale(gen)) return
       logWarn('walletRepay/asyncEstimates', e)
     }
     finally {
-      isEstimatesLoading.value = false
+      if (!asyncEstimatesGuard.isStale(gen)) {
+        isEstimatesLoading.value = false
+      }
     }
   }, 500)
 

--- a/composables/repay/useWalletRepay.ts
+++ b/composables/repay/useWalletRepay.ts
@@ -257,9 +257,9 @@ export const useWalletRepay = (options: UseWalletRepayOptions) => {
         getAssetUsdValueOrZero(remainingBorrow > 0n ? remainingBorrow : 0n, borrowVault.value, 'off-chain'),
       ])
 
-      const currentRawBorrowApy = nanoToValue(borrowVault.value.interestRateInfo.borrowAPY, 25)
-      const projectedRawBorrowApy = nanoToValue(projected.borrowAPY, 25)
-      const projectedBorrowApy = borrowApy.value + (projectedRawBorrowApy - currentRawBorrowApy)
+      const projectedBorrowApy = projected
+        ? borrowApy.value + (nanoToValue(projected.borrowAPY, 25) - nanoToValue(borrowVault.value.interestRateInfo.borrowAPY, 25))
+        : borrowApy.value
 
       _estimateNetAPY.value = getNetAPY(
         supplyUsd,

--- a/composables/repay/useWalletSwapRepay.ts
+++ b/composables/repay/useWalletSwapRepay.ts
@@ -411,9 +411,9 @@ export const useWalletSwapRepay = (options: UseWalletSwapRepayOptions) => {
       ])
       if (estimatesGuard.isStale(gen)) return
 
-      const currentRawBorrowApy = nanoToValue(borrowVault.value.interestRateInfo.borrowAPY, 25)
-      const projectedRawBorrowApy = nanoToValue(projected.borrowAPY, 25)
-      const projectedBorrowApy = borrowApy.value + (projectedRawBorrowApy - currentRawBorrowApy)
+      const projectedBorrowApy = projected
+        ? borrowApy.value + (nanoToValue(projected.borrowAPY, 25) - nanoToValue(borrowVault.value.interestRateInfo.borrowAPY, 25))
+        : borrowApy.value
 
       _estimateNetAPY.value = getNetAPY(
         supplyUsd,

--- a/composables/repay/useWalletSwapRepay.ts
+++ b/composables/repay/useWalletSwapRepay.ts
@@ -8,7 +8,7 @@ import { getTotalCollateralValue } from '~/utils/position-estimates'
 import { useModal } from '~/components/ui/composables/useModal'
 import { OperationReviewModal } from '#components'
 import { useToast } from '~/components/ui/composables/useToast'
-import { getNetAPY, type Vault, type VaultAsset } from '~/entities/vault'
+import { getNetAPY, getProjectedRates, type Vault, type VaultAsset } from '~/entities/vault'
 import { getAssetUsdValueOrZero } from '~/services/pricing/priceProvider'
 import type { AccountBorrowPosition } from '~/entities/account'
 import type { TxPlan } from '~/entities/txPlan'
@@ -313,18 +313,29 @@ export const useWalletSwapRepay = (options: UseWalletSwapRepayOptions) => {
   // --- Estimates ---
   const estimatesGuard = createRaceGuard()
 
-  const updateEstimates = useDebounceFn(async () => {
+  const getDebtRepaidNano = (): bigint => {
+    if (!borrowVault.value) return 0n
+    let debtRepaidNano: bigint
+    if (direction.value === SwapperMode.TARGET_DEBT && debtAmount.value) {
+      debtRepaidNano = valueToNano(debtAmount.value, borrowVault.value.asset.decimals)
+    }
+    else {
+      debtRepaidNano = estimatedDebtRepaid.value
+    }
+    const currentDebt = getCurrentDebt()
+    return debtRepaidNano > currentDebt ? currentDebt : debtRepaidNano
+  }
+
+  const updateSyncEstimates = () => {
     clearSimulationError()
     estimatesError.value = ''
     if (!position.value || !collateralVault.value || !borrowVault.value) return
-    const gen = estimatesGuard.next()
 
     try {
       if (!oraclePriceRatio.value || !Number.isFinite(oraclePriceRatio.value) || oraclePriceRatio.value <= 0) {
         throw new Error('Price data unavailable')
       }
 
-      // Balance check only for EXACT_IN (for TARGET_DEBT, the needed amount comes from the quote)
       if (direction.value === SwapperMode.EXACT_IN) {
         if (selectedAssetBalance.value < valueToNano(amount.value, selectedAsset.value?.decimals)) {
           throw new Error('Not enough balance')
@@ -335,20 +346,6 @@ export const useWalletSwapRepay = (options: UseWalletSwapRepayOptions) => {
         throw new Error('No swap quote available')
       }
 
-      let debtRepaidNano: bigint
-      if (direction.value === SwapperMode.TARGET_DEBT && debtAmount.value) {
-        debtRepaidNano = valueToNano(debtAmount.value, borrowVault.value.asset.decimals)
-      }
-      else {
-        debtRepaidNano = estimatedDebtRepaid.value
-      }
-
-      const currentDebt = getCurrentDebt()
-      if (debtRepaidNano > currentDebt) {
-        debtRepaidNano = currentDebt
-      }
-
-      // Balance check for TARGET_DEBT after quote
       if (direction.value === SwapperMode.TARGET_DEBT && quotes.effectiveQuote.value) {
         const neededInput = BigInt(quotes.effectiveQuote.value.amountInMax || quotes.effectiveQuote.value.amountIn || 0)
         if (selectedAssetBalance.value < neededInput) {
@@ -356,24 +353,8 @@ export const useWalletSwapRepay = (options: UseWalletSwapRepayOptions) => {
         }
       }
 
-      const nextBorrowed = currentDebt - debtRepaidNano
-      const [supplyUsd, borrowUsd] = await Promise.all([
-        getAssetUsdValueOrZero(position.value.supplied || 0n, collateralVault.value, 'off-chain'),
-        getAssetUsdValueOrZero(nextBorrowed > 0n ? nextBorrowed : 0n, borrowVault.value, 'off-chain'),
-      ])
-      if (estimatesGuard.isStale(gen)) return
-
-      _estimateNetAPY.value = getNetAPY(
-        supplyUsd,
-        collateralSupplyApy.value,
-        borrowUsd,
-        borrowApy.value,
-        collateralSupplyRewardApy.value || null,
-        borrowRewardApy.value || null,
-      )
-
+      const debtRepaidNano = getDebtRepaidNano()
       const debtRepaidFixed = FixedPoint.fromValue(debtRepaidNano, Number(borrowVault.value.decimals))
-      // Use on-chain LTV to derive total collateral value (multi-collateral aware)
       const totalValue = getTotalCollateralValue(position.value!)
       const collateralValueFl = totalValue !== null
         ? totalValue
@@ -400,10 +381,52 @@ export const useWalletSwapRepay = (options: UseWalletSwapRepayOptions) => {
       }
     }
     catch (e: unknown) {
-      if (estimatesGuard.isStale(gen)) return
-      logWarn('walletSwapRepay/estimates', e)
+      logWarn('walletSwapRepay/syncEstimates', e)
       hasEstimate.value = false
       estimatesError.value = (e as { message: string }).message
+    }
+  }
+
+  const updateAsyncEstimates = useDebounceFn(async () => {
+    if (!position.value || !collateralVault.value || !borrowVault.value) {
+      isEstimatesLoading.value = false
+      return
+    }
+    const gen = estimatesGuard.next()
+    try {
+      const debtRepaidNano = getDebtRepaidNano()
+      const currentDebt = getCurrentDebt()
+      const nextBorrowed = currentDebt - debtRepaidNano
+
+      const [projected, supplyUsd, borrowUsd] = await Promise.all([
+        getProjectedRates(
+          borrowVault.value.address,
+          borrowVault.value.interestRateInfo.cash,
+          borrowVault.value.interestRateInfo.borrows,
+          debtRepaidNano,
+          -debtRepaidNano,
+        ),
+        getAssetUsdValueOrZero(position.value.supplied || 0n, collateralVault.value, 'off-chain'),
+        getAssetUsdValueOrZero(nextBorrowed > 0n ? nextBorrowed : 0n, borrowVault.value, 'off-chain'),
+      ])
+      if (estimatesGuard.isStale(gen)) return
+
+      const currentRawBorrowApy = nanoToValue(borrowVault.value.interestRateInfo.borrowAPY, 25)
+      const projectedRawBorrowApy = nanoToValue(projected.borrowAPY, 25)
+      const projectedBorrowApy = borrowApy.value + (projectedRawBorrowApy - currentRawBorrowApy)
+
+      _estimateNetAPY.value = getNetAPY(
+        supplyUsd,
+        collateralSupplyApy.value,
+        borrowUsd,
+        projectedBorrowApy,
+        collateralSupplyRewardApy.value || null,
+        borrowRewardApy.value || null,
+      )
+    }
+    catch (e: unknown) {
+      if (estimatesGuard.isStale(gen)) return
+      logWarn('walletSwapRepay/asyncEstimates', e)
     }
     finally {
       if (!estimatesGuard.isStale(gen)) {
@@ -493,7 +516,8 @@ export const useWalletSwapRepay = (options: UseWalletSwapRepayOptions) => {
     if (selectedAsset.value?.address) {
       selectedAssetBalance.value = await fetchSingleBalance(selectedAsset.value.address)
       if (needsSwap.value) {
-        updateEstimates()
+        updateSyncEstimates()
+        updateAsyncEstimates()
       }
     }
   })
@@ -520,10 +544,11 @@ export const useWalletSwapRepay = (options: UseWalletSwapRepayOptions) => {
       }
     }
 
+    updateSyncEstimates()
     if (!isEstimatesLoading.value) {
       isEstimatesLoading.value = true
     }
-    updateEstimates()
+    updateAsyncEstimates()
   })
 
   // --- Build plan ---

--- a/entities/vault/apy.ts
+++ b/entities/vault/apy.ts
@@ -9,27 +9,25 @@ export interface ProjectedRates {
   borrowAPY: bigint // 27 decimals
 }
 
-const ZERO_RATES: ProjectedRates = { supplyAPY: 0n, borrowAPY: 0n }
-
 export const getProjectedRates = async (
   vaultAddress: string,
   currentCash: bigint,
   currentBorrows: bigint,
   cashDelta: bigint,
   borrowsDelta: bigint,
-): Promise<ProjectedRates> => {
+): Promise<ProjectedRates | null> => {
   const { client: rpcClient } = useRpcClient()
   const { eulerLensAddresses } = useEulerAddresses()
 
   if (!eulerLensAddresses.value?.vaultLens) {
-    return ZERO_RATES
+    return null
   }
 
   const adjustedCash = currentCash + cashDelta < 0n ? 0n : currentCash + cashDelta
   const adjustedBorrows = currentBorrows + borrowsDelta < 0n ? 0n : currentBorrows + borrowsDelta
 
   if (adjustedCash === 0n && adjustedBorrows === 0n) {
-    return ZERO_RATES
+    return { supplyAPY: 0n, borrowAPY: 0n }
   }
 
   const result = await rpcClient.value!.readContract({
@@ -41,7 +39,7 @@ export const getProjectedRates = async (
   }) as Record<string, any>
 
   if (result.queryFailure || !result.interestRateInfo?.length) {
-    return ZERO_RATES
+    return null
   }
 
   const info = result.interestRateInfo[0]

--- a/entities/vault/apy.ts
+++ b/entities/vault/apy.ts
@@ -1,8 +1,55 @@
 import { parseUnits, type Address } from 'viem'
 import { logWarn } from '~/utils/errorHandling'
 import { SECONDS_IN_YEAR, TARGET_TIME_AGO } from '~/entities/constants'
-import { eulerUtilsLensABI } from '~/entities/euler/abis'
+import { eulerUtilsLensABI, eulerVaultLensABI } from '~/entities/euler/abis'
 import { vaultConvertToAssetsAbi } from '~/abis/vault'
+
+export interface ProjectedRates {
+  supplyAPY: bigint // 27 decimals
+  borrowAPY: bigint // 27 decimals
+}
+
+const ZERO_RATES: ProjectedRates = { supplyAPY: 0n, borrowAPY: 0n }
+
+export const getProjectedRates = async (
+  vaultAddress: string,
+  currentCash: bigint,
+  currentBorrows: bigint,
+  cashDelta: bigint,
+  borrowsDelta: bigint,
+): Promise<ProjectedRates> => {
+  const { client: rpcClient } = useRpcClient()
+  const { eulerLensAddresses } = useEulerAddresses()
+
+  if (!eulerLensAddresses.value?.vaultLens) {
+    return ZERO_RATES
+  }
+
+  const adjustedCash = currentCash + cashDelta < 0n ? 0n : currentCash + cashDelta
+  const adjustedBorrows = currentBorrows + borrowsDelta < 0n ? 0n : currentBorrows + borrowsDelta
+
+  if (adjustedCash === 0n && adjustedBorrows === 0n) {
+    return ZERO_RATES
+  }
+
+  const result = await rpcClient.value!.readContract({
+    address: eulerLensAddresses.value.vaultLens as Address,
+    abi: eulerVaultLensABI,
+    functionName: 'getVaultInterestRateModelInfo',
+    args: [vaultAddress as Address, [adjustedCash], [adjustedBorrows]],
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- dynamic lens contract return
+  }) as Record<string, any>
+
+  if (result.queryFailure || !result.interestRateInfo?.length) {
+    return ZERO_RATES
+  }
+
+  const info = result.interestRateInfo[0]
+  return {
+    supplyAPY: info.supplyAPY as bigint,
+    borrowAPY: info.borrowAPY as bigint,
+  }
+}
 
 export const computeAPYs = (borrowSPY: bigint, cash: bigint, borrows: bigint, interestFee: bigint) => {
   const { client: rpcClient } = useRpcClient()

--- a/entities/vault/index.ts
+++ b/entities/vault/index.ts
@@ -51,9 +51,11 @@ export {
 // APY computations
 export {
   computeAPYs,
+  getProjectedRates,
   getNetAPY,
   getRoe,
 } from './apy'
+export type { ProjectedRates } from './apy'
 
 // Utility functions
 export {

--- a/pages/earn/[vault]/[subAccount]/withdraw.vue
+++ b/pages/earn/[vault]/[subAccount]/withdraw.vue
@@ -193,12 +193,10 @@ const send = async () => {
     isSubmitting.value = false
   }
 }
-const updateEstimates = useDebounceFn(async () => {
+const updateEstimates = () => {
   clearSimulationError()
   estimatesError.value = ''
-  if (!vault.value) {
-    return
-  }
+  if (!vault.value) return
   try {
     if (assetsBalance.value < amountFixed.value.value) {
       throw new Error('Not enough balance')
@@ -207,15 +205,13 @@ const updateEstimates = useDebounceFn(async () => {
     estimateSupplyAPY.value = nanoToValue(vault.value.interestRateInfo.supplyAPY, 25)
   }
   catch (e) {
-    console.warn(e)
+    logWarn('earn-withdraw/estimates', e)
     delta.value = assetsBalance.value || 0n
     estimateSupplyAPY.value = nanoToValue(vault.value.interestRateInfo.supplyAPY, 25)
     estimatesError.value = (e as { message: string }).message
   }
-  finally {
-    isEstimatesLoading.value = false
-  }
-}, 500)
+  isEstimatesLoading.value = false
+}
 
 load()
 
@@ -236,14 +232,7 @@ watch([isConnected, effectiveAddress], async () => {
     await updateBalance()
   }
 })
-watch(amount, async () => {
-  clearSimulationError()
-  if (!vault.value) {
-    return
-  }
-  if (!isEstimatesLoading.value) {
-    isEstimatesLoading.value = true
-  }
+watch(amount, () => {
   updateEstimates()
 })
 </script>

--- a/pages/earn/[vault]/index.vue
+++ b/pages/earn/[vault]/index.vue
@@ -18,7 +18,7 @@ const route = useRoute()
 const modal = useModal()
 const { error } = useToast()
 const { buildSupplyPlan, executeTxPlan } = useEulerOperations()
-const { getEarnVault, updateEarnVault } = useVaults()
+const { getEarnVault } = useVaults()
 const { isConnected, address } = useAccount()
 const { fetchSingleBalance } = useWallets()
 const { runSimulation, simulationError, clearSimulationError } = useTxPlanSimulation()
@@ -169,27 +169,19 @@ const send = async () => {
     isSubmitting.value = false
   }
 }
-const updateEstimates = useDebounceFn(async () => {
-  if (!vault.value) {
-    return
-  }
+const updateEstimates = () => {
+  if (!vault.value) return
   try {
-    await updateEarnVault(vault.value.address)
-    if (!asset.value?.address) {
-      return
-    }
     estimateSupplyAPY.value = nanoToValue(vault.value.interestRateInfo.supplyAPY, 25) + totalRewardsAPY.value
     monthlyEarnings.value = !amount.value
       ? 0
       : +(amount.value || 0) * (estimateSupplyAPY.value / 12 / 100)
   }
   catch (e) {
-    console.warn(e)
+    logWarn('earn-supply/estimates', e)
   }
-  finally {
-    isEstimatesLoading.value = false
-  }
-}, 500)
+  isEstimatesLoading.value = false
+}
 const onSupplyInfoIconClick = () => {
   modal.open(VaultSupplyApyModal, {
     props: {
@@ -214,14 +206,8 @@ watchEffect(async () => {
   monthlyEarningsUsd.value = await getAssetUsdValueOrZero(monthlyEarnings.value, vault.value, 'off-chain')
 })
 
-watch(amount, async () => {
+watch(amount, () => {
   clearSimulationError()
-  if (!vault.value) {
-    return
-  }
-  if (!isEstimatesLoading.value) {
-    isEstimatesLoading.value = true
-  }
   updateEstimates()
 })
 

--- a/pages/lend/[vault]/[subAccount]/withdraw.vue
+++ b/pages/lend/[vault]/[subAccount]/withdraw.vue
@@ -464,7 +464,7 @@ const updateAsyncEstimates = useDebounceFn(async () => {
       -amountNano,
       0n,
     )
-    estimateSupplyAPY.value = projected.supplyAPY
+    estimateSupplyAPY.value = projected?.supplyAPY ?? v.interestRateInfo.supplyAPY
   }
   catch (e) {
     logWarn('lend-withdraw/asyncEstimates', e)

--- a/pages/lend/[vault]/[subAccount]/withdraw.vue
+++ b/pages/lend/[vault]/[subAccount]/withdraw.vue
@@ -11,6 +11,7 @@ import {
   type Vault,
   type SecuritizeVault,
   type VaultAsset,
+  getProjectedRates,
 } from '~/entities/vault'
 import { isSecuritizeVault } from '~/entities/vault/factory'
 import { getSubAccountAddress } from '~/entities/account'
@@ -423,12 +424,10 @@ const send = async () => {
     isSubmitting.value = false
   }
 }
-const updateEstimates = useDebounceFn(async () => {
+const updateSyncEstimates = () => {
   clearSimulationError()
   estimatesError.value = ''
-  if (!vault.value) {
-    return
-  }
+  if (!vault.value) return
   try {
     if (assetsBalance.value < amountFixed.value.value) {
       throw new Error('Not enough balance')
@@ -442,13 +441,34 @@ const updateEstimates = useDebounceFn(async () => {
     }
 
     delta.value = assetsBalance.value - amountFixed.value.value
-    estimateSupplyAPY.value = vault.value.interestRateInfo.supplyAPY
   }
   catch (e) {
-    console.warn(e)
+    logWarn('lend-withdraw/syncEstimates', e)
     delta.value = assetsBalance.value || 0n
-    estimateSupplyAPY.value = vault.value?.interestRateInfo.supplyAPY || 0n
     estimatesError.value = (e as { message: string }).message
+  }
+}
+
+const updateAsyncEstimates = useDebounceFn(async () => {
+  if (!vault.value || isSecuritizeVaultType.value) {
+    isEstimatesLoading.value = false
+    return
+  }
+  try {
+    const v = vault.value as Vault
+    const amountNano = valueToNano(amount.value, v.decimals)
+    const projected = await getProjectedRates(
+      v.address,
+      v.interestRateInfo.cash,
+      v.interestRateInfo.borrows,
+      -amountNano,
+      0n,
+    )
+    estimateSupplyAPY.value = projected.supplyAPY
+  }
+  catch (e) {
+    logWarn('lend-withdraw/asyncEstimates', e)
+    estimateSupplyAPY.value = (vault.value as Vault)?.interestRateInfo.supplyAPY || 0n
   }
   finally {
     isEstimatesLoading.value = false
@@ -464,14 +484,12 @@ watch([isConnected, effectiveAddress], async () => {
   }
 })
 watch(amount, async () => {
-  clearSimulationError()
-  if (!vault.value) {
-    return
-  }
+  updateSyncEstimates()
+  if (!vault.value) return
   if (!isEstimatesLoading.value) {
     isEstimatesLoading.value = true
   }
-  updateEstimates()
+  updateAsyncEstimates()
   if (needsSwap.value) {
     resetSwapQuoteState()
     requestSwapQuote()

--- a/pages/lend/[vault]/[subAccount]/withdraw.vue
+++ b/pages/lend/[vault]/[subAccount]/withdraw.vue
@@ -449,11 +449,14 @@ const updateSyncEstimates = () => {
   }
 }
 
+const estimatesGuard = createRaceGuard()
+
 const updateAsyncEstimates = useDebounceFn(async () => {
   if (!vault.value || isSecuritizeVaultType.value) {
     isEstimatesLoading.value = false
     return
   }
+  const gen = estimatesGuard.next()
   try {
     const v = vault.value as Vault
     const amountNano = valueToNano(amount.value, v.decimals)
@@ -464,14 +467,18 @@ const updateAsyncEstimates = useDebounceFn(async () => {
       -amountNano,
       0n,
     )
+    if (estimatesGuard.isStale(gen)) return
     estimateSupplyAPY.value = projected?.supplyAPY ?? v.interestRateInfo.supplyAPY
   }
   catch (e) {
+    if (estimatesGuard.isStale(gen)) return
     logWarn('lend-withdraw/asyncEstimates', e)
     estimateSupplyAPY.value = (vault.value as Vault)?.interestRateInfo.supplyAPY || 0n
   }
   finally {
-    isEstimatesLoading.value = false
+    if (!estimatesGuard.isStale(gen)) {
+      isEstimatesLoading.value = false
+    }
   }
 }, 500)
 

--- a/pages/lend/[vault]/index.vue
+++ b/pages/lend/[vault]/index.vue
@@ -494,23 +494,40 @@ const updateEstimates = useDebounceFn(async () => {
   if (!isVaultLoaded.value) return
   try {
     if (features.value.hasInterestRate && evkVault.value) {
-      const projected = await getProjectedRates(
-        evkVault.value.address,
-        evkVault.value.interestRateInfo.cash,
-        evkVault.value.interestRateInfo.borrows,
-        valueToNano(amount.value, evkVault.value.decimals),
-        0n,
-      )
-      estimateSupplyAPY.value = projected.supplyAPY + valueToNano(totalRewardsAPY.value + intrinsicApy.value, 25)
-      monthlyEarnings.value = !amount.value
+      // When swapping, use the swap output amount (vault-asset denominated)
+      const supplyNano = needsSwap.value
+        ? BigInt(swapEffectiveQuote.value?.amountOut || 0)
+        : valueToNano(amount.value, evkVault.value.decimals)
+
+      if (needsSwap.value && !supplyNano) {
+        // No swap quote yet — skip projection, keep current rate
+        estimateSupplyAPY.value = evkVault.value.interestRateInfo.supplyAPY + valueToNano(totalRewardsAPY.value + intrinsicApy.value, 25)
+      }
+      else {
+        const projected = await getProjectedRates(
+          evkVault.value.address,
+          evkVault.value.interestRateInfo.cash,
+          evkVault.value.interestRateInfo.borrows,
+          supplyNano,
+          0n,
+        )
+        const rawAPY = projected?.supplyAPY ?? evkVault.value.interestRateInfo.supplyAPY
+        estimateSupplyAPY.value = rawAPY + valueToNano(totalRewardsAPY.value + intrinsicApy.value, 25)
+      }
+
+      const supplyAmount = needsSwap.value
+        ? nanoToValue(BigInt(swapEffectiveQuote.value?.amountOut || 0), Number(evkVault.value.decimals))
+        : +(amount.value || 0)
+      monthlyEarnings.value = supplyAmount <= 0
         ? 0
-        : (+(amount.value || 0) * nanoToValue(estimateSupplyAPY.value, 27)) / 12
+        : supplyAmount * (nanoToValue(estimateSupplyAPY.value, 27) / 12)
     }
     else {
       estimateSupplyAPY.value = valueToNano(totalRewardsAPY.value + intrinsicApy.value, 25)
-      monthlyEarnings.value = !amount.value
+      const supplyAmount = +(amount.value || 0)
+      monthlyEarnings.value = supplyAmount <= 0
         ? 0
-        : (+(amount.value || 0) * nanoToValue(estimateSupplyAPY.value, 27)) / 12
+        : supplyAmount * (nanoToValue(estimateSupplyAPY.value, 27) / 12)
     }
   }
   catch (e) {

--- a/pages/lend/[vault]/index.vue
+++ b/pages/lend/[vault]/index.vue
@@ -715,10 +715,16 @@ watch(swapSelectedQuote, () => {
 
 // Re-run estimates when swap quote resolves — supplyNano depends on amountOut
 watch(swapEffectiveQuote, () => {
-  if (needsSwap.value && swapEffectiveQuote.value) {
+  if (!needsSwap.value) return
+  if (swapEffectiveQuote.value) {
     if (!isEstimatesLoading.value) {
       isEstimatesLoading.value = true
     }
+    updateEstimates()
+  }
+  else {
+    // quote was cleared (slippage change, manual refresh) — queue estimate so loading is always cleared
+    isEstimatesLoading.value = true
     updateEstimates()
   }
 })

--- a/pages/lend/[vault]/index.vue
+++ b/pages/lend/[vault]/index.vue
@@ -5,7 +5,7 @@ import { isNativeCurrencyAddress, isNativeOfWrapped, resolveWrappedNativeAddress
 import { useModal } from '~/components/ui/composables/useModal'
 import { OperationReviewModal, VaultSupplyApyModal, VaultUnverifiedDisclaimerModal, SwapTokenSelector, SlippageSettingsModal } from '#components'
 import { useToast } from '~/components/ui/composables/useToast'
-import { computeAPYs, getCurrentLiquidationLTV, type SecuritizeVault, type Vault, type VaultAsset } from '~/entities/vault'
+import { getProjectedRates, getCurrentLiquidationLTV, type SecuritizeVault, type Vault, type VaultAsset } from '~/entities/vault'
 import { isSecuritizeVault } from '~/entities/vault/factory'
 import { getUtilisationWarning, getSupplyCapWarning } from '~/composables/useVaultWarnings'
 import { collectPythFeedIds } from '~/entities/oracle'
@@ -491,28 +491,22 @@ const send = async () => {
 }
 
 const updateEstimates = useDebounceFn(async () => {
-  if (!isVaultLoaded.value) {
-    return
-  }
+  if (!isVaultLoaded.value) return
   try {
     if (features.value.hasInterestRate && evkVault.value) {
-      await updateVault(evkVault.value.address)
-      if (!asset.value?.address) {
-        return
-      }
-      const [, supplyAPY] = await computeAPYs(
-        evkVault.value.interestRateInfo.borrowSPY,
-        evkVault.value.interestRateInfo.cash + valueToNano(amount.value, evkVault.value.decimals),
+      const projected = await getProjectedRates(
+        evkVault.value.address,
+        evkVault.value.interestRateInfo.cash,
         evkVault.value.interestRateInfo.borrows,
-        evkVault.value.interestFee,
+        valueToNano(amount.value, evkVault.value.decimals),
+        0n,
       )
-      estimateSupplyAPY.value = supplyAPY + valueToNano(totalRewardsAPY.value + intrinsicApy.value, 25)
+      estimateSupplyAPY.value = projected.supplyAPY + valueToNano(totalRewardsAPY.value + intrinsicApy.value, 25)
       monthlyEarnings.value = !amount.value
         ? 0
         : (+(amount.value || 0) * nanoToValue(estimateSupplyAPY.value, 27)) / 12
     }
     else {
-      // For vaults without interest rate computation
       estimateSupplyAPY.value = valueToNano(totalRewardsAPY.value + intrinsicApy.value, 25)
       monthlyEarnings.value = !amount.value
         ? 0
@@ -520,7 +514,7 @@ const updateEstimates = useDebounceFn(async () => {
     }
   }
   catch (e) {
-    console.warn(e)
+    logWarn('lend-supply/estimates', e)
   }
   finally {
     isEstimatesLoading.value = false

--- a/pages/lend/[vault]/index.vue
+++ b/pages/lend/[vault]/index.vue
@@ -705,6 +705,16 @@ watch(swapSelectedQuote, () => {
   clearSimulationError()
 })
 
+// Re-run estimates when swap quote resolves — supplyNano depends on amountOut
+watch(swapEffectiveQuote, () => {
+  if (needsSwap.value && swapEffectiveQuote.value) {
+    if (!isEstimatesLoading.value) {
+      isEstimatesLoading.value = true
+    }
+    updateEstimates()
+  }
+})
+
 // Update USD value when monthlyEarnings or vault changes
 watchEffect(async () => {
   if (!vault.value || !monthlyEarnings.value) {

--- a/pages/lend/[vault]/index.vue
+++ b/pages/lend/[vault]/index.vue
@@ -25,6 +25,7 @@ import { formatNumber, compactNumber, formatSmartAmount } from '~/utils/string-u
 import { useSwapPriceImpact } from '~/composables/useSwapPriceImpact'
 import { usePriceImpactGate } from '~/composables/usePriceImpactGate'
 import { isOperationBlocked } from '~/utils/operationGuardRegistry'
+import { createRaceGuard } from '~/utils/race-guard'
 
 // Type definitions for vault display
 type VaultType = 'evk' | 'securitize'
@@ -490,8 +491,11 @@ const send = async () => {
   }
 }
 
+const estimatesGuard = createRaceGuard()
+
 const updateEstimates = useDebounceFn(async () => {
   if (!isVaultLoaded.value) return
+  const gen = estimatesGuard.next()
   try {
     if (features.value.hasInterestRate && evkVault.value) {
       // When swapping, use the swap output amount (vault-asset denominated)
@@ -511,6 +515,7 @@ const updateEstimates = useDebounceFn(async () => {
           supplyNano,
           0n,
         )
+        if (estimatesGuard.isStale(gen)) return
         const rawAPY = projected?.supplyAPY ?? evkVault.value.interestRateInfo.supplyAPY
         estimateSupplyAPY.value = rawAPY + valueToNano(totalRewardsAPY.value + intrinsicApy.value, 25)
       }
@@ -531,10 +536,13 @@ const updateEstimates = useDebounceFn(async () => {
     }
   }
   catch (e) {
+    if (estimatesGuard.isStale(gen)) return
     logWarn('lend-supply/estimates', e)
   }
   finally {
-    isEstimatesLoading.value = false
+    if (!estimatesGuard.isStale(gen)) {
+      isEstimatesLoading.value = false
+    }
   }
 }, 500)
 

--- a/pages/position/[number]/borrow/index.vue
+++ b/pages/position/[number]/borrow/index.vue
@@ -373,9 +373,9 @@ const updateAsyncEstimates = useDebounceFn(async () => {
       getAssetUsdValueOrZero(totalBorrow, borrowVault.value!, 'off-chain'),
     ])
 
-    const currentRawBorrowApy = nanoToValue(borrowVault.value.interestRateInfo.borrowAPY, 25)
-    const projectedRawBorrowApy = nanoToValue(borrowProjected.borrowAPY, 25)
-    const projectedBorrowApy = borrowApy.value + (projectedRawBorrowApy - currentRawBorrowApy)
+    const projectedBorrowApy = borrowProjected
+      ? borrowApy.value + (nanoToValue(borrowProjected.borrowAPY, 25) - nanoToValue(borrowVault.value.interestRateInfo.borrowAPY, 25))
+      : borrowApy.value
 
     netAPY.value = getNetAPY(
       collateralUsd,

--- a/pages/position/[number]/borrow/index.vue
+++ b/pages/position/[number]/borrow/index.vue
@@ -16,6 +16,7 @@ import { formatNumber, formatSmartAmount, formatHealthScore, trimTrailingZeros }
 import { formatLiquidationBuffer as formatLiqBuffer } from '~/utils/repayUtils'
 import { nanoToValue } from '~/utils/crypto-utils'
 import { isOperationBlocked } from '~/utils/operationGuardRegistry'
+import { createRaceGuard } from '~/utils/race-guard'
 
 const router = useRouter()
 const _route = useRoute()
@@ -354,8 +355,10 @@ const updateSyncEstimates = () => {
   }
 }
 
+const asyncEstimatesGuard = createRaceGuard()
 const updateAsyncEstimates = useDebounceFn(async () => {
   if (!pair.value || !borrowVault.value || !collateralVault.value) return
+  const gen = asyncEstimatesGuard.next()
   try {
     const additionalBorrowNano = valueToNano(borrowAmount.value || '0', borrowVault.value.decimals)
     const existingBorrow = nanoToValue(position.value?.borrowed || 0n, borrowVault.value.decimals)
@@ -373,6 +376,8 @@ const updateAsyncEstimates = useDebounceFn(async () => {
       getAssetUsdValueOrZero(totalBorrow, borrowVault.value!, 'off-chain'),
     ])
 
+    if (asyncEstimatesGuard.isStale(gen)) return
+
     const projectedBorrowApy = borrowProjected
       ? borrowApy.value + (nanoToValue(borrowProjected.borrowAPY, 25) - nanoToValue(borrowVault.value.interestRateInfo.borrowAPY, 25))
       : borrowApy.value
@@ -387,11 +392,14 @@ const updateAsyncEstimates = useDebounceFn(async () => {
     )
   }
   catch (e) {
+    if (asyncEstimatesGuard.isStale(gen)) return
     logWarn('borrow-more/asyncEstimates', e)
     netAPY.value = undefined
   }
   finally {
-    isEstimatesLoading.value = false
+    if (!asyncEstimatesGuard.isStale(gen)) {
+      isEstimatesLoading.value = false
+    }
   }
 }, 500)
 

--- a/pages/position/[number]/borrow/index.vue
+++ b/pages/position/[number]/borrow/index.vue
@@ -4,7 +4,7 @@ import { FixedPoint } from '~/utils/fixed-point'
 import { useModal } from '~/components/ui/composables/useModal'
 import { OperationReviewModal } from '#components'
 import { useToast } from '~/components/ui/composables/useToast'
-import { type BorrowVaultPair, getNetAPY, type VaultAsset } from '~/entities/vault'
+import { type BorrowVaultPair, getNetAPY, getProjectedRates, type VaultAsset } from '~/entities/vault'
 import { getUtilisationWarning, getBorrowCapWarning } from '~/composables/useVaultWarnings'
 import { getAssetUsdValueOrZero, getAssetOraclePrice, getCollateralOraclePrice, conservativePriceRatio } from '~/services/pricing/priceProvider'
 import { getTotalCollateralValue } from '~/utils/position-estimates'
@@ -22,7 +22,7 @@ const _route = useRoute()
 const modal = useModal()
 const { error } = useToast()
 const { buildBorrowPlan, executeTxPlan } = useEulerOperations()
-const { getBorrowVaultPair, updateVault } = useVaults()
+const { getBorrowVaultPair } = useVaults()
 const { isConnected, address } = useAccount()
 const { isSpyMode } = useSpyMode()
 const { isPositionsLoading, isPositionsLoaded, getPositionBySubAccountIndex } = useEulerAccount()
@@ -338,44 +338,62 @@ const onBorrowInput = async () => {
 const onLtvInput = () => {
   isLtvDriven.value = true
 }
-const updateEstimates = useDebounceFn(async () => {
-  if (!pair.value) {
-    return
-  }
-  await Promise.all([updateVault(collateralVault.value!.address), updateVault(borrowVault.value!.address)])
+const updateSyncEstimates = () => {
+  if (!pair.value) return
   try {
-    // Use LTV from the ratio-based slider (accounts for all collaterals)
     const newLtvFloat = ltvFixed.value.toUnsafeFloat()
     health.value = newLtvFloat <= 0
       ? Infinity
       : (Number(pair.value?.liquidationLTV || 0n) / 100) / newLtvFloat
     liquidationPrice.value = health.value < 1 ? undefined : priceFixed.value.toUnsafeFloat() / health.value
-    // borrowAmount is the ADDITIONAL borrow; estimate Net APY using total borrow
-    const existingBorrow = nanoToValue(position.value?.borrowed || 0n, borrowVault.value!.decimals)
+  }
+  catch (e) {
+    logWarn('borrow-more/syncEstimates', e)
+    health.value = undefined
+    liquidationPrice.value = undefined
+  }
+}
+
+const updateAsyncEstimates = useDebounceFn(async () => {
+  if (!pair.value || !borrowVault.value || !collateralVault.value) return
+  try {
+    const additionalBorrowNano = valueToNano(borrowAmount.value || '0', borrowVault.value.decimals)
+    const existingBorrow = nanoToValue(position.value?.borrowed || 0n, borrowVault.value.decimals)
     const totalBorrow = existingBorrow + (+borrowAmount.value || 0)
-    const [collateralUsd, borrowUsd] = await Promise.all([
+
+    const [borrowProjected, collateralUsd, borrowUsd] = await Promise.all([
+      getProjectedRates(
+        borrowVault.value.address,
+        borrowVault.value.interestRateInfo.cash,
+        borrowVault.value.interestRateInfo.borrows,
+        -additionalBorrowNano,
+        additionalBorrowNano,
+      ),
       getAssetUsdValueOrZero(+collateralAmount.value || 0, collateralVault.value!, 'off-chain'),
       getAssetUsdValueOrZero(totalBorrow, borrowVault.value!, 'off-chain'),
     ])
+
+    const currentRawBorrowApy = nanoToValue(borrowVault.value.interestRateInfo.borrowAPY, 25)
+    const projectedRawBorrowApy = nanoToValue(borrowProjected.borrowAPY, 25)
+    const projectedBorrowApy = borrowApy.value + (projectedRawBorrowApy - currentRawBorrowApy)
+
     netAPY.value = getNetAPY(
       collateralUsd,
       collateralSupplyApy.value,
       borrowUsd,
-      borrowApy.value,
+      projectedBorrowApy,
       collateralSupplyRewardApy.value || null,
       borrowRewardApy.value || null,
     )
   }
   catch (e) {
-    console.warn(e)
-    health.value = undefined
-    liquidationPrice.value = undefined
+    logWarn('borrow-more/asyncEstimates', e)
     netAPY.value = undefined
   }
   finally {
     isEstimatesLoading.value = false
   }
-}, 1000)
+}, 500)
 
 watch(isPositionsLoaded, (val) => {
   if (val) {
@@ -393,10 +411,11 @@ watch([collateralAmount, borrowAmount], async () => {
   if (!pair.value) {
     return
   }
+  updateSyncEstimates()
   if (!isEstimatesLoading.value) {
     isEstimatesLoading.value = true
   }
-  updateEstimates()
+  updateAsyncEstimates()
 })
 </script>
 


### PR DESCRIPTION
## Summary

- Add `getProjectedRates()` utility that calls VaultLens `getVaultInterestRateModelInfo` to compute supply/borrow APY at projected utilization after a user action
- Split all form estimates into sync (health, LTV, liquidation price — instant) and async (projected rates, USD prices, net APY — 500ms debounce)
- Fix incorrect `computeAPYs` usage in lend supply form that used current `borrowSPY` instead of projecting it through the IRM
- Remove unnecessary `updateVault()` calls from debounced estimates — vault state doesn't change from user input
- Add projected rate estimation to multiply form for all 3 vaults (supply, short, long) with same-vault optimization

## Test plan

- [x] Borrow form: drag LTV slider — health/liq price update instantly, net APY updates after ~500ms with projected rates
- [x] Lend supply: enter large amount — projected supply APY should differ from current APY
- [x] Lend withdraw: enter amount — projected supply APY reflects reduced utilization
- [ ] Repay (wallet + swap): net APY reflects reduced borrow cost from projected rates
- [x] Collateral supply/withdraw: health updates instantly, net APY uses projected collateral supply rate
- [x] Multiply form: set multiplier > 1 — ROE reflects projected rates for all 3 vaults
- [ ] Earn supply/withdraw: no regression, estimates update instantly (no debounce)