### PR TITLE
feat: add one-time migration announcement modal

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -5,6 +5,10 @@ import { MigrationAnnouncementModal } from '#components'
 
 const route = useRoute()
 const router = useRouter()
+const { migrationAnnouncementUrl } = useDeployConfig()
+const migrationAnnouncementSeen = useLocalStorage('migration-announcement-seen', false)
+const modal = useModal()
+
 const { loadEulerConfig, chainId } = useEulerAddresses()
 const { loadVaults, isReady: isVaultsReady, resetVaultsState, refreshVaults } = useVaults()
 const { loadTokenList, isLoaded: isTokenListLoaded } = useTokenList()
@@ -74,14 +78,11 @@ watch(route, () => {
 }, { immediate: true })
 
 const checkMigrationAnnouncement = () => {
-  const { migrationAnnouncementUrl } = useDeployConfig()
-  if (!migrationAnnouncementUrl) return
+  if (!migrationAnnouncementUrl || migrationAnnouncementSeen.value) return
 
-  const seen = useLocalStorage('migration-announcement-seen', false)
-  if (seen.value) return
-
-  const modal = useModal()
   modal.open(MigrationAnnouncementModal, {
+    isNotClosable: true,
+    onClose: () => { migrationAnnouncementSeen.value = true },
     props: {
       announcementUrl: migrationAnnouncementUrl,
     },
@@ -90,6 +91,7 @@ const checkMigrationAnnouncement = () => {
 
 await loadEulerConfig()
 checkOnboarding()
+// onMounted (not synchronous like checkOnboarding) because the modal system requires the DOM
 onMounted(checkMigrationAnnouncement)
 
 watch(chainId, () => {

--- a/app.vue
+++ b/app.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
 import { POLL_INTERVAL_60S_MS } from '~/entities/tuning-constants'
+import { useModal } from '~/components/ui/composables/useModal'
+import { MigrationAnnouncementModal } from '#components'
 
 const route = useRoute()
 const router = useRouter()
@@ -71,8 +73,24 @@ watch(route, () => {
   })
 }, { immediate: true })
 
+const checkMigrationAnnouncement = () => {
+  const { migrationAnnouncementUrl } = useDeployConfig()
+  if (!migrationAnnouncementUrl) return
+
+  const seen = useLocalStorage('migration-announcement-seen', false)
+  if (seen.value) return
+
+  const modal = useModal()
+  modal.open(MigrationAnnouncementModal, {
+    props: {
+      announcementUrl: migrationAnnouncementUrl,
+    },
+  })
+}
+
 await loadEulerConfig()
 checkOnboarding()
+onMounted(checkMigrationAnnouncement)
 
 watch(chainId, () => {
   resetVaultsState()

--- a/components/entities/announcement/MigrationAnnouncementModal.vue
+++ b/components/entities/announcement/MigrationAnnouncementModal.vue
@@ -3,19 +3,12 @@ const props = defineProps<{
   announcementUrl: string
 }>()
 const emits = defineEmits(['close'])
-
-const seen = useLocalStorage('migration-announcement-seen', false)
-seen.value = true
-
-const handleClose = () => {
-  emits('close')
-}
 </script>
 
 <template>
   <BaseModalWrapper
     title="We've upgraded the Euler app"
-    @close="handleClose"
+    :close="false"
   >
     <div class="flex flex-col gap-16">
       <p class="text-secondary text-p3">
@@ -55,7 +48,7 @@ const handleClose = () => {
         size="xlarge"
         rounded
         variant="primary"
-        @click="handleClose"
+        @click="emits('close')"
       >
         Got it
       </UiButton>

--- a/components/entities/announcement/MigrationAnnouncementModal.vue
+++ b/components/entities/announcement/MigrationAnnouncementModal.vue
@@ -1,0 +1,64 @@
+<script setup lang="ts">
+const props = defineProps<{
+  announcementUrl: string
+}>()
+const emits = defineEmits(['close'])
+
+const seen = useLocalStorage('migration-announcement-seen', false)
+seen.value = true
+
+const handleClose = () => {
+  emits('close')
+}
+</script>
+
+<template>
+  <BaseModalWrapper
+    title="We've upgraded the Euler app"
+    @close="handleClose"
+  >
+    <div class="flex flex-col gap-16">
+      <p class="text-secondary text-p3">
+        We've replaced the previous interface with a lighter version while we build the
+        next-generation Euler app. Everything works the same — lending, borrowing, and
+        earn are all fully supported.
+      </p>
+
+      <ul class="flex flex-col gap-8 text-p3 text-secondary">
+        <li class="flex items-start gap-8">
+          <span class="text-accent shrink-0">&#10003;</span>
+          <span>All features you rely on are fully supported</span>
+        </li>
+        <li class="flex items-start gap-8">
+          <span class="text-accent shrink-0">&#10003;</span>
+          <span>More reliable with fewer backend dependencies</span>
+        </li>
+        <li class="flex items-start gap-8">
+          <span class="text-accent shrink-0">&#10003;</span>
+          <span>A completely new app is in development</span>
+        </li>
+      </ul>
+
+      <a
+        v-if="props.announcementUrl"
+        :href="props.announcementUrl"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="text-accent text-p3 hover:underline"
+      >
+        Read the full announcement &rarr;
+      </a>
+    </div>
+
+    <div class="flex justify-end mt-16">
+      <UiButton
+        size="xlarge"
+        rounded
+        variant="primary"
+        @click="handleClose"
+      >
+        Got it
+      </UiButton>
+    </div>
+  </BaseModalWrapper>
+</template>

--- a/composables/useDeployConfig.ts
+++ b/composables/useDeployConfig.ts
@@ -52,6 +52,9 @@ export const useDeployConfig = () => {
     enableIncentra: isEnabled(rc.configEnableIncentra),
     enableFuul: isEnabled(rc.configEnableFuul),
 
+    // Migration announcement (opt-in: non-empty URL enables the modal)
+    migrationAnnouncementUrl: String(rc.configMigrationAnnouncementUrl || ''),
+
     // External token lists (defaults in server/api/token-list.get.ts)
     uniswapTokenListUrl: rc.configUniswapTokenListUrl || '',
     defillamaTokenListUrl: rc.configDefillamaTokenListUrl || '',

--- a/composables/useDeployConfig.ts
+++ b/composables/useDeployConfig.ts
@@ -53,7 +53,7 @@ export const useDeployConfig = () => {
     enableFuul: isEnabled(rc.configEnableFuul),
 
     // Migration announcement (opt-in: non-empty URL enables the modal)
-    migrationAnnouncementUrl: String(rc.configMigrationAnnouncementUrl || ''),
+    migrationAnnouncementUrl: rc.configMigrationAnnouncementUrl || '',
 
     // External token lists (defaults in server/api/token-list.get.ts)
     uniswapTokenListUrl: rc.configUniswapTokenListUrl || '',

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -123,6 +123,9 @@ export default defineNuxtConfig({
       configEnableMerkl: '',
       configEnableIncentra: '',
       configEnableFuul: '',
+      // Migration announcement: set to a tweet/announcement URL to show a
+      // one-time modal explaining the app upgrade. Empty = disabled (default).
+      configMigrationAnnouncementUrl: '',
       // External token list URLs for swap token selector
       configUniswapTokenListUrl: '',
       configDefillamaTokenListUrl: '',


### PR DESCRIPTION
## Summary
- Adds a one-time modal that explains the app upgrade to users visiting the new interface
- Gated behind `NUXT_PUBLIC_CONFIG_MIGRATION_ANNOUNCEMENT_URL` env var — disabled by default so forks are unaffected
- Setting the var to a tweet/announcement URL enables the modal and shows a "Read the full announcement" link
- Dismissed state persisted in localStorage (`migration-announcement-seen`)

## Test plan
- [x] Start dev server without the env var — modal should not appear
- [x] Set `NUXT_PUBLIC_CONFIG_MIGRATION_ANNOUNCEMENT_URL=https://x.com/test` — modal appears on first visit
- [x] Dismiss modal (click "Got it", X button, or backdrop) — modal does not reappear on refresh
- [x] Clear `migration-announcement-seen` from localStorage — modal appears again
- [x] Verify announcement link opens in a new tab