### PR TITLE
chore: tighten dependabot config to reduce PR noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 3
     allow:
       - dependency-type: "direct"
     groups:
@@ -15,10 +15,11 @@ updates:
           - "nuxt"
           - "@nuxt/*"
           - "@nuxtjs/*"
-      minor-patch:
+      all-updates:
         update-types:
           - "minor"
           - "patch"
+          - "major"
         exclude-patterns:
           - "nuxt"
           - "@nuxt/*"
@@ -41,4 +42,8 @@ updates:
       - dependency-name: "viem"
         update-types: ["version-update:semver-major"]
       - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@wagmi/*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@reown/*"
         update-types: ["version-update:semver-major"]

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@floating-ui/vue": "1.1.11",
     "@gvade/nuxt3-svg-sprite": "1.0.3",
-    "@keyringnetwork/keyring-connect-sdk": "^3.2.0",
+    "@keyringnetwork/keyring-connect-sdk": "3.2.0",
     "@nuxt/eslint": "1.0.1",
     "@nuxt/kit": "3.17.4",
     "@pythnetwork/price-service-client": "1.11.0",
@@ -33,7 +33,7 @@
     "@reown/appkit-adapter-wagmi": "1.8.19",
     "@tanstack/vue-query": "5.95.2",
     "@vueuse/nuxt": "13.3.0",
-    "@wagmi/core": "^2.22.1",
+    "@wagmi/core": "2.22.1",
     "@wagmi/vue": "0.5.1",
     "axios": "1.13.6",
     "chart.js": "4.5.1",
@@ -51,17 +51,17 @@
     "@types/luxon": "3.7.1",
     "eslint": "9.39.4",
     "lint-staged": "16.4.0",
-    "playwright": "^1.58.2",
+    "playwright": "1.58.2",
     "sass": "1.98.0",
     "simple-git-hooks": "2.13.1",
     "tailwindcss": "3.4.19",
     "typescript": "5.9.3",
-    "vitest": "^4.1.1",
+    "vitest": "4.1.1",
     "vue-tsc": "3.2.6"
   },
   "overrides": {
-    "serialize-javascript": "^7.0.3",
-    "unhead": ">=2.1.11"
+    "serialize-javascript": "7.0.4",
+    "unhead": "2.1.12"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
## Summary
- Group all updates (minor, patch, **and major**) into a single PR instead of only minor/patch
- Lower open PR limit from 5 to 3
- Ignore major bumps on `@wagmi/*` and `@reown/*` (breaking, need manual upgrade)
- Pin all dependencies to exact versions (remove `^` and `>=` ranges)

This reduces Dependabot from ~4+ individual PRs per cycle to at most 2 grouped PRs (nuxt ecosystem + everything else), and pinning ensures `npm install` can never silently pull in a compromised version.