### PR TITLE
fix: skip onboarding redirect for deep link visitors

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -45,6 +45,11 @@ let interval: NodeJS.Timeout | null = null
 const checkOnboarding = () => {
   const isOnboardingCompleted = useLocalStorage('is-onboarding-completed', false)
   if (!isOnboardingCompleted.value) {
+    const isDeepLink = route.path !== '/' && route.path !== '/onboarding'
+    if (isDeepLink) {
+      isOnboardingCompleted.value = true
+      return
+    }
     router.push('/onboarding')
   }
 }


### PR DESCRIPTION
## Summary
- First-time users arriving via deep links (e.g. shared on Twitter, announcements) were unconditionally redirected to the onboarding page, losing their intended destination
- Now any visit to a specific page (path other than `/`) skips onboarding and marks it completed, so the user lands directly on the linked page
- Users visiting the root URL still see onboarding as before

## Test plan
- [x] Visit a deep link like `/lend?network=1&market=Keyring+zkVerified+Cluster` with fresh localStorage — should land on the lend page, not onboarding
- [x] Visit the root URL `/` with fresh localStorage — should still redirect to onboarding
- [x] After deep link visit, verify `is-onboarding-completed` is set to `true` in localStorage
- [x] Returning users (onboarding already completed) are unaffected