### PR TITLE
fix: harden geo-gate with fail-closed logic and dev country override

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,9 @@
 # origin rejection, and HSTS. Injected automatically by Doppler at runtime.
 DOPPLER_ENVIRONMENT=dev
 
+# Dev-only: simulate a country for geo-gate testing (e.g. GB, US, CU, IR). No effect outside dev.
+DEV_GEO_COUNTRY=GB
+
 # Reown (AppKit) configuration
 # The NUXT_PUBLIC_ prefix is required so Nuxt can expose these to the client
 # as a build-time fallback. The server plugin also accepts the short names

--- a/composables/useGeoBlock.ts
+++ b/composables/useGeoBlock.ts
@@ -2,15 +2,14 @@ import { detectCountry } from '~/services/country'
 import { getVaultBlock, getEarnVaultBlock, getVaultRestricted, getEarnVaultRestricted, isVaultDeprecated } from '~/utils/eulerLabelsUtils'
 import { SANCTIONED_COUNTRIES, COUNTRY_GROUPS } from '~/entities/constants'
 
-const country = ref<string | null>(null)
+// undefined = not yet loaded, null = loaded but country unknown, string = loaded with country
+const country = ref<string | null | undefined>(undefined)
 
 export const useGeoBlock = () => {
   const loadCountry = async () => {
     if (!import.meta.client) return
     const detected = await detectCountry()
-    if (detected) {
-      country.value = detected
-    }
+    country.value = detected ?? null
   }
 
   return { country, loadCountry }
@@ -25,7 +24,8 @@ const expandBlockList = (codes: readonly string[]): string[] => {
 }
 
 export const isVaultBlockedByCountry = (vaultAddress: string): boolean => {
-  if (!country.value) return false
+  if (country.value === undefined) return false // still loading
+  if (country.value === null) return true // loaded, country unknown
 
   // Sanctioned countries are always blocked
   if (isCountryInList(SANCTIONED_COUNTRIES)) return true
@@ -44,7 +44,8 @@ export const isAnyVaultBlockedByCountry = (...addresses: string[]): boolean => {
 }
 
 export const isVaultRestrictedByCountry = (vaultAddress: string): boolean => {
-  if (!country.value) return false
+  if (country.value === undefined) return false // still loading
+  if (country.value === null) return true // loaded, country unknown
 
   const vaultRestricted = getVaultRestricted(vaultAddress)
   if (vaultRestricted?.length && isCountryInList(expandBlockList(vaultRestricted))) return true

--- a/composables/useGeoBlock.ts
+++ b/composables/useGeoBlock.ts
@@ -4,12 +4,22 @@ import { SANCTIONED_COUNTRIES, COUNTRY_GROUPS } from '~/entities/constants'
 
 // undefined = not yet loaded, null = loaded but country unknown, string = loaded with country
 const country = ref<string | null | undefined>(undefined)
+let loadingCountry = false
 
 export const useGeoBlock = () => {
   const loadCountry = async () => {
-    if (!import.meta.client) return
-    const detected = await detectCountry()
-    country.value = detected ?? null
+    if (!import.meta.client || loadingCountry) return
+    loadingCountry = true
+    try {
+      const detected = await detectCountry()
+      country.value = detected ?? null
+    }
+    catch {
+      country.value = null
+    }
+    finally {
+      loadingCountry = false
+    }
   }
 
   return { country, loadCountry }

--- a/server/middleware/cors.ts
+++ b/server/middleware/cors.ts
@@ -43,10 +43,13 @@ export default defineEventHandler((event) => {
     allowedOrigins = parseAllowedOrigins()
   }
 
-  const rawCountry = event.node.req.headers['x-country-code']
-  const country = (typeof rawCountry === 'string' && /^[A-Z]{2}$/.test(rawCountry))
-    ? rawCountry
-    : undefined
+  // Strip any client-supplied x-country-code to prevent geo-blocking bypass.
+  // The authoritative value comes from Cloudflare's CF-IPCountry header which is
+  // set by their edge network and cannot be modified by clients.
+  delete event.node.req.headers['x-country-code']
+
+  const cfCountry = (event.node.req.headers['cf-ipcountry'] as string | undefined)?.toUpperCase()
+  const country = (cfCountry && /^[A-Z]{2}$/.test(cfCountry) && cfCountry !== 'XX') ? cfCountry : undefined
   if (country) {
     setResponseHeader(event, 'x-country-code', country)
   }

--- a/server/middleware/cors.ts
+++ b/server/middleware/cors.ts
@@ -49,7 +49,17 @@ export default defineEventHandler((event) => {
   delete event.node.req.headers['x-country-code']
 
   const cfCountry = (event.node.req.headers['cf-ipcountry'] as string | undefined)?.toUpperCase()
-  const country = (cfCountry && /^[A-Z]{2}$/.test(cfCountry) && cfCountry !== 'XX') ? cfCountry : undefined
+  let country = (cfCountry && /^[A-Z]{2}$/.test(cfCountry) && cfCountry !== 'XX') ? cfCountry : undefined
+
+  // In dev, Cloudflare is not in the request path so cf-ipcountry is never set.
+  // Mirror geo-gate.ts: use DEV_GEO_COUNTRY so x-country-code is set in the response.
+  if (!country && process.env.DOPPLER_ENVIRONMENT === 'dev') {
+    const devCountry = process.env.DEV_GEO_COUNTRY?.toUpperCase()
+    if (devCountry && /^[A-Z]{2}$/.test(devCountry) && devCountry !== 'XX') {
+      country = devCountry
+    }
+  }
+
   if (country) {
     setResponseHeader(event, 'x-country-code', country)
   }

--- a/server/middleware/geo-gate.ts
+++ b/server/middleware/geo-gate.ts
@@ -18,7 +18,7 @@ export default defineEventHandler((event) => {
   // DEV_GEO_COUNTRY allows simulating any country for testing geo-blocks locally.
   if (!country && process.env.DOPPLER_ENVIRONMENT === 'dev') {
     const devCountry = process.env.DEV_GEO_COUNTRY?.toUpperCase()
-    if (devCountry && /^[A-Z]{2}$/.test(devCountry)) {
+    if (devCountry && /^[A-Z]{2}$/.test(devCountry) && devCountry !== 'XX') {
       country = devCountry
     }
   }

--- a/server/middleware/geo-gate.ts
+++ b/server/middleware/geo-gate.ts
@@ -8,25 +8,45 @@ export default defineEventHandler((event) => {
     return
   }
 
-  const country = (event.node.req.headers['x-country-code'] as string | undefined)?.toUpperCase()
+  // Use Cloudflare's CF-IPCountry header which is set by their edge network and
+  // cannot be modified by clients. x-country-code is stripped in cors.ts.
+  // CF-IPCountry special values: 'XX' = unknown IP, 'T1' = Tor exit node.
+  const cfCountry = (event.node.req.headers['cf-ipcountry'] as string | undefined)?.toUpperCase()
+  let country = (cfCountry && /^[A-Z]{2}$/.test(cfCountry) && cfCountry !== 'XX') ? cfCountry : undefined
+
+  // In dev, Cloudflare is not in the request path so cf-ipcountry is never set.
+  // DEV_GEO_COUNTRY allows simulating any country for testing geo-blocks locally.
+  if (!country && process.env.DOPPLER_ENVIRONMENT === 'dev') {
+    const devCountry = process.env.DEV_GEO_COUNTRY?.toUpperCase()
+    if (devCountry && /^[A-Z]{2}$/.test(devCountry)) {
+      country = devCountry
+    }
+  }
+
+  // Fail-closed: deny access when country cannot be determined.
+  // This prevents bypassing geo-blocks by omitting or spoofing headers.
+  if (!country) {
+    console.warn('[geo-gate] Blocked: country undetermined', {
+      cfCountry: cfCountry || 'absent',
+      path: url.pathname,
+    })
+    throw createError({
+      statusCode: 451,
+      statusMessage: 'Unavailable For Legal Reasons',
+    })
+  }
+
   const isVpn = event.node.req.headers['x-is-vpn']
   const isProxyOrVpn = event.node.req.headers['x-is-proxy-or-vpn']
 
   // Log VPN/proxy usage for monitoring (do not block -- too many false positives)
   if (isVpn === 'true' || isProxyOrVpn === 'true') {
     console.warn('[geo-gate] VPN/proxy detected', {
-      country: country || 'unknown',
+      country,
       isVpn,
       isProxyOrVpn,
       path: url.pathname,
     })
-  }
-
-  // If country header is missing, allow the request (fail-open).
-  // Cloudflare should always set this header; if it's absent something is wrong
-  // but blocking legitimate users is worse than missing a check.
-  if (!country) {
-    return
   }
 
   // Block sanctioned countries

--- a/server/middleware/geo-gate.ts
+++ b/server/middleware/geo-gate.ts
@@ -25,7 +25,8 @@ export default defineEventHandler((event) => {
 
   // Fail-closed: deny access when country cannot be determined.
   // This prevents bypassing geo-blocks by omitting or spoofing headers.
-  if (!country) {
+  // In dev without DEV_GEO_COUNTRY set, allow the request through.
+  if (!country && process.env.DOPPLER_ENVIRONMENT !== 'dev') {
     console.warn('[geo-gate] Blocked: country undetermined', {
       cfCountry: cfCountry || 'absent',
       path: url.pathname,


### PR DESCRIPTION
- Switch from x-country-code to cf-ipcountry (Cloudflare edge header) to prevent client spoofing.
- Block requests when country is undetermined (fail-closed).
- Add DEV_GEO_COUNTRY env var to simulate countries locally since Cloudflare is not in the request path during development.
- Add tri-state country ref so UI reactively blocks when country detection resolves to null

____

NOTE: This has been tested locally, without cloudflare, need a deployment to test properly (with VPN etc)

NOTE: Any dev returning to this repo post merge must set DEV_GEO_COUNTRY=GB (or any non-sanctioned country) in their .env. Without it, the geo-gate fails closed and blocks all /api/* routes locally, since Cloudflare is not in the request path during development and cf-ipcountry is never set.