### PR TITLE
fix: remove RPC URLs from window.__CHAIN_CONFIG__

### DIFF
--- a/composables/useChainConfig.ts
+++ b/composables/useChainConfig.ts
@@ -12,21 +12,17 @@
 interface ChainConfig {
   enabledChainIds: number[]
   subgraphUris: Record<string, string>
-  rpcUrls: Record<string, string>
 }
 
 let cached: ChainConfig | null = null
 
 function scanEnv(): ChainConfig {
-  const rpcUrls: Record<string, string> = {}
   const enabledChainIds: number[] = []
 
-  for (const [key, value] of Object.entries(process.env)) {
+  for (const [key] of Object.entries(process.env)) {
     const rpcMatch = key.match(/^RPC_URL_HTTP_(\d+)$/)
-    if (rpcMatch && value) {
-      const chainId = Number(rpcMatch[1])
-      enabledChainIds.push(chainId)
-      rpcUrls[String(chainId)] = value
+    if (rpcMatch) {
+      enabledChainIds.push(Number(rpcMatch[1]))
     }
   }
 
@@ -40,7 +36,7 @@ function scanEnv(): ChainConfig {
 
   enabledChainIds.sort((a, b) => a - b)
 
-  return { enabledChainIds, subgraphUris, rpcUrls }
+  return { enabledChainIds, subgraphUris }
 }
 
 export const useChainConfig = (): ChainConfig => {
@@ -55,7 +51,7 @@ export const useChainConfig = (): ChainConfig => {
   /* eslint-enable @typescript-eslint/no-explicit-any */
   }
   else {
-    cached = { enabledChainIds: [], subgraphUris: {}, rpcUrls: {} }
+    cached = { enabledChainIds: [], subgraphUris: {} }
   }
 
   return cached!

--- a/composables/useChainConfig.ts
+++ b/composables/useChainConfig.ts
@@ -19,9 +19,9 @@ let cached: ChainConfig | null = null
 function scanEnv(): ChainConfig {
   const enabledChainIds: number[] = []
 
-  for (const [key] of Object.entries(process.env)) {
+  for (const [key, value] of Object.entries(process.env)) {
     const rpcMatch = key.match(/^RPC_URL_HTTP_(\d+)$/)
-    if (rpcMatch) {
+    if (rpcMatch && value) {
       enabledChainIds.push(Number(rpcMatch[1]))
     }
   }

--- a/plugins/00.wagmi.ts
+++ b/plugins/00.wagmi.ts
@@ -9,7 +9,7 @@ export default defineNuxtPlugin((nuxtApp) => {
   const projectId = envConfig.appKitProjectId
   const appUrl = envConfig.appUrl
   const normalizedAppUrl = appUrl ? appUrl.replace(/\/+$/, '') : ''
-  const { enabledChainIds, rpcUrls } = useChainConfig()
+  const { enabledChainIds } = useChainConfig()
 
   if (!projectId) {
     console.warn('[wagmi] Missing APPKIT_PROJECT_ID in runtime config')
@@ -37,8 +37,8 @@ export default defineNuxtPlugin((nuxtApp) => {
   }
 
   const customRpcUrls: Record<string, { url: string }[]> = {}
-  for (const [chainId, url] of Object.entries(rpcUrls)) {
-    customRpcUrls[`eip155:${chainId}`] = [{ url }]
+  for (const chainId of enabledChainIds) {
+    customRpcUrls[`eip155:${chainId}`] = [{ url: `/api/rpc/${chainId}` }]
   }
 
   const wagmiAdapter = new WagmiAdapter({

--- a/server/plugins/chain-config.ts
+++ b/server/plugins/chain-config.ts
@@ -7,15 +7,12 @@
  * accessible to the client synchronously via window.__CHAIN_CONFIG__.
  */
 export default defineNitroPlugin((nitroApp) => {
-  const rpcUrls: Record<string, string> = {}
   const enabledChainIds: number[] = []
 
   for (const [key, value] of Object.entries(process.env)) {
     const rpcMatch = key.match(/^RPC_URL_HTTP_(\d+)$/)
     if (rpcMatch && value) {
-      const chainId = Number(rpcMatch[1])
-      enabledChainIds.push(chainId)
-      rpcUrls[String(chainId)] = value
+      enabledChainIds.push(Number(rpcMatch[1]))
     }
   }
 
@@ -29,7 +26,7 @@ export default defineNitroPlugin((nitroApp) => {
 
   enabledChainIds.sort((a, b) => a - b)
 
-  const scriptTag = `<script>window.__CHAIN_CONFIG__=${JSON.stringify({ enabledChainIds, subgraphUris, rpcUrls })}</script>`
+  const scriptTag = `<script>window.__CHAIN_CONFIG__=${JSON.stringify({ enabledChainIds, subgraphUris })}</script>`
 
   nitroApp.hooks.hook('render:html', (html) => {
     html.head.push(scriptTag)


### PR DESCRIPTION
- Routes wagmi RPC calls through the existing /api/rpc/[chainId] server proxy instead of injecting provider URLs (which contain API keys) into the page HTML.

- Removes rpcUrls from window.__CHAIN_CONFIG__ and the ChainConfig interface entirely.