### PR TITLE
fix: make wallet screening fail-closed on all error paths

### DIFF
--- a/server/api/screen-address.post.ts
+++ b/server/api/screen-address.post.ts
@@ -1,5 +1,6 @@
 import { createError, readBody } from 'h3'
 import { createRateLimiter } from '~/server/utils/rate-limit'
+import { logWarn } from '~/server/utils/log'
 import { isAbortError } from '~/utils/errorHandling'
 
 const SCREENING_TIMEOUT_MS = 5000
@@ -29,7 +30,7 @@ export default defineEventHandler(async (event) => {
   const screeningUri = process.env.WALLET_SCREENING_URI
 
   if (!screeningUri) {
-    console.warn('[screen-address] WALLET_SCREENING_URI is not set — failing closed')
+    logWarn('screen-address', 'WALLET_SCREENING_URI is not set — failing closed')
     return { addressIsSuspicious: true }
   }
 
@@ -45,7 +46,7 @@ export default defineEventHandler(async (event) => {
     })
 
     if (!resp.ok) {
-      console.warn('[screen-address] TRM API returned', resp.status, '— failing closed')
+      logWarn('screen-address', 'TRM API returned', resp.status, '— failing closed')
       return { addressIsSuspicious: true }
     }
 
@@ -53,17 +54,17 @@ export default defineEventHandler(async (event) => {
     const isSuspicious = Boolean(data?.addressIsSuspicious)
 
     if (isSuspicious) {
-      console.warn('[screen-address] Flagged address:', address)
+      logWarn('screen-address', 'Flagged address:', address)
     }
 
     return { addressIsSuspicious: isSuspicious }
   }
   catch (error) {
     if (isAbortError(error)) {
-      console.warn('[screen-address] TRM API timeout — failing closed')
+      logWarn('screen-address', 'TRM API timeout — failing closed')
     }
     else {
-      console.warn('[screen-address] TRM API error — failing closed:', error)
+      logWarn('screen-address', 'TRM API error — failing closed:', error)
     }
     return { addressIsSuspicious: true }
   }

--- a/server/api/screen-address.post.ts
+++ b/server/api/screen-address.post.ts
@@ -29,7 +29,8 @@ export default defineEventHandler(async (event) => {
   const screeningUri = process.env.WALLET_SCREENING_URI
 
   if (!screeningUri) {
-    return { addressIsSuspicious: false }
+    console.warn('[screen-address] WALLET_SCREENING_URI is not set — failing closed')
+    return { addressIsSuspicious: true }
   }
 
   const controller = new AbortController()
@@ -44,9 +45,8 @@ export default defineEventHandler(async (event) => {
     })
 
     if (!resp.ok) {
-      console.warn('[screen-address] TRM API returned', resp.status)
-      // Fail open on API errors (same as current client-side behavior)
-      return { addressIsSuspicious: false }
+      console.warn('[screen-address] TRM API returned', resp.status, '— failing closed')
+      return { addressIsSuspicious: true }
     }
 
     const data = await resp.json()
@@ -60,13 +60,12 @@ export default defineEventHandler(async (event) => {
   }
   catch (error) {
     if (isAbortError(error)) {
-      console.warn('[screen-address] TRM API timeout')
+      console.warn('[screen-address] TRM API timeout — failing closed')
     }
     else {
-      console.warn('[screen-address] TRM API error:', error)
+      console.warn('[screen-address] TRM API error — failing closed:', error)
     }
-    // Fail open on errors (same as current client-side behavior)
-    return { addressIsSuspicious: false }
+    return { addressIsSuspicious: true }
   }
   finally {
     clearTimeout(timeout)

--- a/services/trm.ts
+++ b/services/trm.ts
@@ -15,6 +15,6 @@ export async function screenAddress(
     return Boolean(data?.addressIsSuspicious)
   }
   catch {
-    return false
+    return true
   }
 }


### PR DESCRIPTION
Previously, any error (missing config, non-2xx response, network failure, timeout) would silently pass the address through as clean. This changes all four error paths to return addressIsSuspicious: true instead, so a misbehaving or unreachable screening service blocks access rather than granting it.

The only path that returns the actual TRM result is a clean 200 response — everything else fails closed.

Tested locally against stubs covering all failure modes (missing URI, 503, ECONNRESET, 5s timeout) and verified the BlockedAddressModal appears in each case.
                                                                          