### PR TITLE
fix: show an error message if tenderly simulation is created but reverts

### DIFF
--- a/components/entities/operation/OperationReviewModal.vue
+++ b/components/entities/operation/OperationReviewModal.vue
@@ -198,6 +198,10 @@ const usesPermit2 = computed(() => {
   return plan?.steps?.some(step => step.label?.includes('Permit2')) ?? false
 })
 
+const hasTenderlyFailedSimulation = computed(() => {
+  return !!(tenderlyUrl.value && tenderlyError.value)
+})
+
 const permit2DisclaimerText = 'You are granting the permit2 contract unlimited access to your tokens. This is a safe, one-time setup — permit2 (by Uniswap) is a widely trusted and audited contract that replaces repeated approval transactions with gasless signatures. Each future transaction still requires your explicit signature, limited in both amount and duration.'
 </script>
 
@@ -238,13 +242,21 @@ const permit2DisclaimerText = 'You are granting the permit2 contract unlimited a
           :href="tenderlyUrl"
           target="_blank"
           rel="noopener noreferrer"
-          class="flex items-center gap-6 text-p3 text-success-500 hover:text-success-600 transition-colors"
+          class="flex items-center gap-6 text-p3 transition-colors"
+          :class="hasTenderlyFailedSimulation
+            ? 'text-error-500 hover:text-error-600'
+            : 'text-success-500 hover:text-success-600'"
         >
           <SvgIcon
-            name="check-circle"
+            :name="hasTenderlyFailedSimulation ? 'warning-circle' : 'check-circle'"
             class="!w-16 !h-16"
           />
-          View simulation
+          {{ hasTenderlyFailedSimulation ? 'Simulation failed' : 'View simulation' }}
+          <SvgIcon
+            v-if="hasTenderlyFailedSimulation"
+            name="arrow-top-right"
+            class="!w-14 !h-14"
+          />
         </a>
         <button
           v-else-if="tenderlyEnabled"
@@ -270,7 +282,7 @@ const permit2DisclaimerText = 'You are granting the permit2 contract unlimited a
 
       <!-- Tenderly error -->
       <UiToast
-        v-if="tenderlyError"
+        v-if="tenderlyError && !hasTenderlyFailedSimulation"
         title="Simulation failed"
         variant="warning"
         :description="tenderlyError"

--- a/composables/useTenderlySimulation.ts
+++ b/composables/useTenderlySimulation.ts
@@ -11,6 +11,36 @@ interface TenderlySimulateParams {
 
 interface TenderlySimulateResponse {
   url: string
+  errorMessage?: string
+}
+
+interface TenderlyFetchError {
+  message?: string
+  statusMessage?: string
+  data?: {
+    statusMessage?: string
+    message?: string
+  }
+}
+
+function getTenderlyErrorMessage(error: unknown): string {
+  if (error && typeof error === 'object') {
+    const fetchError = error as TenderlyFetchError
+    const candidates = [
+      fetchError.data?.statusMessage,
+      fetchError.statusMessage,
+      fetchError.data?.message,
+      fetchError.message,
+    ]
+
+    for (const candidate of candidates) {
+      if (typeof candidate === 'string' && candidate.trim()) {
+        return candidate.trim()
+      }
+    }
+  }
+
+  return 'Tenderly simulation failed'
 }
 
 export const useTenderlySimulation = () => {
@@ -34,12 +64,11 @@ export const useTenderlySimulation = () => {
       })
 
       simulationUrl.value = response.url
+      simulationError.value = response.errorMessage?.trim() || ''
       return response.url
     }
     catch (error: unknown) {
-      simulationError.value = error instanceof Error
-        ? error.message
-        : 'Tenderly simulation failed'
+      simulationError.value = getTenderlyErrorMessage(error)
       return null
     }
     finally {

--- a/server/api/tenderly/simulate.post.ts
+++ b/server/api/tenderly/simulate.post.ts
@@ -24,6 +24,26 @@ interface SimulateRequest {
   stateOverrides: ViemStateOverrideEntry[]
 }
 
+interface TenderlySimulationResult {
+  id?: string
+  status?: boolean
+  error_message?: string | null
+}
+
+interface TenderlyTransactionResult {
+  status?: boolean
+  error_message?: string | null
+  transaction_info?: {
+    error_message?: string | null
+  }
+}
+
+interface TenderlySimulateResponse {
+  simulation?: TenderlySimulationResult
+  transaction?: TenderlyTransactionResult
+  error_message?: string | null
+}
+
 function isValidHex(value: unknown): value is string {
   return typeof value === 'string' && /^0x[0-9a-fA-F]*$/.test(value)
 }
@@ -50,6 +70,28 @@ function isValidStateOverride(entry: unknown): entry is ViemStateOverrideEntry {
     }
   }
   return true
+}
+
+function getTenderlySimulationErrorMessage(response: TenderlySimulateResponse): string | undefined {
+  const candidates = [
+    response.transaction?.error_message,
+    response.transaction?.transaction_info?.error_message,
+    response.simulation?.error_message,
+    response.error_message,
+  ]
+
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate.trim()) {
+      return candidate.trim()
+    }
+  }
+
+  const status = response.simulation?.status ?? response.transaction?.status
+  if (status === false) {
+    return 'The simulated transaction reverted.'
+  }
+
+  return undefined
 }
 
 export default defineEventHandler(async (event) => {
@@ -133,7 +175,7 @@ export default defineEventHandler(async (event) => {
       })
     }
 
-    const simulateData = await simulateResponse.json() as { simulation?: { id?: string, status?: boolean } }
+    const simulateData = await simulateResponse.json() as TenderlySimulateResponse
     const simulationId = simulateData?.simulation?.id
 
     if (!simulationId) {
@@ -147,10 +189,16 @@ export default defineEventHandler(async (event) => {
     })
 
     if (!shareResponse.ok) {
-      return { url: `https://tdly.co/shared/simulation/${simulationId}` }
+      return {
+        url: `https://tdly.co/shared/simulation/${simulationId}`,
+        errorMessage: getTenderlySimulationErrorMessage(simulateData),
+      }
     }
 
-    return { url: `https://tdly.co/shared/simulation/${simulationId}` }
+    return {
+      url: `https://tdly.co/shared/simulation/${simulationId}`,
+      errorMessage: getTenderlySimulationErrorMessage(simulateData),
+    }
   }
   catch (error: unknown) {
     if (isAbortError(error)) {


### PR DESCRIPTION
When tenderly simulation is run it always shows green success for getting created, even if the actual tx reverts. Fixed to show error message