### PR TITLE
feat: add min-release-age=7 to .npmrc

### DIFF
--- a/.github/workflows/npm-audit.yml
+++ b/.github/workflows/npm-audit.yml
@@ -16,8 +16,10 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
+
+      - run: npm install -g npm@11.10.0
 
       - run: npm ci
 

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7


### PR DESCRIPTION
Adds a project-level `.npmrc` with `min-release-age=7`, preventing npm from installing package versions published less than 7 days ago.