### PR TITLE
perf: add stale-while-revalidate to server proxy endpoints

### DIFF
--- a/server/api/intrinsic-apy/[provider].get.ts
+++ b/server/api/intrinsic-apy/[provider].get.ts
@@ -1,5 +1,7 @@
 import { createError, getRouterParam, getQuery } from 'h3'
 import { createRateLimiter } from '~/server/utils/rate-limit'
+import { createTtlCache } from '~/server/utils/cache'
+import { logWarn } from '~/server/utils/log'
 
 const TIMEOUT_MS = 10_000
 const CACHE_TTL_MS = 5 * 60 * 1000
@@ -28,38 +30,23 @@ const PROVIDER_URLS: Record<string, string> = {
 
 const PENDLE_API_BASE = 'https://api-v2.pendle.finance/core/v2'
 
-interface CacheEntry {
-  data: unknown
-  expiresAt: number
-}
+const cache = createTtlCache<unknown>({ ttlMs: CACHE_TTL_MS, maxEntries: 200 })
 
-const MAX_CACHE_ENTRIES = 200
-const cache = new Map<string, CacheEntry>()
-
-const pruneExpired = () => {
-  const now = Date.now()
-  for (const [key, entry] of cache) {
-    if (now > entry.expiresAt) cache.delete(key)
+const fetchUpstream = async (url: string, cacheKey: string): Promise<unknown> => {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS)
+  try {
+    const resp = await fetch(url, { signal: controller.signal })
+    if (!resp.ok) {
+      throw createError({ statusCode: 502, statusMessage: `Upstream returned ${resp.status}` })
+    }
+    const data = await resp.json()
+    cache.set(cacheKey, data)
+    return data
   }
-}
-
-const getCached = (key: string): unknown | undefined => {
-  const entry = cache.get(key)
-  if (!entry) return undefined
-  if (Date.now() > entry.expiresAt) {
-    cache.delete(key)
-    return undefined
+  finally {
+    clearTimeout(timeout)
   }
-  return entry.data
-}
-
-const setCache = (key: string, data: unknown) => {
-  if (cache.size >= MAX_CACHE_ENTRIES) pruneExpired()
-  if (cache.size >= MAX_CACHE_ENTRIES) {
-    const oldest = cache.keys().next().value
-    if (oldest) cache.delete(oldest)
-  }
-  cache.set(key, { data, expiresAt: Date.now() + CACHE_TTL_MS })
 }
 
 export default defineEventHandler(async (event) => {
@@ -112,32 +99,26 @@ export default defineEventHandler(async (event) => {
     cacheKey = provider
   }
 
-  const cached = getCached(cacheKey)
-  if (cached !== undefined) return cached
+  const fresh = cache.get(cacheKey)
+  if (fresh !== undefined) return fresh
 
-  const controller = new AbortController()
-  const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS)
+  const stale = cache.getStale(cacheKey)
+  if (stale !== undefined) {
+    void fetchUpstream(url, cacheKey).catch((err) => {
+      logWarn(`intrinsic-apy/${provider}`, 'background revalidation failed:', err instanceof Error ? err.message : err)
+    })
+    return stale
+  }
 
+  // Cold — await
   try {
-    const resp = await fetch(url, { signal: controller.signal })
-
-    if (!resp.ok) {
-      throw createError({ statusCode: 502, statusMessage: `Upstream ${provider} returned ${resp.status}` })
-    }
-
-    const data = await resp.json()
-    setCache(cacheKey, data)
-    return data
+    return await fetchUpstream(url, cacheKey)
   }
   catch (error) {
     if (error && typeof error === 'object' && 'statusCode' in error) {
       throw error
     }
-    const message = error instanceof Error ? error.message : 'Unknown error'
-    console.warn(`[intrinsic-apy/${provider}] error:`, message)
+    logWarn(`intrinsic-apy/${provider}`, 'upstream error:', error instanceof Error ? error.message : error)
     throw createError({ statusCode: 502, statusMessage: 'Upstream error' })
-  }
-  finally {
-    clearTimeout(timeout)
   }
 })

--- a/server/api/intrinsic-apy/[provider].get.ts
+++ b/server/api/intrinsic-apy/[provider].get.ts
@@ -31,22 +31,31 @@ const PROVIDER_URLS: Record<string, string> = {
 const PENDLE_API_BASE = 'https://api-v2.pendle.finance/core/v2'
 
 const cache = createTtlCache<unknown>({ ttlMs: CACHE_TTL_MS, maxEntries: 200 })
+const inFlight = new Map<string, Promise<unknown>>()
 
-const fetchUpstream = async (url: string, cacheKey: string): Promise<unknown> => {
+const fetchUpstream = (url: string, cacheKey: string): Promise<unknown> => {
+  const existing = inFlight.get(cacheKey)
+  if (existing) return existing
+
   const controller = new AbortController()
   const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS)
-  try {
-    const resp = await fetch(url, { signal: controller.signal })
-    if (!resp.ok) {
-      throw createError({ statusCode: 502, statusMessage: `Upstream returned ${resp.status}` })
-    }
-    const data = await resp.json()
-    cache.set(cacheKey, data)
-    return data
-  }
-  finally {
-    clearTimeout(timeout)
-  }
+
+  const promise = fetch(url, { signal: controller.signal })
+    .then(async (resp) => {
+      if (!resp.ok) {
+        throw createError({ statusCode: 502, statusMessage: `Upstream returned ${resp.status}` })
+      }
+      const data = await resp.json()
+      cache.set(cacheKey, data)
+      return data
+    })
+    .finally(() => {
+      clearTimeout(timeout)
+      inFlight.delete(cacheKey)
+    })
+
+  inFlight.set(cacheKey, promise)
+  return promise
 }
 
 export default defineEventHandler(async (event) => {

--- a/server/api/screen-address.post.ts
+++ b/server/api/screen-address.post.ts
@@ -1,6 +1,7 @@
 import { createError, readBody } from 'h3'
 import { createRateLimiter } from '~/server/utils/rate-limit'
 import { isAbortError } from '~/utils/errorHandling'
+import { logWarn } from '~/server/utils/log'
 
 const SCREENING_TIMEOUT_MS = 5000
 
@@ -44,7 +45,7 @@ export default defineEventHandler(async (event) => {
     })
 
     if (!resp.ok) {
-      console.warn('[screen-address] TRM API returned', resp.status)
+      logWarn('screen-address', 'TRM API returned', resp.status)
       // Fail open on API errors (same as current client-side behavior)
       return { addressIsSuspicious: false }
     }
@@ -53,17 +54,17 @@ export default defineEventHandler(async (event) => {
     const isSuspicious = Boolean(data?.addressIsSuspicious)
 
     if (isSuspicious) {
-      console.warn('[screen-address] Flagged address:', address)
+      logWarn('screen-address', 'Flagged address:', address)
     }
 
     return { addressIsSuspicious: isSuspicious }
   }
   catch (error) {
     if (isAbortError(error)) {
-      console.warn('[screen-address] TRM API timeout')
+      logWarn('screen-address', 'TRM API timeout')
     }
     else {
-      console.warn('[screen-address] TRM API error:', error)
+      logWarn('screen-address', 'TRM API error:', error)
     }
     // Fail open on errors (same as current client-side behavior)
     return { addressIsSuspicious: false }

--- a/server/api/token-list.get.ts
+++ b/server/api/token-list.get.ts
@@ -37,94 +37,108 @@ const eulerApiCache = createTtlCache<TokenEntry[]>({ ttlMs: CACHE_TTL_MS })
 const uniswapCache = createTtlCache<TokenEntry[]>({ ttlMs: CACHE_TTL_MS })
 const defillamaCache = createTtlCache<TokenEntry[]>({ ttlMs: CACHE_TTL_MS })
 
-async function fetchEulerApi(chainId: number): Promise<TokenEntry[]> {
+const eulerInFlight = new Map<string, Promise<TokenEntry[]>>()
+const uniswapInFlight = new Map<string, Promise<TokenEntry[]>>()
+const defillamaInFlight = new Map<string, Promise<TokenEntry[]>>()
+
+function fetchEulerApi(chainId: number): Promise<TokenEntry[]> {
   const key = String(chainId)
   const cached = eulerApiCache.get(key)
-  if (cached) return cached
+  if (cached) return Promise.resolve(cached)
 
-  try {
-    const url = process.env.EULER_API_URL || process.env.NUXT_PUBLIC_EULER_API_URL
-    if (!url) return []
+  const existing = eulerInFlight.get(key)
+  if (existing) return existing
 
-    const resp = await fetchWithTimeout(`${url}/v1/tokens?chainId=${chainId}`, TIMEOUT_MS)
-    if (!resp.ok) {
-      throw new Error(`Euler API returned ${resp.status}`)
-    }
+  const url = process.env.EULER_API_URL || process.env.NUXT_PUBLIC_EULER_API_URL
+  if (!url) return Promise.resolve([])
 
-    const data = (await resp.json()) as EulerApiToken[]
-    const tokens: TokenEntry[] = data.map(t => ({
-      chainId: t.chainId,
-      address: t.address,
-      name: t.name,
-      symbol: t.symbol,
-      decimals: t.decimals,
-      logoURI: t.logoURI || undefined,
-    }))
+  const promise = fetchWithTimeout(`${url}/v1/tokens?chainId=${chainId}`, TIMEOUT_MS)
+    .then(async (resp) => {
+      if (!resp.ok) throw new Error(`Euler API returned ${resp.status}`)
+      const data = (await resp.json()) as EulerApiToken[]
+      const tokens: TokenEntry[] = data.map(t => ({
+        chainId: t.chainId,
+        address: t.address,
+        name: t.name,
+        symbol: t.symbol,
+        decimals: t.decimals,
+        logoURI: t.logoURI || undefined,
+      }))
+      eulerApiCache.set(key, tokens)
+      return tokens
+    })
+    .catch((err: unknown) => {
+      logWarn('token-list', 'Euler API fetch failed:', err instanceof Error ? err.message : err, 'for chain', chainId)
+      return eulerApiCache.getStale(key) || []
+    })
+    .finally(() => { eulerInFlight.delete(key) })
 
-    eulerApiCache.set(key, tokens)
-    return tokens
-  }
-  catch (err) {
-    logWarn('token-list', 'Euler API fetch failed:', err instanceof Error ? err.message : err, 'for chain', chainId)
-    return eulerApiCache.getStale(key) || []
-  }
+  eulerInFlight.set(key, promise)
+  return promise
 }
 
-async function fetchUniswap(): Promise<TokenEntry[]> {
+function fetchUniswap(): Promise<TokenEntry[]> {
   const url = process.env.NUXT_PUBLIC_CONFIG_UNISWAP_TOKEN_LIST_URL || 'https://tokens.uniswap.org'
 
   const cached = uniswapCache.get('all')
-  if (cached) return cached
+  if (cached) return Promise.resolve(cached)
 
-  try {
-    const resp = await fetchWithTimeout(url, TIMEOUT_MS)
-    if (!resp.ok) {
-      throw new Error(`Uniswap upstream returned ${resp.status}`)
-    }
+  const existing = uniswapInFlight.get('all')
+  if (existing) return existing
 
-    const data = await resp.json()
-    const tokens: TokenEntry[] = data.tokens || []
-    uniswapCache.set('all', tokens)
-    return tokens
-  }
-  catch (err) {
-    logWarn('token-list', 'Uniswap fetch failed:', err instanceof Error ? err.message : err)
-    return uniswapCache.getStale('all') || []
-  }
+  const promise = fetchWithTimeout(url, TIMEOUT_MS)
+    .then(async (resp) => {
+      if (!resp.ok) throw new Error(`Uniswap upstream returned ${resp.status}`)
+      const data = await resp.json()
+      const tokens: TokenEntry[] = data.tokens || []
+      uniswapCache.set('all', tokens)
+      return tokens
+    })
+    .catch((err: unknown) => {
+      logWarn('token-list', 'Uniswap fetch failed:', err instanceof Error ? err.message : err)
+      return uniswapCache.getStale('all') || []
+    })
+    .finally(() => { uniswapInFlight.delete('all') })
+
+  uniswapInFlight.set('all', promise)
+  return promise
 }
 
-async function fetchDefillama(chainId: number): Promise<TokenEntry[]> {
+function fetchDefillama(chainId: number): Promise<TokenEntry[]> {
   const key = String(chainId)
   const cached = defillamaCache.get(key)
-  if (cached) return cached
+  if (cached) return Promise.resolve(cached)
 
-  try {
-    const baseUrl = process.env.NUXT_PUBLIC_CONFIG_DEFILLAMA_TOKEN_LIST_URL || DEFILLAMA_DEFAULT_URL
-    const url = `${baseUrl}/tokenlists-${chainId}.json`
-    const resp = await fetchWithTimeout(url, TIMEOUT_MS)
-    if (!resp.ok) {
-      throw new Error(`DefiLlama upstream returned ${resp.status}`)
-    }
+  const existing = defillamaInFlight.get(key)
+  if (existing) return existing
 
-    const data = await resp.json()
+  const baseUrl = process.env.NUXT_PUBLIC_CONFIG_DEFILLAMA_TOKEN_LIST_URL || DEFILLAMA_DEFAULT_URL
+  const url = `${baseUrl}/tokenlists-${chainId}.json`
 
-    // DefiLlama format: object keyed by address → normalize to array
-    const tokens: TokenEntry[] = (Object.values(data) as Record<string, unknown>[]).map(entry => ({
-      chainId: Number(entry.chainId) || chainId,
-      address: entry.address as string,
-      name: entry.name as string,
-      symbol: entry.symbol as string,
-      decimals: entry.decimals as number,
-      logoURI: (entry.logoURI || entry.logoURI2) as string | undefined,
-    }))
+  const promise = fetchWithTimeout(url, TIMEOUT_MS)
+    .then(async (resp) => {
+      if (!resp.ok) throw new Error(`DefiLlama upstream returned ${resp.status}`)
+      const data = await resp.json()
+      // DefiLlama format: object keyed by address → normalize to array
+      const tokens: TokenEntry[] = (Object.values(data) as Record<string, unknown>[]).map(entry => ({
+        chainId: Number(entry.chainId) || chainId,
+        address: entry.address as string,
+        name: entry.name as string,
+        symbol: entry.symbol as string,
+        decimals: entry.decimals as number,
+        logoURI: (entry.logoURI || entry.logoURI2) as string | undefined,
+      }))
+      defillamaCache.set(key, tokens)
+      return tokens
+    })
+    .catch((err: unknown) => {
+      logWarn('token-list', 'DefiLlama fetch failed:', err instanceof Error ? err.message : err, 'for chain', chainId)
+      return defillamaCache.getStale(key) || []
+    })
+    .finally(() => { defillamaInFlight.delete(key) })
 
-    defillamaCache.set(key, tokens)
-    return tokens
-  }
-  catch (err) {
-    logWarn('token-list', 'DefiLlama fetch failed:', err instanceof Error ? err.message : err, 'for chain', chainId)
-    return defillamaCache.getStale(key) || []
-  }
+  defillamaInFlight.set(key, promise)
+  return promise
 }
 
 /** Merge two token arrays, deduplicating by chain+address. Primary entries take precedence. */
@@ -176,9 +190,9 @@ export default defineEventHandler(async (event) => {
   // defillamaStale is intentionally excluded: DefiLlama is supplementary; Euler or Uniswap
   // stale data is sufficient to justify returning a response without a cold await.
   if (eulerStale !== undefined || uniswapStale !== undefined) {
-    if (eulerFresh === undefined && chainId) void fetchEulerApi(chainId).catch(err => logWarn('token-list', 'Background Euler revalidation failed:', err instanceof Error ? err.message : err))
-    if (uniswapFresh === undefined) void fetchUniswap().catch(err => logWarn('token-list', 'Background Uniswap revalidation failed:', err instanceof Error ? err.message : err))
-    if (defillamaFresh === undefined && chainId) void fetchDefillama(chainId).catch(err => logWarn('token-list', 'Background DefiLlama revalidation failed:', err instanceof Error ? err.message : err))
+    if (eulerFresh === undefined && chainId) void fetchEulerApi(chainId)
+    if (uniswapFresh === undefined) void fetchUniswap()
+    if (defillamaFresh === undefined && chainId) void fetchDefillama(chainId)
 
     const euler = eulerFresh ?? eulerStale ?? []
     const uniswap = uniswapFresh ?? uniswapStale ?? []

--- a/server/api/token-list.get.ts
+++ b/server/api/token-list.get.ts
@@ -172,11 +172,13 @@ export default defineEventHandler(async (event) => {
   const uniswapStale = uniswapCache.getStale('all')
   const defillamaStale = key ? defillamaCache.getStale(key) : undefined
 
-  // Have stale data — return it immediately and revalidate in background
+  // Have stale data — return it immediately and revalidate in background.
+  // defillamaStale is intentionally excluded: DefiLlama is supplementary; Euler or Uniswap
+  // stale data is sufficient to justify returning a response without a cold await.
   if (eulerStale !== undefined || uniswapStale !== undefined) {
-    if (eulerFresh === undefined && chainId) void fetchEulerApi(chainId)
-    if (uniswapFresh === undefined) void fetchUniswap().catch(() => {})
-    if (defillamaFresh === undefined && chainId) void fetchDefillama(chainId)
+    if (eulerFresh === undefined && chainId) void fetchEulerApi(chainId).catch(err => logWarn('token-list', 'Background Euler revalidation failed:', err instanceof Error ? err.message : err))
+    if (uniswapFresh === undefined) void fetchUniswap().catch(err => logWarn('token-list', 'Background Uniswap revalidation failed:', err instanceof Error ? err.message : err))
+    if (defillamaFresh === undefined && chainId) void fetchDefillama(chainId).catch(err => logWarn('token-list', 'Background DefiLlama revalidation failed:', err instanceof Error ? err.message : err))
 
     const euler = eulerFresh ?? eulerStale ?? []
     const uniswap = uniswapFresh ?? uniswapStale ?? []

--- a/server/api/token-list.get.ts
+++ b/server/api/token-list.get.ts
@@ -2,6 +2,7 @@ import { createError, getQuery } from 'h3'
 import { createRateLimiter } from '~/server/utils/rate-limit'
 import { createTtlCache } from '~/server/utils/cache'
 import { fetchWithTimeout } from '~/server/utils/fetchWithTimeout'
+import { logWarn } from '~/server/utils/log'
 
 const TIMEOUT_MS = 10_000
 const CACHE_TTL_MS = 300_000
@@ -64,7 +65,7 @@ async function fetchEulerApi(chainId: number): Promise<TokenEntry[]> {
     return tokens
   }
   catch (err) {
-    console.warn('[token-list] Euler API fetch failed:', err instanceof Error ? err.message : err, 'for chain', chainId)
+    logWarn('token-list', 'Euler API fetch failed:', err instanceof Error ? err.message : err, 'for chain', chainId)
     return eulerApiCache.getStale(key) || []
   }
 }
@@ -75,16 +76,21 @@ async function fetchUniswap(): Promise<TokenEntry[]> {
   const cached = uniswapCache.get('all')
   if (cached) return cached
 
-  const resp = await fetchWithTimeout(url, TIMEOUT_MS)
-  if (!resp.ok) {
-    console.warn('[token-list] Uniswap upstream returned', resp.status)
-    throw new Error(`Uniswap upstream returned ${resp.status}`)
-  }
+  try {
+    const resp = await fetchWithTimeout(url, TIMEOUT_MS)
+    if (!resp.ok) {
+      throw new Error(`Uniswap upstream returned ${resp.status}`)
+    }
 
-  const data = await resp.json()
-  const tokens: TokenEntry[] = data.tokens || []
-  uniswapCache.set('all', tokens)
-  return tokens
+    const data = await resp.json()
+    const tokens: TokenEntry[] = data.tokens || []
+    uniswapCache.set('all', tokens)
+    return tokens
+  }
+  catch (err) {
+    logWarn('token-list', 'Uniswap fetch failed:', err instanceof Error ? err.message : err)
+    return uniswapCache.getStale('all') || []
+  }
 }
 
 async function fetchDefillama(chainId: number): Promise<TokenEntry[]> {
@@ -116,7 +122,7 @@ async function fetchDefillama(chainId: number): Promise<TokenEntry[]> {
     return tokens
   }
   catch (err) {
-    console.warn('[token-list] DefiLlama fetch failed:', err instanceof Error ? err.message : err, 'for chain', chainId)
+    logWarn('token-list', 'DefiLlama fetch failed:', err instanceof Error ? err.message : err, 'for chain', chainId)
     return defillamaCache.getStale(key) || []
   }
 }
@@ -150,38 +156,45 @@ export default defineEventHandler(async (event) => {
 
   const query = getQuery(event)
   const chainId = query.chainId ? Number(query.chainId) : null
+  const key = chainId ? String(chainId) : null
 
-  // Fetch all sources in parallel; Euler API and DefiLlama are best-effort
-  const [eulerResult, uniswapResult, defillamaResult] = await Promise.allSettled([
+  const eulerFresh = key ? eulerApiCache.get(key) : []
+  const uniswapFresh = uniswapCache.get('all')
+  const defillamaFresh = key ? defillamaCache.get(key) : []
+
+  // All data is fresh — return immediately
+  if (eulerFresh !== undefined && uniswapFresh !== undefined && defillamaFresh !== undefined) {
+    return { tokens: deduplicateTokens(eulerFresh, deduplicateTokens(defillamaFresh, uniswapFresh)) }
+  }
+
+  // Check stale fallbacks
+  const eulerStale = key ? eulerApiCache.getStale(key) : undefined
+  const uniswapStale = uniswapCache.getStale('all')
+  const defillamaStale = key ? defillamaCache.getStale(key) : undefined
+
+  // Have stale data — return it immediately and revalidate in background
+  if (eulerStale !== undefined || uniswapStale !== undefined) {
+    if (eulerFresh === undefined && chainId) void fetchEulerApi(chainId)
+    if (uniswapFresh === undefined) void fetchUniswap().catch(() => {})
+    if (defillamaFresh === undefined && chainId) void fetchDefillama(chainId)
+
+    const euler = eulerFresh ?? eulerStale ?? []
+    const uniswap = uniswapFresh ?? uniswapStale ?? []
+    const defillama = defillamaFresh ?? defillamaStale ?? []
+    return { tokens: deduplicateTokens(euler, deduplicateTokens(defillama, uniswap)) }
+  }
+
+  // Completely cold — await all sources in parallel; all three handle errors internally
+  const [euler, uniswap, defillama] = await Promise.all([
     chainId ? fetchEulerApi(chainId) : Promise.resolve([]),
     fetchUniswap(),
     chainId ? fetchDefillama(chainId) : Promise.resolve([]),
   ])
 
-  const eulerTokens = eulerResult.status === 'fulfilled' ? eulerResult.value : []
-
-  if (uniswapResult.status === 'rejected') {
-    console.warn('[token-list] Uniswap fetch failed:', uniswapResult.reason?.message || 'Unknown error')
-
-    // If we have stale Uniswap cache, use it
-    const stale = uniswapCache.getStale('all')
-    if (stale) {
-      const defillamaTokens = defillamaResult.status === 'fulfilled' ? defillamaResult.value : []
-      return { tokens: deduplicateTokens(eulerTokens, deduplicateTokens(defillamaTokens, stale)) }
-    }
-
-    // No Uniswap data at all — still return Euler + DefiLlama if available
-    const defillamaTokens = defillamaResult.status === 'fulfilled' ? defillamaResult.value : []
-    if (eulerTokens.length > 0 || defillamaTokens.length > 0) {
-      return { tokens: deduplicateTokens(eulerTokens, defillamaTokens) }
-    }
-
+  if (euler.length === 0 && uniswap.length === 0 && defillama.length === 0) {
     throw createError({ statusCode: 502, statusMessage: 'Upstream error' })
   }
 
-  const uniswapTokens = uniswapResult.value
-  const defillamaTokens = defillamaResult.status === 'fulfilled' ? defillamaResult.value : []
-
   // Priority: Euler API > DefiLlama > Uniswap
-  return { tokens: deduplicateTokens(eulerTokens, deduplicateTokens(defillamaTokens, uniswapTokens)) }
+  return { tokens: deduplicateTokens(euler, deduplicateTokens(defillama, uniswap)) }
 })


### PR DESCRIPTION
## Summary

- **token-list**: on TTL expiry, return stale data immediately and revalidate all three sources (Euler, Uniswap, DefiLlama) in the background. Only a cold cache (server restart / first ever request) blocks on upstream fetches. Uniswap fetch unified with the same try/catch pattern as the other two, allowing `Promise.all` instead of `Promise.allSettled` in the cold path.
- **intrinsic-apy**: hand-rolled `Map` cache replaced with `createTtlCache`; fetch logic extracted into a `fetchUpstream` helper; same SWR pattern applied across all 14 providers.
- **logging**: `console.warn` replaced with `logWarn` (`~/server/utils/log`) in `token-list`, `intrinsic-apy`, and `screen-address`.

## Test plan

- [x] Cold cache: first request after server restart should fetch all sources and return results
- [x] Warm cache: subsequent requests within 5 min return immediately without upstream calls
- [x] Stale cache: after 5 min, response is instant (stale data) and background logs show revalidation fetches completing
- [x] Upstream failure on cold cache: if all sources fail, endpoint returns 502
- [x] Upstream failure on stale cache: stale data still returned, background revalidation error logged via `logWarn`