### PR TITLE
feat: add 7-day cooldown to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 3
+    cooldown:
+      default-days: 7
     allow:
       - dependency-type: "direct"
     groups:


### PR DESCRIPTION
Noticed Dependabot opened a PR for a package version only 3 days old after merging the npm min-release-age config.

The .npmrc setting only affects npm install/ci — Dependabot has its own independent update mechanism. Added a 7-day cooldown to dependabot.yml so Dependabot won't raise PRs until a package version has been published for at least 7 days.