### PR TITLE
fix: disable autocomplete on high price impact confirmation input

### DIFF
--- a/components/entities/operation/HighPriceImpactModal.vue
+++ b/components/entities/operation/HighPriceImpactModal.vue
@@ -64,6 +64,7 @@ const onSubmit = async () => {
           id="confirm-input"
           v-model="confirmText"
           placeholder="I understand"
+          autocomplete="off"
           @keydown.enter="onSubmit"
         />
       </div>

--- a/components/ui/UiInput.vue
+++ b/components/ui/UiInput.vue
@@ -15,6 +15,7 @@ const props = withDefaults(
     icon?: string
     clearable?: boolean
     compact?: boolean
+    autocomplete?: string
   }>(),
   {
     type: 'text',
@@ -58,6 +59,7 @@ const classes = computed(() => {
       :disabled="disabled"
       :name="name"
       :placeholder="placeholder"
+      :autocomplete="autocomplete"
       :aria-invalid="error"
       :aria-disabled="disabled"
       :class="['ui-input__field', icon && 'icon', showClear && 'has-clear']"


### PR DESCRIPTION
## Summary
- Adds `autocomplete` prop to `UiInput` component, bound to the underlying `<input>` element
- Sets `autocomplete="off"` on the confirmation input in `HighPriceImpactModal` to prevent browsers from suggesting previously typed values, forcing the user to manually type "I understand"

## Test plan
- [ ] Open a high price impact trade and verify the confirmation modal appears
- [ ] Click the input field and confirm no browser autocomplete dropdown appears
- [ ] Verify typing "I understand" (case-insensitive) still enables the Confirm button