### PR TITLE
feat: add vault cache for faster first load

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -104,9 +104,9 @@ watch(chainId, () => {
   resetBalances()
   const targetChainId = chainId.value
   const labelsPromise = loadLabels()
-  void loadTokenList()
+  const tokenListPromise = loadTokenList()
   void loadCountry()
-  void labelsPromise.then(() => {
+  void Promise.all([labelsPromise, tokenListPromise]).then(() => {
     if (chainId.value !== targetChainId) return
     void loadVaults()
   })

--- a/composables/useVaults.ts
+++ b/composables/useVaults.ts
@@ -340,8 +340,8 @@ const loadVaultsFromCache = async (categorized: CategorizedVaults, generation: n
     isEarnUpdating.value = false
     isSecuritizeLoading.value = false
     isSecuritizeUpdating.value = false
-    // Escrow flags intentionally NOT cleared — escrow vaults are loaded
-    // later by fetchNeededEscrowVaults in the background load phase.
+    isEscrowLoading.value = false
+    isEscrowUpdating.value = false
     loadedChainId.value = chainId.value
     return true
   }

--- a/composables/useVaults.ts
+++ b/composables/useVaults.ts
@@ -1,4 +1,4 @@
-import { getAddress, zeroAddress } from 'viem'
+import { getAddress, zeroAddress, decodeFunctionResult, type Hex } from 'viem'
 import { useVaultRegistry } from './useVaultRegistry'
 import { logWarn } from '~/utils/errorHandling'
 import {
@@ -14,10 +14,24 @@ import {
   fetchVaults,
   clearPriceCaches,
   type Vault,
+  processRawVaultData,
+  processRawEarnVaultData,
+  processRawSecuritizeVaultData,
 } from '~/entities/vault'
+import {
+  eulerVaultLensABI,
+  eulerEarnVaultLensABI,
+  eulerUtilsLensABI,
+} from '~/entities/euler/abis'
 import { fetchVaultFactories, isSecuritizeVault } from '~/entities/vault/factory'
 import { getProductByVault, isVaultNotExplorable, isEarnVaultNotExplorable } from '~/utils/eulerLabelsUtils'
 import { getEulerRouterGovernor } from '~/entities/oracle'
+
+interface CategorizedVaults {
+  evkAddresses: string[]
+  earnAddresses: string[]
+  securitizeAddresses: string[]
+}
 
 const isReady = ref(false)
 const isEVKLoading = ref(false)
@@ -214,10 +228,11 @@ const fetchNeededEscrowVaults = async (addresses: string[], generation: number):
   })
 }
 
-const updateSecuritizeVaults = async (securitizeAddresses: string[], generation: number, silent = false) => {
+const updateSecuritizeVaults = async (securitizeAddresses: string[], generation?: number, silent = false) => {
   const { set: registrySet } = useVaultRegistry()
+  const gen = generation ?? loadGeneration.value
 
-  if (!securitizeAddresses.length || loadGeneration.value !== generation) {
+  if (!securitizeAddresses.length || loadGeneration.value !== gen) {
     return
   }
 
@@ -231,7 +246,7 @@ const updateSecuritizeVaults = async (securitizeAddresses: string[], generation:
       securitizeAddresses.map(addr => fetchSecuritizeVault(addr)),
     )
 
-    if (loadGeneration.value !== generation) return
+    if (loadGeneration.value !== gen) return
 
     results.forEach((result, index) => {
       if (result.status === 'fulfilled') {
@@ -246,10 +261,92 @@ const updateSecuritizeVaults = async (securitizeAddresses: string[], generation:
     logWarn('useVaults/updateSecuritizeVaults', e)
   }
   finally {
-    if (!silent && loadGeneration.value === generation) {
+    if (!silent && loadGeneration.value === gen) {
       isSecuritizeUpdating.value = false
       isSecuritizeLoading.value = false
     }
+  }
+}
+
+/**
+ * Populate vault state from the server-side vault cache.
+ * Returns true if the cache had data, false if cold.
+ */
+const loadVaultsFromCache = async (categorized: CategorizedVaults, generation: number): Promise<boolean> => {
+  const { chainId } = useEulerAddresses()
+  const { verifiedVaultAddresses, earnVaults: earnVaultAddresses } = useEulerLabels()
+  const { set: registrySet } = useVaultRegistry()
+
+  const allAddresses = [...categorized.evkAddresses, ...categorized.earnAddresses, ...categorized.securitizeAddresses]
+  if (allAddresses.length === 0) return false
+
+  const evkSet = new Set(categorized.evkAddresses.map(a => a.toLowerCase()))
+  const earnSet = new Set(categorized.earnAddresses.map(a => a.toLowerCase()))
+  const securitizeSet = new Set(categorized.securitizeAddresses.map(a => a.toLowerCase()))
+
+  try {
+    const cacheMap = await $fetch<Record<string, string>>(
+      `/api/vault-cache/${chainId.value}`,
+      { method: 'POST', body: { vaults: allAddresses } },
+    )
+
+    // Chain switch happened during $fetch — discard stale results
+    if (loadGeneration.value !== generation) return false
+
+    const entries = Object.entries(cacheMap)
+    if (entries.length === 0) return false
+
+    let count = 0
+    for (const [vaultAddress, hex] of entries) {
+      const addrLower = vaultAddress.toLowerCase()
+      try {
+        if (evkSet.has(addrLower)) {
+          const raw = decodeFunctionResult({
+            abi: eulerVaultLensABI,
+            functionName: 'getVaultInfoFull',
+            data: hex as Hex,
+          }) as Record<string, unknown>
+          registrySet(vaultAddress, processRawVaultData(raw, vaultAddress, verifiedVaultAddresses.value), 'evk')
+          count++
+        }
+        else if (earnSet.has(addrLower)) {
+          const raw = decodeFunctionResult({
+            abi: eulerEarnVaultLensABI,
+            functionName: 'getVaultInfoFull',
+            data: hex as Hex,
+          }) as Record<string, unknown>
+          registrySet(vaultAddress, processRawEarnVaultData(raw, vaultAddress, earnVaultAddresses.value), 'earn')
+          count++
+        }
+        else if (securitizeSet.has(addrLower)) {
+          const raw = decodeFunctionResult({
+            abi: eulerUtilsLensABI,
+            functionName: 'getVaultInfoERC4626',
+            data: hex as Hex,
+          }) as Record<string, unknown>
+          registrySet(vaultAddress, processRawSecuritizeVaultData(raw, vaultAddress, verifiedVaultAddresses.value), 'securitize')
+          count++
+        }
+      }
+      catch { /* skip malformed cache entries */ }
+    }
+
+    if (count === 0) return false
+
+    isReady.value = true
+    isEVKLoading.value = false
+    isEVKUpdating.value = false
+    isEarnLoading.value = false
+    isEarnUpdating.value = false
+    isSecuritizeLoading.value = false
+    isSecuritizeUpdating.value = false
+    isEscrowLoading.value = false
+    isEscrowUpdating.value = false
+    loadedChainId.value = chainId.value
+    return true
+  }
+  catch {
+    return false
   }
 }
 
@@ -295,9 +392,18 @@ const loadVaults = async () => {
       }
     })
 
-    // Phase 2: Fetch all vault types + escrow addresses in parallel
-    // Escrow vault info fetch starts when EVK, Earn, AND escrow addresses are all ready
-    // (need EVK collateralLTVs + Earn strategies to know which escrow vaults are needed)
+    // Try vault cache — gives an early render while the full load continues below
+    const cacheHit = await loadVaultsFromCache({
+      evkAddresses,
+      earnAddresses: explorableEarnAddresses,
+      securitizeAddresses,
+    }, generation)
+
+    if (loadGeneration.value !== generation) return
+
+    // Phase 2: Fetch all vault types + escrow addresses in parallel.
+    // Runs silently (no loading spinners) when cache provided an early render.
+    const silent = cacheHit
 
     // Signals for coordination
     let evkResolve: () => void = () => {}
@@ -315,14 +421,14 @@ const loadVaults = async () => {
 
     await Promise.all([
       (async () => {
-        await updateEarnVaults(explorableEarnAddresses, generation)
+        await updateEarnVaults(explorableEarnAddresses, generation, silent)
         earnResolve()
       })(),
       (async () => {
-        await updateEVKVaults(evkAddresses, generation)
+        await updateEVKVaults(evkAddresses, generation, silent)
         evkResolve()
       })(),
-      updateSecuritizeVaults(securitizeAddresses, generation),
+      updateSecuritizeVaults(securitizeAddresses, generation, silent),
       // Escrow addresses - fetch in parallel, populate set when ready
       (async () => {
         const addrs = await fetchEscrowAddresses()

--- a/composables/useVaults.ts
+++ b/composables/useVaults.ts
@@ -340,8 +340,8 @@ const loadVaultsFromCache = async (categorized: CategorizedVaults, generation: n
     isEarnUpdating.value = false
     isSecuritizeLoading.value = false
     isSecuritizeUpdating.value = false
-    isEscrowLoading.value = false
-    isEscrowUpdating.value = false
+    // Escrow flags intentionally NOT cleared — escrow vaults are loaded
+    // later by fetchNeededEscrowVaults in the background load phase.
     loadedChainId.value = chainId.value
     return true
   }

--- a/composables/useVaults.ts
+++ b/composables/useVaults.ts
@@ -31,6 +31,7 @@ interface CategorizedVaults {
   evkAddresses: string[]
   earnAddresses: string[]
   securitizeAddresses: string[]
+  escrowAddresses: string[]
 }
 
 const isReady = ref(false)
@@ -277,12 +278,13 @@ const loadVaultsFromCache = async (categorized: CategorizedVaults, generation: n
   const { verifiedVaultAddresses, earnVaults: earnVaultAddresses } = useEulerLabels()
   const { set: registrySet } = useVaultRegistry()
 
-  const allAddresses = [...categorized.evkAddresses, ...categorized.earnAddresses, ...categorized.securitizeAddresses]
+  const allAddresses = [...categorized.evkAddresses, ...categorized.earnAddresses, ...categorized.securitizeAddresses, ...categorized.escrowAddresses]
   if (allAddresses.length === 0) return false
 
   const evkSet = new Set(categorized.evkAddresses.map(a => a.toLowerCase()))
   const earnSet = new Set(categorized.earnAddresses.map(a => a.toLowerCase()))
   const securitizeSet = new Set(categorized.securitizeAddresses.map(a => a.toLowerCase()))
+  const escrowSet = new Set(categorized.escrowAddresses.map(a => a.toLowerCase()))
 
   try {
     const cacheMap = await $fetch<Record<string, string>>(
@@ -318,6 +320,15 @@ const loadVaultsFromCache = async (categorized: CategorizedVaults, generation: n
           registrySet(vaultAddress, processRawEarnVaultData(raw, vaultAddress, earnVaultAddresses.value), 'earn')
           count++
         }
+        else if (escrowSet.has(addrLower)) {
+          const raw = decodeFunctionResult({
+            abi: eulerVaultLensABI,
+            functionName: 'getVaultInfoFull',
+            data: hex as Hex,
+          }) as Record<string, unknown>
+          registrySet(vaultAddress, processRawVaultData(raw, vaultAddress, undefined, { verified: true, vaultCategory: 'escrow' }), 'evk')
+          count++
+        }
         else if (securitizeSet.has(addrLower)) {
           const raw = decodeFunctionResult({
             abi: eulerUtilsLensABI,
@@ -342,6 +353,7 @@ const loadVaultsFromCache = async (categorized: CategorizedVaults, generation: n
     isSecuritizeUpdating.value = false
     isEscrowLoading.value = false
     isEscrowUpdating.value = false
+    isEscrowLoadedOnce.value = true
     loadedChainId.value = chainId.value
     return true
   }
@@ -371,10 +383,15 @@ const loadVaults = async () => {
     isEscrowUpdating.value = true
     isEscrowLoading.value = true
 
-    // Phase 1: Fetch vault factories (escrow addresses fetched in Phase 2)
-    const factories = await fetchVaultFactories(explorableVaultAddresses)
+    // Phase 1: Fetch vault factories + escrow addresses in parallel
+    const [factories, escrowAddresses] = await Promise.all([
+      fetchVaultFactories(explorableVaultAddresses),
+      fetchEscrowAddresses(),
+    ])
 
     if (loadGeneration.value !== generation) return
+
+    setEscrowAddresses(escrowAddresses)
 
     // Separate EVK vaults from Securitize vaults based on factory
     const evkAddresses: string[] = []
@@ -397,6 +414,7 @@ const loadVaults = async () => {
       evkAddresses,
       earnAddresses: explorableEarnAddresses,
       securitizeAddresses,
+      escrowAddresses,
     }, generation)
 
     if (loadGeneration.value !== generation) return
@@ -405,18 +423,15 @@ const loadVaults = async () => {
     // Runs silently (no loading spinners) when cache provided an early render.
     const silent = cacheHit
 
-    // Signals for coordination
+    // Signals for coordination — escrow vault info needs EVK + Earn to determine
+    // which escrow vaults are actually used as collateral
     let evkResolve: () => void = () => {}
     let earnResolve: () => void = () => {}
-    let escrowAddrsResolve: (addrs: string[]) => void = () => {}
     const evkLoaded = new Promise<void>((resolve) => {
       evkResolve = resolve
     })
     const earnLoaded = new Promise<void>((resolve) => {
       earnResolve = resolve
-    })
-    const escrowAddrsLoaded = new Promise<string[]>((resolve) => {
-      escrowAddrsResolve = resolve
     })
 
     await Promise.all([
@@ -429,18 +444,9 @@ const loadVaults = async () => {
         evkResolve()
       })(),
       updateSecuritizeVaults(securitizeAddresses, generation, silent),
-      // Escrow addresses - fetch in parallel, populate set when ready
-      (async () => {
-        const addrs = await fetchEscrowAddresses()
-        if (loadGeneration.value !== generation) {
-          escrowAddrsResolve([]) // Unblock downstream even if stale
-          return
-        }
-        setEscrowAddresses(addrs)
-        escrowAddrsResolve(addrs)
-      })(),
-      // Escrow vault info - waits for EVK, Earn, AND escrow addresses
-      Promise.all([evkLoaded, earnLoaded, escrowAddrsLoaded]).then(async () => {
+      // Escrow vault info - escrow addresses already fetched in Phase 1,
+      // waits for EVK + Earn to know which escrow vaults are needed as collateral
+      Promise.all([evkLoaded, earnLoaded]).then(async () => {
         const neededEscrowAddresses = extractNeededEscrowAddresses()
         await fetchNeededEscrowVaults(neededEscrowAddresses, generation)
       }),

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -290,7 +290,7 @@ The Nuxt server layer (`server/api/`) proxies requests to external services (RPC
 The app includes a built-in per-IP rate limiter as a defense-in-depth measure. Default budgets per 60-second window:
 
 - **RPC proxy**: 10,000 units (batch of N costs N)
-- **All other proxies**: 1,000 requests (token list, Pyth updates, labels, oracle adapter, euler chains, intrinsic APY, TOS)
+- **All other proxies**: 1,000 requests (token list, Pyth updates, labels, oracle adapter, euler chains, intrinsic APY, TOS, vault cache)
 - **Tenderly simulate**: 10 requests
 - **Address screening**: 10 requests
 

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -85,6 +85,7 @@ External metadata (contract addresses, labels, oracle checks) is fetched through
 | `GET /api/oracle-adapter?chainId=X&address=0x...` | Per-adapter JSON from oracle-checks | 5 min | `NUXT_PUBLIC_CONFIG_ORACLE_CHECKS_BASE_URL` |
 | `GET /api/token-list?chainId=X` | Euler API + Uniswap + DefiLlama token lists | 5 min | `EULER_API_URL`, `NUXT_PUBLIC_CONFIG_UNISWAP_TOKEN_LIST_URL`, `NUXT_PUBLIC_CONFIG_DEFILLAMA_TOKEN_LIST_URL` |
 | `GET /api/pyth/updates?ids[]=...` | Pyth Hermes (`/v2/updates/price/latest`) | No cache | `PYTH_HERMES_URL` (server-only) |
+| `POST /api/vault-cache/:chainId` | In-memory (populated by RPC proxy interception) | 5 min | — |
 
 All endpoints use rate limiting and return stale cached data when upstream is unavailable (except `/api/pyth/updates` which requires real-time data and returns no-store cache headers). The shared caching utility is in `server/utils/cache.ts`.
 
@@ -105,6 +106,24 @@ The `/api/pyth/updates` endpoint proxies Pyth Hermes price update requests throu
 - **Rate limit**: 600 requests per 60-second window
 - **Validation**: Feed IDs must match `0x[64 hex chars]` format, max 100 per request
 - **Env var**: `PYTH_HERMES_URL` (server-only; not exposed to client)
+
+### Vault Cache (Fast First Load)
+
+The vault cache reduces time to first load by serving previously-seen vault data from an in-memory server-side cache. It works passively — no pre-warming schedule, no client push, no idle RPC calls.
+
+**How it works:**
+
+1. **Cache population** — The RPC proxy (`server/api/rpc/[chainId].ts`) passively intercepts vault lens calls as they flow through. When it detects an EVC `batchSimulation` targeting the vault lens, or a direct `getVaultInfoFull`/`getVaultInfoERC4626` call to a known lens address, it decodes the response and stores the raw hex result per vault address. This is a fire-and-forget side effect that never blocks or modifies the response.
+
+2. **Cache serving** — `POST /api/vault-cache/:chainId` accepts `{ vaults: string[] }` and returns `{ [address]: hex }` for whichever vaults have fresh data (within 5-minute TTL). Stale entries are swept on every request.
+
+3. **Client integration** — Inside `loadVaults()`, after factory detection, the client queries the vault cache. On a hit, it decodes hex per vault type (EVK, Earn, Securitize), populates the registry, and sets `isReady = true` for an immediate render. The full RPC load then continues silently in the background (including escrow vaults, pricing, and Pyth simulation).
+
+**Intercepted patterns:** EVK/Escrow via EVC `batchSimulation`, Earn via direct `getVaultInfoFull` to earnLens, Securitize via direct `getVaultInfoERC4626` to utilsLens. Both single JSON-RPC requests and batch arrays (from viem's HTTP transport batching) are handled.
+
+**Cache characteristics:** 5-minute TTL, 5000 max entries, stale entries auto-deleted on access and swept on every `/api/vault-cache` request. The server is the only writer (reads from its own proxy traffic) — no client push, no attack surface.
+
+**Key files:** `server/utils/vault-cache-store.ts` (shared cache), `server/api/vault-cache/[chainId].post.ts` (read endpoint), `server/api/rpc/[chainId].ts` (write via interception).
 
 ## Code layout (high level)
 

--- a/entities/vault/escrow-fetcher.ts
+++ b/entities/vault/escrow-fetcher.ts
@@ -4,11 +4,12 @@ import { resolveAssetPriceInfo, resolveFullAssetPriceInfo, resolveUnitOfAccountP
 import { processRawVaultData, fetchVault } from './fetcher'
 import { logWarn } from '~/utils/errorHandling'
 import { USD_ADDRESS } from '~/entities/constants'
-import { BATCH_SIZE_RPC_CALLS } from '~/entities/tuning-constants'
+import { BATCH_SIZE_VAULT_FETCH } from '~/entities/tuning-constants'
 import {
   eulerPerspectiveABI,
   eulerVaultLensABI,
 } from '~/entities/euler/abis'
+import { batchLensCalls } from '~/utils/multicall'
 
 export const fetchEscrowVault = async (vaultAddress: string): Promise<Vault> => {
   const { rpcUrl } = useRpcClient()
@@ -93,7 +94,7 @@ export const fetchEscrowVaults = async function* (): AsyncGenerator<
   unknown
 > {
   const { client: rpcClient, rpcUrl } = useRpcClient()
-  const { eulerPeripheryAddresses, eulerLensAddresses, chainId } = useEulerAddresses()
+  const { eulerPeripheryAddresses, eulerLensAddresses, eulerCoreAddresses, chainId } = useEulerAddresses()
 
   const startChainId = chainId.value
 
@@ -130,32 +131,95 @@ export const fetchEscrowVaults = async function* (): AsyncGenerator<
     verifiedVaults = []
   }
 
-  const batchSize = BATCH_SIZE_RPC_CALLS
+  const batchSize = BATCH_SIZE_VAULT_FETCH
+
+  const fetchBatch = async (batchAddresses: string[]): Promise<Vault[]> => {
+    if (eulerCoreAddresses.value?.evc) {
+      const calls = batchAddresses.map(vaultAddress => ({
+        functionName: 'getVaultInfoFull',
+        args: [vaultAddress],
+      }))
+
+      const results = await batchLensCalls<Record<string, unknown>>(
+        eulerCoreAddresses.value.evc,
+        eulerLensAddresses.value!.vaultLens,
+        eulerVaultLensABI,
+        calls,
+        rpcUrl.value,
+      )
+
+      const vaults: Vault[] = []
+      const failedAddresses: string[] = []
+
+      for (let i = 0; i < results.length; i++) {
+        const result = results[i]
+        if (result.success && result.result) {
+          try {
+            vaults.push(processRawVaultData(result.result as Record<string, unknown>, batchAddresses[i], undefined, { verified: true, vaultCategory: 'escrow' }))
+          }
+          catch (e) {
+            logWarn('escrow/processResult', e, { severity: 'error' })
+            failedAddresses.push(batchAddresses[i])
+          }
+        }
+        else {
+          failedAddresses.push(batchAddresses[i])
+        }
+      }
+
+      if (failedAddresses.length > 0) {
+        logWarn('escrow/fetchBatch', `Retrying ${failedAddresses.length} failed escrow vaults individually`)
+        const retries = await Promise.all(
+          failedAddresses.map(async (addr) => {
+            try {
+              const raw = await client.readContract({
+                address: eulerLensAddresses.value!.vaultLens as Address,
+                abi: eulerVaultLensABI,
+                functionName: 'getVaultInfoFull',
+                args: [addr],
+              }) as Record<string, unknown>
+              return processRawVaultData(raw, addr, undefined, { verified: true, vaultCategory: 'escrow' })
+            }
+            catch (e) {
+              logWarn('escrow/fetchIndividual', e, { severity: 'error' })
+              return undefined
+            }
+          }),
+        )
+        vaults.push(...retries.filter((v): v is Vault => !!v))
+      }
+
+      return vaults
+    }
+
+    // Fallback: individual readContract calls
+    const res = await Promise.all(
+      batchAddresses.map(async (vaultAddress) => {
+        try {
+          const raw = await client.readContract({
+            address: eulerLensAddresses.value!.vaultLens as Address,
+            abi: eulerVaultLensABI,
+            functionName: 'getVaultInfoFull',
+            args: [vaultAddress],
+          }) as Record<string, unknown>
+          return processRawVaultData(raw, vaultAddress, undefined, { verified: true, vaultCategory: 'escrow' })
+        }
+        catch (e) {
+          logWarn('escrow/fetchVault', e, { severity: 'error' })
+          return undefined
+        }
+      }),
+    )
+    return res.filter((v): v is Vault => !!v)
+  }
 
   for (let i = 0; i < verifiedVaults.length; i += batchSize) {
-    if (chainId.value !== startChainId) {
-      return
-    }
+    if (chainId.value !== startChainId) return
+
     const batch = verifiedVaults.slice(i, i + batchSize)
-    const batchPromises = batch.map(async (vaultAddress) => {
-      try {
-        const raw = await client.readContract({
-          address: eulerLensAddresses.value!.vaultLens as Address,
-          abi: eulerVaultLensABI,
-          functionName: 'getVaultInfoFull',
-          args: [vaultAddress],
-        }) as Record<string, unknown>
+    let validVaults = await fetchBatch(batch)
 
-        return processRawVaultData(raw, vaultAddress, undefined, { verified: true, vaultCategory: 'escrow' })
-      }
-      catch (e) {
-        logWarn('escrow/fetchVault', e, { severity: 'error' })
-        return undefined
-      }
-    })
-
-    const res = await Promise.all(batchPromises)
-    let validVaults = res.filter(o => !!o) as Vault[]
+    if (chainId.value !== startChainId) return
 
     const utilsLensAddress = eulerLensAddresses.value!.utilsLens
     validVaults = await Promise.all(
@@ -170,7 +234,6 @@ export const fetchEscrowVaults = async function* (): AsyncGenerator<
 
     validVaults = await Promise.all(
       validVaults.map(async (vault) => {
-        // Refetch price if missing or query failed (0n is valid - very small price)
         if (
           !vault.liabilityPriceInfo
           || vault.liabilityPriceInfo.queryFailure

--- a/entities/vault/fetcher.ts
+++ b/entities/vault/fetcher.ts
@@ -93,6 +93,111 @@ export const processRawVaultData = (
 }
 
 /**
+ * Process raw earn vault lens data into an EarnVault object.
+ * APY and pricing are NOT included — the caller is expected to fill those in
+ * (e.g. via background refresh). Used by the vault cache fast path.
+ */
+export const processRawEarnVaultData = (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- raw lens data with dynamic shape
+  raw: any,
+  vaultAddress: string,
+  verifiedEarnVaults?: string[],
+): EarnVault => {
+  const strategies = (raw.strategies as EarnVaultStrategyInfo[]).map(strategy => ({
+    strategy: strategy.strategy,
+    allocatedAssets: strategy.allocatedAssets,
+    availableAssets: strategy.availableAssets,
+    currentAllocationCap: strategy.currentAllocationCap,
+    pendingAllocationCap: strategy.pendingAllocationCap,
+    pendingAllocationCapValidAt: strategy.pendingAllocationCapValidAt,
+    removableAt: strategy.removableAt,
+    info: strategy.info,
+  }))
+
+  return {
+    verified: verifiedEarnVaults?.includes(vaultAddress) ?? false,
+    type: 'earn',
+    address: raw.vault,
+    name: raw.vaultName,
+    symbol: raw.vaultSymbol,
+    decimals: raw.vaultDecimals,
+    totalShares: raw.totalShares,
+    totalAssets: raw.totalAssets,
+    lostAssets: raw.lostAssets,
+    availableAssets: raw.availableAssets,
+    timelock: raw.timelock,
+    performanceFee: raw.performanceFee,
+    feeReceiver: raw.feeReceiver,
+    owner: raw.owner,
+    creator: raw.creator,
+    curator: raw.curator,
+    guardian: raw.guardian,
+    evc: raw.evc,
+    permit2: raw.permit2,
+    pendingTimelock: raw.pendingTimelock,
+    pendingTimelockValidAt: raw.pendingTimelockValidAt,
+    pendingGuardian: raw.pendingGuardian,
+    pendingGuardianValidAt: raw.pendingGuardianValidAt,
+    supplyQueue: raw.supplyQueue,
+    asset: {
+      address: raw.asset,
+      name: raw.assetName,
+      symbol: raw.assetSymbol,
+      decimals: raw.assetDecimals,
+    },
+    strategies,
+    interestRateInfo: {
+      borrowAPY: 0n,
+      borrowSPY: 0n,
+      borrows: 0n,
+      cash: raw.totalAssets as bigint,
+      supplyAPY: 0n,
+    },
+  } as EarnVault
+}
+
+/**
+ * Process raw securitize vault lens data into a SecuritizeVault object.
+ * governorAdmin, supplyCap, and assetPriceInfo are NOT included — these
+ * require separate RPC calls and will be filled in by background refresh.
+ */
+export const processRawSecuritizeVaultData = (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- raw lens data with dynamic shape
+  raw: any,
+  vaultAddress: string,
+  verifiedVaultAddresses?: string[],
+): SecuritizeVault => {
+  return {
+    type: 'securitize',
+    verified: verifiedVaultAddresses?.includes(vaultAddress) ?? false,
+    address: raw.vault,
+    name: raw.vaultName,
+    symbol: raw.vaultSymbol,
+    decimals: raw.vaultDecimals,
+    totalShares: raw.totalShares,
+    totalAssets: raw.totalAssets,
+    isEVault: raw.isEVault,
+    asset: {
+      address: raw.asset,
+      name: raw.assetName,
+      symbol: raw.assetSymbol,
+      decimals: raw.assetDecimals,
+    },
+    governorAdmin: zeroAddress,
+    supplyCap: 0n,
+    supply: raw.totalAssets,
+    borrow: 0n,
+    interestRateInfo: {
+      borrowAPY: 0n,
+      borrowSPY: 0n,
+      borrows: 0n,
+      cash: raw.totalAssets,
+      supplyAPY: 0n,
+    },
+  } as SecuritizeVault
+}
+
+/**
  * Fetch vault using EVC batchSimulation with Pyth updates.
  * This ensures fresh Pyth prices are available when querying vault info.
  *

--- a/entities/vault/index.ts
+++ b/entities/vault/index.ts
@@ -29,6 +29,9 @@ export {
   fetchEarnVault,
   fetchVaults,
   fetchEarnVaults,
+  processRawVaultData,
+  processRawEarnVaultData,
+  processRawSecuritizeVaultData,
 } from './fetcher'
 
 // Pricing

--- a/server/api/rpc/[chainId].ts
+++ b/server/api/rpc/[chainId].ts
@@ -1,7 +1,183 @@
 import { createError, getMethod, readBody, setResponseHeader, setResponseStatus } from 'h3'
+import { decodeAbiParameters, getFunctionSelector, type Hex } from 'viem'
 import { createRateLimiter } from '~/server/utils/rate-limit'
 import { resolveRpcUrl } from '~/server/utils/rpc'
 import { isAbortError } from '~/utils/errorHandling'
+import { BATCH_ITEM_COMPONENTS, BATCH_ITEM_RESULT_COMPONENTS } from '~/abis/evc'
+import { vaultHexCache, vaultCacheKey } from '~/server/utils/vault-cache-store'
+
+// ---------------------------------------------------------------------------
+// Vault cache interception — passively caches vault lens results as they
+// flow through the proxy. Never blocks or modifies the response.
+// ---------------------------------------------------------------------------
+
+const BATCH_SIMULATION_SELECTOR = getFunctionSelector('batchSimulation((address,address,uint256,bytes)[])')
+const GET_VAULT_INFO_FULL_SELECTOR = getFunctionSelector('getVaultInfoFull(address)')
+const GET_VAULT_INFO_ERC4626_SELECTOR = getFunctionSelector('getVaultInfoERC4626(address)')
+
+interface ChainAddresses {
+  evcAddress: string
+  vaultLensAddress: string
+  earnLensAddress: string
+  utilsLensAddress: string
+}
+
+const chainAddressCache = new Map<number, ChainAddresses>()
+
+async function getChainAddresses(chainId: number): Promise<ChainAddresses | undefined> {
+  if (chainAddressCache.has(chainId)) return chainAddressCache.get(chainId)!
+  try {
+    const chains = await $fetch<Array<{
+      chainId: number
+      addresses: {
+        coreAddrs: { evc: string }
+        lensAddrs: { vaultLens: string, eulerEarnVaultLens: string, utilsLens: string }
+      }
+    }>>('/api/euler-chains')
+    for (const chain of chains) {
+      chainAddressCache.set(chain.chainId, {
+        evcAddress: chain.addresses.coreAddrs.evc,
+        vaultLensAddress: chain.addresses.lensAddrs.vaultLens,
+        earnLensAddress: chain.addresses.lensAddrs.eulerEarnVaultLens,
+        utilsLensAddress: chain.addresses.lensAddrs.utilsLens,
+      })
+    }
+  }
+  catch { /* euler-chains unavailable — skip caching */ }
+  return chainAddressCache.get(chainId)
+}
+
+// ABI parameter definitions for decoding (avoids viem strict ABI type issues)
+const BATCH_SIMULATION_INPUT_PARAMS = [
+  { name: 'items', type: 'tuple[]', components: [...BATCH_ITEM_COMPONENTS] },
+] as const
+
+const BATCH_SIMULATION_OUTPUT_PARAMS = [
+  { name: 'batchItemsResult', type: 'tuple[]', components: [...BATCH_ITEM_RESULT_COMPONENTS] },
+  { name: 'accountsStatusResult', type: 'tuple[]', components: [{ name: 'account', type: 'address' }, { name: 'isValid', type: 'bool' }] },
+  { name: 'vaultsStatusResult', type: 'tuple[]', components: [{ name: 'vault', type: 'address' }, { name: 'isValid', type: 'bool' }] },
+] as const
+
+const ADDRESS_PARAM = [{ name: 'vault', type: 'address' }] as const
+
+/** Strip 4-byte function selector, return the parameter-encoded portion. */
+const stripSelector = (calldata: string): Hex => (`0x${calldata.slice(10)}`) as Hex
+
+function tryCacheSingleEthCall(
+  chainId: number,
+  to: string,
+  data: string,
+  resultHex: string,
+  addresses: ChainAddresses,
+): void {
+  const toLower = to.toLowerCase()
+
+  // Pattern 1: EVK vaults via EVC batchSimulation
+  if (data.startsWith(BATCH_SIMULATION_SELECTOR) && toLower === addresses.evcAddress.toLowerCase()) {
+    const [items] = decodeAbiParameters(BATCH_SIMULATION_INPUT_PARAMS, stripSelector(data))
+
+    const vaultLensCalls: Array<{ index: number, vaultAddress: string }> = []
+    for (let i = 0; i < items.length; i++) {
+      if (items[i].targetContract.toLowerCase() !== addresses.vaultLensAddress.toLowerCase()) continue
+      if (!(items[i].data as string).startsWith(GET_VAULT_INFO_FULL_SELECTOR)) continue
+      try {
+        const [vaultAddr] = decodeAbiParameters(ADDRESS_PARAM, stripSelector(items[i].data as string))
+        vaultLensCalls.push({ index: i, vaultAddress: vaultAddr })
+      }
+      catch { /* skip */ }
+    }
+
+    if (vaultLensCalls.length === 0) return
+
+    const [batchResults] = decodeAbiParameters(BATCH_SIMULATION_OUTPUT_PARAMS, resultHex as Hex)
+
+    for (const { index, vaultAddress } of vaultLensCalls) {
+      const item = batchResults[index]
+      if (item?.success && item.result) {
+        vaultHexCache.set(vaultCacheKey(chainId, vaultAddress), item.result)
+      }
+    }
+    return
+  }
+
+  // Patterns 2-4: direct eth_call to individual lens contracts
+  let isVaultCall = false
+
+  if (data.startsWith(GET_VAULT_INFO_FULL_SELECTOR)) {
+    isVaultCall = toLower === addresses.vaultLensAddress.toLowerCase()
+      || toLower === addresses.earnLensAddress.toLowerCase()
+  }
+  else if (data.startsWith(GET_VAULT_INFO_ERC4626_SELECTOR)) {
+    isVaultCall = toLower === addresses.utilsLensAddress.toLowerCase()
+  }
+
+  if (!isVaultCall) return
+
+  const [vaultAddress] = decodeAbiParameters(ADDRESS_PARAM, stripSelector(data))
+  vaultHexCache.set(vaultCacheKey(chainId, vaultAddress), resultHex)
+}
+
+interface JsonRpcResponse {
+  id?: unknown
+  result?: string
+  error?: { data?: string }
+}
+
+/** Extract usable hex from a JSON-RPC response (success or batchSimulation revert). */
+function extractResultHex(res: JsonRpcResponse): string | undefined {
+  return res.result ?? res.error?.data
+}
+
+async function tryPopulateVaultCache(
+  chainId: number,
+  body: unknown,
+  responseText: string,
+): Promise<void> {
+  const addresses = await getChainAddresses(chainId)
+  if (!addresses) return
+
+  // JSON-RPC batch request
+  if (Array.isArray(body)) {
+    const responses: JsonRpcResponse[] = JSON.parse(responseText)
+    if (!Array.isArray(responses)) return
+
+    const resultById = new Map<string | number, string>()
+    for (const res of responses) {
+      if (res.id == null) continue
+      const hex = extractResultHex(res)
+      if (hex) resultById.set(typeof res.id === 'number' ? res.id : String(res.id), hex)
+    }
+
+    for (const req of body as Array<{ method?: string, params?: unknown[], id?: unknown }>) {
+      if (req.method !== 'eth_call' || req.id == null) continue
+      const callParams = req.params as [{ to?: string, data?: string }] | undefined
+      if (!callParams?.[0]?.to || !callParams[0].data) continue
+
+      const key = typeof req.id === 'number' ? req.id : String(req.id)
+      const resultHex = resultById.get(key)
+      if (!resultHex) continue
+
+      tryCacheSingleEthCall(chainId, callParams[0].to, callParams[0].data, resultHex, addresses)
+    }
+    return
+  }
+
+  // Single JSON-RPC request
+  if (typeof body !== 'object' || body === null) return
+  const req = body as { method?: string, params?: unknown[] }
+  if (req.method !== 'eth_call') return
+
+  const callParams = req.params as [{ to?: string, data?: string }] | undefined
+  if (!callParams?.[0]?.to || !callParams[0].data) return
+
+  const parsed: JsonRpcResponse = JSON.parse(responseText)
+  const resultHex = extractResultHex(parsed)
+  if (!resultHex) return
+
+  tryCacheSingleEthCall(chainId, callParams[0].to, callParams[0].data, resultHex, addresses)
+}
+
+// ---------------------------------------------------------------------------
 
 const ALLOWED_METHODS = new Set([
   'eth_call',
@@ -114,7 +290,11 @@ export default defineEventHandler(async (event) => {
     setResponseStatus(event, response.status)
     setResponseHeader(event, 'content-type', response.headers.get('content-type') || 'application/json')
 
-    return await response.text()
+    const text = await response.text()
+
+    tryPopulateVaultCache(chainId, body, text).catch(() => {})
+
+    return text
   }
   catch (error: unknown) {
     if (isAbortError(error)) {

--- a/server/api/vault-cache/[chainId].post.ts
+++ b/server/api/vault-cache/[chainId].post.ts
@@ -1,0 +1,38 @@
+import { createError, readBody } from 'h3'
+import { createRateLimiter } from '~/server/utils/rate-limit'
+import { vaultHexCache, vaultCacheKey } from '~/server/utils/vault-cache-store'
+
+const rateLimiter = createRateLimiter({
+  max: 1000,
+  windowMs: 60_000,
+  label: 'vault-cache',
+})
+
+export default defineEventHandler(async (event) => {
+  const chainId = Number(event.context.params?.chainId)
+
+  if (!Number.isInteger(chainId) || chainId <= 0) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid chainId' })
+  }
+
+  rateLimiter.consume(event)
+
+  const body = await readBody(event)
+  const vaults: unknown = body?.vaults
+
+  if (!Array.isArray(vaults) || vaults.length === 0) {
+    throw createError({ statusCode: 400, statusMessage: 'vaults must be a non-empty array' })
+  }
+
+  vaultHexCache.deleteExpired()
+
+  const result: Record<string, string> = {}
+
+  for (const vaultAddress of vaults) {
+    if (typeof vaultAddress !== 'string') continue
+    const hex = vaultHexCache.get(vaultCacheKey(chainId, vaultAddress))
+    if (hex) result[vaultAddress] = hex
+  }
+
+  return result
+})

--- a/server/utils/cache.ts
+++ b/server/utils/cache.ts
@@ -35,7 +35,10 @@ export function createTtlCache<T>(options: TtlCacheOptions) {
     get(key: string): T | undefined {
       const entry = map.get(key)
       if (!entry) return undefined
-      if ((Date.now() - entry.timestamp) >= ttlMs) return undefined
+      if ((Date.now() - entry.timestamp) >= ttlMs) {
+        map.delete(key)
+        return undefined
+      }
       return entry.data
     },
 
@@ -47,6 +50,14 @@ export function createTtlCache<T>(options: TtlCacheOptions) {
     set(key: string, data: T): void {
       map.set(key, { data, timestamp: Date.now() })
       evictOldest()
+    },
+
+    /** Remove all entries whose TTL has expired. */
+    deleteExpired(): void {
+      const now = Date.now()
+      for (const [key, entry] of map) {
+        if ((now - entry.timestamp) >= ttlMs) map.delete(key)
+      }
     },
   }
 }

--- a/server/utils/vault-cache-store.ts
+++ b/server/utils/vault-cache-store.ts
@@ -1,0 +1,11 @@
+import { createTtlCache } from './cache'
+
+const VAULT_CACHE_TTL_MS = 5 * 60 * 1000
+
+export const vaultHexCache = createTtlCache<string>({
+  ttlMs: VAULT_CACHE_TTL_MS,
+  maxEntries: 5000,
+})
+
+export const vaultCacheKey = (chainId: number, vaultAddress: string): string =>
+  `${chainId}:${vaultAddress.toLowerCase()}`


### PR DESCRIPTION
## Summary

- The RPC proxy passively intercepts vault lens calls (batchSimulation + direct eth_call) and caches raw hex results per vault address in a 5-minute TTL in-memory cache
- New `POST /api/vault-cache/:chainId` endpoint serves cached hex for requested vault addresses
- `loadVaults()` tries the cache after factory detection — on hit, renders immediately and continues the full load (including escrow, pricing, Pyth) silently in background
- Escrow vault fetching refactored to use EVC batchSimulation instead of individual readContract calls
- Extracted `processRawEarnVaultData` and `processRawSecuritizeVaultData` for cache decoding
- Generation-aware race condition protection for chain switches during cache fetch

## How it works

No client push, no pre-warming schedule, no idle RPC calls. The server is the only writer — it reads from its own proxy traffic. Cache is populated as a side effect of normal user RPC calls. Subsequent users benefit from the warm cache.

## Test plan

- [ ] First user loads app — vaults load normally (cold cache), cache warms
- [ ] Second user loads within 5 min — vaults render instantly from cache, background refresh updates
- [ ] Borrow page loads correctly (escrow vaults loaded via background refresh)
- [ ] Chain switch during cache fetch doesn't show stale chain data
- [ ] Server restart gracefully falls back to normal load