### PR TITLE
fix: remove swap /log endpoint and logContext references

### DIFF
--- a/composables/borrow/useBorrowForm.ts
+++ b/composables/borrow/useBorrowForm.ts
@@ -400,13 +400,6 @@ export const useBorrowForm = (options: UseBorrowFormOptions) => {
       isRepay: false,
       targetDebt: 0n,
       currentDebt: 0n,
-    }, {
-      logContext: {
-        tokenIn: borrowSelectedAsset.value.address,
-        tokenOut: collateralVault.value.asset.address,
-        amount: collateralAmount.value,
-        slippage: borrowSwapSlippage.value,
-      },
     })
   }, 500)
 

--- a/composables/borrow/useMultiplyForm.ts
+++ b/composables/borrow/useMultiplyForm.ts
@@ -546,14 +546,6 @@ export const useMultiplyForm = (options: UseMultiplyFormOptions) => {
     }
     await requestMultiplyQuotes(requestParams, {
       errorMessage: 'Unable to fetch swap quote. Multiply feature is not available for this asset.',
-      logContext: {
-        fromVault: multiplyShortVault.value?.address,
-        toVault: multiplyLongVault.value?.address,
-        amount: formatUnits(debtAmount, Number(multiplyShortVault.value.asset.decimals)),
-        slippage: multiplySlippage.value,
-        swapperMode: SwapperMode.EXACT_IN,
-        isRepay: false,
-      },
     })
   }, 500)
 

--- a/composables/position/useCollateralForm.ts
+++ b/composables/position/useCollateralForm.ts
@@ -364,12 +364,7 @@ export const useCollateralForm = (options: UseCollateralFormOptions) => {
       return
     }
 
-    await requestSwapQuotes(params, {
-      logContext: {
-        amount: amount.value,
-        slippage: swapSlippage.value,
-      },
-    })
+    await requestSwapQuotes(params)
   }, 500)
 
   const openSwapTokenSelector = (currentAddress?: string, onSelect?: (a: VaultAsset, meta?: SwapTokenSelectMeta) => void) => {

--- a/composables/useSwapApi.ts
+++ b/composables/useSwapApi.ts
@@ -146,20 +146,10 @@ export const useSwapApi = () => {
     return quotes[0] || null
   }
 
-  const logSwapFailure = async (payload: unknown) => {
-    try {
-      await axios.post(`${baseUrl}/log`, payload)
-    }
-    catch (error) {
-      logWarn('swapApi/log', error)
-    }
-  }
-
   return {
     baseUrl,
     getSwapQuote,
     getSwapQuotes,
     getSwapProviders,
-    logSwapFailure,
   }
 }

--- a/composables/useSwapPageLogic.ts
+++ b/composables/useSwapPageLogic.ts
@@ -40,7 +40,7 @@ export interface UseSwapPageLogicOptions {
    * Build the swap-API params for a given input amount.
    * Return `null` to skip the request (e.g. amount exceeds debt).
    */
-  buildQuoteRequest: (amount: bigint) => { params: SwapApiRequestInput, logContext: Record<string, unknown> } | null
+  buildQuoteRequest: (amount: bigint) => { params: SwapApiRequestInput } | null
   /** Build the TxPlan for the current swap (same-asset or quote-based). Must throw on failure. */
   buildPlan: () => Promise<TxPlan>
   /** Page-specific balance validation error. Receives the parsed nano amount. */
@@ -237,7 +237,7 @@ export const useSwapPageLogic = (options: UseSwapPageLogicOptions) => {
     }
 
     toAmount.value = ''
-    await requestQuotes(request.params, { logContext: request.logContext })
+    await requestQuotes(request.params)
   }, 500)
 
   // ── Input handlers ─────────────────────────────────────────────────────

--- a/composables/useSwapQuotesParallel.ts
+++ b/composables/useSwapQuotesParallel.ts
@@ -18,13 +18,12 @@ type SwapQuotesParallelOptions = {
 }
 
 type SwapQuotesRequestOptions = {
-  logContext?: Record<string, unknown>
   providers?: string[]
   errorMessage?: string
 }
 
 export const useSwapQuotesParallel = (options: SwapQuotesParallelOptions) => {
-  const { getSwapQuotes, getSwapProviders, logSwapFailure } = useSwapApi()
+  const { getSwapQuotes, getSwapProviders } = useSwapApi()
 
   const quoteCards = ref<SwapQuoteCard[]>([])
   const selectedProvider = ref<string | null>(null)
@@ -143,16 +142,9 @@ export const useSwapQuotesParallel = (options: SwapQuotesParallelOptions) => {
           if (isAbortError(err)) {
             return
           }
-          const axiosErr = err as { response?: { status?: number }, message?: string }
+          const axiosErr = err as { response?: { status?: number } }
           if (axiosErr.response?.status === 429) {
             rateLimitedCount += 1
-          }
-          if (requestOptions.logContext) {
-            logSwapFailure({
-              reason: axiosErr.message || 'Unknown error',
-              provider,
-              ...requestOptions.logContext,
-            })
           }
         }
         finally {

--- a/pages/lend/[vault]/[subAccount]/swap.vue
+++ b/pages/lend/[vault]/[subAccount]/swap.vue
@@ -100,14 +100,6 @@ const swap = useSwapPageLogic({
         targetDebt: 0n,
         currentDebt: 0n,
       },
-      logContext: {
-        fromVault: fromVault.value.address,
-        toVault: toVault.value.address,
-        amount: fromAmount.value,
-        slippage: slippage.value,
-        swapperMode: SwapperMode.EXACT_IN,
-        isRepay: false,
-      },
     }
   },
 

--- a/pages/lend/[vault]/[subAccount]/withdraw.vue
+++ b/pages/lend/[vault]/[subAccount]/withdraw.vue
@@ -217,13 +217,6 @@ const requestSwapQuote = useDebounceFn(async () => {
     isRepay: false,
     targetDebt: 0n,
     currentDebt: 0n,
-  }, {
-    logContext: {
-      tokenIn: asset.value.address,
-      tokenOut: selectedOutputAsset.value.address,
-      amount: amount.value,
-      slippage: swapSlippage.value,
-    },
   })
 }, 500)
 

--- a/pages/lend/[vault]/index.vue
+++ b/pages/lend/[vault]/index.vue
@@ -617,13 +617,6 @@ const requestSwapQuote = useDebounceFn(async () => {
     isRepay: false,
     targetDebt: 0n,
     currentDebt: 0n,
-  }, {
-    logContext: {
-      tokenIn: selectedAsset.value.address,
-      tokenOut: asset.value.address,
-      amount: amount.value,
-      slippage: swapSlippage.value,
-    },
   })
 }, 500)
 

--- a/pages/position/[number]/borrow/swap.vue
+++ b/pages/position/[number]/borrow/swap.vue
@@ -203,14 +203,6 @@ const swap = useSwapPageLogic({
         targetDebt: 0n,
         currentDebt: currentDebt.value,
       },
-      logContext: {
-        fromVault: fromVault.value.address,
-        toVault: toVault.value.address,
-        amount: fromAmount.value,
-        slippage: slippage.value,
-        swapperMode: SwapperMode.TARGET_DEBT,
-        isRepay: true,
-      },
     }
   },
 

--- a/pages/position/[number]/collateral/swap.vue
+++ b/pages/position/[number]/collateral/swap.vue
@@ -125,14 +125,6 @@ const swap = useSwapPageLogic({
         targetDebt: 0n,
         currentDebt: 0n,
       },
-      logContext: {
-        fromVault: fromVault.value.address,
-        toVault: toVault.value.address,
-        amount: fromAmount.value,
-        slippage: slippage.value,
-        swapperMode: SwapperMode.EXACT_IN,
-        isRepay: false,
-      },
     }
   },
 

--- a/pages/position/[number]/multiply.vue
+++ b/pages/position/[number]/multiply.vue
@@ -552,14 +552,6 @@ const requestMultiplyQuote = useDebounceFn(async () => {
   }
   await requestMultiplyQuotes(requestParams, {
     errorMessage: 'Unable to fetch swap quote. Multiply feature is not available for this asset.',
-    logContext: {
-      fromVault: multiplyShortVault.value?.address,
-      toVault: multiplyLongVault.value?.address,
-      amount: formatUnits(debtAmount, Number(multiplyShortVault.value.asset.decimals)),
-      slippage: multiplySlippage.value,
-      swapperMode: SwapperMode.EXACT_IN,
-      isRepay: false,
-    },
   })
 }, 500)
 


### PR DESCRIPTION
The swap API's `/log` endpoint was being called on every provider quote failure to report errors back to the server. This caused a cascade: when the swap API rate-limited quote requests (429), each failed provider would fire a `POST /log` to the same overloaded server, which also returned 429. Since 429 responses don't include CORS headers, the browser reported these as CORS errors, making the issue look like a misconfiguration rather than rate limiting. With multiple providers failing simultaneously, this produced N redundant log calls per debounce cycle, flooding the console with noise.

The `/log` endpoint doesn't exist in the monorepo — removed `logSwapFailure` entirely along with all `logContext` plumbing that fed into it across composables and pages. Quote fetch failures still surface correctly via the existing `quoteError` state in the UI.