### PR TITLE
refactor: keep tx review modal open during execution

### DIFF
--- a/components/entities/operation/OperationReviewModal.vue
+++ b/components/entities/operation/OperationReviewModal.vue
@@ -21,7 +21,7 @@ interface REULUnlockInfo {
   daysUntilMaturity: number
 }
 
-const { type, asset, assetIconUrl, campaignInfo: _campaignInfo, reulUnlockInfo, amount, onConfirm, plan, swapToAsset, swapToAmount, supplyingAssetForBorrow, supplyingAmount, transferAmounts } = defineProps<{
+const { type, asset, assetIconUrl, campaignInfo: _campaignInfo, reulUnlockInfo, amount, onConfirm, plan, swapToAsset, swapToAmount, supplyingAssetForBorrow, supplyingAmount, transferAmounts, submittingLabel } = defineProps<{
   type?: 'supply' | 'withdraw' | 'borrow' | 'repay' | 'swap' | 'transfer' | 'reward' | 'brevis-reward' | 'fuul-reward' | 'reul-unlock' | 'disableCollateral' | 'swap-supply' | 'swap-withdraw' | 'swap-borrow'
   asset: VaultAsset
   assetIconUrl?: string
@@ -33,11 +33,13 @@ const { type, asset, assetIconUrl, campaignInfo: _campaignInfo, reulUnlockInfo, 
   swapToAmount?: number | string
   campaignInfo?: Campaign
   reulUnlockInfo?: REULUnlockInfo
-  onConfirm: () => void
+  onConfirm: () => void | Promise<void>
   subAccount?: string
   hasBorrows?: boolean
   /** Known amounts for transferFromMax steps, keyed by vault address (lowercase) */
   transferAmounts?: Record<string, string>
+  /** Label shown on the button while executing */
+  submittingLabel?: string
 }>()
 
 const { address: walletAddress, chainId: currentChainId } = useWagmi()
@@ -108,9 +110,25 @@ const handleTenderlySimulate = async () => {
   }
 }
 
-const handleConfirm = () => {
-  emits('close')
-  onConfirm()
+const internalSubmitting = ref(false)
+
+const handleConfirm = async () => {
+  const result = onConfirm()
+  // If onConfirm returns a promise, keep the modal open with a loading state
+  // and let the caller close it via modal.close(). Otherwise close immediately
+  // (backwards-compatible with existing sync callbacks).
+  if (result && typeof (result as Promise<void>).then === 'function') {
+    internalSubmitting.value = true
+    try {
+      await result
+    }
+    finally {
+      internalSubmitting.value = false
+    }
+  }
+  else {
+    emits('close')
+  }
 }
 
 const displaySteps = computed((): DisplayStep[] => {
@@ -305,10 +323,11 @@ const permit2DisclaimerText = 'You are granting the permit2 contract unlimited a
         variant="primary"
         size="xlarge"
         rounded
-        :disabled="isSpyMode"
+        :disabled="isSpyMode || internalSubmitting"
+        :loading="internalSubmitting"
         @click="handleConfirm"
       >
-        {{ isSpyMode ? 'Spy mode (read-only)' : btnLabel }}
+        {{ isSpyMode ? 'Spy mode (read-only)' : (internalSubmitting && submittingLabel ? submittingLabel : btnLabel) }}
       </UiButton>
     </div>
   </BaseModalWrapper>

--- a/components/entities/portfolio/PortfolioBrevisRewardItem.vue
+++ b/components/entities/portfolio/PortfolioBrevisRewardItem.vue
@@ -89,10 +89,9 @@ const onClaimClick = async () => {
         amount: rewardAmount.value,
         campaignInfo: campaign,
         plan: plan.value || undefined,
-        onConfirm: () => {
-          setTimeout(() => {
-            claim()
-          }, 400)
+        submittingLabel: 'Claiming...',
+        onConfirm: async () => {
+          await claim()
         },
       },
     })

--- a/components/entities/portfolio/PortfolioFuulRewardItem.vue
+++ b/components/entities/portfolio/PortfolioFuulRewardItem.vue
@@ -82,10 +82,9 @@ const onClaimClick = async () => {
         },
         amount: rewardAmount.value,
         plan: plan.value || undefined,
-        onConfirm: () => {
-          setTimeout(() => {
-            claim()
-          }, 400)
+        submittingLabel: 'Claiming...',
+        onConfirm: async () => {
+          await claim()
         },
       },
     })

--- a/components/entities/portfolio/PortfolioRewardItem.vue
+++ b/components/entities/portfolio/PortfolioRewardItem.vue
@@ -97,10 +97,9 @@ const onClaimClick = async () => {
         assetIconUrl: externalIconUrl.value,
         amount: amountToClaim.value,
         plan: plan.value || undefined,
-        onConfirm: () => {
-          setTimeout(() => {
-            claim()
-          }, 400)
+        submittingLabel: 'Claiming...',
+        onConfirm: async () => {
+          await claim()
         },
       },
     })

--- a/components/entities/reward/RewardUnlockItem.vue
+++ b/components/entities/reward/RewardUnlockItem.vue
@@ -122,10 +122,9 @@ const onUnlockClick = async () => {
           maturityDate: formattedDate.value,
           daysUntilMaturity: daysUntilMaturity.value,
         },
-        onConfirm: () => {
-          setTimeout(() => {
-            unlock()
-          }, 400)
+        submittingLabel: 'Unlocking...',
+        onConfirm: async () => {
+          await unlock()
         },
       },
     })

--- a/composables/borrow/useBorrowForm.ts
+++ b/composables/borrow/useBorrowForm.ts
@@ -588,11 +588,10 @@ export const useBorrowForm = (options: UseBorrowFormOptions) => {
             plan: plan.value || undefined,
             swapToAsset: collateralVault.value.asset,
             swapToAmount: borrowSwapEstimatedCollateral.value,
-            onConfirm: () => {
-              setTimeout(() => {
-                send()
-              }, 400)
+            onConfirm: async () => {
+              await send()
             },
+            submittingLabel: 'Submitting...',
           },
         })
         return
@@ -658,11 +657,10 @@ export const useBorrowForm = (options: UseBorrowFormOptions) => {
           plan: plan.value || undefined,
           supplyingAssetForBorrow: collateralVault.value?.asset,
           supplyingAmount: collateralAmount.value,
-          onConfirm: () => {
-            setTimeout(() => {
-              send()
-            }, 400)
+          onConfirm: async () => {
+            await send()
           },
+          submittingLabel: 'Submitting...',
         },
       })
     }

--- a/composables/position/useCollateralForm.ts
+++ b/composables/position/useCollateralForm.ts
@@ -576,11 +576,10 @@ export const useCollateralForm = (options: UseCollateralFormOptions) => {
             hasBorrows: (position.value?.borrowed || 0n) > 0n,
             swapToAsset: options.needsSwap.value ? options.getSwapToAsset() : undefined,
             swapToAmount: options.needsSwap.value ? swapEstimatedOutput.value : undefined,
-            onConfirm: () => {
-              setTimeout(() => {
-                send()
-              }, 400)
+            onConfirm: async () => {
+              await send()
             },
+            submittingLabel: 'Submitting...',
           },
         })
       })

--- a/composables/repay/useCollateralSwapRepay.ts
+++ b/composables/repay/useCollateralSwapRepay.ts
@@ -361,11 +361,10 @@ export const useCollateralSwapRepay = (options: UseCollateralSwapRepayOptions) =
           swapToAmount: !core.isSameAsset.value ? core.debtAmount.value : undefined,
           subAccount: position.value?.subAccount,
           hasBorrows: (position.value?.borrowed || 0n) > 0n,
-          onConfirm: () => {
-            setTimeout(() => {
-              send()
-            }, 400)
+          onConfirm: async () => {
+            await send()
           },
+          submittingLabel: 'Submitting...',
         },
       })
     }

--- a/composables/repay/useSavingsRepay.ts
+++ b/composables/repay/useSavingsRepay.ts
@@ -292,11 +292,10 @@ export const useSavingsRepay = (options: UseSavingsRepayOptions) => {
           subAccount: position.value?.subAccount,
           hasBorrows: (position.value?.borrowed || 0n) > 0n,
           transferAmounts,
-          onConfirm: () => {
-            setTimeout(() => {
-              send()
-            }, 400)
+          onConfirm: async () => {
+            await send()
           },
+          submittingLabel: 'Submitting...',
         },
       })
     }

--- a/composables/repay/useWalletRepay.ts
+++ b/composables/repay/useWalletRepay.ts
@@ -139,11 +139,10 @@ export const useWalletRepay = (options: UseWalletRepayOptions) => {
           plan: plan.value || undefined,
           subAccount: position.value?.subAccount,
           hasBorrows: (position.value?.borrowed || 0n) > 0n,
-          onConfirm: () => {
-            setTimeout(() => {
-              send()
-            }, 400)
+          onConfirm: async () => {
+            await send()
           },
+          submittingLabel: 'Submitting...',
         },
       })
     }

--- a/composables/repay/useWalletSwapRepay.ts
+++ b/composables/repay/useWalletSwapRepay.ts
@@ -610,11 +610,10 @@ export const useWalletSwapRepay = (options: UseWalletSwapRepayOptions) => {
           plan: plan.value || undefined,
           subAccount: position.value?.subAccount,
           hasBorrows: (position.value?.borrowed || 0n) > 0n,
-          onConfirm: () => {
-            setTimeout(() => {
-              send()
-            }, 400)
+          onConfirm: async () => {
+            await send()
           },
+          submittingLabel: 'Submitting...',
         },
       })
     }

--- a/composables/useSwapPageLogic.ts
+++ b/composables/useSwapPageLogic.ts
@@ -466,11 +466,10 @@ export const useSwapPageLogic = (options: UseSwapPageLogicOptions) => {
             swapToAsset: showSwapAmounts ? toVault.value?.asset : undefined,
             swapToAmount: showSwapAmounts ? toAmount.value : undefined,
             plan: plan.value || undefined,
-            onConfirm: () => {
-              setTimeout(() => {
-                send()
-              }, 400)
+            onConfirm: async () => {
+              await send()
             },
+            submittingLabel: 'Submitting...',
           },
         })
       })

--- a/pages/earn/[vault]/[subAccount]/withdraw.vue
+++ b/pages/earn/[vault]/[subAccount]/withdraw.vue
@@ -154,10 +154,9 @@ const submit = async () => {
         asset: asset.value,
         amount: amount.value,
         plan: plan.value || undefined,
-        onConfirm: () => {
-          setTimeout(() => {
-            send()
-          }, 400)
+        submittingLabel: 'Submitting...',
+        onConfirm: async () => {
+          await send()
         },
       },
     })

--- a/pages/earn/[vault]/index.vue
+++ b/pages/earn/[vault]/index.vue
@@ -134,10 +134,9 @@ const submit = async () => {
         asset: asset.value,
         amount: amount.value,
         plan: plan.value || undefined,
-        onConfirm: () => {
-          setTimeout(() => {
-            send()
-          }, 400)
+        submittingLabel: 'Submitting...',
+        onConfirm: async () => {
+          await send()
         },
       },
     })

--- a/pages/lend/[vault]/[subAccount]/withdraw.vue
+++ b/pages/lend/[vault]/[subAccount]/withdraw.vue
@@ -361,10 +361,9 @@ const submit = async () => {
           plan: plan.value || undefined,
           swapToAsset: needsSwap.value ? selectedOutputAsset.value : undefined,
           swapToAmount: needsSwap.value ? swapEstimatedOutput.value : undefined,
-          onConfirm: () => {
-            setTimeout(() => {
-              send()
-            }, 400)
+          submittingLabel: 'Submitting...',
+          onConfirm: async () => {
+            await send()
           },
         },
       })

--- a/pages/lend/[vault]/index.vue
+++ b/pages/lend/[vault]/index.vue
@@ -435,10 +435,9 @@ const submit = async () => {
           plan: plan.value || undefined,
           swapToAsset: needsSwap.value ? asset.value : undefined,
           swapToAmount: needsSwap.value ? swapEstimatedOutput.value : undefined,
-          onConfirm: () => {
-            setTimeout(() => {
-              send()
-            }, 400)
+          submittingLabel: 'Submitting...',
+          onConfirm: async () => {
+            await send()
           },
         },
       })

--- a/pages/position/[number]/borrow/index.vue
+++ b/pages/position/[number]/borrow/index.vue
@@ -252,10 +252,9 @@ const submit = async () => {
         plan: plan.value || undefined,
         subAccount: position.value?.subAccount,
         hasBorrows: (position.value?.borrowed || 0n) > 0n,
-        onConfirm: () => {
-          setTimeout(() => {
-            send()
-          }, 400)
+        submittingLabel: 'Submitting...',
+        onConfirm: async () => {
+          await send()
         },
       },
     })

--- a/pages/position/[number]/index.vue
+++ b/pages/position/[number]/index.vue
@@ -580,10 +580,9 @@ const disableCollateral = async (vault: Vault) => {
         plan: plan || undefined,
         subAccount: position.value?.subAccount,
         hasBorrows: (position.value?.borrowed || 0n) > 0n,
-        onConfirm: () => {
-          setTimeout(() => {
-            send(vault.address)
-          }, 400)
+        submittingLabel: 'Submitting...',
+        onConfirm: async () => {
+          await send(vault.address)
         },
       },
     })

--- a/pages/position/[number]/multiply.vue
+++ b/pages/position/[number]/multiply.vue
@@ -642,10 +642,9 @@ const submitMultiply = async () => {
           swapToAsset: quote ? multiplyLongVault.value.asset : undefined,
           swapToAmount: quote ? multiplyLongAmount.value : undefined,
           subAccount,
-          onConfirm: () => {
-            setTimeout(() => {
-              sendMultiply()
-            }, 400)
+          submittingLabel: 'Submitting...',
+          onConfirm: async () => {
+            await sendMultiply()
           },
         },
       })


### PR DESCRIPTION
## Summary
- OperationReviewModal now keeps the modal open while `onConfirm` executes, showing a loading spinner on the button
- When `onConfirm` returns a Promise, the modal awaits it and shows the `submittingLabel` text. Sync callbacks close immediately (backwards compatible)
- All 19 callers upgraded from fire-and-forget `setTimeout(() => send(), 400)` to `async () => { await send() }`

## Test plan
- [ ] Verify supply, withdraw, borrow, repay, swap, reward claim, REUL unlock all show loading state on confirm
- [ ] Verify modal stays open until tx completes or fails
- [ ] Verify button re-enables on error so user can retry
- [ ] Verify modal closes on success