### PR TITLE
fix: use DEV_GEO_COUNTRY fallback regardless of DOPPLER_ENVIRONMENT

### DIFF
--- a/server/middleware/cors.ts
+++ b/server/middleware/cors.ts
@@ -51,9 +51,10 @@ export default defineEventHandler((event) => {
   const cfCountry = (event.node.req.headers['cf-ipcountry'] as string | undefined)?.toUpperCase()
   let country = (cfCountry && /^[A-Z]{2}$/.test(cfCountry) && cfCountry !== 'XX') ? cfCountry : undefined
 
-  // In dev, Cloudflare is not in the request path so cf-ipcountry is never set.
-  // Mirror geo-gate.ts: use DEV_GEO_COUNTRY so x-country-code is set in the response.
-  if (!country && process.env.DOPPLER_ENVIRONMENT === 'dev') {
+  // When Cloudflare is not in the request path (local dev, PR previews, etc.)
+  // cf-ipcountry is never set. Mirror geo-gate.ts: use DEV_GEO_COUNTRY as a
+  // fallback regardless of environment so x-country-code is set in the response.
+  if (!country) {
     const devCountry = process.env.DEV_GEO_COUNTRY?.toUpperCase()
     if (devCountry && /^[A-Z]{2}$/.test(devCountry) && devCountry !== 'XX') {
       country = devCountry

--- a/server/middleware/geo-gate.ts
+++ b/server/middleware/geo-gate.ts
@@ -14,9 +14,11 @@ export default defineEventHandler((event) => {
   const cfCountry = (event.node.req.headers['cf-ipcountry'] as string | undefined)?.toUpperCase()
   let country = (cfCountry && /^[A-Z]{2}$/.test(cfCountry) && cfCountry !== 'XX') ? cfCountry : undefined
 
-  // In dev, Cloudflare is not in the request path so cf-ipcountry is never set.
-  // DEV_GEO_COUNTRY allows simulating any country for testing geo-blocks locally.
-  if (!country && process.env.DOPPLER_ENVIRONMENT === 'dev') {
+  // When Cloudflare is not in the request path (local dev, PR previews, etc.)
+  // cf-ipcountry is never set. DEV_GEO_COUNTRY allows injecting a country code
+  // as a fallback regardless of environment, so preview deployments aren't
+  // universally fail-closed when no CF header is present.
+  if (!country) {
     const devCountry = process.env.DEV_GEO_COUNTRY?.toUpperCase()
     if (devCountry && /^[A-Z]{2}$/.test(devCountry) && devCountry !== 'XX') {
       country = devCountry
@@ -25,7 +27,7 @@ export default defineEventHandler((event) => {
 
   // Fail-closed: deny access when country cannot be determined.
   // This prevents bypassing geo-blocks by omitting or spoofing headers.
-  // In dev without DEV_GEO_COUNTRY set, allow the request through.
+  // In dev (DOPPLER_ENVIRONMENT=dev) without DEV_GEO_COUNTRY set, allow through.
   if (!country && process.env.DOPPLER_ENVIRONMENT !== 'dev') {
     console.warn('[geo-gate] Blocked: country undetermined', {
       cfCountry: cfCountry || 'absent',


### PR DESCRIPTION
## Problem

PR preview deployments on Railway are not behind Cloudflare, so the `cf-ipcountry` header is never present. Both `geo-gate.ts` and `cors.ts` previously only fell back to `DEV_GEO_COUNTRY` when `DOPPLER_ENVIRONMENT === 'dev'`, causing every API request on a preview to be fail-closed with HTTP 451 — making previews completely unusable for review.

## Solution

Remove the `DOPPLER_ENVIRONMENT === 'dev'` guard from the `DEV_GEO_COUNTRY` fallback in both middleware files. The var is now consulted whenever `cf-ipcountry` is absent, regardless of environment.

Need to inject `DEV_GEO_COUNTRY=US` (or any non-sanctioned ISO 3166-1 alpha-2 code) into the Railway preview container environment.

## Safety

- **Production / staging**: unaffected. Cloudflare always sets `cf-ipcountry` there, so the `DEV_GEO_COUNTRY` block is never reached.
- **Fail-closed behavior preserved**: previews without `DEV_GEO_COUNTRY` set still return 451.
- **No new attack surface**: the var cannot override a real CF header, and the same regex + `XX` exclusion validation applies.

## Files changed

- `server/middleware/geo-gate.ts` — server-side geo block
- `server/middleware/cors.ts` — `x-country-code` response header used by client-side UI blocking