### PR TITLE
fix: use configurable URLs in AcknowledgeTermsModal

### DIFF
--- a/components/entities/operation/AcknowledgeTermsModal.vue
+++ b/components/entities/operation/AcknowledgeTermsModal.vue
@@ -5,6 +5,8 @@ const props = defineProps<{
 }>()
 const emits = defineEmits(['close'])
 
+const { tosUrl, privacyPolicyUrl, riskDisclosuresUrl } = useDeployConfig()
+
 const terms = [
   {
     icon: 'map-pin-off',
@@ -56,19 +58,19 @@ const onAccept = () => {
       <div class="text-p3 text-content-secondary">
         By accessing or using Euler's products and services, I agree to the
         <a
-          href="https://www.euler.finance/terms"
+          :href="tosUrl"
           target="_blank"
           rel="noopener noreferrer"
           class="text-accent-500 underline cursor-pointer hover:text-accent-600"
         >Terms of Use</a>,
         <a
-          href="https://www.euler.finance/privacy"
+          :href="privacyPolicyUrl"
           target="_blank"
           rel="noopener noreferrer"
           class="text-accent-500 underline cursor-pointer hover:text-accent-600"
         >Privacy Policy</a>, and
         <a
-          href="https://www.euler.finance/risk"
+          :href="riskDisclosuresUrl"
           target="_blank"
           rel="noopener noreferrer"
           class="text-accent-500 underline cursor-pointer hover:text-accent-600"

--- a/composables/guards/useTosGuard.ts
+++ b/composables/guards/useTosGuard.ts
@@ -112,11 +112,12 @@ export const useTosGuard = () => {
     }
   }
 
-  // Register/unregister blocker
-  // When TOS fails to load, we fail open — don't block operations (user might need to repay etc.)
-  // The TOS signing will happen on a future operation when the endpoint recovers.
+  // Register/unregister blocker — fail closed
   const updateBlockerRegistration = () => {
-    if (isTermsRequired.value && !tosLoadFailed.value) {
+    if (enableTosSignature && tosLoadFailed.value) {
+      registerOperationBlocker('tos', 'Unable to load Terms of Use')
+    }
+    else if (isTermsRequired.value) {
       registerOperationBlocker('tos', 'Terms of Use acceptance required')
     }
     else {

--- a/composables/useTosData.ts
+++ b/composables/useTosData.ts
@@ -1,5 +1,5 @@
 import type { Hex } from 'viem'
-import { hashMessage, keccak256, stringToHex } from 'viem'
+import { keccak256, stringToHex } from 'viem'
 import { logWarn } from '~/utils/errorHandling'
 
 let cachedTosData: TosData | null = null
@@ -28,8 +28,8 @@ export async function getTosData(): Promise<TosData> {
       return response.text()
     })
     .then((content) => {
-      const tosHash = hashMessage(content)
-      const tosHashShort = `0x${tosHash.slice(-6)}`
+      const tosHash = keccak256(stringToHex(content))
+      const tosHashShort = tosHash.slice(0, 14)
       const tosMessage = `By proceeding to engage with and use Euler, you accept and agree to abide by the Terms of Use: ${tosUrl}\n\nhash:${tosHashShort}`
       const tosMessageHash = keccak256(stringToHex(tosMessage))
       cachedTosData = { tosMessage, tosMessageHash }

--- a/docs/tos-signing.md
+++ b/docs/tos-signing.md
@@ -77,7 +77,7 @@ See: `composables/guards/useTosGuard.ts`
 
 ## Failure handling
 
-- If `/api/tos` is unreachable and no cached content exists, `tosLoadFailed` is set to `true`. The app **fails open** — operations are not blocked, so users can still repay/withdraw. The TOS signing will happen on a future operation when the endpoint recovers.
+- If `/api/tos` is unreachable and no cached content exists, `tosLoadFailed` is set to `true`. The app **fails closed** — operations are blocked with "Unable to load Terms of Use".
 - If the `TermsOfUseSigner` contract read fails, `hasSigned` is set to `false` and the modal will show.
 
 ## Key files

--- a/docs/tos-signing.md
+++ b/docs/tos-signing.md
@@ -1,0 +1,94 @@
+# Terms of Use Signing Flow
+
+Users must sign the Terms of Use on-chain before executing operations. The signature is recorded by the `TermsOfUseSigner` contract and checked on every subsequent visit.
+
+## Configuration
+
+| Env var | Purpose |
+|---------|---------|
+| `NUXT_PUBLIC_CONFIG_TOS_MD_URL` | URL to raw TOS markdown. **Master switch** — if empty, TOS signing is disabled entirely. |
+| `NUXT_PUBLIC_CONFIG_TOS_URL` | URL to the human-readable TOS page (shown in the modal). Fallback: `https://www.euler.finance/terms` |
+
+## How the signed message is constructed
+
+1. The app fetches the TOS markdown from `/api/tos` (which proxies `NUXT_PUBLIC_CONFIG_TOS_MD_URL` with a 5-min cache).
+
+2. A content hash is computed:
+   ```
+   tosHash = keccak256(stringToHex(markdownContent))
+   tosHashShort = tosHash.slice(0, 14)   // first 6 bytes, e.g. "0x1a2b3c4d5e6f"
+   ```
+
+3. The human-readable message is assembled:
+   ```
+   By proceeding to engage with and use Euler, you accept and agree to abide by the Terms of Use: {tosUrl}
+
+   hash:{tosHashShort}
+   ```
+   Where `{tosUrl}` is from `NUXT_PUBLIC_CONFIG_TOS_URL`.
+
+4. The message hash used as the on-chain key:
+   ```
+   tosMessageHash = keccak256(stringToHex(tosMessage))
+   ```
+
+**Key point:** if the TOS markdown content changes OR the TOS URL changes, the hashes change and users must re-sign.
+
+See: `composables/useTosData.ts`
+
+## On-chain contract
+
+The `TermsOfUseSigner` contract (address from `eulerPeripheryAddresses.termsOfUseSigner`) exposes:
+
+```solidity
+// Record signature — called as part of an EVC batch
+function signTermsOfUse(string message, bytes32 messageHash) external
+
+// Check if user signed a specific TOS version
+function lastTermsOfUseSignatureTimestamp(address account, bytes32 termsOfUseHash) view returns (uint256)
+```
+
+- `signTermsOfUse` stores `block.timestamp` keyed by `(account, messageHash)`
+- `lastTermsOfUseSignatureTimestamp` returns `0` if never signed, otherwise the timestamp
+
+See: `abis/tos.ts`
+
+## Checking if a user signed (and which version)
+
+To verify off-chain or on-chain whether a user has signed a specific TOS version:
+
+1. **Reconstruct `tosMessageHash`** using the steps above (fetch markdown, compute hashes, build message, hash message).
+2. **Call** `lastTermsOfUseSignatureTimestamp(userAddress, tosMessageHash)` on the `TermsOfUseSigner` contract.
+3. If the result is `> 0`, the user signed that version at that timestamp.
+
+To check against the **current** TOS version, the app does this automatically in `useTosGuard`.
+
+See: `composables/guards/useTosGuard.ts`
+
+## User-facing flow
+
+1. User navigates to an operation page (supply, borrow, etc.).
+2. `useOperationGuard` initializes `useTosGuard`, which checks the on-chain signature.
+3. If not signed: the submit button shows "Accept Terms Of Use" instead of the normal action.
+4. User clicks it → `AcknowledgeTermsModal` opens with legal checkpoints.
+5. User clicks "Accept" → `sessionAccepted` flag is set.
+6. The normal submit button reappears. When the user executes their operation, a `signTermsOfUse` call is **prepended** to the EVC batch — so the TOS signature and the operation happen in a single transaction.
+7. On next visit, the on-chain check finds `timestamp > 0` and skips the modal.
+
+## Failure handling
+
+- If `/api/tos` is unreachable and no cached content exists, `tosLoadFailed` is set to `true`. The app **fails open** — operations are not blocked, so users can still repay/withdraw. The TOS signing will happen on a future operation when the endpoint recovers.
+- If the `TermsOfUseSigner` contract read fails, `hasSigned` is set to `false` and the modal will show.
+
+## Key files
+
+| File | Role |
+|------|------|
+| `composables/useTosData.ts` | Fetches TOS markdown, computes hashes |
+| `composables/guards/useTosGuard.ts` | Guard logic, on-chain signature check, blocker/guard registration |
+| `utils/tos-injection.ts` | Prepends `signTermsOfUse` call to EVC batch |
+| `utils/operationGuardRegistry.ts` | Generic guard registry (TOS guard registers here) |
+| `server/api/tos.get.ts` | Server proxy for TOS markdown with caching |
+| `abis/tos.ts` | `TermsOfUseSigner` contract ABIs |
+| `components/entities/operation/AcknowledgeTermsModal.vue` | Acceptance modal UI |
+| `components/entities/vault/form/VaultFormSubmit.vue` | Submit button that triggers the modal |


### PR DESCRIPTION
## Summary
- Replace hardcoded Terms of Use, Privacy Policy, and Risk Disclosures URLs in `AcknowledgeTermsModal.vue` with configurable values from `useDeployConfig()`
- Fix TOS content hash: replace `hashMessage` (EIP-191 prefixed) with plain `keccak256(stringToHex(...))` for consistency with `tosMessageHash`
- Use first 6 bytes of content hash as short fingerprint (was last 3 bytes)
- Add documentation for the TOS signing flow

## Breaking change
Users who previously signed TOS will need to re-sign — the `tosMessageHash` changes due to the different content hash and short hash format.

## Test plan
- [ ] Verify modal links work with default fallback URLs
- [ ] Verify links update when env vars are set to custom values
- [ ] Verify TOS signing flow works end-to-end with new hash computation
- [ ] Verify re-signing is required for existing users