### PR TITLE
fix: require CF-Connecting-IP in production to close X-Forwarded-For rate limit bypass

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -307,7 +307,13 @@ The app includes a built-in per-IP rate limiter as a defense-in-depth measure. D
 1. **Geo-gate** (`server/middleware/geo-gate.ts`) reads `CF-IPCountry` to enforce sanctioned-country blocks. Without Cloudflare, the country cannot be determined and all API requests are rejected with HTTP 451.
 2. **Rate limiter** (`server/utils/rate-limit.ts`) uses `CF-Connecting-IP` as the trusted client IP. Without Cloudflare, `CF-Connecting-IP` is absent and all API requests are rejected with HTTP 403.
 
-Both checks are bypassed only in `dev` (`DOPPLER_ENVIRONMENT=dev`), where Cloudflare is not in the path and `DEV_GEO_COUNTRY` can be used to simulate a country for geo-block testing.
+Bypass behaviour per environment:
+
+| Environment | Geo-gate | Rate limiter |
+|---|---|---|
+| `prd` | CF required; fail-closed (HTTP 451) if absent. `DEV_GEO_COUNTRY` bypasses fail-closed if set. | CF required; fail-closed (HTTP 403) if absent. |
+| `stg` | CF required; fail-closed (HTTP 451) if absent. `DEV_GEO_COUNTRY` bypasses fail-closed if set. | CF **not** required; falls back to `X-Forwarded-For`. |
+| `dev` | CF not required; falls back to `DEV_GEO_COUNTRY`, then allows through if unset. | CF not required; falls back to `X-Forwarded-For`. |
 
 ## 📱 Mobile-First Architecture
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -282,7 +282,7 @@ The Nuxt server layer (`server/api/`) proxies requests to external services (RPC
 | **Body size limits** (`server/middleware/body-limit.ts`) | Caps request payloads (1 MB RPC, 2 MB Tenderly) |
 | **Geo-blocking** (`server/middleware/geo-gate.ts`) | Blocks sanctioned countries via Cloudflare `CF-IPCountry`; fails closed (HTTP 451) if country is undetermined in prod |
 | **RPC method whitelist** (`server/api/rpc/[chainId].ts`) | Only 16 safe read/send methods are proxied |
-| **Rate limiting** (`server/utils/rate-limit.ts`) | Per-IP cost-based budgets (see below) |
+| **Rate limiting** (`server/utils/rate-limit.ts`) | Per-IP cost-based budgets (see below); fails closed (HTTP 403) if `CF-Connecting-IP` is absent in prod |
 | **Swap verifier validation** (`utils/swap-validation.ts`) | Validates swap verifier addresses against known config |
 
 #### Rate Limiting
@@ -299,15 +299,15 @@ The app includes a built-in per-IP rate limiter as a defense-in-depth measure. D
 **Important**: This is a best-effort safeguard, not a security boundary. It catches accidental abuse (e.g. a client stuck in a retry loop) but will not stop a determined attacker. Known limitations:
 
 - **In-memory state is per-process** — if Nitro spawns multiple workers, each gets its own budget, effectively multiplying the limit.
-- **IP detection depends on the network layer** — behind Cloudflare, the limiter uses `CF-Connecting-IP` (reliable, not spoofable). Without a trusted reverse proxy, it falls back to `X-Forwarded-For`, which is client-controlled and trivially spoofable.
 
-#### Deployment Recommendations
+#### Cloudflare Requirement
 
-For production, operators should run the app behind a reverse proxy that handles rate limiting at the infrastructure level:
+**Production deployments must be behind Cloudflare.** This is a hard requirement, not a recommendation — two independent server features depend on it:
 
-- **Cloudflare**: Recommended. Provides rate limiting, DDoS protection, geo-headers, and a trustworthy `CF-Connecting-IP` header out of the box.
-- **Nginx / Caddy / HAProxy**: Configure `limit_req` (Nginx) or equivalent, and ensure the proxy forwards the real client IP in a header the app can trust.
-- **No reverse proxy**: The built-in rate limiter still provides basic protection against casual abuse, but should not be relied upon as the sole defense for API keys and upstream service quotas.
+1. **Geo-gate** (`server/middleware/geo-gate.ts`) reads `CF-IPCountry` to enforce sanctioned-country blocks. Without Cloudflare, the country cannot be determined and all API requests are rejected with HTTP 451.
+2. **Rate limiter** (`server/utils/rate-limit.ts`) uses `CF-Connecting-IP` as the trusted client IP. Without Cloudflare, `CF-Connecting-IP` is absent and all API requests are rejected with HTTP 403.
+
+Both checks are bypassed only in `dev` (`DOPPLER_ENVIRONMENT=dev`), where Cloudflare is not in the path and `DEV_GEO_COUNTRY` can be used to simulate a country for geo-block testing.
 
 ## 📱 Mobile-First Architecture
 

--- a/server/utils/rate-limit.ts
+++ b/server/utils/rate-limit.ts
@@ -15,24 +15,30 @@ interface RateLimiterConfig {
   label: string
 }
 
-// NOTE: This rate limiter is a best-effort defense-in-depth measure, not a
-// security boundary. Known limitations:
+// NOTE: This rate limiter relies on Cloudflare being in the request path for
+// production (DOPPLER_ENVIRONMENT=prd). CF-Connecting-IP is set by Cloudflare's
+// edge and cannot be spoofed by clients going through Cloudflare. In production,
+// requests arriving without this header are rejected fail-closed, which closes
+// the X-Forwarded-For rotation attack that was possible via the old fallback path.
 //
+// Residual limitation: an attacker who knows the origin IP and bypasses Cloudflare
+// can still manually set CF-Connecting-IP with rotating values. Closing that fully
+// requires network-level enforcement (allowlisting Cloudflare's IP ranges at the
+// origin firewall).
+//
+// In dev and stg, Cloudflare is not always in the request path, so the CF
+// requirement is not enforced and X-Forwarded-For / socket is used instead.
+//
+// Remaining known limitation:
 // - In-memory state is per-process. If Nitro runs multiple workers the
 //   effective limit is multiplied by the worker count.
-// - Without Cloudflare (or another trusted reverse proxy), the X-Forwarded-For
-//   fallback is client-controlled and trivially spoofable. Attackers can bypass
-//   the limit by varying the header value on each request.
-//
-// For production deployments, run the app behind a reverse proxy (Cloudflare,
-// Nginx, etc.) that performs its own rate limiting and sets a trusted client IP
-// header. See docs/architecture.md for deployment recommendations.
 
 /**
  * Extract the client IP from an H3 event.
  *
- * Prefers CF-Connecting-IP (set by Cloudflare, cannot be spoofed by the
- * client), falls back to X-Forwarded-For, then the raw socket address.
+ * Prefers CF-Connecting-IP (set by Cloudflare, cannot be spoofed by clients
+ * going through Cloudflare), falls back to X-Forwarded-For, then the raw
+ * socket address.
  */
 export function getClientIp(event: H3Event): string {
   const cfIp = event.node.req.headers['cf-connecting-ip']
@@ -70,8 +76,22 @@ export function createRateLimiter(config: RateLimiterConfig) {
     /**
      * Consume `cost` units from the client's rate-limit budget.
      * Throws a 429 error when the budget is exceeded.
+     * In production, throws 403 if the request did not arrive via Cloudflare.
      */
     consume(event: H3Event, cost = 1): void {
+      // In production, CF-Connecting-IP must be present. Requests that arrive
+      // without it bypassed Cloudflare entirely — reject them fail-closed.
+      // Outside production (stg, preview, dev) Cloudflare may not be in the
+      // path, so the check is skipped.
+      const cfIp = event.node.req.headers['cf-connecting-ip']
+      // Fail-closed in production when CF-Connecting-IP is absent.
+      // stg and dev are exempt: they don't always run behind Cloudflare.
+      const hasCfIp = typeof cfIp === 'string' && !!cfIp.trim()
+      if (!hasCfIp && process.env.DOPPLER_ENVIRONMENT === 'prd') {
+        console.warn('[rate-limit] Blocked: CF-Connecting-IP absent, request bypassed Cloudflare')
+        throw createError({ statusCode: 403, statusMessage: 'Forbidden' })
+      }
+
       const ip = getClientIp(event)
       const now = Date.now()
       const entry = map.get(ip)


### PR DESCRIPTION
In production, consume() now rejects requests with 403 if CF-Connecting-IP is absent, preventing attackers from bypassing per-IP rate limits by rotating the X-Forwarded-For header when accessing the origin directly. Dev and stg are exempt as they don't always run behind Cloudflare.