### PR TITLE
feat: add transaction-level warning for unverified vaults

### DIFF
--- a/components/entities/vault/VaultUnverifiedDisclaimerModal.vue
+++ b/components/entities/vault/VaultUnverifiedDisclaimerModal.vue
@@ -1,11 +1,17 @@
 <script setup lang="ts">
 const emits = defineEmits(['close'])
-const { cancelAction } = defineProps<{
-  cancelAction: () => void
+const { cancelAction, acceptAction } = defineProps<{
+  cancelAction?: () => void
+  acceptAction?: () => void
 }>()
 
+const handleAccept = () => {
+  acceptAction?.()
+  emits('close')
+}
+
 const handleCancel = () => {
-  cancelAction()
+  cancelAction?.()
   emits('close')
 }
 </script>
@@ -32,7 +38,7 @@ const handleCancel = () => {
         size="large"
         rounded
         variant="primary-stroke"
-        @click="emits('close')"
+        @click="handleAccept"
       >
         Yes
       </UiButton>

--- a/components/entities/vault/form/VaultFormSubmit.vue
+++ b/components/entities/vault/form/VaultFormSubmit.vue
@@ -6,9 +6,10 @@ import { flip, offset, shift, useFloating } from '@floating-ui/vue'
 
 import { isOperationBlocked, operationBlockReason } from '~/utils/operationGuardRegistry'
 import { useModal } from '~/components/ui/composables/useModal'
-import { AcknowledgeTermsModal } from '#components'
+import { AcknowledgeTermsModal, VaultUnverifiedDisclaimerModal } from '#components'
 import type { KeyringFlowState, CredentialData } from '~/composables/useKeyring'
 import type { TosGuardState } from '~/composables/guards/useTosGuard'
+import type { UnverifiedVaultGuardState } from '~/composables/guards/useUnverifiedVaultGuard'
 
 interface KeyringGuardState {
   needsVerification: boolean
@@ -29,6 +30,7 @@ const modal = useModal()
 
 const keyringGuard = inject<KeyringGuardState | null>('keyring-guard', null)
 const tosGuard = inject<TosGuardState | null>('tos-guard', null)
+const unverifiedVaultGuard = inject<UnverifiedVaultGuardState | null>('unverified-vault-guard', null)
 
 const reference = ref(null)
 const floating = ref(null)
@@ -85,6 +87,20 @@ const showTosFlow = computed(() =>
   !showKeyringFlow.value && tosGuard?.isTermsRequired === true && !tosGuard?.tosLoadFailed,
 )
 
+const showUnverifiedVaultFlow = computed(() =>
+  !showKeyringFlow.value && !showTosFlow.value && unverifiedVaultGuard?.isAcknowledgmentRequired === true,
+)
+
+const openUnverifiedVaultModal = () => {
+  modal.open(VaultUnverifiedDisclaimerModal, {
+    props: {
+      acceptAction: () => {
+        unverifiedVaultGuard?.acknowledgeRisk()
+      },
+    },
+  })
+}
+
 const openTermsModal = () => {
   modal.open(AcknowledgeTermsModal, {
     props: {
@@ -129,6 +145,17 @@ const openTermsModal = () => {
         @click="openTermsModal"
       >
         Accept Terms Of Use
+      </UiButton>
+    </template>
+
+    <!-- Unverified vault acknowledgment flow -->
+    <template v-else-if="showUnverifiedVaultFlow">
+      <UiButton
+        size="large"
+        variant="red"
+        @click="openUnverifiedVaultModal"
+      >
+        Acknowledge Unverified Vault Risk
       </UiButton>
     </template>
 

--- a/composables/guards/useUnverifiedVaultGuard.ts
+++ b/composables/guards/useUnverifiedVaultGuard.ts
@@ -1,0 +1,50 @@
+import { computed, provide, reactive, ref, watch, onUnmounted, type ComputedRef } from 'vue'
+import { normalizeAddress } from '~/utils/normalizeAddress'
+import { verifiedVaultAddresses, earnVaults } from '~/utils/eulerLabelsState'
+import { registerOperationBlocker, unregisterOperationBlocker } from '~/utils/operationGuardRegistry'
+
+export interface UnverifiedVaultGuardState {
+  isAcknowledgmentRequired: boolean
+  acknowledgeRisk: () => void
+}
+
+export const useUnverifiedVaultGuard = (vaultAddresses: ComputedRef<string[]>) => {
+  const { isKnownEscrowAddress } = useVaultRegistry()
+
+  const sessionAccepted = ref(false)
+
+  const hasUnverifiedVault = computed(() =>
+    vaultAddresses.value.some((addr) => {
+      const normalized = normalizeAddress(addr)
+      return !verifiedVaultAddresses.value.includes(normalized)
+        && !earnVaults.value.includes(normalized)
+        && !isKnownEscrowAddress(normalized)
+    }),
+  )
+
+  const isAcknowledgmentRequired = computed(() =>
+    hasUnverifiedVault.value && !sessionAccepted.value,
+  )
+
+  const acknowledgeRisk = () => {
+    sessionAccepted.value = true
+  }
+
+  watch(isAcknowledgmentRequired, (required) => {
+    if (required) {
+      registerOperationBlocker('unverified-vault', 'Unverified vault risk acknowledgment required')
+    }
+    else {
+      unregisterOperationBlocker('unverified-vault')
+    }
+  }, { immediate: true })
+
+  onUnmounted(() => {
+    unregisterOperationBlocker('unverified-vault')
+  })
+
+  provide('unverified-vault-guard', reactive({
+    isAcknowledgmentRequired,
+    acknowledgeRisk,
+  }))
+}

--- a/composables/useOperationGuard.ts
+++ b/composables/useOperationGuard.ts
@@ -3,6 +3,7 @@ import { useAccount, useChainId } from '@wagmi/vue'
 import type { Address } from 'viem'
 import { useKeyring, KeyringFlowState } from '~/composables/useKeyring'
 import { useTosGuard } from '~/composables/guards/useTosGuard'
+import { useUnverifiedVaultGuard } from '~/composables/guards/useUnverifiedVaultGuard'
 import { registerOperationGuard, unregisterOperationGuard, registerOperationBlocker, unregisterOperationBlocker } from '~/utils/operationGuardRegistry'
 import { injectKeyringCredential } from '~/utils/keyring-injection'
 import { isVaultKeyring } from '~/utils/eulerLabelsUtils'
@@ -18,6 +19,9 @@ export const useOperationGuard = (vaultAddresses: Ref<(string | undefined)[]> | 
 
   // --- TOS guard (global, not vault-specific) ---
   useTosGuard()
+
+  // --- Unverified vault guard ---
+  useUnverifiedVaultGuard(addresses)
 
   // --- Keyring guard ---
   const keyringVaultAddress = computed(() =>


### PR DESCRIPTION
## Summary
- Adds a transaction-level gate for unverified vaults using the existing operation guard system (same pattern as TOS signing and Keyring verification)
- When a user attempts to submit a transaction involving an unverified vault, the submit button is replaced with "Acknowledge Unverified Vault Risk" which opens the disclaimer modal
- After acknowledgment, the normal submit button appears; state resets on navigation so each page visit requires fresh acknowledgment
- Reuses the existing `VaultUnverifiedDisclaimerModal` by adding an optional `acceptAction` prop (backward-compatible with page-level usage)

## Test plan
- [x] Navigate to an unverified vault page → page-level warning shows (existing behavior unchanged)
- [x] Accept page warning, fill in form → submit button shows "Acknowledge Unverified Vault Risk" instead of normal action
- [x] Click it → disclaimer modal opens → click "Yes" → normal submit button appears
- [x] Click "Cancel" in modal → modal closes, acknowledgment button remains (no navigation)
- [x] Navigate away and back → must acknowledge again
- [x] Verified vault pages → normal flow, no extra button
- [x] Position pages with mixed verified/unverified vaults → guard triggers if any vault is unverified
- [x] Keyring and TOS flows still take priority over unverified vault flow