### PR TITLE
fix: prevent layout shift when modal removes page scrollbar

### DIFF
--- a/components/ui/composables/useModal.ts
+++ b/components/ui/composables/useModal.ts
@@ -87,7 +87,7 @@ export const useModal = () => {
       window.history.back()
     }
 
-    if (!hasModal.value) {
+    if (!list.some(item => !item.data.noLock)) {
       unlockScroll()
     }
 

--- a/components/ui/composables/useModal.ts
+++ b/components/ui/composables/useModal.ts
@@ -1,4 +1,4 @@
-import { useScrollLock, useEventBus } from '@vueuse/core'
+import { useEventBus } from '@vueuse/core'
 import type { Raw } from 'vue'
 
 export interface ModalData {
@@ -12,10 +12,27 @@ export interface ModalData {
   [key: string]: any // eslint-disable-line
 }
 
+let scrollLocked = false
+
+function lockScroll() {
+  if (scrollLocked) return
+  scrollLocked = true
+  const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth
+  document.body.style.overflow = 'hidden'
+  if (scrollbarWidth > 0) {
+    document.body.style.paddingRight = `${scrollbarWidth}px`
+  }
+}
+
+function unlockScroll() {
+  scrollLocked = false
+  document.body.style.overflow = ''
+  document.body.style.paddingRight = ''
+}
+
 let popstateHandler: EventListener | undefined
 const list: { id: number, component: Raw<Component>, data: ModalData }[] = reactive([])
 const hasModal = computed(() => list.length > 0)
-const lock = useScrollLock(document.body)
 const bus = useEventBus<string>('modal')
 
 export const useModal = () => {
@@ -45,7 +62,7 @@ export const useModal = () => {
     }
 
     if (!data.noLock) {
-      lock.value = true
+      lockScroll()
     }
 
     if (data.absolute) {
@@ -71,7 +88,7 @@ export const useModal = () => {
     }
 
     if (!hasModal.value) {
-      lock.value = false
+      unlockScroll()
     }
 
     bus.emit('close')


### PR DESCRIPTION
## Summary

- Opening a modal locks body scroll via `useScrollLock`, which removes the page scrollbar and causes all content to shift horizontally by the scrollbar width
- Replaced `useScrollLock` with a manual implementation that measures the scrollbar width before locking and applies it as `padding-right` to `document.body`
- A module-level flag prevents stacked modals from re-applying the lock, and the padding is only cleared once all modals are closed

## Test plan

- [ ] Open a modal on a page with a visible scrollbar — confirm no layout shift on open or close
- [ ] Open a modal from within a modal — confirm layout remains stable throughout
- [ ] Close inner modal while outer is open — confirm page stays locked with correct padding
- [ ] Close all modals — confirm scrollbar returns and padding is removed