### PR TITLE
feat: Redesign vault overview card layout to 2-column grid

### DIFF
--- a/components/entities/vault/overview/VaultOverviewBlockGeneral.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockGeneral.vue
@@ -52,7 +52,7 @@ watchEffect(async () => {
     <p class="text-h3 text-content-primary">
       Overview
     </p>
-    <div class="flex flex-col items-start gap-24">
+    <div class="flex flex-col gap-20">
       <div
         v-if="isDeprecated && deprecationReason"
         class="w-full rounded-12 p-16 bg-warning-100 text-warning-500"
@@ -84,97 +84,92 @@ watchEffect(async () => {
           </p>
         </div>
       </div>
-      <div
+      <!-- eslint-disable vue/no-v-html -- trusted label content -->
+      <p
         v-if="description"
-        class="w-full rounded-12 p-16 bg-surface-tertiary"
-      >
-        <!-- eslint-disable vue/no-v-html -- trusted label content -->
-        <p
-          class="text-p3 text-content-secondary auto-link"
-          v-html="autoLink(description)"
-        />
-        <!-- eslint-enable vue/no-v-html -->
-      </div>
-      <VaultOverviewLabelValue
-        label="Price"
-        :value="priceDisplay"
+        class="text-p2 text-content-secondary auto-link"
+        v-html="autoLink(description)"
       />
-      <VaultOverviewLabelValue label="Market">
-        <NuxtLink
-          v-if="marketProductKey"
-          :to="{ name: 'explore-market', params: { market: marketProductKey } }"
-          class="text-p2 text-content-primary hover:text-accent-600 underline transition-colors"
-        >
-          {{ product.name }}
-        </NuxtLink>
-        <template v-else>
-          {{ product.name || '-' }}
-        </template>
-      </VaultOverviewLabelValue>
-      <VaultOverviewLabelValue
-        v-if="enableEntityBrandingDisplay"
-        label="Risk manager"
-      >
-        <VaultTypeChip
-          v-if="!isGovernorVerified"
-          :vault="vault"
-          type="unknown"
+      <!-- eslint-enable vue/no-v-html -->
+      <div class="grid grid-cols-2 gap-x-32 gap-y-24">
+        <VaultOverviewLabelValue
+          label="Price"
+          :value="priceDisplay"
         />
-        <div
-          v-else-if="entities.length"
-          class="flex flex-col gap-16"
-        >
-          <div
-            v-for="(entity, idx) in entities"
-            :key="idx"
-            class="flex items-center gap-8"
-            :class="{ 'opacity-20': isGovernanceLimited }"
+        <VaultOverviewLabelValue label="Market">
+          <NuxtLink
+            v-if="marketProductKey"
+            :to="{ name: 'explore-market', params: { market: marketProductKey } }"
+            class="text-p2 text-content-primary hover:text-accent-600 underline transition-colors"
           >
-            <BaseAvatar
-              :label="entity.name"
-              :src="getEulerLabelEntityLogo(entity.logo)"
-            />
-            <a
-              :href="entity.url"
-              target="_blank"
-              class="text-p2 text-content-primary hover:text-accent-600 underline transition-colors"
-            >{{ entity.name }}</a>
+            {{ product.name }}
+          </NuxtLink>
+          <template v-else>
+            {{ product.name || '-' }}
+          </template>
+        </VaultOverviewLabelValue>
+        <VaultOverviewLabelValue
+          v-if="enableEntityBrandingDisplay"
+          label="Risk manager"
+        >
+          <VaultTypeChip
+            v-if="!isGovernorVerified"
+            :vault="vault"
+            type="unknown"
+            class="w-fit"
+          />
+          <div
+            v-else-if="entities.length"
+            class="flex flex-col gap-8"
+          >
+            <div
+              v-for="(entity, idx) in entities"
+              :key="idx"
+              class="flex items-center gap-8"
+              :class="{ 'opacity-20': isGovernanceLimited }"
+            >
+              <BaseAvatar
+                :label="entity.name"
+                :src="getEulerLabelEntityLogo(entity.logo)"
+              />
+              <a
+                :href="entity.url"
+                target="_blank"
+                class="text-p2 text-content-primary hover:text-accent-600 underline transition-colors"
+              >{{ entity.name }}</a>
+            </div>
+            <span
+              v-if="isGovernanceLimited"
+              class="text-p3 text-content-tertiary"
+            >Limited risk management</span>
           </div>
-          <span
-            v-if="isGovernanceLimited"
-            class="text-p3 text-content-tertiary"
-          >Limited risk management</span>
-        </div>
-        <div v-else>
-          -
-        </div>
-      </VaultOverviewLabelValue>
-      <VaultOverviewLabelValue
-        v-if="enableVaultTypeDisplay"
-        label="Vault type"
-      >
-        <VaultTypeBadges :vault-address="vault.address" />
-      </VaultOverviewLabelValue>
-      <VaultOverviewLabelValue label="Can be borrowed">
-        <div class="flex items-center gap-8">
-          <div>
+          <div v-else>
+            -
+          </div>
+        </VaultOverviewLabelValue>
+        <VaultOverviewLabelValue
+          v-if="enableVaultTypeDisplay"
+          label="Vault type"
+        >
+          <VaultTypeBadges :vault-address="vault.address" />
+        </VaultOverviewLabelValue>
+        <VaultOverviewLabelValue label="Can be borrowed">
+          <div class="flex items-center gap-8">
             <UiIcon :name="borrowCount ? 'green-tick' : 'red-cross'" />
+            <span class="text-p2 text-content-primary">
+              {{ borrowCount ? `Yes in ${borrowCount} markets` : 'No' }}
+            </span>
           </div>
-          <span class="text-p2 text-content-primary">
-            {{ borrowCount ? `Yes in ${borrowCount} markets` : 'No' }}
-          </span>
-        </div>
-      </VaultOverviewLabelValue>
-      <VaultOverviewLabelValue label="Can be used as collateral">
-        <div class="flex items-center gap-8">
-          <div>
+        </VaultOverviewLabelValue>
+        <VaultOverviewLabelValue label="Can be used as collateral">
+          <div class="flex items-center gap-8">
             <UiIcon :name="collateralCount ? 'green-tick' : 'red-cross'" />
+            <span class="text-p2 text-content-primary">
+              {{ collateralCount ? `Yes in ${collateralCount} markets` : 'No' }}
+            </span>
           </div>
-          <span class="text-p2 text-content-primary">
-            {{ collateralCount ? `Yes in ${collateralCount} markets` : 'No' }}
-          </span>
-        </div>
-      </VaultOverviewLabelValue>
+        </VaultOverviewLabelValue>
+      </div>
     </div>
   </div>
 </template>

--- a/components/entities/vault/overview/VaultOverviewPairBlockGeneral.vue
+++ b/components/entities/vault/overview/VaultOverviewPairBlockGeneral.vue
@@ -121,7 +121,7 @@ const onRampDownInfoIconClick = (event: MouseEvent, pair: LTVRampConfig) => {
     <p class="text-h3 text-content-primary">
       Overview
     </p>
-    <div class="flex flex-col items-start gap-24">
+    <div class="flex flex-col gap-20">
       <div
         v-if="isDeprecated"
         class="w-full rounded-12 p-16 bg-warning-100 text-warning-500"
@@ -150,109 +150,107 @@ const onRampDownInfoIconClick = (event: MouseEvent, pair: LTVRampConfig) => {
           </p>
         </div>
       </div>
-      <VaultOverviewLabelValue
-        label="Price"
-      >
-        <template v-if="price !== null">
-          {{ formatSignificant(priceInvert.invertValue(price), 4) }}
-          <span class="text-content-tertiary">{{ priceInvert.displaySymbol }}</span>
-          <button
-            type="button"
-            class="ml-4 text-content-tertiary hover:text-content-primary transition-colors inline-flex"
-            @click.stop="priceInvert.toggle"
-          >
-            <SvgIcon
-              name="swap-horizontal"
-              class="!w-12 !h-12"
-            />
-          </button>
-        </template>
-        <template v-else>
-          <span class="flex items-center text-warning-500">
-            <SvgIcon
-              name="warning"
-              class="mr-2 !w-20 !h-20"
-            />
-            Unknown
-          </span>
-        </template>
-      </VaultOverviewLabelValue>
-      <VaultOverviewLabelValue>
-        <template #label>
+      <div class="grid grid-cols-2 gap-x-32 gap-y-24">
+        <VaultOverviewLabelValue label="Price">
+          <template v-if="price !== null">
+            {{ formatSignificant(priceInvert.invertValue(price), 4) }}
+            <span class="text-content-tertiary">{{ priceInvert.displaySymbol }}</span>
+            <button
+              type="button"
+              class="ml-4 text-content-tertiary hover:text-content-primary transition-colors inline-flex"
+              @click.stop="priceInvert.toggle"
+            >
+              <SvgIcon
+                name="swap-horizontal"
+                class="!w-12 !h-12"
+              />
+            </button>
+          </template>
+          <template v-else>
+            <span class="flex items-center text-warning-500">
+              <SvgIcon
+                name="warning"
+                class="mr-2 !w-20 !h-20"
+              />
+              Unknown
+            </span>
+          </template>
+        </VaultOverviewLabelValue>
+        <VaultOverviewLabelValue>
+          <template #label>
+            <span class="flex items-center gap-4">
+              Net APY
+              <SvgIcon
+                class="!w-20 !h-20 text-content-muted cursor-pointer hover:text-content-secondary"
+                name="info-circle"
+                @click="onNetApyInfoIconClick"
+              />
+            </span>
+          </template>
           <span class="flex items-center gap-4">
-            Net APY
             <SvgIcon
-              class="!w-20 !h-20 text-content-muted cursor-pointer hover:text-content-secondary"
-              name="info-circle"
+              v-if="hasSupplyRewards(pair.collateral.address) || hasBorrowRewards(pair.borrow.address, pair.collateral.address) || hasLoopingRewards(pair.borrow.address, pair.collateral.address)"
+              class="!w-20 !h-20 text-accent-500 cursor-pointer"
+              name="sparks"
               @click="onNetApyInfoIconClick"
             />
+            {{ formatNumber(netApy) }}%
           </span>
-        </template>
-        <span class="flex items-center gap-4">
-          <SvgIcon
-            v-if="hasSupplyRewards(pair.collateral.address) || hasBorrowRewards(pair.borrow.address, pair.collateral.address) || hasLoopingRewards(pair.borrow.address, pair.collateral.address)"
-            class="!w-20 !h-20 text-accent-500 cursor-pointer"
-            name="sparks"
-            @click="onNetApyInfoIconClick"
-          />
-          {{ formatNumber(netApy) }}%
-        </span>
-      </VaultOverviewLabelValue>
-      <VaultOverviewLabelValue
-        v-if="isBorrowable"
-      >
-        <template #label>
+        </VaultOverviewLabelValue>
+        <VaultOverviewLabelValue v-if="isBorrowable">
+          <template #label>
+            <span class="flex items-center gap-4">
+              Max ROE
+              <SvgIcon
+                class="!w-20 !h-20 text-content-muted cursor-pointer hover:text-content-secondary"
+                name="info-circle"
+                @click="onMaxRoeInfoIconClick"
+              />
+            </span>
+          </template>
           <span class="flex items-center gap-4">
-            Max ROE
             <SvgIcon
-              class="!w-20 !h-20 text-content-muted cursor-pointer hover:text-content-secondary"
-              name="info-circle"
+              v-if="hasSupplyRewards(pair.collateral.address) || hasBorrowRewards(pair.borrow.address, pair.collateral.address) || hasLoopingRewards(pair.borrow.address, pair.collateral.address)"
+              class="!w-20 !h-20 text-accent-500 cursor-pointer"
+              name="sparks"
               @click="onMaxRoeInfoIconClick"
             />
+            {{ formatNumber(maxRoe) }}%
           </span>
-        </template>
-        <span class="flex items-center gap-4">
-          <SvgIcon
-            v-if="hasSupplyRewards(pair.collateral.address) || hasBorrowRewards(pair.borrow.address, pair.collateral.address) || hasLoopingRewards(pair.borrow.address, pair.collateral.address)"
-            class="!w-20 !h-20 text-accent-500 cursor-pointer"
-            name="sparks"
-            @click="onMaxRoeInfoIconClick"
-          />
-          {{ formatNumber(maxRoe) }}%
-        </span>
-      </VaultOverviewLabelValue>
-      <VaultOverviewLabelValue
-        v-if="isBorrowable"
-        label="Max multiplier"
-        :value="`${formatNumber(maxMultiplier, 2, 2)}x`"
-      />
-      <VaultOverviewLabelValue
-        label="Max LTV"
-        :value="`${formatNumber(nanoToValue(pair.borrowLTV, 2), 2)}%`"
-      />
-      <VaultOverviewLabelValue>
-        <template #label>
+        </VaultOverviewLabelValue>
+        <VaultOverviewLabelValue
+          v-if="isBorrowable"
+          label="Max multiplier"
+          :value="`${formatNumber(maxMultiplier, 2, 2)}x`"
+        />
+        <VaultOverviewLabelValue
+          label="Max LTV"
+          :value="`${formatNumber(nanoToValue(pair.borrowLTV, 2), 2)}%`"
+        />
+        <VaultOverviewLabelValue>
+          <template #label>
+            <span class="flex items-center gap-4">
+              Liquidation LTV
+              <SvgIcon
+                v-if="isRamping"
+                class="!w-20 !h-20 text-content-muted cursor-pointer hover:text-content-secondary"
+                name="info-circle"
+                @click.stop.prevent="onRampDownInfoIconClick($event, pair as AnyBorrowVaultPair)"
+              />
+            </span>
+          </template>
           <span class="flex items-center gap-4">
-            Liquidation LTV
             <SvgIcon
               v-if="isRamping"
-              class="!w-20 !h-20 text-content-muted cursor-pointer hover:text-content-secondary"
-              name="info-circle"
+              name="arrow-top-right"
+              class="!w-14 !h-14 text-warning-500 shrink-0 rotate-180 cursor-pointer"
+              title="Liquidation LTV ramping down"
               @click.stop.prevent="onRampDownInfoIconClick($event, pair as AnyBorrowVaultPair)"
             />
+            {{ `${formatNumber(nanoToValue(currentLiquidationLTV, 2), 2)}%` }}
           </span>
-        </template>
-        <span class="flex items-center gap-4">
-          <SvgIcon
-            v-if="isRamping"
-            name="arrow-top-right"
-            class="!w-14 !h-14 text-warning-500 shrink-0 rotate-180 cursor-pointer"
-            title="Liquidation LTV ramping down"
-            @click.stop.prevent="onRampDownInfoIconClick($event, pair as AnyBorrowVaultPair)"
-          />
-          {{ `${formatNumber(nanoToValue(currentLiquidationLTV, 2), 2)}%` }}
-        </span>
-      </VaultOverviewLabelValue>
+        </VaultOverviewLabelValue>
+      </div>
     </div>
   </div>
 </template>

--- a/components/entities/vault/overview/VaultOverviewPairBlockGeneral.vue
+++ b/components/entities/vault/overview/VaultOverviewPairBlockGeneral.vue
@@ -176,6 +176,11 @@ const onRampDownInfoIconClick = (event: MouseEvent, pair: LTVRampConfig) => {
             </span>
           </template>
         </VaultOverviewLabelValue>
+        <VaultOverviewLabelValue
+          v-if="isBorrowable"
+          label="Max multiplier"
+          :value="`${formatNumber(maxMultiplier, 2, 2)}x`"
+        />
         <VaultOverviewLabelValue>
           <template #label>
             <span class="flex items-center gap-4">
@@ -218,11 +223,6 @@ const onRampDownInfoIconClick = (event: MouseEvent, pair: LTVRampConfig) => {
             {{ formatNumber(maxRoe) }}%
           </span>
         </VaultOverviewLabelValue>
-        <VaultOverviewLabelValue
-          v-if="isBorrowable"
-          label="Max multiplier"
-          :value="`${formatNumber(maxMultiplier, 2, 2)}x`"
-        />
         <VaultOverviewLabelValue
           label="Max LTV"
           :value="`${formatNumber(nanoToValue(pair.borrowLTV, 2), 2)}%`"

--- a/components/entities/vault/overview/earn/VaultOverviewEarnBlockGeneral.vue
+++ b/components/entities/vault/overview/earn/VaultOverviewEarnBlockGeneral.vue
@@ -45,7 +45,7 @@ const feeDisplay = computed(() => {
     <p class="text-h3 text-content-primary">
       Overview
     </p>
-    <div class="flex flex-col items-start gap-24">
+    <div class="flex flex-col gap-20">
       <div
         v-if="isDeprecated && deprecationReason"
         class="w-full rounded-12 p-16 bg-warning-100 text-warning-500"
@@ -77,72 +77,65 @@ const feeDisplay = computed(() => {
           </p>
         </div>
       </div>
-      <div
+      <!-- eslint-disable vue/no-v-html -- trusted label content -->
+      <p
         v-if="earnDescription"
-        class="w-full rounded-12 p-16 bg-surface-tertiary"
-      >
-        <!-- eslint-disable vue/no-v-html -- trusted label content -->
-        <p
-          class="text-p3 text-content-secondary auto-link"
-          v-html="autoLink(earnDescription)"
-        />
-        <!-- eslint-enable vue/no-v-html -->
-      </div>
-      <div
+        class="text-p2 text-content-secondary auto-link"
+        v-html="autoLink(earnDescription)"
+      />
+      <p
         v-if="product.description"
-        class="w-full rounded-12 p-16 bg-surface-tertiary"
-      >
-        <!-- eslint-disable vue/no-v-html -- trusted label content -->
-        <p
-          class="text-p3 text-content-secondary auto-link"
-          v-html="autoLink(product.description)"
+        class="text-p2 text-content-secondary auto-link"
+        v-html="autoLink(product.description)"
+      />
+      <!-- eslint-enable vue/no-v-html -->
+      <div class="grid grid-cols-2 gap-x-32 gap-y-24">
+        <VaultOverviewLabelValue
+          label="Price"
+          :value="priceDisplay"
         />
-        <!-- eslint-enable vue/no-v-html -->
-      </div>
-      <VaultOverviewLabelValue
-        label="Price"
-        :value="priceDisplay"
-      />
-      <VaultOverviewLabelValue
-        label="Performance fee"
-        :value="feeDisplay"
-      />
-      <VaultOverviewLabelValue
-        v-if="enableEntityBrandingDisplay"
-        label="Capital allocator"
-      >
-        <div
-          v-if="entities.length && isOwnerVerified"
-          class="flex flex-col gap-16"
+        <VaultOverviewLabelValue
+          label="Performance fee"
+          :value="feeDisplay"
+        />
+        <VaultOverviewLabelValue
+          v-if="enableEntityBrandingDisplay"
+          label="Capital allocator"
         >
           <div
-            v-for="(entity, idx) in entities"
-            :key="idx"
-            class="flex items-center gap-8"
+            v-if="entities.length && isOwnerVerified"
+            class="flex flex-col gap-8"
           >
-            <BaseAvatar
-              :label="entity.name"
-              :src="getEulerLabelEntityLogo(entity.logo)"
-            />
-            <a
-              :href="entity.url"
-              target="_blank"
-              class="text-p2 text-neutral-800 hover:text-accent-600 underline transition-colors"
-            >{{ entity.name }}</a>
+            <div
+              v-for="(entity, idx) in entities"
+              :key="idx"
+              class="flex items-center gap-8"
+            >
+              <BaseAvatar
+                :label="entity.name"
+                :src="getEulerLabelEntityLogo(entity.logo)"
+              />
+              <a
+                :href="entity.url"
+                target="_blank"
+                class="text-p2 text-neutral-800 hover:text-accent-600 underline transition-colors"
+              >{{ entity.name }}</a>
+            </div>
           </div>
-        </div>
-        <VaultTypeChip
-          v-else
-          :vault="vault"
-          type="unknown"
-        />
-      </VaultOverviewLabelValue>
-      <VaultOverviewLabelValue
-        v-if="enableVaultTypeDisplay"
-        label="Vault type"
-      >
-        <VaultTypeBadges :vault-address="vault.address" />
-      </VaultOverviewLabelValue>
+          <VaultTypeChip
+            v-else
+            :vault="vault"
+            type="unknown"
+            class="w-fit"
+          />
+        </VaultOverviewLabelValue>
+        <VaultOverviewLabelValue
+          v-if="enableVaultTypeDisplay"
+          label="Vault type"
+        >
+          <VaultTypeBadges :vault-address="vault.address" />
+        </VaultOverviewLabelValue>
+      </div>
     </div>
   </div>
 </template>


### PR DESCRIPTION
## Summary
- The overview card on vault detail pages rendered all metadata fields as a single vertical list, making the card disproportionately tall relative to the rest of the page
- Vault descriptions were wrapped in a styled box (`bg-surface-tertiary`) inside an already-padded card, creating a visual box-within-a-box that looked misaligned
- Fields are now displayed in a 2-column CSS grid, halving the vertical footprint and giving the card a layout clearly distinct from the single-column Statistics and Risk parameters blocks below it

## Changes
- Description text rendered as a plain `text-p2` paragraph instead of a boxed `text-p3` element — removes the redundant visual container and increases legibility
- `VaultOverviewBlockGeneral`, `VaultOverviewPairBlockGeneral`, and `VaultOverviewEarnBlockGeneral` all updated consistently
- `VaultTypeChip` in the unknown risk manager / capital allocator state gains `w-fit` to prevent it stretching to fill the full grid cell
- The overview modal (used on mobile below the `laptop` breakpoint) is not affected by the grid change since the layout collapses to single-column before the modal is ever reachable

## Test plan
- [ ] Lend vault detail page (`/lend/[vault]`) — overview card shows 2-column grid, description renders as plain text above it
- [ ] Borrow pair detail page (`/borrow/[collateral]/[borrow]`) — pair overview card shows 2-column grid
- [ ] Earn vault detail page (`/earn/[vault]`) — earn overview card shows 2-column grid
- [ ] Vault with unknown/unverified risk manager — `Unknown` chip does not stretch full cell width
- [ ] Vault with a deprecation or geo-restriction warning — warning banner still renders full-width above the grid
- [ ] Vault with no description — grid renders without gap above it

Lend before/after
<img width="634" height="719" alt="Overview" src="https://github.com/user-attachments/assets/75eab9dc-acd4-4eba-9f13-0fb1c471b120" />
<img width="698" height="480" alt="Sentora Ondo Global Markets" src="https://github.com/user-attachments/assets/2f2a6ea1-385c-47a8-a7e0-9adb1a08e328" />

Earn before/after
<img width="688" height="470" alt="Euler Earn USDT" src="https://github.com/user-attachments/assets/60623dc6-029b-4700-a4ed-080f16fc9acc" />
<img width="678" height="344" alt="Euler Eam USDT" src="https://github.com/user-attachments/assets/7ad19060-613a-4772-8d42-bb70aef3cfa2" />

Borrow before/after
<img width="672" height="658" alt="Sentora Ondo Global Markets" src="https://github.com/user-attachments/assets/da55cdc9-549f-489c-92dc-ea90705f8ea5" />
<img width="691" height="449" alt="Sentora Ondo Global Markets" src="https://github.com/user-attachments/assets/6526e8ff-539e-4ca6-a792-3e4f3a33ba0c" />
