### PR TITLE
Feat/Add branded scrollbar styling for dark mode

### DIFF
--- a/assets/styles/main.scss
+++ b/assets/styles/main.scss
@@ -14,32 +14,11 @@ html {
 
 // Page-level scrollbar — dark mode only, light mode uses browser default
 html[data-theme="dark"] {
-  scrollbar-width: auto;
   scrollbar-color: var(--neutral-400) var(--neutral-200);
 
   &::-webkit-scrollbar {
     width: 10px;
     height: 10px;
-  }
-
-  &::-webkit-scrollbar-thumb {
-    background-color: var(--neutral-400);
-    border-radius: 9999px;
-  }
-
-  &::-webkit-scrollbar-track {
-    background-color: var(--neutral-200);
-  }
-}
-
-// In-app slim scrollbar utility — dark mode only
-html[data-theme="dark"] .scroll-slim {
-  scrollbar-width: thin;
-  scrollbar-color: var(--neutral-400) var(--neutral-200);
-
-  &::-webkit-scrollbar {
-    width: 6px;
-    height: 6px;
   }
 
   &::-webkit-scrollbar-thumb {

--- a/assets/styles/main.scss
+++ b/assets/styles/main.scss
@@ -9,6 +9,47 @@ html {
   &.rtl {
     direction: rtl;
   }
+
+}
+
+// Page-level scrollbar — dark mode only, light mode uses browser default
+html[data-theme="dark"] {
+  scrollbar-width: auto;
+  scrollbar-color: var(--neutral-400) var(--neutral-200);
+
+  &::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background-color: var(--neutral-400);
+    border-radius: 9999px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background-color: var(--neutral-200);
+  }
+}
+
+// In-app slim scrollbar utility — dark mode only
+html[data-theme="dark"] .scroll-slim {
+  scrollbar-width: thin;
+  scrollbar-color: var(--neutral-400) var(--neutral-200);
+
+  &::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background-color: var(--neutral-400);
+    border-radius: 9999px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background-color: var(--neutral-200);
+  }
 }
 
 body {


### PR DESCRIPTION
## Summary
- The browser's default scrollbar in dark mode uses system colours that don't match the app's dark palette, making it visually inconsistent
- Adds custom scrollbar styling scoped to `html[data-theme="dark"]` so dark mode gets a on-brand scrollbar while light mode keeps the native browser default, which looks correct against light backgrounds

## Changes
- Scoped to `html[data-theme="dark"]` to avoid overriding the light mode scrollbar, which looks fine as-is
- Uses existing `--neutral-400` (thumb) and `--neutral-200` (track) tokens, which resolve to `#435971` and `#10263e` in dark mode — matching the palette used in the protocol monorepo's scrollbar component
- `scrollbar-color` handles Firefox; `::-webkit-scrollbar` rules handle Chromium/Safari
- The 10px width is consistent with the monorepo's `normal` size variant

## Test plan
- [ ] Switch to dark mode — page scrollbar should show branded dark blue-grey thumb and track
- [ ] Switch to light mode — page scrollbar should revert to the browser/OS default
- [ ] Open a modal in dark mode — no layout shift (modal scroll-lock compensation in `useModal.ts` already handles non-zero scrollbar widths)
- [ ] Check Firefox and Chrome/Safari — both should render the styled scrollbar in dark mode
