### PR TITLE
fix: upgrade Docker base images to Node 24 LTS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ── Build stage 
-FROM node:20.12.2 AS builder
+FROM node:24.14.1 AS builder
 
 WORKDIR /usr/src/app
 COPY package.json package-lock.json ./
@@ -11,7 +11,7 @@ RUN npm run build
 RUN (curl -Ls --tlsv1.2 --proto "=https" --retry 3 https://cli.doppler.com/install.sh || wget -t 3 -qO- https://cli.doppler.com/install.sh) | sh -s -- --no-package-manager --no-install
 
 # ── Production stage (distroless: no shell, no tools, non-root) ──
-FROM gcr.io/distroless/nodejs20-debian12:nonroot AS production
+FROM gcr.io/distroless/nodejs24-debian12:nonroot AS production
 
 ENV MODE=production
 ENV NODE_ENV=production


### PR DESCRIPTION
## Summary
- Node 20.12.2 reaches end-of-life April 30, 2026 and shipped with npm 10, which fails to run `npm ci` against lockfiles generated by npm 11
- Node 24 (Active LTS, "Krypton") ships with npm 11.11.0 bundled, resolving the `npm ERR! Invalid Version` failure during `npm ci` without any additional package manager installation step

## Changes
- Builder updated from `node:20.12.2` to `node:24.14.1` — no `npm install -g` needed since npm 11 is bundled in the image, avoiding an external registry call at build time
- Production runtime updated from `gcr.io/distroless/nodejs20-debian12:nonroot` to `gcr.io/distroless/nodejs24-debian12:nonroot` to keep builder and runtime Node versions aligned

## Test plan
- [ ] Railway preview deployment builds successfully
- [ ] App boots and `/api/tenderly/status` healthcheck passes in the preview environment