### PR TITLE
fix: parallelize Pyth getUpdateFee calls and prevent portfolio interval leak

### DIFF
--- a/composables/useEulerAccount.ts
+++ b/composables/useEulerAccount.ts
@@ -159,7 +159,9 @@ export const useEulerAccount = () => {
     lensAddresses: EulerLensAddresses,
     walletAddress: string,
   ) => {
-    if (fetchInProgress) return
+    if (fetchInProgress) {
+      return
+    }
     fetchInProgress = true
     try {
       const gen = positionGuard.current()

--- a/pages/portfolio.vue
+++ b/pages/portfolio.vue
@@ -70,6 +70,7 @@ onActivated(async () => {
   checkTab()
   await updateBalances()
   updatePositions()
+  if (interval.value) clearInterval(interval.value)
   interval.value = setInterval(updatePositions, POLL_INTERVAL_30S_MS)
 })
 onDeactivated(() => {

--- a/server/api/intrinsic-apy/[provider].get.ts
+++ b/server/api/intrinsic-apy/[provider].get.ts
@@ -109,7 +109,9 @@ export default defineEventHandler(async (event) => {
   }
 
   const fresh = cache.get(cacheKey)
-  if (fresh !== undefined) return fresh
+  if (fresh !== undefined) {
+    return fresh
+  }
 
   const stale = cache.getStale(cacheKey)
   if (stale !== undefined) {

--- a/server/api/oracle-adapter.get.ts
+++ b/server/api/oracle-adapter.get.ts
@@ -43,7 +43,9 @@ export default defineEventHandler(async (event) => {
   const key = `${chainId}:${address.toLowerCase()}`
 
   const cached = cache.get(key)
-  if (cached !== undefined) return cached
+  if (cached !== undefined) {
+    return cached
+  }
 
   try {
     const resp = await fetchWithTimeout(getUpstreamUrl(chainId, address), TIMEOUT_MS)

--- a/utils/pyth.ts
+++ b/utils/pyth.ts
@@ -280,39 +280,48 @@ export const buildPythUpdateCallsFromFeeds = async (
   })
 
   const client = getPublicClient(providerUrl)
+
+  const settled = await Promise.all(
+    [...grouped.values()].map(async ({ pythAddress, feedIds: feedSet }) => {
+      const updateData = await fetchPythUpdateData([...feedSet], hermesEndpoint)
+      if (!updateData.length) return null
+
+      let fee = 0n
+      try {
+        fee = await client.readContract({
+          address: pythAddress,
+          abi: PYTH_ABI,
+          functionName: 'getUpdateFee',
+          args: [updateData],
+        }) as bigint
+      }
+      catch (err) {
+        console.warn('[buildPythUpdateCalls] getUpdateFee failed', err)
+        return null
+      }
+
+      return {
+        call: {
+          targetContract: pythAddress,
+          onBehalfOfAccount: sender,
+          value: fee,
+          data: encodeFunctionData({
+            abi: PYTH_ABI,
+            functionName: 'updatePriceFeeds',
+            args: [updateData],
+          }) as Hex,
+        } satisfies EVCCall,
+        fee,
+      }
+    }),
+  )
+
   const calls: EVCCall[] = []
   let totalFee = 0n
-
-  for (const [, { pythAddress, feedIds: feedSet }] of grouped.entries()) {
-    const updateData = await fetchPythUpdateData([...feedSet], hermesEndpoint)
-    if (!updateData.length) continue
-
-    let fee = 0n
-    try {
-      fee = await client.readContract({
-        address: pythAddress,
-        abi: PYTH_ABI,
-        functionName: 'getUpdateFee',
-        args: [updateData],
-      }) as bigint
-    }
-    catch (err) {
-      console.warn('[buildPythUpdateCalls] getUpdateFee failed', err)
-      continue
-    }
-
-    calls.push({
-      targetContract: pythAddress,
-      onBehalfOfAccount: sender,
-      value: fee,
-      data: encodeFunctionData({
-        abi: PYTH_ABI,
-        functionName: 'updatePriceFeeds',
-        args: [updateData],
-      }) as Hex,
-    })
-
-    totalFee += fee
+  for (const result of settled) {
+    if (!result) continue
+    calls.push(result.call)
+    totalFee += result.fee
   }
 
   return { calls, totalFee }
@@ -417,38 +426,48 @@ export const buildPythBatchItems = async (
   })
 
   const client = getPublicClient(providerUrl)
+
+  const settled = await Promise.all(
+    [...grouped.entries()].map(async ([pythAddress, feedSet]) => {
+      const updateData = await fetchPythUpdateData([...feedSet], hermesEndpoint)
+      if (!updateData.length) return null
+
+      let fee = 0n
+      try {
+        fee = await client.readContract({
+          address: pythAddress,
+          abi: PYTH_ABI,
+          functionName: 'getUpdateFee',
+          args: [updateData],
+        }) as bigint
+      }
+      catch (err) {
+        console.warn('[buildPythBatchItems] getUpdateFee failed', err)
+        return null
+      }
+
+      return {
+        item: {
+          targetContract: pythAddress,
+          onBehalfOfAccount: zeroAddress,
+          value: fee,
+          data: encodeFunctionData({
+            abi: PYTH_ABI,
+            functionName: 'updatePriceFeeds',
+            args: [updateData],
+          }),
+        } satisfies BatchItem,
+        fee,
+      }
+    }),
+  )
+
   const items: BatchItem[] = []
   let totalFee = 0n
-
-  for (const [pythAddress, feedSet] of grouped.entries()) {
-    const updateData = await fetchPythUpdateData([...feedSet], hermesEndpoint)
-    if (!updateData.length) continue
-
-    let fee = 0n
-    try {
-      fee = await client.readContract({
-        address: pythAddress,
-        abi: PYTH_ABI,
-        functionName: 'getUpdateFee',
-        args: [updateData],
-      }) as bigint
-    }
-    catch (err) {
-      console.warn('[buildPythBatchItems] getUpdateFee failed', err)
-      continue
-    }
-
-    items.push({
-      targetContract: pythAddress,
-      onBehalfOfAccount: zeroAddress,
-      value: fee,
-      data: encodeFunctionData({
-        abi: PYTH_ABI,
-        functionName: 'updatePriceFeeds',
-        args: [updateData],
-      }),
-    })
-    totalFee += fee
+  for (const result of settled) {
+    if (!result) continue
+    items.push(result.item)
+    totalFee += result.fee
   }
 
   return { items, totalFee }
@@ -482,38 +501,48 @@ export const buildPythBatchItemsFromFeeds = async (
   })
 
   const client = getPublicClient(providerUrl)
+
+  const settled = await Promise.all(
+    [...grouped.entries()].map(async ([pythAddress, feedSet]) => {
+      const updateData = await fetchPythUpdateData([...feedSet], hermesEndpoint)
+      if (!updateData.length) return null
+
+      let fee = 0n
+      try {
+        fee = await client.readContract({
+          address: pythAddress,
+          abi: PYTH_ABI,
+          functionName: 'getUpdateFee',
+          args: [updateData],
+        }) as bigint
+      }
+      catch (err) {
+        console.warn('[buildPythBatchItemsFromFeeds] getUpdateFee failed', err)
+        return null
+      }
+
+      return {
+        item: {
+          targetContract: pythAddress,
+          onBehalfOfAccount: zeroAddress,
+          value: fee,
+          data: encodeFunctionData({
+            abi: PYTH_ABI,
+            functionName: 'updatePriceFeeds',
+            args: [updateData],
+          }),
+        } satisfies BatchItem,
+        fee,
+      }
+    }),
+  )
+
   const items: BatchItem[] = []
   let totalFee = 0n
-
-  for (const [pythAddress, feedSet] of grouped.entries()) {
-    const updateData = await fetchPythUpdateData([...feedSet], hermesEndpoint)
-    if (!updateData.length) continue
-
-    let fee = 0n
-    try {
-      fee = await client.readContract({
-        address: pythAddress,
-        abi: PYTH_ABI,
-        functionName: 'getUpdateFee',
-        args: [updateData],
-      }) as bigint
-    }
-    catch (err) {
-      console.warn('[buildPythBatchItemsFromFeeds] getUpdateFee failed', err)
-      continue
-    }
-
-    items.push({
-      targetContract: pythAddress,
-      onBehalfOfAccount: zeroAddress,
-      value: fee,
-      data: encodeFunctionData({
-        abi: PYTH_ABI,
-        functionName: 'updatePriceFeeds',
-        args: [updateData],
-      }),
-    })
-    totalFee += fee
+  for (const result of settled) {
+    if (!result) continue
+    items.push(result.item)
+    totalFee += result.fee
   }
 
   return { items, totalFee }

--- a/utils/pyth.ts
+++ b/utils/pyth.ts
@@ -296,7 +296,7 @@ export const buildPythUpdateCallsFromFeeds = async (
         }) as bigint
       }
       catch (err) {
-        console.warn('[buildPythUpdateCalls] getUpdateFee failed', err)
+        logWarn('[buildPythUpdateCalls] getUpdateFee failed', err)
         return null
       }
 
@@ -442,7 +442,7 @@ export const buildPythBatchItems = async (
         }) as bigint
       }
       catch (err) {
-        console.warn('[buildPythBatchItems] getUpdateFee failed', err)
+        logWarn('[buildPythBatchItems] getUpdateFee failed', err)
         return null
       }
 
@@ -517,7 +517,7 @@ export const buildPythBatchItemsFromFeeds = async (
         }) as bigint
       }
       catch (err) {
-        console.warn('[buildPythBatchItemsFromFeeds] getUpdateFee failed', err)
+        logWarn('[buildPythBatchItemsFromFeeds] getUpdateFee failed', err)
         return null
       }
 


### PR DESCRIPTION
Sequential for-of loops in buildPythUpdateCallsFromFeeds, buildPythBatchItems, and buildPythBatchItemsFromFeeds awaited each fetchPythUpdateData + getUpdateFee call one at a time, producing N sequential RPC requests to the proxied /api/rpc endpoint during transaction building.

Switch to Promise.all so all fetches and readContract calls fire concurrently, coalescing into a single batched eth_call via viem's 100ms batch window.

Also fixes a leaked setInterval in portfolio.vue where onActivated fires twice on hydration — the second call overwrote interval.value without clearing the first timer, causing a permanent duplicate 30s polling loop.