### PR TITLE
fix: clear existing interval before setting new one in portfolio onActivated

### DIFF
--- a/pages/portfolio.vue
+++ b/pages/portfolio.vue
@@ -70,6 +70,7 @@ onActivated(async () => {
   checkTab()
   await updateBalances()
   updatePositions()
+  if (interval.value) clearInterval(interval.value)
   interval.value = setInterval(updatePositions, POLL_INTERVAL_30S_MS)
 })
 onDeactivated(() => {


### PR DESCRIPTION
onActivated fires twice on hydration — once during server render and once on client mount. The second call overwrote interval.value without clearing the first timer, leaking a permanent duplicate 30s polling loop for the session.