### PR TITLE
feat: add oracle checks display to borrow pair oracle section

### DIFF
--- a/components/entities/vault/overview/VaultOverviewBlockOracleAdapters.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockOracleAdapters.vue
@@ -100,6 +100,9 @@ const adapterViews = computed(() => adapters.value.map((adapter) => {
     provider,
     methodology: meta?.methodology || (isERC4626 ? 'Exchange Rate' : undefined),
     logo: getOracleProviderLogo(provider, name),
+    label: meta?.label
+      ? { primary: meta.label.split('(')[0].trimEnd(), suffix: meta.label.includes('(') ? meta.label.slice(meta.label.indexOf('(')).trim() : undefined }
+      : undefined,
     checks,
     checksStatus: getChecksStatus(checks),
     failedChecks: checks?.filter(c => !c.pass) ?? [],
@@ -306,27 +309,38 @@ const onTooltipMouseLeave = () => {
         :key="getAdapterKey(adapter)"
         class="w-full rounded-xl bg-surface p-16 flex flex-col gap-12 border border-line-subtle"
       >
-        <div class="flex flex-wrap items-center gap-8">
+        <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-4 sm:gap-8">
           <div class="p2 text-content-primary">
-            {{ resolveSymbol(adapter.base) }}/{{ resolveSymbol(adapter.quote) }}
+            <template v-if="adapter.label">
+              {{ adapter.label.primary }}
+              <span
+                v-if="adapter.label.suffix"
+                class="text-content-tertiary ml-2"
+              >{{ adapter.label.suffix }}</span>
+            </template>
+            <template v-else>
+              {{ resolveSymbol(adapter.base) }}/{{ resolveSymbol(adapter.quote) }}
+            </template>
           </div>
-          <NuxtLink
-            :to="getExplorerAddressLink(adapter.oracle)"
-            class="text-accent-600 underline cursor-pointer hover:text-accent-500"
-            target="_blank"
-          >
-            {{ shortenAddress(adapter.oracle) }}
-          </NuxtLink>
-          <button
-            :class="$style.copyBtn"
-            class="text-content-muted"
-            @click="onCopyClick(adapter.oracle)"
-          >
-            <SvgIcon
-              class="!w-18 !h-18"
-              name="copy"
-            />
-          </button>
+          <div class="flex items-center gap-8 flex-shrink-0">
+            <NuxtLink
+              :to="getExplorerAddressLink(adapter.oracle)"
+              class="text-accent-600 underline cursor-pointer hover:text-accent-500"
+              target="_blank"
+            >
+              {{ shortenAddress(adapter.oracle) }}
+            </NuxtLink>
+            <button
+              :class="$style.copyBtn"
+              class="text-content-muted"
+              @click="onCopyClick(adapter.oracle)"
+            >
+              <SvgIcon
+                class="!w-18 !h-18"
+                name="copy"
+              />
+            </button>
+          </div>
         </div>
         <div class="grid grid-cols-2 md:grid-cols-4 gap-12 text-p3">
           <div class="flex flex-col gap-4">
@@ -352,9 +366,13 @@ const onTooltipMouseLeave = () => {
           </div>
           <div
             class="flex flex-col gap-4 order-4 md:order-3"
+            :role="isMobile && adapter.checks?.length ? 'button' : undefined"
+            :tabindex="isMobile && adapter.checks?.length ? 0 : undefined"
             @mouseenter="onChecksMouseEnter(adapter, $event)"
             @mouseleave="onChecksMouseLeave"
             @click.stop="onChecksClick(adapter)"
+            @keydown.enter.stop="onChecksClick(adapter)"
+            @keydown.space.stop.prevent="onChecksClick(adapter)"
           >
             <span class="text-content-tertiary">Checks</span>
             <span
@@ -410,8 +428,8 @@ const onTooltipMouseLeave = () => {
           class="flex flex-col gap-6 border-t border-line-subtle pt-12 text-p3"
         >
           <div
-            v-for="check in adapter.failedChecks"
-            :key="check.id"
+            v-for="(check, i) in adapter.failedChecks"
+            :key="`${check.id}-${i}`"
             class="flex items-start gap-8"
           >
             <SvgIcon
@@ -481,13 +499,17 @@ const onTooltipMouseLeave = () => {
           @touchcancel="onScrollTouchCancel"
         >
           <div
-            v-for="check in hoveredChecksAdapter.checks"
-            :key="check.id"
+            v-for="(check, i) in hoveredChecksAdapter.checks"
+            :key="`${check.id}-${i}`"
             class="flex items-start gap-10"
           >
             <span
               class="flex-shrink-0 w-20 h-20 rounded-full flex items-center justify-center mt-8"
-              :class="check.pass ? 'bg-success-500' : 'bg-error-500'"
+              :class="{
+                'bg-success-500': check.pass,
+                'bg-error-500': !check.pass && check.severity === OracleAdapterCheckSeverity.High,
+                'bg-warning-500': !check.pass && check.severity !== OracleAdapterCheckSeverity.High,
+              }"
             >
               <SvgIcon
                 :name="check.pass ? 'check' : 'x'"

--- a/components/entities/vault/overview/VaultOverviewBlockOracleAdapters.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockOracleAdapters.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
+import type { CSSProperties } from 'vue'
 import type { Address } from 'viem'
 import type { Vault, SecuritizeVault } from '~/entities/vault'
-import { collectOracleAdapters, type OracleAdapterEntry, type OracleAdapterMeta } from '~/entities/oracle'
+import { collectOracleAdapters, getChecksStatus, OracleAdapterCheckSeverity, type OracleAdapterEntry, type OracleAdapterMeta } from '~/entities/oracle'
 import { getOracleProviderLogo } from '~/entities/oracle-providers'
 import { getExplorerLink } from '~/utils/block-explorer'
 import { formatNumber } from '~/utils/string-utils'
@@ -91,6 +92,7 @@ const adapterViews = computed(() => adapters.value.map((adapter) => {
   const isERC4626 = adapter.name === 'ERC4626Vault'
   const provider = meta?.provider || adapter.name
   const name = meta?.name || adapter.name
+  const checks = meta?.checks
 
   return {
     ...adapter,
@@ -98,6 +100,9 @@ const adapterViews = computed(() => adapters.value.map((adapter) => {
     provider,
     methodology: meta?.methodology || (isERC4626 ? 'Exchange Rate' : undefined),
     logo: getOracleProviderLogo(provider, name),
+    checks,
+    checksStatus: getChecksStatus(checks),
+    failedChecks: checks?.filter(c => !c.pass) ?? [],
   }
 }))
 
@@ -141,6 +146,45 @@ const formatAdapterPrice = (adapter: OracleAdapterEntry) => {
   const info = adapterPrices.value.get(key)
   if (!info?.success) return '-'
   return formatNumber(info.rate, 4)
+}
+
+const hoveredChecksAdapter = ref<(typeof adapterViews.value)[0] | null>(null)
+const tooltipStyle = ref<CSSProperties>({})
+const TOOLTIP_WIDTH = 520
+let hideTimer: ReturnType<typeof setTimeout> | null = null
+
+const onChecksMouseEnter = (adapter: (typeof adapterViews.value)[0], event: MouseEvent) => {
+  if (!adapter.checks?.length) return
+  if (hideTimer) {
+    clearTimeout(hideTimer)
+    hideTimer = null
+  }
+  const rect = (event.currentTarget as HTMLElement).getBoundingClientRect()
+  const left = Math.min(rect.left, window.innerWidth - TOOLTIP_WIDTH - 16)
+  const spaceBelow = window.innerHeight - rect.bottom - 16
+  const spaceAbove = rect.top - 16
+  const flipUp = spaceAbove > spaceBelow
+  tooltipStyle.value = flipUp
+    ? { top: `${rect.top - 8}px`, left: `${left}px`, transform: 'translateY(-100%)', maxHeight: `${spaceAbove}px` }
+    : { top: `${rect.bottom + 8}px`, left: `${left}px`, transform: 'none', maxHeight: `${spaceBelow}px` }
+  hoveredChecksAdapter.value = adapter
+}
+
+const onChecksMouseLeave = () => {
+  hideTimer = setTimeout(() => {
+    hoveredChecksAdapter.value = null
+  }, 150)
+}
+
+const onTooltipMouseEnter = () => {
+  if (hideTimer) {
+    clearTimeout(hideTimer)
+    hideTimer = null
+  }
+}
+
+const onTooltipMouseLeave = () => {
+  hoveredChecksAdapter.value = null
 }
 </script>
 
@@ -186,7 +230,7 @@ const formatAdapterPrice = (adapter: OracleAdapterEntry) => {
             />
           </button>
         </div>
-        <div class="grid grid-cols-3 gap-12 text-p4">
+        <div class="grid grid-cols-4 gap-12 text-p3">
           <div class="flex flex-col gap-4">
             <span class="text-content-tertiary">Provider</span>
             <div class="flex items-center gap-8">
@@ -207,6 +251,38 @@ const formatAdapterPrice = (adapter: OracleAdapterEntry) => {
           <div class="flex flex-col gap-4">
             <span class="text-content-tertiary">Methodology</span>
             <span class="text-content-primary">{{ adapter.methodology || 'Unknown' }}</span>
+          </div>
+          <div
+            class="flex flex-col gap-4"
+            @mouseenter="onChecksMouseEnter(adapter, $event)"
+            @mouseleave="onChecksMouseLeave"
+          >
+            <span class="text-content-tertiary">Checks</span>
+            <span
+              v-if="!adapter.checks?.length"
+              class="text-content-secondary"
+            >N/A</span>
+            <span
+              v-else
+              class="flex items-center gap-6 cursor-default"
+            >
+              <span
+                class="inline-block w-8 h-8 rounded-full flex-shrink-0"
+                :class="{
+                  'bg-success-500': adapter.checksStatus === 'positive',
+                  'bg-warning-500': adapter.checksStatus === 'warning',
+                  'bg-error-500': adapter.checksStatus === 'negative',
+                }"
+              />
+              <span class="text-content-primary">
+                <template v-if="adapter.checksStatus === 'positive'">
+                  {{ adapter.checks.length }} passed
+                </template>
+                <template v-else>
+                  {{ adapter.failedChecks.length }} failed
+                </template>
+              </span>
+            </span>
           </div>
           <div class="flex flex-col gap-4">
             <span class="text-content-tertiary">Price</span>
@@ -230,9 +306,71 @@ const formatAdapterPrice = (adapter: OracleAdapterEntry) => {
             >{{ formatAdapterPrice(adapter) }}</span>
           </div>
         </div>
+        <div
+          v-if="adapter.failedChecks.length"
+          class="flex flex-col gap-6 border-t border-line-subtle pt-12 text-p3"
+        >
+          <div
+            v-for="check in adapter.failedChecks"
+            :key="check.id"
+            class="flex items-start gap-8"
+          >
+            <SvgIcon
+              name="warning"
+              class="!w-16 !h-16 mt-1 flex-shrink-0"
+              :class="{
+                'text-error-500': check.severity === OracleAdapterCheckSeverity.High,
+                'text-warning-500': check.severity !== OracleAdapterCheckSeverity.High,
+              }"
+            />
+            <div>
+              <span class="text-content-primary font-medium">{{ check.id }}: </span>
+              <span class="text-content-secondary">{{ check.message }}</span>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </div>
+
+  <Teleport to="body">
+    <div
+      v-if="hoveredChecksAdapter?.checks?.length"
+      class="fixed z-[9999] bg-surface-secondary rounded-xl p-16 shadow-card border border-line-subtle overflow-y-auto overflow-x-hidden"
+      :style="[tooltipStyle, { width: `${TOOLTIP_WIDTH}px` }]"
+      @mouseenter="onTooltipMouseEnter"
+      @mouseleave="onTooltipMouseLeave"
+    >
+      <p class="text-p3 font-medium text-content-primary mb-12">
+        Checks
+      </p>
+      <div class="flex flex-col gap-10">
+        <div
+          v-for="check in hoveredChecksAdapter.checks"
+          :key="check.id"
+          class="flex items-start gap-10"
+        >
+          <span
+            class="flex-shrink-0 w-20 h-20 rounded-full flex items-center justify-center mt-8"
+            :class="check.pass ? 'bg-success-500' : 'bg-error-500'"
+          >
+            <SvgIcon
+              :name="check.pass ? 'check' : 'x'"
+              class="!w-10 !h-10 text-white"
+            />
+          </span>
+          <div>
+            <p class="text-p3 font-medium text-content-primary">
+              {{ check.id }}
+            </p>
+            <p class="text-p3 text-content-secondary break-words">
+              {{ check.message }}
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </Teleport>
 </template>
 
 <style module lang="scss">

--- a/components/entities/vault/overview/VaultOverviewBlockOracleAdapters.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockOracleAdapters.vue
@@ -152,12 +152,106 @@ const hoveredChecksAdapter = ref<(typeof adapterViews.value)[0] | null>(null)
 const tooltipStyle = ref<CSSProperties>({})
 const TOOLTIP_WIDTH = 520
 let hideTimer: ReturnType<typeof setTimeout> | null = null
+
+const isMobile = ref(false)
+const updateIsMobile = () => {
+  isMobile.value = window.innerWidth < 768
+}
+onMounted(() => {
+  updateIsMobile()
+  window.addEventListener('resize', updateIsMobile)
+})
 onUnmounted(() => {
+  window.removeEventListener('resize', updateIsMobile)
   if (hideTimer) clearTimeout(hideTimer)
 })
 
+// ── Bottom sheet swipe-to-close (mirrors BaseModalWrapper) ───────────────────
+const sheetEl = ref<HTMLElement>()
+const sheetDragY = ref(0)
+let sheetStartY = 0
+
+const isAnyDescendantScrolled = () => {
+  if (!sheetEl.value) return false
+  for (const el of sheetEl.value.querySelectorAll('*')) {
+    if ((el as HTMLElement).scrollTop > 0) return true
+  }
+  return false
+}
+
+const onSheetPointerDown = (e: PointerEvent) => {
+  if (e.pointerType !== 'touch') return
+  if (isAnyDescendantScrolled()) return
+  sheetStartY = e.clientY
+  sheetDragY.value = 0
+  ;(e.currentTarget as HTMLElement).setPointerCapture(e.pointerId)
+}
+const onSheetPointerMove = (e: PointerEvent) => {
+  if (!(e.currentTarget as HTMLElement).hasPointerCapture(e.pointerId)) return
+  sheetDragY.value = Math.max(0, e.clientY - sheetStartY)
+}
+const onSheetPointerUp = (e: PointerEvent) => {
+  if (!(e.currentTarget as HTMLElement).hasPointerCapture(e.pointerId)) return
+  if (sheetDragY.value > 80) hoveredChecksAdapter.value = null
+  sheetDragY.value = 0
+}
+const onSheetPointerCancel = () => {
+  sheetDragY.value = 0
+}
+
+const isTouchTargetScrolled = (target: EventTarget | null): boolean => {
+  let el = target as HTMLElement | null
+  while (el && el !== sheetEl.value) {
+    if (el.scrollTop > 0) return true
+    el = el.parentElement
+  }
+  return false
+}
+
+let scrollTouchStartY = 0
+let scrollGestureDecided = false
+let scrollDragActive = false
+
+const onScrollTouchStart = (e: TouchEvent) => {
+  scrollTouchStartY = e.touches[0].clientY
+  scrollGestureDecided = false
+  scrollDragActive = false
+}
+const onScrollTouchMove = (e: TouchEvent) => {
+  const delta = e.touches[0].clientY - scrollTouchStartY
+  if (!scrollGestureDecided) {
+    scrollGestureDecided = true
+    if (delta > 0 && !isTouchTargetScrolled(e.target)) scrollDragActive = true
+  }
+  if (!scrollDragActive) return
+  e.preventDefault()
+  sheetDragY.value = Math.max(0, delta)
+}
+const onScrollTouchEnd = () => {
+  scrollGestureDecided = false
+  if (!scrollDragActive) return
+  scrollDragActive = false
+  if (sheetDragY.value > 80) hoveredChecksAdapter.value = null
+  sheetDragY.value = 0
+}
+const onScrollTouchCancel = () => {
+  scrollGestureDecided = false
+  scrollDragActive = false
+  sheetDragY.value = 0
+}
+
+const sheetDragStyle = computed(() => ({
+  transform: sheetDragY.value ? `translateY(${sheetDragY.value}px)` : undefined,
+  transition: sheetDragY.value ? 'none' : 'transform 0.3s ease',
+}))
+
+const onChecksClick = (adapter: (typeof adapterViews.value)[0]) => {
+  if (!isMobile.value || !adapter.checks?.length) return
+  hoveredChecksAdapter.value = hoveredChecksAdapter.value === adapter ? null : adapter
+}
+
 const onChecksMouseEnter = (adapter: (typeof adapterViews.value)[0], event: MouseEvent) => {
-  if (!adapter.checks?.length) return
+  if (isMobile.value || !adapter.checks?.length) return
   if (hideTimer) {
     clearTimeout(hideTimer)
     hideTimer = null
@@ -174,6 +268,7 @@ const onChecksMouseEnter = (adapter: (typeof adapterViews.value)[0], event: Mous
 }
 
 const onChecksMouseLeave = () => {
+  if (isMobile.value) return
   hideTimer = setTimeout(() => {
     hoveredChecksAdapter.value = null
   }, 150)
@@ -233,7 +328,7 @@ const onTooltipMouseLeave = () => {
             />
           </button>
         </div>
-        <div class="grid grid-cols-4 gap-12 text-p3">
+        <div class="grid grid-cols-2 md:grid-cols-4 gap-12 text-p3">
           <div class="flex flex-col gap-4">
             <span class="text-content-tertiary">Provider</span>
             <div class="flex items-center gap-8">
@@ -251,14 +346,15 @@ const onTooltipMouseLeave = () => {
               <span class="text-content-primary">{{ adapter.provider || 'Unknown' }}</span>
             </div>
           </div>
-          <div class="flex flex-col gap-4">
+          <div class="flex flex-col gap-4 order-3 md:order-2">
             <span class="text-content-tertiary">Methodology</span>
             <span class="text-content-primary">{{ adapter.methodology || 'Unknown' }}</span>
           </div>
           <div
-            class="flex flex-col gap-4"
+            class="flex flex-col gap-4 order-4 md:order-3"
             @mouseenter="onChecksMouseEnter(adapter, $event)"
             @mouseleave="onChecksMouseLeave"
+            @click.stop="onChecksClick(adapter)"
           >
             <span class="text-content-tertiary">Checks</span>
             <span
@@ -287,7 +383,7 @@ const onTooltipMouseLeave = () => {
               </span>
             </span>
           </div>
-          <div class="flex flex-col gap-4">
+          <div class="flex flex-col gap-4 order-2 md:order-4">
             <span class="text-content-tertiary">Price</span>
             <span
               v-if="isPriceLoading"
@@ -337,42 +433,79 @@ const onTooltipMouseLeave = () => {
   </div>
 
   <Teleport to="body">
-    <div
-      v-if="hoveredChecksAdapter?.checks?.length"
-      class="fixed z-[9999] bg-surface-secondary rounded-xl p-16 shadow-card border border-line-subtle overflow-y-auto overflow-x-hidden"
-      :style="[tooltipStyle, { width: `${TOOLTIP_WIDTH}px` }]"
-      @mouseenter="onTooltipMouseEnter"
-      @mouseleave="onTooltipMouseLeave"
-    >
-      <p class="text-p3 font-medium text-content-primary mb-12">
-        Checks
-      </p>
-      <div class="flex flex-col gap-10">
+    <template v-if="hoveredChecksAdapter?.checks?.length">
+      <!-- Mobile backdrop -->
+      <div
+        v-if="isMobile"
+        class="fixed inset-0 z-[9998] bg-black/50"
+        @click="hoveredChecksAdapter = null"
+      />
+      <!-- Tooltip (desktop) / Bottom sheet (mobile) -->
+      <div
+        ref="sheetEl"
+        class="fixed z-[9999] bg-surface-secondary border border-line-subtle overflow-x-hidden"
+        :class="isMobile
+          ? 'bottom-0 left-0 right-0 rounded-t-2xl max-h-[70vh] shadow-card flex flex-col'
+          : 'rounded-xl p-16 shadow-card overflow-y-auto'"
+        :style="isMobile ? sheetDragStyle : [tooltipStyle, { width: `${TOOLTIP_WIDTH}px` }]"
+        @mouseenter="onTooltipMouseEnter"
+        @mouseleave="onTooltipMouseLeave"
+      >
+        <!-- Drag handle zone (mobile only) -->
         <div
-          v-for="check in hoveredChecksAdapter.checks"
-          :key="check.id"
-          class="flex items-start gap-10"
+          v-if="isMobile"
+          class="shrink-0 px-24 pt-12 touch-none select-none"
+          @pointerdown="onSheetPointerDown"
+          @pointermove="onSheetPointerMove"
+          @pointerup="onSheetPointerUp"
+          @pointercancel="onSheetPointerCancel"
         >
-          <span
-            class="flex-shrink-0 w-20 h-20 rounded-full flex items-center justify-center mt-8"
-            :class="check.pass ? 'bg-success-500' : 'bg-error-500'"
+          <div class="w-32 h-4 rounded-full bg-line-subtle mx-auto mb-16" />
+          <p class="text-p3 font-medium text-content-primary mb-12">
+            Checks
+          </p>
+        </div>
+        <p
+          v-else
+          class="text-p3 font-medium text-content-primary mb-12"
+        >
+          Checks
+        </p>
+        <!-- Scroll container -->
+        <div
+          class="flex flex-col gap-10 overflow-y-auto overscroll-contain [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+          :class="isMobile ? 'px-24 pb-24' : ''"
+          @touchstart="onScrollTouchStart"
+          @touchmove="onScrollTouchMove"
+          @touchend="onScrollTouchEnd"
+          @touchcancel="onScrollTouchCancel"
+        >
+          <div
+            v-for="check in hoveredChecksAdapter.checks"
+            :key="check.id"
+            class="flex items-start gap-10"
           >
-            <SvgIcon
-              :name="check.pass ? 'check' : 'x'"
-              class="!w-10 !h-10 text-white"
-            />
-          </span>
-          <div>
-            <p class="text-p3 font-medium text-content-primary">
-              {{ check.id }}
-            </p>
-            <p class="text-p3 text-content-secondary break-words">
-              {{ check.message }}
-            </p>
+            <span
+              class="flex-shrink-0 w-20 h-20 rounded-full flex items-center justify-center mt-8"
+              :class="check.pass ? 'bg-success-500' : 'bg-error-500'"
+            >
+              <SvgIcon
+                :name="check.pass ? 'check' : 'x'"
+                class="!w-10 !h-10 text-white"
+              />
+            </span>
+            <div class="min-w-0">
+              <p class="text-p3 font-medium text-content-primary break-words">
+                {{ check.id }}
+              </p>
+              <p class="text-p3 text-content-secondary break-words">
+                {{ check.message }}
+              </p>
+            </div>
           </div>
         </div>
       </div>
-    </div>
+    </template>
   </Teleport>
 </template>
 

--- a/components/entities/vault/overview/VaultOverviewBlockOracleAdapters.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockOracleAdapters.vue
@@ -174,17 +174,8 @@ const sheetEl = ref<HTMLElement>()
 const sheetDragY = ref(0)
 let sheetStartY = 0
 
-const isAnyDescendantScrolled = () => {
-  if (!sheetEl.value) return false
-  for (const el of sheetEl.value.querySelectorAll('*')) {
-    if ((el as HTMLElement).scrollTop > 0) return true
-  }
-  return false
-}
-
 const onSheetPointerDown = (e: PointerEvent) => {
   if (e.pointerType !== 'touch') return
-  if (isAnyDescendantScrolled()) return
   sheetStartY = e.clientY
   sheetDragY.value = 0
   ;(e.currentTarget as HTMLElement).setPointerCapture(e.pointerId)
@@ -333,6 +324,7 @@ const onTooltipMouseLeave = () => {
             <button
               :class="$style.copyBtn"
               class="text-content-muted"
+              aria-label="Copy address"
               @click="onCopyClick(adapter.oracle)"
             >
               <SvgIcon
@@ -542,6 +534,12 @@ const onTooltipMouseLeave = () => {
 
   &:active {
     color: var(--text-primary);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--color-accent-600);
+    outline-offset: 2px;
+    border-radius: 4px;
   }
 }
 </style>

--- a/components/entities/vault/overview/VaultOverviewBlockOracleAdapters.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockOracleAdapters.vue
@@ -152,6 +152,9 @@ const hoveredChecksAdapter = ref<(typeof adapterViews.value)[0] | null>(null)
 const tooltipStyle = ref<CSSProperties>({})
 const TOOLTIP_WIDTH = 520
 let hideTimer: ReturnType<typeof setTimeout> | null = null
+onUnmounted(() => {
+  if (hideTimer) clearTimeout(hideTimer)
+})
 
 const onChecksMouseEnter = (adapter: (typeof adapterViews.value)[0], event: MouseEvent) => {
   if (!adapter.checks?.length) return

--- a/entities/oracle.ts
+++ b/entities/oracle.ts
@@ -53,6 +53,20 @@ export type OracleAdapterEntry = {
   quote: Address
 }
 
+export enum OracleAdapterCheckSeverity {
+  High = 'HIGH',
+  Medium = 'MEDIUM',
+  Low = 'LOW',
+  Info = 'INFO',
+}
+
+export type OracleAdapterCheck = {
+  id: string
+  message: string
+  pass: boolean
+  severity: OracleAdapterCheckSeverity
+}
+
 export type OracleAdapterMeta = {
   oracle: Address
   base?: Address
@@ -61,7 +75,15 @@ export type OracleAdapterMeta = {
   provider?: string
   methodology?: string
   label?: string
-  checks?: string[]
+  checks?: OracleAdapterCheck[]
+}
+
+export function getChecksStatus(checks: OracleAdapterCheck[] | undefined): 'positive' | 'warning' | 'negative' | null {
+  if (!checks?.length) return null
+  const failed = checks.filter(c => !c.pass)
+  if (!failed.length) return 'positive'
+  if (failed.some(c => c.severity === OracleAdapterCheckSeverity.High)) return 'negative'
+  return 'warning'
 }
 
 type OracleAdapterOptions = {

--- a/utils/eulerLabelsUtils.ts
+++ b/utils/eulerLabelsUtils.ts
@@ -5,7 +5,7 @@ import {
   type EulerLabelVaultOverride,
 } from '~/entities/euler/labels'
 import type { EarnVault, Vault } from '~/entities/vault'
-import type { OracleAdapterMeta } from '~/entities/oracle'
+import { type OracleAdapterMeta, OracleAdapterCheckSeverity } from '~/entities/oracle'
 import { normalizeAddress } from '~/utils/normalizeAddress'
 import {
   products,
@@ -21,6 +21,10 @@ import {
 } from '~/utils/eulerLabelsState'
 
 // ── Internal helpers ─────────────────────────────────────────
+
+// This check reflects internal indexing state,
+// not an oracle health signal surfaced to end users.
+const SUPPRESSED_CHECK_ID = 'Adapter whitelist'
 
 function isHttpUrl(value: string): boolean {
   if (!value) return false
@@ -117,7 +121,19 @@ export const normalizeOracleAdapters = (data: unknown) => {
       provider: typeof raw.provider === 'string' ? raw.provider : undefined,
       methodology: typeof raw.methodology === 'string' ? raw.methodology : undefined,
       label: typeof raw.label === 'string' ? raw.label : undefined,
-      checks: Array.isArray(raw.checks) ? raw.checks.filter((v): v is string => typeof v === 'string') : undefined,
+      checks: Array.isArray(raw.checks)
+        ? raw.checks
+            .filter((v): v is Record<string, unknown> => !!v && typeof v === 'object')
+            .filter(c => c.id !== SUPPRESSED_CHECK_ID)
+            .map(c => ({
+              id: typeof c.id === 'string' ? c.id : '',
+              message: typeof c.message === 'string' ? c.message : '',
+              pass: typeof c.pass === 'boolean' ? c.pass : false,
+              severity: Object.values(OracleAdapterCheckSeverity).includes(c.severity as OracleAdapterCheckSeverity)
+                ? c.severity as OracleAdapterCheckSeverity
+                : OracleAdapterCheckSeverity.Info,
+            }))
+        : undefined,
     }
 
     normalized[meta.oracle.toLowerCase()] = meta


### PR DESCRIPTION
- Surface per-adapter check results (pass/fail, severity) from the oracle-checks metadata as a Checks column in the oracle adapters grid
- Green/yellow/red dot based on pass status and highest failure severity
- Hover tooltip via Teleport shows full check breakdown with icons
- Failed checks rendered inline below the grid for quick visibility
- Suppress internal 'Adapter whitelist' check per monorepo parity

<img width="615" height="444" alt="Oracles" src="https://github.com/user-attachments/assets/a2f967f2-45cf-449e-bafa-fbc2e97d24d3" />

<img width="845" height="510" alt="Overview" src="https://github.com/user-attachments/assets/7bef0bc6-fc60-4702-a983-5f2c180faf8c" />

<img width="619" height="205" alt="PYUSDUSD 0x2289 BIRE C" src="https://github.com/user-attachments/assets/b3c78094-ca35-4e21-9cca-96db9e804ccc" />
