### PR TITLE
Feat/ai pr review

### DIFF
--- a/.claude/skills/claude-autofix/SKILL.md
+++ b/.claude/skills/claude-autofix/SKILL.md
@@ -1,111 +1,113 @@
 ---
 name: claude-autofix
-description: Read open review feedback on the current PR and implement fixes directly in the codebase
+description: Read 🚨 CRITICAL review findings on the current PR, implement fixes on a new branch, open a fix PR, and comment the link on the original PR
 ---
 
 # Auto-fix PR Review Comments
 
-Read all open review feedback on the current PR and implement fixes directly in the codebase.
+Read all `🚨 CRITICAL:` findings from review feedback on the current PR, implement fixes on a new branch, open a PR targeting the original PR branch, and comment the link back.
 
 ## Instructions
 
-### Step 1: Gather all review feedback
+### Step 1: Gather critical findings
 
 ```bash
-# Inline review comments (line-specific)
+# Inline review comments — filter to CRITICAL only
 gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/comments" \
-  --jq '.[] | {id: .id, path: .path, line: .line, body: .body, user: .user.login}'
+  --jq '.[] | select(.body // "" | contains("🚨 CRITICAL:")) | {id: .id, path: .path, line: .line, body: .body, user: .user.login}'
 
-# Review summaries (overall assessments)
+# Review summaries — filter to CRITICAL only
 gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" \
-  --jq '.[] | select(.state != "DISMISSED") | {id: .id, state: .state, body: .body, user: .user.login}'
-
-# General PR comments
-gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
-  --jq '.[] | {id: .id, body: .body, user: .user.login}'
+  --jq '.[] | select(.state != "DISMISSED" and (.body // "" | contains("🚨 CRITICAL:"))) | {id: .id, body: .body, user: .user.login}'
 ```
 
-### Step 2: Triage feedback — be conservative
+If there are no `🚨 CRITICAL:` findings, post a comment saying there is nothing to fix and stop.
 
-For each piece of feedback, **read the actual code at the referenced location first**, then decide:
+### Step 2: Triage — be conservative
+
+For each `🚨 CRITICAL:` finding, **read the actual code at the referenced location first**, then decide:
 
 **Implement only if ALL of the following are true:**
 1. The issue actually exists in the code (verify by reading the file — don't trust the review blindly)
-2. The correct fix is unambiguous — there is one obvious, safe resolution
-3. The fix is self-contained and does not require understanding a product or UX decision
-4. No human reviewer has pushed back on or disagreed with this finding
+2. The correct fix is unambiguous — one obvious, safe resolution
+3. The fix is self-contained and does not require a product or UX decision
+4. No human reviewer has pushed back on this finding
 
 **Skip — and note in summary — if any of the following apply:**
-- The flagged code looks correct after reading it in context (false positive)
+- The flagged code looks correct in context (false positive)
 - The fix would change observable behaviour beyond what the comment describes
-- Multiple reviewers contradict each other on this point
-- The fix requires a product decision ("should this round up or down?")
-- It's a question, a `💬 SUGGESTION:`, or a style preference
-- You are not confident the original finding was correct
+- Reviewers contradict each other on this point
+- You are not confident the finding is correct
 
-**When in doubt, skip it.** A skipped item costs the author 30 seconds to review. A bad auto-fix costs everyone much more.
+**When in doubt, skip it.**
 
-### Step 3: Implement fixes
+If all critical findings are false positives after triage, post a comment on the PR via `gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments"` explaining why each was skipped, and stop — do not create a branch or PR.
 
-Read the relevant files, make the fixes. Follow the existing code patterns — don't refactor surrounding code.
+### Step 3: Apply fixes
 
-For each fix:
-1. Read the file at the referenced path
-2. Understand the context
-3. Apply the minimal change that resolves the feedback
-4. Do not "improve" surrounding code beyond what was requested
+For each finding that passed triage, use your file editing tools to apply the fix. Read the file, understand the context, make the minimal change.
 
-### Step 4: Commit
+### Steps 4–7: Branch, commit, open PR, and comment
 
-Stage only the specific files you edited — never `git add .` or `git add -A`:
+**Run this entire block as a single bash script** — shell variables (`FIX_BRANCH`, `FIX_PR_URL`) must persist across all steps and will not survive if run as separate commands.
 
-```bash
-# Stage each file you modified explicitly
-git add composables/repay/useWalletRepay.ts utils/fixed-point.ts
-git status  # verify only intended files are staged before committing
-git commit -m "fix: address PR review comments"
-git push origin HEAD
+Before running, write the actual fix summary to `/tmp/fix-pr-body.md` with the real list of what you fixed and what you skipped. Do not use placeholder text. Example:
+
 ```
+## Auto-fix for PR #123
 
-If there are multiple logical groups of fixes (e.g. stack hygiene vs business logic), split into separate commits, staging the relevant files for each:
-
-```bash
-git add composables/repay/useMaxRepay.ts
-git commit -m "fix: correct bigint arithmetic in repay flow"
-
-git add pages/position/index.vue
-git commit -m "fix: resolve stack hygiene review findings"
-
-git push origin HEAD
-```
-
-Always run `git status` before committing to confirm only the expected files are staged.
-
-### Step 5: Post a summary comment
-
-Write the summary to a temp file first, then post — do not use heredoc inside `$()` inside a quoted string (shell parsing failure):
-
-```bash
-cat > /tmp/autofix-summary.md << 'EOF'
-## Auto-fix Summary
+This PR implements fixes for `🚨 CRITICAL:` findings from the AI review on #123.
 
 ### Fixed
-- [list each fix with file:line reference]
+- `utils/autoLink.ts:11`: Restored `&quot;` HTML entity for double-quote escaping
 
 ### Skipped
-- [list each item skipped and why — question, contradiction, style preference, etc.]
+- `useRepay.ts:88`: false positive — denominator is always non-zero per vault invariant
 
-If any skipped items need human input, please clarify and re-run `@claude fix`.
+> Generated by `@claude fix`. Review carefully before merging.
+```
+
+Then run the following as a single script:
+
+```bash
+set -e
+
+# create fix branch
+FIX_BRANCH="fix/claude-${PR_NUMBER}-$(date +%s)"
+git checkout -b "$FIX_BRANCH"
+
+# stage ONLY the exact files you edited in Step 3 — substitute real paths below, never use git add . or git add -A
+git add <path/to/file-you-changed.ts> <path/to/another-file.vue>
+git status
+git commit -m "fix: address critical PR review findings"
+git push origin "$FIX_BRANCH"
+
+# open fix PR, capture URL from stdout
+FIX_PR_URL=$(gh pr create \
+  --title "fix: auto-fix critical findings from PR #${PR_NUMBER}" \
+  --body-file /tmp/fix-pr-body.md \
+  --base "$HEAD_REF" \
+  --head "$FIX_BRANCH")
+
+# comment link on original PR
+cat > /tmp/autofix-comment.md << EOF
+## 🤖 Auto-fix PR opened
+
+I've opened a fix PR for the \`🚨 CRITICAL:\` findings: $FIX_PR_URL
+
+Please review the changes before merging. You can close the fix PR if the proposed fixes aren't right.
 EOF
 
 gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
   --method POST \
-  -F body=@/tmp/autofix-summary.md
+  -F body=@/tmp/autofix-comment.md
 ```
+
+If the commit is rejected by the pre-commit hook (lint-staged), run `npx eslint --fix` on the changed files, re-stage them, and rerun the full script.
 
 ## Important Constraints
 
+- Only fix `🚨 CRITICAL:` findings — never `⚠️ WARNING:` or `💬 SUGGESTION:`
 - Never commit secrets, `.env` files, or unrelated files
 - Never force-push or amend commits — always create new commits
-- If a fix would require understanding a product decision or changing behaviour beyond the review comment scope, skip it and note it in the summary
-- If the same issue appears in multiple places but the review only flagged one, fix all occurrences (and note this in the summary)
+- Never push directly to the original PR branch — always use the fix branch

--- a/.claude/skills/claude-autofix/SKILL.md
+++ b/.claude/skills/claude-autofix/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: claude-autofix
+description: Read open review feedback on the current PR and implement fixes directly in the codebase
+---
+
+# Auto-fix PR Review Comments
+
+Read all open review feedback on the current PR and implement fixes directly in the codebase.
+
+## Instructions
+
+### Step 1: Gather all review feedback
+
+```bash
+# Inline review comments (line-specific)
+gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/comments" \
+  --jq '.[] | {id: .id, path: .path, line: .line, body: .body, user: .user.login}'
+
+# Review summaries (overall assessments)
+gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" \
+  --jq '.[] | select(.state != "DISMISSED") | {id: .id, state: .state, body: .body, user: .user.login}'
+
+# General PR comments
+gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
+  --jq '.[] | {id: .id, body: .body, user: .user.login}'
+```
+
+### Step 2: Triage feedback — be conservative
+
+For each piece of feedback, **read the actual code at the referenced location first**, then decide:
+
+**Implement only if ALL of the following are true:**
+1. The issue actually exists in the code (verify by reading the file — don't trust the review blindly)
+2. The correct fix is unambiguous — there is one obvious, safe resolution
+3. The fix is self-contained and does not require understanding a product or UX decision
+4. No human reviewer has pushed back on or disagreed with this finding
+
+**Skip — and note in summary — if any of the following apply:**
+- The flagged code looks correct after reading it in context (false positive)
+- The fix would change observable behaviour beyond what the comment describes
+- Multiple reviewers contradict each other on this point
+- The fix requires a product decision ("should this round up or down?")
+- It's a question, a `💬 SUGGESTION:`, or a style preference
+- You are not confident the original finding was correct
+
+**When in doubt, skip it.** A skipped item costs the author 30 seconds to review. A bad auto-fix costs everyone much more.
+
+### Step 3: Implement fixes
+
+Read the relevant files, make the fixes. Follow the existing code patterns — don't refactor surrounding code.
+
+For each fix:
+1. Read the file at the referenced path
+2. Understand the context
+3. Apply the minimal change that resolves the feedback
+4. Do not "improve" surrounding code beyond what was requested
+
+### Step 4: Commit
+
+Stage only the specific files you edited — never `git add .` or `git add -A`:
+
+```bash
+# Stage each file you modified explicitly
+git add composables/repay/useWalletRepay.ts utils/fixed-point.ts
+git status  # verify only intended files are staged before committing
+git commit -m "fix: address PR review comments"
+git push origin HEAD
+```
+
+If there are multiple logical groups of fixes (e.g. stack hygiene vs business logic), split into separate commits, staging the relevant files for each:
+
+```bash
+git add composables/repay/useMaxRepay.ts
+git commit -m "fix: correct bigint arithmetic in repay flow"
+
+git add pages/position/index.vue
+git commit -m "fix: resolve stack hygiene review findings"
+
+git push origin HEAD
+```
+
+Always run `git status` before committing to confirm only the expected files are staged.
+
+### Step 5: Post a summary comment
+
+Write the summary to a temp file first, then post — do not use heredoc inside `$()` inside a quoted string (shell parsing failure):
+
+```bash
+cat > /tmp/autofix-summary.md << 'EOF'
+## Auto-fix Summary
+
+### Fixed
+- [list each fix with file:line reference]
+
+### Skipped
+- [list each item skipped and why — question, contradiction, style preference, etc.]
+
+If any skipped items need human input, please clarify and re-run `@claude fix`.
+EOF
+
+gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
+  --method POST \
+  -F body=@/tmp/autofix-summary.md
+```
+
+## Important Constraints
+
+- Never commit secrets, `.env` files, or unrelated files
+- Never force-push or amend commits — always create new commits
+- If a fix would require understanding a product decision or changing behaviour beyond the review comment scope, skip it and note it in the summary
+- If the same issue appears in multiple places but the review only flagged one, fix all occurrences (and note this in the summary)

--- a/.claude/skills/claude-autofix/SKILL.md
+++ b/.claude/skills/claude-autofix/SKILL.md
@@ -111,3 +111,4 @@ If the commit is rejected by the pre-commit hook (lint-staged), run `npx eslint 
 - Never commit secrets, `.env` files, or unrelated files
 - Never force-push or amend commits — always create new commits
 - Never push directly to the original PR branch — always use the fix branch
+- Never add `Co-Authored-By` trailers to commit messages

--- a/.claude/skills/claude-review-business/SKILL.md
+++ b/.claude/skills/claude-review-business/SKILL.md
@@ -52,7 +52,7 @@ Also read any composables in `composables/repay/`, `composables/borrow/`, `compo
 
 **Flow Correctness**
 - `useGeoBlock` checked before allowing any transaction that moves funds — new flows must not bypass geo-blocking
-- Operation guard registry (`utils/operationGuardRegistry.ts`) consulted for any new operations — guards prevent invalid state transitions
+- Operation guard registry (`utils/operationGuardRegistry.ts`) consulted for any new operations — two distinct mechanisms: `isOperationBlocked` is the hard gate that prevents execution; `applyOperationGuards` transforms the tx plan but does not block. Check that new flows call `isOperationBlocked` before submission and pass the plan through `applyOperationGuards`
 - Error states (wallet rejection, RPC failure, slippage exceeded) handled and surfaced to user — no silent failures
 - Loading/pending states correctly tracked so UI doesn't allow double-submission
 

--- a/.claude/skills/claude-review-business/SKILL.md
+++ b/.claude/skills/claude-review-business/SKILL.md
@@ -62,8 +62,8 @@ Also read any composables in `composables/repay/`, `composables/borrow/`, `compo
 
 ### Step 3: Classify findings
 
-- `🔴 BLOCKING:` — incorrect financial calculation, missing guard that could cause fund loss, silent failure on transaction error, broken repay/borrow flow
-- `🟡 WARNING:` — imprecise rounding, missing edge case (zero balance, max uint), fragile assumption about vault decimals
+- `🚨 CRITICAL:` — incorrect financial calculation, missing guard that could cause fund loss, silent failure on transaction error, broken repay/borrow flow
+- `⚠️ WARNING:` — imprecise rounding, missing edge case (zero balance, max uint), fragile assumption about vault decimals
 - `💬 SUGGESTION:` — clarity improvement, better use of existing utility
 
 ### Step 4: Post findings

--- a/.claude/skills/claude-review-business/SKILL.md
+++ b/.claude/skills/claude-review-business/SKILL.md
@@ -66,6 +66,6 @@ Also read any composables in `composables/repay/`, `composables/borrow/`, `compo
 - `⚠️ WARNING:` — imprecise rounding, missing edge case (zero balance, max uint), fragile assumption about vault decimals
 - `💬 SUGGESTION:` — clarity improvement, better use of existing utility
 
-### Step 4: Post findings
+### Step 4: Return findings
 
-Hand off all findings to /inline-pr-comments. Include a summary of which flows were reviewed.
+Return all findings as structured text to the orchestrator. Do NOT call /inline-pr-comments — the orchestrator collects findings from all three reviews and posts them in a single consolidated review. Include a summary of which flows were reviewed.

--- a/.claude/skills/claude-review-business/SKILL.md
+++ b/.claude/skills/claude-review-business/SKILL.md
@@ -21,6 +21,18 @@ euler-lite is the frontend for Euler v2, a modular DeFi lending protocol. Key do
 
 ## Instructions
 
+### Step 0: Fetch relevant protocol skills
+
+Fetch the euler-xyz skill files whose domain overlaps with the diff. If in doubt, always fetch `euler-vaults`.
+
+- `euler-vaults` — vault operations, EVC orchestration, risk management, batching: `https://raw.githubusercontent.com/euler-xyz/agent-skills/77b444666398f8471747edf014aeed832831ee5e/skills/euler-vaults/SKILL.md`
+- `euler-irm-oracles` — oracle adapters, price feed configuration, IRM types: `https://raw.githubusercontent.com/euler-xyz/agent-skills/77b444666398f8471747edf014aeed832831ee5e/skills/euler-irm-oracles/SKILL.md`
+- `euler-earn` — EulerEarn yield aggregation, allocator roles: `https://raw.githubusercontent.com/euler-xyz/agent-skills/77b444666398f8471747edf014aeed832831ee5e/skills/euler-earn/SKILL.md`
+- `euler-advanced` — hooks, flash loans, debt mechanics, reward systems: `https://raw.githubusercontent.com/euler-xyz/agent-skills/77b444666398f8471747edf014aeed832831ee5e/skills/euler-advanced/SKILL.md`
+- `euler-data` — subgraph queries, contract interfaces, deployment tooling: `https://raw.githubusercontent.com/euler-xyz/agent-skills/77b444666398f8471747edf014aeed832831ee5e/skills/euler-data/SKILL.md`
+
+Protocol docs: https://docs.euler.finance — cross-check any flow that diverges from documented semantics.
+
 ### Step 1: Get the diff
 
 ```bash

--- a/.claude/skills/claude-review-business/SKILL.md
+++ b/.claude/skills/claude-review-business/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: claude-review-business
+description: Review PR changes for correctness of DeFi business logic in the Euler lending protocol UI
+---
+
+# Business Logic Review
+
+Review this PR's changes for correctness of DeFi business logic in the Euler lending protocol UI.
+
+## Context
+
+euler-lite is the frontend for Euler v2, a modular DeFi lending protocol. Key domain concepts:
+- **Vaults** — ERC-4626 lending/borrowing vaults; assets and shares are distinct
+- **Positions** — a user's borrow or collateral position in a vault
+- **Health factor** — ratio of collateral value to borrow value; below 1 = liquidatable
+- **Collateral swap** — swapping collateral assets while maintaining a position
+- **Repay** — paying back borrowed assets, reducing debt
+- **Leverage / multiply** — using borrowed assets to buy more collateral, amplifying exposure
+- All on-chain values are `bigint` in wei; display values use fixed-point utilities in `utils/fixed-point.ts`
+- Position estimates live in `utils/position-estimates.ts`
+
+## Instructions
+
+### Step 1: Get the diff
+
+```bash
+git diff origin/$BASE_REF...HEAD
+```
+
+Also read any composables in `composables/repay/`, `composables/borrow/`, `composables/position/` that are touched by the diff to understand full context.
+
+### Step 2: Check against these criteria
+
+**Arithmetic Safety**
+- All on-chain arithmetic uses `bigint` — no `Number()` conversion on values that could exceed `Number.MAX_SAFE_INTEGER`
+- Division never loses precision silently — check that `utils/fixed-point.ts` helpers are used for scaled arithmetic
+- Rounding direction is correct for user safety: when in doubt, round against the user (e.g. debt rounds up, collateral rounds down)
+- No floating-point arithmetic on values that will be sent on-chain or displayed as exact amounts
+
+**Vault / Position Logic**
+- Shares vs assets distinction respected — `convertToAssets` / `convertToShares` called where needed, not assumed 1:1
+- Health factor calculations use up-to-date oracle prices and account for both sides of the position
+- Collateral swap flows correctly handle: approval, swap execution, vault deposit/withdraw ordering
+- Repay flows: correct handling of `type(uint256).max` for full repay vs exact amount
+- Borrow flows: collateral check before borrow, correct controller/vault sequencing
+
+**User-Facing Number Formatting**
+- `formatUnits` called with the correct vault asset decimals (not hardcoded 18)
+- Display values shown to appropriate precision — not truncating significant digits on small amounts
+- "Max" input values account for gas/buffer where relevant (e.g. don't allow borrowing 100% of available liquidity)
+- Signed vs unsigned: debt amounts displayed as positive to user even though internally they may be negative deltas
+
+**Flow Correctness**
+- `useGeoBlock` checked before allowing any transaction that moves funds — new flows must not bypass geo-blocking
+- Operation guard registry (`utils/operationGuardRegistry.ts`) consulted for any new operations — guards prevent invalid state transitions
+- Error states (wallet rejection, RPC failure, slippage exceeded) handled and surfaced to user — no silent failures
+- Loading/pending states correctly tracked so UI doesn't allow double-submission
+
+**Leverage / Multiply Math**
+- Leverage calculations in `utils/leverage.ts` / `utils/multiply-math.ts` used — not reimplemented inline
+- Slippage tolerance applied correctly on swap leg
+
+### Step 3: Classify findings
+
+- `🔴 BLOCKING:` — incorrect financial calculation, missing guard that could cause fund loss, silent failure on transaction error, broken repay/borrow flow
+- `🟡 WARNING:` — imprecise rounding, missing edge case (zero balance, max uint), fragile assumption about vault decimals
+- `💬 SUGGESTION:` — clarity improvement, better use of existing utility
+
+### Step 4: Post findings
+
+Hand off all findings to /inline-pr-comments. Include a summary of which flows were reviewed.

--- a/.claude/skills/claude-review-security/SKILL.md
+++ b/.claude/skills/claude-review-security/SKILL.md
@@ -49,13 +49,25 @@ git diff origin/$BASE_REF...HEAD
 - Wallet connection flows don't expose private keys or mnemonics in state/logs
 - `simulateTxPlan` is opt-in, not mandatory — do not flag `executeTxPlan` calls without prior simulation as violations; flag only if a new flow explicitly skips simulation where it was previously used in the same composable
 
+**Transaction Flow Safety**
+- Funds are always sent to the user's own address — flag any flow where the recipient is mutable, derived from external input, or could be redirected
+- Output amounts are verified against expected minimums before submission — slippage tolerance must be enforced on every swap leg
+- Token approvals are granted only to known, audited contract addresses (Euler vault/EVC addresses, known routers) — never to arbitrary or user-supplied addresses
+- Approvals must never be unlimited (`type(uint256).max`) unless the contract is trusted and the pattern is already established in the codebase; flag any new unlimited approval
+- Signed message deadlines (`deadline` / `expiry` fields) are reasonable — not `type(uint256).max` or an unbounded far-future timestamp; flag any hardcoded or unconstrained deadline
+
+**Wallet Screening / Terms Gate**
+- New transaction flows check wallet screening status before allowing submission — the screening composable must be consulted, not bypassed
+- Terms of use acceptance is verified before any fund-moving transaction — new flows must not skip the terms gate that existing flows enforce
+- Screening and terms checks must be consistently applied — flag any new flow that omits them where equivalent flows include them
+
 **Dependency / Supply Chain**
 - New `npm` packages are well-known and actively maintained — flag any obscure packages touching crypto/wallet code
 - No `postinstall` scripts in newly added packages that could execute arbitrary code
 
 ### Step 3: Classify findings
 
-- `🚨 CRITICAL:` — secret exposure risk, XSS vector, geo-blocking bypass, RPC URL leakage to client
+- `🚨 CRITICAL:` — secret exposure risk, XSS vector, geo-blocking bypass, RPC URL leakage to client, funds sent to wrong recipient, unlimited approval to untrusted address, missing screening/terms gate on fund-moving transaction
 - `⚠️ WARNING:` — potential exposure path that requires specific conditions, missing `simulateContract`, missing guard
 - `💬 SUGGESTION:` — defence-in-depth improvement, better validation
 

--- a/.claude/skills/claude-review-security/SKILL.md
+++ b/.claude/skills/claude-review-security/SKILL.md
@@ -59,6 +59,6 @@ git diff origin/$BASE_REF...HEAD
 - `⚠️ WARNING:` — potential exposure path that requires specific conditions, missing `simulateContract`, missing guard
 - `💬 SUGGESTION:` — defence-in-depth improvement, better validation
 
-### Step 4: Post findings
+### Step 4: Return findings
 
-Hand off all findings to /inline-pr-comments. Include a summary of the security surface reviewed.
+Return all findings as structured text to the orchestrator. Do NOT call /inline-pr-comments — the orchestrator collects findings from all three reviews and posts them in a single consolidated review. Include a summary of the security surface reviewed.

--- a/.claude/skills/claude-review-security/SKILL.md
+++ b/.claude/skills/claude-review-security/SKILL.md
@@ -55,8 +55,8 @@ git diff origin/$BASE_REF...HEAD
 
 ### Step 3: Classify findings
 
-- `🔴 BLOCKING:` — secret exposure risk, XSS vector, geo-blocking bypass, RPC URL leakage to client
-- `🟡 WARNING:` — potential exposure path that requires specific conditions, missing `simulateContract`, missing guard
+- `🚨 CRITICAL:` — secret exposure risk, XSS vector, geo-blocking bypass, RPC URL leakage to client
+- `⚠️ WARNING:` — potential exposure path that requires specific conditions, missing `simulateContract`, missing guard
 - `💬 SUGGESTION:` — defence-in-depth improvement, better validation
 
 ### Step 4: Post findings

--- a/.claude/skills/claude-review-security/SKILL.md
+++ b/.claude/skills/claude-review-security/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: claude-review-security
+description: Review PR changes for web security issues in the euler-lite frontend
+---
+
+# Security Review
+
+Review this PR's changes for web security issues in the euler-lite frontend.
+
+## Context
+
+euler-lite is a DeFi frontend that interacts with Ethereum wallets and external RPCs. Security-sensitive surfaces:
+- Environment variables / chain config exposed to the client bundle
+- User wallet addresses and transaction data rendered in the UI
+- External RPC endpoints used for on-chain reads
+- Geo-blocking and screening enforced on the server (not just client)
+- `window.__CHAIN_CONFIG__` — chain configuration injected server-side; must never contain secrets
+
+## Instructions
+
+### Step 1: Get the diff
+
+```bash
+git diff origin/$BASE_REF...HEAD
+```
+
+### Step 2: Check against these criteria
+
+**Environment Variable & Secret Exposure**
+- No API keys, RPC auth tokens, or secrets assigned to `NUXT_PUBLIC_*` env vars (those are client-exposed)
+- No new keys added to `window.__CHAIN_CONFIG__` or any other `window.*` injection — recent fix (Dec 2024) explicitly removed RPC URLs from this object
+- `runtimeConfig.public.*` only contains truly public, non-sensitive values
+- Server-only secrets accessed via `runtimeConfig.*` (non-public), never in `pages/` or `composables/` that run client-side
+
+**XSS / Injection**
+- No use of `v-html` on user-provided or contract-derived data (token names, vault descriptions)
+- No `innerHTML` / `document.write` / `eval` in any JS/TS files
+- External URLs (e.g. token icon URLs from on-chain data) not injected as `src` without validation — malicious SVGs can execute scripts
+- User-input strings (amounts, addresses) sanitised before display if rendered in a context that could escape text nodes
+
+**Geo-blocking / Access Control**
+- New pages or transaction flows consult `useGeoBlock` — server-side blocking is the source of truth but client must not expose restricted UI
+- No new client-side-only blocking logic that could be bypassed — geo check must be server-enforced for any restricted operation
+- Routes that should be protected are not accidentally accessible without the guard composable
+
+**RPC / Wallet Surface**
+- RPC URLs are not logged to console or included in error messages surfaced to users
+- No RPC endpoint constructed from user-supplied input without validation
+- Wallet connection flows don't expose private keys or mnemonics in state/logs
+- `simulateContract` used before `writeContract` to catch reverts before wallet prompt — prevents confusing failed transactions
+
+**Dependency / Supply Chain**
+- New `npm` packages are well-known and actively maintained — flag any obscure packages touching crypto/wallet code
+- No `postinstall` scripts in newly added packages that could execute arbitrary code
+
+### Step 3: Classify findings
+
+- `🔴 BLOCKING:` — secret exposure risk, XSS vector, geo-blocking bypass, RPC URL leakage to client
+- `🟡 WARNING:` — potential exposure path that requires specific conditions, missing `simulateContract`, missing guard
+- `💬 SUGGESTION:` — defence-in-depth improvement, better validation
+
+### Step 4: Post findings
+
+Hand off all findings to /inline-pr-comments. Include a summary of the security surface reviewed.

--- a/.claude/skills/claude-review-security/SKILL.md
+++ b/.claude/skills/claude-review-security/SKILL.md
@@ -47,7 +47,7 @@ git diff origin/$BASE_REF...HEAD
 - RPC URLs are not logged to console or included in error messages surfaced to users
 - No RPC endpoint constructed from user-supplied input without validation
 - Wallet connection flows don't expose private keys or mnemonics in state/logs
-- `simulateContract` used before `writeContract` to catch reverts before wallet prompt — prevents confusing failed transactions
+- `simulateTxPlan` is opt-in, not mandatory — do not flag `executeTxPlan` calls without prior simulation as violations; flag only if a new flow explicitly skips simulation where it was previously used in the same composable
 
 **Dependency / Supply Chain**
 - New `npm` packages are well-known and actively maintained — flag any obscure packages touching crypto/wallet code

--- a/.claude/skills/claude-review-security/SKILL.md
+++ b/.claude/skills/claude-review-security/SKILL.md
@@ -28,7 +28,7 @@ git diff origin/$BASE_REF...HEAD
 
 **Environment Variable & Secret Exposure**
 - No API keys, RPC auth tokens, or secrets assigned to `NUXT_PUBLIC_*` env vars (those are client-exposed)
-- No new keys added to `window.__CHAIN_CONFIG__` or any other `window.*` injection — recent fix (Dec 2024) explicitly removed RPC URLs from this object
+- No new keys added to `window.__CHAIN_CONFIG__` or any other `window.*` injection — RPC URLs must not be included in this object
 - `runtimeConfig.public.*` only contains truly public, non-sensitive values
 - Server-only secrets accessed via `runtimeConfig.*` (non-public), never in `pages/` or `composables/` that run client-side
 

--- a/.claude/skills/claude-review-stack/SKILL.md
+++ b/.claude/skills/claude-review-stack/SKILL.md
@@ -62,8 +62,8 @@ Read the diff carefully. Focus only on changed lines and their immediate context
 ### Step 3: Classify findings
 
 For each issue found:
-- `🔴 BLOCKING:` — broken pattern that will cause runtime errors, hydration mismatches, or type safety regressions
-- `🟡 WARNING:` — bad practice that should be fixed but won't immediately break
+- `🚨 CRITICAL:` — broken pattern that will cause runtime errors, hydration mismatches, or type safety regressions
+- `⚠️ WARNING:` — bad practice that should be fixed but won't immediately break
 - `💬 SUGGESTION:` — minor improvement
 
 Skip nits about formatting, comment style, or ordering unless they create confusion.

--- a/.claude/skills/claude-review-stack/SKILL.md
+++ b/.claude/skills/claude-review-stack/SKILL.md
@@ -68,6 +68,6 @@ For each issue found:
 
 Skip nits about formatting, comment style, or ordering unless they create confusion.
 
-### Step 4: Post findings
+### Step 4: Return findings
 
-Hand off all findings to /inline-pr-comments. Include a brief summary of which files were reviewed and overall assessment.
+Return all findings as structured text to the orchestrator. Do NOT call /inline-pr-comments — the orchestrator collects findings from all three reviews and posts them in a single consolidated review. Include a brief summary of which files were reviewed and overall assessment.

--- a/.claude/skills/claude-review-stack/SKILL.md
+++ b/.claude/skills/claude-review-stack/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: claude-review-stack
+description: Review PR changes for Vue 3 / Nuxt 3 / TypeScript / Viem best practices in the euler-lite codebase
+---
+
+# Tech Stack Hygiene Review
+
+Review this PR's changes for Vue 3 / Nuxt 3 / TypeScript / Viem best practices as used in the euler-lite codebase.
+
+## Context
+
+euler-lite is a Nuxt 3 frontend for the Euler DeFi lending protocol. Key tech:
+- **Vue 3** with `<script setup>` composition API (no Options API)
+- **Nuxt 3** with file-based routing in `pages/`, SSR-aware composables
+- **TypeScript** throughout — strict typing expected, especially for on-chain data
+- **Viem** for all Ethereum interactions (no ethers.js)
+- **Tailwind CSS** for styling
+- State is managed via composables in `composables/` (no Pinia — Nuxt 3 native composition)
+- Business logic lives in `composables/`, `utils/`, and `entities/`
+
+## Instructions
+
+### Step 1: Get the diff
+
+```bash
+git diff origin/$BASE_REF...HEAD -- '*.vue' '*.ts' '*.js' '*.json'
+```
+
+Read the diff carefully. Focus only on changed lines and their immediate context.
+
+### Step 2: Check against these criteria
+
+**Vue 3 / Nuxt 3 Patterns**
+- All components use `<script setup lang="ts">` — no Options API, no `defineComponent` wrapper unless required
+- `defineProps` and `defineEmits` use TypeScript generic syntax, not runtime declarations
+- `computed()`, `ref()`, `watch()` are imported from `vue` — not used as global injections
+- No `.value` access forgotten on refs inside `<template>` (auto-unwrapped there)
+- Composables in `composables/` follow the pattern: accept `Ref`/`ComputedRef` options, return reactive state/computed refs
+- `useAsyncData` / `useFetch` used for server-side data fetching; plain `fetch` only in client-only contexts
+- No `process.server` / `process.client` checks in components (use `onMounted` or `<ClientOnly>` instead)
+- Auto-imports are relied upon for composables and Vue APIs — avoid manual imports of things Nuxt auto-imports
+
+**TypeScript Strictness**
+- No `any` types — use proper types or `unknown` with narrowing
+- On-chain values (balances, amounts) typed as `bigint`, not `number` or `string`
+- Contract return types properly typed via viem's inferred ABI types
+- No `as unknown as X` double-cast unless absolutely necessary
+- `computed<T>(() => ...)` explicit generic when return type is ambiguous
+
+**Viem Patterns**
+- `readContract` / `writeContract` / `simulateContract` used correctly
+- No manual ABI encoding/decoding when viem helpers exist
+- Address comparisons use `getAddress()` normalisation, not raw string equality
+- `parseUnits` / `formatUnits` used with correct decimals — never hardcoded to 18 without justification
+
+**Component Structure**
+- Props are the only source of truth for component inputs — no direct store reads inside deeply-nested components
+- Events flow up via `emit`, not by mutating props or calling parent composables directly
+- `v-for` always has `:key` bound to a stable, unique value (not array index for dynamic lists)
+- No inline styles — Tailwind classes only; no `style=""` attribute unless truly dynamic
+
+### Step 3: Classify findings
+
+For each issue found:
+- `🔴 BLOCKING:` — broken pattern that will cause runtime errors, hydration mismatches, or type safety regressions
+- `🟡 WARNING:` — bad practice that should be fixed but won't immediately break
+- `💬 SUGGESTION:` — minor improvement
+
+Skip nits about formatting, comment style, or ordering unless they create confusion.
+
+### Step 4: Post findings
+
+Hand off all findings to /inline-pr-comments. Include a brief summary of which files were reviewed and overall assessment.

--- a/.claude/skills/claude-review-stack/SKILL.md
+++ b/.claude/skills/claude-review-stack/SKILL.md
@@ -59,6 +59,22 @@ Read the diff carefully. Focus only on changed lines and their immediate context
 - `v-for` always has `:key` bound to a stable, unique value (not array index for dynamic lists)
 - No inline styles — Tailwind classes only; no `style=""` attribute unless truly dynamic
 
+**Code Reuse**
+
+Before evaluating any finding related to missing logic, duplication, or new helpers, read the relevant directories so you can compare against what already exists:
+
+```bash
+# List all utility and composable files so you know what exists
+find utils/ composables/ entities/ -name "*.ts" | sort
+```
+
+Then read the files most likely to overlap with the diff's domain (e.g. if the diff touches borrow flows, read `composables/borrow/` and `utils/` files related to borrow/position math).
+
+- Inline logic that already exists as a named utility in `utils/` should be replaced with the utility call, not left inline
+- Flag duplicate implementations even if the new one is slightly different — the canonical version is the one already in `utils/` or `composables/`
+- If a pattern appears more than once in the diff and no utility exists, flag it as a candidate for extraction rather than accepting the duplication
+- New helper functions must not shadow or partially replicate existing ones — check for name collisions and functional overlap before accepting a new abstraction
+
 ### Step 3: Classify findings
 
 For each issue found:

--- a/.claude/skills/inline-pr-comments/SKILL.md
+++ b/.claude/skills/inline-pr-comments/SKILL.md
@@ -81,32 +81,7 @@ Write a JSON file to `/tmp/review.json`:
   - `start_line` + `line` + `side: "RIGHT"` — For multi-line comments on added/changed lines
   - `body` — Markdown-formatted feedback with severity prefix
 
-### Step 4: Write sentinel if critical issues found
-
-Before submitting, count `🚨 CRITICAL:` occurrences and write a sentinel file. This must happen BEFORE the API call so the CI shell step can read it even if the API call fails.
-
-```bash
-python3 -c "
-import json, sys
-
-with open('/tmp/review.json') as f:
-    data = json.load(f)
-
-body = data.get('body', '')
-comments = data.get('comments', [])
-
-count = body.count('🚨 CRITICAL:') + sum(1 for c in comments if '🚨 CRITICAL:' in c.get('body', ''))
-
-if count > 0:
-    with open('/tmp/claude_critical', 'w') as f:
-        f.write(str(count))
-    print(f'Sentinel written — {count} critical issue(s)')
-else:
-    print('No critical issues')
-"
-```
-
-### Step 5: Submit the Review
+### Step 4: Submit the Review
 
 ```bash
 gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" --input /tmp/review.json

--- a/.claude/skills/inline-pr-comments/SKILL.md
+++ b/.claude/skills/inline-pr-comments/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: inline-pr-comments
+description: Submit code review findings as a single consolidated GitHub PR review with inline comments via gh api
+---
+
+# Consolidated PR Review Skill
+
+Use this skill to submit code review feedback as a **single consolidated GitHub review** containing both the summary body and all inline comments.
+
+## When to Use
+
+- After completing any code review (use with /claude-review-stack, /claude-review-business, /claude-review-security)
+- When you have specific line-by-line feedback to deliver
+
+## Instructions
+
+Submit one consolidated review per run using the GitHub API. **Do NOT post inline comments individually.** Each run produces a new review — nothing is overwritten.
+
+### Step 1: Fetch Prior Review Context
+
+Before posting, read existing reviews and comments on the PR to avoid duplication:
+
+```bash
+# Fetch existing reviews (summaries)
+gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" --jq '.[] | {user: .user.login, state: .state, body: .body}'
+
+# Fetch inline review comments
+gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/comments" --jq '.[] | {user: .user.login, path: .path, line: .line, body: .body}'
+
+# Fetch general PR discussion comments
+gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" --jq '.[] | {user: .user.login, body: .body}'
+```
+
+Use this context to:
+- **Skip issues already raised** — don't re-flag something a prior review already pointed out
+- **Flag unresolved issues** — if a prior review raised something that still isn't fixed, note it briefly
+- **Avoid contradictions** — don't suggest the opposite of what a human reviewer requested
+
+### Step 2: Collect All Findings
+
+Complete the full review. Collect:
+- **Summary** — Overall assessment, architecture concerns, non-diff observations, BLOCKING issue count
+- **Inline comments** — Specific issues on changed lines (path, line, body)
+
+Mark each finding with a severity prefix:
+- `🔴 BLOCKING:` — must be fixed before merge (incorrect logic, security issue, data loss risk)
+- `🟡 WARNING:` — should be fixed but won't block merge (bad pattern, fragile code)
+- `💬 SUGGESTION:` — optional improvement (style, minor optimisation)
+
+### Step 3: Build Review JSON
+
+Write a JSON file to `/tmp/review.json`:
+
+```json
+{
+  "body": "## Review Summary\n\nOverall assessment here.\n\n**Blocking issues: N**\n\n## Observations Outside This PR\n- `file:line`: description",
+  "event": "COMMENT",
+  "comments": [
+    {
+      "path": "composables/repay/useWalletRepay.ts",
+      "line": 42,
+      "body": "🔴 BLOCKING: Issue description here"
+    },
+    {
+      "path": "utils/fixed-point.ts",
+      "start_line": 10,
+      "line": 15,
+      "side": "RIGHT",
+      "body": "🟡 WARNING: Multi-line comment"
+    }
+  ]
+}
+```
+
+**Fields:**
+- `body` — Markdown review summary (required), must include blocking issue count
+- `event` — Always `"COMMENT"` (never APPROVE or REQUEST_CHANGES)
+- `comments` — Array of inline comment objects (can be empty)
+  - `path` — File path relative to repo root
+  - `line` — Line number in the **NEW** version of the file
+  - `start_line` + `line` + `side: "RIGHT"` — For multi-line comments on added/changed lines
+  - `body` — Markdown-formatted feedback with severity prefix
+
+### Step 4: Submit the Review
+
+```bash
+gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" --input /tmp/review.json
+```
+
+If the API call fails (e.g. a comment targeted an unchanged line causing a 422), note the error in a follow-up PR comment and stop.
+
+### Limitations
+
+- Inline comments can only target lines in the diff (changed/added lines)
+- Comments targeting unchanged lines will cause the API call to fail
+- If unsure whether a line is in the diff, put the finding in the summary body instead
+
+### Handling Non-Diff Findings
+
+Issues in code NOT changed by the PR go in the review `body`:
+
+```markdown
+## Observations Outside This PR
+
+- `composables/useEulerAccount.ts:142`: Pre-existing null check missing
+- `utils/fixed-point.ts:78-82`: Similar pattern to line 45 issue
+```
+
+### Feedback Guidelines
+
+| Feedback Type | In Diff? | Where |
+|---|---|---|
+| Specific code issue | Yes | `comments` array |
+| Pattern repeated across files | Yes | First in `comments` + note others in body |
+| Related issue found | No | `body` under "Observations Outside This PR" |
+| Pre-existing bug | No | `body` (consider separate issue if critical) |
+| Overall architecture concern | N/A | `body` |
+
+Be concise. Group minor style issues together. Never use APPROVE or REQUEST_CHANGES.

--- a/.claude/skills/inline-pr-comments/SKILL.md
+++ b/.claude/skills/inline-pr-comments/SKILL.md
@@ -39,12 +39,12 @@ Use this context to:
 ### Step 2: Collect All Findings
 
 Complete the full review. Collect:
-- **Summary** — Overall assessment, architecture concerns, non-diff observations, BLOCKING issue count
+- **Summary** — Overall assessment, architecture concerns, non-diff observations, CRITICAL issue count
 - **Inline comments** — Specific issues on changed lines (path, line, body)
 
 Mark each finding with a severity prefix:
-- `🔴 BLOCKING:` — must be fixed before merge (incorrect logic, security issue, data loss risk)
-- `🟡 WARNING:` — should be fixed but won't block merge (bad pattern, fragile code)
+- `🚨 CRITICAL:` — must be fixed before merge (incorrect logic, security issue, data loss risk)
+- `⚠️ WARNING:` — should be fixed but won't block merge (bad pattern, fragile code)
 - `💬 SUGGESTION:` — optional improvement (style, minor optimisation)
 
 ### Step 3: Build Review JSON
@@ -53,27 +53,27 @@ Write a JSON file to `/tmp/review.json`:
 
 ```json
 {
-  "body": "## Review Summary\n\nOverall assessment here.\n\n**Blocking issues: N**\n\n## Observations Outside This PR\n- `file:line`: description",
+  "body": "## Review Summary\n\nOverall assessment here.\n\n**Critical issues: N**\n\n## Observations Outside This PR\n- `file:line`: description",
   "event": "COMMENT",
   "comments": [
     {
       "path": "composables/repay/useWalletRepay.ts",
       "line": 42,
-      "body": "🔴 BLOCKING: Issue description here"
+      "body": "🚨 CRITICAL: Issue description here"
     },
     {
       "path": "utils/fixed-point.ts",
       "start_line": 10,
       "line": 15,
       "side": "RIGHT",
-      "body": "🟡 WARNING: Multi-line comment"
+      "body": "⚠️ WARNING: Multi-line comment"
     }
   ]
 }
 ```
 
 **Fields:**
-- `body` — Markdown review summary (required), must include blocking issue count
+- `body` — Markdown review summary (required), must include critical issue count
 - `event` — Always `"COMMENT"` (never APPROVE or REQUEST_CHANGES)
 - `comments` — Array of inline comment objects (can be empty)
   - `path` — File path relative to repo root
@@ -81,7 +81,32 @@ Write a JSON file to `/tmp/review.json`:
   - `start_line` + `line` + `side: "RIGHT"` — For multi-line comments on added/changed lines
   - `body` — Markdown-formatted feedback with severity prefix
 
-### Step 4: Submit the Review
+### Step 4: Write sentinel if critical issues found
+
+Before submitting, count `🚨 CRITICAL:` occurrences and write a sentinel file. This must happen BEFORE the API call so the CI shell step can read it even if the API call fails.
+
+```bash
+python3 -c "
+import json, sys
+
+with open('/tmp/review.json') as f:
+    data = json.load(f)
+
+body = data.get('body', '')
+comments = data.get('comments', [])
+
+count = body.count('🚨 CRITICAL:') + sum(1 for c in comments if '🚨 CRITICAL:' in c.get('body', ''))
+
+if count > 0:
+    with open('/tmp/claude_critical', 'w') as f:
+        f.write(str(count))
+    print(f'Sentinel written — {count} critical issue(s)')
+else:
+    print('No critical issues')
+"
+```
+
+### Step 5: Submit the Review
 
 ```bash
 gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" --input /tmp/review.json

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -43,9 +43,9 @@ jobs:
     env:
       ANTHROPIC_BASE_URL: ${{ secrets.LLM_BASE_URL }}
       ANTHROPIC_AUTH_TOKEN: ${{ secrets.LLM_API_KEY }}
-      ANTHROPIC_DEFAULT_OPUS_MODEL: ${{ vars.LLM_REVIEW_MODEL || 'anthropic/claude-sonnet-4.6' }}
-      ANTHROPIC_DEFAULT_SONNET_MODEL: ${{ vars.LLM_COORDINATOR_MODEL || 'anthropic/claude-sonnet-4.6' }}
-      CLAUDE_CODE_SUBAGENT_MODEL: ${{ vars.LLM_REVIEW_MODEL || 'anthropic/claude-sonnet-4.6' }}
+      ANTHROPIC_DEFAULT_OPUS_MODEL: ${{ vars.LLM_REVIEW_MODEL || 'anthropic/claude-opus-4.6' }}
+      ANTHROPIC_DEFAULT_SONNET_MODEL: ${{ vars.LLM_COORDINATOR_MODEL || 'anthropic/claude-opus-4.6' }}
+      CLAUDE_CODE_SUBAGENT_MODEL: ${{ vars.LLM_REVIEW_MODEL || 'anthropic/claude-opus-4.6' }}
     permissions:
       contents: read
       pull-requests: write
@@ -90,7 +90,7 @@ jobs:
           settings: |
             {
               "permissions": {
-                "allow": ["Bash(git diff *)", "Bash(gh api *)", "Bash(python3 *)", "Read", "Glob", "Grep"]
+                "allow": ["Bash(git diff *)", "Bash(gh api repos/*)", "Read", "Write", "Glob", "Grep", "WebFetch"]
               }
             }
           prompt: |
@@ -102,11 +102,13 @@ jobs:
       - name: Fail if critical issues found
         id: critical-check
         run: |
-          if [ -f /tmp/claude_critical ]; then
-            count=$(cat /tmp/claude_critical)
-            echo "has_critical=true" >> $GITHUB_OUTPUT
-            echo "::error::Review found $count critical issue(s) that must be resolved before merging."
-            exit 1
+          if [ -f /tmp/review.json ]; then
+            count=$(python3 -c "import json; d=json.load(open('/tmp/review.json')); b=d.get('body',''); cs=d.get('comments',[]); print(b.count('🚨 CRITICAL:') + sum(1 for c in cs if '🚨 CRITICAL:' in c.get('body','')))")
+            if [ "$count" -gt 0 ]; then
+              echo "has_critical=true" >> $GITHUB_OUTPUT
+              echo "::error::Review found $count critical issue(s) that must be resolved before merging."
+              exit 1
+            fi
           fi
 
   autofix:
@@ -143,9 +145,9 @@ jobs:
     env:
       ANTHROPIC_BASE_URL: ${{ secrets.LLM_BASE_URL }}
       ANTHROPIC_AUTH_TOKEN: ${{ secrets.LLM_API_KEY }}
-      ANTHROPIC_DEFAULT_OPUS_MODEL: ${{ vars.LLM_REVIEW_MODEL || 'anthropic/claude-sonnet-4.6' }}
-      ANTHROPIC_DEFAULT_SONNET_MODEL: ${{ vars.LLM_COORDINATOR_MODEL || 'anthropic/claude-sonnet-4.6' }}
-      CLAUDE_CODE_SUBAGENT_MODEL: ${{ vars.LLM_REVIEW_MODEL || 'anthropic/claude-sonnet-4.6' }}
+      ANTHROPIC_DEFAULT_OPUS_MODEL: ${{ vars.LLM_REVIEW_MODEL || 'anthropic/claude-opus-4.6' }}
+      ANTHROPIC_DEFAULT_SONNET_MODEL: ${{ vars.LLM_COORDINATOR_MODEL || 'anthropic/claude-opus-4.6' }}
+      CLAUDE_CODE_SUBAGENT_MODEL: ${{ vars.LLM_REVIEW_MODEL || 'anthropic/claude-opus-4.6' }}
     permissions:
       contents: write
       pull-requests: write
@@ -213,7 +215,7 @@ jobs:
           settings: |
             {
               "permissions": {
-                "allow": ["Bash(git *)", "Bash(gh *)", "Bash(python3 *)", "Read", "Write", "Edit", "Glob", "Grep"]
+                "allow": ["Bash(git *)", "Bash(gh *)", "Bash(python3 /tmp/*)", "Read", "Write", "Edit", "Glob", "Grep"]
               }
             }
           prompt: |
@@ -227,6 +229,7 @@ jobs:
       group: claude-interactive-${{ github.event.issue.number || github.event.pull_request.number }}
       cancel-in-progress: true
     if: |
+      github.event.sender.type != 'Bot' &&
       startsWith(github.event.comment.body, '@claude') &&
       !contains(github.event.comment.body, '@claude review') &&
       !contains(github.event.comment.body, '@claude fix') &&
@@ -246,9 +249,9 @@ jobs:
     env:
       ANTHROPIC_BASE_URL: ${{ secrets.LLM_BASE_URL }}
       ANTHROPIC_AUTH_TOKEN: ${{ secrets.LLM_API_KEY }}
-      ANTHROPIC_DEFAULT_OPUS_MODEL: ${{ vars.LLM_REVIEW_MODEL || 'anthropic/claude-sonnet-4.6' }}
-      ANTHROPIC_DEFAULT_SONNET_MODEL: ${{ vars.LLM_COORDINATOR_MODEL || 'anthropic/claude-sonnet-4.6' }}
-      CLAUDE_CODE_SUBAGENT_MODEL: ${{ vars.LLM_REVIEW_MODEL || 'anthropic/claude-sonnet-4.6' }}
+      ANTHROPIC_DEFAULT_OPUS_MODEL: ${{ vars.LLM_REVIEW_MODEL || 'anthropic/claude-opus-4.6' }}
+      ANTHROPIC_DEFAULT_SONNET_MODEL: ${{ vars.LLM_COORDINATOR_MODEL || 'anthropic/claude-opus-4.6' }}
+      CLAUDE_CODE_SUBAGENT_MODEL: ${{ vars.LLM_REVIEW_MODEL || 'anthropic/claude-opus-4.6' }}
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,218 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - '**.vue'
+      - '**.ts'
+      - '**.js'
+      - 'package.json'
+      - 'nuxt.config.*'
+  issue_comment:
+    types: [created]
+
+env:
+  CLAUDE_OPUS_MODEL: claude-opus-4-6
+
+jobs:
+  review-stack:
+    name: Review / Stack Hygiene
+    concurrency:
+      group: claude-review-stack-${{ github.event.pull_request.number || github.event.issue.number }}
+      cancel-in-progress: true
+    if: |
+      (
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.draft == false &&
+        github.event.pull_request.head.repo.full_name == github.repository
+      ) ||
+      (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        contains(github.event.comment.body, '@claude review') &&
+        (
+          github.event.comment.author_association == 'MEMBER' ||
+          github.event.comment.author_association == 'OWNER' ||
+          github.event.comment.author_association == 'COLLABORATOR'
+        )
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - name: Get PR info
+        id: pr-info
+        uses: actions/github-script@v7
+        with:
+          script: |
+            if (context.eventName === 'issue_comment') {
+              const { data: pr } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.issue.number
+              });
+              core.setOutput('head_sha', pr.head.sha);
+              core.setOutput('pr_number', context.issue.number);
+              core.setOutput('base_ref', pr.base.ref);
+            } else {
+              core.setOutput('head_sha', context.payload.pull_request.head.sha);
+              core.setOutput('pr_number', context.payload.pull_request.number);
+              core.setOutput('base_ref', context.payload.pull_request.base.ref);
+            }
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.pr-info.outputs.head_sha }}
+          fetch-depth: 0
+
+      - name: Run Stack Hygiene Review
+        uses: anthropics/claude-code-action@v1
+        env:
+          PR_NUMBER: ${{ steps.pr-info.outputs.pr_number }}
+          BASE_REF: ${{ steps.pr-info.outputs.base_ref }}
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: Run /claude-review-stack to review this PR, then use /inline-pr-comments to post findings as a consolidated PR review with inline comments.
+          track_progress: true
+          use_sticky_comment: false
+          claude_args: --model ${{ env.CLAUDE_OPUS_MODEL }}
+
+  review-business:
+    name: Review / Business Logic
+    concurrency:
+      group: claude-review-business-${{ github.event.pull_request.number || github.event.issue.number }}
+      cancel-in-progress: true
+    if: |
+      (
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.draft == false &&
+        github.event.pull_request.head.repo.full_name == github.repository
+      ) ||
+      (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        contains(github.event.comment.body, '@claude review') &&
+        (
+          github.event.comment.author_association == 'MEMBER' ||
+          github.event.comment.author_association == 'OWNER' ||
+          github.event.comment.author_association == 'COLLABORATOR'
+        )
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - name: Get PR info
+        id: pr-info
+        uses: actions/github-script@v7
+        with:
+          script: |
+            if (context.eventName === 'issue_comment') {
+              const { data: pr } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.issue.number
+              });
+              core.setOutput('head_sha', pr.head.sha);
+              core.setOutput('pr_number', context.issue.number);
+              core.setOutput('base_ref', pr.base.ref);
+            } else {
+              core.setOutput('head_sha', context.payload.pull_request.head.sha);
+              core.setOutput('pr_number', context.payload.pull_request.number);
+              core.setOutput('base_ref', context.payload.pull_request.base.ref);
+            }
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.pr-info.outputs.head_sha }}
+          fetch-depth: 0
+
+      - name: Run Business Logic Review
+        uses: anthropics/claude-code-action@v1
+        env:
+          PR_NUMBER: ${{ steps.pr-info.outputs.pr_number }}
+          BASE_REF: ${{ steps.pr-info.outputs.base_ref }}
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: Run /claude-review-business to review this PR, then use /inline-pr-comments to post findings as a consolidated PR review with inline comments.
+          track_progress: true
+          use_sticky_comment: false
+          claude_args: --model ${{ env.CLAUDE_OPUS_MODEL }}
+
+  review-security:
+    name: Review / Security
+    concurrency:
+      group: claude-review-security-${{ github.event.pull_request.number || github.event.issue.number }}
+      cancel-in-progress: true
+    if: |
+      (
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.draft == false &&
+        github.event.pull_request.head.repo.full_name == github.repository
+      ) ||
+      (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        contains(github.event.comment.body, '@claude review') &&
+        (
+          github.event.comment.author_association == 'MEMBER' ||
+          github.event.comment.author_association == 'OWNER' ||
+          github.event.comment.author_association == 'COLLABORATOR'
+        )
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - name: Get PR info
+        id: pr-info
+        uses: actions/github-script@v7
+        with:
+          script: |
+            if (context.eventName === 'issue_comment') {
+              const { data: pr } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.issue.number
+              });
+              core.setOutput('head_sha', pr.head.sha);
+              core.setOutput('pr_number', context.issue.number);
+              core.setOutput('base_ref', pr.base.ref);
+            } else {
+              core.setOutput('head_sha', context.payload.pull_request.head.sha);
+              core.setOutput('pr_number', context.payload.pull_request.number);
+              core.setOutput('base_ref', context.payload.pull_request.base.ref);
+            }
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.pr-info.outputs.head_sha }}
+          fetch-depth: 0
+
+      - name: Run Security Review
+        uses: anthropics/claude-code-action@v1
+        env:
+          PR_NUMBER: ${{ steps.pr-info.outputs.pr_number }}
+          BASE_REF: ${{ steps.pr-info.outputs.base_ref }}
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: Run /claude-review-security to review this PR, then use /inline-pr-comments to post findings as a consolidated PR review with inline comments.
+          track_progress: true
+          use_sticky_comment: false
+          claude_args: --model ${{ env.CLAUDE_OPUS_MODEL }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -202,6 +202,7 @@ jobs:
           BASE_REF: ${{ steps.pr-info.outputs.base_ref }}
           HEAD_REF: ${{ steps.pr-info.outputs.head_ref }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
         with:
           anthropic_api_key: ${{ secrets.LLM_API_KEY }}
           use_sticky_comment: "true"
@@ -212,7 +213,10 @@ jobs:
                 "allow": ["Bash(git *)", "Bash(gh *)", "Bash(python3 *)", "Read", "Write", "Edit", "Glob", "Grep"]
               }
             }
-          prompt: Run /claude-autofix to implement fixes for critical issues found in the review for this PR, open a fix PR, and comment the link on this PR.
+          prompt: |
+            Check the COMMENT_BODY env var.
+            If it contains specific instructions after "@claude fix" (e.g. "@claude fix move apiSecret to server-only config"), implement exactly those instructions on the PR branch, commit, push, and post a comment on PR #$PR_NUMBER summarising what was done.
+            If COMMENT_BODY is empty or is just "@claude fix" with no further instructions, run /claude-autofix to implement fixes for all critical issues found in the review, open a fix PR, and comment the link on this PR.
           claude_args: --model ${{ env.CLAUDE_OPUS_MODEL }}
 
   interactive:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -43,6 +43,7 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+      id-token: write
     steps:
       - name: Get PR info
         id: pr-info
@@ -78,8 +79,6 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: Run /claude-review-stack to review this PR, then use /inline-pr-comments to post findings as a consolidated PR review with inline comments.
-          track_progress: true
-          use_sticky_comment: false
           claude_args: --model ${{ env.CLAUDE_OPUS_MODEL }}
 
   review-business:
@@ -109,6 +108,7 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+      id-token: write
     steps:
       - name: Get PR info
         id: pr-info
@@ -144,8 +144,6 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: Run /claude-review-business to review this PR, then use /inline-pr-comments to post findings as a consolidated PR review with inline comments.
-          track_progress: true
-          use_sticky_comment: false
           claude_args: --model ${{ env.CLAUDE_OPUS_MODEL }}
 
   review-security:
@@ -175,6 +173,7 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+      id-token: write
     steps:
       - name: Get PR info
         id: pr-info
@@ -210,6 +209,4 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: Run /claude-review-security to review this PR, then use /inline-pr-comments to post findings as a consolidated PR review with inline comments.
-          track_progress: true
-          use_sticky_comment: false
           claude_args: --model ${{ env.CLAUDE_OPUS_MODEL }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, reopened, ready_for_review]
     paths:
       - '**.vue'
       - '**.ts'
@@ -11,21 +11,27 @@ on:
       - 'nuxt.config.*'
   issue_comment:
     types: [created]
+  pull_request_review_comment:
+    types: [created]
 
 env:
   CLAUDE_OPUS_MODEL: claude-opus-4-6
+  CLAUDE_SONNET_MODEL: claude-sonnet-4-6
 
 jobs:
-  review-stack:
-    name: Review / Stack Hygiene
+  review:
+    name: Review
     concurrency:
-      group: claude-review-stack-${{ github.event.pull_request.number || github.event.issue.number }}
+      group: claude-review-${{ github.event.pull_request.number || github.event.issue.number }}
       cancel-in-progress: true
+    outputs:
+      has_critical: ${{ steps.critical-check.outputs.has_critical }}
     if: |
       (
         github.event_name == 'pull_request' &&
         github.event.pull_request.draft == false &&
-        github.event.pull_request.head.repo.full_name == github.repository
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        github.event.pull_request.user.type != 'Bot'
       ) ||
       (
         github.event_name == 'issue_comment' &&
@@ -37,11 +43,11 @@ jobs:
         )
       )
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     permissions:
       contents: read
       pull-requests: write
-      issues: write
+      actions: read
       id-token: write
     steps:
       - name: Get PR info
@@ -70,180 +76,66 @@ jobs:
           ref: ${{ steps.pr-info.outputs.head_sha }}
           fetch-depth: 0
 
-      - name: Run Stack Hygiene Review
+      - name: Run Reviews
         uses: anthropics/claude-code-action@v1
         env:
           PR_NUMBER: ${{ steps.pr-info.outputs.pr_number }}
           BASE_REF: ${{ steps.pr-info.outputs.base_ref }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          prompt: Run /claude-review-stack to review this PR, then use /inline-pr-comments to post findings as a consolidated PR review with inline comments.
-          claude_args: --model ${{ env.CLAUDE_OPUS_MODEL }}
-
-      - name: Fail if critical issues found
-        run: |
-          if [ -f /tmp/claude_critical ]; then
-            count=$(cat /tmp/claude_critical)
-            echo "::error::Review found $count critical issue(s) that must be resolved before merging."
-            exit 1
-          fi
-
-  review-business:
-    name: Review / Business Logic
-    concurrency:
-      group: claude-review-business-${{ github.event.pull_request.number || github.event.issue.number }}
-      cancel-in-progress: true
-    if: |
-      (
-        github.event_name == 'pull_request' &&
-        github.event.pull_request.draft == false &&
-        github.event.pull_request.head.repo.full_name == github.repository
-      ) ||
-      (
-        github.event_name == 'issue_comment' &&
-        github.event.issue.pull_request &&
-        startsWith(github.event.comment.body, '@claude review') &&
-        (
-          github.event.comment.author_association == 'MEMBER' ||
-          github.event.comment.author_association == 'OWNER'
-        )
-      )
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    permissions:
-      contents: read
-      pull-requests: write
-      issues: write
-      id-token: write
-    steps:
-      - name: Get PR info
-        id: pr-info
-        uses: actions/github-script@v7
-        with:
-          script: |
-            if (context.eventName === 'issue_comment') {
-              const { data: pr } = await github.rest.pulls.get({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: context.issue.number
-              });
-              core.setOutput('head_sha', pr.head.sha);
-              core.setOutput('pr_number', context.issue.number);
-              core.setOutput('base_ref', pr.base.ref);
-            } else {
-              core.setOutput('head_sha', context.payload.pull_request.head.sha);
-              core.setOutput('pr_number', context.payload.pull_request.number);
-              core.setOutput('base_ref', context.payload.pull_request.base.ref);
+          use_sticky_comment: "true"
+          track_progress: "true"
+          settings: |
+            {
+              "permissions": {
+                "allow": ["Bash(git diff *)", "Bash(gh api *)", "Bash(python3 *)", "Read", "Glob", "Grep"]
+              }
             }
-
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ steps.pr-info.outputs.head_sha }}
-          fetch-depth: 0
-
-      - name: Run Business Logic Review
-        uses: anthropics/claude-code-action@v1
-        env:
-          PR_NUMBER: ${{ steps.pr-info.outputs.pr_number }}
-          BASE_REF: ${{ steps.pr-info.outputs.base_ref }}
-        with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          prompt: Run /claude-review-business to review this PR, then use /inline-pr-comments to post findings as a consolidated PR review with inline comments.
+          prompt: |
+            First, create three tasks upfront before doing anything else: "Stack review", "Business review", "Security review".
+            Then use agent teams to run /claude-review-stack, /claude-review-business, and /claude-review-security in parallel.
+            Mark each task complete only when that specific agent returns its findings.
+            Once all three are marked complete, use /inline-pr-comments once to post a single consolidated PR review with inline comments.
           claude_args: --model ${{ env.CLAUDE_OPUS_MODEL }}
 
       - name: Fail if critical issues found
+        id: critical-check
         run: |
           if [ -f /tmp/claude_critical ]; then
             count=$(cat /tmp/claude_critical)
-            echo "::error::Review found $count critical issue(s) that must be resolved before merging."
-            exit 1
-          fi
-
-  review-security:
-    name: Review / Security
-    concurrency:
-      group: claude-review-security-${{ github.event.pull_request.number || github.event.issue.number }}
-      cancel-in-progress: true
-    if: |
-      (
-        github.event_name == 'pull_request' &&
-        github.event.pull_request.draft == false &&
-        github.event.pull_request.head.repo.full_name == github.repository
-      ) ||
-      (
-        github.event_name == 'issue_comment' &&
-        github.event.issue.pull_request &&
-        startsWith(github.event.comment.body, '@claude review') &&
-        (
-          github.event.comment.author_association == 'MEMBER' ||
-          github.event.comment.author_association == 'OWNER'
-        )
-      )
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    permissions:
-      contents: read
-      pull-requests: write
-      issues: write
-      id-token: write
-    steps:
-      - name: Get PR info
-        id: pr-info
-        uses: actions/github-script@v7
-        with:
-          script: |
-            if (context.eventName === 'issue_comment') {
-              const { data: pr } = await github.rest.pulls.get({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: context.issue.number
-              });
-              core.setOutput('head_sha', pr.head.sha);
-              core.setOutput('pr_number', context.issue.number);
-              core.setOutput('base_ref', pr.base.ref);
-            } else {
-              core.setOutput('head_sha', context.payload.pull_request.head.sha);
-              core.setOutput('pr_number', context.payload.pull_request.number);
-              core.setOutput('base_ref', context.payload.pull_request.base.ref);
-            }
-
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ steps.pr-info.outputs.head_sha }}
-          fetch-depth: 0
-
-      - name: Run Security Review
-        uses: anthropics/claude-code-action@v1
-        env:
-          PR_NUMBER: ${{ steps.pr-info.outputs.pr_number }}
-          BASE_REF: ${{ steps.pr-info.outputs.base_ref }}
-        with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          prompt: Run /claude-review-security to review this PR, then use /inline-pr-comments to post findings as a consolidated PR review with inline comments.
-          claude_args: --model ${{ env.CLAUDE_OPUS_MODEL }}
-
-      - name: Fail if critical issues found
-        run: |
-          if [ -f /tmp/claude_critical ]; then
-            count=$(cat /tmp/claude_critical)
+            echo "has_critical=true" >> $GITHUB_OUTPUT
             echo "::error::Review found $count critical issue(s) that must be resolved before merging."
             exit 1
           fi
 
   autofix:
     name: Auto-fix / Open PR
+    needs: [review]
     concurrency:
-      group: claude-autofix-${{ github.event.issue.number }}
-      cancel-in-progress: true
+      group: claude-autofix-${{ github.event.issue.number || github.event.pull_request.number }}
+      cancel-in-progress: false
     if: |
-      github.event_name == 'issue_comment' &&
-      github.event.issue.pull_request &&
-      startsWith(github.event.comment.body, '@claude fix') &&
+      always() &&
+      needs.review.result != 'cancelled' &&
       (
-        github.event.comment.author_association == 'MEMBER' ||
-        github.event.comment.author_association == 'OWNER'
+        (
+          needs.review.outputs.has_critical == 'true' &&
+          github.event_name == 'pull_request'
+        ) ||
+        (
+          startsWith(github.event.comment.body, '@claude fix') &&
+          (
+            (
+              github.event_name == 'issue_comment' &&
+              github.event.issue.pull_request &&
+              (
+                github.event.comment.author_association == 'MEMBER' ||
+                github.event.comment.author_association == 'OWNER'
+              )
+            ) ||
+            github.event_name == 'pull_request_review_comment'
+          )
+        )
       )
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -251,23 +143,44 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+      actions: read
       id-token: write
     steps:
+      - name: Check commenter permission
+        if: github.event_name == 'pull_request_review_comment'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: context.actor
+            });
+            if (!['admin', 'write'].includes(data.permission)) {
+              core.setFailed(`${context.actor} does not have write access.`);
+            }
+
       - name: Get PR info
         id: pr-info
         uses: actions/github-script@v7
         with:
           script: |
-            const { data: pr } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number
-            });
+            let pr;
+            if (context.eventName === 'pull_request' || context.eventName === 'pull_request_review_comment') {
+              pr = context.payload.pull_request;
+            } else {
+              const { data } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.issue.number
+              });
+              pr = data;
+            }
             core.setOutput('head_sha', pr.head.sha);
-            core.setOutput('pr_number', context.issue.number);
+            core.setOutput('pr_number', pr.number);
             core.setOutput('base_ref', pr.base.ref);
             core.setOutput('head_ref', pr.head.ref);
-            if (pr.head.repo.full_name !== context.repo.full_name) {
+            if (pr.head.repo?.full_name !== `${context.repo.owner}/${context.repo.repo}`) {
               core.setFailed('Cannot auto-fix: PR is from a fork. Push access is required.');
             }
 
@@ -287,23 +200,36 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          use_sticky_comment: "true"
+          track_progress: "true"
+          settings: |
+            {
+              "permissions": {
+                "allow": ["Bash(git *)", "Bash(gh *)", "Bash(python3 *)", "Read", "Write", "Edit", "Glob", "Grep"]
+              }
+            }
           prompt: Run /claude-autofix to implement fixes for critical issues found in the review for this PR, open a fix PR, and comment the link on this PR.
           claude_args: --model ${{ env.CLAUDE_OPUS_MODEL }}
 
   interactive:
     name: Interactive
     concurrency:
-      group: claude-interactive-${{ github.event.issue.number }}
+      group: claude-interactive-${{ github.event.issue.number || github.event.pull_request.number }}
       cancel-in-progress: true
     if: |
-      github.event_name == 'issue_comment' &&
-      github.event.issue.pull_request &&
       startsWith(github.event.comment.body, '@claude') &&
       !contains(github.event.comment.body, '@claude review') &&
       !contains(github.event.comment.body, '@claude fix') &&
       (
-        github.event.comment.author_association == 'MEMBER' ||
-        github.event.comment.author_association == 'OWNER'
+        (
+          github.event_name == 'issue_comment' &&
+          github.event.issue.pull_request &&
+          (
+            github.event.comment.author_association == 'MEMBER' ||
+            github.event.comment.author_association == 'OWNER'
+          )
+        ) ||
+        github.event_name == 'pull_request_review_comment'
       )
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -311,20 +237,41 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+      actions: read
       id-token: write
     steps:
+      - name: Check commenter permission
+        if: github.event_name == 'pull_request_review_comment'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: context.actor
+            });
+            if (!['admin', 'write'].includes(data.permission)) {
+              core.setFailed(`${context.actor} does not have write access.`);
+            }
+
       - name: Get PR info
         id: pr-info
         uses: actions/github-script@v7
         with:
           script: |
-            const { data: pr } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number
-            });
+            let pr;
+            if (context.eventName === 'pull_request_review_comment') {
+              pr = context.payload.pull_request;
+            } else {
+              const { data } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.issue.number
+              });
+              pr = data;
+            }
             core.setOutput('head_sha', pr.head.sha);
-            core.setOutput('pr_number', context.issue.number);
+            core.setOutput('pr_number', pr.number);
             core.setOutput('base_ref', pr.base.ref);
 
       - name: Checkout repository
@@ -338,13 +285,20 @@ jobs:
         env:
           PR_NUMBER: ${{ steps.pr-info.outputs.pr_number }}
           BASE_REF: ${{ steps.pr-info.outputs.base_ref }}
-          USER_COMMENT: ${{ github.event.comment.body }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          use_sticky_comment: "true"
+          track_progress: "true"
+          settings: |
+            {
+              "permissions": {
+                "allow": ["Bash(git diff *)", "Bash(gh api *)", "Read", "Glob", "Grep"]
+              }
+            }
           prompt: |
             A team member commented on this PR: "${{ github.event.comment.body }}"
 
             You have access to the full repository. Focus your response on the context of this PR and the changed files.
             Use git diff origin/$BASE_REF...HEAD to understand what changed.
             Post your response as a comment on PR #$PR_NUMBER using gh api.
-          claude_args: --model ${{ env.CLAUDE_OPUS_MODEL }}
+          claude_args: --model ${{ env.CLAUDE_SONNET_MODEL }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -43,7 +43,6 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
-      id-token: write
     steps:
       - name: Get PR info
         id: pr-info
@@ -110,7 +109,6 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
-      id-token: write
     steps:
       - name: Get PR info
         id: pr-info
@@ -177,7 +175,6 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
-      id-token: write
     steps:
       - name: Get PR info
         id: pr-info

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -30,7 +30,7 @@ jobs:
       (
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
-        contains(github.event.comment.body, '@claude review') &&
+        startsWith(github.event.comment.body, '@claude review') &&
         (
           github.event.comment.author_association == 'MEMBER' ||
           github.event.comment.author_association == 'OWNER' ||
@@ -81,6 +81,14 @@ jobs:
           prompt: Run /claude-review-stack to review this PR, then use /inline-pr-comments to post findings as a consolidated PR review with inline comments.
           claude_args: --model ${{ env.CLAUDE_OPUS_MODEL }}
 
+      - name: Fail if critical issues found
+        run: |
+          if [ -f /tmp/claude_critical ]; then
+            count=$(cat /tmp/claude_critical)
+            echo "::error::Review found $count critical issue(s) that must be resolved before merging."
+            exit 1
+          fi
+
   review-business:
     name: Review / Business Logic
     concurrency:
@@ -95,7 +103,7 @@ jobs:
       (
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
-        contains(github.event.comment.body, '@claude review') &&
+        startsWith(github.event.comment.body, '@claude review') &&
         (
           github.event.comment.author_association == 'MEMBER' ||
           github.event.comment.author_association == 'OWNER' ||
@@ -146,6 +154,14 @@ jobs:
           prompt: Run /claude-review-business to review this PR, then use /inline-pr-comments to post findings as a consolidated PR review with inline comments.
           claude_args: --model ${{ env.CLAUDE_OPUS_MODEL }}
 
+      - name: Fail if critical issues found
+        run: |
+          if [ -f /tmp/claude_critical ]; then
+            count=$(cat /tmp/claude_critical)
+            echo "::error::Review found $count critical issue(s) that must be resolved before merging."
+            exit 1
+          fi
+
   review-security:
     name: Review / Security
     concurrency:
@@ -160,7 +176,7 @@ jobs:
       (
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
-        contains(github.event.comment.body, '@claude review') &&
+        startsWith(github.event.comment.body, '@claude review') &&
         (
           github.event.comment.author_association == 'MEMBER' ||
           github.event.comment.author_association == 'OWNER' ||
@@ -209,4 +225,131 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: Run /claude-review-security to review this PR, then use /inline-pr-comments to post findings as a consolidated PR review with inline comments.
+          claude_args: --model ${{ env.CLAUDE_OPUS_MODEL }}
+
+      - name: Fail if critical issues found
+        run: |
+          if [ -f /tmp/claude_critical ]; then
+            count=$(cat /tmp/claude_critical)
+            echo "::error::Review found $count critical issue(s) that must be resolved before merging."
+            exit 1
+          fi
+
+  autofix:
+    name: Auto-fix / Open PR
+    concurrency:
+      group: claude-autofix-${{ github.event.issue.number }}
+      cancel-in-progress: true
+    if: |
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '@claude fix') &&
+      (
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'COLLABORATOR'
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - name: Get PR info
+        id: pr-info
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+            core.setOutput('head_sha', pr.head.sha);
+            core.setOutput('pr_number', context.issue.number);
+            core.setOutput('base_ref', pr.base.ref);
+            core.setOutput('head_ref', pr.head.ref);
+            if (pr.head.repo.full_name !== context.repo.full_name) {
+              core.setFailed('Cannot auto-fix: PR is from a fork. Push access is required.');
+            }
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.pr-info.outputs.head_sha }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run Auto-fix
+        uses: anthropics/claude-code-action@v1
+        env:
+          PR_NUMBER: ${{ steps.pr-info.outputs.pr_number }}
+          BASE_REF: ${{ steps.pr-info.outputs.base_ref }}
+          HEAD_REF: ${{ steps.pr-info.outputs.head_ref }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: Run /claude-autofix to implement fixes for critical issues found in the review for this PR, open a fix PR, and comment the link on this PR.
+          claude_args: --model ${{ env.CLAUDE_OPUS_MODEL }}
+
+  interactive:
+    name: Interactive
+    concurrency:
+      group: claude-interactive-${{ github.event.issue.number }}
+      cancel-in-progress: true
+    if: |
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '@claude') &&
+      !contains(github.event.comment.body, '@claude review') &&
+      !contains(github.event.comment.body, '@claude fix') &&
+      (
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'COLLABORATOR'
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - name: Get PR info
+        id: pr-info
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+            core.setOutput('head_sha', pr.head.sha);
+            core.setOutput('pr_number', context.issue.number);
+            core.setOutput('base_ref', pr.base.ref);
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.pr-info.outputs.head_sha }}
+          fetch-depth: 0
+
+      - name: Respond to comment
+        uses: anthropics/claude-code-action@v1
+        env:
+          PR_NUMBER: ${{ steps.pr-info.outputs.pr_number }}
+          BASE_REF: ${{ steps.pr-info.outputs.base_ref }}
+          USER_COMMENT: ${{ github.event.comment.body }}
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            A team member commented on this PR: "${{ github.event.comment.body }}"
+
+            You have access to the full repository. Focus your response on the context of this PR and the changed files.
+            Use git diff origin/$BASE_REF...HEAD to understand what changed.
+            Post your response as a comment on PR #$PR_NUMBER using gh api.
           claude_args: --model ${{ env.CLAUDE_OPUS_MODEL }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -102,13 +102,12 @@ jobs:
       - name: Fail if critical issues found
         id: critical-check
         run: |
-          if [ -f /tmp/review.json ]; then
-            count=$(python3 -c "import json; d=json.load(open('/tmp/review.json')); b=d.get('body',''); cs=d.get('comments',[]); print(b.count('🚨 CRITICAL:') + sum(1 for c in cs if '🚨 CRITICAL:' in c.get('body','')))")
-            if [ "$count" -gt 0 ]; then
-              echo "has_critical=true" >> $GITHUB_OUTPUT
-              echo "::error::Review found $count critical issue(s) that must be resolved before merging."
-              exit 1
-            fi
+          if [ ! -f /tmp/review.json ]; then exit 1; fi
+          count=$(python3 -c "import json; d=json.load(open('/tmp/review.json')); b=d.get('body',''); cs=d.get('comments',[]); print(b.count('🚨 CRITICAL:') + sum(1 for c in cs if '🚨 CRITICAL:' in c.get('body','')))")
+          if [ "$count" -gt 0 ]; then
+            echo "has_critical=true" >> $GITHUB_OUTPUT
+            echo "::error::Review found $count critical issue(s) that must be resolved before merging."
+            exit 1
           fi
 
   autofix:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -14,10 +14,6 @@ on:
   pull_request_review_comment:
     types: [created]
 
-env:
-  CLAUDE_OPUS_MODEL: anthropic/claude-opus-4-6
-  CLAUDE_SONNET_MODEL: anthropic/claude-sonnet-4-6
-
 jobs:
   review:
     name: Review
@@ -46,6 +42,10 @@ jobs:
     timeout-minutes: 30
     env:
       ANTHROPIC_BASE_URL: ${{ secrets.LLM_BASE_URL }}
+      ANTHROPIC_AUTH_TOKEN: ${{ secrets.LLM_API_KEY }}
+      ANTHROPIC_DEFAULT_OPUS_MODEL: ${{ vars.LLM_REVIEW_MODEL || 'anthropic/claude-sonnet-4.6' }}
+      ANTHROPIC_DEFAULT_SONNET_MODEL: ${{ vars.LLM_COORDINATOR_MODEL || 'anthropic/claude-sonnet-4.6' }}
+      CLAUDE_CODE_SUBAGENT_MODEL: ${{ vars.LLM_REVIEW_MODEL || 'anthropic/claude-sonnet-4.6' }}
     permissions:
       contents: read
       pull-requests: write
@@ -98,7 +98,6 @@ jobs:
             Then use agent teams to run /claude-review-stack, /claude-review-business, and /claude-review-security in parallel.
             Mark each task complete only when that specific agent returns its findings.
             Once all three are marked complete, use /inline-pr-comments once to post a single consolidated PR review with inline comments.
-          claude_args: --model ${{ env.CLAUDE_OPUS_MODEL }}
 
       - name: Fail if critical issues found
         id: critical-check
@@ -143,6 +142,10 @@ jobs:
     timeout-minutes: 30
     env:
       ANTHROPIC_BASE_URL: ${{ secrets.LLM_BASE_URL }}
+      ANTHROPIC_AUTH_TOKEN: ${{ secrets.LLM_API_KEY }}
+      ANTHROPIC_DEFAULT_OPUS_MODEL: ${{ vars.LLM_REVIEW_MODEL || 'anthropic/claude-sonnet-4.6' }}
+      ANTHROPIC_DEFAULT_SONNET_MODEL: ${{ vars.LLM_COORDINATOR_MODEL || 'anthropic/claude-sonnet-4.6' }}
+      CLAUDE_CODE_SUBAGENT_MODEL: ${{ vars.LLM_REVIEW_MODEL || 'anthropic/claude-sonnet-4.6' }}
     permissions:
       contents: write
       pull-requests: write
@@ -215,9 +218,8 @@ jobs:
             }
           prompt: |
             Check the COMMENT_BODY env var.
-            If it contains specific instructions after "@claude fix" (e.g. "@claude fix move apiSecret to server-only config"), implement exactly those instructions on the PR branch, commit, push, and post a comment on PR #$PR_NUMBER summarising what was done.
+            If it contains specific instructions after "@claude fix" (e.g. "@claude fix move apiSecret to server-only config"), implement exactly those instructions, then commit and push directly to the current PR branch ($HEAD_REF), and post a comment on PR #$PR_NUMBER summarising what was done. Do NOT open a new PR.
             If COMMENT_BODY is empty or is just "@claude fix" with no further instructions, run /claude-autofix to implement fixes for all critical issues found in the review, open a fix PR, and comment the link on this PR.
-          claude_args: --model ${{ env.CLAUDE_OPUS_MODEL }}
 
   interactive:
     name: Interactive
@@ -243,6 +245,10 @@ jobs:
     timeout-minutes: 20
     env:
       ANTHROPIC_BASE_URL: ${{ secrets.LLM_BASE_URL }}
+      ANTHROPIC_AUTH_TOKEN: ${{ secrets.LLM_API_KEY }}
+      ANTHROPIC_DEFAULT_OPUS_MODEL: ${{ vars.LLM_REVIEW_MODEL || 'anthropic/claude-sonnet-4.6' }}
+      ANTHROPIC_DEFAULT_SONNET_MODEL: ${{ vars.LLM_COORDINATOR_MODEL || 'anthropic/claude-sonnet-4.6' }}
+      CLAUDE_CODE_SUBAGENT_MODEL: ${{ vars.LLM_REVIEW_MODEL || 'anthropic/claude-sonnet-4.6' }}
     permissions:
       contents: read
       pull-requests: write
@@ -311,4 +317,3 @@ jobs:
             You have access to the full repository. Focus your response on the context of this PR and the changed files.
             Use git diff origin/$BASE_REF...HEAD to understand what changed.
             Post your response as a comment on PR #$PR_NUMBER using gh api.
-          claude_args: --model ${{ env.CLAUDE_SONNET_MODEL }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -33,8 +33,7 @@ jobs:
         startsWith(github.event.comment.body, '@claude review') &&
         (
           github.event.comment.author_association == 'MEMBER' ||
-          github.event.comment.author_association == 'OWNER' ||
-          github.event.comment.author_association == 'COLLABORATOR'
+          github.event.comment.author_association == 'OWNER'
         )
       )
     runs-on: ubuntu-latest
@@ -106,8 +105,7 @@ jobs:
         startsWith(github.event.comment.body, '@claude review') &&
         (
           github.event.comment.author_association == 'MEMBER' ||
-          github.event.comment.author_association == 'OWNER' ||
-          github.event.comment.author_association == 'COLLABORATOR'
+          github.event.comment.author_association == 'OWNER'
         )
       )
     runs-on: ubuntu-latest
@@ -179,8 +177,7 @@ jobs:
         startsWith(github.event.comment.body, '@claude review') &&
         (
           github.event.comment.author_association == 'MEMBER' ||
-          github.event.comment.author_association == 'OWNER' ||
-          github.event.comment.author_association == 'COLLABORATOR'
+          github.event.comment.author_association == 'OWNER'
         )
       )
     runs-on: ubuntu-latest
@@ -246,8 +243,7 @@ jobs:
       startsWith(github.event.comment.body, '@claude fix') &&
       (
         github.event.comment.author_association == 'MEMBER' ||
-        github.event.comment.author_association == 'OWNER' ||
-        github.event.comment.author_association == 'COLLABORATOR'
+        github.event.comment.author_association == 'OWNER'
       )
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -307,8 +303,7 @@ jobs:
       !contains(github.event.comment.body, '@claude fix') &&
       (
         github.event.comment.author_association == 'MEMBER' ||
-        github.event.comment.author_association == 'OWNER' ||
-        github.event.comment.author_association == 'COLLABORATOR'
+        github.event.comment.author_association == 'OWNER'
       )
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -15,8 +15,8 @@ on:
     types: [created]
 
 env:
-  CLAUDE_OPUS_MODEL: claude-opus-4-6
-  CLAUDE_SONNET_MODEL: claude-sonnet-4-6
+  CLAUDE_OPUS_MODEL: anthropic/claude-opus-4-6
+  CLAUDE_SONNET_MODEL: anthropic/claude-sonnet-4-6
 
 jobs:
   review:
@@ -44,6 +44,8 @@ jobs:
       )
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      ANTHROPIC_BASE_URL: ${{ secrets.LLM_BASE_URL }}
     permissions:
       contents: read
       pull-requests: write
@@ -82,7 +84,7 @@ jobs:
           PR_NUMBER: ${{ steps.pr-info.outputs.pr_number }}
           BASE_REF: ${{ steps.pr-info.outputs.base_ref }}
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ secrets.LLM_API_KEY }}
           use_sticky_comment: "true"
           track_progress: "true"
           settings: |
@@ -139,6 +141,8 @@ jobs:
       )
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      ANTHROPIC_BASE_URL: ${{ secrets.LLM_BASE_URL }}
     permissions:
       contents: write
       pull-requests: write
@@ -199,7 +203,7 @@ jobs:
           HEAD_REF: ${{ steps.pr-info.outputs.head_ref }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ secrets.LLM_API_KEY }}
           use_sticky_comment: "true"
           track_progress: "true"
           settings: |
@@ -233,6 +237,8 @@ jobs:
       )
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    env:
+      ANTHROPIC_BASE_URL: ${{ secrets.LLM_BASE_URL }}
     permissions:
       contents: read
       pull-requests: write
@@ -286,7 +292,7 @@ jobs:
           PR_NUMBER: ${{ steps.pr-info.outputs.pr_number }}
           BASE_REF: ${{ steps.pr-info.outputs.base_ref }}
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ secrets.LLM_API_KEY }}
           use_sticky_comment: "true"
           track_progress: "true"
           settings: |


### PR DESCRIPTION
## Summary

- Add an automated CI pipeline that runs three parallel AI review agents (stack, business logic, security) on every PR, consolidates findings into a single inline review, and fails the build if critical issues are found
- Add an auto-fix job that either opens a fix PR for critical findings automatically, or applies targeted changes when triggered via `@claude fix <instructions>` comment
- Add an interactive job that responds to arbitrary `@claude` comments on PRs with context-aware answers
- Make the LLM provider fully configurable via repository secrets and variables, with no hardcoded model references

## Changes

- **`.github/workflows/claude-code-review.yml`**: Three-job CI workflow — `review` (parallel sub-agents + consolidated inline comments), `autofix` (critical-finding fix PRs and targeted fixes), `interactive` (comment responder); per-job env blocks for `ANTHROPIC_AUTH_TOKEN`, model vars, and subagent model; fork and permission guards on all write-capable paths
- **`.claude/skills/claude-review-stack`**: Vue 3 / Nuxt 3 / TypeScript / Viem hygiene review agent with classified findings output
- **`.claude/skills/claude-review-business`**: DeFi business logic review agent covering arithmetic safety, vault/position correctness, and flow integrity
- **`.claude/skills/claude-review-security`**: Security review agent covering env var exposure, XSS vectors, geo-blocking bypasses, and RPC leakage
- **`.claude/skills/inline-pr-comments`**: Consolidation agent that collects findings from all three review agents and posts a single structured GitHub PR review with inline comments; writes `/tmp/claude_critical` sentinel to drive the CI blocking gate
- **`.claude/skills/claude-autofix`**: Auto-fix agent that reads critical findings, triages false positives, applies minimal fixes on a new branch, opens a fix PR, and comments the link back on the original PR

## Notes

The CI blocking gate relies on `/tmp/claude_critical` being written by the `inline-pr-comments` skill and read by a subsequent shell step — this works because `claude-code-action@v1` is a JavaScript action that shares the runner filesystem. The `pull_request_review_comment` trigger on `autofix` and `interactive` jobs spins up a runner before the in-job permission check runs; this is a known tradeoff accepted in favour of simpler job conditions.
