### PR TITLE
fix: preserve verified flag for escrow vaults during EVK refresh

### DIFF
--- a/composables/useVaults.ts
+++ b/composables/useVaults.ts
@@ -102,7 +102,8 @@ const updateEVKVaults = async (vaultAddresses: string[], generation?: number, si
       result.vaults.forEach((vault) => {
         const existing = registryGetVault(vault.address) as Vault | undefined
         const vaultCategory = existing?.vaultCategory
-        registrySet(vault.address, vaultCategory ? { ...vault, vaultCategory } : vault, 'evk')
+        const verified = vaultCategory === 'escrow' ? true : vault.verified
+        registrySet(vault.address, vaultCategory ? { ...vault, vaultCategory, verified } : vault, 'evk')
       })
 
       if (!silent) {


### PR DESCRIPTION
## Summary
- Escrow vault cards intermittently showed "Unknown" on the explore page and earn vault exposure sections
- `refreshVaults()` re-fetches escrow vaults through the EVK path, which sets `verified` based on `verifiedVaultAddresses` from euler-labels. Since escrow vaults come from the `escrowedCollateralPerspective` and are not in that list, `verified` was overwritten to `false` while `vaultCategory` was correctly preserved
- Navigating to the vault detail page fixed it because `fetchEscrowVault()` always sets `verified: true`, masking the refresh bug
- Now `updateEVKVaults` preserves `verified: true` for escrow vaults (`vaultCategory === 'escrow'`) during refresh

## Test plan
- [ ] Load explore page, verify escrow vault cards show "Escrowed collateral" (not "Unknown")
- [ ] Wait for a refresh cycle, verify escrow vault cards remain correctly labeled
- [ ] Check earn vault exposure section for escrow strategy vaults — should not show "Unknown"