### PR TITLE
fix: Euler-first token list loading with CSP wildcard for logo URLs

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { POLL_INTERVAL_60S_MS } from '~/entities/tuning-constants'
+import { POLL_INTERVAL_60S_MS, TOKEN_LIST_RETRY_DELAY_MS } from '~/entities/tuning-constants'
 import { useModal } from '~/components/ui/composables/useModal'
 import { MigrationAnnouncementModal } from '#components'
 
@@ -47,6 +47,7 @@ useHead({
 const isMenuVisible = ref(true)
 const isHeaderVisible = ref(true)
 let interval: NodeJS.Timeout | null = null
+let tokenListRetryTimeout: NodeJS.Timeout | null = null
 
 const checkOnboarding = () => {
   const isOnboardingCompleted = useLocalStorage('is-onboarding-completed', false)
@@ -102,10 +103,22 @@ onMounted(checkMigrationAnnouncement)
 watch(chainId, () => {
   resetVaultsState()
   resetBalances()
+  if (tokenListRetryTimeout) {
+    clearTimeout(tokenListRetryTimeout)
+    tokenListRetryTimeout = null
+  }
   const targetChainId = chainId.value
   const labelsPromise = loadLabels()
   void loadTokenList()
   void loadCountry()
+  // One-shot retry after 15s to pick up supplemental token sources
+  // (Uniswap/DefiLlama background fetches complete on the server by then)
+  tokenListRetryTimeout = setTimeout(async () => {
+    tokenListRetryTimeout = null
+    if (chainId.value !== targetChainId) return
+    await loadTokenList(true)
+    updateBalances()
+  }, TOKEN_LIST_RETRY_DELAY_MS)
   void labelsPromise.then(() => {
     if (chainId.value !== targetChainId) return
     void loadVaults()
@@ -150,6 +163,9 @@ watch(portfolioRefreshCounter, () => {
 onUnmounted(() => {
   if (interval) {
     clearInterval(interval)
+  }
+  if (tokenListRetryTimeout) {
+    clearTimeout(tokenListRetryTimeout)
   }
 })
 </script>

--- a/composables/useTokenList.ts
+++ b/composables/useTokenList.ts
@@ -84,6 +84,7 @@ const loadTokenList = async (forceRefresh = false) => {
 
     const gen = guard.next()
     isLoading.value = true
+    isLoaded.value = false
 
     const res = await axios.get('/api/token-list', { params: { chainId } })
     if (guard.isStale(gen)) return

--- a/docs/README.md
+++ b/docs/README.md
@@ -74,6 +74,13 @@ Welcome to the documentation for the Euler Lite project. This documentation is d
 - Operation guard registry for automatic TxPlan injection
 - UI components (badges, alerts, verification flow)
 
+### 🪙 [Token List](./token-list.md)
+
+- Three-source token list (Euler API, DefiLlama, Uniswap)
+- Euler-first blocking strategy with lazy supplemental sources
+- One-shot 15s retry for supplemental data pickup
+- CSP considerations for logo URLs
+
 ### 🌍 [Geo-Blocking](./geo-blocking.md)
 
 - Country detection and sanctioned country lists

--- a/docs/token-list.md
+++ b/docs/token-list.md
@@ -36,6 +36,14 @@ The Euler API is the blocking call. Uniswap and DefiLlama are non-blocking: if t
 
 **Deduplication**: tokens are merged with Euler taking priority. If the same `chainId:address` appears in multiple sources, the higher-priority entry wins. This ensures Euler's metadata (name, symbol, decimals, logo URL) takes precedence over supplemental sources.
 
+**Error contract**:
+
+| Status | Condition | Body |
+|--------|-----------|------|
+| `200` | At least one source returned tokens | `{ tokens: TokenEntry[] }` |
+| `400` | `chainId` is missing, non-numeric, zero, or negative | `{ statusCode: 400, statusMessage: "chainId is required and must be a positive integer" }` |
+| `502` | All sources returned empty (Euler down, no stale data, supplemental caches cold) | `{ statusCode: 502, statusMessage: "Upstream error" }` |
+
 ## Client Composable
 
 **`composables/useTokenList.ts`**

--- a/docs/token-list.md
+++ b/docs/token-list.md
@@ -1,0 +1,71 @@
+# Token List
+
+The token list provides token metadata (name, symbol, decimals, logo URL) used across the app for asset logos, the swap token selector, and wallet balance fetching.
+
+## Architecture
+
+```
+Client (composables/useTokenList.ts)
+  |
+  |  GET /api/token-list?chainId=X  (on chain switch + 15s retry)
+  v
+Server (server/api/token-list.get.ts)
+  |
+  +-- Euler API      [primary, always awaited]
+  +-- DefiLlama      [supplemental, best-effort]
+  +-- Uniswap        [supplemental, best-effort]
+  |
+  v
+Merge with deduplicateTokens()
+Priority: Euler API > DefiLlama > Uniswap
+```
+
+## Server Endpoint
+
+**`/api/token-list?chainId=<number>`**
+
+Three data sources, each with its own 5-minute TTL cache and in-flight request deduplication:
+
+| Source | Scope | Role |
+|--------|-------|------|
+| Euler API | Per-chain | Primary. Always awaited. Has reliable logo URLs. |
+| DefiLlama | Per-chain | Supplemental. Served from cache or stale; fetched in background if missing. |
+| Uniswap | All chains | Supplemental. Same as DefiLlama. |
+
+The Euler API is the blocking call. Uniswap and DefiLlama are non-blocking: if their cache is warm they're included immediately, otherwise a background fetch is fired and the response is returned without waiting.
+
+**Deduplication**: tokens are merged with Euler taking priority. If the same `chainId:address` appears in multiple sources, the higher-priority entry wins. This ensures Euler's logo URLs (from known, CSP-safe domains) are preferred.
+
+## Client Composable
+
+**`composables/useTokenList.ts`**
+
+Singleton state with a `shallowRef` token map, keyed by normalized address.
+
+- **Cache TTL**: 5 minutes. The client skips the API call if the same chain's data was fetched within the last 5 minutes (bypassed by `forceRefresh`).
+- **Race guard**: prevents stale responses (from a previous chain) from overwriting current data.
+- **`filterByChain()`**: filters the raw token array by `chainId`, normalizes addresses, and conditionally includes the native currency (address zero) when the wrapped variant exists.
+
+### Exported functions
+
+| Function | Description |
+|----------|-------------|
+| `loadTokenList(forceRefresh?)` | Fetch token list from server. Respects 5-min cache unless `forceRefresh` is true. |
+| `getAssetLogoUrl(address, symbol)` | Returns logo URL. Checks local overrides (`assets/tokens/`) first, then token list, then `''`. |
+| `getTokenListLogoUrl(address)` | Returns logo URL from token list only. Upgrades CoinGecko `/thumb/` to `/small/`. |
+| `hasToken(address)` | Check if a token is in the current map. |
+| `getAllTokens()` | Get all tokens for the current chain. |
+| `toVaultAsset(entry)` | Convert a token list entry to a `VaultAsset`. |
+
+## Loading Strategy
+
+The token list is loaded:
+
+1. **On chain switch** via `watch(chainId)` in `app.vue` — gets Euler tokens immediately
+2. **One-shot retry after 15 seconds** — picks up supplemental Uniswap/DefiLlama data that the server fetched in the background after the first request, then refreshes balances to include newly discovered tokens
+
+The 15s retry timer is cancelled on chain switch so it never fires for a stale chain.
+
+## CSP
+
+The `img-src` directive uses `https:` as a wildcard because token logos come from unpredictable CDNs (CoinGecko, DefiLlama, Uniswap, etc.) that cannot be whitelisted upfront. Images are passive content with no script execution risk. All other CSP directives remain locked down.

--- a/docs/token-list.md
+++ b/docs/token-list.md
@@ -42,7 +42,7 @@ The Euler API is the blocking call. Uniswap and DefiLlama are non-blocking: if t
 |--------|-----------|------|
 | `200` | At least one source returned tokens | `{ tokens: TokenEntry[] }` |
 | `400` | `chainId` is missing, non-numeric, zero, or negative | `{ statusCode: 400, statusMessage: "chainId is required and must be a positive integer" }` |
-| `502` | All sources returned empty (Euler down, no stale data, supplemental caches cold) | `{ statusCode: 502, statusMessage: "Upstream error" }` |
+| `502` | Merged token list is empty after combining all sources | `{ statusCode: 502, statusMessage: "Upstream error" }` |
 
 ## Client Composable
 

--- a/docs/token-list.md
+++ b/docs/token-list.md
@@ -4,7 +4,7 @@ The token list provides token metadata (name, symbol, decimals, logo URL) used a
 
 ## Architecture
 
-```
+```text
 Client (composables/useTokenList.ts)
   |
   |  GET /api/token-list?chainId=X  (on chain switch + 15s retry)
@@ -34,7 +34,7 @@ Three data sources, each with its own 5-minute TTL cache and in-flight request d
 
 The Euler API is the blocking call. Uniswap and DefiLlama are non-blocking: if their cache is warm they're included immediately, otherwise a background fetch is fired and the response is returned without waiting.
 
-**Deduplication**: tokens are merged with Euler taking priority. If the same `chainId:address` appears in multiple sources, the higher-priority entry wins. This ensures Euler's logo URLs (from known, CSP-safe domains) are preferred.
+**Deduplication**: tokens are merged with Euler taking priority. If the same `chainId:address` appears in multiple sources, the higher-priority entry wins. This ensures Euler's metadata (name, symbol, decimals, logo URL) takes precedence over supplemental sources.
 
 ## Client Composable
 

--- a/entities/tuning-constants.ts
+++ b/entities/tuning-constants.ts
@@ -3,6 +3,9 @@ export const CACHE_TTL_15S_MS = 15_000
 export const CACHE_TTL_1MIN_MS = 60_000
 export const CACHE_TTL_5MIN_MS = 300_000
 
+// ── Retry Delays ─────────────────────────────────────────
+export const TOKEN_LIST_RETRY_DELAY_MS = 15_000
+
 // ── Polling Intervals ─────────────────────────────────────
 export const POLL_INTERVAL_5S_MS = 5_000
 export const POLL_INTERVAL_10S_MS = 10_000

--- a/server/api/token-list.get.ts
+++ b/server/api/token-list.get.ts
@@ -170,47 +170,31 @@ export default defineEventHandler(async (event) => {
 
   const query = getQuery(event)
   const chainId = query.chainId ? Number(query.chainId) : null
+
+  // --- Primary source: Euler API (always awaited) ---
+  const euler = chainId ? await fetchEulerApi(chainId) : []
+
+  // --- Supplemental: Uniswap (best-effort, non-blocking) ---
+  let uniswap = uniswapCache.get('all')
+  if (uniswap === undefined) {
+    void fetchUniswap()
+    uniswap = uniswapCache.getStale('all') ?? []
+  }
+
+  // --- Supplemental: DefiLlama (best-effort, non-blocking) ---
   const key = chainId ? String(chainId) : null
-
-  const eulerFresh = key ? eulerApiCache.get(key) : []
-  const uniswapFresh = uniswapCache.get('all')
-  const defillamaFresh = key ? defillamaCache.get(key) : []
-
-  // All data is fresh — return immediately
-  if (eulerFresh !== undefined && uniswapFresh !== undefined && defillamaFresh !== undefined) {
-    return { tokens: deduplicateTokens(eulerFresh, deduplicateTokens(defillamaFresh, uniswapFresh)) }
-  }
-
-  // Check stale fallbacks
-  const eulerStale = key ? eulerApiCache.getStale(key) : undefined
-  const uniswapStale = uniswapCache.getStale('all')
-  const defillamaStale = key ? defillamaCache.getStale(key) : undefined
-
-  // Have stale data — return it immediately and revalidate in background.
-  // defillamaStale is intentionally excluded: DefiLlama is supplementary; Euler or Uniswap
-  // stale data is sufficient to justify returning a response without a cold await.
-  if (eulerStale !== undefined || uniswapStale !== undefined) {
-    if (eulerFresh === undefined && chainId) void fetchEulerApi(chainId)
-    if (uniswapFresh === undefined) void fetchUniswap()
-    if (defillamaFresh === undefined && chainId) void fetchDefillama(chainId)
-
-    const euler = eulerFresh ?? eulerStale ?? []
-    const uniswap = uniswapFresh ?? uniswapStale ?? []
-    const defillama = defillamaFresh ?? defillamaStale ?? []
-    return { tokens: deduplicateTokens(euler, deduplicateTokens(defillama, uniswap)) }
-  }
-
-  // Completely cold — await all sources in parallel; all three handle errors internally
-  const [euler, uniswap, defillama] = await Promise.all([
-    chainId ? fetchEulerApi(chainId) : Promise.resolve([]),
-    fetchUniswap(),
-    chainId ? fetchDefillama(chainId) : Promise.resolve([]),
-  ])
-
-  if (euler.length === 0 && uniswap.length === 0 && defillama.length === 0) {
-    throw createError({ statusCode: 502, statusMessage: 'Upstream error' })
+  let defillama = key ? defillamaCache.get(key) : ([] as TokenEntry[])
+  if (defillama === undefined) {
+    if (chainId) void fetchDefillama(chainId)
+    defillama = key ? (defillamaCache.getStale(key) ?? []) : []
   }
 
   // Priority: Euler API > DefiLlama > Uniswap
-  return { tokens: deduplicateTokens(euler, deduplicateTokens(defillama, uniswap)) }
+  const tokens = deduplicateTokens(euler, deduplicateTokens(defillama, uniswap))
+
+  if (tokens.length === 0) {
+    throw createError({ statusCode: 502, statusMessage: 'Upstream error' })
+  }
+
+  return { tokens }
 })

--- a/server/api/token-list.get.ts
+++ b/server/api/token-list.get.ts
@@ -169,10 +169,13 @@ export default defineEventHandler(async (event) => {
   rateLimiter.consume(event)
 
   const query = getQuery(event)
-  const chainId = query.chainId ? Number(query.chainId) : null
+  const chainId = Number(query.chainId)
+  if (!Number.isInteger(chainId) || chainId <= 0) {
+    throw createError({ statusCode: 400, statusMessage: 'chainId is required and must be a positive integer' })
+  }
 
   // --- Primary source: Euler API (always awaited) ---
-  const euler = chainId ? await fetchEulerApi(chainId) : []
+  const euler = await fetchEulerApi(chainId)
 
   // --- Supplemental: Uniswap (best-effort, non-blocking) ---
   let uniswap = uniswapCache.get('all')
@@ -182,11 +185,11 @@ export default defineEventHandler(async (event) => {
   }
 
   // --- Supplemental: DefiLlama (best-effort, non-blocking) ---
-  const key = chainId ? String(chainId) : null
-  let defillama = key ? defillamaCache.get(key) : ([] as TokenEntry[])
+  const key = String(chainId)
+  let defillama = defillamaCache.get(key)
   if (defillama === undefined) {
-    if (chainId) void fetchDefillama(chainId)
-    defillama = key ? (defillamaCache.getStale(key) ?? []) : []
+    void fetchDefillama(chainId)
+    defillama = defillamaCache.getStale(key) ?? []
   }
 
   // Priority: Euler API > DefiLlama > Uniswap

--- a/server/plugins/csp.ts
+++ b/server/plugins/csp.ts
@@ -64,7 +64,7 @@ function scanDynamicEnvUrls(): string[] {
 }
 
 /** Derive CSP origins from URL env vars so deployers don't need to duplicate them. */
-function parseEnvOrigins(): { connect: string[], img: string[] } {
+function parseEnvOrigins(): { connect: string[] } {
   // Labels, oracle checks, token lists, and euler-chains are proxied through
   // server /api/* endpoints, so their origins are not needed in connect-src.
   const connectVars = [
@@ -75,14 +75,9 @@ function parseEnvOrigins(): { connect: string[], img: string[] } {
     // Dynamic per-chain URLs (RPC for wagmi, subgraph for GraphQL)
     ...scanDynamicEnvUrls(),
   ]
-  const imgVars = [
-    process.env.NUXT_PUBLIC_CONFIG_LABELS_BASE_URL,
-    env('LOGO_URL', 'NUXT_PUBLIC_CONFIG_LOGO_URL'),
-  ]
 
   const connect = [...new Set(connectVars.map(safeOrigin).filter(Boolean))] as string[]
-  const img = [...new Set(imgVars.map(safeOrigin).filter(Boolean))] as string[]
-  return { connect, img }
+  return { connect }
 }
 
 const CONNECT_SRC_BASE = [
@@ -127,15 +122,13 @@ const CONNECT_SRC_BASE = [
   'wss://relay.walletconnect.org',
 ]
 
-function buildCsp(nonce: string, extraConnectSrc: string[], envOrigins: { connect: string[], img: string[] }): string {
+function buildCsp(nonce: string, extraConnectSrc: string[], envOrigins: { connect: string[] }): string {
   const connectSrc = [
     ...CONNECT_SRC_BASE,
     ...(isDev ? CONNECT_SRC_DEV : []),
     ...extraConnectSrc,
     ...envOrigins.connect,
   ]
-
-  const imgSuffix = envOrigins.img.map(o => ` ${o}`).join('')
 
   const directives = [
     'default-src \'self\'',
@@ -147,7 +140,9 @@ function buildCsp(nonce: string, extraConnectSrc: string[], envOrigins: { connec
     'font-src \'self\' https://fonts.reown.com',
     'frame-src \'self\' https://verify.walletconnect.org https://verify.walletconnect.com',
     'frame-ancestors \'none\'',
-    `img-src 'self' data: blob: https://raw.githubusercontent.com https://storage.googleapis.com https://token-images.euler.finance https://assets.coingecko.com https://token-icons.llamao.fi https://tokens.1inch.io${imgSuffix}`,
+    // Token logos come from arbitrary CDNs (CoinGecko, DefiLlama, Uniswap, etc.)
+    // that cannot be whitelisted upfront. Images are passive content — no script execution risk.
+    'img-src \'self\' data: blob: https:',
     'manifest-src \'self\'',
     'media-src \'self\'',
     'worker-src \'self\' blob:',


### PR DESCRIPTION
## Summary
- Token logos sometimes missing after chain switch because the server returned only Uniswap data (cached all-chains source) while Euler API data for the new chain wasn't yet available. Uniswap logo URLs come from CDNs blocked by the CSP `img-src` policy.
- Server endpoint now always awaits the Euler API (primary source with reliable logo URLs). Uniswap and DefiLlama are served best-effort from cache/stale with background revalidation.
- Client does a one-shot 15s retry after chain switch to pick up supplemental tokens once their server-side background fetches complete, then refreshes balances. Timer cancelled on chain switch.
- CSP `img-src` replaced with `https:` wildcard since token logos come from arbitrary CDNs that cannot be whitelisted upfront.

## Test plan
- [ ] Cold start on chain A — Euler tokens load immediately, supplemental tokens appear after 15s retry
- [ ] Switch to chain B — logos visible immediately (Euler API), no CSP violations in console
- [ ] Switch chains rapidly (A→B→A) — no stale token data, 15s timer cancelled correctly
- [ ] Wait 15s after chain switch — check network tab for second `/api/token-list` request
- [ ] Verify no CSP violations for any logo domain in browser console