### PR TITLE
fix: clamp slider thumb to prevent overflow at min position

### DIFF
--- a/components/ui/UiRange.vue
+++ b/components/ui/UiRange.vue
@@ -31,7 +31,7 @@ const styles = reactive({
     width: `0px`,
   },
   thumb: {
-    transform: `translate(-10px, -50%)`,
+    transform: `translate(0px, -50%)`,
   },
 })
 
@@ -60,7 +60,8 @@ const render = async () => {
   }
   const x = ((model.value - min) / (max - min)) * trackBox.width
   styles.trackActive.width = `${Math.min(x, trackBox.width)}px`
-  styles.thumb.transform = `translate(calc(${Math.min(x, trackBox.width)}px - 10px), -50%)`
+  const thumbX = Math.max(0, Math.min(x - 10, trackBox.width - 20))
+  styles.thumb.transform = `translate(${thumbX}px, -50%)`
 }
 const onPointerDown = () => {
   if (!trackBox && trackEl.value) {


### PR DESCRIPTION
Before:
<img width="530" height="111" alt="Pasted Graphic 18" src="https://github.com/user-attachments/assets/78b6b084-0434-4e34-ae3a-58eb120c595f" />
<img width="518" height="107" alt="Pasted Graphic 16" src="https://github.com/user-attachments/assets/078bae4b-df13-4879-8dff-0205ebe57a9c" />


After:
<img width="542" height="126" alt="Pasted Graphic 14" src="https://github.com/user-attachments/assets/a9830b7b-f55d-4b4f-8968-b9dde0175047" />
<img width="525" height="115" alt="Pasted Graphic 15" src="https://github.com/user-attachments/assets/02960023-3251-4630-b0a9-e465932acea7" />
