### PR TITLE
feat: add icons to sort type modal options

### DIFF
--- a/components/entities/vault/VaultSortButton.vue
+++ b/components/entities/vault/VaultSortButton.vue
@@ -5,7 +5,7 @@ import { VaultSortTypeModal } from '#components'
 const model = defineModel<string>({ required: true })
 const dir = defineModel<'desc' | 'asc'>('dir', { default: 'desc' })
 const props = defineProps<{
-  options: string[]
+  options: { label: string, icon?: string }[]
   placeholder?: string
   title?: string
   disableDir?: boolean

--- a/components/entities/vault/VaultSortTypeModal.vue
+++ b/components/entities/vault/VaultSortTypeModal.vue
@@ -1,13 +1,13 @@
 <script setup lang="ts">
 const emits = defineEmits(['close'])
 const { options, selected, onSave } = defineProps<{
-  options: string[]
+  options: { label: string, icon?: string }[]
   selected?: string
   title?: string
   onSave: (selected: string) => void
 }>()
 
-const selectedIdx = ref(options.findIndex(option => option === selected))
+const selectedIdx = ref(options.findIndex(option => option.label === selected))
 
 const handleClose = () => {
   emits('close')
@@ -22,13 +22,18 @@ const handleClose = () => {
     <div
       v-for="(option, idx) in options"
       :key="`options-${idx}`"
-      class="flex items-center py-12 px-16 cursor-pointer rounded-16"
+      class="flex items-center gap-12 py-12 px-16 cursor-pointer rounded-16"
       :class="[selectedIdx === idx ? 'bg-card-hover' : '']"
-      @click="onSave(option)"
+      @click="onSave(option.label)"
     >
+      <UiIcon
+        v-if="option.icon"
+        :name="option.icon"
+        class="!w-20 !h-20 text-content-secondary flex-shrink-0"
+      />
       <div class="grow-1">
         <div class="text-content-primary mb-2">
-          {{ option }}
+          {{ option.label }}
         </div>
       </div>
     </div>

--- a/pages/borrow/index.vue
+++ b/pages/borrow/index.vue
@@ -382,7 +382,15 @@ const sortedBorrowList = computed(() => {
           v-model="sortBy"
           v-model:dir="sortDir"
           class="shrink-0 mobile:flex-1 mobile:basis-[calc(50%-4px)]"
-          :options="['Recommended', 'Liquidity', 'Total Borrowed', 'Utilization', 'Borrow APY', 'Net APY', 'Max ROE']"
+          :options="[
+            { label: 'Recommended', icon: 'sparks' },
+            { label: 'Liquidity', icon: 'wallet' },
+            { label: 'Total Borrowed', icon: 'borrow-outline' },
+            { label: 'Utilization', icon: 'pulse' },
+            { label: 'Borrow APY', icon: 'percent' },
+            { label: 'Net APY', icon: 'percent' },
+            { label: 'Max ROE', icon: 'percent' },
+          ]"
           :disable-dir="sortBy === 'Recommended'"
           title="Sorting type"
         />

--- a/pages/earn/index.vue
+++ b/pages/earn/index.vue
@@ -210,7 +210,11 @@ const sortedList = computed(() => {
         <VaultSortButton
           v-model="sortBy"
           v-model:dir="sortDir"
-          :options="['Total Supply', 'Liquidity', 'Supply APY']"
+          :options="[
+            { label: 'Total Supply', icon: 'lend-outline' },
+            { label: 'Liquidity', icon: 'wallet' },
+            { label: 'Supply APY', icon: 'percent' },
+          ]"
           title="Sorting type"
         />
         <UiSelect

--- a/pages/explore/index.vue
+++ b/pages/explore/index.vue
@@ -296,7 +296,13 @@ const { isSlow } = useSlowLoading(isLoading)
         <VaultSortButton
           v-model="sortBy"
           v-model:dir="sortDir"
-          :options="['Recommended', 'Best Max ROE', 'Total Supply', 'Total Borrowed', 'Available Liquidity']"
+          :options="[
+            { label: 'Recommended', icon: 'sparks' },
+            { label: 'Best Max ROE', icon: 'percent' },
+            { label: 'Total Supply', icon: 'lend-outline' },
+            { label: 'Total Borrowed', icon: 'borrow-outline' },
+            { label: 'Available Liquidity', icon: 'wallet' },
+          ]"
           :disable-dir="sortBy === 'Recommended'"
           title="Sorting type"
         />

--- a/pages/lend/index.vue
+++ b/pages/lend/index.vue
@@ -276,7 +276,11 @@ const sortedList = computed(() => {
         <VaultSortButton
           v-model="sortBy"
           v-model:dir="sortDir"
-          :options="['Total Supply', 'Utilization', 'Supply APY']"
+          :options="[
+            { label: 'Total Supply', icon: 'lend-outline' },
+            { label: 'Utilization', icon: 'pulse' },
+            { label: 'Supply APY', icon: 'percent' },
+          ]"
           title="Sorting type"
         />
         <UiSelect


### PR DESCRIPTION
- Change VaultSortButton/VaultSortTypeModal options type from string[] to { label, icon? }[]
- Map each sort option to a fitting sprite icon across explore, lend, borrow, and earn pages

Before:

<img width="516" height="399" alt="it Mark" src="https://github.com/user-attachments/assets/9dc3b7c2-9287-470b-97bc-fd4c72b9aaae" />


After:

<img width="495" height="386" alt="ill Marke" src="https://github.com/user-attachments/assets/0451cda9-9fd0-4d3d-a848-2220004feef3" />

<img width="440" height="454" alt="Sorting type" src="https://github.com/user-attachments/assets/e1cb71d9-b821-4926-9323-c104e11dcb19" />

