### PR TITLE
fix: use dark text on active select chip in dark theme

### DIFF
--- a/assets/sprite/svg/check.svg
+++ b/assets/sprite/svg/check.svg
@@ -1,3 +1,3 @@
 <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <path d="M5 12L10 17L20 7" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M5 12L10 17L20 7" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" />
 </svg>

--- a/components/ui/styles/main.scss
+++ b/components/ui/styles/main.scss
@@ -244,6 +244,7 @@
   --ui-checkbox-background-color: #08131f;
   --ui-checkbox-box-shadow-color: #14304e;
   --ui-checkbox-hover-background-color: #0c1d2f;
+  --ui-checkbox-color: #020508;
   --ui-checkbox-label-color: #f7f7f8;
 
   // Switch

--- a/components/ui/styles/main.scss
+++ b/components/ui/styles/main.scss
@@ -277,6 +277,8 @@
   --ui-select-field-color: #f7f7f8;
   --ui-select-field-background-color: #08131f;
   --ui-select-chip-background-color: #0c1d2f;
+  --ui-select-chip-active-background-color: #2ae5b9;
+  --ui-select-chip-active-color: #020508;
 
   // Tabs
   --ui-tabs-pills-background-color: #0c1d2f;


### PR DESCRIPTION
## Summary
- In dark mode, active select chips (e.g. the "Greater than"/"Less than" condition toggles) rendered white text on a bright teal (`#2ae5b9`) background, producing low contrast and poor readability
- The light-theme default `--ui-select-chip-active-color: #ffffff` was inherited unchanged by dark mode, but the dark-mode accent palette uses a much lighter `#2ae5b9` for `--accent-500`, making white text illegible

## Changes
- Adds `--ui-select-chip-active-background-color: #2ae5b9` and `--ui-select-chip-active-color: #020508` to the `[data-theme="dark"]` block in `main.scss`
- Uses the same contrast pairing (`#2ae5b9` bg / `#020508` text) already established for `--ui-button-primary` in dark mode, keeping the design system consistent

## Test plan
- [ ] Open the app in dark mode and navigate to a view with a select chip toggle (e.g. custom filter modal — "Greater than" / "Less than" condition buttons)
- [ ] Confirm the active chip shows dark text on bright teal background
- [ ] Switch to light mode and confirm the active chip appearance is unchanged
- [ ] Verify no other chip/select components are visually broken in either theme

Before:
<img width="445" height="569" alt="image" src="https://github.com/user-attachments/assets/ba2edf26-0e6a-4f89-adca-a05fe2fd2184" />

After:
<img width="437" height="619" alt="image" src="https://github.com/user-attachments/assets/18e7aa3a-c339-48c8-b2bf-6d96825e6716" />


Edit: also added it for checkboxes

<img width="84" height="80" alt="image" src="https://github.com/user-attachments/assets/62f3f3d9-d0fa-48f8-adef-b7292e13b729" />
