### PR TITLE
fix: prevent RPC retry amplification on transport errors

### DIFF
--- a/composables/useAccountPositions.ts
+++ b/composables/useAccountPositions.ts
@@ -145,11 +145,14 @@ const updateBorrowPositions = async (
       rpcUrl.value,
     )
 
+    let hasTransportError = false
     for (let i = 0; i < results.length; i++) {
-      if (results[i].success && results[i].result) {
+      if (results[i].transportError) hasTransportError = true
+      else if (results[i].success && results[i].result) {
         accountInfoMap.set(nonPythEntries[i].key, results[i].result!)
       }
     }
+    if (hasTransportError) logWarn('useAccountPositions/accountInfo', 'RPC transport error — account info results may be incomplete')
   }
 
   if (positionGuard.isStale(gen)) return
@@ -308,13 +311,16 @@ const updateBorrowPositions = async (
       rpcUrl.value,
     )
 
+    let hasTransportError = false
     for (let i = 0; i < collateralResults.length; i++) {
       const r = collateralResults[i]
-      if (r.success && r.result) {
+      if (r.transportError) hasTransportError = true
+      else if (r.success && r.result) {
         const key = `${processed[i].entry.subAccount}:${processed[i].collateralAddress}`
         collateralAssets.set(key, toBigInt(r.result.assets))
       }
     }
+    if (hasTransportError) logWarn('useAccountPositions/collateralInfo', 'RPC transport error — collateral asset results may be incomplete')
   }
 
   if (positionGuard.isStale(gen)) return
@@ -515,8 +521,13 @@ const updateSavingsPositions = async (
       rpcUrl.value,
     )
 
+    let hasTransportError = false
     for (let i = 0; i < results.length; i++) {
       const r = results[i]
+      if (r.transportError) {
+        hasTransportError = true
+        continue
+      }
       if (!r.success || !r.result) continue
 
       const res = r.result
@@ -529,6 +540,7 @@ const updateSavingsPositions = async (
         assets: res.vaultAccountInfo.assets,
       } as AccountDepositPosition)
     }
+    if (hasTransportError) logWarn('useAccountPositions/depositInfo', 'RPC transport error — deposit position results may be incomplete')
   }
 
   if (positionGuard.isStale(gen)) return

--- a/entities/vault/fetcher.ts
+++ b/entities/vault/fetcher.ts
@@ -463,10 +463,14 @@ export const fetchVaults = async function* (
 
       const vaults: Vault[] = []
       const failedAddresses: string[] = []
+      let hasTransportError = false
 
       for (let i = 0; i < results.length; i++) {
         const result = results[i]
-        if (result.success && result.result) {
+        if (result.transportError) {
+          hasTransportError = true
+        }
+        else if (result.success && result.result) {
           // batchLensCalls returns decoded result directly (viem unwraps single outputs)
           const raw = result.result as Record<string, unknown>
           const vault = processVaultResult(raw, batchAddresses[i])
@@ -482,8 +486,8 @@ export const fetchVaults = async function* (
         }
       }
 
-      // Retry failed items individually
-      if (failedAddresses.length > 0) {
+      // Only retry individually for on-chain reverts, not transport errors (403, network failures)
+      if (failedAddresses.length > 0 && !hasTransportError) {
         logWarn('vault/fetchBatch', `Retrying ${failedAddresses.length} failed vaults individually`)
         const retryResults = await Promise.all(
           failedAddresses.map(addr => fetchVaultIndividually(addr)),
@@ -493,6 +497,9 @@ export const fetchVaults = async function* (
             vaults.push(vault)
           }
         }
+      }
+      else if (hasTransportError) {
+        logWarn('vault/fetchBatch', `Skipping individual retries — RPC transport error`)
       }
 
       return vaults

--- a/utils/multicall.ts
+++ b/utils/multicall.ts
@@ -1,4 +1,4 @@
-import { encodeFunctionData, decodeFunctionResult, zeroAddress, type Address, type Hex, type Abi } from 'viem'
+import { encodeFunctionData, decodeFunctionResult, zeroAddress, type Address, type Hex, type Abi, BaseError } from 'viem'
 import { EVC_ABI, type BatchItem, type BatchItemResult } from '~/abis/evc'
 import { getPublicClient } from '~/utils/public-client'
 
@@ -6,6 +6,23 @@ export type MulticallResult<T = unknown> = {
   success: boolean
   result: T | null
   error?: Error
+}
+
+export type BatchLensResult<T = unknown> = {
+  success: boolean
+  result: T | null
+  /** True when the entire RPC request failed (e.g. 403, network error) vs individual call revert */
+  transportError?: boolean
+}
+
+/**
+ * Check if an error is a transport-level failure (HTTP error, network down, timeout)
+ * vs an on-chain revert that could be retried individually.
+ */
+const isTransportError = (err: unknown): boolean => {
+  if (!(err instanceof BaseError)) return true // Unknown error — treat as transport to be safe
+  const root = err.walk()
+  return root.name === 'HttpRequestError' || root.name === 'TimeoutError' || root.name === 'WebSocketRequestError'
 }
 
 /**
@@ -32,43 +49,36 @@ export const evcBatchCall = async (
   const client = getPublicClient(rpcUrl)
   const totalValue = items.reduce((sum, item) => sum + item.value, 0n)
 
-  try {
-    const callData = encodeFunctionData({
-      abi: EVC_ABI,
-      functionName: 'batchSimulation',
-      args: [items],
-    })
+  // Errors (403, network failures, timeouts) propagate to callers so they can
+  // distinguish "RPC is down" from "individual call reverted on-chain".
+  const callData = encodeFunctionData({
+    abi: EVC_ABI,
+    functionName: 'batchSimulation',
+    args: [items],
+  })
 
-    const result = await client.call({
-      to: evcAddress as Address,
-      data: callData,
-      value: totalValue,
-      ...(totalValue > 0n ? { stateOverride: [{ address: zeroAddress as `0x${string}`, balance: totalValue }] } : {}),
-    })
+  const result = await client.call({
+    to: evcAddress as Address,
+    data: callData,
+    value: totalValue,
+    ...(totalValue > 0n ? { stateOverride: [{ address: zeroAddress as `0x${string}`, balance: totalValue }] } : {}),
+  })
 
-    if (!result.data) {
-      return items.map(() => ({
-        success: false,
-        result: '0x',
-      }))
-    }
-
-    const decoded = decodeFunctionResult({
-      abi: EVC_ABI,
-      functionName: 'batchSimulation',
-      data: result.data,
-    })
-
-    const batchResults = decoded[0] as unknown as BatchItemResult[]
-    return batchResults
-  }
-  catch (err) {
-    console.warn('[evcBatchCall] batchSimulation failed:', err)
+  if (!result.data) {
     return items.map(() => ({
       success: false,
       result: '0x',
     }))
   }
+
+  const decoded = decodeFunctionResult({
+    abi: EVC_ABI,
+    functionName: 'batchSimulation',
+    data: result.data,
+  })
+
+  const batchResults = decoded[0] as unknown as BatchItemResult[]
+  return batchResults
 }
 
 /**
@@ -94,7 +104,7 @@ const executeLensChunk = async <T>(
   lensAbi: Abi | readonly unknown[],
   calls: Array<{ functionName: string, args: unknown[] }>,
   rpcUrl: string,
-): Promise<Array<{ success: boolean, result: T | null }>> => {
+): Promise<Array<BatchLensResult<T>>> => {
   const items: BatchItem[] = calls.map((call) => {
     const callData = encodeFunctionData({
       abi: lensAbi as Abi,
@@ -104,7 +114,17 @@ const executeLensChunk = async <T>(
     return buildBatchItem(lensAddress, callData)
   })
 
-  const batchResults = await evcBatchCall(evcAddress, items, rpcUrl)
+  let batchResults: BatchItemResult[]
+  try {
+    batchResults = await evcBatchCall(evcAddress, items, rpcUrl)
+  }
+  catch (err) {
+    if (isTransportError(err)) {
+      return calls.map(() => ({ success: false, result: null, transportError: true }))
+    }
+    // On-chain revert of the whole batch (e.g. out of gas) — let caller retry individually
+    return calls.map(() => ({ success: false, result: null }))
+  }
 
   return batchResults.map((result, index) => {
     if (!result.success) {
@@ -145,7 +165,7 @@ export const batchLensCalls = async <T>(
   calls: Array<{ functionName: string, args: unknown[] }>,
   rpcUrl: string,
   batchSize = 25,
-): Promise<Array<{ success: boolean, result: T | null }>> => {
+): Promise<Array<BatchLensResult<T>>> => {
   if (calls.length === 0) {
     return []
   }
@@ -154,11 +174,21 @@ export const batchLensCalls = async <T>(
     return executeLensChunk<T>(evcAddress, lensAddress, lensAbi, calls, rpcUrl)
   }
 
-  const allResults: Array<{ success: boolean, result: T | null }> = []
+  const allResults: Array<BatchLensResult<T>> = []
   for (let i = 0; i < calls.length; i += batchSize) {
     const chunk = calls.slice(i, i + batchSize)
     const chunkResults = await executeLensChunk<T>(evcAddress, lensAddress, lensAbi, chunk, rpcUrl)
     allResults.push(...chunkResults)
+
+    // Stop processing further chunks if the RPC endpoint itself is failing
+    if (chunkResults.some(r => r.transportError)) {
+      // Mark remaining calls as transport errors
+      const remaining = calls.length - (i + chunk.length)
+      for (let j = 0; j < remaining; j++) {
+        allResults.push({ success: false, result: null, transportError: true })
+      }
+      break
+    }
   }
   return allResults
 }

--- a/utils/multicall.ts
+++ b/utils/multicall.ts
@@ -28,8 +28,15 @@ const TRANSPORT_ERROR_NAMES = new Set([
 ])
 
 const isTransportError = (err: unknown): boolean => {
-  if (!(err instanceof BaseError)) return true // Unknown error — treat as transport to be safe
+  // Non-viem errors (e.g. TypeError from a misconfigured client) are treated as transport errors.
+  // This is intentionally conservative: suppressing retries against an already-broken endpoint is
+  // safer than amplifying load by retrying every address individually.
+  if (!(err instanceof BaseError)) return true
+  // Walk to the deepest BaseError in the chain. If walk() returns a non-BaseError (e.g. a
+  // TypeError: Failed to fetch buried as the root cause), that is by definition a network-level
+  // failure — treat it as a transport error.
   const root = err.walk()
+  if (!(root instanceof BaseError)) return true
   return TRANSPORT_ERROR_NAMES.has(root.name)
 }
 

--- a/utils/multicall.ts
+++ b/utils/multicall.ts
@@ -16,13 +16,21 @@ export type BatchLensResult<T = unknown> = {
 }
 
 /**
- * Check if an error is a transport-level failure (HTTP error, network down, timeout)
- * vs an on-chain revert that could be retried individually.
+ * Check if an error is a transport/provider-level failure (HTTP error, network down,
+ * timeout, RPC rate limit) vs an on-chain revert that could be retried individually.
  */
+const TRANSPORT_ERROR_NAMES = new Set([
+  'HttpRequestError',
+  'TimeoutError',
+  'WebSocketRequestError',
+  'LimitExceededRpcError', // JSON-RPC -32005 (provider rate limit)
+  'ResourceUnavailableRpcError', // JSON-RPC -32002 (provider temporarily unavailable)
+])
+
 const isTransportError = (err: unknown): boolean => {
   if (!(err instanceof BaseError)) return true // Unknown error — treat as transport to be safe
   const root = err.walk()
-  return root.name === 'HttpRequestError' || root.name === 'TimeoutError' || root.name === 'WebSocketRequestError'
+  return TRANSPORT_ERROR_NAMES.has(root.name)
 }
 
 /**


### PR DESCRIPTION
## Summary
- When a batch RPC call failed (e.g. Cloudflare 403), `evcBatchCall` swallowed the error and returned `{ success: false }` for every item — indistinguishable from individual on-chain reverts. This caused `fetchBatch` to retry each item individually, amplifying 1 failed batch of 25 into 25+ separate requests against an already rate-limited endpoint, creating a cascading flood.
- Transport errors (HTTP failures, timeouts) are now distinguished from on-chain reverts using viem's error hierarchy (`HttpRequestError`, `TimeoutError`, `WebSocketRequestError`). Individual retries only fire for on-chain reverts. Transport errors skip retries and stop processing further batch chunks.
- `batchLensCalls` returns a new `BatchLensResult<T>` type with a `transportError` flag. Existing consumers (`useAccountPositions`, pyth utils) are unaffected — they already skip `success: false` items gracefully.

## Test plan
- [ ] Verify normal vault loading works (all vaults appear)
- [ ] Simulate 403 by throttling `/api/rpc/1` in devtools — confirm console is no longer flooded with individual retry errors
- [ ] Confirm vaults missing due to transient transport error appear after the 60s poll cycle