### PR TITLE
feat: improve portfolio and position page UX on desktop

### DIFF
--- a/assets/sprite/svg/arrow-left.svg
+++ b/assets/sprite/svg/arrow-left.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M15 18L9 12L15 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+</svg>

--- a/components/entities/portfolio/PortfolioSavingItem.vue
+++ b/components/entities/portfolio/PortfolioSavingItem.vue
@@ -200,7 +200,7 @@ const onClick = () => {
           </div>
         </div>
         <div
-          class="flex items-center gap-8 [&>*]:whitespace-nowrap"
+          class="flex flex-wrap items-center gap-8 laptop:flex-nowrap laptop:[&>*]:whitespace-nowrap"
           @click.stop
         >
           <UiButton
@@ -331,7 +331,7 @@ const onClick = () => {
           </div>
         </div>
         <div
-          class="flex items-center gap-8 [&>*]:whitespace-nowrap"
+          class="flex flex-wrap items-center gap-8 laptop:flex-nowrap laptop:[&>*]:whitespace-nowrap"
           @click.stop
         >
           <UiButton

--- a/components/entities/portfolio/PortfolioSavingItem.vue
+++ b/components/entities/portfolio/PortfolioSavingItem.vue
@@ -200,7 +200,7 @@ const onClick = () => {
           </div>
         </div>
         <div
-          class="flex flex-wrap items-center gap-8"
+          class="flex items-center gap-8"
           @click.stop
         >
           <UiButton
@@ -331,7 +331,7 @@ const onClick = () => {
           </div>
         </div>
         <div
-          class="flex flex-wrap items-center gap-8"
+          class="flex items-center gap-8"
           @click.stop
         >
           <UiButton

--- a/components/entities/portfolio/PortfolioSavingItem.vue
+++ b/components/entities/portfolio/PortfolioSavingItem.vue
@@ -200,7 +200,7 @@ const onClick = () => {
           </div>
         </div>
         <div
-          class="flex items-center gap-8"
+          class="flex items-center gap-8 [&>*]:whitespace-nowrap"
           @click.stop
         >
           <UiButton
@@ -331,7 +331,7 @@ const onClick = () => {
           </div>
         </div>
         <div
-          class="flex items-center gap-8"
+          class="flex items-center gap-8 [&>*]:whitespace-nowrap"
           @click.stop
         >
           <UiButton

--- a/components/ui/UiFootnote.vue
+++ b/components/ui/UiFootnote.vue
@@ -106,7 +106,7 @@ onClickOutside(reference, () => {
     border-radius: 12px;
     background-color: var(--ui-footnote-floating-background-color);
     box-shadow: 0 8px 32px var(--ui-footnote-floating-box-shadow-color);
-    z-index: 1;
+    z-index: 10;
   }
 
   &__floating-content {

--- a/components/ui/UiFootnote.vue
+++ b/components/ui/UiFootnote.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onClickOutside, useWindowSize } from '@vueuse/core'
+import { onClickOutside } from '@vueuse/core'
 import { flip, offset, shift, useFloating, type AlignedPlacement } from '@floating-ui/vue'
 import { useModal } from '~/components/ui/composables/useModal'
 import { UiFootnoteModal } from '#components'
@@ -17,7 +17,6 @@ const floating = ref(null)
 const isVisible = ref(false)
 
 const modal = useModal()
-const { width } = useWindowSize()
 const { floatingStyles, update } = useFloating(reference, floating, {
   placement: tooltipPlacement,
   middleware: [
@@ -27,10 +26,10 @@ const { floatingStyles, update } = useFloating(reference, floating, {
   ],
 })
 
-const isMobile = computed(() => width.value < 768)
+const canHover = typeof window !== 'undefined' && window.matchMedia('(hover: hover)').matches
 
 const onClick = () => {
-  if (isMobile.value) {
+  if (!canHover) {
     modal.open(customModal || UiFootnoteModal, {
       props: {
         modalTitle: title,
@@ -41,14 +40,14 @@ const onClick = () => {
 }
 
 const onMouseEnter = () => {
-  if (!isMobile.value) {
+  if (canHover) {
     isVisible.value = true
     update()
   }
 }
 
 const onMouseLeave = () => {
-  if (!isMobile.value) {
+  if (canHover) {
     isVisible.value = false
   }
 }

--- a/components/ui/UiFootnote.vue
+++ b/components/ui/UiFootnote.vue
@@ -27,8 +27,10 @@ const { floatingStyles, update } = useFloating(reference, floating, {
   ],
 })
 
+const isMobile = computed(() => width.value < 768)
+
 const onClick = () => {
-  if (width.value < 768) {
+  if (isMobile.value) {
     modal.open(customModal || UiFootnoteModal, {
       props: {
         modalTitle: title,
@@ -36,9 +38,18 @@ const onClick = () => {
       },
     })
   }
-  else {
-    isVisible.value = !isVisible.value
+}
+
+const onMouseEnter = () => {
+  if (!isMobile.value) {
+    isVisible.value = true
     update()
+  }
+}
+
+const onMouseLeave = () => {
+  if (!isMobile.value) {
+    isVisible.value = false
   }
 }
 
@@ -52,6 +63,8 @@ onClickOutside(reference, () => {
     ref="reference"
     class="ui-footnote"
     @click.stop.prevent="onClick"
+    @mouseenter="onMouseEnter"
+    @mouseleave="onMouseLeave"
   >
     <SvgIcon
       class="ui-footnote__icon"

--- a/components/ui/UiTab.vue
+++ b/components/ui/UiTab.vue
@@ -87,7 +87,6 @@ const onClick = () => {
 
   &.is-pill {
     min-height: 44px;
-    padding-bottom: 6px;
 
     &:hover {
       box-shadow: none;

--- a/components/ui/UiTab.vue
+++ b/components/ui/UiTab.vue
@@ -87,6 +87,7 @@ const onClick = () => {
 
   &.is-pill {
     min-height: 44px;
+    padding-bottom: 6px;
 
     &:hover {
       box-shadow: none;
@@ -94,6 +95,10 @@ const onClick = () => {
 
     &.is-active {
       box-shadow: none;
+
+      .ui-tab__badge {
+        background-color: var(--ui-tab-active-pill-badge-background-color);
+      }
     }
   }
 

--- a/components/ui/UiTabs.vue
+++ b/components/ui/UiTabs.vue
@@ -228,7 +228,8 @@ defineExpose({
     #{$block}__block {
       min-height: 44px;
       background-color: var(--ui-tabs-block-background-color);
-      border-radius: 12px;
+      border-radius: 12px 12px 0 0;
+      border-bottom: 2px solid var(--accent-600);
       width: auto;
       bottom: auto;
       max-width: none;

--- a/components/ui/styles/main.scss
+++ b/components/ui/styles/main.scss
@@ -141,6 +141,7 @@
   --ui-tabs-pills-background-color: var(--neutral-100);
   --ui-tabs-block-background-color: #ffffff;
   --ui-tab-badge-background-color: var(--neutral-200);
+  --ui-tab-active-pill-badge-background-color: var(--neutral-300);
   --ui-tab-active-box-shadow-color: var(--accent-500);
   --ui-tab-text-color: var(--neutral-500);
   --ui-tab-active-text-color: var(--neutral-900);
@@ -282,6 +283,7 @@
   --ui-tabs-pills-background-color: #0c1d2f;
   --ui-tabs-block-background-color: #10263e;
   --ui-tab-badge-background-color: #10263e;
+  --ui-tab-active-pill-badge-background-color: #081522;
   --ui-tab-text-color: #728395;
   --ui-tab-active-text-color: #f7f7f8;
 

--- a/pages/portfolio.vue
+++ b/pages/portfolio.vue
@@ -109,8 +109,8 @@ watch(portfolioRefreshCounter, () => {
 
     <PortfolioShowAllHint />
 
-    <div class="flex flex-col gap-16 p-16 rounded-12 mx-16 border border-line-default bg-card shadow-card">
-      <div class="flex justify-between items-center">
+    <div class="flex flex-col gap-16 p-16 rounded-12 mx-16 border border-line-default bg-card shadow-card laptop:flex-row laptop:gap-0 laptop:divide-x laptop:divide-line-default laptop:p-0">
+      <div class="flex justify-between items-center laptop:flex-col laptop:items-start laptop:gap-4 laptop:flex-1 laptop:p-16">
         <div class="flex items-center gap-4 text-p2 text-content-secondary">
           Portfolio Net APY
           <UiFootnote
@@ -129,7 +129,7 @@ watch(portfolioRefreshCounter, () => {
           </div>
         </BaseLoadableContent>
       </div>
-      <div class="flex justify-between items-center">
+      <div class="flex justify-between items-center laptop:flex-col laptop:items-start laptop:gap-4 laptop:flex-1 laptop:p-16">
         <div class="flex items-center gap-4 text-p2 text-content-secondary">
           Portfolio ROE
           <UiFootnote
@@ -148,7 +148,7 @@ watch(portfolioRefreshCounter, () => {
           </div>
         </BaseLoadableContent>
       </div>
-      <div class="flex justify-between items-center">
+      <div class="flex justify-between items-center laptop:flex-col laptop:items-start laptop:gap-4 laptop:flex-1 laptop:p-16">
         <div class="text-p2 text-content-secondary">
           Net asset value
         </div>
@@ -164,12 +164,12 @@ watch(portfolioRefreshCounter, () => {
               v-if="totalSuppliedValueInfo.hasMissingPrices || totalBorrowedValueInfo.hasMissingPrices"
               title="Incomplete pricing"
               text="Some assets in your portfolio don't have price data available. The displayed value may be higher than shown."
-              tooltip-placement="top-end"
+              tooltip-placement="bottom-end"
             />
           </div>
         </BaseLoadableContent>
       </div>
-      <div class="flex justify-between items-center">
+      <div class="flex justify-between items-center laptop:flex-col laptop:items-start laptop:gap-4 laptop:flex-1 laptop:p-16">
         <div class="text-p2 text-content-secondary">
           Total supplied value
         </div>
@@ -184,12 +184,12 @@ watch(portfolioRefreshCounter, () => {
               v-if="totalSuppliedValueInfo.hasMissingPrices"
               title="Incomplete pricing"
               text="Some supplied assets don't have price data available. The displayed value may be higher than shown."
-              tooltip-placement="top-end"
+              tooltip-placement="bottom-end"
             />
           </div>
         </BaseLoadableContent>
       </div>
-      <div class="flex justify-between items-center">
+      <div class="flex justify-between items-center laptop:flex-col laptop:items-start laptop:gap-4 laptop:flex-1 laptop:p-16">
         <div class="text-p2 text-content-secondary">
           Total borrowed value
         </div>
@@ -204,7 +204,7 @@ watch(portfolioRefreshCounter, () => {
               v-if="totalBorrowedValueInfo.hasMissingPrices"
               title="Incomplete pricing"
               text="Some borrowed assets don't have price data available. The displayed value may be higher than shown."
-              tooltip-placement="top-end"
+              tooltip-placement="bottom-end"
             />
           </div>
         </BaseLoadableContent>
@@ -213,7 +213,9 @@ watch(portfolioRefreshCounter, () => {
 
     <UiTabs
       v-model="tabsModel"
+      class="mx-16"
       rounded
+      pills
       :list="tabs"
     />
 

--- a/pages/portfolio.vue
+++ b/pages/portfolio.vue
@@ -109,105 +109,118 @@ watch(portfolioRefreshCounter, () => {
 
     <PortfolioShowAllHint />
 
-    <div class="flex flex-col gap-16 p-16 rounded-12 mx-16 border border-line-default bg-card shadow-card laptop:flex-row laptop:gap-0 laptop:divide-x laptop:divide-line-default laptop:p-0">
-      <div class="flex justify-between items-center laptop:flex-col laptop:items-start laptop:gap-4 laptop:flex-1 laptop:p-16">
-        <div class="flex items-center gap-4 text-p2 text-content-secondary">
-          Portfolio Net APY
-          <UiFootnote
-            title="Portfolio Net APY"
-            text="Net annual percentage yield across all positions. Calculated as total net yield (supply income minus borrow costs) divided by total supplied value."
-            tooltip-placement="bottom-start"
-            class="[--ui-footnote-icon-color:var(--c-content-tertiary)]"
-          />
+    <div class="flex flex-col gap-16 mx-16 laptop:flex-row laptop:items-stretch">
+      <div class="flex flex-col gap-16 p-16 rounded-12 border border-line-default bg-card shadow-card laptop:flex-1">
+        <div class="text-h4 text-content-primary">
+          Portfolio performance
         </div>
-        <BaseLoadableContent :loading="isConnected && (!isPositionsLoaded || !isBalancesLoaded)">
-          <div
-            class="text-h5"
-            :class="[portfolioNetApy >= 0 ? 'text-accent-600' : 'text-error-500']"
-          >
-            {{ Number.isFinite(portfolioNetApy) ? `${formatNumber(portfolioNetApy)}%` : '-' }}
-          </div>
-        </BaseLoadableContent>
-      </div>
-      <div class="flex justify-between items-center laptop:flex-col laptop:items-start laptop:gap-4 laptop:flex-1 laptop:p-16">
-        <div class="flex items-center gap-4 text-p2 text-content-secondary">
-          Portfolio ROE
-          <UiFootnote
-            title="Portfolio ROE"
-            text="Return on equity across all positions. Calculated as total net yield divided by total equity (supplied value minus borrowed value)."
-            tooltip-placement="bottom-start"
-            class="[--ui-footnote-icon-color:var(--c-content-tertiary)]"
-          />
-        </div>
-        <BaseLoadableContent :loading="isConnected && (!isPositionsLoaded || !isBalancesLoaded)">
-          <div
-            class="text-h5"
-            :class="[portfolioRoe >= 0 ? 'text-accent-600' : 'text-error-500']"
-          >
-            {{ Number.isFinite(portfolioRoe) ? `${formatNumber(portfolioRoe)}%` : '-' }}
-          </div>
-        </BaseLoadableContent>
-      </div>
-      <div class="flex justify-between items-center laptop:flex-col laptop:items-start laptop:gap-4 laptop:flex-1 laptop:p-16">
-        <div class="text-p2 text-content-secondary">
-          Net asset value
-        </div>
-        <BaseLoadableContent :loading="isConnected && (!isPositionsLoaded || !isBalancesLoaded)">
-          <div class="flex items-center gap-4 text-h5 text-content-primary">
-            {{ (() => {
-              const netValue = totalSuppliedValueInfo.total - totalBorrowedValueInfo.total
-              const hasMissing = totalSuppliedValueInfo.hasMissingPrices || totalBorrowedValueInfo.hasMissingPrices
-              if (netValue === 0 && hasMissing) return '—'
-              return formatCompactUsdValue(netValue)
-            })() }}
+        <div class="flex justify-between items-center">
+          <div class="flex items-center gap-4 text-p2 text-content-secondary">
+            Net APY
             <UiFootnote
-              v-if="totalSuppliedValueInfo.hasMissingPrices || totalBorrowedValueInfo.hasMissingPrices"
-              title="Incomplete pricing"
-              text="Some assets in your portfolio don't have price data available. The displayed value may be higher than shown."
-              tooltip-placement="bottom-end"
+              title="Portfolio Net APY"
+              text="Net annual percentage yield across all positions. Calculated as total net yield (supply income minus borrow costs) divided by total supplied value."
+              tooltip-placement="bottom-start"
+              class="[--ui-footnote-icon-color:var(--c-content-tertiary)]"
             />
           </div>
-        </BaseLoadableContent>
-      </div>
-      <div class="flex justify-between items-center laptop:flex-col laptop:items-start laptop:gap-4 laptop:flex-1 laptop:p-16">
-        <div class="text-p2 text-content-secondary">
-          Total supplied value
+          <BaseLoadableContent :loading="isConnected && (!isPositionsLoaded || !isBalancesLoaded)">
+            <div
+              class="text-h5"
+              :class="[portfolioNetApy >= 0 ? 'text-accent-600' : 'text-error-500']"
+            >
+              {{ Number.isFinite(portfolioNetApy) ? `${formatNumber(portfolioNetApy)}%` : '-' }}
+            </div>
+          </BaseLoadableContent>
         </div>
-        <BaseLoadableContent :loading="isConnected && (!isPositionsLoaded || !isBalancesLoaded)">
-          <div class="flex items-center gap-4 text-h5 text-content-primary">
-            {{ (() => {
-              const { total, hasMissingPrices } = totalSuppliedValueInfo
-              if (total === 0 && hasMissingPrices) return '—'
-              return formatCompactUsdValue(total)
-            })() }}
+        <div class="flex justify-between items-center">
+          <div class="flex items-center gap-4 text-p2 text-content-secondary">
+            ROE
+            <UiFootnote
+              title="Portfolio ROE"
+              text="Return on equity across all positions. Calculated as total net yield divided by total equity (supplied value minus borrowed value)."
+              tooltip-placement="bottom-start"
+              class="[--ui-footnote-icon-color:var(--c-content-tertiary)]"
+            />
+          </div>
+          <BaseLoadableContent :loading="isConnected && (!isPositionsLoaded || !isBalancesLoaded)">
+            <div
+              class="text-h5"
+              :class="[portfolioRoe >= 0 ? 'text-accent-600' : 'text-error-500']"
+            >
+              {{ Number.isFinite(portfolioRoe) ? `${formatNumber(portfolioRoe)}%` : '-' }}
+            </div>
+          </BaseLoadableContent>
+        </div>
+      </div>
+      <div class="flex flex-col gap-16 p-16 rounded-12 border border-line-default bg-card shadow-card laptop:flex-1">
+        <div class="text-h4 text-content-primary">
+          Portfolio value
+        </div>
+        <div class="flex justify-between items-center">
+          <div class="flex items-center gap-4 text-p2 text-content-secondary">
+            Total supplied
             <UiFootnote
               v-if="totalSuppliedValueInfo.hasMissingPrices"
               title="Incomplete pricing"
               text="Some supplied assets don't have price data available. The displayed value may be higher than shown."
               tooltip-placement="bottom-end"
+              class="[--ui-footnote-icon-color:var(--warning-500)]"
             />
           </div>
-        </BaseLoadableContent>
-      </div>
-      <div class="flex justify-between items-center laptop:flex-col laptop:items-start laptop:gap-4 laptop:flex-1 laptop:p-16">
-        <div class="text-p2 text-content-secondary">
-          Total borrowed value
+          <BaseLoadableContent :loading="isConnected && (!isPositionsLoaded || !isBalancesLoaded)">
+            <div class="text-h5 text-content-primary">
+              {{ (() => {
+                const { total, hasMissingPrices } = totalSuppliedValueInfo
+                if (total === 0 && hasMissingPrices) return '—'
+                return formatCompactUsdValue(total)
+              })() }}
+            </div>
+          </BaseLoadableContent>
         </div>
-        <BaseLoadableContent :loading="isConnected && (!isPositionsLoaded || !isBalancesLoaded)">
-          <div class="flex items-center gap-4 text-h5 text-content-primary">
-            {{ (() => {
-              const { total, hasMissingPrices } = totalBorrowedValueInfo
-              if (total === 0 && hasMissingPrices) return '—'
-              return formatCompactUsdValue(total)
-            })() }}
+        <div class="flex justify-between items-center">
+          <div class="flex items-center gap-4 text-p2 text-content-secondary">
+            Total borrowed
             <UiFootnote
               v-if="totalBorrowedValueInfo.hasMissingPrices"
               title="Incomplete pricing"
               text="Some borrowed assets don't have price data available. The displayed value may be higher than shown."
               tooltip-placement="bottom-end"
+              class="[--ui-footnote-icon-color:var(--warning-500)]"
             />
           </div>
-        </BaseLoadableContent>
+          <BaseLoadableContent :loading="isConnected && (!isPositionsLoaded || !isBalancesLoaded)">
+            <div class="text-h5 text-content-primary">
+              {{ (() => {
+                const { total, hasMissingPrices } = totalBorrowedValueInfo
+                if (total === 0 && hasMissingPrices) return '—'
+                return formatCompactUsdValue(total)
+              })() }}
+            </div>
+          </BaseLoadableContent>
+        </div>
+        <div class="flex justify-between items-center">
+          <div class="flex items-center gap-4 text-p2 text-content-secondary">
+            Net asset value
+            <UiFootnote
+              v-if="totalSuppliedValueInfo.hasMissingPrices || totalBorrowedValueInfo.hasMissingPrices"
+              title="Incomplete pricing"
+              text="Some assets in your portfolio don't have price data available. The displayed value may be higher than shown."
+              tooltip-placement="bottom-end"
+              class="[--ui-footnote-icon-color:var(--warning-500)]"
+            />
+          </div>
+          <BaseLoadableContent :loading="isConnected && (!isPositionsLoaded || !isBalancesLoaded)">
+            <div class="text-h5 text-content-primary">
+              {{ (() => {
+                const netValue = totalSuppliedValueInfo.total - totalBorrowedValueInfo.total
+                const hasMissing = totalSuppliedValueInfo.hasMissingPrices || totalBorrowedValueInfo.hasMissingPrices
+                if (netValue === 0 && hasMissing) return '—'
+                return formatCompactUsdValue(netValue)
+              })() }}
+            </div>
+          </BaseLoadableContent>
+        </div>
       </div>
     </div>
 

--- a/pages/portfolio/index.vue
+++ b/pages/portfolio/index.vue
@@ -19,47 +19,56 @@ const sortedBorrowPositions = computed(() => {
 </script>
 
 <template>
-  <div
-    class="flex mx-16 p-8 rounded-12 border border-line-default bg-surface shadow-card"
-    :class="sortedBorrowPositions.length === 0 ? 'flex-1' : ''"
-  >
-    <div
-      v-if="isConnected && (!isPositionsLoaded || (!isReady && sortedBorrowPositions.length === 0))"
-      class="flex flex-1 justify-center items-center"
-    >
-      <UiLoader class="text-content-tertiary" />
+  <div class="mx-16">
+    <div class="flex justify-between items-center mb-8">
+      <h3 class="text-h3 font-normal text-neutral-800">
+        Borrow positions
+      </h3>
     </div>
-
+    <p class="text-p2 text-neutral-500 mb-16">
+      Active loans backed by your supplied collateral.
+    </p>
     <div
-      v-else-if="sortedBorrowPositions.length === 0"
-      class="flex flex-1 justify-center items-center"
+      class="flex flex-1 p-8 rounded-12 border border-line-default bg-card"
     >
-      <div class="flex flex-col gap-8 items-center text-content-tertiary">
-        <div class="flex w-48 h-48 justify-center items-center rounded-12 bg-surface-secondary">
-          <SvgIcon name="search" />
-        </div>
-        <template v-if="isConnected">
-          You don't have positions yet
-        </template>
-        <template v-else>
-          Connect your wallet to see your positions
-        </template>
-      </div>
-    </div>
-
-    <div
-      v-else
-      class="w-full"
-    >
-      <PortfolioList
-        :items="sortedBorrowPositions"
-        type="borrow"
-      />
       <div
-        v-if="!isReady"
-        class="flex justify-center items-center mt-12"
+        v-if="isConnected && (!isPositionsLoaded || (!isReady && sortedBorrowPositions.length === 0))"
+        class="flex flex-1 justify-center items-center"
       >
-        <UiLoader class="text-content-tertiary" />
+        <UiLoader class="text-neutral-500 my-8" />
+      </div>
+
+      <div
+        v-else-if="sortedBorrowPositions.length === 0"
+        class="flex flex-1 justify-center items-center"
+      >
+        <div class="flex flex-col gap-8 items-center text-neutral-500 py-32">
+          <div class="flex w-48 h-48 justify-center items-center rounded-12 bg-neutral-100">
+            <SvgIcon name="search" />
+          </div>
+          <template v-if="isConnected">
+            You don't have positions yet
+          </template>
+          <template v-else>
+            Connect your wallet to see your positions
+          </template>
+        </div>
+      </div>
+
+      <div
+        v-else
+        class="flex-1"
+      >
+        <PortfolioList
+          :items="sortedBorrowPositions"
+          type="borrow"
+        />
+        <div
+          v-if="!isReady"
+          class="flex justify-center items-center mt-12"
+        >
+          <UiLoader class="text-neutral-500" />
+        </div>
       </div>
     </div>
   </div>

--- a/pages/portfolio/saving.vue
+++ b/pages/portfolio/saving.vue
@@ -43,7 +43,7 @@ watchEffect(async () => {
       </h3>
     </div>
     <p class="text-p2 text-neutral-500 mb-16">
-      Supply-only positions that earn you yield. They are not used as collateral to back a borrowing position.
+      Passive yield earned across professionally curated strategies.
     </p>
     <div class="flex flex-1 p-8 rounded-12 mb-16 border border-line-default bg-card">
       <div
@@ -91,7 +91,7 @@ watchEffect(async () => {
       </h3>
     </div>
     <p class="text-p2 text-neutral-500 mb-16">
-      Supply-only positions on your main account that earn you yield. They are not used as collateral to back a borrowing position.
+      Yield earned by lending assets directly to borrowers.
     </p>
     <div class="flex flex-1 p-8 rounded-12 border border-line-default bg-card">
       <div

--- a/pages/position/[number]/index.vue
+++ b/pages/position/[number]/index.vue
@@ -705,6 +705,7 @@ watch([isConnected, isSpyMode], () => {
       <div class="flex items-center gap-12">
         <NuxtLink
           to="/portfolio"
+          aria-label="Back to portfolio"
           class="flex items-center justify-center self-stretch px-8 rounded-8 border border-line-default bg-surface-elevated hover:bg-card-hover transition-colors text-content-secondary hover:text-content-primary flex-shrink-0"
         >
           <UiIcon

--- a/pages/position/[number]/index.vue
+++ b/pages/position/[number]/index.vue
@@ -740,7 +740,7 @@ watch([isConnected, isSpyMode], () => {
           <div class="text-h4 text-content-primary">
             Position summary
           </div>
-          <div class="flex justify-between items-center mt-6">
+          <div class="flex justify-between items-center">
             <div class="flex items-center gap-4 text-p2 text-content-secondary">
               Net APY
               <SvgIcon
@@ -793,15 +793,15 @@ watch([isConnected, isSpyMode], () => {
             </div>
           </div>
         </div>
-        <div class="rounded-12 bg-card border border-line-default shadow-card p-16 laptop:flex-1">
-          <div class="text-h4 text-neutral-800 mb-16">
+        <div class="flex flex-col gap-16 rounded-12 bg-card border border-line-default shadow-card p-16 laptop:flex-1">
+          <div class="text-h4 text-content-primary">
             Position risk
           </div>
-          <div class="flex justify-between gap-8 flex-wrap mb-16">
-            <div class="text-neutral-500 text-p3">
+          <div class="flex justify-between gap-8 flex-wrap">
+            <div class="text-content-secondary text-p3">
               Health score
             </div>
-            <div class="text-neutral-800 text-p3">
+            <div class="text-content-primary text-p3">
               <span
                 v-if="hasQueryFailure"
                 class="text-warning-500"
@@ -811,11 +811,11 @@ watch([isConnected, isSpyMode], () => {
               </template>
             </div>
           </div>
-          <div class="flex justify-between gap-8 flex-wrap mb-16">
-            <div class="text-neutral-500 text-p3">
+          <div class="flex justify-between gap-8 flex-wrap">
+            <div class="text-content-secondary text-p3">
               Time to liquidation
             </div>
-            <div class="text-neutral-800 text-p3">
+            <div class="text-content-primary text-p3">
               <span
                 v-if="hasQueryFailure"
                 class="text-warning-500"
@@ -825,11 +825,11 @@ watch([isConnected, isSpyMode], () => {
               </template>
             </div>
           </div>
-          <div class="flex justify-between gap-8 flex-wrap mb-12">
-            <div class="text-neutral-500 text-p3">
+          <div class="flex justify-between gap-8 flex-wrap">
+            <div class="text-content-secondary text-p3">
               Liquidation LTV
             </div>
-            <div class="text-neutral-800 text-p3">
+            <div class="text-content-primary text-p3">
               <span
                 v-if="hasQueryFailure"
                 class="text-warning-500"

--- a/pages/position/[number]/index.vue
+++ b/pages/position/[number]/index.vue
@@ -702,8 +702,19 @@ watch([isConnected, isSpyMode], () => {
       </div>
     </template>
     <template v-else-if="position">
-      <div class="text-h6 text-content-secondary bg-surface-elevated py-4 px-12 rounded-8 border border-line-default self-start">
-        Position {{ positionIndex }}
+      <div class="flex items-center gap-12">
+        <NuxtLink
+          to="/portfolio"
+          class="flex items-center justify-center self-stretch px-8 rounded-8 border border-line-default bg-surface-elevated hover:bg-card-hover transition-colors text-content-secondary hover:text-content-primary flex-shrink-0"
+        >
+          <UiIcon
+            name="arrow-left"
+            class="!w-16 !h-16"
+          />
+        </NuxtLink>
+        <div class="text-h6 text-content-secondary bg-surface-elevated py-4 px-12 rounded-8 border border-line-default">
+          Position {{ positionIndex }}
+        </div>
       </div>
 
       <VaultLabelsAndAssets

--- a/pages/position/[number]/index.vue
+++ b/pages/position/[number]/index.vue
@@ -733,117 +733,119 @@ watch([isConnected, isSpyMode], () => {
 
       <div
         v-if="!hasNoBorrow"
-        class="flex flex-col gap-16 p-16 rounded-12 border border-line-default bg-card shadow-card"
+        class="flex flex-col gap-16 laptop:flex-row laptop:items-stretch"
       >
-        <div class="flex justify-between items-center">
-          <div class="flex items-center gap-4 text-p2 text-content-secondary">
-            Net APY
-            <SvgIcon
-              class="!w-16 !h-16 text-content-muted cursor-pointer hover:text-content-secondary"
-              name="info-circle"
-              @click="onNetApyInfoClick"
-            />
+        <div class="flex flex-col gap-16 p-16 rounded-12 border border-line-default bg-card shadow-card laptop:flex-1">
+          <div class="text-h4 text-content-primary">
+            Position summary
           </div>
-          <div
-            class="text-h5 flex items-center gap-4"
-            :class="[netAPY >= 0 ? 'text-accent-600' : 'text-error-500']"
-          >
-            <SvgIcon
-              v-if="hasSupplyRewards(collateralVault?.address || '') || hasBorrowRewards(borrowVault?.address || '', collateralVault?.address || '')"
-              class="!w-20 !h-20 text-accent-500 cursor-pointer"
-              name="sparks"
-              @click="onNetApyInfoClick"
-            />
-            {{ Number.isFinite(netAPY) ? `${formatNumber(netAPY)}%` : '-' }}
+          <div class="flex justify-between items-center mt-6">
+            <div class="flex items-center gap-4 text-p2 text-content-secondary">
+              Net APY
+              <SvgIcon
+                class="!w-16 !h-16 text-content-muted cursor-pointer hover:text-content-secondary"
+                name="info-circle"
+                @click="onNetApyInfoClick"
+              />
+            </div>
+            <div
+              class="text-h5 flex items-center gap-4"
+              :class="[netAPY >= 0 ? 'text-accent-600' : 'text-error-500']"
+            >
+              <SvgIcon
+                v-if="hasSupplyRewards(collateralVault?.address || '') || hasBorrowRewards(borrowVault?.address || '', collateralVault?.address || '')"
+                class="!w-20 !h-20 text-accent-500 cursor-pointer"
+                name="sparks"
+                @click="onNetApyInfoClick"
+              />
+              {{ Number.isFinite(netAPY) ? `${formatNumber(netAPY)}%` : '-' }}
+            </div>
           </div>
-        </div>
-        <div class="flex justify-between items-center">
-          <div class="flex items-center gap-4 text-p2 text-content-secondary">
-            ROE
-            <SvgIcon
-              class="!w-16 !h-16 text-content-muted cursor-pointer hover:text-content-secondary"
-              name="info-circle"
-              @click="onRoeInfoClick"
-            />
+          <div class="flex justify-between items-center">
+            <div class="flex items-center gap-4 text-p2 text-content-secondary">
+              ROE
+              <SvgIcon
+                class="!w-16 !h-16 text-content-muted cursor-pointer hover:text-content-secondary"
+                name="info-circle"
+                @click="onRoeInfoClick"
+              />
+            </div>
+            <div
+              class="text-h5 flex items-center gap-4"
+              :class="[roe >= 0 ? 'text-accent-600' : 'text-error-500']"
+            >
+              <SvgIcon
+                v-if="hasSupplyRewards(collateralVault?.address || '') || hasBorrowRewards(borrowVault?.address || '', collateralVault?.address || '')"
+                class="!w-20 !h-20 text-accent-500 cursor-pointer"
+                name="sparks"
+                @click="onRoeInfoClick"
+              />
+              {{ Number.isFinite(roe) ? `${formatNumber(roe)}%` : '-' }}
+            </div>
           </div>
-          <div
-            class="text-h5 flex items-center gap-4"
-            :class="[roe >= 0 ? 'text-accent-600' : 'text-error-500']"
-          >
-            <SvgIcon
-              v-if="hasSupplyRewards(collateralVault?.address || '') || hasBorrowRewards(borrowVault?.address || '', collateralVault?.address || '')"
-              class="!w-20 !h-20 text-accent-500 cursor-pointer"
-              name="sparks"
-              @click="onRoeInfoClick"
-            />
-            {{ Number.isFinite(roe) ? `${formatNumber(roe)}%` : '-' }}
-          </div>
-        </div>
-        <div class="flex justify-between items-center">
-          <div class="text-p2 text-content-secondary">
-            Net asset value
-          </div>
-          <div class="text-h5 text-content-primary">
-            {{ isCollateralsLoading ? '-' : netAssetValue.hasPrice ? formatCompactUsdValue(netAssetValue.usd) : '-' }}
-          </div>
-        </div>
-      </div>
-      <div
-        v-if="!hasNoBorrow"
-        class="rounded-12 bg-card border border-line-default shadow-card p-16"
-      >
-        <div class="text-h4 text-neutral-800 mb-16">
-          Position risk
-        </div>
-        <div class="flex justify-between gap-8 flex-wrap mb-16">
-          <div class="text-neutral-500 text-p3">
-            Health score
-          </div>
-          <div class="text-neutral-800 text-p3">
-            <span
-              v-if="hasQueryFailure"
-              class="text-warning-500"
-            >Unknown</span>
-            <template v-else>
-              {{ formatHealthScore(nanoToValue(position.health, 18)) }}
-            </template>
+          <div class="flex justify-between items-center">
+            <div class="text-p2 text-content-secondary">
+              Net asset value
+            </div>
+            <div class="text-h5 text-content-primary">
+              {{ isCollateralsLoading ? '-' : netAssetValue.hasPrice ? formatCompactUsdValue(netAssetValue.usd) : '-' }}
+            </div>
           </div>
         </div>
-        <div class="flex justify-between gap-8 flex-wrap mb-16">
-          <div class="text-neutral-500 text-p3">
-            Time to liquidation
+        <div class="rounded-12 bg-card border border-line-default shadow-card p-16 laptop:flex-1">
+          <div class="text-h4 text-neutral-800 mb-16">
+            Position risk
           </div>
-          <div class="text-neutral-800 text-p3">
-            <span
-              v-if="hasQueryFailure"
-              class="text-warning-500"
-            >Unknown</span>
-            <template v-else>
-              {{ timeToLiquidationDisplay }}
-            </template>
+          <div class="flex justify-between gap-8 flex-wrap mb-16">
+            <div class="text-neutral-500 text-p3">
+              Health score
+            </div>
+            <div class="text-neutral-800 text-p3">
+              <span
+                v-if="hasQueryFailure"
+                class="text-warning-500"
+              >Unknown</span>
+              <template v-else>
+                {{ formatHealthScore(nanoToValue(position.health, 18)) }}
+              </template>
+            </div>
           </div>
+          <div class="flex justify-between gap-8 flex-wrap mb-16">
+            <div class="text-neutral-500 text-p3">
+              Time to liquidation
+            </div>
+            <div class="text-neutral-800 text-p3">
+              <span
+                v-if="hasQueryFailure"
+                class="text-warning-500"
+              >Unknown</span>
+              <template v-else>
+                {{ timeToLiquidationDisplay }}
+              </template>
+            </div>
+          </div>
+          <div class="flex justify-between gap-8 flex-wrap mb-12">
+            <div class="text-neutral-500 text-p3">
+              Liquidation LTV
+            </div>
+            <div class="text-neutral-800 text-p3">
+              <span
+                v-if="hasQueryFailure"
+                class="text-warning-500"
+              >Unknown</span>
+              <template v-else>
+                {{ formatNumber(nanoToValue(position.userLTV, 18), 2) }}/{{ nanoToValue(position.liquidationLTV, 2) }}%
+              </template>
+            </div>
+          </div>
+          <UiProgress
+            v-if="!hasQueryFailure"
+            :model-value="nanoToValue(position.userLTV, 18)"
+            :max="nanoToValue(position.liquidationLTV, 2)"
+            :color="nanoToValue(position.userLTV, 18) >= (nanoToValue(position.liquidationLTV, 2) - 2) ? 'danger' : undefined"
+            size="small"
+          />
         </div>
-        <div class="flex justify-between gap-8 flex-wrap mb-12">
-          <div class="text-neutral-500 text-p3">
-            Liquidation LTV
-          </div>
-          <div class="text-neutral-800 text-p3">
-            <span
-              v-if="hasQueryFailure"
-              class="text-warning-500"
-            >Unknown</span>
-            <template v-else>
-              {{ formatNumber(nanoToValue(position.userLTV, 18), 2) }}/{{ nanoToValue(position.liquidationLTV, 2) }}%
-            </template>
-          </div>
-        </div>
-        <UiProgress
-          v-if="!hasQueryFailure"
-          :model-value="nanoToValue(position.userLTV, 18)"
-          :max="nanoToValue(position.liquidationLTV, 2)"
-          :color="nanoToValue(position.userLTV, 18) >= (nanoToValue(position.liquidationLTV, 2) - 2) ? 'danger' : undefined"
-          size="small"
-        />
       </div>
       <div
         v-if="!hasNoBorrow"


### PR DESCRIPTION
## Summary
- The portfolio and position pages were heavily optimised for mobile, leaving desktop with a poor layout — stats displayed as a narrow vertical list, tabs lacked visual hierarchy, and tooltips had usability issues
- This PR improves the desktop experience across both pages without regressing mobile behaviour

## Changes
- **Portfolio stats card**: on desktop, stats switch from a stacked vertical list to a horizontal row of equal-width columns separated by dividers (`laptop:flex-row` + `laptop:divide-x`)
- **Portfolio tabs**: switched from underline style to pill style with an accent green bottom border on the active tab to preserve selection clarity; badge contrast adjusted for dark theme so counts remain legible on the active pill background
- **Footnote tooltips**: open on hover on desktop instead of requiring a click; z-index raised from 1 to 10 so tooltips render above the pill tab slider
- **Position page — back button**: added a back-to-portfolio button alongside the "Position N" badge using a new `arrow-left` SVG sprite icon
- **Position page — stat cards**: "Position summary" and "Position risk" cards are now displayed side by side on desktop (`laptop:flex-row laptop:items-stretch`) rather than stacked; "Position summary" card gets a title to balance heights between the two cards
- **Saving item action buttons**: removed `flex-wrap` and added `whitespace-nowrap` so Supply / Withdraw / Asset swap always render in a single row without label wrapping

## Test plan
- [ ] Portfolio page desktop: stats display as 5 horizontal columns with dividers
- [ ] Portfolio page mobile: stats remain stacked vertically
- [ ] Portfolio tabs: active pill shows accent green bottom border; badge is visible in both light and dark themes
- [ ] Hovering a footnote info icon on desktop shows tooltip without clicking; clicking still works on mobile
- [ ] Tooltip renders above tab pill slider (no z-index bleed-through)
- [ ] Position page: back button navigates to `/portfolio`
- [ ] Position page desktop: "Position summary" and "Position risk" cards appear side by side
- [ ] Position page mobile: cards stack vertically
- [ ] Portfolio saving items: Supply / Withdraw / Asset swap buttons sit in a single row and labels do not wrap on narrow cards
