### PR TITLE
fix: fetch Merkl Earn vault rewards independently of protocol tagging

### DIFF
--- a/composables/useMerkl.ts
+++ b/composables/useMerkl.ts
@@ -161,7 +161,7 @@ const loadOpportunities = async (chainId: number, isInitialLoading = true, force
     // ERC20LOGPROCESSOR is fetched without mainProtocolId filter (unreliable tagging by Merkl)
     // and filtered client-side against known Earn vault addresses from labels.
     // Merkl API caps items at 100, so we paginate ERC20LOGPROCESSOR to get all results.
-    const fetchAllPages = async (baseUrl: string): Promise<Opportunity[]> => {
+    const fetchAllPages = async (baseUrl: string): Promise<{ data: Opportunity[], complete: boolean }> => {
       const pageSize = 100
       const allData: Opportunity[] = []
       let page = 0
@@ -176,11 +176,11 @@ const loadOpportunities = async (chainId: number, isInitialLoading = true, force
         }
         catch (error) {
           logWarn('merkl/fetchOpportunity', error)
-          break
+          return { data: allData, complete: false }
         }
       }
 
-      return allData
+      return { data: allData, complete: true }
     }
 
     // Always fetch EULER campaigns. Only fetch ERC20LOGPROCESSOR when Earn vault
@@ -192,27 +192,24 @@ const loadOpportunities = async (chainId: number, isInitialLoading = true, force
       ? new Set(earnAddrs.map(addr => addr.toLowerCase()))
       : undefined
 
-    // Claim ERC20 fetch for this chainId before any async work so that the
-    // earnVaults watcher (fired concurrently on mount) doesn't duplicate the call.
-    if (knownEarnVaults) {
-      erc20FetchedForChainId = chainId
-    }
-
-    const fetches: Promise<Opportunity[]>[] = [fetchAllPages(eulerUrl)]
+    const fetches: Promise<{ data: Opportunity[], complete: boolean }>[] = [fetchAllPages(eulerUrl)]
     if (knownEarnVaults) {
       const erc20Url = `${MERKL_API_BASE_URL}/opportunities/?chainId=${chainId}&type=ERC20LOGPROCESSOR&campaigns=true`
       fetches.push(fetchAllPages(erc20Url))
     }
 
-    const [eulerData, erc20Data = []] = await Promise.all(fetches)
+    const results = await Promise.all(fetches)
 
     if (requestId !== latestOpportunitiesRequestId) return
+
+    const allComplete = results.every(r => r.complete)
+    const [eulerResult, erc20Result] = results
 
     const merged = new Map<string, RewardCampaign[]>()
 
     for (const { data, type } of [
-      { data: eulerData, type: 'EULER' as const },
-      { data: erc20Data, type: 'ERC20LOGPROCESSOR' as const },
+      { data: eulerResult.data, type: 'EULER' as const },
+      { data: erc20Result?.data ?? [], type: 'ERC20LOGPROCESSOR' as const },
     ]) {
       const partial = processOpportunitiesToCampaigns(data, type, type === 'ERC20LOGPROCESSOR' ? knownEarnVaults : undefined)
       for (const [vault, campaigns] of partial) {
@@ -223,7 +220,11 @@ const loadOpportunities = async (chainId: number, isInitialLoading = true, force
     }
 
     merklCampaigns.value = merged
-    cacheState.opportunities = { chainId, timestamp: Date.now() }
+    // Only cache when all pages were fetched successfully — partial results
+    // from a mid-pagination failure should not be treated as a complete dataset.
+    if (allComplete) {
+      cacheState.opportunities = { chainId, timestamp: Date.now() }
+    }
   }
   catch (e) {
     logWarn('merkl/loadOpportunities', e)
@@ -382,11 +383,13 @@ export const useMerkl = () => {
   // so ERC20LOGPROCESSOR campaigns are properly filtered.
   // { immediate: true } catches the case where labels are already loaded by the time
   // the watcher is registered (e.g. component remounts after a chain switch).
-  // erc20FetchedForChainId is set optimistically before the async call so that
-  // concurrent watcher fires from other component mounts skip the duplicate fetch.
+  // erc20FetchedForChainId is set synchronously before the async call and only here
+  // (never inside loadOpportunities) so it is always claimed against correct chain
+  // data, and concurrent watcher fires from other component mounts skip the duplicate.
   watch(earnVaults, (val) => {
     if (enableMerkl && val.length > 0 && chainId.value
       && erc20FetchedForChainId !== chainId.value) {
+      erc20FetchedForChainId = chainId.value
       loadOpportunities(chainId.value, false, true)
     }
   }, { immediate: true })

--- a/composables/useMerkl.ts
+++ b/composables/useMerkl.ts
@@ -43,6 +43,7 @@ const cacheState = {
 
 let latestOpportunitiesRequestId = 0
 let latestRewardsRequestId = 0
+let erc20FetchedForChainId = 0
 
 const loadTokens = async (chainId: number, isInitialLoading = true, forceRefresh = false) => {
   const now = Date.now()
@@ -190,6 +191,12 @@ const loadOpportunities = async (chainId: number, isInitialLoading = true, force
     const knownEarnVaults = earnAddrs.length > 0
       ? new Set(earnAddrs.map(addr => addr.toLowerCase()))
       : undefined
+
+    // Claim ERC20 fetch for this chainId before any async work so that the
+    // earnVaults watcher (fired concurrently on mount) doesn't duplicate the call.
+    if (knownEarnVaults) {
+      erc20FetchedForChainId = chainId
+    }
 
     const fetches: Promise<Opportunity[]>[] = [fetchAllPages(eulerUrl)]
     if (knownEarnVaults) {
@@ -372,12 +379,17 @@ export const useMerkl = () => {
   }, { immediate: true })
 
   // Re-fetch opportunities when Earn vault labels become available,
-  // so ERC20LOGPROCESSOR campaigns are properly filtered
-  watch(earnVaults, (val, oldVal) => {
-    if (enableMerkl && val.length > 0 && oldVal.length === 0 && chainId.value) {
+  // so ERC20LOGPROCESSOR campaigns are properly filtered.
+  // { immediate: true } catches the case where labels are already loaded by the time
+  // the watcher is registered (e.g. component remounts after a chain switch).
+  // erc20FetchedForChainId is set optimistically before the async call so that
+  // concurrent watcher fires from other component mounts skip the duplicate fetch.
+  watch(earnVaults, (val) => {
+    if (enableMerkl && val.length > 0 && chainId.value
+      && erc20FetchedForChainId !== chainId.value) {
       loadOpportunities(chainId.value, false, true)
     }
-  })
+  }, { immediate: true })
 
   watch([isConnected, chainId], (val, oldVal) => {
     const [connected, currentChainId] = val
@@ -388,6 +400,7 @@ export const useMerkl = () => {
       merklCampaigns.value = new Map()
       rewards.value = []
       cacheState.opportunities = { chainId: 0, timestamp: 0 }
+      erc20FetchedForChainId = 0
       cacheState.rewards = { chainId: 0, address: '', timestamp: 0 }
     }
 
@@ -399,7 +412,11 @@ export const useMerkl = () => {
     }
 
     if (enableMerkl && !isLoaded.value) {
-      loadOpportunities(chainId.value)
+      // Skip if the earnVaults watcher already initiated the fetch synchronously
+      // (happens when earn labels are loaded before this watcher fires on mount)
+      if (erc20FetchedForChainId !== chainId.value) {
+        loadOpportunities(chainId.value)
+      }
       loadTokens(chainId.value)
       loadRewards(chainId.value)
       isLoaded.value = true

--- a/composables/useMerkl.ts
+++ b/composables/useMerkl.ts
@@ -9,6 +9,7 @@ import { mapMerklSubType } from '~/entities/reward-campaign'
 import type { TxPlan } from '~/entities/txPlan'
 import { CACHE_TTL_1MIN_MS, POLL_INTERVAL_30S_MS } from '~/entities/tuning-constants'
 import { logWarn } from '~/utils/errorHandling'
+import { earnVaults } from '~/utils/eulerLabelsState'
 
 const {
   MERKL_API_BASE_URL,
@@ -73,6 +74,7 @@ const loadTokens = async (chainId: number, isInitialLoading = true, forceRefresh
 const processOpportunitiesToCampaigns = (
   opportunities: Opportunity[],
   opType: 'EULER' | 'ERC20LOGPROCESSOR',
+  knownVaultAddresses?: Set<string>,
 ): Map<string, RewardCampaign[]> => {
   const campaignMap = new Map<string, RewardCampaign[]>()
   const now = Math.floor(Date.now() / 1000)
@@ -81,6 +83,13 @@ const processOpportunitiesToCampaigns = (
     if (opportunity.status !== 'LIVE') continue
     if (!opportunity.campaigns?.length) continue
     if (!opportunity.aprRecord?.breakdowns) continue
+
+    // For ERC20LOGPROCESSOR: filter against known Earn vault addresses
+    // since this endpoint returns campaigns for all protocols
+    if (opType === 'ERC20LOGPROCESSOR' && knownVaultAddresses) {
+      const opportunityAddress = opportunity.identifier?.toLowerCase()
+      if (!opportunityAddress || !knownVaultAddresses.has(opportunityAddress)) continue
+    }
 
     // Build APR map from aprRecord breakdowns (keyed by campaign ID)
     // This is the actual computed APR, not the stale campaign.apr field
@@ -147,32 +156,58 @@ const loadOpportunities = async (chainId: number, isInitialLoading = true, force
       isOpportunitiesLoading.value = true
     }
 
-    // Fetch from both endpoints: EULER type for standard vaults and ERC20LOGPROCESSOR for Earn vaults
-    const urls = [
-      { url: `${MERKL_API_BASE_URL}/opportunities/?chainId=${chainId}&type=EULER&campaigns=true`, type: 'EULER' as const },
-      { url: `${MERKL_API_BASE_URL}/opportunities/?chainId=${chainId}&mainProtocolId=euler&campaigns=true&type=ERC20LOGPROCESSOR`, type: 'ERC20LOGPROCESSOR' as const },
-    ]
+    // Fetch from both endpoints: EULER type for standard vaults and ERC20LOGPROCESSOR for Earn vaults.
+    // ERC20LOGPROCESSOR is fetched without mainProtocolId filter (unreliable tagging by Merkl)
+    // and filtered client-side against known Earn vault addresses from labels.
+    // Merkl API caps items at 100, so we paginate ERC20LOGPROCESSOR to get all results.
+    const fetchAllPages = async (baseUrl: string): Promise<Opportunity[]> => {
+      const pageSize = 100
+      const allData: Opportunity[] = []
+      let page = 0
 
-    const results = await Promise.all(
-      urls.map(async ({ url, type }) => {
+      while (true) {
         try {
-          const res = await axios.get(url)
-          const data: Opportunity[] = Array.isArray(res.data) ? res.data : []
-          return { data, type }
+          const res = await axios.get(`${baseUrl}&items=${pageSize}&page=${page}`)
+          const results: Opportunity[] = Array.isArray(res.data) ? res.data : []
+          allData.push(...results)
+          if (results.length < pageSize) break
+          page++
         }
         catch (error) {
           logWarn('merkl/fetchOpportunity', error)
-          return { data: [] as Opportunity[], type }
+          break
         }
-      }),
-    )
+      }
+
+      return allData
+    }
+
+    // Always fetch EULER campaigns. Only fetch ERC20LOGPROCESSOR when Earn vault
+    // labels are available for client-side filtering (the earnVaults watcher will
+    // trigger a force-refresh once labels load).
+    const eulerUrl = `${MERKL_API_BASE_URL}/opportunities/?chainId=${chainId}&type=EULER&campaigns=true`
+    const earnAddrs = earnVaults.value
+    const knownEarnVaults = earnAddrs.length > 0
+      ? new Set(earnAddrs.map(addr => addr.toLowerCase()))
+      : undefined
+
+    const fetches: Promise<Opportunity[]>[] = [fetchAllPages(eulerUrl)]
+    if (knownEarnVaults) {
+      const erc20Url = `${MERKL_API_BASE_URL}/opportunities/?chainId=${chainId}&type=ERC20LOGPROCESSOR&campaigns=true`
+      fetches.push(fetchAllPages(erc20Url))
+    }
+
+    const [eulerData, erc20Data = []] = await Promise.all(fetches)
 
     if (requestId !== latestOpportunitiesRequestId) return
 
     const merged = new Map<string, RewardCampaign[]>()
 
-    for (const { data, type } of results) {
-      const partial = processOpportunitiesToCampaigns(data, type)
+    for (const { data, type } of [
+      { data: eulerData, type: 'EULER' as const },
+      { data: erc20Data, type: 'ERC20LOGPROCESSOR' as const },
+    ]) {
+      const partial = processOpportunitiesToCampaigns(data, type, type === 'ERC20LOGPROCESSOR' ? knownEarnVaults : undefined)
       for (const [vault, campaigns] of partial) {
         const existing = merged.get(vault)
         if (existing) existing.push(...campaigns)
@@ -335,6 +370,14 @@ export const useMerkl = () => {
       loadRewards(chainId.value, true, true)
     }
   }, { immediate: true })
+
+  // Re-fetch opportunities when Earn vault labels become available,
+  // so ERC20LOGPROCESSOR campaigns are properly filtered
+  watch(earnVaults, (val, oldVal) => {
+    if (enableMerkl && val.length > 0 && oldVal.length === 0 && chainId.value) {
+      loadOpportunities(chainId.value, false, true)
+    }
+  })
 
   watch([isConnected, chainId], (val, oldVal) => {
     const [connected, currentChainId] = val

--- a/entities/merkl.ts
+++ b/entities/merkl.ts
@@ -6,7 +6,7 @@ export interface Opportunity {
   description: string
   howToSteps: string[]
   status: 'LIVE' | 'PAST'
-  action: 'LEND' | 'BORROW'
+  action: string
   tvl: number
   apr: number
   dailyRewards: number


### PR DESCRIPTION
## Summary

- Drop `mainProtocolId=euler` filter from the Merkl ERC20LOGPROCESSOR endpoint — Merkl does not reliably tag all Earn vault campaigns (e.g. Clearstar vaults had `protocol: N/A` and `action: HOLD` instead of `LEND`)
- Fetch all ERC20LOGPROCESSOR opportunities with pagination (`items=100`, `page=N`) and filter client-side against known Earn vault addresses from `euler-labels`
- Defer ERC20LOGPROCESSOR fetch until labels are loaded to avoid wasted requests; a watcher on `earnVaults` triggers a force-refresh once available
- Relax `Opportunity.action` type from `'LEND' | 'BORROW'` to `string` to accommodate `HOLD` action on some Earn vaults

## Test plan

- [x] Verify Earn vault rewards APY displays correctly on Monad (eeWETH, CSUSDC, CSAUSD vaults)
- [x] Verify EVK vault rewards (supply + borrow) are unaffected
- [x] Verify no duplicate Merkl API calls on initial load (ERC20LOGPROCESSOR only fetched after labels load)
- [x] Verify rewards refresh correctly on chain switch and wallet change