### PR TITLE
fix/restyle: remove duplicate section headings and polish page header

### DIFF
--- a/components/base/BasePageHeader.vue
+++ b/components/base/BasePageHeader.vue
@@ -20,7 +20,7 @@ defineProps({
 <template>
   <div class="flex items-center animate-fade-in-up">
     <div
-      class="w-[52px] h-[52px] rounded-[14px] mr-16 bg-gradient-to-br from-accent-300/30 to-accent-400/40 flex items-center justify-center text-accent-600 flex-shrink-0 shadow-sm"
+      class="w-[64px] h-[64px] rounded-[16px] mr-16 bg-gradient-to-br from-accent-300/30 to-accent-400/40 flex items-center justify-center text-accent-600 flex-shrink-0 shadow-sm"
       :class="[
         !icon && arrowRight ? '[&>svg]:-rotate-90' : '',
         !icon && arrowDown && !arrowRight ? '[&>svg]:rotate-0' : '',
@@ -29,14 +29,14 @@ defineProps({
     >
       <SvgIcon
         :name="icon || 'arrow-big'"
-        :class="icon ? '!w-28 !h-28' : ''"
+        :class="icon ? '!w-40 !h-40' : '!w-36 !h-36'"
       />
     </div>
     <div>
-      <h1 class="text-h3 mb-4 text-content-primary">
+      <h1 class="text-h2 mb-4 text-content-primary">
         {{ title }}
       </h1>
-      <p class="text-content-tertiary">
+      <p class="text-content-tertiary text-lg">
         {{ description }}
       </p>
     </div>

--- a/components/base/BasePageHeader.vue
+++ b/components/base/BasePageHeader.vue
@@ -20,7 +20,7 @@ defineProps({
 <template>
   <div class="flex items-center animate-fade-in-up">
     <div
-      class="w-[64px] h-[64px] rounded-[16px] mr-16 bg-gradient-to-br from-accent-300/30 to-accent-400/40 flex items-center justify-center text-accent-600 flex-shrink-0 shadow-sm"
+      class="w-[64px] h-[64px] mobile:w-[48px] mobile:h-[48px] rounded-[16px] mobile:rounded-[12px] mr-16 mobile:mr-12 bg-gradient-to-br from-accent-300/30 to-accent-400/40 flex items-center justify-center text-accent-600 flex-shrink-0 shadow-sm"
       :class="[
         !icon && arrowRight ? '[&>svg]:-rotate-90' : '',
         !icon && arrowDown && !arrowRight ? '[&>svg]:rotate-0' : '',
@@ -33,10 +33,10 @@ defineProps({
       />
     </div>
     <div>
-      <h1 class="text-h2 mb-4 text-content-primary">
+      <h1 class="text-h2 mobile:text-h3 mb-4 text-content-primary">
         {{ title }}
       </h1>
-      <p class="text-content-tertiary text-lg">
+      <p class="text-content-tertiary text-lg mobile:text-p3">
         {{ description }}
       </p>
     </div>

--- a/pages/borrow/index.vue
+++ b/pages/borrow/index.vue
@@ -372,7 +372,7 @@ const sortedBorrowList = computed(() => {
           icon="search"
           clearable
           compact
-          class="flex-1 min-w-[200px]"
+          class="flex-1 min-w-[200px] mobile:basis-full"
         />
         <VaultSortButton
           v-model="sortBy"

--- a/pages/borrow/index.vue
+++ b/pages/borrow/index.vue
@@ -360,24 +360,20 @@ const sortedBorrowList = computed(() => {
   <section class="flex flex-col min-h-[calc(100dvh-178px)]">
     <BasePageHeader
       title="Borrow"
-      description="Borrow against your collateral"
-      class="mb-24"
+      description="Discover vaults, borrow against your collateral."
+      class="mb-16"
     />
 
     <div class="mb-16">
-      <h3 class="text-h3 mb-16 text-neutral-900">
-        Discover vaults
-      </h3>
-      <div class="mb-8">
+      <div class="flex justify-start items-center w-full gap-8 flex-wrap">
         <UiInput
           v-model="searchQuery"
           placeholder="Search by asset, market, curator..."
           icon="search"
           clearable
           compact
+          class="flex-1 min-w-[200px]"
         />
-      </div>
-      <div class="flex justify-start items-center w-full gap-8 flex-wrap">
         <VaultSortButton
           v-model="sortBy"
           v-model:dir="sortDir"

--- a/pages/earn/index.vue
+++ b/pages/earn/index.vue
@@ -188,25 +188,21 @@ const sortedList = computed(() => {
   <section class="flex flex-col min-h-[calc(100dvh-178px)]">
     <BasePageHeader
       title="Earn"
-      description="Deposit once, earn passive yield across multiple professionally curated strategies."
-      class="mb-24"
+      description="Discover vaults, deposit once, earn passive yield across multiple professionally curated strategies."
+      class="mb-16"
       arrow-right
     />
 
     <div class="mb-16 -mx-16">
-      <h3 class="text-h3 mb-16 pl-16 text-neutral-900">
-        Discover vaults
-      </h3>
-      <div class="px-16 mb-8">
+      <div class="flex items-center flex-wrap gap-8 px-16">
         <UiInput
           v-model="searchQuery"
           placeholder="Search by asset, market, curator..."
           icon="search"
           clearable
           compact
+          class="flex-1 min-w-[200px]"
         />
-      </div>
-      <div class="flex items-center flex-wrap gap-8 px-16">
         <VaultSortButton
           v-model="sortBy"
           v-model:dir="sortDir"

--- a/pages/earn/index.vue
+++ b/pages/earn/index.vue
@@ -201,7 +201,7 @@ const sortedList = computed(() => {
           icon="search"
           clearable
           compact
-          class="flex-1 min-w-[200px]"
+          class="flex-1 min-w-[200px] mobile:basis-full"
         />
         <VaultSortButton
           v-model="sortBy"

--- a/pages/explore/index.vue
+++ b/pages/explore/index.vue
@@ -287,7 +287,7 @@ const { isSlow } = useSlowLoading(isLoading)
           icon="search"
           clearable
           compact
-          class="flex-1 min-w-[200px]"
+          class="flex-1 min-w-[200px] mobile:basis-full"
         />
         <VaultSortButton
           v-model="sortBy"

--- a/pages/explore/index.vue
+++ b/pages/explore/index.vue
@@ -275,24 +275,20 @@ const { isSlow } = useSlowLoading(isLoading)
     <BasePageHeader
       title="Explore"
       description="Discover markets structure and collateral relationships."
-      class="mb-24"
+      class="mb-16"
       icon="nodes"
     />
 
     <div class="mb-16 -mx-16">
-      <h3 class="text-h3 mb-16 pl-16 text-content-primary">
-        Discover markets
-      </h3>
-      <div class="px-16 mb-8">
+      <div class="flex items-center flex-wrap gap-8 px-16">
         <UiInput
           v-model="searchQuery"
           placeholder="Search by asset, market, curator..."
           icon="search"
           clearable
           compact
+          class="flex-1 min-w-[200px]"
         />
-      </div>
-      <div class="flex items-center flex-wrap gap-8 px-16">
         <VaultSortButton
           v-model="sortBy"
           v-model:dir="sortDir"

--- a/pages/lend/index.vue
+++ b/pages/lend/index.vue
@@ -265,7 +265,7 @@ const sortedList = computed(() => {
           icon="search"
           clearable
           compact
-          class="flex-1 min-w-[200px]"
+          class="flex-1 min-w-[200px] mobile:basis-full"
         />
         <VaultSortButton
           v-model="sortBy"

--- a/pages/lend/index.vue
+++ b/pages/lend/index.vue
@@ -252,27 +252,21 @@ const sortedList = computed(() => {
   <section class="flex flex-col min-h-[calc(100dvh-178px)]">
     <BasePageHeader
       title="Lend"
-      description="Earn yield on assets by lending them out."
-      class="mb-24"
+      description="Discover vaults, earn yield on assets by lending them out."
+      class="mb-16"
       arrow-down
     />
 
     <div class="mb-16 -mx-16">
-      <h3 class="text-h3 mb-16 pl-16 text-content-primary">
-        Discover vaults
-      </h3>
-
-      <div class="px-16 mb-8">
+      <div class="flex items-center flex-wrap gap-8 px-16">
         <UiInput
           v-model="searchQuery"
           placeholder="Search by asset, market, curator..."
           icon="search"
           clearable
           compact
+          class="flex-1 min-w-[200px]"
         />
-      </div>
-
-      <div class="flex items-center flex-wrap gap-8 px-16">
         <VaultSortButton
           v-model="sortBy"
           v-model:dir="sortDir"


### PR DESCRIPTION
- Remove redundant "Discover vaults/markets" h3 from all index pages
- Fold section heading text into BasePageHeader description copy
- Increase title to text-h2, description to text-lg, icon to 64px
- Merge search input and filter chips into a single flex row
- Mobile styling has adjusted sizing and small adjusted layout

Before:
<img width="1581" height="399" alt="image" src="https://github.com/user-attachments/assets/48a6b03e-6bbe-462f-957c-2d15377222c0" />


After:
<img width="1485" height="456" alt="image" src="https://github.com/user-attachments/assets/eb0f1782-e26c-4544-9b72-308ef45cf41a" />
