### PR TITLE
fix: fix disconnected subpath stroke joins in arrow SVGs

### DIFF
--- a/assets/sprite/svg/arrow-big.svg
+++ b/assets/sprite/svg/arrow-big.svg
@@ -1,3 +1,3 @@
-<svg width="19" height="19" viewBox="0 0 19 19" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M9.50342 0V18M9.50342 18L18.5034 9.19486M9.50342 18L0.503418 9.19486" stroke="currentColor" stroke-width="1.44" stroke-miterlimit="10" stroke-linejoin="round"/>
+<svg width="19" height="19" viewBox="-1 -1 21 21" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M9.50342 0V18M0.503418 9.19486L9.50342 18L18.5034 9.19486" stroke="currentColor" stroke-width="1.44" stroke-miterlimit="10" stroke-linejoin="round" stroke-linecap="round"/>
 </svg>

--- a/assets/sprite/svg/arrow-top-right.svg
+++ b/assets/sprite/svg/arrow-top-right.svg
@@ -1,4 +1,4 @@
 <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <path d="M17 7L7 17M17 7H8M17 7V16" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+  <path d="M7 17L17 7M8 7H17V16" stroke="currentColor" stroke-width="2" stroke-linecap="round"
     stroke-linejoin="round" />
 </svg>


### PR DESCRIPTION
- Merge chevron into a single subpath in arrow-big so stroke-linejoin renders a clean tip
- Merge bracket into a single subpath in arrow-top-right for same reason
- Expand arrow-big viewBox to prevent round linecap clipping at edges