### PR TITLE
fix: align range slider active bar with thumb and restore earn vault APY fetch

### DIFF
--- a/components/ui/UiRange.vue
+++ b/components/ui/UiRange.vue
@@ -59,8 +59,8 @@ const render = async () => {
     return
   }
   const x = ((model.value - min) / (max - min)) * trackBox.width
-  styles.trackActive.width = `${Math.min(x, trackBox.width)}px`
   const thumbX = Math.max(0, Math.min(x - 10, trackBox.width - 20))
+  styles.trackActive.width = `${thumbX + 10}px`
   styles.thumb.transform = `translate(${thumbX}px, -50%)`
 }
 const onPointerDown = () => {

--- a/pages/earn/[vault]/index.vue
+++ b/pages/earn/[vault]/index.vue
@@ -18,7 +18,7 @@ const route = useRoute()
 const modal = useModal()
 const { error } = useToast()
 const { buildSupplyPlan, executeTxPlan } = useEulerOperations()
-const { getEarnVault } = useVaults()
+const { getEarnVault, updateEarnVault } = useVaults()
 const { isConnected, address } = useAccount()
 const { fetchSingleBalance } = useWallets()
 const { runSimulation, simulationError, clearSimulationError } = useTxPlanSimulation()
@@ -168,9 +168,11 @@ const send = async () => {
     isSubmitting.value = false
   }
 }
-const updateEstimates = () => {
+const updateEstimates = async () => {
   if (!vault.value) return
   try {
+    await updateEarnVault(vault.value.address)
+    if (!asset.value?.address) return
     estimateSupplyAPY.value = nanoToValue(vault.value.interestRateInfo.supplyAPY, 25) + totalRewardsAPY.value
     monthlyEarnings.value = !amount.value
       ? 0
@@ -179,7 +181,9 @@ const updateEstimates = () => {
   catch (e) {
     logWarn('earn-supply/estimates', e)
   }
-  isEstimatesLoading.value = false
+  finally {
+    isEstimatesLoading.value = false
+  }
 }
 const onSupplyInfoIconClick = () => {
   modal.open(VaultSupplyApyModal, {


### PR DESCRIPTION
Fix range slider active bar misalignment and earn APY data freshness

## Summary
- The overflow clamp added to `UiRange` to prevent thumb overflow at track edges caused the active bar to desync from the thumb — at max value the bar extended past the thumb center, making the control visually misrepresent the selected value
- `updateEstimates` on the earn supply page was inadvertently made synchronous during a broader async refactor, dropping the `updateEarnVault` call that ensures the APY estimate uses fresh on-chain data rather than potentially stale cached state

## Changes
- Active bar width is now derived from `thumbX + 10` (thumb center position) rather than raw `x`, so bar and thumb always align regardless of endpoint clamping
- `updateEstimates` restored to `async` with `updateEarnVault` call and `finally` block for `isEstimatesLoading` — matches the original structure before it was collapsed into a sync function

## Test plan
- [ ] Open any lend or borrow page with a range slider; drag to min and max and confirm the active bar ends exactly at the thumb center at both extremes
- [ ] Open an earn vault supply page, enter an amount, and confirm the estimated APY and monthly earnings update (loading state clears correctly)
- [ ] Complete a supply transaction on an earn vault and confirm the APY/earnings reflect the post-transaction vault state
