### PR TITLE
fix: remove eth_sendRawTransaction relay and OFAC screening dedup race

### DIFF
--- a/composables/useAddressScreen.ts
+++ b/composables/useAddressScreen.ts
@@ -6,9 +6,6 @@ import { resetCountryCache } from '~/services/country'
 import { screenAddress } from '~/services/trm'
 import { getDefaultPageRoute } from '~/entities/menu'
 
-// Track last screened address to avoid duplicate API calls
-let lastScreenedAddress: string | null = null
-
 export const useAddressScreen = () => {
   const modal = useModal()
   const { disconnect } = useDisconnect()
@@ -38,16 +35,10 @@ export const useAddressScreen = () => {
       return false
     }
 
-    if (lastScreenedAddress === address.toLowerCase()) {
-      return false
-    }
-
     isScreening.value = true
     try {
       const vpnIsUsed = await detectVpn()
       const isRestricted = await screenAddress(address, vpnIsUsed)
-
-      lastScreenedAddress = address.toLowerCase()
 
       if (isRestricted) {
         await disconnect()
@@ -62,7 +53,6 @@ export const useAddressScreen = () => {
   }
 
   const resetScreeningCache = () => {
-    lastScreenedAddress = null
     resetVpnCache()
     resetCountryCache()
   }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -281,7 +281,7 @@ The Nuxt server layer (`server/api/`) proxies requests to external services (RPC
 | **CORS** (`server/middleware/cors.ts`) | Restricts API access to configured origins |
 | **Body size limits** (`server/middleware/body-limit.ts`) | Caps request payloads (1 MB RPC, 2 MB Tenderly) |
 | **Geo-blocking** (`server/middleware/geo-gate.ts`) | Blocks sanctioned countries via Cloudflare `CF-IPCountry`; fails closed (HTTP 451) if country is undetermined in prod |
-| **RPC method whitelist** (`server/api/rpc/[chainId].ts`) | Only 16 safe read/send methods are proxied |
+| **RPC method whitelist** (`server/api/rpc/[chainId].ts`) | Only 15 safe read-only methods are proxied |
 | **Rate limiting** (`server/utils/rate-limit.ts`) | Per-IP cost-based budgets (see below); fails closed (HTTP 403) if `CF-Connecting-IP` is absent in prod |
 | **Swap verifier validation** (`utils/swap-validation.ts`) | Validates swap verifier addresses against known config |
 

--- a/server/api/rpc/[chainId].ts
+++ b/server/api/rpc/[chainId].ts
@@ -6,7 +6,6 @@ import { isAbortError } from '~/utils/errorHandling'
 const ALLOWED_METHODS = new Set([
   'eth_call',
   'eth_estimateGas',
-  'eth_sendRawTransaction',
   'eth_getTransactionReceipt',
   'eth_getTransactionByHash',
   'eth_blockNumber',


### PR DESCRIPTION
- Drop eth_sendRawTransaction from the RPC proxy allowlist; the proxy is read-only transport and wallet connectors broadcast via their own providers, so no app functionality is affected
- Eliminate the module-level lastScreenedAddress dedup in useAddressScreen — the synchronous guard was ineffective against concurrent async invocations and created a window where a sanctioned wallet could reconnect and skip OFAC re-validation; caching is handled server-side at the screening proxy
- Update architecture docs to reflect 15 read-only proxied methods