### PR TITLE
feat: deprecated chains collapsible section in chain selector

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,11 @@ TENDERLY_PROJECT_SLUG=
 # Each RPC URL also needs a matching NUXT_PUBLIC_SUBGRAPH_URI_<chainId>.
 # Any chain ID supported by @reown/appkit/networks works — no code changes needed.
 #
+# Deprecated chains (comma-separated chain IDs, e.g. "1,56,236")
+# These chains are shown in a collapsed section in the chain selector.
+# Only chains that also have a RPC_URL_HTTP_<chainId> will appear.
+DEPRECATED_CHAINS=
+#
 # RPC URLs (server-side only, never exposed to client bundle)
 RPC_URL_HTTP_1=
 

--- a/components/entities/chains/ChainSelectorItem.vue
+++ b/components/entities/chains/ChainSelectorItem.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+const props = defineProps<{
+  chainId: number
+  name: string
+  deprecated?: boolean
+}>()
+</script>
+
+<template>
+  <div
+    class="flex items-center py-12 font-semibold leading-20 text-[16px] cursor-pointer"
+    :class="props.deprecated ? 'text-content-tertiary' : ''"
+  >
+    <BaseAvatar
+      class="mr-8 w-32 h-32 shadow-[inset_0_0_0_1px_var(--border-subtle)] rounded-full"
+      :class="props.deprecated ? 'opacity-40' : ''"
+      :src="`/chains/${props.chainId}.webp`"
+      :label="props.name"
+    />
+    {{ props.name }}
+  </div>
+</template>

--- a/components/entities/chains/ChainSelectorItem.vue
+++ b/components/entities/chains/ChainSelectorItem.vue
@@ -7,8 +7,9 @@ const props = defineProps<{
 </script>
 
 <template>
-  <div
-    class="flex items-center py-12 font-semibold leading-20 text-[16px] cursor-pointer"
+  <button
+    type="button"
+    class="flex items-center w-full py-12 font-semibold leading-20 text-[16px] cursor-pointer"
     :class="props.deprecated ? 'text-content-tertiary' : ''"
   >
     <BaseAvatar
@@ -18,5 +19,5 @@ const props = defineProps<{
       :label="props.name"
     />
     {{ props.name }}
-  </div>
+  </button>
 </template>

--- a/components/entities/chains/SelectChainModal.vue
+++ b/components/entities/chains/SelectChainModal.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useChains } from '@wagmi/vue'
 
-const emits = defineEmits(['close'])
+const emits = defineEmits<{ close: [] }>()
 const chains = useChains()
 const { deprecatedChainIds } = useChainConfig()
 const deprecatedSet = new Set(deprecatedChainIds)
@@ -37,23 +37,17 @@ const onClick = (chainId: number) => {
     @close="handleClose"
   >
     <div class="mb-24">
-      <div
+      <ChainSelectorItem
         v-for="chain in activeChains"
         :key="chain.id"
-        class="flex items-center py-12 font-semibold leading-20 text-[16px] cursor-pointer"
+        :chain-id="chain.id"
+        :name="chain.name"
         @click="onClick(chain.id)"
-      >
-        <BaseAvatar
-          class="mr-8 w-32 h-32 shadow-[inset_0_0_0_1px_var(--border-subtle)] rounded-full"
-          :src="`/chains/${chain.id}.webp`"
-          :label="chain.name"
-        />
-        {{ chain.name }}
-      </div>
+      />
 
       <template v-if="deprecatedChains.length">
         <div
-          class="flex items-center justify-between pt-12 pb-0 cursor-pointer text-content-secondary"
+          class="flex items-center justify-between pt-12 pb-8 cursor-pointer text-content-secondary"
           @click="showDeprecated = !showDeprecated"
         >
           <span class="text-[14px] font-medium">Deprecated chains</span>
@@ -65,19 +59,14 @@ const onClick = (chainId: number) => {
         </div>
 
         <template v-if="showDeprecated">
-          <div
+          <ChainSelectorItem
             v-for="chain in deprecatedChains"
             :key="chain.id"
-            class="flex items-center py-12 font-semibold leading-20 text-[16px] cursor-pointer"
+            :chain-id="chain.id"
+            :name="chain.name"
+            deprecated
             @click="onClick(chain.id)"
-          >
-            <BaseAvatar
-              class="mr-8 w-32 h-32 shadow-[inset_0_0_0_1px_var(--border-subtle)] rounded-full"
-              :src="`/chains/${chain.id}.webp`"
-              :label="chain.name"
-            />
-            {{ chain.name }}
-          </div>
+          />
         </template>
       </template>
     </div>

--- a/components/entities/chains/SelectChainModal.vue
+++ b/components/entities/chains/SelectChainModal.vue
@@ -3,7 +3,21 @@ import { useChains } from '@wagmi/vue'
 
 const emits = defineEmits(['close'])
 const chains = useChains()
-const sortedChains = computed(() => [...chains.value].sort((a, b) => a.id - b.id))
+const { deprecatedChainIds } = useChainConfig()
+const deprecatedSet = new Set(deprecatedChainIds)
+
+const activeChains = computed(() =>
+  [...chains.value]
+    .filter(c => !deprecatedSet.has(c.id))
+    .sort((a, b) => a.id - b.id),
+)
+const deprecatedChains = computed(() =>
+  [...chains.value]
+    .filter(c => deprecatedSet.has(c.id))
+    .sort((a, b) => a.id - b.id),
+)
+
+const showDeprecated = ref(false)
 const { changeChain } = useWagmi()
 
 const handleClose = () => {
@@ -24,7 +38,7 @@ const onClick = (chainId: number) => {
   >
     <div class="mb-24">
       <div
-        v-for="chain in sortedChains"
+        v-for="chain in activeChains"
         :key="chain.id"
         class="flex items-center py-12 font-semibold leading-20 text-[16px] cursor-pointer"
         @click="onClick(chain.id)"
@@ -36,6 +50,36 @@ const onClick = (chainId: number) => {
         />
         {{ chain.name }}
       </div>
+
+      <template v-if="deprecatedChains.length">
+        <div
+          class="flex items-center justify-between pt-12 pb-0 cursor-pointer text-content-secondary"
+          @click="showDeprecated = !showDeprecated"
+        >
+          <span class="text-[14px] font-medium">Deprecated chains</span>
+          <SvgIcon
+            name="arrow-down"
+            class="!w-16 !h-16 transition-transform duration-fast"
+            :class="showDeprecated ? 'rotate-180' : ''"
+          />
+        </div>
+
+        <template v-if="showDeprecated">
+          <div
+            v-for="chain in deprecatedChains"
+            :key="chain.id"
+            class="flex items-center py-12 font-semibold leading-20 text-[16px] cursor-pointer"
+            @click="onClick(chain.id)"
+          >
+            <BaseAvatar
+              class="mr-8 w-32 h-32 shadow-[inset_0_0_0_1px_var(--border-subtle)] rounded-full"
+              :src="`/chains/${chain.id}.webp`"
+              :label="chain.name"
+            />
+            {{ chain.name }}
+          </div>
+        </template>
+      </template>
     </div>
   </BaseModalWrapper>
 </template>

--- a/components/entities/chains/SelectChainModal.vue
+++ b/components/entities/chains/SelectChainModal.vue
@@ -46,8 +46,10 @@ const onClick = (chainId: number) => {
       />
 
       <template v-if="deprecatedChains.length">
-        <div
-          class="flex items-center justify-between pt-12 pb-8 cursor-pointer text-content-secondary"
+        <button
+          type="button"
+          class="flex items-center justify-between w-full pt-12 pb-8 cursor-pointer text-content-secondary"
+          :aria-expanded="showDeprecated"
           @click="showDeprecated = !showDeprecated"
         >
           <span class="text-[14px] font-medium">Deprecated chains</span>
@@ -56,7 +58,7 @@ const onClick = (chainId: number) => {
             class="!w-16 !h-16 transition-transform duration-fast"
             :class="showDeprecated ? 'rotate-180' : ''"
           />
-        </div>
+        </button>
 
         <template v-if="showDeprecated">
           <ChainSelectorItem

--- a/composables/useChainConfig.ts
+++ b/composables/useChainConfig.ts
@@ -11,6 +11,7 @@
 
 interface ChainConfig {
   enabledChainIds: number[]
+  deprecatedChainIds: number[]
   subgraphUris: Record<string, string>
 }
 
@@ -36,7 +37,17 @@ function scanEnv(): ChainConfig {
 
   enabledChainIds.sort((a, b) => a - b)
 
-  return { enabledChainIds, subgraphUris }
+  const enabledSet = new Set(enabledChainIds)
+  const rawDeprecated = process.env.DEPRECATED_CHAINS?.trim()
+  const deprecatedChainIds = rawDeprecated
+    ? rawDeprecated
+        .split(',')
+        .map(s => Number(s.trim()))
+        .filter(id => !Number.isNaN(id) && enabledSet.has(id))
+        .sort((a, b) => a - b)
+    : []
+
+  return { enabledChainIds, deprecatedChainIds, subgraphUris }
 }
 
 export const useChainConfig = (): ChainConfig => {
@@ -51,7 +62,7 @@ export const useChainConfig = (): ChainConfig => {
   /* eslint-enable @typescript-eslint/no-explicit-any */
   }
   else {
-    cached = { enabledChainIds: [], subgraphUris: {} }
+    cached = { enabledChainIds: [], deprecatedChainIds: [], subgraphUris: {} }
   }
 
   return cached!

--- a/composables/useChainConfig.ts
+++ b/composables/useChainConfig.ts
@@ -38,14 +38,7 @@ function scanEnv(): ChainConfig {
   enabledChainIds.sort((a, b) => a - b)
 
   const enabledSet = new Set(enabledChainIds)
-  const rawDeprecated = process.env.DEPRECATED_CHAINS?.trim()
-  const deprecatedChainIds = rawDeprecated
-    ? rawDeprecated
-        .split(',')
-        .map(s => Number(s.trim()))
-        .filter(id => !Number.isNaN(id) && enabledSet.has(id))
-        .sort((a, b) => a - b)
-    : []
+  const deprecatedChainIds = parseDeprecatedChains(process.env.DEPRECATED_CHAINS, enabledSet)
 
   return { enabledChainIds, deprecatedChainIds, subgraphUris }
 }

--- a/server/plugins/chain-config.ts
+++ b/server/plugins/chain-config.ts
@@ -6,6 +6,8 @@
  * The config is embedded as a <script> tag in the HTML head, making it
  * accessible to the client synchronously via window.__CHAIN_CONFIG__.
  */
+import { parseDeprecatedChains } from '../../utils/parseDeprecatedChains'
+
 export default defineNitroPlugin((nitroApp) => {
   const enabledChainIds: number[] = []
 
@@ -27,14 +29,7 @@ export default defineNitroPlugin((nitroApp) => {
   enabledChainIds.sort((a, b) => a - b)
 
   const enabledSet = new Set(enabledChainIds)
-  const rawDeprecated = process.env.DEPRECATED_CHAINS?.trim()
-  const deprecatedChainIds = rawDeprecated
-    ? rawDeprecated
-        .split(',')
-        .map(s => Number(s.trim()))
-        .filter(id => !Number.isNaN(id) && enabledSet.has(id))
-        .sort((a, b) => a - b)
-    : []
+  const deprecatedChainIds = parseDeprecatedChains(process.env.DEPRECATED_CHAINS, enabledSet)
 
   const scriptTag = `<script>window.__CHAIN_CONFIG__=${JSON.stringify({ enabledChainIds, deprecatedChainIds, subgraphUris })}</script>`
 

--- a/server/plugins/chain-config.ts
+++ b/server/plugins/chain-config.ts
@@ -26,7 +26,17 @@ export default defineNitroPlugin((nitroApp) => {
 
   enabledChainIds.sort((a, b) => a - b)
 
-  const scriptTag = `<script>window.__CHAIN_CONFIG__=${JSON.stringify({ enabledChainIds, subgraphUris })}</script>`
+  const enabledSet = new Set(enabledChainIds)
+  const rawDeprecated = process.env.DEPRECATED_CHAINS?.trim()
+  const deprecatedChainIds = rawDeprecated
+    ? rawDeprecated
+        .split(',')
+        .map(s => Number(s.trim()))
+        .filter(id => !Number.isNaN(id) && enabledSet.has(id))
+        .sort((a, b) => a - b)
+    : []
+
+  const scriptTag = `<script>window.__CHAIN_CONFIG__=${JSON.stringify({ enabledChainIds, deprecatedChainIds, subgraphUris })}</script>`
 
   nitroApp.hooks.hook('render:html', (html) => {
     html.head.push(scriptTag)

--- a/utils/parseDeprecatedChains.ts
+++ b/utils/parseDeprecatedChains.ts
@@ -1,0 +1,9 @@
+export function parseDeprecatedChains(rawEnv: string | undefined, enabledSet: Set<number>): number[] {
+  const raw = rawEnv?.trim()
+  if (!raw) return []
+  return raw
+    .split(',')
+    .map(s => Number(s.trim()))
+    .filter(id => !Number.isNaN(id) && enabledSet.has(id))
+    .sort((a, b) => a - b)
+}

--- a/utils/parseDeprecatedChains.ts
+++ b/utils/parseDeprecatedChains.ts
@@ -3,7 +3,9 @@ export function parseDeprecatedChains(rawEnv: string | undefined, enabledSet: Se
   if (!raw) return []
   return raw
     .split(',')
-    .map(s => Number(s.trim()))
-    .filter(id => !Number.isNaN(id) && enabledSet.has(id))
+    .map(s => s.trim())
+    .filter(s => /^\d+$/.test(s))
+    .map(s => parseInt(s, 10))
+    .filter(id => enabledSet.has(id))
     .sort((a, b) => a - b)
 }


### PR DESCRIPTION
## Summary
- Adds `DEPRECATED_CHAINS` env var (comma-separated chain IDs) to mark chains as deprecated
- Deprecated chains (with valid RPC URLs) appear in a collapsible section at the bottom of the chain selector modal, collapsed by default
- Parsing logic added to both `server/plugins/chain-config.ts` and `composables/useChainConfig.ts`

## Test plan
- [ ] Set `DEPRECATED_CHAINS=1,56` with matching `RPC_URL_HTTP_*` — verify chains move to collapsed section
- [ ] Click "Deprecated chains" header — section expands/collapses with chevron animation
- [ ] Click a deprecated chain — switches chain normally
- [ ] Remove RPC URL for a deprecated chain — it disappears from the section
- [ ] Leave `DEPRECATED_CHAINS` empty — no deprecated section shown
- [ ] Set invalid value (e.g. `abc`) — graceful fallback, no section shown

<img width="495" height="908" alt="image" src="https://github.com/user-attachments/assets/016d94c1-4404-406a-aabe-57ffc33a4969" />
