### PR TITLE
docs: fix Node version, missing env vars, and broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ Euler Lite provides all the core functionality of Euler Finance in a customizabl
 
 - **Lending & Borrowing**: Users can deposit assets to earn yield or borrow against collateral
 - **Portfolio Management**: Track positions and performance
-- **Rewards**: Participate in Merkl/Brevis reward programs
+- **Rewards**: Participate in Merkl, Incentra, and Fuul reward programs
 - **Multi-chain Support**: Connect to multiple EVM-compatible networks
 
 ## Prerequisites
 
-- **Node.js** 18+ (recommended: 20.12.2)
+- **Node.js** 24+ (recommended: 24.14.1)
 - **npm** package manager
 - **Git**
 - A **Reown Project ID** (formerly WalletConnect) - get one at [reown.com](https://reown.com/)
@@ -66,19 +66,28 @@ These use Nuxt's `runtimeConfig` and are set via `NUXT_PUBLIC_CONFIG_*` env vars
 | `NUXT_PUBLIC_CONFIG_LABELS_REPO`            | `euler-xyz/euler-labels`                   | GitHub labels repo                                    |
 | `NUXT_PUBLIC_CONFIG_LABELS_REPO_BRANCH`     | `master`                                   | Branch to fetch labels from                           |
 | `NUXT_PUBLIC_CONFIG_LABELS_BASE_URL`        | —                                          | S3/CDN base URL for labels (overrides repo/branch)    |
+| `NUXT_PUBLIC_CONFIG_ORACLE_CHECKS_REPO`     | `euler-xyz/oracle-checks`                  | GitHub repo for oracle check results                  |
 | `NUXT_PUBLIC_CONFIG_ORACLE_CHECKS_BASE_URL` | —                                          | S3/CDN base URL for oracle checks (overrides repo)    |
+| `NUXT_PUBLIC_CONFIG_EULER_CHAINS_URL`       | —                                          | URL for EulerChains.json (overrides default upstream) |
 | `NUXT_PUBLIC_CONFIG_DOCS_URL`               | —                                          | Documentation link                                    |
 | `NUXT_PUBLIC_CONFIG_TOS_URL`                | —                                          | Terms of Service link                                 |
 | `NUXT_PUBLIC_CONFIG_TOS_MD_URL`             | —                                          | TOS markdown URL (enables TOS signing when set)       |
+| `NUXT_PUBLIC_CONFIG_PRIVACY_POLICY_URL`     | `https://www.euler.finance/privacy-policy` | Privacy policy link                                   |
+| `NUXT_PUBLIC_CONFIG_RISK_DISCLOSURES_URL`   | `https://www.euler.finance/risk-disclosures` | Risk disclosures link                               |
+| `NUXT_PUBLIC_CONFIG_MICA_WHITEPAPER_URL`    | `https://www.euler.finance/MICA-Whitepaper.pdf` | MiCA whitepaper link                           |
 | `NUXT_PUBLIC_CONFIG_X_URL`                  | —                                          | X (Twitter) link                                      |
 | `NUXT_PUBLIC_CONFIG_DISCORD_URL`            | —                                          | Discord link                                          |
 | `NUXT_PUBLIC_CONFIG_TELEGRAM_URL`           | —                                          | Telegram link                                         |
 | `NUXT_PUBLIC_CONFIG_GITHUB_URL`             | —                                          | GitHub link                                           |
 | `NUXT_PUBLIC_CONFIG_ENABLE_EARN_PAGE`       | `true`                                     | Show Earn page                                        |
 | `NUXT_PUBLIC_CONFIG_ENABLE_LEND_PAGE`       | `true`                                     | Show Lend page                                        |
+| `NUXT_PUBLIC_CONFIG_ENABLE_EXPLORE_PAGE`    | `true`                                     | Show Explore page                                     |
 | `NUXT_PUBLIC_CONFIG_ENABLE_ENTITY_BRANDING` | `true`                                     | Show entity branding                                  |
 | `NUXT_PUBLIC_CONFIG_ENABLE_VAULT_TYPE`      | `true`                                     | Show vault type labels                                |
 | `NUXT_PUBLIC_CONFIG_ENABLE_APP_TITLE`       | `true`                                     | Show app title in the navbar                          |
+| `NUXT_PUBLIC_CONFIG_ENABLE_MERKL`           | `true`                                     | Enable Merkl rewards integration                      |
+| `NUXT_PUBLIC_CONFIG_ENABLE_INCENTRA`        | `true`                                     | Enable Incentra rewards integration                   |
+| `NUXT_PUBLIC_CONFIG_ENABLE_FUUL`            | `true`                                     | Enable Fuul rewards integration                       |
 | `NUXT_PUBLIC_CONFIG_UNISWAP_TOKEN_LIST_URL` | `https://tokens.uniswap.org`               | Uniswap token list for swap selector                  |
 | `NUXT_PUBLIC_CONFIG_DEFILLAMA_TOKEN_LIST_URL` | `https://d3g10bzo9rdluh.cloudfront.net`  | DefiLlama token list for swap selector                |
 
@@ -287,6 +296,11 @@ server/
 | `npm run build`       | Build for production              |
 | `npm run preview`     | Preview production build locally  |
 | `npm run generate`    | Generate static site              |
+| `npm run lint`        | Run ESLint                        |
+| `npm run lint:fix`    | Run ESLint with auto-fix          |
+| `npm run test`        | Run unit tests (watch mode)       |
+| `npm run test:run`    | Run unit tests (single pass)      |
+| `npm run typecheck`   | Type-check the project            |
 | `npm run postinstall` | Prepare Nuxt (runs automatically) |
 
 ## Configuration Checklist
@@ -311,7 +325,7 @@ Before deploying:
 
 ### Build Errors
 
-- Ensure Node.js version is 18+ (20.12.2 recommended)
+- Ensure Node.js version is 24+ (24.14.1 recommended)
 - Clear and reinstall: `rm -rf node_modules && npm install`
 
 ### Wallet Connection Issues

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,13 +18,6 @@ Welcome to the documentation for the Euler Lite project. This documentation is d
 - Data flow patterns
 - Technology decisions
 
-### 📁 [Project Structure](./project-structure.md)
-
-- Folder organization
-- File naming conventions
-- Key directories explanation
-- Component organization
-
 ### 🚀 [Development Guide](./development-guide.md)
 
 - Development workflow

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -4,7 +4,7 @@ This guide covers the concrete steps and scripts needed to work on this reposito
 
 ## Prerequisites
 
-- Node.js 18+
+- Node.js 24+
 - npm (or yarn/pnpm if you prefer)
 
 ## Install and run
@@ -124,7 +124,7 @@ The `/api/pyth/updates` endpoint proxies Pyth Hermes price update requests throu
 
 ## Troubleshooting
 
-- If the app fails to start, ensure Node 18+ and reinstall deps.
+- If the app fails to start, ensure Node 24+ and reinstall deps.
 - If blockchain calls fail, verify `RPC_URL_HTTP_<chainId>` env vars and check that matching `NUXT_PUBLIC_SUBGRAPH_URI_<chainId>` is set.
 - If token logos don't load, verify `EULER_API_URL` (or `NUXT_PUBLIC_EULER_API_URL`) is set. Token data is fetched server-side via `/api/token-list` which aggregates Euler API, Uniswap, and DefiLlama sources with fallback.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -38,7 +38,7 @@ Welcome to the Euler Lite project! This guide will help you get up and running w
 
 ### Prerequisites
 
-- Node.js 18+
+- Node.js 24+
 - npm or yarn package manager
 - Git
 - Basic knowledge of Vue.js and TypeScript
@@ -143,7 +143,7 @@ NUXT_PUBLIC_SUBGRAPH_URI_1=https://your-subgraph.com
 
 ### Build Errors
 
-- Ensure Node.js version is 18+
+- Ensure Node.js version is 24+
 - Clear `node_modules` and reinstall dependencies
 - Check TypeScript compilation errors
 


### PR DESCRIPTION
- Bump Node requirement from 18+/20.12.2 to 24+/24.14.1 to match Dockerfile
- Add 9 missing NUXT_PUBLIC_CONFIG_* env vars to README table (ORACLE_CHECKS_REPO, EULER_CHAINS_URL, PRIVACY_POLICY_URL, RISK_DISCLOSURES_URL, MICA_WHITEPAPER_URL, ENABLE_EXPLORE_PAGE, ENABLE_MERKL, ENABLE_INCENTRA, ENABLE_FUUL)
- Fix reward providers: "Merkl/Brevis" -> "Merkl, Incentra, and Fuul"
- Add missing scripts to Available Scripts table (lint, lint:fix, test, test:run, typecheck)
- Remove broken link to non-existent project-structure.md in docs/README.md