### PR TITLE
fix: hide IRM chart on vaults with no live borrow exposure

### DIFF
--- a/components/entities/vault/overview/VaultOverviewBlockBorrow.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockBorrow.vue
@@ -3,7 +3,11 @@ import { formatNumber } from '~/utils/string-utils'
 import { nanoToValue } from '~/utils/crypto-utils'
 import type { Vault, SecuritizeVault } from '~/entities/vault'
 import type { LTVRampConfig } from '~/entities/vault/ltv'
-import { getCurrentLiquidationLTV, isLiquidationLTVRamping } from '~/entities/vault'
+import {
+  getCollateralExposurePairs,
+  getCurrentLiquidationLTV,
+  isLiquidationLTVRamping,
+} from '~/entities/vault'
 import { useModal } from '~/components/ui/composables/useModal'
 import { useVaultRegistry } from '~/composables/useVaultRegistry'
 import { VaultRampDownModal } from '#components'
@@ -26,41 +30,12 @@ const onRampDownInfoIconClick = (event: MouseEvent, pair: LTVRampConfig) => {
   })
 }
 
-// Build collateral pairs from collateralLTVs where currentLiquidationLTV > 0
-// Excludes fully ramped-down collaterals (borrowLTV == 0) with no remaining supply
-const allCollateralPairs = computed(() => {
-  const pairs: Array<{
-    collateral: Vault | SecuritizeVault
-    borrowLTV: bigint
-    liquidationLTV: bigint
-    initialLiquidationLTV: bigint
-    targetTimestamp: bigint
-    rampDuration: bigint
-  }> = []
-
-  vault.collateralLTVs.forEach((ltv) => {
-    if (getCurrentLiquidationLTV(ltv) <= 0n) return
-
-    // Try to find the collateral vault from registry
-    const collateralEntry = registryGet(ltv.collateral)
-    if (collateralEntry) {
-      const collateral = collateralEntry.vault as Vault | SecuritizeVault
-      if (ltv.borrowLTV <= 0n && collateral.totalAssets <= 0n) return
-
-      pairs.push({
-        collateral,
-        borrowLTV: ltv.borrowLTV,
-        liquidationLTV: ltv.liquidationLTV,
-        initialLiquidationLTV: ltv.initialLiquidationLTV,
-        targetTimestamp: ltv.targetTimestamp,
-        rampDuration: ltv.rampDuration,
-      })
-    }
-  })
-
-  // Sort by borrow LTV descending (highest first)
-  return pairs.sort((a, b) => (b.borrowLTV > a.borrowLTV ? 1 : b.borrowLTV < a.borrowLTV ? -1 : 0))
-})
+const allCollateralPairs = computed(() =>
+  getCollateralExposurePairs(
+    vault,
+    addr => registryGet(addr)?.vault as Vault | SecuritizeVault | undefined,
+  ),
+)
 </script>
 
 <template>

--- a/components/entities/vault/overview/VaultOverviewBlockIRM.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockIRM.vue
@@ -18,8 +18,9 @@ import { formatUnits, type Address, type Abi } from 'viem'
 import { logWarn } from '~/utils/errorHandling'
 import { INTEREST_RATE_MODEL_TYPE } from '~/entities/constants'
 import { BPS_BASE } from '~/entities/tuning-constants'
-import type { Vault } from '~/entities/vault'
-import { getVaultUtilization } from '~/entities/vault'
+import type { Vault, SecuritizeVault } from '~/entities/vault'
+import { getVaultUtilization, hasCollateralExposure } from '~/entities/vault'
+import { useVaultRegistry } from '~/composables/useVaultRegistry'
 import { eulerVaultLensABI } from '~/entities/euler/abis'
 
 // Register Chart.js components
@@ -47,10 +48,20 @@ const { getChartColors, isDark } = useThemeColors()
 
 const { client: rpcClient } = useRpcClient()
 const { eulerLensAddresses } = useEulerAddresses()
+const { get: registryGet } = useVaultRegistry()
 
-// Check if IRM is valid (not zero address)
+// Only render the IRM chart for vaults that have live borrow-side exposure —
+// either currently borrowable, or still accruing interest on existing debt
+// while the liquidation LTV ramps down. This mirrors the visibility rule of
+// the "Collateral exposure" block and correctly excludes collateral-only
+// vaults that may still carry a non-zero interestRateModelAddress.
 const hasValidIRM = computed(() => {
-  return vault.interestRateModelAddress
+  const hasExposure = hasCollateralExposure(
+    vault,
+    addr => registryGet(addr)?.vault as Vault | SecuritizeVault | undefined,
+  )
+  return hasExposure
+    && vault.interestRateModelAddress
     && vault.interestRateModelAddress !== '0x0000000000000000000000000000000000000000'
 })
 

--- a/components/entities/vault/overview/VaultOverviewBlockIRM.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockIRM.vue
@@ -14,7 +14,7 @@ import {
   type ChartData,
 } from 'chart.js'
 import annotationPlugin from 'chartjs-plugin-annotation'
-import { formatUnits, type Address, type Abi } from 'viem'
+import { formatUnits, zeroAddress, type Address, type Abi } from 'viem'
 import { logWarn } from '~/utils/errorHandling'
 import { INTEREST_RATE_MODEL_TYPE } from '~/entities/constants'
 import { BPS_BASE } from '~/entities/tuning-constants'
@@ -62,7 +62,7 @@ const hasValidIRM = computed(() => {
   )
   return hasExposure
     && vault.interestRateModelAddress
-    && vault.interestRateModelAddress !== '0x0000000000000000000000000000000000000000'
+    && vault.interestRateModelAddress !== zeroAddress
 })
 
 const irmTypeLabel = computed(() => {
@@ -393,6 +393,16 @@ const renderChart = async () => {
 
 onMounted(async () => {
   if (hasValidIRM.value) {
+    await nextTick()
+    await renderChart()
+  }
+})
+
+// Re-render chart when hasValidIRM transitions false → true after mount.
+// This happens when the vault registry loads collateral vaults asynchronously
+// after the component has already mounted with an empty registry.
+watch(hasValidIRM, async (newVal) => {
+  if (newVal && !chartData.value) {
     await nextTick()
     await renderChart()
   }

--- a/entities/vault/collateral-exposure.ts
+++ b/entities/vault/collateral-exposure.ts
@@ -32,6 +32,12 @@ export type CollateralVaultResolver =
  *    collateral vault has outstanding supply — meaning existing borrows can
  *    still accrue interest even after `borrowLTV` has been set to zero mid
  *    ramp-down.
+ *
+ * Note: `collateral.totalAssets > 0n` is an intentional over-approximation.
+ * It checks whether the collateral vault has *any* deposits, not whether those
+ * deposits are actively backing borrows on *this* vault. This errs on the side
+ * of showing the IRM chart (false positive) rather than hiding it (false
+ * negative), and matches the heuristic used by the original inline code.
  */
 const isLiveExposure = (
   ltv: VaultCollateralLTV,

--- a/entities/vault/collateral-exposure.ts
+++ b/entities/vault/collateral-exposure.ts
@@ -1,0 +1,98 @@
+import type { Vault, SecuritizeVault, VaultCollateralLTV } from './types'
+import { getCurrentLiquidationLTV } from './ltv'
+
+/**
+ * A collateral pair with live borrow-side exposure to a vault. Matches the
+ * fields rendered by the "Collateral exposure" overview block.
+ */
+export interface CollateralExposurePair {
+  collateral: Vault | SecuritizeVault
+  borrowLTV: bigint
+  liquidationLTV: bigint
+  initialLiquidationLTV: bigint
+  targetTimestamp: bigint
+  rampDuration: bigint
+}
+
+/**
+ * Resolves a collateral vault by address. Returns `undefined` when the
+ * collateral is unknown (not yet loaded in the vault registry).
+ */
+export type CollateralVaultResolver =
+  (address: string) => Vault | SecuritizeVault | undefined
+
+/**
+ * Internal predicate: is this collateral/LTV combination "live" — i.e. does it
+ * represent active or residual borrow-side exposure against the vault?
+ *
+ * A pair is live when:
+ *  - the current liquidation LTV is still non-zero (i.e. not fully ramped
+ *    down), AND
+ *  - either the pair is currently borrowable (`borrowLTV > 0`) or the
+ *    collateral vault has outstanding supply — meaning existing borrows can
+ *    still accrue interest even after `borrowLTV` has been set to zero mid
+ *    ramp-down.
+ */
+const isLiveExposure = (
+  ltv: VaultCollateralLTV,
+  collateral: Vault | SecuritizeVault,
+  nowSeconds?: bigint,
+): boolean => {
+  if (getCurrentLiquidationLTV(ltv, nowSeconds) <= 0n) return false
+  return ltv.borrowLTV > 0n || collateral.totalAssets > 0n
+}
+
+/**
+ * Build the list of collateral pairs with live borrow-side exposure to a vault.
+ * Returns them sorted by `borrowLTV` descending (currently borrowable first).
+ *
+ * See {@link isLiveExposure} for the liveness definition. Pairs whose
+ * collateral is missing from the registry (resolver returns `undefined`) are
+ * skipped.
+ */
+export const getCollateralExposurePairs = (
+  vault: Pick<Vault, 'collateralLTVs'>,
+  resolveCollateralVault: CollateralVaultResolver,
+  nowSeconds?: bigint,
+): CollateralExposurePair[] => {
+  const pairs: CollateralExposurePair[] = []
+
+  vault.collateralLTVs.forEach((ltv) => {
+    const collateral = resolveCollateralVault(ltv.collateral)
+    if (!collateral) return
+    if (!isLiveExposure(ltv, collateral, nowSeconds)) return
+
+    pairs.push({
+      collateral,
+      borrowLTV: ltv.borrowLTV,
+      liquidationLTV: ltv.liquidationLTV,
+      initialLiquidationLTV: ltv.initialLiquidationLTV,
+      targetTimestamp: ltv.targetTimestamp,
+      rampDuration: ltv.rampDuration,
+    })
+  })
+
+  return pairs.sort((a, b) =>
+    b.borrowLTV > a.borrowLTV ? 1 : b.borrowLTV < a.borrowLTV ? -1 : 0,
+  )
+}
+
+/**
+ * Predicate: does the vault have any live borrow-side collateral exposure?
+ * Mirrors the filter used by {@link getCollateralExposurePairs} but
+ * short-circuits on the first match.
+ *
+ * Use this to gate borrow-side UI (IRM chart, collateral-exposure block, etc.)
+ * on vaults that either are currently borrowable or still carry outstanding
+ * debt being wound down via a liquidation-LTV ramp.
+ */
+export const hasCollateralExposure = (
+  vault: Pick<Vault, 'collateralLTVs'>,
+  resolveCollateralVault: CollateralVaultResolver,
+  nowSeconds?: bigint,
+): boolean =>
+  vault.collateralLTVs.some((ltv) => {
+    const collateral = resolveCollateralVault(ltv.collateral)
+    if (!collateral) return false
+    return isLiveExposure(ltv, collateral, nowSeconds)
+  })

--- a/entities/vault/index.ts
+++ b/entities/vault/index.ts
@@ -48,6 +48,16 @@ export {
   getRampTimeRemaining,
 } from './ltv'
 
+// Collateral exposure (borrow-side pair derivation)
+export {
+  getCollateralExposurePairs,
+  hasCollateralExposure,
+} from './collateral-exposure'
+export type {
+  CollateralExposurePair,
+  CollateralVaultResolver,
+} from './collateral-exposure'
+
 // APY computations
 export {
   computeAPYs,

--- a/tests/entities/vault/collateral-exposure.test.ts
+++ b/tests/entities/vault/collateral-exposure.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect } from 'vitest'
+import {
+  getCollateralExposurePairs,
+  hasCollateralExposure,
+  type CollateralVaultResolver,
+} from '~/entities/vault/collateral-exposure'
+import type { Vault, SecuritizeVault, VaultCollateralLTV } from '~/entities/vault/types'
+
+// Time anchors used across tests. All ramp configs below are expressed relative
+// to these so the ramp maths are easy to reason about.
+const NOW = 1500n
+const BEFORE_RAMP = 500n
+const RAMP_COMPLETE = 3000n
+
+/**
+ * Build a VaultCollateralLTV with reasonable defaults. By default the
+ * liquidation LTV has fully ramped down to 0 — tests opt in to live config by
+ * overriding the fields they care about.
+ */
+const makeLtv = (overrides: Partial<VaultCollateralLTV> = {}): VaultCollateralLTV => ({
+  collateral: '0xcoll0000000000000000000000000000000000000',
+  borrowLTV: 0n,
+  liquidationLTV: 0n,
+  initialLiquidationLTV: 0n,
+  rampDuration: 1000n,
+  targetTimestamp: 2000n,
+  ...overrides,
+})
+
+/**
+ * Minimal collateral vault for assertion; the predicate only reads
+ * `totalAssets`, but we stamp an address so callers can distinguish pairs in
+ * the returned array.
+ */
+const makeCollateral = (
+  address: string,
+  totalAssets: bigint,
+): Vault | SecuritizeVault =>
+  ({ address, totalAssets } as unknown as Vault)
+
+/**
+ * Build a resolver that returns the collateral at a given address, or
+ * undefined if it wasn't registered. This matches the contract of the real
+ * `useVaultRegistry().get(addr)?.vault` lookup.
+ */
+const makeResolver = (
+  entries: Record<string, Vault | SecuritizeVault>,
+): CollateralVaultResolver => addr => entries[addr]
+
+const borrowableLtv = (collateralAddress: string): VaultCollateralLTV =>
+  makeLtv({
+    collateral: collateralAddress,
+    borrowLTV: 7500n,
+    liquidationLTV: 8000n,
+    initialLiquidationLTV: 8000n,
+    targetTimestamp: 2000n, // already at target → not ramping, current = 8000n
+  })
+
+const rampingDownLtv = (collateralAddress: string): VaultCollateralLTV =>
+  makeLtv({
+    collateral: collateralAddress,
+    borrowLTV: 0n, // no new borrows allowed
+    liquidationLTV: 7000n, // target
+    initialLiquidationLTV: 9000n, // started higher → ramping DOWN
+    targetTimestamp: 2000n,
+    rampDuration: 1000n,
+  })
+
+const fullyRampedDownLtv = (collateralAddress: string): VaultCollateralLTV =>
+  makeLtv({
+    collateral: collateralAddress,
+    borrowLTV: 0n,
+    liquidationLTV: 0n,
+    initialLiquidationLTV: 9000n,
+    targetTimestamp: 2000n, // now >= target → current = liquidationLTV = 0n
+  })
+
+describe('getCollateralExposurePairs', () => {
+  it('returns pairs that are currently borrowable', () => {
+    const vault = { collateralLTVs: [borrowableLtv('0xaaa')] }
+    const resolver = makeResolver({ '0xaaa': makeCollateral('0xaaa', 1_000n) })
+    const pairs = getCollateralExposurePairs(vault, resolver, NOW)
+
+    expect(pairs).toHaveLength(1)
+    expect(pairs[0].collateral.address).toBe('0xaaa')
+    expect(pairs[0].borrowLTV).toBe(7500n)
+  })
+
+  it('includes pairs where borrowLTV is 0 but the collateral has outstanding supply during ramp-down', () => {
+    const vault = { collateralLTVs: [rampingDownLtv('0xaaa')] }
+    const resolver = makeResolver({ '0xaaa': makeCollateral('0xaaa', 1_000n) })
+    const pairs = getCollateralExposurePairs(vault, resolver, NOW)
+
+    // borrowLTV == 0 but collateral has supply → open interest can still
+    // accrue while liquidation LTV ramps down, so the pair must be kept.
+    expect(pairs).toHaveLength(1)
+    expect(pairs[0].borrowLTV).toBe(0n)
+  })
+
+  it('excludes pairs that have fully ramped down', () => {
+    const vault = { collateralLTVs: [fullyRampedDownLtv('0xaaa')] }
+    const resolver = makeResolver({ '0xaaa': makeCollateral('0xaaa', 1_000n) })
+    // After targetTimestamp, liquidationLTV settles at the target value (0 here).
+    const pairs = getCollateralExposurePairs(vault, resolver, RAMP_COMPLETE)
+
+    // currentLiquidationLTV == 0 → no exposure regardless of supply.
+    expect(pairs).toHaveLength(0)
+  })
+
+  it('keeps a pair mid ramp-down with outstanding supply even when the target LTV is 0', () => {
+    const vault = { collateralLTVs: [fullyRampedDownLtv('0xaaa')] }
+    const resolver = makeResolver({ '0xaaa': makeCollateral('0xaaa', 1_000n) })
+    // At NOW=1500 the ramp is only half-done: current LTV ≈ 4500, so the
+    // pair is still live and existing borrows can still accrue interest.
+    const pairs = getCollateralExposurePairs(vault, resolver, NOW)
+
+    expect(pairs).toHaveLength(1)
+  })
+
+  it('excludes pairs with borrowLTV 0 and no collateral supply', () => {
+    const vault = { collateralLTVs: [rampingDownLtv('0xaaa')] }
+    const resolver = makeResolver({ '0xaaa': makeCollateral('0xaaa', 0n) })
+    const pairs = getCollateralExposurePairs(vault, resolver, NOW)
+
+    // Not borrowable now, and no open interest possible without supply.
+    expect(pairs).toHaveLength(0)
+  })
+
+  it('skips pairs whose collateral is not in the registry', () => {
+    const vault = {
+      collateralLTVs: [borrowableLtv('0xaaa'), borrowableLtv('0xbbb')],
+    }
+    const resolver = makeResolver({ '0xaaa': makeCollateral('0xaaa', 1_000n) })
+    const pairs = getCollateralExposurePairs(vault, resolver, NOW)
+
+    expect(pairs).toHaveLength(1)
+    expect(pairs[0].collateral.address).toBe('0xaaa')
+  })
+
+  it('sorts pairs by borrowLTV descending', () => {
+    const vault = {
+      collateralLTVs: [
+        makeLtv({ collateral: '0xlow', borrowLTV: 5000n, liquidationLTV: 6000n, initialLiquidationLTV: 6000n }),
+        makeLtv({ collateral: '0xhigh', borrowLTV: 8500n, liquidationLTV: 9000n, initialLiquidationLTV: 9000n }),
+        makeLtv({ collateral: '0xmid', borrowLTV: 7000n, liquidationLTV: 7500n, initialLiquidationLTV: 7500n }),
+      ],
+    }
+    const resolver = makeResolver({
+      '0xlow': makeCollateral('0xlow', 1n),
+      '0xhigh': makeCollateral('0xhigh', 1n),
+      '0xmid': makeCollateral('0xmid', 1n),
+    })
+
+    const pairs = getCollateralExposurePairs(vault, resolver, RAMP_COMPLETE)
+
+    expect(pairs.map(p => p.collateral.address)).toEqual(['0xhigh', '0xmid', '0xlow'])
+  })
+
+  it('returns an empty array when vault has no collateral LTVs', () => {
+    const vault = { collateralLTVs: [] }
+    const resolver = makeResolver({})
+    expect(getCollateralExposurePairs(vault, resolver, NOW)).toEqual([])
+  })
+
+  it('honours the nowSeconds override for ramp-down math', () => {
+    // Before the ramp starts, initial LTV caps liquidation at 9000 → live.
+    const vault = { collateralLTVs: [rampingDownLtv('0xaaa')] }
+    const resolver = makeResolver({ '0xaaa': makeCollateral('0xaaa', 1_000n) })
+
+    expect(getCollateralExposurePairs(vault, resolver, BEFORE_RAMP)).toHaveLength(1)
+    // After the ramp completes, current LTV drops to target=7000 → still live.
+    expect(getCollateralExposurePairs(vault, resolver, RAMP_COMPLETE)).toHaveLength(1)
+  })
+})
+
+describe('hasCollateralExposure', () => {
+  it('returns true when any collateral pair is live (borrowable)', () => {
+    const vault = { collateralLTVs: [borrowableLtv('0xaaa')] }
+    const resolver = makeResolver({ '0xaaa': makeCollateral('0xaaa', 0n) })
+    expect(hasCollateralExposure(vault, resolver, NOW)).toBe(true)
+  })
+
+  it('returns true when any collateral pair is mid ramp-down with outstanding supply', () => {
+    const vault = { collateralLTVs: [rampingDownLtv('0xaaa')] }
+    const resolver = makeResolver({ '0xaaa': makeCollateral('0xaaa', 1_000n) })
+    expect(hasCollateralExposure(vault, resolver, NOW)).toBe(true)
+  })
+
+  it('returns false when all pairs are fully ramped down', () => {
+    const vault = {
+      collateralLTVs: [fullyRampedDownLtv('0xaaa'), fullyRampedDownLtv('0xbbb')],
+    }
+    const resolver = makeResolver({
+      '0xaaa': makeCollateral('0xaaa', 1_000n),
+      '0xbbb': makeCollateral('0xbbb', 1_000n),
+    })
+    // RAMP_COMPLETE > targetTimestamp so current LTV settles at 0 for both.
+    expect(hasCollateralExposure(vault, resolver, RAMP_COMPLETE)).toBe(false)
+  })
+
+  it('returns false when ramping pairs have no remaining supply', () => {
+    const vault = { collateralLTVs: [rampingDownLtv('0xaaa')] }
+    const resolver = makeResolver({ '0xaaa': makeCollateral('0xaaa', 0n) })
+    expect(hasCollateralExposure(vault, resolver, NOW)).toBe(false)
+  })
+
+  it('returns false when collateral is unresolved', () => {
+    const vault = { collateralLTVs: [borrowableLtv('0xaaa')] }
+    const resolver = makeResolver({})
+    expect(hasCollateralExposure(vault, resolver, NOW)).toBe(false)
+  })
+
+  it('returns false for a vault with no collateral LTVs (collateral-only / escrow)', () => {
+    const vault = { collateralLTVs: [] }
+    const resolver = makeResolver({})
+    expect(hasCollateralExposure(vault, resolver, NOW)).toBe(false)
+  })
+
+  it('short-circuits: at least one live pair makes the whole vault "exposed"', () => {
+    const vault = {
+      collateralLTVs: [
+        fullyRampedDownLtv('0xdead'),
+        borrowableLtv('0xlive'),
+        fullyRampedDownLtv('0xalsodead'),
+      ],
+    }
+    const resolver = makeResolver({
+      '0xdead': makeCollateral('0xdead', 0n),
+      '0xlive': makeCollateral('0xlive', 0n),
+      '0xalsodead': makeCollateral('0xalsodead', 0n),
+    })
+    expect(hasCollateralExposure(vault, resolver, NOW)).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- Hide the IRM chart on vaults with no live borrow-side exposure. Previously it was shown whenever `interestRateModelAddress` was non-zero, so collateral-only / escrow vaults could display it.
- Extract the collateral-exposure predicate used by the "Collateral exposure" block into a shared helper in `entities/vault/collateral-exposure.ts` and reuse it to gate the IRM chart, so both stay in sync.
- A pair is considered live when its current liquidation LTV is non-zero **and** either `borrowLTV > 0` or the collateral vault still has outstanding supply — i.e. open interest can still accrue while the LTV ramps down.

## Test plan
- [x] `npx vitest run tests/entities/vault/collateral-exposure.test.ts` — 16 new cases
- [x] `npx vitest run` — full suite (342/342)
- [x] `npm run typecheck` — exit 0
- [x] Borrowable vault detail page — IRM chart still renders.
- [x] Collateral-only / escrow vault detail page — IRM chart is hidden.
- [x] Vault mid ramp-down with outstanding debt (`borrowLTV = 0` but open positions) — IRM chart still renders.
- [x] "Collateral exposure" block lists the same pairs as before (refactor has no behavioural change on the borrow block).