### PR TITLE
feat: link to previous app from header dropdown and migration modal

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -5,7 +5,7 @@ import { MigrationAnnouncementModal } from '#components'
 
 const route = useRoute()
 const router = useRouter()
-const { migrationAnnouncementUrl } = useDeployConfig()
+const { migrationAnnouncementUrl, migrationLegacyAppUrl } = useDeployConfig()
 const migrationAnnouncementSeen = useLocalStorage('migration-announcement-seen', false)
 const modal = useModal()
 
@@ -91,6 +91,7 @@ const checkMigrationAnnouncement = () => {
     onClose: () => { migrationAnnouncementSeen.value = true },
     props: {
       announcementUrl: migrationAnnouncementUrl,
+      legacyAppUrl: migrationLegacyAppUrl,
     },
   })
 }

--- a/components/entities/announcement/MigrationAnnouncementModal.vue
+++ b/components/entities/announcement/MigrationAnnouncementModal.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 const props = defineProps<{
   announcementUrl: string
+  legacyAppUrl?: string
 }>()
 const emits = defineEmits(['close'])
 </script>
@@ -31,7 +32,10 @@ const emits = defineEmits(['close'])
         </li>
       </ul>
 
-      <p class="text-secondary text-p3">
+      <p
+        v-if="props.legacyAppUrl"
+        class="text-secondary text-p3"
+      >
         The legacy app is accessible via the link in the top-left corner but is no longer maintained.
       </p>
 

--- a/components/entities/announcement/MigrationAnnouncementModal.vue
+++ b/components/entities/announcement/MigrationAnnouncementModal.vue
@@ -7,34 +7,32 @@ const emits = defineEmits(['close'])
 
 <template>
   <BaseModalWrapper
-    title="We've upgraded the Euler app"
+    title="The Euler app has a new interface"
     :close="false"
   >
     <div class="flex flex-col gap-16">
       <p class="text-secondary text-p3">
-        We've replaced the previous interface with a lighter version while we build the
-        next-generation Euler app. Everything works the same — lending, borrowing, and
-        earn are all fully supported.
+        We've streamlined the app for speed and reliability. All core functionality —
+        lending, borrowing, and earn — is fully supported.
       </p>
 
       <ul class="flex flex-col gap-8 text-p3 text-secondary">
         <li class="flex items-start gap-8">
           <span class="text-accent shrink-0">&#10003;</span>
-          <span>All features you rely on are fully supported</span>
+          <span>More reliable with fewer dependencies</span>
         </li>
         <li class="flex items-start gap-8">
           <span class="text-accent shrink-0">&#10003;</span>
-          <span>More reliable with fewer backend dependencies</span>
+          <span>Access to all your existing positions</span>
         </li>
         <li class="flex items-start gap-8">
           <span class="text-accent shrink-0">&#10003;</span>
-          <span>A completely new app is in development</span>
+          <span>A next-generation app is in development</span>
         </li>
       </ul>
 
       <p class="text-secondary text-p3">
-        You can still access the legacy app by clicking the link in the top-left corner,
-        but please note that it will no longer be maintained.
+        The legacy app is accessible via the link in the top-left corner but is no longer maintained.
       </p>
 
       <a

--- a/components/entities/announcement/MigrationAnnouncementModal.vue
+++ b/components/entities/announcement/MigrationAnnouncementModal.vue
@@ -32,6 +32,11 @@ const emits = defineEmits(['close'])
         </li>
       </ul>
 
+      <p class="text-secondary text-p3">
+        You can still access the previous app by clicking the link in the top-left corner,
+        but please note that it will no longer be maintained.
+      </p>
+
       <a
         v-if="props.announcementUrl"
         :href="props.announcementUrl"

--- a/components/entities/announcement/MigrationAnnouncementModal.vue
+++ b/components/entities/announcement/MigrationAnnouncementModal.vue
@@ -33,7 +33,7 @@ const emits = defineEmits(['close'])
       </ul>
 
       <p class="text-secondary text-p3">
-        You can still access the previous app by clicking the link in the top-left corner,
+        You can still access the legacy app by clicking the link in the top-left corner,
         but please note that it will no longer be maintained.
       </p>
 

--- a/components/layout/TheHeader.vue
+++ b/components/layout/TheHeader.vue
@@ -65,6 +65,7 @@ const socials = computed(
     ].filter(Boolean) as Array<{ name: string, url: string }>,
 )
 
+const wrapperRef = ref(null)
 const reference = ref(null)
 const floating = ref(null)
 const isSocialsTooltipVisible = ref(false)
@@ -95,7 +96,7 @@ const getIsMenuItemActive = (link: MenuItem) => {
   return route.name?.toString().startsWith(link.name)
 }
 
-onClickOutside(reference, () => {
+onClickOutside(wrapperRef, () => {
   isSocialsTooltipVisible.value = false
 })
 </script>
@@ -105,30 +106,35 @@ onClickOutside(reference, () => {
     class="sticky top-0 right-0 left-0 z-[101] min-h-[72px] border-b border-line-default py-16 px-24 mobile:min-h-[56px] mobile:border-b-0 mobile:p-16 flex items-center justify-between bg-header backdrop-blur-[20px]"
   >
     <!-- Left: Logo -->
-    <button
-      ref="reference"
-      class="flex items-center gap-8 relative cursor-pointer outline-none flex-shrink-0"
-      @click="onLogoClick"
+    <div
+      ref="wrapperRef"
+      class="relative flex-shrink-0"
     >
-      <LogoBrand class="text-accent-600" />
-      <div
-        v-if="enableAppTitle || enablePoweredByEuler"
-        class="flex flex-col items-start mr-4 mobile:hidden"
+      <button
+        ref="reference"
+        class="flex items-center gap-8 cursor-pointer outline-none"
+        @click="onLogoClick"
       >
-        <span
-          v-if="enableAppTitle"
-          class="text-[14px] font-semibold text-content-primary leading-tight"
-        >{{ appTitle }}</span>
-        <span
-          v-if="enablePoweredByEuler"
-          class="text-[10px] text-content-tertiary leading-tight"
-        >Powered by Euler</span>
-      </div>
-      <SvgIcon
-        class="!w-18 !h-18 transition-transform duration-fast text-content-tertiary"
-        :class="[isSocialsTooltipVisible ? 'rotate-180' : '']"
-        name="arrow-down"
-      />
+        <LogoBrand class="text-accent-600" />
+        <div
+          v-if="enableAppTitle || enablePoweredByEuler"
+          class="flex flex-col items-start mr-4 mobile:hidden"
+        >
+          <span
+            v-if="enableAppTitle"
+            class="text-[14px] font-semibold text-content-primary leading-tight"
+          >{{ appTitle }}</span>
+          <span
+            v-if="enablePoweredByEuler"
+            class="text-[10px] text-content-tertiary leading-tight"
+          >Powered by Euler</span>
+        </div>
+        <SvgIcon
+          class="!w-18 !h-18 transition-transform duration-fast text-content-tertiary"
+          :class="[isSocialsTooltipVisible ? 'rotate-180' : '']"
+          name="arrow-down"
+        />
+      </button>
       <Transition
         name="tooltip"
         @enter="update"
@@ -189,7 +195,7 @@ onClickOutside(reference, () => {
           </div>
         </div>
       </Transition>
-    </button>
+    </div>
 
     <!-- Center: Navigation -->
     <div class="flex flex-1 justify-center mobile:!hidden">

--- a/components/layout/TheHeader.vue
+++ b/components/layout/TheHeader.vue
@@ -151,7 +151,7 @@ onClickOutside(wrapperRef, () => {
             <a
               v-if="migrationLegacyAppUrl"
               :href="migrationLegacyAppUrl"
-              class="block mb-12 pb-12 border-b border-line-default text-content-primary hover:text-accent-600 transition-colors"
+              class="block pb-12 border-b border-line-default text-content-primary hover:text-accent-600 transition-colors"
               target="_blank"
               rel="noopener noreferrer"
             >
@@ -159,7 +159,7 @@ onClickOutside(wrapperRef, () => {
             </a>
             <div
               v-if="links.length"
-              class="mb-12"
+              class="mb-12 pt-5"
             >
               <p class="mb-8 text-content-tertiary text-h6 text-left">
                 Resources

--- a/components/layout/TheHeader.vue
+++ b/components/layout/TheHeader.vue
@@ -36,6 +36,7 @@ const {
   enableExplorePage,
   enablePoweredByEuler,
   enableAppTitle,
+  migrationOldAppUrl,
 } = useDeployConfig()
 const menuItems = getMenuItems(
   enableEarnPage,
@@ -141,6 +142,15 @@ onClickOutside(reference, () => {
           @click.stop
         >
           <div class="flex flex-col gap-4 w-full">
+            <a
+              v-if="migrationOldAppUrl"
+              :href="migrationOldAppUrl"
+              class="block mb-12 pb-12 border-b border-line-default text-content-primary hover:text-accent-600 transition-colors"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <span class="text-h6">Go to the previous app</span>
+            </a>
             <div
               v-if="links.length"
               class="mb-12"

--- a/components/layout/TheHeader.vue
+++ b/components/layout/TheHeader.vue
@@ -36,7 +36,7 @@ const {
   enableExplorePage,
   enablePoweredByEuler,
   enableAppTitle,
-  migrationOldAppUrl,
+  migrationLegacyAppUrl,
 } = useDeployConfig()
 const menuItems = getMenuItems(
   enableEarnPage,
@@ -143,13 +143,13 @@ onClickOutside(reference, () => {
         >
           <div class="flex flex-col gap-4 w-full">
             <a
-              v-if="migrationOldAppUrl"
-              :href="migrationOldAppUrl"
+              v-if="migrationLegacyAppUrl"
+              :href="migrationLegacyAppUrl"
               class="block mb-12 pb-12 border-b border-line-default text-content-primary hover:text-accent-600 transition-colors"
               target="_blank"
               rel="noopener noreferrer"
             >
-              <span class="text-h6">Go to the previous app</span>
+              <span class="text-h6">Go to the legacy app</span>
             </a>
             <div
               v-if="links.length"

--- a/composables/useDeployConfig.ts
+++ b/composables/useDeployConfig.ts
@@ -54,6 +54,8 @@ export const useDeployConfig = () => {
 
     // Migration announcement (opt-in: non-empty URL enables the modal)
     migrationAnnouncementUrl: rc.configMigrationAnnouncementUrl || '',
+    // Migration: link to previous app shown in the header dropdown
+    migrationOldAppUrl: rc.configMigrationOldAppUrl || '',
 
     // External token lists (defaults in server/api/token-list.get.ts)
     uniswapTokenListUrl: rc.configUniswapTokenListUrl || '',

--- a/composables/useDeployConfig.ts
+++ b/composables/useDeployConfig.ts
@@ -54,8 +54,8 @@ export const useDeployConfig = () => {
 
     // Migration announcement (opt-in: non-empty URL enables the modal)
     migrationAnnouncementUrl: rc.configMigrationAnnouncementUrl || '',
-    // Migration: link to previous app shown in the header dropdown
-    migrationOldAppUrl: rc.configMigrationOldAppUrl || '',
+    // Migration: link to legacy app shown in the header dropdown
+    migrationLegacyAppUrl: rc.configMigrationLegacyAppUrl || '',
 
     // External token lists (defaults in server/api/token-list.get.ts)
     uniswapTokenListUrl: rc.configUniswapTokenListUrl || '',

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -126,6 +126,9 @@ export default defineNuxtConfig({
       // Migration announcement: set to a tweet/announcement URL to show a
       // one-time modal explaining the app upgrade. Empty = disabled (default).
       configMigrationAnnouncementUrl: '',
+      // Migration: link to the previous app shown in the header dropdown.
+      // Empty = no link rendered (default).
+      configMigrationOldAppUrl: '',
       // External token list URLs for swap token selector
       configUniswapTokenListUrl: '',
       configDefillamaTokenListUrl: '',

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -126,9 +126,9 @@ export default defineNuxtConfig({
       // Migration announcement: set to a tweet/announcement URL to show a
       // one-time modal explaining the app upgrade. Empty = disabled (default).
       configMigrationAnnouncementUrl: '',
-      // Migration: link to the previous app shown in the header dropdown.
+      // Migration: link to the legacy app shown in the header dropdown.
       // Empty = no link rendered (default).
-      configMigrationOldAppUrl: '',
+      configMigrationLegacyAppUrl: '',
       // External token list URLs for swap token selector
       configUniswapTokenListUrl: '',
       configDefillamaTokenListUrl: '',


### PR DESCRIPTION
## Summary
- Adds opt-in `NUXT_PUBLIC_CONFIG_MIGRATION_OLD_APP_URL` (wired in `nuxt.config.ts` + `useDeployConfig.ts`). When set, a "Go to the previous app" link is rendered as the first item in the logo dropdown in `TheHeader.vue`. When unset, the dropdown is unchanged.
- Updates `MigrationAnnouncementModal.vue` to tell users they can still reach the previous app via that top-left link, and that it will no longer be maintained.

This is intentionally a temporary, transitional flag, so it is not added to `.env.example` — only consumers who need it (production deploys) configure it via Doppler.

## Test plan
- [x] With `NUXT_PUBLIC_CONFIG_MIGRATION_OLD_APP_URL` unset: header dropdown shows only Resources + socials (no migration row, no extra divider).
- [x] With the var set to a URL: dropdown shows "Go to the previous app" at the top, separated by a bottom border, opens in a new tab with `rel="noopener noreferrer"`.
- [x] With `NUXT_PUBLIC_CONFIG_MIGRATION_ANNOUNCEMENT_URL` set (modal trigger): the modal includes the new paragraph about the previous app.
- [x] Modal still dismisses correctly and persists `migration-announcement-seen` in localStorage.