### PR TITLE
chore: add defense-in-depth iframe/clickjacking protections

### DIFF
--- a/components/entities/vault/overview/SecuritizeVaultOverview.vue
+++ b/components/entities/vault/overview/SecuritizeVaultOverview.vue
@@ -245,6 +245,7 @@ const supplyCapPercentageDisplay = computed(() => {
               <a
                 :href="entity.url"
                 target="_blank"
+                rel="noopener noreferrer"
                 class="text-p2 text-content-primary underline"
               >{{ entity.name }}</a>
             </div>

--- a/components/layout/TheHeader.vue
+++ b/components/layout/TheHeader.vue
@@ -155,6 +155,7 @@ onClickOutside(reference, () => {
                 :href="link.url"
                 class="flex gap-4 mb-4 text-content-primary hover:text-accent-600 transition-colors"
                 target="_blank"
+                rel="noopener noreferrer"
               >
                 <span class="text-h6">{{ link.title }}</span>
               </a>
@@ -169,6 +170,7 @@ onClickOutside(reference, () => {
                 :href="item.url"
                 class="flex justify-center items-center p-8 text-content-secondary bg-surface-secondary w-36 h-36 rounded-[32px] border border-line-default hover:bg-card-hover transition-colors"
                 target="_blank"
+                rel="noopener noreferrer"
               >
                 <SvgIcon
                   class="!w-20 !h-20"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -315,6 +315,32 @@ Bypass behaviour per environment:
 | `stg` | CF required; fail-closed (HTTP 451) if absent. `DEV_GEO_COUNTRY` bypasses fail-closed if set. | CF **not** required; falls back to `X-Forwarded-For`. |
 | `dev` | CF not required; falls back to `DEV_GEO_COUNTRY`, then allows through if unset. | CF not required; falls back to `X-Forwarded-For`. |
 
+### Clickjacking & Framing Defenses
+
+The app is a wallet-bearing DeFi interface. Loading it inside an attacker-controlled `<iframe>` could let the attacker overlay invisible elements on top of transaction approval buttons (UI-redressing / clickjacking). Four independent layers prevent this, following a defense-in-depth model:
+
+| Layer | Mechanism | Implementation |
+|---|---|---|
+| **HTTP header — legacy** | `X-Frame-Options: DENY` | `server/middleware/security-headers.ts` |
+| **HTTP header — modern** | `Content-Security-Policy: frame-ancestors 'none'` | `server/plugins/csp.ts` |
+| **HTTP header — opener isolation** | `Cross-Origin-Opener-Policy: same-origin-allow-popups` | `server/middleware/security-headers.ts` |
+| **Inline script — last resort** | JS frame-busting: hides the page and navigates `window.top` | `server/plugins/00-anti-clickjack.ts` |
+
+**Why all four?**
+
+- `X-Frame-Options` is the universally-supported legacy header; some older user agents or edge workers only check this one.
+- `frame-ancestors 'none'` is the modern CSP equivalent and takes precedence in browsers that support CSP Level 2+. It is set alongside `X-Frame-Options` for belt-and-suspenders coverage.
+- `Cross-Origin-Opener-Policy: same-origin-allow-popups` prevents a cross-origin page from retaining a `window.opener` reference to ours after the user navigates away. `same-origin-allow-popups` (rather than `same-origin`) is the strictest value that still allows Reown AppKit and Coinbase Wallet SDK to open wallet connection popups.
+- The inline script is the last line of defense in case a CDN, edge worker, or proxy strips the headers. It detects `window.self !== window.top`, hides the document root immediately, and attempts `window.top.location` navigation. Because `csp.ts` runs after `00-anti-clickjack.ts` in alphabetical Nitro plugin order, every `<script>` in `html.head` (including this one) already has a per-request CSP nonce injected before the response is sent.
+
+**Wallet popup compatibility**
+
+`COOP: same-origin` would fully isolate the browsing context but breaks popup-based wallet connection flows (Reown AppKit, Coinbase Wallet SDK). `same-origin-allow-popups` is the correct trade-off: it isolates the opener reference from cross-origin navigations while preserving same-origin popup handles.
+
+**Regression coverage**
+
+`tests/server/security.test.ts` locks in all four layers with pure-function unit tests (no Nitro boot required). The tests assert that `frame-ancestors 'none'`, `X-Frame-Options: DENY`, `Cross-Origin-Opener-Policy`, and the frame-busting script content cannot silently regress. Do not weaken these assertions without reviewing the threat model above.
+
 ## 📱 Mobile-First Architecture
 
 ### Responsive Design Principles

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,6 +17,7 @@ export default withNuxt(
       '@typescript-eslint/no-explicit-any': 'warn',
       'vue/require-explicit-emits': 'error',
       'vue/no-unused-refs': 'warn',
+      'vue/no-template-target-blank': 'error',
     },
   },
   {

--- a/server/middleware/security-headers.ts
+++ b/server/middleware/security-headers.ts
@@ -1,9 +1,16 @@
+import type { H3Event } from 'h3'
 import { setResponseHeader } from 'h3'
 
 const isDev = process.env.DOPPLER_ENVIRONMENT === 'dev'
 
-export default defineEventHandler((event) => {
-  // Prevent clickjacking: deny all framing
+/**
+ * Pure header application so this logic can be unit-tested without
+ * Nitro's auto-imported defineEventHandler wrapper. See
+ * tests/server/security.test.ts.
+ */
+export function applySecurityHeaders(event: H3Event): void {
+  // Prevent clickjacking: deny all framing (legacy header, CSP frame-ancestors
+  // is the modern equivalent — we set both for belt-and-suspenders).
   setResponseHeader(event, 'X-Frame-Options', 'DENY')
 
   // Prevent MIME-type sniffing
@@ -15,6 +22,12 @@ export default defineEventHandler((event) => {
   // Restrict browser features the app does not need
   setResponseHeader(event, 'Permissions-Policy', 'geolocation=(), microphone=(), camera=()')
 
+  // Isolate the browsing context group so a cross-origin window cannot
+  // hold a reference to ours via window.opener. `same-origin-allow-popups`
+  // is the strictest value that still lets Reown AppKit and Coinbase
+  // Wallet SDK open wallet popups — strict `same-origin` would break them.
+  setResponseHeader(event, 'Cross-Origin-Opener-Policy', 'same-origin-allow-popups')
+
   // HSTS: only in production (localhost uses plain HTTP in dev)
   if (!isDev) {
     setResponseHeader(
@@ -23,4 +36,8 @@ export default defineEventHandler((event) => {
       'max-age=31536000; includeSubDomains; preload',
     )
   }
+}
+
+export default defineEventHandler((event) => {
+  applySecurityHeaders(event)
 })

--- a/server/plugins/00-anti-clickjack.ts
+++ b/server/plugins/00-anti-clickjack.ts
@@ -1,0 +1,38 @@
+/**
+ * Defense-in-depth frame-busting script.
+ *
+ * Primary clickjacking protection is delivered via HTTP response headers:
+ *   - X-Frame-Options: DENY             (server/middleware/security-headers.ts)
+ *   - CSP frame-ancestors 'none'        (server/plugins/csp.ts)
+ *   - Cross-Origin-Opener-Policy        (server/middleware/security-headers.ts)
+ *
+ * All modern browsers honor those headers and refuse to render the page
+ * inside a frame, so this script is the last line of defense: if a CDN,
+ * edge worker, or proxy ever strips or rewrites those headers, the inline
+ * script below detects the frame, hides the UI, and tries to break out.
+ *
+ * The script is prepended (unshift) to html.head so it is the very first
+ * <script> in <head> — it runs before wagmi / Reown AppKit / __APP_CONFIG__.
+ * The `00-` filename prefix puts this Nitro plugin first in alphabetical
+ * load order so its <script> lands in html.head before any other plugin
+ * pushes its own tags.
+ *
+ * csp.ts runs last and rewrites every `<script` to `<script nonce="...">`,
+ * so this tag automatically picks up the per-request nonce and is allowed
+ * to execute under the strict script-src policy.
+ *
+ * IMPORTANT: do not weaken this without review. This is paired with
+ * server/plugins/csp.ts and server/middleware/security-headers.ts to
+ * prevent clickjacking attacks on a wallet-bearing DeFi app. See
+ * tests/server/security.test.ts for regression coverage.
+ */
+
+export const ANTI_CLICKJACK_SCRIPT
+  = '<script>(function(){if(window.self===window.top)return;document.documentElement.style.display=\'none\';try{window.top.location=window.self.location}catch(e){}throw new Error(\'[anti-clickjack] Blocked: page loaded inside a frame\')})()</script>'
+
+export default defineNitroPlugin((nitroApp) => {
+  nitroApp.hooks.hook('render:html', (html) => {
+    // Prepend so this runs before any other <script> in <head>.
+    html.head.unshift(ANTI_CLICKJACK_SCRIPT)
+  })
+})

--- a/server/plugins/csp.ts
+++ b/server/plugins/csp.ts
@@ -122,7 +122,7 @@ const CONNECT_SRC_BASE = [
   'wss://relay.walletconnect.org',
 ]
 
-function buildCsp(nonce: string, extraConnectSrc: string[], envOrigins: { connect: string[] }): string {
+export function buildCsp(nonce: string, extraConnectSrc: string[], envOrigins: { connect: string[] }): string {
   const connectSrc = [
     ...CONNECT_SRC_BASE,
     ...(isDev ? CONNECT_SRC_DEV : []),

--- a/tests/server/security.test.ts
+++ b/tests/server/security.test.ts
@@ -12,6 +12,7 @@
  * docs/architecture.md (Clickjacking & Framing Defenses) first.
  */
 import { describe, it, expect } from 'vitest'
+import type { H3Event } from 'h3'
 import { buildCsp } from '~/server/plugins/csp'
 import { applySecurityHeaders } from '~/server/middleware/security-headers'
 import { ANTI_CLICKJACK_SCRIPT } from '~/server/plugins/00-anti-clickjack'
@@ -71,7 +72,7 @@ describe('applySecurityHeaders', () => {
             },
           },
         },
-      } as never,
+      } as unknown as H3Event,
       headers,
     }
   }

--- a/tests/server/security.test.ts
+++ b/tests/server/security.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Regression tests for clickjacking / iframe-embedding defenses.
+ *
+ * These are pure-function tests — they do not boot Nitro. They lock in
+ * the directives and headers that must never silently regress. If a
+ * future edit removes `frame-ancestors 'none'`, `X-Frame-Options: DENY`,
+ * the COOP header, or the frame-busting script, one of these tests will
+ * fail loud.
+ *
+ * If you find yourself weakening an assertion here because a header /
+ * directive is "no longer needed," stop and review the threat model in
+ * docs/architecture.md (Clickjacking & Framing Defenses) first.
+ */
+import { describe, it, expect } from 'vitest'
+import { buildCsp } from '~/server/plugins/csp'
+import { applySecurityHeaders } from '~/server/middleware/security-headers'
+import { ANTI_CLICKJACK_SCRIPT } from '~/server/plugins/00-anti-clickjack'
+
+describe('buildCsp', () => {
+  const csp = buildCsp('test-nonce', [], { connect: [] })
+
+  it('forbids all frame ancestors', () => {
+    expect(csp).toContain('frame-ancestors \'none\'')
+  })
+
+  it('embeds the per-request script nonce', () => {
+    expect(csp).toContain('\'nonce-test-nonce\'')
+  })
+
+  it('disallows <object>/<embed> entirely', () => {
+    expect(csp).toContain('object-src \'none\'')
+  })
+
+  it('never allows unsafe-inline in script-src', () => {
+    // Extract the script-src directive to avoid false positives from
+    // style-src which legitimately uses 'unsafe-inline'.
+    const scriptSrc = csp
+      .split(';')
+      .map(d => d.trim())
+      .find(d => d.startsWith('script-src'))
+    expect(scriptSrc, 'script-src directive must be present').toBeDefined()
+    expect(scriptSrc).not.toContain('\'unsafe-inline\'')
+  })
+
+  it('keeps strict-dynamic in script-src', () => {
+    // strict-dynamic is what allows our nonce-bearing bootstrap to load
+    // further scripts without explicit origin allowlists — losing it
+    // would break the SPA under CSP.
+    const scriptSrc = csp
+      .split(';')
+      .map(d => d.trim())
+      .find(d => d.startsWith('script-src'))
+    expect(scriptSrc).toContain('\'strict-dynamic\'')
+  })
+
+  it('locks base-uri to self (prevents base-tag hijack)', () => {
+    expect(csp).toContain('base-uri \'self\'')
+  })
+})
+
+describe('applySecurityHeaders', () => {
+  function createMockEvent() {
+    const headers: Record<string, string> = {}
+    return {
+      event: {
+        node: {
+          req: {},
+          res: {
+            setHeader: (name: string, value: string) => {
+              headers[name] = value
+            },
+          },
+        },
+      } as never,
+      headers,
+    }
+  }
+
+  it('sets X-Frame-Options: DENY (legacy clickjacking header)', () => {
+    const { event, headers } = createMockEvent()
+    applySecurityHeaders(event)
+    expect(headers['X-Frame-Options']).toBe('DENY')
+  })
+
+  it('sets Cross-Origin-Opener-Policy allowing wallet popups', () => {
+    const { event, headers } = createMockEvent()
+    applySecurityHeaders(event)
+    // `same-origin-allow-popups` is the strictest value that does not
+    // break Reown AppKit / Coinbase Wallet popup-based connect flows.
+    expect(headers['Cross-Origin-Opener-Policy']).toBe('same-origin-allow-popups')
+  })
+
+  it('sets X-Content-Type-Options: nosniff', () => {
+    const { event, headers } = createMockEvent()
+    applySecurityHeaders(event)
+    expect(headers['X-Content-Type-Options']).toBe('nosniff')
+  })
+
+  it('sets a referrer policy that does not leak cross-origin paths', () => {
+    const { event, headers } = createMockEvent()
+    applySecurityHeaders(event)
+    expect(headers['Referrer-Policy']).toBe('strict-origin-when-cross-origin')
+  })
+
+  it('restricts browser features the app does not use', () => {
+    const { event, headers } = createMockEvent()
+    applySecurityHeaders(event)
+    expect(headers['Permissions-Policy']).toContain('geolocation=()')
+    expect(headers['Permissions-Policy']).toContain('microphone=()')
+    expect(headers['Permissions-Policy']).toContain('camera=()')
+  })
+})
+
+describe('ANTI_CLICKJACK_SCRIPT', () => {
+  it('is a <script> tag', () => {
+    expect(ANTI_CLICKJACK_SCRIPT.startsWith('<script>')).toBe(true)
+    expect(ANTI_CLICKJACK_SCRIPT.endsWith('</script>')).toBe(true)
+  })
+
+  it('compares window.self against window.top', () => {
+    // The core frame detection — if this is removed the whole defense
+    // is a no-op.
+    expect(ANTI_CLICKJACK_SCRIPT).toContain('window.self')
+    expect(ANTI_CLICKJACK_SCRIPT).toContain('window.top')
+  })
+
+  it('hides the document root when framed', () => {
+    expect(ANTI_CLICKJACK_SCRIPT).toContain('display')
+    expect(ANTI_CLICKJACK_SCRIPT).toContain('none')
+  })
+
+  it('attempts to break out by navigating window.top', () => {
+    expect(ANTI_CLICKJACK_SCRIPT).toContain('window.top.location')
+  })
+
+  it('contains no template literals (guards against accidental syntax breaks when inlined into HTML)', () => {
+    // A stray backtick would be a common bug if someone refactors this
+    // to use template strings — escaping inside HTML `<script>` gets
+    // tricky fast. Keep it as a plain single-quoted string literal.
+    expect(ANTI_CLICKJACK_SCRIPT).not.toContain('`')
+  })
+})

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,21 @@
+/**
+ * Vitest setup: stub Nitro / Nuxt auto-imports that are injected by
+ * unimport at build time but absent under plain Node/vitest.
+ *
+ * Keeping this surface minimal: add a stub only when a test imports a
+ * server/ module that calls one of these globals at module top level.
+ */
+
+type AnyFn = (...args: unknown[]) => unknown
+
+const g = globalThis as unknown as {
+  defineEventHandler?: (fn: AnyFn) => AnyFn
+  defineNitroPlugin?: (fn: AnyFn) => AnyFn
+}
+
+if (!g.defineEventHandler) {
+  g.defineEventHandler = (fn: AnyFn) => fn
+}
+if (!g.defineNitroPlugin) {
+  g.defineNitroPlugin = (fn: AnyFn) => fn
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,5 +11,6 @@ export default defineConfig({
   test: {
     include: ['tests/**/*.test.ts'],
     globals: true,
+    setupFiles: ['./tests/setup.ts'],
   },
 })


### PR DESCRIPTION
## Summary
- Adds a JS-level frame-buster as belt-and-suspenders behind the existing `X-Frame-Options` / CSP `frame-ancestors` headers — in case a CDN or edge proxy ever strips them.
- Adds `Cross-Origin-Opener-Policy: same-origin-allow-popups` to the security headers. The `allow-popups` form is required so Reown AppKit / Coinbase Wallet connect popups keep working.
- Adds a regression test suite (`tests/server/security.test.ts`) asserting the critical headers and CSP directives are in place, so a future edit can't silently remove them. 16 new tests; full suite stays green (342 total).
- Adds `rel="noopener noreferrer"` to three raw `<a target="_blank">` tags that were missing it. `<NuxtLink>` already handles this automatically, so most `target="_blank"` usages were already safe.
- Small refactor: extracts `applySecurityHeaders` as a pure function and exports `buildCsp` so both are unit-testable without booting Nitro. Runtime behavior unchanged.

Changes are additive / hardening only; no existing flows should behave differently.

## Test plan
- [x] `npm run test:run` passes (new `tests/server/security.test.ts` + all existing tests)
- [x] `npm run typecheck` passes
- [x] Dev server (`npm run dev`) starts; response headers on `/` include `X-Frame-Options: DENY`, `Cross-Origin-Opener-Policy: same-origin-allow-popups`, and a `Content-Security-Policy` containing `frame-ancestors 'none'`
- [x] View-source on the root page: the first `<script>` tag in `<head>` is the anti-clickjack check, with a `nonce` attribute matching the CSP
- [x] Wallet connect flow (Reown AppKit) still works end-to-end — specifically WalletConnect QR popup and any injected-wallet popup openers