### PR TITLE
fix: defer AppKit init for signed-out visitors

### DIFF
--- a/components/entities/vault/form/VaultFormSubmit.vue
+++ b/components/entities/vault/form/VaultFormSubmit.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { inject } from 'vue'
 import { useAccount } from '@wagmi/vue'
-import { useAppKit } from '@reown/appkit/vue'
 import { flip, offset, shift, useFloating } from '@floating-ui/vue'
 
 import { isOperationBlocked, operationBlockReason } from '~/utils/operationGuardRegistry'
@@ -23,9 +22,8 @@ interface KeyringGuardState {
 
 const props = defineProps<{ disabled?: boolean, loading?: boolean, disabledReason?: string }>()
 const { isConnected } = useAccount()
-const { open } = useAppKit()
 const { chainId: _chainId } = useEulerAddresses()
-const { chainId, switchChain } = useWagmi()
+const { chainId, switchChain, connect } = useWagmi()
 const modal = useModal()
 
 const keyringGuard = inject<KeyringGuardState | null>('keyring-guard', null)
@@ -74,7 +72,7 @@ const onClick = (e: Event) => {
   }
   if (!isConnected.value) {
     e.preventDefault()
-    open()
+    connect()
     return
   }
 }

--- a/components/layout/TheHeader.vue
+++ b/components/layout/TheHeader.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { onClickOutside } from '@vueuse/core'
 import { offset, useFloating } from '@floating-ui/vue'
-import { useAppKit } from '@reown/appkit/vue'
 import { useAccount } from '@wagmi/vue'
 import {
   WalletDisconnectModal,
@@ -11,8 +10,8 @@ import {
 import { useModal } from '~/components/ui/composables/useModal'
 import { type MenuItem, getMenuItems } from '~/entities/menu'
 
-// AppKit modal controls
-const { open } = useAppKit()
+// Wallet connect modal (lazy-initializes AppKit on first call)
+const { connect } = useWagmi()
 
 // Wagmi account info
 const { address, isConnected } = useAccount()
@@ -78,7 +77,7 @@ const onWalletButtonClick = () => {
     modal.open(WalletDisconnectModal)
   }
   else {
-    open()
+    connect()
   }
 }
 const onChainButtonClick = () => {

--- a/composables/useWagmi.ts
+++ b/composables/useWagmi.ts
@@ -1,5 +1,4 @@
 import { useAccount, useAccountEffect, useDisconnect, useBalance, useSwitchChain, useEnsName } from '@wagmi/vue'
-import { useAppKit } from '@reown/appkit/vue'
 import { formatUnits, getAddress, isAddress, type Address } from 'viem'
 import { logWarn } from '~/utils/errorHandling'
 import { truncate } from '~/utils/string-utils'
@@ -43,7 +42,15 @@ function initializeWagmi() {
   const { data: balanceData, isLoading: isLoadingBalance, refetch: refetchBalance } = useBalance({
     address: wagmiAddress,
   })
-  const { open: modal } = useAppKit()
+
+  // AppKit may be deferred-initialized (see plugins/00.wagmi.ts). Route
+  // through the plugin-provided helper so the AppKit singleton is created
+  // only on first connect for signed-out visitors.
+  const modal = () => {
+    const nuxtApp = useNuxtApp()
+    const open = nuxtApp.$openWalletModal as (() => void) | undefined
+    open?.()
+  }
 
   useAccountEffect({
     onConnect: ({ address }) => {

--- a/composables/useWagmi.ts
+++ b/composables/useWagmi.ts
@@ -49,7 +49,11 @@ function initializeWagmi() {
   const modal = () => {
     const nuxtApp = useNuxtApp()
     const open = nuxtApp.$openWalletModal as (() => void) | undefined
-    open?.()
+    if (!open) {
+      console.warn('[useWagmi] $openWalletModal not available — wallet plugin may not have loaded')
+      return
+    }
+    open()
   }
 
   useAccountEffect({

--- a/pages/onboarding.vue
+++ b/pages/onboarding.vue
@@ -1,11 +1,10 @@
 <script setup lang="ts">
 import { useAccount } from '@wagmi/vue'
-import { useAppKit } from '@reown/appkit/vue'
 import { getDefaultPageRoute } from '~/entities/menu'
 
 const { isConnected } = useAccount()
 
-const { open } = useAppKit()
+const { connect } = useWagmi()
 const {
   appTitle,
   appDescription,
@@ -22,7 +21,7 @@ const defaultPageRoute = getDefaultPageRoute(
 const isOnboardingCompleted = useLocalStorage('is-onboarding-completed', false)
 
 const onConnectWalletClick = () => {
-  open()
+  connect()
 }
 
 const onConnectLaterClick = () => {

--- a/plugins/00.wagmi.ts
+++ b/plugins/00.wagmi.ts
@@ -4,6 +4,52 @@ import type { AppKitNetwork } from '@reown/appkit/networks'
 import { WagmiAdapter } from '@reown/appkit-adapter-wagmi'
 import { getNetworksByChainIds } from '~/entities/chainRegistry'
 
+/**
+ * Detects whether the user has previously connected a wallet on this origin.
+ *
+ * AppKit / Wagmi eagerly probe injected providers and attempt silent reconnect
+ * at startup. For users in "default EVM wallet" modes (notably Phantom), that
+ * probe can surface an unsolicited connection prompt on every page visit — even
+ * when the visitor has never connected. To avoid that we only eagerly initialize
+ * AppKit when we know the user previously connected. Otherwise we defer AppKit
+ * creation until the user explicitly clicks "Connect Wallet".
+ */
+const hasPersistedWalletSession = (): boolean => {
+  if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
+    return false
+  }
+
+  try {
+    if (window.localStorage.getItem('wagmi.recentConnectorId')) {
+      return true
+    }
+
+    const storeRaw = window.localStorage.getItem('wagmi.store')
+    if (storeRaw) {
+      try {
+        const parsed = JSON.parse(storeRaw)
+        if (parsed?.state?.current) return true
+        if (Array.isArray(parsed?.state?.connections) && parsed.state.connections.length > 0) return true
+      }
+      catch {
+        // Malformed store — treat as no session.
+      }
+    }
+
+    for (let i = 0; i < window.localStorage.length; i++) {
+      const key = window.localStorage.key(i)
+      if (key && key.startsWith('wc@2:client:')) {
+        return true
+      }
+    }
+  }
+  catch {
+    // localStorage may be blocked (Safari private mode, etc.) — treat as no session.
+  }
+
+  return false
+}
+
 export default defineNuxtPlugin((nuxtApp) => {
   const envConfig = useEnvConfig()
   const projectId = envConfig.appKitProjectId
@@ -47,15 +93,39 @@ export default defineNuxtPlugin((nuxtApp) => {
     customRpcUrls,
   })
 
-  createAppKit({
-    adapters: [wagmiAdapter],
-    networks,
-    projectId: projectId || '',
-    metadata,
-    themeVariables: {
-      '--w3m-font-family': 'inherit',
-    },
-  })
-
   nuxtApp.vueApp.use(WagmiPlugin, { config: wagmiAdapter.wagmiConfig })
+
+  let appKitInstance: ReturnType<typeof createAppKit> | null = null
+  const ensureAppKit = () => {
+    if (appKitInstance) return appKitInstance
+    appKitInstance = createAppKit({
+      adapters: [wagmiAdapter],
+      networks,
+      projectId: projectId || '',
+      metadata,
+      themeVariables: {
+        '--w3m-font-family': 'inherit',
+      },
+    })
+    return appKitInstance
+  }
+
+  const openWalletModal = () => {
+    const kit = ensureAppKit()
+    kit.open()
+  }
+
+  // Returning users who previously connected get the full modal up front so
+  // silent reconnect works as before. First-time / signed-out visitors don't
+  // pay that cost until they actually ask to connect.
+  if (hasPersistedWalletSession()) {
+    ensureAppKit()
+  }
+
+  return {
+    provide: {
+      ensureAppKit,
+      openWalletModal,
+    },
+  }
 })

--- a/plugins/00.wagmi.ts
+++ b/plugins/00.wagmi.ts
@@ -29,17 +29,9 @@ const hasPersistedWalletSession = (): boolean => {
       try {
         const parsed = JSON.parse(storeRaw)
         if (parsed?.state?.current) return true
-        if (Array.isArray(parsed?.state?.connections) && parsed.state.connections.length > 0) return true
       }
       catch {
         // Malformed store — treat as no session.
-      }
-    }
-
-    for (let i = 0; i < window.localStorage.length; i++) {
-      const key = window.localStorage.key(i)
-      if (key && key.startsWith('wc@2:client:')) {
-        return true
       }
     }
   }


### PR DESCRIPTION
## Summary
- Prevents unsolicited wallet-extension prompts (notably Phantom in "default EVM wallet" mode) from firing on page load for users who have never connected.
- `plugins/00.wagmi.ts` now only calls `createAppKit()` eagerly when there is a persisted wagmi/WalletConnect session in `localStorage`. Otherwise AppKit is instantiated lazily on the first Connect Wallet click via a provided `$openWalletModal` helper.
- Returning connected users are unaffected — `wagmi.recentConnectorId` / `wagmi.store` / `wc@2:client:*` keys trigger eager init so silent reconnect still works on first paint.

## Why
External report: visiting the site in a signed-out state was immediately popping up Phantom, which reads as suspicious. Root cause is AppKit's startup provider-probe + silent reconnect; Phantom's default-wallet mode surfaces that probe as a user-facing prompt.

## Changes
- `plugins/00.wagmi.ts` — session-detection helper, lazy `ensureAppKit()`, new `$openWalletModal` provide.
- `composables/useWagmi.ts` — `connect()` / internal `modal()` route through `$openWalletModal` instead of resolving `useAppKit()` at module init time.
- `pages/onboarding.vue`, `components/layout/TheHeader.vue`, `components/entities/vault/form/VaultFormSubmit.vue` — swap direct `useAppKit().open()` usage for `useWagmi().connect()` so every entry point uses the same lazy-init path.

## Test plan
- [ ] Fresh profile (no wagmi/WC keys in `localStorage`) with Phantom installed + "Set as default Ethereum wallet" enabled → load the app → Phantom does **not** prompt until Connect Wallet is clicked.
- [x] Connect a wallet, refresh → silent reconnect still restores the session on first paint (no extra modal popup).
- [x] Disconnect, refresh → next visit behaves like a fresh profile (no eager prompts).
- [x] Onboarding page Connect button still opens the modal.
- [x] Header Connect button still opens the modal; Disconnect still shows the disconnect modal.
- [x] Vault action submit button (`VaultFormSubmit`) still opens the Connect modal when called while disconnected.
- [x] WalletConnect flow works for a fresh and a returning user.