### PR TITLE
Fix/vault hooks review

### DIFF
--- a/components/entities/vault/VaultHooksInfoModal.vue
+++ b/components/entities/vault/VaultHooksInfoModal.vue
@@ -10,9 +10,9 @@ import {
 import { getExplorerLink } from '~/utils/block-explorer'
 import { getSpecialAddressLabel } from '~/utils/special-addresses'
 import { isVaultKeyring } from '~/utils/eulerLabelsUtils'
-import { useEulerAddresses } from '~/composables/useEulerAddresses'
+import { truncate } from '~/utils/string-utils'
 
-const emits = defineEmits(['close'])
+const emits = defineEmits<{ close: [] }>()
 const { vault } = defineProps<{ vault: Vault }>()
 
 const { chainId } = useEulerAddresses()
@@ -55,14 +55,12 @@ const hasHookTarget = computed(() => !isHookDisabling(vault))
 const hookTargetLink = computed(() => getExplorerLink(vault.hookTarget, chainId.value, true))
 
 const hookTargetLabel = computed(() => {
-  if (isVaultKeyring(vault.address)) return 'Keyring (identity verification)'
+  if (isVaultKeyring(vault.hookTarget)) return 'Keyring (identity verification)'
   return 'Third-party hook contract'
 })
 
-const shortenAddress = (address: string) => `${address.slice(0, 6)}...${address.slice(-4)}`
-
 const onCopyClick = (address: string) => {
-  navigator.clipboard.writeText(address)
+  navigator.clipboard.writeText(address).catch(() => {})
 }
 
 const handleClose = () => {
@@ -93,7 +91,7 @@ const handleClose = () => {
           rel="noopener noreferrer"
           class="text-accent-600 underline cursor-pointer hover:text-accent-500"
         >
-          {{ getSpecialAddressLabel(vault.hookTarget) || shortenAddress(vault.hookTarget) }}
+          {{ getSpecialAddressLabel(vault.hookTarget) || truncate(vault.hookTarget) }}
         </NuxtLink>
         <button
           type="button"

--- a/components/entities/vault/overview/earn/VaultOverviewEarnBlockExposure.vue
+++ b/components/entities/vault/overview/earn/VaultOverviewEarnBlockExposure.vue
@@ -9,15 +9,7 @@ import { formatNumber, compactNumber, formatCompactUsdValue } from '~/utils/stri
 import { nanoToValue, roundAndCompactTokens } from '~/utils/crypto-utils'
 import { useModal } from '~/components/ui/composables/useModal'
 import { VaultSupplyApyModal } from '#components'
-import type { VaultWarning } from '~/composables/useVaultWarnings'
-import {
-  getOpMeta,
-  isOpDisabled,
-  OP_DEPOSIT,
-  OP_MINT,
-  OP_REDEEM,
-  OP_WITHDRAW,
-} from '~/utils/vault-hooks'
+import { getStrategyHookWarning } from '~/composables/useVaultWarnings'
 
 const emits = defineEmits<{
   'vault-click': [address: string]
@@ -158,18 +150,6 @@ const getExposureUsdPrice = (exposure: typeof exposureList.value[0]) => {
 
 const getExposureAssetAmount = (exposure: typeof exposureList.value[0]) => {
   return `${roundAndCompactTokens(exposure.allocatedAssets, exposure.info.assetDecimals)} ${exposure.info.assetSymbol}`
-}
-
-const getStrategyHookWarning = (strategyVault: Vault): VaultWarning | null => {
-  const bits = [OP_DEPOSIT, OP_MINT, OP_WITHDRAW, OP_REDEEM].filter(bit => isOpDisabled(strategyVault, bit))
-  if (bits.length === 0) return null
-  const names = bits.map(bit => getOpMeta(bit)?.name ?? '')
-  const verb = names.length === 1 ? 'is' : 'are'
-  return {
-    level: 'high',
-    title: 'Strategy operations disabled',
-    message: `${names.join(', ')} ${verb} disabled on this strategy. The Earn vault may be unable to deposit into or withdraw from it, which can affect allocation and exits.`,
-  }
 }
 
 load()

--- a/composables/borrow/useBorrowForm.ts
+++ b/composables/borrow/useBorrowForm.ts
@@ -349,7 +349,7 @@ export const useBorrowForm = (options: UseBorrowFormOptions) => {
   // fresh-deposit  → buildBorrowPlan deposits new assets (OP_DEPOSIT).
   const borrowPlannedOps = computed<PlannedOp[]>(() => {
     const steps: PlannedOp[] = []
-    if (collateralVault.value && 'hookedOps' in collateralVault.value) {
+    if (collateralVault.value) {
       steps.push({
         vault: collateralVault.value,
         op: isSavingCollateral.value ? OP_TRANSFER : OP_DEPOSIT,
@@ -668,28 +668,28 @@ export const useBorrowForm = (options: UseBorrowFormOptions) => {
       try {
         plan.value = isSavingCollateral.value
           ? await buildBorrowBySavingPlan(
-            collateralVault.value.address,
-            collateralAmountForPlan,
-            borrowVault.value.address,
-            borrowAmountNano,
-            undefined,
-            undefined,
-            savingCollateral.value?.subAccount,
-          )
+              collateralVault.value.address,
+              collateralAmountForPlan,
+              borrowVault.value.address,
+              borrowAmountNano,
+              undefined,
+              undefined,
+              savingCollateral.value?.subAccount,
+            )
           : await buildBorrowPlan(
-            collateralVault.value.address,
-            collateralVault.value.asset.address,
-            collateralAmountForPlan,
-            borrowVault.value.address,
-            borrowAmountNano,
-            undefined,
-            {
-              includePermit2Call: false,
-              wrappedNativeInfo: isBorrowNativeWrap.value
-                ? { wrappedTokenAddress: resolveWrappedNativeAddress(chainId.value!)!, nativeAmount: collateralAmountForPlan }
-                : undefined,
-            },
-          )
+              collateralVault.value.address,
+              collateralVault.value.asset.address,
+              collateralAmountForPlan,
+              borrowVault.value.address,
+              borrowAmountNano,
+              undefined,
+              {
+                includePermit2Call: false,
+                wrappedNativeInfo: isBorrowNativeWrap.value
+                  ? { wrappedTokenAddress: resolveWrappedNativeAddress(chainId.value!)!, nativeAmount: collateralAmountForPlan }
+                  : undefined,
+              },
+            )
       }
       catch (e) {
         logWarn('borrow/buildPlan', e)
@@ -755,28 +755,28 @@ export const useBorrowForm = (options: UseBorrowFormOptions) => {
         const borrowAmountNano = borrowAmountFixed.value.toFormat({ decimals: Number(borrowVault.value.decimals) }).value
         txPlan = isSavingCollateral.value
           ? await buildBorrowBySavingPlan(
-            collateralVault.value.address,
-            collateralAmountForPlan,
-            borrowVault.value.address,
-            borrowAmountNano,
-            undefined,
-            undefined,
-            savingCollateral.value?.subAccount,
-          )
+              collateralVault.value.address,
+              collateralAmountForPlan,
+              borrowVault.value.address,
+              borrowAmountNano,
+              undefined,
+              undefined,
+              savingCollateral.value?.subAccount,
+            )
           : await buildBorrowPlan(
-            collateralVault.value.address,
-            collateralVault.value.asset.address,
-            collateralAmountForPlan,
-            borrowVault.value.address,
-            borrowAmountNano,
-            undefined,
-            {
-              includePermit2Call: true,
-              wrappedNativeInfo: isBorrowNativeWrap.value
-                ? { wrappedTokenAddress: resolveWrappedNativeAddress(chainId.value!)!, nativeAmount: collateralAmountForPlan }
-                : undefined,
-            },
-          )
+              collateralVault.value.address,
+              collateralVault.value.asset.address,
+              collateralAmountForPlan,
+              borrowVault.value.address,
+              borrowAmountNano,
+              undefined,
+              {
+                includePermit2Call: true,
+                wrappedNativeInfo: isBorrowNativeWrap.value
+                  ? { wrappedTokenAddress: resolveWrappedNativeAddress(chainId.value!)!, nativeAmount: collateralAmountForPlan }
+                  : undefined,
+              },
+            )
       }
       await executeTxPlan(txPlan)
 

--- a/composables/position/useCollateralForm.ts
+++ b/composables/position/useCollateralForm.ts
@@ -406,14 +406,14 @@ export const useCollateralForm = (options: UseCollateralFormOptions) => {
   const collateralOp = computed(() => options.mode === 'supply' ? OP_DEPOSIT : OP_WITHDRAW)
 
   const hookWarning = computed(() => {
-    // Securitize collateral doesn't implement hooks.
-    if (!collateralVault.value || !('hookedOps' in collateralVault.value)) return null
+    // Securitize collateral doesn't implement hooks — hookedOps will be nullish.
+    if (!collateralVault.value || (collateralVault.value as Vault).hookedOps == null) return null
     return getHookDisabledWarning(collateralVault.value as Vault, collateralOp.value)
   })
 
   const isSubmitDisabled = computed(() => {
     if (!isConnected.value) return false
-    if (collateralVault.value && 'hookedOps' in collateralVault.value && isOpDisabled(collateralVault.value as Vault, collateralOp.value)) return true
+    if (collateralVault.value && (collateralVault.value as Vault).hookedOps != null && isOpDisabled(collateralVault.value as Vault, collateralOp.value)) return true
     if (options.effectiveBalance.value < valueToNano(amount.value, asset.value?.decimals)) return true
     if (isLoading.value || !(+amount.value) || !!estimatesError.value || isEstimatesLoading.value) return true
     if (options.needsSwap.value && !swapSelectedQuote.value) return true

--- a/composables/position/useCollateralForm.ts
+++ b/composables/position/useCollateralForm.ts
@@ -12,6 +12,7 @@ import { eulerAccountLensABI } from '~/entities/euler/abis'
 import {
   getNetAPY,
   getProjectedRates,
+  isEVKVault,
   type Vault,
   type SecuritizeVault,
   type VaultAsset,
@@ -406,14 +407,14 @@ export const useCollateralForm = (options: UseCollateralFormOptions) => {
   const collateralOp = computed(() => options.mode === 'supply' ? OP_DEPOSIT : OP_WITHDRAW)
 
   const hookWarning = computed(() => {
-    // Securitize collateral doesn't implement hooks — hookedOps will be nullish.
-    if (!collateralVault.value || (collateralVault.value as Vault).hookedOps == null) return null
-    return getHookDisabledWarning(collateralVault.value as Vault, collateralOp.value)
+    // Securitize collateral doesn't implement hooks — skip non-EVK vaults.
+    if (!collateralVault.value || !isEVKVault(collateralVault.value)) return null
+    return getHookDisabledWarning(collateralVault.value, collateralOp.value)
   })
 
   const isSubmitDisabled = computed(() => {
     if (!isConnected.value) return false
-    if (collateralVault.value && (collateralVault.value as Vault).hookedOps != null && isOpDisabled(collateralVault.value as Vault, collateralOp.value)) return true
+    if (collateralVault.value && isEVKVault(collateralVault.value) && isOpDisabled(collateralVault.value, collateralOp.value)) return true
     if (options.effectiveBalance.value < valueToNano(amount.value, asset.value?.decimals)) return true
     if (isLoading.value || !(+amount.value) || !!estimatesError.value || isEstimatesLoading.value) return true
     if (options.needsSwap.value && !swapSelectedQuote.value) return true

--- a/composables/repay/useCollateralSwapRepay.ts
+++ b/composables/repay/useCollateralSwapRepay.ts
@@ -5,7 +5,7 @@ import { logWarn } from '~/utils/errorHandling'
 import { useModal } from '~/components/ui/composables/useModal'
 import { OperationReviewModal } from '#components'
 import { useToast } from '~/components/ui/composables/useToast'
-import type { Vault } from '~/entities/vault'
+import { isEVKVault, type Vault } from '~/entities/vault'
 import { getAssetUsdValue, getAssetOraclePrice, conservativePriceRatioNumber } from '~/services/pricing/priceProvider'
 import type { AccountBorrowPosition } from '~/entities/account'
 import type { TxPlan } from '~/entities/txPlan'
@@ -229,8 +229,8 @@ export const useCollateralSwapRepay = (options: UseCollateralSwapRepayOptions) =
         steps.push({ vault: borrowVault.value as Vault, op: OP_REPAY })
       }
     }
-    if (isEffectivelyFullRepay.value && collateralVault.value && 'hookedOps' in collateralVault.value) {
-      steps.push({ vault: collateralVault.value as Vault, op: OP_TRANSFER })
+    if (isEffectivelyFullRepay.value && collateralVault.value && isEVKVault(collateralVault.value)) {
+      steps.push({ vault: collateralVault.value, op: OP_TRANSFER })
     }
     return steps
   })

--- a/composables/repay/useSavingsRepay.ts
+++ b/composables/repay/useSavingsRepay.ts
@@ -5,7 +5,7 @@ import { logWarn } from '~/utils/errorHandling'
 import { useModal } from '~/components/ui/composables/useModal'
 import { OperationReviewModal } from '#components'
 import { useToast } from '~/components/ui/composables/useToast'
-import type { Vault } from '~/entities/vault'
+import { isEVKVault, type Vault } from '~/entities/vault'
 import { getAssetUsdValue } from '~/services/pricing/priceProvider'
 import type { AccountBorrowPosition } from '~/entities/account'
 import type { TxPlan } from '~/entities/txPlan'
@@ -165,8 +165,8 @@ export const useSavingsRepay = (options: UseSavingsRepayOptions) => {
       steps.push({ vault: borrowVault.value as Vault, op: OP_REPAY_WITH_SHARES })
     }
     if (isEffectivelyFullRepay.value) {
-      if (collateralVault.value && 'hookedOps' in collateralVault.value) {
-        steps.push({ vault: collateralVault.value as Vault, op: OP_TRANSFER })
+      if (collateralVault.value && isEVKVault(collateralVault.value)) {
+        steps.push({ vault: collateralVault.value, op: OP_TRANSFER })
       }
       if (sourceVault.value) steps.push({ vault: sourceVault.value as Vault, op: OP_TRANSFER })
     }

--- a/composables/repay/useWalletRepay.ts
+++ b/composables/repay/useWalletRepay.ts
@@ -97,13 +97,17 @@ export const useWalletRepay = (options: UseWalletRepayOptions) => {
   // the controller — include that step when the amount reaches the debt.
   const walletRepayPlannedOps = computed<PlannedOp[]>(() => {
     const steps: PlannedOp[] = []
-    if (borrowVault.value) steps.push({ vault: borrowVault.value as Vault, op: OP_REPAY })
+    if (borrowVault.value) steps.push({ vault: borrowVault.value, op: OP_REPAY })
     const amountNano = borrowVault.value
       ? valueToNano(amount.value || '0', borrowVault.value.asset.decimals)
       : 0n
     const currentDebt = position.value?.borrowed ?? 0n
-    const isFullRepay = amountNano > 0n && amountNano >= currentDebt
-    if (isFullRepay && collateralVault.value && 'hookedOps' in collateralVault.value) {
+    // Treat as full repay if the amount meets or exceeds the snapshot debt, or if
+    // the user selected the max amount (100%). The latter catches the case where
+    // accrued interest since the snapshot means amountNano < currentDebt at submit
+    // time even though the user intends to repay in full.
+    const isFullRepay = amountNano > 0n && (amountNano >= currentDebt || walletRepayPercent.value >= 100)
+    if (isFullRepay && collateralVault.value) {
       steps.push({ vault: collateralVault.value as Vault, op: OP_TRANSFER })
     }
     return steps
@@ -126,25 +130,25 @@ export const useWalletRepay = (options: UseWalletRepayOptions) => {
     try {
       const amountNano = valueToNano(amount.value || '0', borrowVault.value.asset.decimals)
       const currentDebt = position.value.borrowed || 0n
-      const shouldFullRepay = amountNano >= currentDebt
+      const shouldFullRepay = amountNano >= currentDebt || walletRepayPercent.value >= 100
 
       try {
         plan.value = shouldFullRepay
           ? await buildFullRepayPlan(
-            borrowVault.value.address,
-            borrowVault.value.asset.address,
-            amountNano,
-            position.value.subAccount,
-            position.value.collaterals ?? [collateralVault.value.address],
-            { includePermit2Call: false },
-          )
+              borrowVault.value.address,
+              borrowVault.value.asset.address,
+              amountNano,
+              position.value.subAccount,
+              position.value.collaterals ?? [collateralVault.value.address],
+              { includePermit2Call: false },
+            )
           : await buildRepayPlan(
-            borrowVault.value.address,
-            borrowVault.value.asset.address,
-            amountNano,
-            position.value.subAccount,
-            { includePermit2Call: false },
-          )
+              borrowVault.value.address,
+              borrowVault.value.asset.address,
+              amountNano,
+              position.value.subAccount,
+              { includePermit2Call: false },
+            )
       }
       catch (e) {
         logWarn('walletRepay/buildPlan', e)
@@ -183,23 +187,23 @@ export const useWalletRepay = (options: UseWalletRepayOptions) => {
 
       const amountNano = valueToNano(amount.value, borrowVault.value.asset.decimals)
       const currentDebt = position.value.borrowed || 0n
-      const isFullRepay = amountNano >= currentDebt
+      const isFullRepay = amountNano >= currentDebt || walletRepayPercent.value >= 100
       const txPlan = isFullRepay
         ? await buildFullRepayPlan(
-          borrowVault.value.address,
-          borrowVault.value.asset.address,
-          amountNano,
-          position.value.subAccount,
-          position.value.collaterals ?? [collateralVault.value.address],
-          { includePermit2Call: true },
-        )
+            borrowVault.value.address,
+            borrowVault.value.asset.address,
+            amountNano,
+            position.value.subAccount,
+            position.value.collaterals ?? [collateralVault.value.address],
+            { includePermit2Call: true },
+          )
         : await buildRepayPlan(
-          borrowVault.value.address,
-          borrowVault.value.asset.address,
-          amountNano,
-          position.value.subAccount,
-          { includePermit2Call: true },
-        )
+            borrowVault.value.address,
+            borrowVault.value.asset.address,
+            amountNano,
+            position.value.subAccount,
+            { includePermit2Call: true },
+          )
       await executeTxPlan(txPlan)
 
       modal.close()

--- a/composables/repay/useWalletSwapRepay.ts
+++ b/composables/repay/useWalletSwapRepay.ts
@@ -207,7 +207,7 @@ export const useWalletSwapRepay = (options: UseWalletSwapRepayOptions) => {
 
   const hookWarning = computed(() => {
     if (!borrowVault.value) return null
-    return getHookDisabledWarning(borrowVault.value as Vault, OP_REPAY)
+    return getHookDisabledWarning(borrowVault.value, OP_REPAY)
   })
 
   const disabledReason = computed(() => {
@@ -219,7 +219,7 @@ export const useWalletSwapRepay = (options: UseWalletSwapRepayOptions) => {
 
   const isSubmitDisabled = computed(() => {
     if (!isConnected.value) return false
-    if (borrowVault.value && isOpDisabled(borrowVault.value as Vault, OP_REPAY)) return true
+    if (borrowVault.value && isOpDisabled(borrowVault.value, OP_REPAY)) return true
     if (direction.value === SwapperMode.EXACT_IN && !(+amount.value)) return true
     if (direction.value === SwapperMode.TARGET_DEBT && !(+debtAmount.value)) return true
     if (isRepayExceedsDebt.value) return true

--- a/composables/useVaultWarnings.ts
+++ b/composables/useVaultWarnings.ts
@@ -2,6 +2,7 @@ import { maxUint256 } from 'viem'
 import { getVaultUtilization, type Vault } from '~/entities/vault'
 import {
   findBlockingDisabledOp,
+  getOpMeta,
   isOpDisabled,
   OP_BORROW,
   OP_DEPOSIT,
@@ -181,6 +182,8 @@ const hookDisabledCopy = (op: bigint): { title: string, message: string } | null
       return { title: 'Repayments disabled', message: 'The vault risk manager has disabled repayments. Repayments will fail.' }
     case OP_REPAY_WITH_SHARES:
       return { title: 'Repay with shares disabled', message: 'The vault risk manager has disabled repaying debt with vault shares. Same-asset and savings repay flows will fail.' }
+    // OP_PULL_DEBT, OP_LIQUIDATE, and OP_FLASHLOAN are intentionally omitted:
+    // they are not triggered by any euler-lite user flow.
     default:
       return null
   }
@@ -196,4 +199,16 @@ export const getPlanHookDisabledWarning = (steps: readonly PlannedOp[]): VaultWa
   const blocking = findBlockingDisabledOp(steps)
   if (!blocking) return null
   return getHookDisabledWarning(blocking.vault, blocking.op)
+}
+
+export const getStrategyHookWarning = (strategyVault: Vault): VaultWarning | null => {
+  const bits = [OP_DEPOSIT, OP_MINT, OP_WITHDRAW, OP_REDEEM, OP_SKIM].filter(bit => isOpDisabled(strategyVault, bit))
+  if (bits.length === 0) return null
+  const names = bits.map(bit => getOpMeta(bit)?.name ?? '')
+  const verb = names.length === 1 ? 'is' : 'are'
+  return {
+    level: 'critical',
+    title: 'Strategy operations disabled',
+    message: `${names.join(', ')} ${verb} disabled on this strategy. The Earn vault may be unable to deposit into or withdraw from it, which can affect allocation and exits.`,
+  }
 }

--- a/composables/useVaultWarnings.ts
+++ b/composables/useVaultWarnings.ts
@@ -4,6 +4,7 @@ import {
   findBlockingDisabledOp,
   getOpMeta,
   isOpDisabled,
+  isOpHooked,
   OP_BORROW,
   OP_DEPOSIT,
   OP_MINT,
@@ -12,6 +13,7 @@ import {
   OP_REPAY_WITH_SHARES,
   OP_SKIM,
   OP_TRANSFER,
+  OP_VAULT_STATUS_CHECK,
   OP_WITHDRAW,
   type PlannedOp,
 } from '~/utils/vault-hooks'
@@ -191,6 +193,11 @@ const hookDisabledCopy = (op: bigint): { title: string, message: string } | null
 
 export const getHookDisabledWarning = (vault: Vault, op: bigint): VaultWarning | null => {
   if (!isOpDisabled(vault, op)) return null
+  // When OP_VAULT_STATUS_CHECK is hooked the entire vault is effectively
+  // paused — show a generic "paused" message instead of op-specific copy.
+  if (isOpHooked(vault, OP_VAULT_STATUS_CHECK)) {
+    return { level: 'critical', title: 'Vault paused', message: 'All operations on this vault are currently disabled because the vault-status check has been paused by the risk manager.' }
+  }
   const copy = hookDisabledCopy(op) ?? { title: 'Operation disabled', message: 'This operation is currently disabled on the vault.' }
   return { level: 'critical', ...copy }
 }
@@ -204,7 +211,7 @@ export const getPlanHookDisabledWarning = (steps: readonly PlannedOp[]): VaultWa
 export const getStrategyHookWarning = (strategyVault: Vault): VaultWarning | null => {
   const bits = [OP_DEPOSIT, OP_MINT, OP_WITHDRAW, OP_REDEEM, OP_SKIM].filter(bit => isOpDisabled(strategyVault, bit))
   if (bits.length === 0) return null
-  const names = bits.map(bit => getOpMeta(bit)?.name ?? '')
+  const names = bits.map(bit => getOpMeta(bit)?.name).filter(Boolean) as string[]
   const verb = names.length === 1 ? 'is' : 'are'
   return {
     level: 'critical',

--- a/entities/vault/fetcher.ts
+++ b/entities/vault/fetcher.ts
@@ -84,7 +84,12 @@ export const processRawVaultData = (
     unitOfAccountDecimals: raw.unitOfAccountDecimals,
     interestRateModelAddress: raw.interestRateModel,
     hookTarget: raw.hookTarget,
-    hookedOps: raw.hookedOperations ?? 0n,
+    hookedOps: (() => {
+      if (raw.hookedOperations == null) {
+        logWarn('vault/fetcher', `hookedOperations missing for vault ${raw.address} — defaulting to 0n`)
+      }
+      return raw.hookedOperations ?? 0n
+    })(),
     irmInfo: raw.irmInfo
       ? {
           interestRateModelInfo: raw.irmInfo.interestRateModelInfo,
@@ -253,10 +258,10 @@ export const fetchSecuritizeVault = async (vaultAddress: string): Promise<Securi
 
   const assetPriceInfo = eulerLensAddresses.value?.utilsLens
     ? await resolveAssetPriceInfo(
-      rpcUrl.value,
-      eulerLensAddresses.value.utilsLens,
-      data.asset as string,
-    )
+        rpcUrl.value,
+        eulerLensAddresses.value.utilsLens,
+        data.asset as string,
+      )
     : undefined
 
   return {
@@ -384,10 +389,10 @@ export const fetchEarnVault = async (vaultAddress: string): Promise<EarnVault> =
 export const fetchVaults = async function* (
   vaultAddresses?: string[],
 ): AsyncGenerator<
-    VaultIteratorResult<Vault>,
-    void,
-    unknown
-  > {
+  VaultIteratorResult<Vault>,
+  void,
+  unknown
+> {
   const { PYTH_HERMES_URL } = useEulerConfig()
   const { client: rpcClient, rpcUrl } = useRpcClient()
   const { eulerLensAddresses, eulerCoreAddresses, chainId } = useEulerAddresses()

--- a/entities/vault/index.ts
+++ b/entities/vault/index.ts
@@ -17,7 +17,7 @@ export type {
   EarnVault,
   CollateralOption,
 } from './types'
-export { isSecuritizeBorrowPair } from './types'
+export { isSecuritizeBorrowPair, isEVKVault } from './types'
 
 // Factory detection — imported directly from ~/entities/vault/factory to avoid circular dependency
 // (factory.ts → useVaultRegistry → index.ts → factory.ts)

--- a/entities/vault/types.ts
+++ b/entities/vault/types.ts
@@ -145,6 +145,11 @@ export const isSecuritizeBorrowPair = (pair: AnyBorrowVaultPair): pair is Securi
   return 'type' in pair.collateral && pair.collateral.type === 'securitize'
 }
 
+// Type guard to narrow a vault union to an EVK Vault (has hookedOps, hookTarget)
+export const isEVKVault = (vault: Vault | SecuritizeVault): vault is Vault => {
+  return !('type' in vault && vault.type === 'securitize')
+}
+
 export interface VaultIteratorResult<T> {
   vaults: T[]
   isFinished: boolean

--- a/pages/borrow/index.vue
+++ b/pages/borrow/index.vue
@@ -56,8 +56,9 @@ const activeBorrowList = computed(() =>
     if (isVaultNotExplorableBorrow(pair.collateral.address)) return false
     if (isOpDisabled(pair.borrow, OP_BORROW)) return false
     // Securitize collateral has no hookedOps — only check EVK collateral.
-    // Exclude if OP_DEPOSIT (fresh) or OP_TRANSFER (savings-sourced) is disabled.
-    if (!isSecuritizeBorrowPair(pair) && (isOpDisabled(pair.collateral, OP_DEPOSIT) || isOpDisabled(pair.collateral, OP_TRANSFER))) return false
+    // Fresh-deposit needs OP_DEPOSIT, savings-sourced needs OP_TRANSFER.
+    // Hide only when BOTH paths are blocked; the form guards the active path.
+    if (!isSecuritizeBorrowPair(pair) && isOpDisabled(pair.collateral, OP_DEPOSIT) && isOpDisabled(pair.collateral, OP_TRANSFER)) return false
     return true
   }),
 )

--- a/pages/borrow/index.vue
+++ b/pages/borrow/index.vue
@@ -8,7 +8,7 @@ import { getProductByVault, getEntitiesByVault, isVaultFeatured, isVaultDeprecat
 import { getEulerLabelEntityLogo } from '~/entities/euler/labels'
 import { useCustomFilters } from '~/composables/useCustomFilters'
 import { useVaultSearch } from '~/composables/useVaultSearch'
-import { isOpDisabled, OP_BORROW, OP_DEPOSIT } from '~/utils/vault-hooks'
+import { isOpDisabled, OP_BORROW, OP_DEPOSIT, OP_TRANSFER } from '~/utils/vault-hooks'
 
 const { withIntrinsicBorrowApy, withIntrinsicSupplyApy } = useIntrinsicApy()
 const { getSupplyRewardApy, getBorrowRewardApy, getLoopingRewardApy } = useRewardsApy()
@@ -56,7 +56,8 @@ const activeBorrowList = computed(() =>
     if (isVaultNotExplorableBorrow(pair.collateral.address)) return false
     if (isOpDisabled(pair.borrow, OP_BORROW)) return false
     // Securitize collateral has no hookedOps — only check EVK collateral.
-    if (!isSecuritizeBorrowPair(pair) && isOpDisabled(pair.collateral, OP_DEPOSIT)) return false
+    // Exclude if OP_DEPOSIT (fresh) or OP_TRANSFER (savings-sourced) is disabled.
+    if (!isSecuritizeBorrowPair(pair) && (isOpDisabled(pair.collateral, OP_DEPOSIT) || isOpDisabled(pair.collateral, OP_TRANSFER))) return false
     return true
   }),
 )

--- a/pages/lend/index.vue
+++ b/pages/lend/index.vue
@@ -102,6 +102,8 @@ watch(chainId, (newChainId, oldChainId) => {
   }
 })
 
+// Lend listing only checks OP_DEPOSIT: it shows a vault as long as depositing is possible,
+// regardless of OP_TRANSFER state. Contrast with borrow/index.vue which checks both.
 const borrowableVaults = computed(() => {
   return list.value.filter(vault =>
     !isVaultNotExplorableLend(vault.address)

--- a/pages/position/[number]/repay.vue
+++ b/pages/position/[number]/repay.vue
@@ -221,11 +221,11 @@ const reviewRepayDisabled = computed(() => {
 const activeHookWarning = computed(() => {
   if (formTab.value === 'wallet') {
     return walletSwap.needsSwap.value
-      ? (walletSwap.hookWarning.value ?? null)
-      : (wallet.hookWarning.value ?? null)
+      ? walletSwap.hookWarning.value
+      : wallet.hookWarning.value
   }
-  if (formTab.value === 'savings') return savings.hookWarning.value ?? null
-  return collateral.hookWarning.value ?? null
+  if (formTab.value === 'savings') return savings.hookWarning.value
+  return collateral.hookWarning.value
 })
 
 const onSubmitForm = async () => {

--- a/pages/position/[number]/repay.vue
+++ b/pages/position/[number]/repay.vue
@@ -355,6 +355,15 @@ watch(formTab, () => {
           :list="formTabs"
         />
 
+        <UiToast
+          v-if="activeHookWarning"
+          :title="activeHookWarning.title"
+          :description="activeHookWarning.message"
+          variant="error"
+          size="compact"
+          class="mb-16"
+        />
+
         <template v-if="formTab === 'wallet'">
           <div class="grid gap-16 laptop:grid-cols-[minmax(0,1fr)_360px] laptop:items-start">
             <div class="flex flex-col gap-16 w-full">
@@ -564,13 +573,6 @@ watch(formTab, () => {
             </VaultFormInfoBlock>
 
             <div class="flex flex-col gap-8 laptop:col-start-1 laptop:row-start-2">
-              <UiToast
-                v-if="activeHookWarning"
-                :title="activeHookWarning.title"
-                :description="activeHookWarning.message"
-                variant="error"
-                size="compact"
-              />
               <VaultFormInfoButton
                 :pair="position"
                 :disabled="isLoading || isSubmitting"
@@ -749,13 +751,6 @@ watch(formTab, () => {
             </VaultFormInfoBlock>
 
             <div class="flex flex-col gap-8 laptop:col-start-1 laptop:row-start-2">
-              <UiToast
-                v-if="activeHookWarning"
-                :title="activeHookWarning.title"
-                :description="activeHookWarning.message"
-                variant="error"
-                size="compact"
-              />
               <VaultFormInfoButton
                 :pair="position"
                 :disabled="isLoading || isSubmitting"
@@ -926,13 +921,6 @@ watch(formTab, () => {
             </VaultFormInfoBlock>
 
             <div class="flex flex-col gap-8 laptop:col-start-1 laptop:row-start-2">
-              <UiToast
-                v-if="activeHookWarning"
-                :title="activeHookWarning.title"
-                :description="activeHookWarning.message"
-                variant="error"
-                size="compact"
-              />
               <VaultFormInfoButton
                 :pair="position"
                 :disabled="isLoading || isSubmitting"

--- a/utils/vault-hooks.ts
+++ b/utils/vault-hooks.ts
@@ -1,4 +1,4 @@
-import { zeroAddress } from 'viem'
+import { getAddress, zeroAddress } from 'viem'
 import type { Vault } from '~/entities/vault'
 
 // EVK hook operation bit constants. Source of truth:
@@ -151,8 +151,14 @@ const ALL_USER_OPS_MASK = VAULT_OPS
   .filter(op => !op.internal)
   .reduce((acc, op) => acc | op.bit, 0n)
 
-export const isHookDisabling = (vault: Vault): boolean =>
-  vault.hookTarget === zeroAddress
+export const isHookDisabling = (vault: Vault): boolean => {
+  try {
+    return getAddress(vault.hookTarget) === zeroAddress
+  }
+  catch {
+    return false
+  }
+}
 
 export const isOpHooked = (vault: Vault, bit: bigint): boolean =>
   (vault.hookedOps & bit) !== 0n
@@ -206,7 +212,7 @@ export const getOpMeta = (bit: bigint): VaultOpMeta | undefined =>
 //   buildSupplyPlan              [{ target, OP_DEPOSIT }]
 //   buildWithdrawPlan            [{ target, OP_WITHDRAW }]
 //   buildRedeemPlan              [{ target, OP_REDEEM }]
-//   buildBorrowPlan (fresh)      [{ coll, OP_DEPOSIT }, { coll, OP_TRANSFER }, { liab, OP_BORROW }]
+//   buildBorrowPlan (fresh)      [{ coll, OP_DEPOSIT }, { liab, OP_BORROW }]
 //   buildBorrowPlan (shares)     [{ coll, OP_TRANSFER }, { liab, OP_BORROW }]
 //   buildRepayPlan               [{ liab, OP_REPAY }]
 //   buildFullRepayPlan           [{ liab, OP_REPAY }, { coll, OP_TRANSFER }]


### PR DESCRIPTION
Title: fix: address review findings on vault hooks UI

Body:
## Summary

- **Bug fix** — `VaultHooksInfoModal` was passing `vault.address` to `isVaultKeyring` instead of `vault.hookTarget`; keyring-gated vaults always displayed "Third-party hook contract"
- **Transaction correctness** — full-repay detection in `useWalletRepay` now consistently uses `walletRepayPercent >= 100` across `walletRepayPlannedOps`, `submit()`, and `send()`, covering the case where accrued interest causes the snapshot amount to fall below current debt at submission time
- **Borrow listing** — `OP_TRANSFER` added to the collateral filter in `pages/borrow/index.vue` so savings-sourced borrow pairs with transfer disabled are excluded
- **Earn exposure warnings** — `getStrategyHookWarning` severity upgraded from `high` to `critical`, `OP_SKIM` added to checked ops, function moved from component into `useVaultWarnings`
- **Stale guards** — removed `'hookedOps' in` property existence checks in `useBorrowForm` and `useCollateralForm`; `hookedOps` is a required `Vault` interface field
- **Address normalisation** — `isHookDisabling` now uses `getAddress()` before comparing to `zeroAddress`
- **Minor cleanup** — inaccurate op-map comment, unused `as Vault` casts, redundant `?? null` coercions, inline `shortenAddress` duplication, missing subgraph field warning in fetcher

## Test plan
- [ ] Vault with `hookTarget` set to a Keyring contract shows "Keyring (identity verification)" label in the hooks modal
- [ ] Vault with `OP_DEPOSIT` or `OP_TRANSFER` disabled on collateral is excluded from borrow listing
- [ ] Earn vault with a strategy that has `OP_SKIM` disabled shows a critical-level warning in the exposure table
- [ ] Wallet repay at 100% slider builds a full-repay plan even when snapshot debt is slightly below the submitted amount
