### PR TITLE
feat: add name field to vault overrides

### DIFF
--- a/components/entities/vault/ChooseCollateralModal.vue
+++ b/components/entities/vault/ChooseCollateralModal.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { getProductByVault } from '~/utils/eulerLabelsUtils'
+import { getVaultProductName } from '~/utils/eulerLabelsUtils'
 import type { CollateralOption } from '~/entities/vault'
 import { formatNumber } from '~/utils/string-utils'
 
@@ -22,8 +22,8 @@ const getOptionLabel = (option: CollateralOption) => {
   if (option.vaultAddress && isEscrowVault(option.vaultAddress)) return 'Escrowed collateral'
   if (option.label) return option.label
   if (option.vaultAddress) {
-    const product = getProductByVault(option.vaultAddress)
-    if (product?.name) return product.name
+    const name = getVaultProductName(option.vaultAddress)
+    if (name) return name
   }
   return productName
 }

--- a/composables/useRepaySavingsOptions.ts
+++ b/composables/useRepaySavingsOptions.ts
@@ -1,5 +1,5 @@
 import { getAddress } from 'viem'
-import { getProductByVault } from '~/utils/eulerLabelsUtils'
+import { getVaultProductName } from '~/utils/eulerLabelsUtils'
 import { useIntrinsicApy } from '~/composables/useIntrinsicApy'
 import { useVaultRegistry } from '~/composables/useVaultRegistry'
 import type { AccountDepositPosition } from '~/entities/account'
@@ -41,7 +41,6 @@ export const useRepaySavingsOptions = () => {
     async (position) => {
       const vault = position.vault
       const amount = nanoToValue(position.assets, vault.asset.decimals)
-      const product = getProductByVault(vault.address)
       const baseApy = nanoToValue(vault.interestRateInfo.supplyAPY || 0n, 25)
       const apy = withIntrinsicSupplyApy(baseApy, vault.asset.address) + getSupplyRewardApy(vault.address)
       return {
@@ -51,7 +50,7 @@ export const useRepaySavingsOptions = () => {
         apy,
         symbol: vault.asset.symbol,
         assetAddress: vault.asset.address,
-        label: product.name || vault.name,
+        label: getVaultProductName(vault.address) || vault.name,
         vaultAddress: vault.address,
       }
     },

--- a/entities/euler/labels.ts
+++ b/entities/euler/labels.ts
@@ -13,6 +13,7 @@ export type EulerLabelEntity = {
   }
 }
 export type EulerLabelVaultOverride = {
+  name?: string
   description?: string
   portfolioNotice?: string
   deprecationReason?: string

--- a/pages/borrow/index.vue
+++ b/pages/borrow/index.vue
@@ -5,7 +5,7 @@ import { getAssetLogoUrl } from '~/composables/useTokenList'
 import { getVaultUtilization } from '~/entities/vault'
 import type { AnyBorrowVaultPair, BorrowVaultPair } from '~/entities/vault'
 import { getAssetUsdValueOrZero } from '~/services/pricing/priceProvider'
-import { getProductByVault, getVaultProductName, getEntitiesByVault, isVaultFeatured, isVaultDeprecated, isVaultNotExplorableBorrow } from '~/utils/eulerLabelsUtils'
+import { getProductByVault, applyVaultOverrides, getEntitiesByVault, isVaultFeatured, isVaultDeprecated, isVaultNotExplorableBorrow } from '~/utils/eulerLabelsUtils'
 import { getEulerLabelEntityLogo } from '~/entities/euler/labels'
 import { useCustomFilters } from '~/composables/useCustomFilters'
 import { useVaultSearch } from '~/composables/useVaultSearch'
@@ -57,17 +57,20 @@ const activeBorrowList = computed(() =>
   ),
 )
 
-const { searchQuery, matchesSearch, clearSearch } = useVaultSearch<AnyBorrowVaultPair>(pair => [
-  pair.collateral.asset.symbol,
-  pair.collateral.asset.name,
-  pair.collateral.name,
-  pair.borrow.asset.symbol,
-  pair.borrow.asset.name,
-  pair.borrow.name,
-  getVaultProductName(pair.collateral.address),
-  getProductByVault(pair.collateral.address).description,
-  ...getEntitiesByVault(pair.borrow).map(e => e.name),
-])
+const { searchQuery, matchesSearch, clearSearch } = useVaultSearch<AnyBorrowVaultPair>((pair) => {
+  const product = applyVaultOverrides(getProductByVault(pair.collateral.address), pair.collateral.address)
+  return [
+    pair.collateral.asset.symbol,
+    pair.collateral.asset.name,
+    pair.collateral.name,
+    pair.borrow.asset.symbol,
+    pair.borrow.asset.name,
+    pair.borrow.name,
+    product.name,
+    product.description,
+    ...getEntitiesByVault(pair.borrow).map(e => e.name),
+  ]
+})
 
 const selectedCollateral = ref<string[]>([])
 const selectedDebt = ref<string[]>([])

--- a/pages/borrow/index.vue
+++ b/pages/borrow/index.vue
@@ -5,7 +5,7 @@ import { getAssetLogoUrl } from '~/composables/useTokenList'
 import { getVaultUtilization } from '~/entities/vault'
 import type { AnyBorrowVaultPair, BorrowVaultPair } from '~/entities/vault'
 import { getAssetUsdValueOrZero } from '~/services/pricing/priceProvider'
-import { getProductByVault, getEntitiesByVault, isVaultFeatured, isVaultDeprecated, isVaultNotExplorableBorrow } from '~/utils/eulerLabelsUtils'
+import { getProductByVault, getVaultProductName, getEntitiesByVault, isVaultFeatured, isVaultDeprecated, isVaultNotExplorableBorrow } from '~/utils/eulerLabelsUtils'
 import { getEulerLabelEntityLogo } from '~/entities/euler/labels'
 import { useCustomFilters } from '~/composables/useCustomFilters'
 import { useVaultSearch } from '~/composables/useVaultSearch'
@@ -64,7 +64,7 @@ const { searchQuery, matchesSearch, clearSearch } = useVaultSearch<AnyBorrowVaul
   pair.borrow.asset.symbol,
   pair.borrow.asset.name,
   pair.borrow.name,
-  getProductByVault(pair.collateral.address).name,
+  getVaultProductName(pair.collateral.address),
   getProductByVault(pair.collateral.address).description,
   ...getEntitiesByVault(pair.borrow).map(e => e.name),
 ])

--- a/pages/earn/index.vue
+++ b/pages/earn/index.vue
@@ -5,7 +5,7 @@ import { useEulerAddresses } from '~/composables/useEulerAddresses'
 import { getAssetLogoUrl } from '~/composables/useTokenList'
 import type { EarnVault } from '~/entities/vault'
 import { getAssetUsdValueOrZero } from '~/services/pricing/priceProvider'
-import { getProductByVault, getEntitiesByEarnVault, isVaultFeatured, isVaultDeprecated, isEarnVaultNotExplorable } from '~/utils/eulerLabelsUtils'
+import { getProductByVault, getVaultProductName, getEntitiesByEarnVault, isVaultFeatured, isVaultDeprecated, isEarnVaultNotExplorable } from '~/utils/eulerLabelsUtils'
 import { getEulerLabelEntityLogo } from '~/entities/euler/labels'
 import { useCustomFilters } from '~/composables/useCustomFilters'
 import { useVaultSearch } from '~/composables/useVaultSearch'
@@ -28,7 +28,7 @@ const { searchQuery, matchesSearch, clearSearch } = useVaultSearch<EarnVault>(va
   vault.asset.symbol,
   vault.asset.name,
   vault.name,
-  getProductByVault(vault.address).name,
+  getVaultProductName(vault.address),
   getProductByVault(vault.address).description,
   ...getEntitiesByEarnVault(vault).map(e => e.name),
 ])

--- a/pages/earn/index.vue
+++ b/pages/earn/index.vue
@@ -5,7 +5,7 @@ import { useEulerAddresses } from '~/composables/useEulerAddresses'
 import { getAssetLogoUrl } from '~/composables/useTokenList'
 import type { EarnVault } from '~/entities/vault'
 import { getAssetUsdValueOrZero } from '~/services/pricing/priceProvider'
-import { getProductByVault, getVaultProductName, getEntitiesByEarnVault, isVaultFeatured, isVaultDeprecated, isEarnVaultNotExplorable } from '~/utils/eulerLabelsUtils'
+import { getProductByVault, applyVaultOverrides, getEntitiesByEarnVault, isVaultFeatured, isVaultDeprecated, isEarnVaultNotExplorable } from '~/utils/eulerLabelsUtils'
 import { getEulerLabelEntityLogo } from '~/entities/euler/labels'
 import { useCustomFilters } from '~/composables/useCustomFilters'
 import { useVaultSearch } from '~/composables/useVaultSearch'
@@ -24,14 +24,17 @@ const list = computed(() => getEarnVaults().filter(v => v.verified && !isEarnVau
 
 const { enableEntityBranding } = useDeployConfig()
 
-const { searchQuery, matchesSearch, clearSearch } = useVaultSearch<EarnVault>(vault => [
-  vault.asset.symbol,
-  vault.asset.name,
-  vault.name,
-  getVaultProductName(vault.address),
-  getProductByVault(vault.address).description,
-  ...getEntitiesByEarnVault(vault).map(e => e.name),
-])
+const { searchQuery, matchesSearch, clearSearch } = useVaultSearch<EarnVault>((vault) => {
+  const product = applyVaultOverrides(getProductByVault(vault.address), vault.address)
+  return [
+    vault.asset.symbol,
+    vault.asset.name,
+    vault.name,
+    product.name,
+    product.description,
+    ...getEntitiesByEarnVault(vault).map(e => e.name),
+  ]
+})
 
 const selectedCollateral = ref<string[]>([])
 const selectedCurators = ref<string[]>([])

--- a/pages/explore/index.vue
+++ b/pages/explore/index.vue
@@ -2,7 +2,7 @@
 import { useMarketGroups } from '~/composables/useMarketGroups'
 import { useEulerAddresses } from '~/composables/useEulerAddresses'
 import { getAssetLogoUrl } from '~/composables/useTokenList'
-import { getProductByVault, getVaultProductName, getEntitiesByVault, isVaultDeprecated } from '~/utils/eulerLabelsUtils'
+import { getProductByVault, applyVaultOverrides, getEntitiesByVault, isVaultDeprecated } from '~/utils/eulerLabelsUtils'
 import { getEulerLabelEntityLogo } from '~/entities/euler/labels'
 import { useCustomFilters } from '~/composables/useCustomFilters'
 import { useBestMaxROE } from '~/composables/useBestMaxROE'
@@ -29,9 +29,9 @@ const { searchQuery, matchesSearch, clearSearch } = useVaultSearch<MarketGroup>(
   ...group.vaults.flatMap((vault) => {
     const addr = isVaultType(vault) ? vault.address : ''
     if (!addr) return []
-    const product = getProductByVault(addr)
+    const product = applyVaultOverrides(getProductByVault(addr), addr)
     return [
-      getVaultProductName(addr),
+      product.name,
       product.description,
       ...getEntitiesByVault(vault as Vault).map(e => e.name),
     ]

--- a/pages/explore/index.vue
+++ b/pages/explore/index.vue
@@ -2,7 +2,7 @@
 import { useMarketGroups } from '~/composables/useMarketGroups'
 import { useEulerAddresses } from '~/composables/useEulerAddresses'
 import { getAssetLogoUrl } from '~/composables/useTokenList'
-import { getProductByVault, getEntitiesByVault, isVaultDeprecated } from '~/utils/eulerLabelsUtils'
+import { getProductByVault, getVaultProductName, getEntitiesByVault, isVaultDeprecated } from '~/utils/eulerLabelsUtils'
 import { getEulerLabelEntityLogo } from '~/entities/euler/labels'
 import { useCustomFilters } from '~/composables/useCustomFilters'
 import { useBestMaxROE } from '~/composables/useBestMaxROE'
@@ -31,7 +31,7 @@ const { searchQuery, matchesSearch, clearSearch } = useVaultSearch<MarketGroup>(
     if (!addr) return []
     const product = getProductByVault(addr)
     return [
-      product.name,
+      getVaultProductName(addr),
       product.description,
       ...getEntitiesByVault(vault as Vault).map(e => e.name),
     ]

--- a/pages/lend/index.vue
+++ b/pages/lend/index.vue
@@ -6,7 +6,7 @@ import { getAssetLogoUrl } from '~/composables/useTokenList'
 import { getVaultUtilization } from '~/entities/vault'
 import type { Vault } from '~/entities/vault'
 import { getAssetUsdValueOrZero } from '~/services/pricing/priceProvider'
-import { getProductByVault, getVaultProductName, getEntitiesByVault, isVaultFeatured, isVaultDeprecated, isVaultNotExplorableLend } from '~/utils/eulerLabelsUtils'
+import { getProductByVault, applyVaultOverrides, getEntitiesByVault, isVaultFeatured, isVaultDeprecated, isVaultNotExplorableLend } from '~/utils/eulerLabelsUtils'
 import { getEulerLabelEntityLogo } from '~/entities/euler/labels'
 import { useCustomFilters } from '~/composables/useCustomFilters'
 import { useVaultSearch } from '~/composables/useVaultSearch'
@@ -31,14 +31,17 @@ const { getBalance } = useWallets()
 
 const { enableEntityBranding } = useDeployConfig()
 
-const { searchQuery, matchesSearch, clearSearch } = useVaultSearch<Vault>(vault => [
-  vault.asset.symbol,
-  vault.asset.name,
-  vault.name,
-  getVaultProductName(vault.address),
-  getProductByVault(vault.address).description,
-  ...getEntitiesByVault(vault).map(e => e.name),
-])
+const { searchQuery, matchesSearch, clearSearch } = useVaultSearch<Vault>((vault) => {
+  const product = applyVaultOverrides(getProductByVault(vault.address), vault.address)
+  return [
+    vault.asset.symbol,
+    vault.asset.name,
+    vault.name,
+    product.name,
+    product.description,
+    ...getEntitiesByVault(vault).map(e => e.name),
+  ]
+})
 
 const selectedCollateral = ref<string[]>([])
 const selectedMarkets = ref<string[]>([])

--- a/pages/lend/index.vue
+++ b/pages/lend/index.vue
@@ -6,7 +6,7 @@ import { getAssetLogoUrl } from '~/composables/useTokenList'
 import { getVaultUtilization } from '~/entities/vault'
 import type { Vault } from '~/entities/vault'
 import { getAssetUsdValueOrZero } from '~/services/pricing/priceProvider'
-import { getProductByVault, getEntitiesByVault, isVaultFeatured, isVaultDeprecated, isVaultNotExplorableLend } from '~/utils/eulerLabelsUtils'
+import { getProductByVault, getVaultProductName, getEntitiesByVault, isVaultFeatured, isVaultDeprecated, isVaultNotExplorableLend } from '~/utils/eulerLabelsUtils'
 import { getEulerLabelEntityLogo } from '~/entities/euler/labels'
 import { useCustomFilters } from '~/composables/useCustomFilters'
 import { useVaultSearch } from '~/composables/useVaultSearch'
@@ -35,7 +35,7 @@ const { searchQuery, matchesSearch, clearSearch } = useVaultSearch<Vault>(vault 
   vault.asset.symbol,
   vault.asset.name,
   vault.name,
-  getProductByVault(vault.address).name,
+  getVaultProductName(vault.address),
   getProductByVault(vault.address).description,
   ...getEntitiesByVault(vault).map(e => e.name),
 ])

--- a/utils/collateralOptions.ts
+++ b/utils/collateralOptions.ts
@@ -1,4 +1,4 @@
-import { getProductByVault } from '~/utils/eulerLabelsUtils'
+import { getVaultProductName } from '~/utils/eulerLabelsUtils'
 import { getVaultTags, type VaultTagContext } from '~/composables/useGeoBlock'
 import type { CollateralOption, Vault } from '~/entities/vault'
 import { getAssetUsdValueOrZero } from '~/services/pricing/priceProvider'
@@ -31,7 +31,6 @@ export async function buildCollateralOption(params: {
   tagContext: VaultTagContext
 }): Promise<CollateralOption> {
   const { vault, type, amount, priceAmount, apy, tagContext } = params
-  const product = getProductByVault(vault.address)
   const { tags, disabled } = getVaultTags(vault.address, tagContext)
 
   return {
@@ -41,7 +40,7 @@ export async function buildCollateralOption(params: {
     apy,
     symbol: vault.asset.symbol,
     assetAddress: vault.asset.address,
-    label: product.name || vault.name,
+    label: getVaultProductName(vault.address) || vault.name,
     vaultAddress: vault.address,
     tags,
     disabled,

--- a/utils/eulerLabelsUtils.ts
+++ b/utils/eulerLabelsUtils.ts
@@ -316,7 +316,6 @@ export const applyVaultOverrides = (product: EulerLabelProduct, vaultAddress: st
 }
 
 export const getVaultProductName = (vaultAddress: string): string => {
-  const normalized = normalizeAddress(vaultAddress)
-  const product = getProductByVault(normalized)
-  return product.vaultOverrides?.[normalized]?.name ?? product.name
+  const product = getProductByVault(vaultAddress)
+  return applyVaultOverrides(product, vaultAddress).name
 }

--- a/utils/eulerLabelsUtils.ts
+++ b/utils/eulerLabelsUtils.ts
@@ -45,6 +45,7 @@ export const extractVaultOverrides = (raw: Record<string, unknown>): Record<stri
     if (!key.startsWith('0x') || typeof value !== 'object' || value === null) continue
     const entry = value as Record<string, unknown>
     const override: EulerLabelVaultOverride = {}
+    if (typeof entry.name === 'string') override.name = entry.name
     if (typeof entry.description === 'string') override.description = entry.description
     if (typeof entry.portfolioNotice === 'string') override.portfolioNotice = entry.portfolioNotice
     const reason = entry.deprecationReason ?? entry.deprecateReason
@@ -307,8 +308,15 @@ export const applyVaultOverrides = (product: EulerLabelProduct, vaultAddress: st
   if (!override) return product
   return {
     ...product,
+    ...(override.name !== undefined && { name: override.name }),
     ...(override.description !== undefined && { description: override.description }),
     ...(override.portfolioNotice !== undefined && { portfolioNotice: override.portfolioNotice }),
     ...(override.deprecationReason !== undefined && { deprecationReason: override.deprecationReason }),
   }
+}
+
+export const getVaultProductName = (vaultAddress: string): string => {
+  const normalized = normalizeAddress(vaultAddress)
+  const product = getProductByVault(normalized)
+  return product.vaultOverrides?.[normalized]?.name ?? product.name
 }


### PR DESCRIPTION
## Summary

- Adds optional `name` field to `EulerLabelVaultOverride` so individual vaults can override their product display name
- Propagates the override through `applyVaultOverrides()` (covers all `useEulerProductOfVault()` consumers) and adds `getVaultProductName()` helper for direct call sites
- Updated 7 call sites: search terms (explore, lend, earn, borrow pages), collateral options, repay savings labels, and choose collateral modal

## Test plan

- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes (no new errors)
- [ ] Set a vault override with `"name": "Custom Name"` in labels and verify it displays in vault list items, overview pages, collateral modals, portfolio items, and search results
- [ ] Verify market filter dropdowns still group by original product name (not overridden)