### PR TITLE
fix: show unknown capital allocator for unverified earn vaults

### DIFF
--- a/composables/useVaults.ts
+++ b/composables/useVaults.ts
@@ -694,6 +694,10 @@ export const useVaults = () => {
   const isEarnVaultOwnerVerified = (earnVault: EarnVault): boolean => {
     const { entities } = useEulerLabels()
 
+    if (!earnVault.verified) {
+      return false
+    }
+
     const product = getProductByVault(earnVault.address)
     if (!product.name) {
       return true


### PR DESCRIPTION
## Summary
- Earn vault capital allocator now shows "Unknown" for unverified vaults, matching the behavior of EVK and Securitize vault risk manager display
- `isEarnVaultOwnerVerified` was returning `true` for unlabeled vaults, causing entity names to leak through even when the vault itself is unknown

## Test plan
- [ ] Open an earn vault page for a vault NOT in the labels set — capital allocator should show "Unknown"
- [ ] Open an earn vault page for a known/labeled vault — capital allocator should show the entity name as before
- [ ] Verify EVK and Securitize vault risk manager display remains unchanged