### PR TITLE
fix: close planned ops hook-check gaps in swap repay and multiply

### DIFF
--- a/composables/borrow/useMultiplyForm.ts
+++ b/composables/borrow/useMultiplyForm.ts
@@ -560,9 +560,7 @@ export const useMultiplyForm = (options: UseMultiplyFormOptions) => {
       })
     }
     if (multiplyShortVault.value) steps.push({ vault: multiplyShortVault.value, op: OP_BORROW })
-    const isSameVault = multiplySupplyVault.value && multiplyLongVault.value
-      && normalizeAddress(multiplySupplyVault.value.address) === normalizeAddress(multiplyLongVault.value.address)
-    if (multiplyLongVault.value && !isSameVault) {
+    if (multiplyLongVault.value) {
       if (multiplySelectedQuote.value) {
         // Cross-asset: verifyAmountMinAndSkim calls skim() on the long vault
         steps.push({ vault: multiplyLongVault.value, op: OP_SKIM })

--- a/composables/repay/useWalletSwapRepay.ts
+++ b/composables/repay/useWalletSwapRepay.ts
@@ -70,6 +70,7 @@ export const useWalletSwapRepay = (options: UseWalletSwapRepayOptions) => {
   const { isConnected, address } = useAccount()
   const { fetchSingleBalance } = useWallets()
   const { slippage } = useSlippage()
+  const { getVault: registryGetVault } = useVaultRegistry()
 
   // --- State ---
   const selectedAsset = ref<VaultAsset | undefined>()
@@ -211,8 +212,12 @@ export const useWalletSwapRepay = (options: UseWalletSwapRepayOptions) => {
   const walletSwapRepayPlannedOps = computed<PlannedOp[]>(() => {
     const steps: PlannedOp[] = []
     if (borrowVault.value) steps.push({ vault: borrowVault.value, op: OP_REPAY })
-    if (isFullRepay.value && collateralVault.value) {
-      steps.push({ vault: collateralVault.value as Vault, op: OP_TRANSFER })
+    if (isFullRepay.value) {
+      const collAddrs = position.value?.collaterals ?? (collateralVault.value ? [collateralVault.value.address] : [])
+      for (const addr of collAddrs) {
+        const v = registryGetVault(addr) as Vault | undefined
+        if (v) steps.push({ vault: v, op: OP_TRANSFER })
+      }
     }
     return steps
   })


### PR DESCRIPTION
- useWalletSwapRepay: check OP_TRANSFER on all enabled collaterals during full repay, not just the primary (matching useWalletRepay and useSavingsRepay)
- useMultiplyForm: remove isSameVault guard so OP_SKIM is checked on the long vault even when supply vault == long vault, which is the default multiply path