### PR TITLE
fix: prevent infinite loading on explore page when no vaults match

### DIFF
--- a/pages/explore/[market].vue
+++ b/pages/explore/[market].vue
@@ -13,7 +13,7 @@ const { isEVKUpdating, isEarnUpdating, isSecuritizeUpdating, isEscrowUpdating } 
 
 const isLoading = computed(() =>
   isEVKUpdating.value || isEarnUpdating.value || isSecuritizeUpdating.value || isEscrowUpdating.value
-  || isResolvingTVL.value || marketGroups.value.length === 0,
+  || isResolvingTVL.value,
 )
 
 const market = computed(() =>

--- a/pages/explore/index.vue
+++ b/pages/explore/index.vue
@@ -264,8 +264,7 @@ const sortedMarkets = computed(() => {
 
 const isLoading = computed(() =>
   isEVKUpdating.value || isEarnUpdating.value || isSecuritizeUpdating.value || isEscrowUpdating.value
-  || (isResolvingTVL.value && marketGroups.value.length === 0)
-  || marketGroups.value.length === 0,
+  || isResolvingTVL.value,
 )
 const { isSlow } = useSlowLoading(isLoading)
 </script>


### PR DESCRIPTION
## Summary
- Remove `marketGroups.value.length === 0` from the `isLoading` computed on both explore pages
- When all vaults are non-explorable/deprecated, `marketGroups` is legitimately empty — the empty state should render instead of an infinite spinner
- The `isUpdating` flags and `isResolvingTVL` already correctly cover the loading period

## Test plan
- [ ] Switch to a chain where all products are non-explorable/deprecated and verify the empty state shows instead of infinite spinner
- [ ] Verify normal explore page loading still works (spinner shows during fetch, then results appear)
- [ ] Verify `/explore/[market]` page still loads correctly for valid markets
- [ ] Verify `/explore/[market]` page shows 'Market not found' for invalid markets instead of infinite spinner

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading state behavior on market explore pages, allowing "not found" messages to display immediately instead of showing a loading indicator when no markets are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->