### PR TITLE
fix: set cache-control headers to prevent stale HTML after deploys

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -166,6 +166,10 @@ export default defineNuxtConfig({
   nitro: {
     compressPublicAssets: true,
     esbuild: { options: { target: 'esnext' } },
+    routeRules: {
+      '/_nuxt/**': { headers: { 'Cache-Control': 'public, max-age=31536000, immutable' } },
+      '/**': { headers: { 'Cache-Control': 'no-store' } },
+    },
   },
 
   vite: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * HTTP caching headers now configured to differentiate between static and dynamic content. Build assets include immutable, long-term cache control directives. All other routes use no-store cache control headers to prevent unintended caching of dynamic content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->