### PR TITLE
fix: resolve infinite loading for not-explorable earn vaults

### DIFF
--- a/composables/useDeployConfig.ts
+++ b/composables/useDeployConfig.ts
@@ -30,14 +30,6 @@ export const useDeployConfig = () => {
     labelsRepo: rc.configLabelsRepo || 'euler-xyz/euler-labels',
     labelsRepoBranch: rc.configLabelsRepoBranch || 'master',
     labelsBaseUrl,
-    isCustomLabelsRepo: computed(() => {
-      if (labelsBaseUrl) {
-        return !labelsBaseUrl.includes('master')
-      }
-      const repo = rc.configLabelsRepo || 'euler-xyz/euler-labels'
-      const branch = rc.configLabelsRepoBranch || 'master'
-      return repo !== 'euler-xyz/euler-labels' || branch !== 'master'
-    }),
 
     // Feature flags: all enabled by default, set env var to 'false' to disable
     enableTosSignature: !!rc.configTosMdUrl,

--- a/composables/useVaults.ts
+++ b/composables/useVaults.ts
@@ -413,36 +413,20 @@ const getVault = async (address: string): Promise<Vault> => {
   return registryGetVault(normalizedAddress) as Vault
 }
 const getEarnVault = async (address: string): Promise<EarnVault> => {
-  const { getEarnVaults, getVault: registryGetVault, set: registrySet } = useVaultRegistry()
+  const { getVault: registryGetVault, set: registrySet } = useVaultRegistry()
   const normalizedAddress = getAddress(address)
+  const { earnVaults } = useEulerLabels()
 
-  // For custom labels repo, skip waiting and fetch directly
-  const { isCustomLabelsRepo } = useDeployConfig()
-  if (isCustomLabelsRepo.value) {
-    const { earnVaults } = useEulerLabels()
-
-    if (earnVaults.value.includes(normalizedAddress) && !isEarnVaultNotExplorable(normalizedAddress)) {
-      await until(computed(() => registryGetVault(normalizedAddress))).toBeTruthy()
-    }
-    else {
-      const vault = await fetchEarnVault(normalizedAddress)
-      registrySet(normalizedAddress, vault, 'earn')
-      return vault
-    }
+  if (earnVaults.value.includes(normalizedAddress) && !isEarnVaultNotExplorable(normalizedAddress)) {
+    await until(computed(() => registryGetVault(normalizedAddress))).toBeTruthy()
   }
   else {
-    // Wait for earn vaults to be loaded from governed perspective
-    await until(computed(() => getEarnVaults().length > 0)).toBeTruthy()
+    const vault = await fetchEarnVault(normalizedAddress)
+    registrySet(normalizedAddress, vault, 'earn')
+    return vault
   }
 
-  const existingVault = registryGetVault(normalizedAddress)
-  if (existingVault) {
-    return existingVault as EarnVault
-  }
-
-  const vault = await fetchEarnVault(normalizedAddress)
-  registrySet(normalizedAddress, vault, 'earn')
-  return vault
+  return registryGetVault(normalizedAddress) as EarnVault
 }
 const updateVault = async (vaultAddress: string): Promise<Vault | SecuritizeVault> => {
   const { set: registrySet, isKnownEscrowAddress, getType } = useVaultRegistry()

--- a/docs/vault-labels-and-verification.md
+++ b/docs/vault-labels-and-verification.md
@@ -215,8 +215,6 @@ Structure: `Array<string | EarnVaultEntry>` — each entry is either a plain add
 | `description` | `string` | No | Custom description displayed on earn vault items and overview pages |
 | `portfolioNotice` | `string` | No | Operational notice shown on portfolio position cards. Supports auto-linked URLs and **bold** formatting. |
 
-**Note**: This file is optional. If missing, earn vaults are loaded from the `eulerEarnGovernedPerspective` on-chain contract instead.
-
 ---
 
 ### Oracle Adapter Files (oracle-checks repo)


### PR DESCRIPTION
## Summary
- `getEarnVault` awaited any earn vault to appear in the registry (`getEarnVaults().length > 0`), which hangs forever when all earn vaults on a chain are marked `notExplorable` (e.g. Arbitrum with only the deprecated Resolv vault)
- Mirrors the EVK `getVault` pattern: wait for the specific vault in the registry when explorable, otherwise fetch directly
- Removes stale `isCustomLabelsRepo` branching — earn vaults are sourced from labels in all deployments, the governed perspective path no longer exists
- Removes unused `isCustomLabelsRepo` from `useDeployConfig`

## Test plan
- [ ] Navigate directly to a not-explorable earn vault URL (e.g. `/earn/0xe4783824593a50Bfe9dc873204CEc171ebC62dE0/?network=42161`) — should load instead of spinning
- [ ] Navigate to an explorable earn vault — should still load normally
- [ ] Verify earn vault list on explore/earn pages is unaffected