### PR TITLE
fix: align hook warning icon with badges in earn exposure rows & sync with master

### DIFF
--- a/components/entities/vault/VaultLabelsAndAssets.vue
+++ b/components/entities/vault/VaultLabelsAndAssets.vue
@@ -131,6 +131,7 @@ const displayAssetsLabel = computed(() => assetsLabel || assets.map(asset => ass
           />
           Restricted
         </span>
+        <slot />
       </div>
 
       <p class="text-p2 font-semibold text-content-primary">

--- a/components/entities/vault/overview/earn/VaultOverviewEarnBlockExposure.vue
+++ b/components/entities/vault/overview/earn/VaultOverviewEarnBlockExposure.vue
@@ -187,23 +187,22 @@ load()
           class="px-16 pt-16 pb-12 border-b border-line-subtle flex items-center justify-between"
         >
           <template v-if="row.vault">
-            <div class="flex items-center gap-8 min-w-0">
-              <VaultLabelsAndAssets
-                :vault="row.vault"
-                :assets="[{
-                  address: row.exposure.info.asset,
-                  decimals: row.exposure.info.assetDecimals,
-                  name: row.exposure.info.assetName,
-                  symbol: row.exposure.info.assetSymbol,
-                }]"
-              />
+            <VaultLabelsAndAssets
+              :vault="row.vault"
+              :assets="[{
+                address: row.exposure.info.asset,
+                decimals: row.exposure.info.assetDecimals,
+                name: row.exposure.info.assetName,
+                symbol: row.exposure.info.assetSymbol,
+              }]"
+            >
               <span
                 v-if="row.hookWarning"
                 @click.stop.prevent
               >
                 <VaultWarningIcon :warning="row.hookWarning" />
               </span>
-            </div>
+            </VaultLabelsAndAssets>
           </template>
           <template v-else>
             <div class="flex items-center gap-12">

--- a/composables/useDeployConfig.ts
+++ b/composables/useDeployConfig.ts
@@ -30,14 +30,6 @@ export const useDeployConfig = () => {
     labelsRepo: rc.configLabelsRepo || 'euler-xyz/euler-labels',
     labelsRepoBranch: rc.configLabelsRepoBranch || 'master',
     labelsBaseUrl,
-    isCustomLabelsRepo: computed(() => {
-      if (labelsBaseUrl) {
-        return !labelsBaseUrl.includes('master')
-      }
-      const repo = rc.configLabelsRepo || 'euler-xyz/euler-labels'
-      const branch = rc.configLabelsRepoBranch || 'master'
-      return repo !== 'euler-xyz/euler-labels' || branch !== 'master'
-    }),
 
     // Feature flags: all enabled by default, set env var to 'false' to disable
     enableTosSignature: !!rc.configTosMdUrl,

--- a/composables/useVaults.ts
+++ b/composables/useVaults.ts
@@ -413,36 +413,20 @@ const getVault = async (address: string): Promise<Vault> => {
   return registryGetVault(normalizedAddress) as Vault
 }
 const getEarnVault = async (address: string): Promise<EarnVault> => {
-  const { getEarnVaults, getVault: registryGetVault, set: registrySet } = useVaultRegistry()
+  const { getVault: registryGetVault, set: registrySet } = useVaultRegistry()
   const normalizedAddress = getAddress(address)
+  const { earnVaults } = useEulerLabels()
 
-  // For custom labels repo, skip waiting and fetch directly
-  const { isCustomLabelsRepo } = useDeployConfig()
-  if (isCustomLabelsRepo.value) {
-    const { earnVaults } = useEulerLabels()
-
-    if (earnVaults.value.includes(normalizedAddress) && !isEarnVaultNotExplorable(normalizedAddress)) {
-      await until(computed(() => registryGetVault(normalizedAddress))).toBeTruthy()
-    }
-    else {
-      const vault = await fetchEarnVault(normalizedAddress)
-      registrySet(normalizedAddress, vault, 'earn')
-      return vault
-    }
+  if (earnVaults.value.includes(normalizedAddress) && !isEarnVaultNotExplorable(normalizedAddress)) {
+    await until(computed(() => registryGetVault(normalizedAddress))).toBeTruthy()
   }
   else {
-    // Wait for earn vaults to be loaded from governed perspective
-    await until(computed(() => getEarnVaults().length > 0)).toBeTruthy()
+    const vault = await fetchEarnVault(normalizedAddress)
+    registrySet(normalizedAddress, vault, 'earn')
+    return vault
   }
 
-  const existingVault = registryGetVault(normalizedAddress)
-  if (existingVault) {
-    return existingVault as EarnVault
-  }
-
-  const vault = await fetchEarnVault(normalizedAddress)
-  registrySet(normalizedAddress, vault, 'earn')
-  return vault
+  return registryGetVault(normalizedAddress) as EarnVault
 }
 const updateVault = async (vaultAddress: string): Promise<Vault | SecuritizeVault> => {
   const { set: registrySet, isKnownEscrowAddress, getType } = useVaultRegistry()

--- a/docs/vault-labels-and-verification.md
+++ b/docs/vault-labels-and-verification.md
@@ -215,8 +215,6 @@ Structure: `Array<string | EarnVaultEntry>` — each entry is either a plain add
 | `description` | `string` | No | Custom description displayed on earn vault items and overview pages |
 | `portfolioNotice` | `string` | No | Operational notice shown on portfolio position cards. Supports auto-linked URLs and **bold** formatting. |
 
-**Note**: This file is optional. If missing, earn vaults are loaded from the `eulerEarnGovernedPerspective` on-chain contract instead.
-
 ---
 
 ### Oracle Adapter Files (oracle-checks repo)

--- a/pages/explore/[market].vue
+++ b/pages/explore/[market].vue
@@ -13,7 +13,7 @@ const { isEVKUpdating, isEarnUpdating, isSecuritizeUpdating, isEscrowUpdating } 
 
 const isLoading = computed(() =>
   isEVKUpdating.value || isEarnUpdating.value || isSecuritizeUpdating.value || isEscrowUpdating.value
-  || isResolvingTVL.value || marketGroups.value.length === 0,
+  || isResolvingTVL.value,
 )
 
 const market = computed(() =>

--- a/pages/explore/index.vue
+++ b/pages/explore/index.vue
@@ -264,8 +264,7 @@ const sortedMarkets = computed(() => {
 
 const isLoading = computed(() =>
   isEVKUpdating.value || isEarnUpdating.value || isSecuritizeUpdating.value || isEscrowUpdating.value
-  || (isResolvingTVL.value && marketGroups.value.length === 0)
-  || marketGroups.value.length === 0,
+  || isResolvingTVL.value,
 )
 const { isSlow } = useSlowLoading(isLoading)
 </script>


### PR DESCRIPTION
## Summary
- VaultWarningIcon in earn vault exposure rows was vertically centered against the full VaultLabelsAndAssets block, causing it to float between the name and asset rows
- Added a default slot to VaultLabelsAndAssets so extra inline content renders in the badges row (alongside Deprecated/Restricted badges)
- Moved the hook warning icon into that slot so it aligns on the same line as the vault name and badges

## Test plan
- [ ] Navigate to a deprecated earn vault with hooked strategies (e.g. Euler Arbitrum Yield on Arbitrum)
- [ ] Verify the hook warning icon sits inline with the "Deprecated" badge, not floating between rows
- [ ] Verify other pages using VaultLabelsAndAssets are unaffected (lend vault pages, borrow pages, portfolio)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed page navigation on market exploration pages when fetching market data.

* **Refactor**
  * Simplified vault label verification and initialization logic.
  * Improved earn vault loading and caching mechanism.
  * Enhanced vault header component structure for better content flexibility.

* **Documentation**
  * Updated vault label verification documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->