### PR TITLE
fix: portfolio refresh after tx + reduce allowance slot probing

### DIFF
--- a/composables/useEulerOperations/execution.ts
+++ b/composables/useEulerOperations/execution.ts
@@ -49,6 +49,7 @@ export const createExecutionHelpers = (ctx: OperationsContext, allowanceHelpers:
     }
 
     triggerPortfolioRefresh()
+    setTimeout(triggerPortfolioRefresh, 5000)
     return lastHash
   }
 

--- a/entities/constants.ts
+++ b/entities/constants.ts
@@ -66,9 +66,10 @@ export const ETH_ADDRESS: Address = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'
 // ERC-20 allowance slot candidates checked during simulation state-override probing.
 // Sequential range (0..ALLOWANCE_MAX_SEQUENTIAL_SLOT) covers standard ERC-20 layouts
 // and OZ Upgradeable tokens where inherited contracts shift the base slot index.
-// ALLOWANCE_EXTRA_SLOT_CANDIDATES holds non-sequential slots (e.g. ERC-7201 namespaced
-// storage for OpenZeppelin 5.x). Add entries there for any exotic token layouts.
-export const ALLOWANCE_MAX_SEQUENTIAL_SLOT = 500
+// Tokens using unstructured/namespaced storage (ERC-7201) won't be found by sequential
+// probing — simulation falls back to the non-blocking error path for those.
+// ALLOWANCE_EXTRA_SLOT_CANDIDATES holds non-sequential slots for known exotic layouts.
+export const ALLOWANCE_MAX_SEQUENTIAL_SLOT = 20
 export const ALLOWANCE_EXTRA_SLOT_CANDIDATES: bigint[] = []
 export const PERMIT2_SIG_WINDOW = 60n * 60n
 

--- a/pages/portfolio.vue
+++ b/pages/portfolio.vue
@@ -63,10 +63,8 @@ const updatePositions = async () => {
 }
 
 watch(tabsModel, checkTab, { immediate: true })
-const isActive = ref(false)
 
 onActivated(async () => {
-  isActive.value = true
   checkTab()
   await updateBalances()
   updatePositions()
@@ -74,7 +72,6 @@ onActivated(async () => {
   interval.value = setInterval(updatePositions, POLL_INTERVAL_30S_MS)
 })
 onDeactivated(() => {
-  isActive.value = false
   if (interval.value) {
     clearInterval(interval.value)
     interval.value = null
@@ -82,9 +79,7 @@ onDeactivated(() => {
 })
 
 watch(portfolioRefreshCounter, () => {
-  if (isActive.value) {
-    updatePositions()
-  }
+  updatePositions()
 })
 </script>
 


### PR DESCRIPTION
## Summary
- **Portfolio refresh**: add 5s delayed retry after tx confirmation to handle subgraph indexing lag. Remove the `isActive` guard from the counter watcher (event-driven, not polling) so it fires regardless of page state.
- **Allowance probing**: reduce `ALLOWANCE_MAX_SEQUENTIAL_SLOT` from 500 to 20. Tokens using unstructured storage (ERC-7201) won't be found by sequential probing anyway — simulation already falls back to the non-blocking error path for those.

## Test plan
- [x] Verified portfolio shows updated positions within ~5s after tx (previously required 30s poll)
- [ ] Verify supply flow with standard tokens (low slot index) still simulates correctly
- [ ] Verify supply flow with exotic tokens (e.g. weETH) no longer spams hundreds of RPC calls

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed loading indicators on explore pages to accurately reflect data sync status rather than empty states.
  * Improved portfolio refresh timing to ensure consistent updates.

* **Improvements**
  * Optimized vault discovery and allowance detection mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->