### PR TITLE
feat: support legacy URL redirects from app.euler.finance

### DIFF
--- a/composables/useWagmi.ts
+++ b/composables/useWagmi.ts
@@ -3,6 +3,7 @@ import { formatUnits, getAddress, isAddress, type Address } from 'viem'
 import { logWarn } from '~/utils/errorHandling'
 import { truncate } from '~/utils/string-utils'
 import { useAddressScreen } from '~/composables/useAddressScreen'
+import { parseChainId } from '~/entities/chainRegistry'
 
 let isChangingChain = false
 let chainChangeCooldownUntil = 0
@@ -15,17 +16,6 @@ const routeNetworkId: Ref<number | null> = ref(null)
 
 let cachedWagmiData: ReturnType<typeof initializeWagmi> | null = null
 let watchersInitialized = false
-
-const parseChainId = (value: unknown): number | null => {
-  const normalized = Array.isArray(value) ? value[0] : value
-  const parsed = typeof normalized === 'string'
-    ? Number.parseInt(normalized, 10)
-    : typeof normalized === 'number'
-      ? normalized
-      : NaN
-
-  return Number.isFinite(parsed) ? parsed : null
-}
 
 function initializeWagmi() {
   const { address: wagmiAddress, isConnected: wagmiIsConnected, connector, chain: wagmiChain, status } = useAccount()

--- a/entities/chainRegistry.ts
+++ b/entities/chainRegistry.ts
@@ -26,10 +26,18 @@ for (const [key, chain] of Object.entries(allChains)) {
   }
 }
 
+// Aliases for legacy slugs that don't match the viem export key or chain name.
+// Add here whenever a legacy URL surfaces that isn't auto-resolved.
+const LEGACY_CHAIN_ALIASES: ReadonlyMap<string, number> = new Map([
+  ['arbitrumone', 42161],
+  ['bnbsmartchain', 56],
+  ['lineamainnet', 59144],
+])
+
 export const getChainIdByName = (name: string): number | undefined => {
   const normalized = name.trim().toLowerCase().replace(/\s+/g, '-')
   if (!normalized) return undefined
-  return nameToChainId.get(normalized)
+  return LEGACY_CHAIN_ALIASES.get(normalized) ?? nameToChainId.get(normalized)
 }
 
 export const parseChainId = (value: unknown): number | null => {

--- a/entities/chainRegistry.ts
+++ b/entities/chainRegistry.ts
@@ -1,11 +1,54 @@
 import * as allChains from '@reown/appkit/networks'
 import type { AppKitNetwork } from '@reown/appkit/networks'
 
+const isAppKitNetwork = (v: unknown): v is AppKitNetwork =>
+  v != null && typeof v === 'object' && 'id' in v && typeof (v as { id: unknown }).id === 'number'
+
 const chainMap = new Map<number, AppKitNetwork>(
   (Object.values(allChains) as unknown[])
-    .filter((v): v is AppKitNetwork => v != null && typeof v === 'object' && 'id' in v)
+    .filter(isAppKitNetwork)
     .map((chain): [number, AppKitNetwork] => [chain.id as number, chain]),
 )
+
+// Reverse lookup: chain slug → chainId. Built from both the export key
+// (e.g. `monad`, `swellchain`) and the chain's `name` field (e.g. `Monad`,
+// `Swellchain`) — both lowercased. Used to redirect legacy URLs that pass
+// a chain name in the `network` query param (e.g. `?network=monad`) to the
+// canonical numeric chainId.
+const nameToChainId = new Map<string, number>()
+for (const [key, chain] of Object.entries(allChains)) {
+  if (!isAppKitNetwork(chain)) continue
+  const id = chain.id as number
+  nameToChainId.set(key.toLowerCase(), id)
+  if (typeof chain.name === 'string') {
+    const nameSlug = chain.name.toLowerCase().replace(/\s+/g, '-')
+    if (!nameToChainId.has(nameSlug)) nameToChainId.set(nameSlug, id)
+  }
+}
+
+export const getChainIdByName = (name: string): number | undefined => {
+  const normalized = name.trim().toLowerCase()
+  if (!normalized) return undefined
+  return nameToChainId.get(normalized)
+}
+
+export const parseChainId = (value: unknown): number | null => {
+  const normalized = Array.isArray(value) ? value[0] : value
+  if (normalized == null) return null
+
+  if (typeof normalized === 'number') {
+    return Number.isFinite(normalized) ? normalized : null
+  }
+
+  if (typeof normalized !== 'string') return null
+
+  const parsed = Number.parseInt(normalized, 10)
+  if (Number.isFinite(parsed) && String(parsed) === normalized.trim()) {
+    return parsed
+  }
+
+  return getChainIdByName(normalized) ?? null
+}
 
 export const getNetworksByChainIds = (ids: readonly number[]): AppKitNetwork[] =>
   ids.map((id) => {

--- a/entities/chainRegistry.ts
+++ b/entities/chainRegistry.ts
@@ -27,7 +27,7 @@ for (const [key, chain] of Object.entries(allChains)) {
 }
 
 export const getChainIdByName = (name: string): number | undefined => {
-  const normalized = name.trim().toLowerCase()
+  const normalized = name.trim().toLowerCase().replace(/\s+/g, '-')
   if (!normalized) return undefined
   return nameToChainId.get(normalized)
 }

--- a/middleware/01.network.global.ts
+++ b/middleware/01.network.global.ts
@@ -1,12 +1,23 @@
-const parseChainId = (value: unknown): number | null => {
-  const normalized = Array.isArray(value) ? value[0] : value
-  const parsed = typeof normalized === 'string'
-    ? Number.parseInt(normalized, 10)
-    : typeof normalized === 'number'
-      ? normalized
-      : NaN
+import { parseChainId } from '~/entities/chainRegistry'
 
-  return Number.isFinite(parsed) ? parsed : null
+const rawNetworkParam = (value: unknown): string | null => {
+  const normalized = Array.isArray(value) ? value[0] : value
+  return typeof normalized === 'string' ? normalized : null
+}
+
+// Legacy path rewrites from the pre-lite app. Preserves any trailing segments
+// (e.g. vault/collateral addresses) after the renamed prefix.
+const LEGACY_PATH_REWRITES: ReadonlyArray<{ from: RegExp, to: string }> = [
+  { from: /^\/vault(\/.*)?$/, to: '/lend' },
+  { from: /^\/positions(\/.*)?$/, to: '/borrow' },
+]
+
+const rewriteLegacyPath = (path: string): string | null => {
+  for (const { from, to } of LEGACY_PATH_REWRITES) {
+    const match = path.match(from)
+    if (match) return to + (match[1] ?? '')
+  }
+  return null
 }
 
 export default defineNuxtRouteMiddleware((to) => {
@@ -14,15 +25,31 @@ export default defineNuxtRouteMiddleware((to) => {
     return
   }
 
-  const { chainId } = useEulerAddresses()
+  const { chainId, changeCurrentChainId } = useEulerAddresses()
 
   const queryChainId = parseChainId(to.query.network)
   const savedChainId = parseChainId(localStorage.getItem('chainId'))
   const fallbackChainId = queryChainId ?? savedChainId ?? (chainId.value || 1)
 
-  if (!queryChainId || queryChainId !== fallbackChainId) {
+  const rawNetwork = rawNetworkParam(to.query.network)
+  const needsNormalization = queryChainId != null && rawNetwork !== String(queryChainId)
+  const rewrittenPath = rewriteLegacyPath(to.path)
+
+  // Sync state chainId to the URL's chainId before downstream middleware
+  // (e.g. ensure-vault) runs chain-scoped lookups. Without this, a legacy URL
+  // like /vault/0x…?network=monad would redirect to /lend/0x…?network=143 but
+  // ensure-vault would still try to resolve the vault on the previously-set
+  // chain (typically allowedChainIds[0]), fail, and bounce to the default page.
+  // changeCurrentChainId is a no-op if the target isn't in allowedChainIds or
+  // already matches. The wallet-level chain switch still happens via useWagmi's
+  // route.query.network watcher.
+  if (fallbackChainId) {
+    changeCurrentChainId(fallbackChainId)
+  }
+
+  if (rewrittenPath || !queryChainId || queryChainId !== fallbackChainId || needsNormalization) {
     return navigateTo({
-      path: to.path,
+      path: rewrittenPath ?? to.path,
       query: {
         ...to.query,
         network: fallbackChainId,

--- a/middleware/01.network.global.ts
+++ b/middleware/01.network.global.ts
@@ -45,6 +45,7 @@ export default defineNuxtRouteMiddleware((to) => {
   // route.query.network watcher.
   if (fallbackChainId) {
     changeCurrentChainId(fallbackChainId)
+    localStorage.setItem('chainId', String(fallbackChainId))
   }
 
   if (rewrittenPath || !queryChainId || queryChainId !== fallbackChainId || needsNormalization) {

--- a/middleware/01.network.global.ts
+++ b/middleware/01.network.global.ts
@@ -55,6 +55,6 @@ export default defineNuxtRouteMiddleware((to) => {
         network: fallbackChainId,
       },
       hash: to.hash,
-    })
+    }, { replace: true })
   }
 })

--- a/middleware/ensure-vault.global.ts
+++ b/middleware/ensure-vault.global.ts
@@ -2,19 +2,9 @@ import { getAddress } from 'viem'
 import { logWarn } from '~/utils/errorHandling'
 import { useToast } from '~/components/ui/composables/useToast'
 import { getDefaultPageRoute } from '~/entities/menu'
+import { parseChainId } from '~/entities/chainRegistry'
 
 const normalizeParam = (value: unknown) => (Array.isArray(value) ? value[0] : value)
-
-const parseChainId = (value: unknown): number | null => {
-  const normalized = normalizeParam(value)
-  const parsed = typeof normalized === 'string'
-    ? Number.parseInt(normalized, 10)
-    : typeof normalized === 'number'
-      ? normalized
-      : NaN
-
-  return Number.isFinite(parsed) ? parsed : null
-}
 
 const getDefaultRoute = () => {
   const { enableEarnPage, enableLendPage, enableExplorePage } = useDeployConfig()


### PR DESCRIPTION
- rewrite /vault → /lend and /positions → /borrow path prefixes
- resolve ?network=<slug> to canonical numeric chain ID
- sync chain state before downstream middleware runs
- extract parseChainId to chainRegistry for shared use

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added automatic redirects for legacy vault and positions URLs to their new locations.
  * Improved network chain state synchronization when switching networks.

* **Enhancements**
  * Refined network parameter handling in URLs for better chain detection accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->