### PR TITLE
fix: make modal scrollbars visible across the app

### DIFF
--- a/assets/styles/main.scss
+++ b/assets/styles/main.scss
@@ -12,21 +12,28 @@ html {
 
 }
 
-// Page-level scrollbar — dark mode only, light mode uses browser default
+// Styled scrollbar — dark mode only, light mode uses browser default.
+// Applied to the page (html) and opt-in via the `.styled-scrollbar` class.
 html[data-theme="dark"] {
-  scrollbar-color: var(--neutral-400) var(--neutral-200);
+  &,
+  .styled-scrollbar {
+    scrollbar-color: var(--neutral-400) var(--neutral-200);
+  }
 
-  &::-webkit-scrollbar {
+  &::-webkit-scrollbar,
+  .styled-scrollbar::-webkit-scrollbar {
     width: 10px;
     height: 10px;
   }
 
-  &::-webkit-scrollbar-thumb {
+  &::-webkit-scrollbar-thumb,
+  .styled-scrollbar::-webkit-scrollbar-thumb {
     background-color: var(--neutral-400);
     border-radius: 9999px;
   }
 
-  &::-webkit-scrollbar-track {
+  &::-webkit-scrollbar-track,
+  .styled-scrollbar::-webkit-scrollbar-track {
     background-color: var(--neutral-200);
   }
 }

--- a/components/base/BaseModalWrapper.vue
+++ b/components/base/BaseModalWrapper.vue
@@ -154,7 +154,7 @@ const dragStyle = computed(() => ({
 
     <!-- Scroll container -->
     <div
-      class="flex flex-col overflow-auto overscroll-contain [scrollbar-width:none] [&::-webkit-scrollbar]:hidden px-16 pb-16"
+      class="flex flex-col overflow-x-hidden overflow-y-auto overscroll-contain styled-scrollbar px-16 pb-16"
       :class="[full ? 'flex-grow min-h-0' : '']"
       @touchstart="onScrollTouchStart"
       @touchmove="onScrollTouchMove"
@@ -163,7 +163,7 @@ const dragStyle = computed(() => ({
     >
       <div
         class="flex flex-col"
-        :class="[full ? 'flex-grow min-h-0 overflow-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden' : '']"
+        :class="[full ? 'flex-grow min-h-0 overflow-x-hidden overflow-y-auto styled-scrollbar' : '']"
       >
         <slot />
       </div>

--- a/components/base/BaseModalWrapper.vue
+++ b/components/base/BaseModalWrapper.vue
@@ -154,8 +154,8 @@ const dragStyle = computed(() => ({
 
     <!-- Scroll container -->
     <div
-      class="flex flex-col overflow-x-hidden overflow-y-auto overscroll-contain styled-scrollbar px-16 pb-16"
-      :class="[full ? 'flex-grow min-h-0' : '']"
+      class="flex flex-col overflow-x-hidden overscroll-contain px-16 pb-16"
+      :class="[full ? 'flex-grow min-h-0' : 'overflow-y-auto styled-scrollbar']"
       @touchstart="onScrollTouchStart"
       @touchmove="onScrollTouchMove"
       @touchend="onScrollTouchEnd"

--- a/components/entities/asset/SwapTokenSelector.vue
+++ b/components/entities/asset/SwapTokenSelector.vue
@@ -182,7 +182,7 @@ const handleSelectCustomToken = () => {
           clearable
         />
       </div>
-      <div class="flex-1 min-h-0 overflow-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+      <div class="flex-1 min-h-0 overflow-auto styled-scrollbar">
         <div
           v-for="opt in filteredOptions"
           :key="opt.asset.address"

--- a/components/entities/operation/AcknowledgeTermsModal.vue
+++ b/components/entities/operation/AcknowledgeTermsModal.vue
@@ -54,7 +54,7 @@ const onAccept = () => {
     title="Acknowledge terms"
     @close="onReject"
   >
-    <div class="flex flex-col gap-24 full flex-grow [scrollbar-width:none]">
+    <div class="flex flex-col gap-24 full flex-grow min-h-0 [scrollbar-width:none]">
       <div class="text-p3 text-content-secondary">
         By accessing or using Euler's products and services, I agree to the
         <a
@@ -78,7 +78,7 @@ const onAccept = () => {
         I further represent and warrant:
       </div>
 
-      <div class="bg-surface-secondary rounded-12 overflow-auto flex-1 [scrollbar-width:none]">
+      <div class="bg-surface-secondary rounded-12 overflow-y-auto flex-1 styled-scrollbar">
         <div
           v-for="(term, index) in terms"
           :key="index"

--- a/components/entities/operation/AcknowledgeTermsModal.vue
+++ b/components/entities/operation/AcknowledgeTermsModal.vue
@@ -54,7 +54,7 @@ const onAccept = () => {
     title="Acknowledge terms"
     @close="onReject"
   >
-    <div class="flex flex-col gap-24 full flex-grow min-h-0 [scrollbar-width:none]">
+    <div class="flex flex-col gap-24 full flex-grow min-h-0">
       <div class="text-p3 text-content-secondary">
         By accessing or using Euler's products and services, I agree to the
         <a

--- a/components/entities/reward/RewardUnlockConfirmModal.vue
+++ b/components/entities/reward/RewardUnlockConfirmModal.vue
@@ -26,7 +26,7 @@ const amountToBeBurned = computed(() => {
 
 <template>
   <div
-    class="flex flex-col absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 p-16 min-w-[375px] max-w-[600px] overflow-auto [scrollbar-width:none] max-h-[85dvh] rounded-16 mobile:top-auto mobile:left-0 mobile:bottom-0 mobile:w-full mobile:min-w-full mobile:max-h-[95dvh] mobile:translate-x-0 mobile:translate-y-0 mobile:rounded-t-16 mobile:rounded-b-0 bg-card [&::-webkit-scrollbar]:hidden"
+    class="flex flex-col absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 p-16 min-w-[375px] max-w-[600px] overflow-auto styled-scrollbar max-h-[85dvh] rounded-16 mobile:top-auto mobile:left-0 mobile:bottom-0 mobile:w-full mobile:min-w-full mobile:max-h-[95dvh] mobile:translate-x-0 mobile:translate-y-0 mobile:rounded-t-16 mobile:rounded-b-0 bg-card"
   >
     <div
       class="flex justify-between mb-12 items-center text-h3 h-36"

--- a/components/entities/vault/ChooseCollateralModal.vue
+++ b/components/entities/vault/ChooseCollateralModal.vue
@@ -64,7 +64,7 @@ const handleClose = () => {
         clearable
       />
     </div>
-    <div class="flex-1 overflow-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+    <div class="flex-1 overflow-auto styled-scrollbar">
       <div
         v-for="{ option, idx } in filteredOptions"
         :key="`options-${idx}`"

--- a/components/entities/vault/ChooseCollateralModal.vue
+++ b/components/entities/vault/ChooseCollateralModal.vue
@@ -64,7 +64,7 @@ const handleClose = () => {
         clearable
       />
     </div>
-    <div class="flex-1 overflow-auto styled-scrollbar">
+    <div class="flex-1 min-h-0 overflow-auto styled-scrollbar">
       <div
         v-for="{ option, idx } in filteredOptions"
         :key="`options-${idx}`"


### PR DESCRIPTION
Modals hid their scrollbars via [scrollbar-width:none] and [&::-webkit-scrollbar]:hidden, leaving no visual cue that content could be scrolled 

- Extract page scrollbar style into a reusable .styled-scrollbar utility in main.scss (dark-mode only, matches existing convention)
- Apply styled-scrollbar to BaseModalWrapper scroll containers so every modal using the wrapper gets the same scrollbar
- Apply to inner scroll containers in AcknowledgeTermsModal, ChooseCollateralModal, SwapTokenSelector, RewardUnlockConfirmModal
- Switch BaseModalWrapper scroll containers to overflow-x-hidden overflow-y-auto to prevent unwanted horizontal scrollbars from negative-margin children (e.g. VaultOverviewModal tabs)
- Add min-h-0 to AcknowledgeTermsModal outer flex column so the inner terms list scrolls locally rather than the whole modal