### PR TITLE
fix: blank portfolio content after toggling top-level pages

### DIFF
--- a/pages/portfolio.vue
+++ b/pages/portfolio.vue
@@ -30,7 +30,21 @@ const { isSpyMode, spyAddress } = useSpyMode()
 
 const interval: Ref<NodeJS.Timeout | null> = ref(null)
 
-const tabsModel = ref(route.name as string)
+// Drive the tab selection directly off the route so there is no stored state
+// to drift out of sync with the URL while PortfolioPage is kept-alive.
+// Initialising a separate ref and syncing it via `router.replace` in
+// `onActivated` queued a second nested navigation while the first inner
+// `<NuxtPage>` swap was still in flight. On prod (where child routes are
+// async-imported chunks) that produced a timing race with the `out-in` page
+// transition, leaving the inner slot empty.
+const tabsModel = computed<string>({
+  get: () => route.name as string,
+  set: (value) => {
+    if (route.name !== value) {
+      router.replace({ name: value })
+    }
+  },
+})
 
 const tabs = computed(() => [
   {
@@ -50,24 +64,16 @@ const tabs = computed(() => [
   },
 ])
 
-const checkTab = () => {
-  if (route.name !== tabsModel.value) {
-    router.replace({ name: tabsModel.value })
-  }
-}
-
 const updatePositions = async () => {
   const targetAddress = isSpyMode.value ? spyAddress.value : address.value
   if (!targetAddress) return
   await refreshAllPositions(eulerLensAddresses.value, targetAddress)
 }
 
-watch(tabsModel, checkTab, { immediate: true })
 const isActive = ref(false)
 
 onActivated(async () => {
   isActive.value = true
-  checkTab()
   await updateBalances()
   updatePositions()
   if (interval.value) clearInterval(interval.value)
@@ -232,6 +238,10 @@ watch(portfolioRefreshCounter, () => {
       :list="tabs"
     />
 
-    <NuxtPage />
+    <!-- transition disabled on the nested page: the global `mode: 'out-in'`
+         page transition (nuxt.config.ts) interacts poorly with keep-alive and
+         async-imported child chunks on prod, occasionally leaving the inner
+         slot empty when toggling between top-level pages. -->
+    <NuxtPage :transition="false" />
   </section>
 </template>


### PR DESCRIPTION
On prod, toggling Portfolio ↔ another top-level page could leave the inner <NuxtPage> slot empty below the tabs while the outer shell still rendered. Not reproducible on localhost — the race only exists under a production build, where child routes are async-imported chunks.

Root cause:

- `tabsModel` was a `ref` initialised from `route.name` inside `setup()`, which under keep-alive only runs on first mount. On re-activation after visiting a sub-tab, the ref was stale vs the URL and `onActivated` dispatched a `router.replace` to reconcile, queueing a second nested navigation while the first inner page swap was still in flight.
- The global `mode: 'out-in'` page transition also applies to the nested <NuxtPage>. Combined with async child imports in prod, the overlapping inner navigations could settle into a state where no child component was mounted in the slot.

Fix:

- Drive tab selection off `route.name` via a `computed` writable. No stored state, no redundant `router.replace` on activation.
- Disable the transition on the nested <NuxtPage> so inner navigations can't get stuck in an out-in cycle.

Side effect: returning to Portfolio from another top-level page now lands on Positions rather than the previously active sub-tab. Matches what the existing post-tx \`router.replace('/portfolio')\` redirects already intended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal state management for portfolio tab navigation to ensure URL synchronization.
  * Disabled page transitions in the portfolio section for a smoother navigation experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->