### PR TITLE
Fix/portfolio blank after tab switch

### DIFF
--- a/components/entities/vault/VaultLabelsAndAssets.vue
+++ b/components/entities/vault/VaultLabelsAndAssets.vue
@@ -131,6 +131,7 @@ const displayAssetsLabel = computed(() => assetsLabel || assets.map(asset => ass
           />
           Restricted
         </span>
+        <slot />
       </div>
 
       <p class="text-p2 font-semibold text-content-primary">

--- a/components/entities/vault/overview/earn/VaultOverviewEarnBlockExposure.vue
+++ b/components/entities/vault/overview/earn/VaultOverviewEarnBlockExposure.vue
@@ -187,23 +187,22 @@ load()
           class="px-16 pt-16 pb-12 border-b border-line-subtle flex items-center justify-between"
         >
           <template v-if="row.vault">
-            <div class="flex items-center gap-8 min-w-0">
-              <VaultLabelsAndAssets
-                :vault="row.vault"
-                :assets="[{
-                  address: row.exposure.info.asset,
-                  decimals: row.exposure.info.assetDecimals,
-                  name: row.exposure.info.assetName,
-                  symbol: row.exposure.info.assetSymbol,
-                }]"
-              />
+            <VaultLabelsAndAssets
+              :vault="row.vault"
+              :assets="[{
+                address: row.exposure.info.asset,
+                decimals: row.exposure.info.assetDecimals,
+                name: row.exposure.info.assetName,
+                symbol: row.exposure.info.assetSymbol,
+              }]"
+            >
               <span
                 v-if="row.hookWarning"
                 @click.stop.prevent
               >
                 <VaultWarningIcon :warning="row.hookWarning" />
               </span>
-            </div>
+            </VaultLabelsAndAssets>
           </template>
           <template v-else>
             <div class="flex items-center gap-12">

--- a/pages/portfolio.vue
+++ b/pages/portfolio.vue
@@ -30,7 +30,21 @@ const { isSpyMode, spyAddress } = useSpyMode()
 
 const interval: Ref<NodeJS.Timeout | null> = ref(null)
 
-const tabsModel = ref(route.name as string)
+// Drive the tab selection directly off the route so there is no stored state
+// to drift out of sync with the URL while PortfolioPage is kept-alive.
+// Initialising a separate ref and syncing it via `router.replace` in
+// `onActivated` queued a second nested navigation while the first inner
+// `<NuxtPage>` swap was still in flight. On prod (where child routes are
+// async-imported chunks) that produced a timing race with the `out-in` page
+// transition, leaving the inner slot empty.
+const tabsModel = computed<string>({
+  get: () => route.name as string,
+  set: (value) => {
+    if (route.name !== value) {
+      router.replace({ name: value })
+    }
+  },
+})
 
 const tabs = computed(() => [
   {
@@ -50,24 +64,16 @@ const tabs = computed(() => [
   },
 ])
 
-const checkTab = () => {
-  if (route.name !== tabsModel.value) {
-    router.replace({ name: tabsModel.value })
-  }
-}
-
 const updatePositions = async () => {
   const targetAddress = isSpyMode.value ? spyAddress.value : address.value
   if (!targetAddress) return
   await refreshAllPositions(eulerLensAddresses.value, targetAddress)
 }
 
-watch(tabsModel, checkTab, { immediate: true })
 const isActive = ref(false)
 
 onActivated(async () => {
   isActive.value = true
-  checkTab()
   await updateBalances()
   updatePositions()
   if (interval.value) clearInterval(interval.value)
@@ -232,6 +238,10 @@ watch(portfolioRefreshCounter, () => {
       :list="tabs"
     />
 
-    <NuxtPage />
+    <!-- transition disabled on the nested page: the global `mode: 'out-in'`
+         page transition (nuxt.config.ts) interacts poorly with keep-alive and
+         async-imported child chunks on prod, occasionally leaving the inner
+         slot empty when toggling between top-level pages. -->
+    <NuxtPage :transition="false" />
   </section>
 </template>


### PR DESCRIPTION
On prod, toggling Portfolio ↔ another top-level page could leave the inner <NuxtPage> slot empty below the tabs while the outer shell still rendered. Not reproducible on localhost — the race only exists under a production build, where child routes are async-imported chunks.

Root cause:
- `tabsModel` was a `ref` initialised from `route.name` inside `setup()`, which under keep-alive only runs on first mount. On re-activation after visiting a sub-tab, the ref was stale vs the URL and `onActivated` dispatched a `router.replace` to reconcile, queueing a second nested navigation while the first inner page swap was still in flight.

- The global `mode: 'out-in'` page transition also applies to the nested <NuxtPage>. Combined with async child imports in prod, the overlapping inner navigations could settle into a state where no child component was mounted in the slot.

Fix:
- Drive tab selection off `route.name` via a `computed` writable. No stored state, no redundant `router.replace` on activation.
- Disable the transition on the nested <NuxtPage> so inner navigations can't get stuck in an out-in cycle.

Side effect: returning to Portfolio from another top-level page now lands on Positions rather than the previously active sub-tab. Matches what the existing post-tx \`router.replace('/portfolio')\` redirects already intended.