### PR TITLE
fix: blank portfolio content after toggling top-level pages

### DIFF
--- a/pages/portfolio.vue
+++ b/pages/portfolio.vue
@@ -30,7 +30,21 @@ const { isSpyMode, spyAddress } = useSpyMode()
 
 const interval: Ref<NodeJS.Timeout | null> = ref(null)
 
-const tabsModel = ref(route.name as string)
+// Drive the tab selection directly off the route so there is no stored state
+// to drift out of sync with the URL while PortfolioPage is kept-alive.
+// Initialising a separate ref and syncing it via `router.replace` in
+// `onActivated` queued a second nested navigation while the first inner
+// `<NuxtPage>` swap was still in flight. On prod (where child routes are
+// async-imported chunks) that produced a timing race with the `out-in` page
+// transition, leaving the inner slot empty.
+const tabsModel = computed<string>({
+  get: () => route.name as string,
+  set: (value) => {
+    if (route.name !== value) {
+      router.replace({ name: value })
+    }
+  },
+})
 
 const tabs = computed(() => [
   {
@@ -50,22 +64,13 @@ const tabs = computed(() => [
   },
 ])
 
-const checkTab = () => {
-  if (route.name !== tabsModel.value) {
-    router.replace({ name: tabsModel.value })
-  }
-}
-
 const updatePositions = async () => {
   const targetAddress = isSpyMode.value ? spyAddress.value : address.value
   if (!targetAddress) return
   await refreshAllPositions(eulerLensAddresses.value, targetAddress)
 }
 
-watch(tabsModel, checkTab, { immediate: true })
-
 onActivated(async () => {
-  checkTab()
   await updateBalances()
   updatePositions()
   if (interval.value) clearInterval(interval.value)
@@ -227,6 +232,10 @@ watch(portfolioRefreshCounter, () => {
       :list="tabs"
     />
 
-    <NuxtPage />
+    <!-- transition disabled on the nested page: the global `mode: 'out-in'`
+         page transition (nuxt.config.ts) interacts poorly with keep-alive and
+         async-imported child chunks on prod, occasionally leaving the inner
+         slot empty when toggling between top-level pages. -->
+    <NuxtPage :transition="false" />
   </section>
 </template>


### PR DESCRIPTION
On prod, toggling between Portfolio and another top-level page (Borrow/Lend/Earn/Explore) occasionally left the nested <NuxtPage> slot empty below the tabs.

Root cause: 

PortfolioPage is kept-alive, so its setup runs once and a `tabsModel` ref was initialised from the route name. The nav links always point at the base `/portfolio` path, so re-entering from a sub-route (`/portfolio/saving` or `/portfolio/rewards`) kept the stale sub-route name in `tabsModel`, and `onActivated` then called `router.replace({ name: tabsModel.value })`, queueing a second nested navigation while the first inner `<NuxtPage>` swap was still in flight. 

In prod the child routes are async-imported chunks, so that replaced navigation overlapped with an unresolved chunk import and the global `mode: 'out-in'` page transition held the slot empty until the leave phase completed — occasionally resolving with no child component mounted. Dev never hit it because Vite serves the child modules synchronously.

Fix:

- Replace the stored `tabsModel` ref (plus `checkTab`, the `watch(tabsModel, ...)` and the `onActivated` sync call) with a writable `computed` that projects `route.name` directly. UiTabs still v-models against it; the setter runs `router.replace` only when the tab value differs from the current route name.
- Disable the transition on the nested `<NuxtPage>` so the global `out-in` mode does not gate the inner slot on a transition leave while an async child chunk is still resolving.