### PR TITLE
feat: env-driven social share image for og:image / twitter:image

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,6 +73,10 @@ NUXT_PUBLIC_CONFIG_TELEGRAM_URL=
 NUXT_PUBLIC_CONFIG_GITHUB_URL="https://github.com/euler-xyz"
 NUXT_PUBLIC_CONFIG_APP_TITLE="Euler Lite"
 NUXT_PUBLIC_CONFIG_APP_DESCRIPTION="Lightweight interface for Euler Finance."
+# Absolute URL to a social share image (og:image / twitter:image).
+# Recommended: 1200x630 or larger (2400x1260), PNG or JPG. Must be publicly
+# reachable — X, Slack, Discord fetch it directly. Empty = no preview image.
+NUXT_PUBLIC_CONFIG_SOCIAL_IMAGE_URL=
 NUXT_PUBLIC_CONFIG_LABELS_REPO="euler-xyz/euler-labels"
 NUXT_PUBLIC_CONFIG_LABELS_REPO_BRANCH="master"
 NUXT_PUBLIC_CONFIG_ORACLE_CHECKS_REPO="euler-xyz/oracle-checks"

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ These use Nuxt's `runtimeConfig` and are set via `NUXT_PUBLIC_CONFIG_*` env vars
 | `NUXT_PUBLIC_CONFIG_APP_TITLE`              | `Euler Lite`                               | App title (SEO, meta tags)                            |
 | `NUXT_PUBLIC_CONFIG_APP_DESCRIPTION`        | `Lightweight interface for Euler Finance.` | App description                                       |
 | `NUXT_PUBLIC_CONFIG_LOGO_URL`               | —                                          | Custom logo URL (falls back to built-in Euler logo)   |
+| `NUXT_PUBLIC_CONFIG_SOCIAL_IMAGE_URL`       | —                                          | Absolute URL to social share image (og:image / twitter:image), 1200×630+ |
 | `NUXT_PUBLIC_CONFIG_LABELS_REPO`            | `euler-xyz/euler-labels`                   | GitHub labels repo                                    |
 | `NUXT_PUBLIC_CONFIG_LABELS_REPO_BRANCH`     | `master`                                   | Branch to fetch labels from                           |
 | `NUXT_PUBLIC_CONFIG_LABELS_BASE_URL`        | —                                          | S3/CDN base URL for labels (overrides repo/branch)    |
@@ -311,7 +312,7 @@ Before deploying:
 - [ ] Set `APPKIT_PROJECT_ID` and `NUXT_PUBLIC_APP_URL`
 - [ ] Set `EULER_API_URL`, `SWAP_API_URL`, `PRICE_API_URL`
 - [ ] Added at least one `RPC_URL_HTTP_<chainId>` with matching `NUXT_PUBLIC_SUBGRAPH_URI_<chainId>`
-- [ ] Configured branding via `NUXT_PUBLIC_CONFIG_*` env vars (title, description, logo, social links)
+- [ ] Configured branding via `NUXT_PUBLIC_CONFIG_*` env vars (title, description, logo, social links, social share image)
 - [ ] Customized theme colors in `assets/styles/variables.scss` (THEME CONFIGURATION section)
 - [ ] Replaced favicon files in `public/favicons/`
 - [ ] Added token icon overrides in `assets/tokens/` (if needed)

--- a/app.vue
+++ b/app.vue
@@ -41,6 +41,15 @@ useHead({
     { property: 'og:description', content: envConfig.appDescription },
     { name: 'twitter:title', content: envConfig.appTitle },
     { name: 'twitter:description', content: envConfig.appDescription },
+    // Crawlers (X, Slack, Discord) read these from the server-rendered HTML,
+    // which is patched by server/plugins/app-config.ts. These entries keep
+    // the SPA in sync after hydration when the env var changes at runtime.
+    ...(envConfig.socialImageUrl
+      ? [
+          { property: 'og:image', content: envConfig.socialImageUrl },
+          { name: 'twitter:image', content: envConfig.socialImageUrl },
+        ]
+      : []),
   ],
 })
 

--- a/composables/useDeployConfig.ts
+++ b/composables/useDeployConfig.ts
@@ -25,6 +25,7 @@ export const useDeployConfig = () => {
     appTitle: envConfig.appTitle,
     appDescription: envConfig.appDescription,
     logoUrl: envConfig.logoUrl,
+    socialImageUrl: envConfig.socialImageUrl,
 
     // Repos (labelsRepo/branch/baseUrl still needed for logo URL construction)
     labelsRepo: rc.configLabelsRepo || 'euler-xyz/euler-labels',

--- a/composables/useEnvConfig.ts
+++ b/composables/useEnvConfig.ts
@@ -14,6 +14,7 @@ interface EnvConfig {
   appTitle: string
   appDescription: string
   logoUrl: string
+  socialImageUrl: string
   pythHermesUrl: string
   appKitProjectId: string
   appUrl: string
@@ -26,6 +27,7 @@ const DEFAULTS: EnvConfig = {
   appTitle: 'Euler Lite',
   appDescription: 'Lightweight interface for Euler Finance lending and borrowing.',
   logoUrl: '',
+  socialImageUrl: '',
   pythHermesUrl: '',
   appKitProjectId: '',
   appUrl: '',
@@ -48,6 +50,7 @@ function scanEnv(): EnvConfig {
     appTitle: env('APP_TITLE', 'NUXT_PUBLIC_CONFIG_APP_TITLE') || DEFAULTS.appTitle,
     appDescription: env('APP_DESCRIPTION', 'NUXT_PUBLIC_CONFIG_APP_DESCRIPTION') || DEFAULTS.appDescription,
     logoUrl: env('LOGO_URL', 'NUXT_PUBLIC_CONFIG_LOGO_URL') || DEFAULTS.logoUrl,
+    socialImageUrl: env('SOCIAL_IMAGE_URL', 'NUXT_PUBLIC_CONFIG_SOCIAL_IMAGE_URL') || DEFAULTS.socialImageUrl,
     pythHermesUrl: env('PYTH_HERMES_URL', 'NUXT_PUBLIC_PYTH_HERMES_URL') || '',
     appKitProjectId: env('APPKIT_PROJECT_ID', 'NUXT_PUBLIC_APP_KIT_PROJECT_ID') || DEFAULTS.appKitProjectId,
     appUrl: env('NUXT_PUBLIC_APP_URL') || DEFAULTS.appUrl,
@@ -65,6 +68,7 @@ function fromRuntimeConfig(): EnvConfig {
     appTitle: str(rc.configAppTitle) || DEFAULTS.appTitle,
     appDescription: str(rc.configAppDescription) || DEFAULTS.appDescription,
     logoUrl: str(rc.configLogoUrl) || DEFAULTS.logoUrl,
+    socialImageUrl: str(rc.configSocialImageUrl) || DEFAULTS.socialImageUrl,
     pythHermesUrl: str(rc.pythHermesUrl) ? 'proxy' : '',
     appKitProjectId: str(rc.appKitProjectId) || DEFAULTS.appKitProjectId,
     appUrl: str(rc.appUrl) || DEFAULTS.appUrl,

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -53,9 +53,15 @@ export default defineNuxtConfig({
           property: 'og:type',
           content: 'website',
         },
+        // og:image / twitter:image are injected at SSR by
+        // server/plugins/app-config.ts from NUXT_PUBLIC_CONFIG_SOCIAL_IMAGE_URL.
+        // Not declared here so forks without that env var get no (broken) tag.
+        // twitter:card is set to summary_large_image because our share image
+        // is landscape (1200x630+); forks without an image will see a basic
+        // link preview — configure NUXT_PUBLIC_CONFIG_SOCIAL_IMAGE_URL to enable.
         {
           name: 'twitter:card',
-          content: 'summary',
+          content: 'summary_large_image',
         },
         {
           name: 'twitter:title',
@@ -105,6 +111,9 @@ export default defineNuxtConfig({
       configGithubUrl: '',
       configAppTitle: 'Euler Lite',
       configAppDescription: 'Lightweight interface for Euler Finance lending and borrowing.',
+      // Absolute URL to an image used for social share previews (og:image /
+      // twitter:image). Empty default so forks don't inherit our branding.
+      configSocialImageUrl: '',
       configLabelsRepo: 'euler-xyz/euler-labels',
       configLabelsRepoBranch: 'master',
       configOracleChecksRepo: 'euler-xyz/oracle-checks',

--- a/server/plugins/app-config.ts
+++ b/server/plugins/app-config.ts
@@ -85,7 +85,9 @@ function injectSocialImage(html: { head: string[] }, socialImageUrl: string) {
   // Only injected when env var is set so forks without one don't ship
   // broken/empty preview tags. Crawlers (X, Slack, Discord) fetch the image
   // directly from this absolute URL; the SPA useHead mirrors this for runtime.
-  if (!socialImageUrl) return
+  // Require https:// so a misconfigured env var can't emit http://, data:, or
+  // javascript: URIs — X and Slack reject non-https og:image anyway.
+  if (!socialImageUrl.startsWith('https://')) return
   const url = escapeHtml(socialImageUrl)
   html.head.push(
     `<meta property="og:image" content="${url}">`

--- a/server/plugins/app-config.ts
+++ b/server/plugins/app-config.ts
@@ -35,6 +35,7 @@ function readAppConfig() {
     appTitle: env('APP_TITLE', 'NUXT_PUBLIC_CONFIG_APP_TITLE') || DEFAULTS.appTitle,
     appDescription: env('APP_DESCRIPTION', 'NUXT_PUBLIC_CONFIG_APP_DESCRIPTION') || DEFAULTS.appDescription,
     logoUrl: env('LOGO_URL', 'NUXT_PUBLIC_CONFIG_LOGO_URL'),
+    socialImageUrl: env('SOCIAL_IMAGE_URL', 'NUXT_PUBLIC_CONFIG_SOCIAL_IMAGE_URL'),
     pythHermesUrl: env('PYTH_HERMES_URL', 'NUXT_PUBLIC_PYTH_HERMES_URL') ? 'proxy' : '',
     appKitProjectId: env('APPKIT_PROJECT_ID', 'NUXT_PUBLIC_APP_KIT_PROJECT_ID'),
     appUrl: env('NUXT_PUBLIC_APP_URL'),
@@ -80,6 +81,18 @@ function patchMeta(html: { head: string[] }, appConfig: ReturnType<typeof readAp
   })
 }
 
+function injectSocialImage(html: { head: string[] }, socialImageUrl: string) {
+  // Only injected when env var is set so forks without one don't ship
+  // broken/empty preview tags. Crawlers (X, Slack, Discord) fetch the image
+  // directly from this absolute URL; the SPA useHead mirrors this for runtime.
+  if (!socialImageUrl) return
+  const url = escapeHtml(socialImageUrl)
+  html.head.push(
+    `<meta property="og:image" content="${url}">`
+    + `<meta name="twitter:image" content="${url}">`,
+  )
+}
+
 export default defineNitroPlugin((nitroApp) => {
   const appConfig = readAppConfig()
   const scriptTag = `<script>window.__APP_CONFIG__=${JSON.stringify(appConfig)}</script>`
@@ -87,5 +100,6 @@ export default defineNitroPlugin((nitroApp) => {
   nitroApp.hooks.hook('render:html', (html) => {
     html.head.push(scriptTag)
     patchMeta(html, appConfig)
+    injectSocialImage(html, appConfig.socialImageUrl)
   })
 })


### PR DESCRIPTION
Social crawlers (X, Slack, Discord) previously got no preview image because no og:image or twitter:image meta tag was ever emitted. Wire a new NUXT_PUBLIC_CONFIG_SOCIAL_IMAGE_URL (short alias SOCIAL_IMAGE_URL) through the existing app-config pipeline.

With ssr: false, crawlers only see HTML produced by the render:html Nitro hook, so the server plugin injects both tags there when the env var is set. useHead mirrors them for the SPA. twitter:card is upgraded to summary_large_image to match the recommended landscape asset.

Empty default keeps the repo fork-neutral: forks without an image configured emit no image tags at all, avoiding inherited Euler branding. Production sets the absolute URL via Doppler.