### PR TITLE
fix: prevent asset logo from collapsing in input modal on mobile

### DIFF
--- a/components/base/BaseAvatar.vue
+++ b/components/base/BaseAvatar.vue
@@ -43,7 +43,7 @@ const images = computed(() => {
 </script>
 
 <template>
-  <div class="relative flex items-center">
+  <div class="relative flex items-center shrink-0">
     <template
       v-for="(image, idx) in images"
       :key="idx"

--- a/components/entities/asset/AssetInput.vue
+++ b/components/entities/asset/AssetInput.vue
@@ -184,7 +184,7 @@ const openChooseCollateralModal = () => {
         ref="inputEl"
         v-text-fit
         :value="model"
-        class="text-h1 text-content-primary w-full h-40 outline-none placeholder:text-content-tertiary"
+        class="text-h1 text-content-primary w-full min-w-0 h-40 outline-none placeholder:text-content-tertiary"
         type="text"
         placeholder="0.00"
         maxlength="24"
@@ -198,7 +198,7 @@ const openChooseCollateralModal = () => {
       >
 
       <div
-        class="bg-card text-p3 font-semibold gap-8 flex items-center justify-center px-12 min-h-36 py-6 rounded-[40px] whitespace-nowrap cursor-pointer"
+        class="bg-card text-p3 font-semibold gap-8 flex items-center justify-center px-12 min-h-36 py-6 rounded-[40px] whitespace-nowrap cursor-pointer shrink-0"
         @click="swappable ? emits('click-asset') : openChooseCollateralModal()"
       >
         <AssetAvatar


### PR DESCRIPTION
fix: prevent asset logo from collapsing in input modal on mobile

## Summary
- The token logo in the amount input modal was collapsing to a ~1px vertical sliver on narrow mobile viewports, leaving users unable to recognise the selected asset.
- Root cause: the outer wrapper in `BaseAvatar.vue` had no flex-shrink protection, so when it was placed inside a flex row competing with a `w-full` input, the wrapper was squeezed below its icon's intrinsic size.

## Changes
- `components/base/BaseAvatar.vue` — added `shrink-0` on the avatar's root wrapper so any usage of the component is immune to flex-shrink compression.
- `components/entities/asset/AssetInput.vue` — added `min-w-0` on the amount input and `shrink-0` on the asset pill. iOS Safari enforces a larger intrinsic min-width on `<input>` in flex containers; `min-w-0` lets the input yield space, and `shrink-0` on the pill keeps it at its content width so a long amount cannot squeeze the pill either.

## Test plan
- [ ] On iOS Safari, open a supply/borrow modal with a long vault name and long symbol (e.g. Sentora Ondo Global Markets / TSLAon) and confirm the token logo renders at full 20×20.
- [ ] Repeat on Android Chrome, desktop Chrome/Safari/Firefox — no regressions.
- [ ] Enter a long amount (many digits) and confirm the input shrinks gracefully instead of pushing the pill off-screen or squishing the logo.
- [ ] Spot-check other `BaseAvatar` usages (asset rows, collateral pickers, earn lists) to confirm no visual regressions from the new `shrink-0` on the wrapper.
