### PR TITLE
fix: add white background to reward provider logos for contrast

### DIFF
--- a/components/entities/vault/PortfolioRoeModal.vue
+++ b/components/entities/vault/PortfolioRoeModal.vue
@@ -157,13 +157,13 @@ const handleClose = () => {
               ><img
                 v-if="PROVIDER_LOGOS[reward.source]"
                 :src="PROVIDER_LOGOS[reward.source]"
-                class="w-14 h-14 inline-block align-middle mr-2"
+                class="w-14 h-14 inline-block align-middle mr-2 bg-white rounded-sm p-1"
                 :alt="PROVIDER_LABELS[reward.source]"
               >{{ PROVIDER_LABELS[reward.source] || reward.source }}</a><template v-else>
                 <img
                   v-if="PROVIDER_LOGOS[reward.source]"
                   :src="PROVIDER_LOGOS[reward.source]"
-                  class="w-14 h-14 inline-block align-middle mr-2"
+                  class="w-14 h-14 inline-block align-middle mr-2 bg-white rounded-sm p-1"
                   :alt="PROVIDER_LABELS[reward.source]"
                 >{{ PROVIDER_LABELS[reward.source] || reward.source }}
               </template>{{ reward.endDate ? `, ends ${reward.endDate.toFormat('MMMM dd, yyyy')}` : '' }})
@@ -229,13 +229,13 @@ const handleClose = () => {
               ><img
                 v-if="PROVIDER_LOGOS[reward.source]"
                 :src="PROVIDER_LOGOS[reward.source]"
-                class="w-14 h-14 inline-block align-middle mr-2"
+                class="w-14 h-14 inline-block align-middle mr-2 bg-white rounded-sm p-1"
                 :alt="PROVIDER_LABELS[reward.source]"
               >{{ PROVIDER_LABELS[reward.source] || reward.source }}</a><template v-else>
                 <img
                   v-if="PROVIDER_LOGOS[reward.source]"
                   :src="PROVIDER_LOGOS[reward.source]"
-                  class="w-14 h-14 inline-block align-middle mr-2"
+                  class="w-14 h-14 inline-block align-middle mr-2 bg-white rounded-sm p-1"
                   :alt="PROVIDER_LABELS[reward.source]"
                 >{{ PROVIDER_LABELS[reward.source] || reward.source }}
               </template>{{ reward.endDate ? `, ends ${reward.endDate.toFormat('MMMM dd, yyyy')}` : '' }})
@@ -290,13 +290,13 @@ const handleClose = () => {
                   ><img
                     v-if="PROVIDER_LOGOS[reward.source]"
                     :src="PROVIDER_LOGOS[reward.source]"
-                    class="w-14 h-14 inline-block align-middle mr-2"
+                    class="w-14 h-14 inline-block align-middle mr-2 bg-white rounded-sm p-1"
                     :alt="PROVIDER_LABELS[reward.source]"
                   >{{ PROVIDER_LABELS[reward.source] || reward.source }}</a><template v-else>
                     <img
                       v-if="PROVIDER_LOGOS[reward.source]"
                       :src="PROVIDER_LOGOS[reward.source]"
-                      class="w-14 h-14 inline-block align-middle mr-2"
+                      class="w-14 h-14 inline-block align-middle mr-2 bg-white rounded-sm p-1"
                       :alt="PROVIDER_LABELS[reward.source]"
                     >{{ PROVIDER_LABELS[reward.source] || reward.source }}
                   </template>{{ reward.endDate ? `, ends ${reward.endDate.toFormat('MMMM dd, yyyy')}` : '' }})

--- a/components/entities/vault/VaultBorrowApyModal.vue
+++ b/components/entities/vault/VaultBorrowApyModal.vue
@@ -138,13 +138,13 @@ const handleClose = () => {
             ><img
               v-if="PROVIDER_LOGOS[reward.source]"
               :src="PROVIDER_LOGOS[reward.source]"
-              class="w-14 h-14 inline-block align-middle mr-2"
+              class="w-14 h-14 inline-block align-middle mr-2 bg-white rounded-sm p-1"
               :alt="PROVIDER_LABELS[reward.source]"
             >{{ PROVIDER_LABELS[reward.source] || reward.source }}</a><template v-else>
               <img
                 v-if="PROVIDER_LOGOS[reward.source]"
                 :src="PROVIDER_LOGOS[reward.source]"
-                class="w-14 h-14 inline-block align-middle mr-2"
+                class="w-14 h-14 inline-block align-middle mr-2 bg-white rounded-sm p-1"
                 :alt="PROVIDER_LABELS[reward.source]"
               >{{ PROVIDER_LABELS[reward.source] || reward.source }}
             </template>{{ reward.isCollateralSpecific ? ', collateral bonus' : '' }}{{ reward.endDate ? `, ends ${reward.endDate.toFormat('MMMM dd, yyyy')}` : '' }})

--- a/components/entities/vault/VaultMaxRoeModal.vue
+++ b/components/entities/vault/VaultMaxRoeModal.vue
@@ -180,13 +180,13 @@ const handleClose = () => {
               ><img
                 v-if="PROVIDER_LOGOS[campaign.source]"
                 :src="PROVIDER_LOGOS[campaign.source]"
-                class="w-14 h-14 inline-block align-middle mr-2"
+                class="w-14 h-14 inline-block align-middle mr-2 bg-white rounded-sm p-1"
                 :alt="PROVIDER_LABELS[campaign.source]"
               >{{ PROVIDER_LABELS[campaign.source] || campaign.source }}</a><template v-else>
                 <img
                   v-if="PROVIDER_LOGOS[campaign.source]"
                   :src="PROVIDER_LOGOS[campaign.source]"
-                  class="w-14 h-14 inline-block align-middle mr-2"
+                  class="w-14 h-14 inline-block align-middle mr-2 bg-white rounded-sm p-1"
                   :alt="PROVIDER_LABELS[campaign.source]"
                 >{{ PROVIDER_LABELS[campaign.source] || campaign.source }}
               </template>{{ campaign.endDate ? `, ends ${campaign.endDate.toFormat('MMMM dd, yyyy')}` : '' }})
@@ -252,13 +252,13 @@ const handleClose = () => {
               ><img
                 v-if="PROVIDER_LOGOS[campaign.source]"
                 :src="PROVIDER_LOGOS[campaign.source]"
-                class="w-14 h-14 inline-block align-middle mr-2"
+                class="w-14 h-14 inline-block align-middle mr-2 bg-white rounded-sm p-1"
                 :alt="PROVIDER_LABELS[campaign.source]"
               >{{ PROVIDER_LABELS[campaign.source] || campaign.source }}</a><template v-else>
                 <img
                   v-if="PROVIDER_LOGOS[campaign.source]"
                   :src="PROVIDER_LOGOS[campaign.source]"
-                  class="w-14 h-14 inline-block align-middle mr-2"
+                  class="w-14 h-14 inline-block align-middle mr-2 bg-white rounded-sm p-1"
                   :alt="PROVIDER_LABELS[campaign.source]"
                 >{{ PROVIDER_LABELS[campaign.source] || campaign.source }}
               </template>{{ campaign.endDate ? `, ends ${campaign.endDate.toFormat('MMMM dd, yyyy')}` : '' }})
@@ -313,13 +313,13 @@ const handleClose = () => {
                   ><img
                     v-if="PROVIDER_LOGOS[campaign.source]"
                     :src="PROVIDER_LOGOS[campaign.source]"
-                    class="w-14 h-14 inline-block align-middle mr-2"
+                    class="w-14 h-14 inline-block align-middle mr-2 bg-white rounded-sm p-1"
                     :alt="PROVIDER_LABELS[campaign.source]"
                   >{{ PROVIDER_LABELS[campaign.source] || campaign.source }}</a><template v-else>
                     <img
                       v-if="PROVIDER_LOGOS[campaign.source]"
                       :src="PROVIDER_LOGOS[campaign.source]"
-                      class="w-14 h-14 inline-block align-middle mr-2"
+                      class="w-14 h-14 inline-block align-middle mr-2 bg-white rounded-sm p-1"
                       :alt="PROVIDER_LABELS[campaign.source]"
                     >{{ PROVIDER_LABELS[campaign.source] || campaign.source }}
                   </template>{{ campaign.endDate ? `, ends ${campaign.endDate.toFormat('MMMM dd, yyyy')}` : '' }})

--- a/components/entities/vault/VaultNetApyModal.vue
+++ b/components/entities/vault/VaultNetApyModal.vue
@@ -150,13 +150,13 @@ const handleClose = () => {
               ><img
                 v-if="PROVIDER_LOGOS[reward.source]"
                 :src="PROVIDER_LOGOS[reward.source]"
-                class="w-14 h-14 inline-block align-middle mr-2"
+                class="w-14 h-14 inline-block align-middle mr-2 bg-white rounded-sm p-1"
                 :alt="PROVIDER_LABELS[reward.source]"
               >{{ PROVIDER_LABELS[reward.source] || reward.source }}</a><template v-else>
                 <img
                   v-if="PROVIDER_LOGOS[reward.source]"
                   :src="PROVIDER_LOGOS[reward.source]"
-                  class="w-14 h-14 inline-block align-middle mr-2"
+                  class="w-14 h-14 inline-block align-middle mr-2 bg-white rounded-sm p-1"
                   :alt="PROVIDER_LABELS[reward.source]"
                 >{{ PROVIDER_LABELS[reward.source] || reward.source }}
               </template>{{ reward.endDate ? `, ends ${reward.endDate.toFormat('MMMM dd, yyyy')}` : '' }})
@@ -240,13 +240,13 @@ const handleClose = () => {
               ><img
                 v-if="PROVIDER_LOGOS[reward.source]"
                 :src="PROVIDER_LOGOS[reward.source]"
-                class="w-14 h-14 inline-block align-middle mr-2"
+                class="w-14 h-14 inline-block align-middle mr-2 bg-white rounded-sm p-1"
                 :alt="PROVIDER_LABELS[reward.source]"
               >{{ PROVIDER_LABELS[reward.source] || reward.source }}</a><template v-else>
                 <img
                   v-if="PROVIDER_LOGOS[reward.source]"
                   :src="PROVIDER_LOGOS[reward.source]"
-                  class="w-14 h-14 inline-block align-middle mr-2"
+                  class="w-14 h-14 inline-block align-middle mr-2 bg-white rounded-sm p-1"
                   :alt="PROVIDER_LABELS[reward.source]"
                 >{{ PROVIDER_LABELS[reward.source] || reward.source }}
               </template>{{ reward.endDate ? `, ends ${reward.endDate.toFormat('MMMM dd, yyyy')}` : '' }})
@@ -305,13 +305,13 @@ const handleClose = () => {
                 ><img
                   v-if="PROVIDER_LOGOS[reward.source]"
                   :src="PROVIDER_LOGOS[reward.source]"
-                  class="w-14 h-14 inline-block align-middle mr-2"
+                  class="w-14 h-14 inline-block align-middle mr-2 bg-white rounded-sm p-1"
                   :alt="PROVIDER_LABELS[reward.source]"
                 >{{ PROVIDER_LABELS[reward.source] || reward.source }}</a><template v-else>
                   <img
                     v-if="PROVIDER_LOGOS[reward.source]"
                     :src="PROVIDER_LOGOS[reward.source]"
-                    class="w-14 h-14 inline-block align-middle mr-2"
+                    class="w-14 h-14 inline-block align-middle mr-2 bg-white rounded-sm p-1"
                     :alt="PROVIDER_LABELS[reward.source]"
                   >{{ PROVIDER_LABELS[reward.source] || reward.source }}
                 </template>{{ reward.endDate ? `, ends ${reward.endDate.toFormat('MMMM dd, yyyy')}` : '' }})

--- a/components/entities/vault/VaultNetApyPairModal.vue
+++ b/components/entities/vault/VaultNetApyPairModal.vue
@@ -150,13 +150,13 @@ const handleClose = () => {
               ><img
                 v-if="PROVIDER_LOGOS[reward.source]"
                 :src="PROVIDER_LOGOS[reward.source]"
-                class="w-14 h-14 inline-block align-middle mr-2"
+                class="w-14 h-14 inline-block align-middle mr-2 bg-white rounded-sm p-1"
                 :alt="PROVIDER_LABELS[reward.source]"
               >{{ PROVIDER_LABELS[reward.source] || reward.source }}</a><template v-else>
                 <img
                   v-if="PROVIDER_LOGOS[reward.source]"
                   :src="PROVIDER_LOGOS[reward.source]"
-                  class="w-14 h-14 inline-block align-middle mr-2"
+                  class="w-14 h-14 inline-block align-middle mr-2 bg-white rounded-sm p-1"
                   :alt="PROVIDER_LABELS[reward.source]"
                 >{{ PROVIDER_LABELS[reward.source] || reward.source }}
               </template>{{ reward.endDate ? `, ends ${reward.endDate.toFormat('MMMM dd, yyyy')}` : '' }})
@@ -240,13 +240,13 @@ const handleClose = () => {
               ><img
                 v-if="PROVIDER_LOGOS[reward.source]"
                 :src="PROVIDER_LOGOS[reward.source]"
-                class="w-14 h-14 inline-block align-middle mr-2"
+                class="w-14 h-14 inline-block align-middle mr-2 bg-white rounded-sm p-1"
                 :alt="PROVIDER_LABELS[reward.source]"
               >{{ PROVIDER_LABELS[reward.source] || reward.source }}</a><template v-else>
                 <img
                   v-if="PROVIDER_LOGOS[reward.source]"
                   :src="PROVIDER_LOGOS[reward.source]"
-                  class="w-14 h-14 inline-block align-middle mr-2"
+                  class="w-14 h-14 inline-block align-middle mr-2 bg-white rounded-sm p-1"
                   :alt="PROVIDER_LABELS[reward.source]"
                 >{{ PROVIDER_LABELS[reward.source] || reward.source }}
               </template>{{ reward.endDate ? `, ends ${reward.endDate.toFormat('MMMM dd, yyyy')}` : '' }})
@@ -305,13 +305,13 @@ const handleClose = () => {
                 ><img
                   v-if="PROVIDER_LOGOS[reward.source]"
                   :src="PROVIDER_LOGOS[reward.source]"
-                  class="w-14 h-14 inline-block align-middle mr-2"
+                  class="w-14 h-14 inline-block align-middle mr-2 bg-white rounded-sm p-1"
                   :alt="PROVIDER_LABELS[reward.source]"
                 >{{ PROVIDER_LABELS[reward.source] || reward.source }}</a><template v-else>
                   <img
                     v-if="PROVIDER_LOGOS[reward.source]"
                     :src="PROVIDER_LOGOS[reward.source]"
-                    class="w-14 h-14 inline-block align-middle mr-2"
+                    class="w-14 h-14 inline-block align-middle mr-2 bg-white rounded-sm p-1"
                     :alt="PROVIDER_LABELS[reward.source]"
                   >{{ PROVIDER_LABELS[reward.source] || reward.source }}
                 </template>{{ reward.endDate ? `, ends ${reward.endDate.toFormat('MMMM dd, yyyy')}` : '' }})

--- a/components/entities/vault/VaultSupplyApyModal.vue
+++ b/components/entities/vault/VaultSupplyApyModal.vue
@@ -144,13 +144,13 @@ const handleClose = () => {
             ><img
               v-if="PROVIDER_LOGOS[reward.source]"
               :src="PROVIDER_LOGOS[reward.source]"
-              class="w-14 h-14 inline-block align-middle mr-2"
+              class="w-14 h-14 inline-block align-middle mr-2 bg-white rounded-sm p-1"
               :alt="PROVIDER_LABELS[reward.source]"
             >{{ PROVIDER_LABELS[reward.source] || reward.source }}</a><template v-else>
               <img
                 v-if="PROVIDER_LOGOS[reward.source]"
                 :src="PROVIDER_LOGOS[reward.source]"
-                class="w-14 h-14 inline-block align-middle mr-2"
+                class="w-14 h-14 inline-block align-middle mr-2 bg-white rounded-sm p-1"
                 :alt="PROVIDER_LABELS[reward.source]"
               >{{ PROVIDER_LABELS[reward.source] || reward.source }}
             </template>{{ reward.endDate ? `, ends ${reward.endDate.toFormat('MMMM dd, yyyy')}` : '' }})


### PR DESCRIPTION
Reward provider logos (Merkl, Brevis) use dark-on-transparent designs that blend into the dark modal surfaces, leaving them effectively invisible. Apply a consistent white backing with subtle rounding and padding to the provider logo frames so any provider logo is legible on dark backgrounds.

<img width="392" height="134" alt="image" src="https://github.com/user-attachments/assets/062cdf4c-3abd-4f3b-89c8-1f66f47c9f35" />
