### PR TITLE
fix: reset debt percent slider when switching repay tabs

### DIFF
--- a/composables/repay/useRepaySwapCore.ts
+++ b/composables/repay/useRepaySwapCore.ts
@@ -376,6 +376,7 @@ export const useRepaySwapCore = (options: UseRepaySwapCoreOptions) => {
   const resetCore = () => {
     amount.value = ''
     debtAmount.value = ''
+    debtPercent.value = 0
     quotes.reset()
   }
 


### PR DESCRIPTION
The slider state (debtPercent) lives in the shared useRepaySwapCore composable and persists across tab switches since tabs are rendered with v-if on a single page. resetCore() cleared amount, debtAmount, and quotes but not debtPercent, and the debtAmount watcher that normally syncs the slider has an early-return guard when the active tab isn't the current one, so clearing debtAmount during a tab switch didn't propagate. Explicitly reset debtPercent to fix the "from collateral" and "from savings" tabs.