### PR TITLE
fix: use pay-with asset decimals for collateral-form balance check

### DIFF
--- a/composables/position/useCollateralForm.ts
+++ b/composables/position/useCollateralForm.ts
@@ -43,6 +43,11 @@ export interface UseCollateralFormOptions {
 
   needsSwap: ComputedRef<boolean>
   effectiveBalance: ComputedRef<bigint>
+  // Asset whose decimals match `effectiveBalance`. In swap mode this is the
+  // "pay with" token (differs from collateralVault.asset). Used to convert
+  // the user-entered amount into the same unit as effectiveBalance for the
+  // balance check — without this the comparison silently mixes decimals.
+  effectiveAsset: ComputedRef<VaultAsset | undefined>
 
   computePriceFixed: (
     position: NonNullable<ReturnType<ReturnType<typeof useEulerAccount>['getPositionBySubAccountIndex']>>,
@@ -415,7 +420,7 @@ export const useCollateralForm = (options: UseCollateralFormOptions) => {
   const isSubmitDisabled = computed(() => {
     if (!isConnected.value) return false
     if (collateralVault.value && isEVKVault(collateralVault.value) && isOpDisabled(collateralVault.value, collateralOp.value)) return true
-    if (options.effectiveBalance.value < valueToNano(amount.value, asset.value?.decimals)) return true
+    if (options.effectiveBalance.value < valueToNano(amount.value, options.effectiveAsset.value?.decimals)) return true
     if (isLoading.value || !(+amount.value) || !!estimatesError.value || isEstimatesLoading.value) return true
     if (options.needsSwap.value && !swapSelectedQuote.value) return true
     return false

--- a/pages/position/[number]/supply.vue
+++ b/pages/position/[number]/supply.vue
@@ -45,12 +45,13 @@ const isNativeWrap = computed(() => {
 })
 
 const activeBalance = computed(() => (needsSwap.value || isNativeWrap.value) ? selectedAssetBalance.value : balance.value)
-const _activeAsset = computed(() => needsSwap.value ? selectedAsset.value : form.asset.value)
+const activeAsset = computed(() => (needsSwap.value || isNativeWrap.value) && selectedAsset.value ? selectedAsset.value : form.asset.value)
 
 const form = useCollateralForm({
   mode: 'supply',
   needsSwap,
   effectiveBalance: activeBalance,
+  effectiveAsset: activeAsset,
 
   computePriceFixed: (_pos, borrowVault, collateralVault) => {
     const collateralPrice = borrowVault && collateralVault

--- a/pages/position/[number]/withdraw.vue
+++ b/pages/position/[number]/withdraw.vue
@@ -41,6 +41,7 @@ const form = useCollateralForm({
   mode: 'withdraw',
   needsSwap,
   effectiveBalance: computed(() => form.collateralAssets.value),
+  effectiveAsset: computed(() => form.asset.value),
 
   computePriceFixed: (_pos, borrowVault, collateralVault) => {
     const collateralPrice = borrowVault && collateralVault


### PR DESCRIPTION
## Summary

The submit gate in `useCollateralForm` compared the wallet balance (in the *selected pay-with* asset's decimals) against the user-entered amount parsed in the *collateral vault's* asset decimals. Whenever the vault asset had more decimals than the pay-with token (e.g. USDtb 18-dec vault, USDC 6-dec wallet), the check looked like:

```
7_793_061  <  5 * 10^18   // always true
```

so the Review Supply button stayed disabled with no visible reason — the tooltip just read "check the messages above for details" while no toast was produced.

## Fix

Added `effectiveAsset: ComputedRef<VaultAsset | undefined>` to `UseCollateralFormOptions`, paired with the existing `effectiveBalance`, and used its decimals when parsing the amount for the balance check. Wired it through both consumers:

- `pages/position/[number]/supply.vue`: reuses the existing (previously unused) `activeAsset` — widened to include the `isNativeWrap` path so it agrees with `activeBalance`.
- `pages/position/[number]/withdraw.vue`: `effectiveBalance` is the user's supplied collateral, so `effectiveAsset` is just `form.asset`.

## Audit

Checked every other form that supports "pay with / receive as" a different asset:

- `pages/lend/[vault]/index.vue` — already correct (`activeBalance` + `activeAsset` paired, L272–285).
- `pages/lend/[vault]/[subAccount]/{withdraw,swap}.vue`, `pages/position/[number]/{borrow,collateral}/swap.vue` — delegate to `useSwapPageLogic`, decimals consistent via `fromVault`.
- `pages/earn/**`, `pages/position/[number]/{borrow,multiply}.vue` — no cross-asset selector.
- `composables/repay/useWalletRepay.ts`, `composables/repay/useWalletSwapRepay.ts` — decimals match in both `EXACT_IN` and `TARGET_DEBT`.

No other mismatches found.

## Test plan

- [ ] Open an existing position on a vault whose underlying has different decimals than the pay-with token (e.g. USDtb collateral, USDC wallet).
- [ ] Go to supply, pick USDC as "Pay with", enter an amount ≤ USDC wallet balance, pick a quote → Review Supply enables.
- [ ] Enter an amount > USDC wallet balance → button disabled AND a "Not enough balance" toast appears above it.
- [ ] Same-asset supply path (pay with the vault's underlying) still works as before.
- [ ] Repeat the same checks on the withdraw flow (amount in collateral decimals, output swap to a different asset).