### PR TITLE
fix: prevent cross-chain token list contamination in wallet balance batch

### DIFF
--- a/composables/useTokenList.ts
+++ b/composables/useTokenList.ts
@@ -82,6 +82,15 @@ const loadTokenList = async (forceRefresh = false) => {
       return
     }
 
+    // When switching chains, wipe stale cross-chain data immediately so
+    // consumers calling getAllTokens()/hasToken() during the refetch
+    // window see "empty" rather than the previous chain's tokens.
+    if (loadState.chainId !== chainId) {
+      tokenMap.value = new Map()
+      loadState.rawTokens = []
+      loadState.chainId = 0
+    }
+
     const gen = guard.next()
     isLoading.value = true
     isLoaded.value = false

--- a/composables/useWallets.ts
+++ b/composables/useWallets.ts
@@ -43,6 +43,10 @@ export const useWallets = () => {
       return
     }
 
+    // Capture chainId up-front so we can (a) filter out stale cross-chain
+    // token-list entries and (b) discard results if the chain changes mid-fetch.
+    const currentChainId = chainId.value
+
     // Collect unique underlying asset addresses from ALL vaults (evk, earn, securitize)
     // plus external token list tokens for the swap selector
     // Note: We only fetch underlying token balances, NOT vault share balances
@@ -61,9 +65,13 @@ export const useWallets = () => {
       }
     })
 
-    // Include token list addresses (for swap selector zero-balance filtering)
+    // Include token list addresses (for swap selector zero-balance filtering).
+    // Defensive filter: only accept entries matching the active chain, so that
+    // a stale useTokenList singleton from a previous chain can never contaminate
+    // the RPC batch with foreign-chain addresses.
     const { getAllTokens } = useTokenList()
     for (const token of getAllTokens()) {
+      if (token.chainId !== currentChainId) continue
       try {
         addresses.add(getAddress(token.address))
       }
@@ -83,7 +91,6 @@ export const useWallets = () => {
       return
     }
 
-    const currentChainId = chainId.value
     isFetching.value = true
 
     try {
@@ -99,7 +106,7 @@ export const useWallets = () => {
       }
 
       const chunkResults = await Promise.all(
-        chunks.map(async (batch) => {
+        chunks.map(async (batch, chunkIndex) => {
           try {
             return await client.readContract({
               address: utilsLensAddress,
@@ -108,8 +115,24 @@ export const useWallets = () => {
               args: [targetAddress, batch],
             }) as bigint[]
           }
-          catch {
-            logWarn('wallets/batchFetch', `Lens tokenBalances failed for chunk of ${batch.length}, using zero fallback`)
+          catch (e) {
+            logWarn(
+              'wallets/batchFetch',
+              `Lens tokenBalances failed, using zero fallback`,
+              {
+                data: {
+                  chainId: currentChainId,
+                  lens: utilsLensAddress,
+                  target: targetAddress,
+                  totalTokens: tokenAddresses.length,
+                  chunkIndex,
+                  chunkCount: chunks.length,
+                  chunkSize: batch.length,
+                  sampleTokens: batch.slice(0, 3),
+                  error: e,
+                },
+              },
+            )
             return batch.map(() => 0n)
           }
         }),

--- a/composables/useWallets.ts
+++ b/composables/useWallets.ts
@@ -272,8 +272,16 @@ export const useWallets = () => {
     }
   }
 
-  // isLoading only true on initial load, not on background refreshes
-  const isLoading = computed(() => !isLoaded.value && isFetching.value)
+  // isLoading is true during initial load (and during the "waiting for the
+  // active chain's vaults to finish loading" window that precedes it), but
+  // stays false during background refreshes. Including the loadedChainId
+  // check prevents the UI from flashing "0" balances between resetBalances()
+  // and the actual fetch firing on chain switch — because updateBalances is
+  // gated on loadedChainId === chainId, there's a real window where neither
+  // isLoaded nor isFetching is true yet, and the balances Map is empty.
+  const isLoading = computed(() =>
+    !isLoaded.value && (isFetching.value || loadedChainId.value !== chainId.value),
+  )
 
   return {
     balances,

--- a/composables/useWallets.ts
+++ b/composables/useWallets.ts
@@ -14,7 +14,7 @@ const lastFetchAddress = ref<string | null>(null)
 let fetchPromise: Promise<void> | null = null
 
 export const useWallets = () => {
-  const { isReady } = useVaults()
+  const { loadedChainId } = useVaults()
   const { getByType } = useVaultRegistry()
   const { address, isConnected } = useWagmi()
   const { eulerLensAddresses } = useEulerAddresses()
@@ -32,8 +32,21 @@ export const useWallets = () => {
       return
     }
 
-    // Guard: vaults must be ready
-    if (!isReady.value) {
+    // Capture chainId up-front so we can (a) filter out stale cross-chain
+    // token-list entries and (b) discard results if the chain changes mid-fetch.
+    const currentChainId = chainId.value
+
+    // Guard: the vault registry must hold vaults for THIS chain. Checking
+    // `isReady` alone is not enough — on chain switch, `eulerLensAddresses`
+    // recomputes to the new chain's lens synchronously, which can trigger
+    // our watcher *before* app.vue's chainId watcher has run
+    // resetVaultsState(). In that window `isReady` is still true (from the
+    // previous chain) and the registry still holds the previous chain's
+    // vaults, which would be sent cross-chain to the new chain's lens.
+    // `loadedChainId` is only set to the actual loaded chain after a
+    // successful loadVaults() and cleared to null on reset, so comparing
+    // it to the current chainId is the reliable gate.
+    if (loadedChainId.value !== currentChainId) {
       return
     }
 
@@ -42,10 +55,6 @@ export const useWallets = () => {
     if (!utilsLensAddress) {
       return
     }
-
-    // Capture chainId up-front so we can (a) filter out stale cross-chain
-    // token-list entries and (b) discard results if the chain changes mid-fetch.
-    const currentChainId = chainId.value
 
     // Collect unique underlying asset addresses from ALL vaults (evk, earn, securitize)
     // plus external token list tokens for the swap selector
@@ -172,7 +181,7 @@ export const useWallets = () => {
   // Check if we need to fetch on each call
   const needsFetch = () => {
     return (isConnected.value || isSpyMode.value)
-      && isReady.value
+      && loadedChainId.value === chainId.value
       && !!balanceAddress.value
       && !!eulerLensAddresses.value?.utilsLens
       && (lastFetchChainId.value !== chainId.value || !isLoaded.value || lastFetchAddress.value !== balanceAddress.value)
@@ -184,8 +193,10 @@ export const useWallets = () => {
     fetchPromise = updateBalances()
   }
 
-  // Retry when dependencies become ready (e.g. vaults load after cold start)
-  watch([isReady, () => balanceAddress.value, () => eulerLensAddresses.value?.utilsLens], () => {
+  // Retry when dependencies become ready (e.g. vaults load after cold start).
+  // Watching loadedChainId (instead of the less-specific isReady) ensures we
+  // only fire once the registry is confirmed to hold vaults for the active chain.
+  watch([loadedChainId, () => balanceAddress.value, () => eulerLensAddresses.value?.utilsLens], () => {
     if (needsFetch() && !fetchPromise) {
       fetchPromise = updateBalances()
     }


### PR DESCRIPTION
## Problem

On chain switch, `useWallets.updateBalances()` was sending stale cross-chain token addresses to the new chain's `UtilsLens.tokenBalances`. On Monad (143), this manifested with two symptoms:

- Initial report: `totalTokens: 5201` — a mainnet-scale batch (Monad has ~70 tokens).
- After first fix: `totalTokens: 79` — the batch was still 100% non-Monad addresses (77 of 79 have no code on Monad, verified via `scripts/check-monad-addresses.mjs`).

The 250-address chunks of mostly non-existent contracts exhausted Monad's `eth_call` gas cap and failed the whole call with a generic `Lens tokenBalances failed, using zero fallback` log carrying no chain context.

## Root causes (two independent leaks)

**1. Token list singleton** — `useTokenList` holds tokens from the previously active chain until its async refetch completes. During that window, any caller reading `getAllTokens()` saw cross-chain data. The initial refresh correctly set `isLoaded = false` but did **not** clear `tokenMap`.

**2. Vault registry watcher race** — `eulerLensAddresses` recomputes synchronously when `chainId` changes, which triggered useWallets' watcher *before* `app.vue`'s `chainId` watcher ran `resetVaultsState()`. In that gap `isReady` was still true from the previous chain and the registry still held the previous chain's vaults. `updateBalances` would fire with the previous chain's vault underlying assets against the new chain's lens — that's where the 79 mainnet addresses came from.

## Fixes

- `useTokenList`: wipe `tokenMap` / `rawTokens` synchronously on chain change before the fetch await.
- `useWallets`: (a) defensive per-entry chainId filter when reading the token list; (b) replace the `isReady` gate with `loadedChainId === chainId` in `updateBalances()`, `needsFetch()`, and the dependency watcher. `loadedChainId` is only set after a successful `loadVaults()` on the active chain and nulled by reset, so it is the reliable 'vaults are loaded for THIS chain' signal.
- Logging: widened the batch-failure log (chainId, lens, target, totalTokens, chunkIndex/count, sampleTokens, raw error) so any future contamination or genuine per-token OOG is diagnosable in one glance.

## Test plan

- [ ] Rapidly switch chains (mainnet → Monad → base → mainnet) with devtools open — no more `[wallets/batchFetch]` warnings.
- [ ] Balances resolve correctly on home/position pages immediately after each switch.
- [ ] Swap selector's hide-zero-balance behaviour still works per chain.
- [ ] No regression on cold load (balances populate once vaults finish loading).