### PR TITLE
fix: clamp source-Max to debt in repay flow when source value exceeds debt

### DIFF
--- a/components/entities/asset/AssetInput.vue
+++ b/components/entities/asset/AssetInput.vue
@@ -22,6 +22,7 @@ const props = defineProps<{
   priceOverride?: number // USD unit price for assets without a vault (e.g., swap-to-deposit)
   swappable?: boolean // When true, asset pill shows dropdown arrow and emits click-asset
   selectedSource?: 'wallet' | 'saving' // Source indicator chip when multiple collateral options exist
+  maxHandler?: () => void // When provided, replaces the default "Max" button behavior
 }>()
 const emits = defineEmits(['input', 'change-collateral', 'click-asset'])
 const model = defineModel<string>({ default: '' })
@@ -99,6 +100,10 @@ const price = computed(() => {
 
 const hasPrice = computed(() => price.value !== null)
 const setMax = () => {
+  if (props.maxHandler) {
+    props.maxHandler()
+    return
+  }
   model.value = trimTrailingZeros(formatUnits(props.balance ?? 0n, Number(props.asset.decimals)))
   emitInputNow()
   if (inputEl.value) {

--- a/composables/repay/useCollateralSwapRepay.ts
+++ b/composables/repay/useCollateralSwapRepay.ts
@@ -16,6 +16,7 @@ import { useEulerProductOfVault } from '~/composables/useEulerLabels'
 import { useRepaySwapCore } from '~/composables/repay/useRepaySwapCore'
 import { useRepaySwapDetails } from '~/composables/repay/useRepaySwapDetails'
 import { useRepayHealthMetrics } from '~/composables/repay/useRepayHealthMetrics'
+import { getSwapInputAmount } from '~/composables/useEulerOperations/swaps/verify'
 import { nanoToValue, valueToNano } from '~/utils/crypto-utils'
 import { normalizeAddressOrEmpty } from '~/utils/accountPositionHelpers'
 import { createRaceGuard } from '~/utils/race-guard'
@@ -243,12 +244,23 @@ export const useCollateralSwapRepay = (options: UseCollateralSwapRepayOptions) =
 
   const hookWarning = computed(() => getPlanHookDisabledWarning(collateralSwapRepayPlannedOps.value))
 
+  // Uses amountInMax (slippage-padded) when available so the user sees an
+  // insufficient-balance error before hitting an on-chain revert.
+  const requiredInput = computed(() => {
+    if (core.isSameAsset.value) return core.spent.value ?? 0n
+    const q = core.quotes.selectedQuote.value
+    if (!q) return 0n
+    return getSwapInputAmount(q, core.direction.value)
+  })
+  const isInsufficientSource = computed(() => requiredInput.value > 0n && requiredInput.value > sourceBalance.value)
+
   // --- Submit disabled ---
   const isSubmitDisabled = computed(() => {
     if (!isConnected.value) return false
     if (findBlockingDisabledOp(collateralSwapRepayPlannedOps.value)) return true
     if (!sourceVault.value || !borrowVault.value) return true
     if (!core.debtAmount.value && !core.amount.value) return true
+    if (isInsufficientSource.value) return true
     if (core.isSameAsset.value) {
       if (isHealthInsufficient.value) return true
       return false
@@ -263,6 +275,9 @@ export const useCollateralSwapRepay = (options: UseCollateralSwapRepayOptions) =
   const disabledReason = computed(() => {
     if (core.isRepayExceedsDebt.value) {
       return 'You repaying more than required'
+    }
+    if (isInsufficientSource.value) {
+      return 'Insufficient collateral balance to cover the required swap amount.'
     }
     if (isHealthInsufficient.value) {
       return 'This swap will not restore account health. Repay the full debt from your wallet instead.'
@@ -498,6 +513,7 @@ export const useCollateralSwapRepay = (options: UseCollateralSwapRepayOptions) =
     onPercentInput: core.onPercentInput,
     onSourceVaultChange,
     onRefreshQuotes: core.onRefreshQuotes,
+    onSourceMax: core.onSourceMax,
     submit,
     send,
     updateSourceBalance,

--- a/composables/repay/useRepaySwapCore.ts
+++ b/composables/repay/useRepaySwapCore.ts
@@ -228,6 +228,50 @@ export const useRepaySwapCore = (options: UseRepaySwapCoreOptions) => {
     requestQuote()
   }
 
+  // Max on source input: if source is worth at least as much as the debt,
+  // behave like Max on debt (TARGET_DEBT with full debt). Otherwise default
+  // to EXACT_IN with full source balance. Prevents accidental over-repay.
+  const onSourceMax = () => {
+    clearSimulationError()
+    if (!sourceVault.value || !borrowVault.value) return
+    const currentDebt = getCurrentDebt()
+    if (currentDebt <= 0n) return
+
+    const sourceDecimals = Number(sourceVault.value.asset.decimals)
+    const borrowDecimals = Number(borrowVault.value.asset.decimals)
+
+    if (isSameAsset.value) {
+      if (sourceBalance.value >= currentDebt) {
+        direction.value = SwapperMode.TARGET_DEBT
+        debtAmount.value = trimTrailingZeros(formatUnits(currentDebt, borrowDecimals))
+        amount.value = ''
+        debtPercent.value = 100
+        requestQuote()
+        return
+      }
+      direction.value = SwapperMode.EXACT_IN
+      amount.value = trimTrailingZeros(formatUnits(sourceBalance.value, sourceDecimals))
+      debtAmount.value = ''
+      requestQuote()
+      return
+    }
+
+    const srcUsd = sourceValueUsd.value
+    const debtUsd = borrowValueUsd.value
+    if (srcUsd !== null && debtUsd !== null && srcUsd > debtUsd) {
+      direction.value = SwapperMode.TARGET_DEBT
+      debtAmount.value = trimTrailingZeros(formatUnits(currentDebt, borrowDecimals))
+      amount.value = ''
+      debtPercent.value = 100
+      requestQuote()
+      return
+    }
+    direction.value = SwapperMode.EXACT_IN
+    amount.value = trimTrailingZeros(formatUnits(sourceBalance.value, sourceDecimals))
+    debtAmount.value = ''
+    requestQuote()
+  }
+
   // --- Quote request ---
   const requestQuote = useDebounceFn(async () => {
     if (!position.value || !sourceVault.value || !borrowVault.value) {
@@ -397,6 +441,7 @@ export const useRepaySwapCore = (options: UseRepaySwapCoreOptions) => {
     onPercentInput,
     onSourceVaultChange,
     onRefreshQuotes,
+    onSourceMax,
     requestQuote,
     resetCore,
   }

--- a/composables/repay/useSavingsRepay.ts
+++ b/composables/repay/useSavingsRepay.ts
@@ -15,6 +15,7 @@ import { useEulerProductOfVault } from '~/composables/useEulerLabels'
 import { useRepaySwapCore } from '~/composables/repay/useRepaySwapCore'
 import { useRepaySwapDetails } from '~/composables/repay/useRepaySwapDetails'
 import { useRepayHealthMetrics } from '~/composables/repay/useRepayHealthMetrics'
+import { getSwapInputAmount } from '~/composables/useEulerOperations/swaps/verify'
 import { nanoToValue, valueToNano } from '~/utils/crypto-utils'
 import { createRaceGuard } from '~/utils/race-guard'
 import { findBlockingDisabledOp, OP_REPAY_WITH_SHARES, OP_SKIM, OP_TRANSFER, OP_WITHDRAW, type PlannedOp } from '~/utils/vault-hooks'
@@ -187,6 +188,16 @@ export const useSavingsRepay = (options: UseSavingsRepayOptions) => {
 
   const hookWarning = computed(() => getPlanHookDisabledWarning(savingsRepayPlannedOps.value))
 
+  // Uses amountInMax (slippage-padded) when available so the user sees an
+  // insufficient-balance error before hitting an on-chain revert.
+  const requiredInput = computed(() => {
+    if (core.isSameAsset.value) return core.spent.value ?? 0n
+    const q = core.quotes.selectedQuote.value
+    if (!q) return 0n
+    return getSwapInputAmount(q, core.direction.value)
+  })
+  const isInsufficientSource = computed(() => requiredInput.value > 0n && requiredInput.value > sourceBalance.value)
+
   // --- Submit disabled ---
   const isSubmitDisabled = computed(() => {
     if (!isConnected.value) return false
@@ -194,7 +205,7 @@ export const useSavingsRepay = (options: UseSavingsRepayOptions) => {
     if (!sourceVault.value || !borrowVault.value) return true
     if (!core.debtAmount.value && !core.amount.value) return true
     if (core.isRepayExceedsDebt.value) return true
-    if (core.spent.value !== null && core.spent.value > sourceBalance.value) return true
+    if (isInsufficientSource.value) return true
     if (core.isSameAsset.value) return false
     if (core.quotes.quoteError.value) return true
     if (!core.quotes.selectedQuote.value) return true
@@ -205,7 +216,7 @@ export const useSavingsRepay = (options: UseSavingsRepayOptions) => {
     if (core.isRepayExceedsDebt.value) {
       return 'You repaying more than required'
     }
-    if (core.spent.value !== null && core.spent.value > sourceBalance.value) {
+    if (isInsufficientSource.value) {
       return 'Insufficient savings balance to cover the required swap amount.'
     }
     return undefined
@@ -432,6 +443,7 @@ export const useSavingsRepay = (options: UseSavingsRepayOptions) => {
     onPercentInput: core.onPercentInput,
     onSourceVaultChange,
     onRefreshQuotes: core.onRefreshQuotes,
+    onSourceMax: core.onSourceMax,
     submit,
     send,
     updateSourceBalance,

--- a/composables/repay/useWalletRepay.ts
+++ b/composables/repay/useWalletRepay.ts
@@ -141,20 +141,20 @@ export const useWalletRepay = (options: UseWalletRepayOptions) => {
       try {
         plan.value = shouldFullRepay
           ? await buildFullRepayPlan(
-            borrowVault.value.address,
-            borrowVault.value.asset.address,
-            amountNano,
-            position.value.subAccount,
-            position.value.collaterals ?? [collateralVault.value.address],
-            { includePermit2Call: false },
-          )
+              borrowVault.value.address,
+              borrowVault.value.asset.address,
+              amountNano,
+              position.value.subAccount,
+              position.value.collaterals ?? [collateralVault.value.address],
+              { includePermit2Call: false },
+            )
           : await buildRepayPlan(
-            borrowVault.value.address,
-            borrowVault.value.asset.address,
-            amountNano,
-            position.value.subAccount,
-            { includePermit2Call: false },
-          )
+              borrowVault.value.address,
+              borrowVault.value.asset.address,
+              amountNano,
+              position.value.subAccount,
+              { includePermit2Call: false },
+            )
       }
       catch (e) {
         logWarn('walletRepay/buildPlan', e)
@@ -196,20 +196,20 @@ export const useWalletRepay = (options: UseWalletRepayOptions) => {
       const isFullRepay = amountNano >= currentDebt || walletRepayPercent.value >= 100
       const txPlan = isFullRepay
         ? await buildFullRepayPlan(
-          borrowVault.value.address,
-          borrowVault.value.asset.address,
-          amountNano,
-          position.value.subAccount,
-          position.value.collaterals ?? [collateralVault.value.address],
-          { includePermit2Call: true },
-        )
+            borrowVault.value.address,
+            borrowVault.value.asset.address,
+            amountNano,
+            position.value.subAccount,
+            position.value.collaterals ?? [collateralVault.value.address],
+            { includePermit2Call: true },
+          )
         : await buildRepayPlan(
-          borrowVault.value.address,
-          borrowVault.value.asset.address,
-          amountNano,
-          position.value.subAccount,
-          { includePermit2Call: true },
-        )
+            borrowVault.value.address,
+            borrowVault.value.asset.address,
+            amountNano,
+            position.value.subAccount,
+            { includePermit2Call: true },
+          )
       await executeTxPlan(txPlan)
 
       modal.close()
@@ -335,6 +335,17 @@ export const useWalletRepay = (options: UseWalletRepayOptions) => {
     amount.value = trimTrailingZeros(formatUnits(amountNano, Number(borrowVault.value.asset.decimals)))
   }
 
+  // Max on source input: clamp to current debt so clicking Max on wallet
+  // balance > debt behaves like Max on debt (no over-repay). The watcher on
+  // `amount` syncs walletRepayPercent and triggers estimates.
+  const onSourceMax = () => {
+    clearSimulationError()
+    if (!borrowVault.value || !position.value) return
+    const currentDebt = position.value.borrowed || 0n
+    const cap = walletBalance.value < currentDebt ? walletBalance.value : currentDebt
+    amount.value = trimTrailingZeros(formatUnits(cap, Number(borrowVault.value.asset.decimals)))
+  }
+
   // Watch amount changes: sync percent slider + trigger estimates
   watch(amount, () => {
     clearSimulationError()
@@ -395,6 +406,7 @@ export const useWalletRepay = (options: UseWalletRepayOptions) => {
     submit,
     send,
     onWalletRepayPercentInput,
+    onSourceMax,
     initEstimates,
     resetOnTabSwitch,
   }

--- a/composables/repay/useWalletSwapRepay.ts
+++ b/composables/repay/useWalletSwapRepay.ts
@@ -195,15 +195,21 @@ export const useWalletSwapRepay = (options: UseWalletSwapRepayOptions) => {
   const sourceValueUsdGuard = createRaceGuard()
   const sourceValueUsd = ref<number | null>(null)
   watchEffect(async () => {
+    const gen = sourceValueUsdGuard.next()
     if (!selectedAsset.value || selectedAssetBalance.value <= 0n) {
       sourceValueUsd.value = null
       return
     }
-    const gen = sourceValueUsdGuard.next()
+    // Native tokens (zero address) aren't indexed by the backend price feed;
+    // resolve to the wrapped native address for pricing.
+    const rawAddress = selectedAsset.value.address
+    const priceAddress = isNativeCurrencyAddress(rawAddress) && chainId.value
+      ? (resolveWrappedNativeAddress(chainId.value) ?? rawAddress)
+      : rawAddress
     const result = (await getTokenUsdValue(
       selectedAssetBalance.value,
       Number(selectedAsset.value.decimals),
-      selectedAsset.value.address,
+      priceAddress,
       null,
     )) ?? null
     if (sourceValueUsdGuard.isStale(gen)) return
@@ -213,11 +219,11 @@ export const useWalletSwapRepay = (options: UseWalletSwapRepayOptions) => {
   const borrowValueUsdGuard = createRaceGuard()
   const borrowValueUsd = ref<number | null>(null)
   watchEffect(async () => {
+    const gen = borrowValueUsdGuard.next()
     if (!borrowVault.value || !position.value) {
       borrowValueUsd.value = null
       return
     }
-    const gen = borrowValueUsdGuard.next()
     const result = (await getAssetUsdValue(position.value.borrowed, borrowVault.value, 'off-chain')) ?? null
     if (borrowValueUsdGuard.isStale(gen)) return
     borrowValueUsd.value = result
@@ -589,7 +595,7 @@ export const useWalletSwapRepay = (options: UseWalletSwapRepayOptions) => {
     // Swap: compare USD values
     const srcUsd = sourceValueUsd.value
     const debtUsd = borrowValueUsd.value
-    if (srcUsd !== null && debtUsd !== null && srcUsd > debtUsd) {
+    if (srcUsd !== null && debtUsd !== null && srcUsd >= debtUsd) {
       debtAmount.value = trimTrailingZeros(formatUnits(currentDebt, borrowDecimals))
       onDebtInput()
       return

--- a/composables/repay/useWalletSwapRepay.ts
+++ b/composables/repay/useWalletSwapRepay.ts
@@ -9,7 +9,7 @@ import { useModal } from '~/components/ui/composables/useModal'
 import { OperationReviewModal } from '#components'
 import { useToast } from '~/components/ui/composables/useToast'
 import { getNetAPY, getProjectedRates, type Vault, type VaultAsset } from '~/entities/vault'
-import { getAssetUsdValueOrZero } from '~/services/pricing/priceProvider'
+import { getAssetUsdValue, getAssetUsdValueOrZero, getTokenUsdValue } from '~/services/pricing/priceProvider'
 import type { AccountBorrowPosition } from '~/entities/account'
 import type { TxPlan } from '~/entities/txPlan'
 import { valueToNano } from '~/utils/crypto-utils'
@@ -187,6 +187,40 @@ export const useWalletSwapRepay = (options: UseWalletSwapRepayOptions) => {
       return FixedPoint.fromValue(BigInt(Math.round(ratio * 1e18)), 18)
     }
     return FixedPoint.fromValue(0n, 18)
+  })
+
+  // --- USD values for source/debt comparison (used by onSourceMax) ---
+  // Source may be an arbitrary wallet token (possibly without a vault), so
+  // fall back to backend-price feed via getTokenUsdValue.
+  const sourceValueUsdGuard = createRaceGuard()
+  const sourceValueUsd = ref<number | null>(null)
+  watchEffect(async () => {
+    if (!selectedAsset.value || selectedAssetBalance.value <= 0n) {
+      sourceValueUsd.value = null
+      return
+    }
+    const gen = sourceValueUsdGuard.next()
+    const result = (await getTokenUsdValue(
+      selectedAssetBalance.value,
+      Number(selectedAsset.value.decimals),
+      selectedAsset.value.address,
+      null,
+    )) ?? null
+    if (sourceValueUsdGuard.isStale(gen)) return
+    sourceValueUsd.value = result
+  })
+
+  const borrowValueUsdGuard = createRaceGuard()
+  const borrowValueUsd = ref<number | null>(null)
+  watchEffect(async () => {
+    if (!borrowVault.value || !position.value) {
+      borrowValueUsd.value = null
+      return
+    }
+    const gen = borrowValueUsdGuard.next()
+    const result = (await getAssetUsdValue(position.value.borrowed, borrowVault.value, 'off-chain')) ?? null
+    if (borrowValueUsdGuard.isStale(gen)) return
+    borrowValueUsd.value = result
   })
 
   // --- Validation ---
@@ -533,6 +567,37 @@ export const useWalletSwapRepay = (options: UseWalletSwapRepayOptions) => {
     requestQuote()
   }
 
+  // Max on source input: if source is worth at least as much as the debt,
+  // behave like Max on debt (TARGET_DEBT with full debt). Otherwise default
+  // to EXACT_IN with full source balance. Prevents accidental over-repay.
+  const onSourceMax = () => {
+    if (!selectedAsset.value || !borrowVault.value || !position.value) return
+    const currentDebt = getCurrentDebt()
+    if (currentDebt <= 0n) return
+
+    const sourceDecimals = Number(selectedAsset.value.decimals)
+    const borrowDecimals = Number(borrowVault.value.asset.decimals)
+
+    // No swap: source asset == borrow asset, 1:1 comparison in native units
+    if (!needsSwap.value) {
+      const cap = selectedAssetBalance.value < currentDebt ? selectedAssetBalance.value : currentDebt
+      amount.value = trimTrailingZeros(formatUnits(cap, sourceDecimals))
+      onAmountInput()
+      return
+    }
+
+    // Swap: compare USD values
+    const srcUsd = sourceValueUsd.value
+    const debtUsd = borrowValueUsd.value
+    if (srcUsd !== null && debtUsd !== null && srcUsd > debtUsd) {
+      debtAmount.value = trimTrailingZeros(formatUnits(currentDebt, borrowDecimals))
+      onDebtInput()
+      return
+    }
+    amount.value = trimTrailingZeros(formatUnits(selectedAssetBalance.value, sourceDecimals))
+    onAmountInput()
+  }
+
   // Refresh selected asset balance and re-validate when wallet address changes
   watch(address, async () => {
     if (selectedAsset.value?.address) {
@@ -742,6 +807,7 @@ export const useWalletSwapRepay = (options: UseWalletSwapRepayOptions) => {
     // Actions
     onAmountInput,
     onDebtInput,
+    onSourceMax,
     onPercentInput,
     onSelectSwapAsset,
     onRefreshSwapQuotes,

--- a/composables/useSwapPriceImpact.ts
+++ b/composables/useSwapPriceImpact.ts
@@ -1,27 +1,10 @@
-import { type Address, formatUnits } from 'viem'
 import type { Ref } from 'vue'
 import type { SwapApiQuote } from '~/entities/swap'
 import type { Vault, SecuritizeVault, EarnVault } from '~/entities/vault'
-import { getAssetUsdValue } from '~/services/pricing/priceProvider'
-import { fetchBackendPrice } from '~/services/pricing/backendClient'
+import { getTokenUsdValue } from '~/services/pricing/priceProvider'
 import { createRaceGuard } from '~/utils/race-guard'
 
 type AnyVault = Vault | SecuritizeVault | EarnVault
-
-const getTokenUsdValue = async (
-  amount: bigint,
-  decimals: number,
-  tokenAddress: string,
-  vault: AnyVault | null | undefined,
-): Promise<number | undefined> => {
-  if (vault) {
-    return getAssetUsdValue(amount, vault, 'off-chain')
-  }
-  const priceData = await fetchBackendPrice(tokenAddress as Address)
-  if (!priceData?.price) return undefined
-  const tokenAmount = Number(formatUnits(amount, decimals))
-  return tokenAmount * priceData.price
-}
 
 export const useSwapPriceImpact = (options: {
   quote: Ref<SwapApiQuote | null>

--- a/pages/position/[number]/repay.vue
+++ b/pages/position/[number]/repay.vue
@@ -377,6 +377,7 @@ watch(formTab, () => {
                   :asset="position.borrow.asset"
                   :vault="position.borrow"
                   :balance="walletBalance"
+                  :max-handler="wallet.onSourceMax"
                   maxable
                 />
 
@@ -410,6 +411,7 @@ watch(formTab, () => {
                   label="Pay from wallet"
                   :asset="walletSwap.selectedAsset.value"
                   :balance="walletSwap.selectedAssetBalance.value"
+                  :max-handler="walletSwap.onSourceMax"
                   maxable
                   @update:model-value="walletSwap.onAmountInput"
                 />
@@ -609,6 +611,7 @@ watch(formTab, () => {
                 :vault="collateral.sourceVault.value"
                 :collateral-options="collateral.repayCollateralOptions.value"
                 :balance="collateral.sourceBalance.value"
+                :max-handler="collateral.onSourceMax"
                 maxable
                 @input="collateral.onAmountInput"
                 @change-collateral="collateral.onSourceVaultChange"
@@ -779,6 +782,7 @@ watch(formTab, () => {
                 :vault="savings.sourceVault.value"
                 :collateral-options="savings.savingsOptions.value"
                 :balance="savings.sourceBalance.value"
+                :max-handler="savings.onSourceMax"
                 maxable
                 @input="savings.onAmountInput"
                 @change-collateral="savings.onSourceVaultChange"

--- a/services/pricing/priceProvider.ts
+++ b/services/pricing/priceProvider.ts
@@ -486,6 +486,32 @@ export const getAssetUsdValueOrZero = async (
 }
 
 /**
+ * Calculate USD value of a token amount, preferring vault pricing when
+ * available and falling back to the backend price feed for tokens without
+ * an associated vault (e.g. arbitrary swap tokens from the wallet).
+ *
+ * @param amount - Token amount in native decimals
+ * @param decimals - Token decimals
+ * @param tokenAddress - Token address, required for backend fallback
+ * @param vault - Optional vault for on-vault pricing
+ * @returns USD value as number, or undefined if no price available
+ */
+export const getTokenUsdValue = async (
+  amount: bigint,
+  decimals: number,
+  tokenAddress: string,
+  vault: AnyVault | null | undefined,
+): Promise<number | undefined> => {
+  if (vault) {
+    return getAssetUsdValue(amount, vault, 'off-chain')
+  }
+  const priceData = await fetchBackendPrice(tokenAddress as `0x${string}`)
+  if (!priceData?.price) return undefined
+  const tokenAmount = nanoToValue(amount, decimals)
+  return tokenAmount * priceData.price
+}
+
+/**
  * Convenience wrapper: same as getCollateralUsdValue but returns 0 instead of undefined.
  */
 export const getCollateralUsdValueOrZero = async (


### PR DESCRIPTION
## Summary

Fixes accidental over-repay when clicking **Max** on the source input in the repay form. Each repay tab (wallet / collateral / savings) has two Max buttons — one for the source balance and one for the debt. Previously, if the wallet/collateral/savings balance was worth more than the debt, clicking source-Max set the amount to the full source balance and the form failed with *"You repaying more than required"*.

Now: when the source is worth at least as much as the debt, source-Max behaves like debt-Max — switches to `TARGET_DEBT` mode with the full debt amount, so the user fully repays without over-paying. When the source is worth less than the debt, behavior is unchanged (EXACT_IN with full source).

### What changed

- `AssetInput.vue` — added optional `maxHandler` prop; when provided, it replaces the default Max behavior.
- `useRepaySwapCore.ts` — added `onSourceMax()` shared by collateral + savings tabs. Compares against already-reactive `sourceValueUsd` / `borrowValueUsd` for cross-asset cases; native-unit comparison for same-asset.
- `useWalletRepay.ts` — added `onSourceMax()` for wallet no-swap (same asset).
- `useWalletSwapRepay.ts` — added `onSourceMax()` + two new reactive USD refs that use `getTokenUsdValue` to price arbitrary wallet tokens (including tokens without a vault, via the backend price feed).
- `useCollateralSwapRepay.ts` / `useSavingsRepay.ts` — re-exported the handler from the core, and upgraded the `isSubmitDisabled` balance check to use `getSwapInputAmount(quote, direction)` so it compares against the slippage-padded `amountInMax` rather than the base `amountIn`. This closes a pre-existing gap where a tight slippage budget in TARGET_DEBT could silently pass submit-disabled and revert on-chain.
- `priceProvider.ts` — promoted `getTokenUsdValue` (vault-or-backend fallback) from inside `useSwapPriceImpact.ts` to a shared export so both the price-impact composable and the wallet-swap flow share one helper.
- `repay.vue` — wired `:max-handler` on the four source inputs (wallet no-swap, wallet-swap, collateral, savings). Debt inputs and percent slider are unchanged.

### Slippage edge case

If the oracle says `sourceValueUsd > borrowValueUsd` but slippage-padded `amountInMax` exceeds the source balance, the switched-to-TARGET_DEBT mode now surfaces *"Insufficient collateral/savings balance to cover the required swap amount"* in the form — clear feedback instead of a silent on-chain revert. The user can then adjust slippage or manually switch back to a partial repay.

If USD refs haven't resolved yet when the user clicks Max, behavior gracefully falls back to EXACT_IN with full source (the pre-existing behavior).

### Scope

- Max-button only. Manual typing of an over-repay amount still shows the existing *"repaying more than required"* error; manual typing is explicit intent.
- The same-asset clamp inside the debounced `requestQuote` (useRepaySwapCore.ts) is left as a safety net for manual entries.

## Test plan

- [x] **Wallet no-swap, balance < debt** — source-Max sets amount to walletBalance, submit enabled, partial repay.
- [x] **Wallet no-swap, balance > debt** — source-Max sets amount to debt, percent slider jumps to 100, submit enabled, full-repay plan selected. (Previously: error.)
- [x] **Wallet swap, source USD < debt USD** — source-Max → EXACT_IN with walletBalance.
- [x] **Wallet swap, source USD > debt USD, slippage fits** — source-Max → TARGET_DEBT with full debt, quote resolves, submit enabled.
- [ ] **Wallet swap, source USD > debt USD, slippage too tight** — "Not enough balance" error shown (already wired in `updateSyncEstimates`).
- [x] **Collateral same-asset, balance > debt** — source-Max → TARGET_DEBT, percent=100, `buildSameAssetFullRepayPlan` is selected.
- [x] **Collateral cross-asset, source USD > debt USD, slippage fits** — source-Max → TARGET_DEBT full debt, quote fills, submit enabled.
- [ ] **Collateral cross-asset, source USD > debt USD, slippage tight** — "Insufficient collateral balance…" error shown (new check).
- [x] **Savings tab** — same scenarios as collateral.
- [x] **Debt-Max button still works** on all tabs (regression check).
- [x] **Percent slider still works** on all tabs (regression check).
- [x] **Manual typing over-debt in source** still shows "repaying more than required" (regression check).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "set max amount" functionality to all repay flows. Users can now quickly set repayment amounts to their maximum available balance across wallet direct repay, cross-asset swaps, collateral swaps, and savings repay options with a single click.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->