### PR TITLE
ci: disable automatic Claude PR review trigger

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,14 +1,18 @@
 name: Claude Code Review
 
 on:
-  pull_request:
-    types: [opened, reopened, ready_for_review]
-    paths:
-      - '**.vue'
-      - '**.ts'
-      - '**.js'
-      - 'package.json'
-      - 'nuxt.config.*'
+  # Automatic PR reviews are temporarily disabled (out of LLM credits;
+  # every run would fail). To re-enable: uncomment the pull_request
+  # block below. All downstream logic (the review job's pull_request
+  # branch in its `if`, and autofix's auto-trigger branch) is intact.
+  # pull_request:
+  #   types: [opened, reopened, ready_for_review]
+  #   paths:
+  #     - '**.vue'
+  #     - '**.ts'
+  #     - '**.js'
+  #     - 'package.json'
+  #     - 'nuxt.config.*'
   issue_comment:
     types: [created]
   pull_request_review_comment:


### PR DESCRIPTION
Comment out the pull_request event in the Claude code-review workflow so reviews no longer run on PR open/reopen/ready_for_review. Manual @claude review / @claude fix / @claude comment triggers are preserved. All job bodies and if-conditions are left untouched so the trigger can be restored by uncommenting the block.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified GitHub Actions workflow configuration to adjust code review automation triggering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->