### PR TITLE
fix: strip CDN-injected geo keys from proxy API responses

### DIFF
--- a/plugins/01.api-sanitizer.client.ts
+++ b/plugins/01.api-sanitizer.client.ts
@@ -1,0 +1,11 @@
+import axios from 'axios'
+import { sanitizeApiResponse } from '~/utils/sanitizeApiResponse'
+
+export default defineNuxtPlugin(() => {
+  axios.interceptors.response.use((response) => {
+    if (response.config.url?.startsWith('/api/')) {
+      response.data = sanitizeApiResponse(response.data)
+    }
+    return response
+  })
+})

--- a/utils/sanitizeApiResponse.ts
+++ b/utils/sanitizeApiResponse.ts
@@ -1,0 +1,30 @@
+/**
+ * Known root-level keys injected into JSON response bodies by the CDN edge
+ * layer (e.g. Cloudflare Worker) on certain hostnames. These are geo/VPN
+ * metadata fields that pollute the intended JSON schema.
+ */
+const EDGE_INJECTED_KEYS = new Set(['countryCode', 'isProxyOrVpn', 'is_vpn'])
+
+/**
+ * Strips CDN-injected geo/VPN metadata keys from a JSON response object.
+ * Returns the input unchanged for arrays, primitives, and objects without
+ * injected keys. Safe to call in environments where injection doesn't occur.
+ */
+export function sanitizeApiResponse<T>(data: T): T {
+  if (data === null || typeof data !== 'object' || Array.isArray(data)) {
+    return data
+  }
+
+  const obj = data as Record<string, unknown>
+  if (!Object.keys(obj).some(k => EDGE_INJECTED_KEYS.has(k))) {
+    return data
+  }
+
+  const cleaned: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(obj)) {
+    if (!EDGE_INJECTED_KEYS.has(key)) {
+      cleaned[key] = value
+    }
+  }
+  return cleaned as T
+}


### PR DESCRIPTION
## Summary
- A Cloudflare Worker on `app.euler.finance` injects `countryCode`, `isProxyOrVpn`, and `is_vpn` keys into JSON response bodies of `/api/*` endpoints
- `normalizeProducts` iterates `Object.entries(data)` and crashes when it hits these injected keys (e.g. `"PT".vaults` is `undefined`)
- Adds `sanitizeApiResponse()` utility that strips known CDN-injected keys from JSON objects
- Applies it via an axios response interceptor (`plugins/01.api-sanitizer.client.ts`) scoped to `/api/*` URLs — all current and future axios proxy calls are automatically sanitized
- No-ops safely when injection is absent (test/dev environments)