### PR TITLE
Fix/slippage edit accessibility

### DIFF
--- a/components/entities/swap/SwapDetailsSummary.vue
+++ b/components/entities/swap/SwapDetailsSummary.vue
@@ -17,22 +17,31 @@ const emit = defineEmits<{
 </script>
 
 <template>
-  <SummaryRow label="Swap in">
+  <SummaryRow
+    v-if="inputDisplay"
+    label="Swap in"
+  >
     <p class="text-p2 text-right">
-      {{ inputDisplay ?? '-' }}
+      {{ inputDisplay }}
     </p>
   </SummaryRow>
-  <SummaryRow label="Swap out">
+  <SummaryRow
+    v-if="outputDisplay"
+    label="Swap out"
+  >
     <p class="text-p2 text-right">
-      {{ outputDisplay ?? '-' }}
+      {{ outputDisplay }}
     </p>
   </SummaryRow>
-  <SummaryRow label="Price impact">
+  <SummaryRow
+    v-if="priceImpact !== null"
+    label="Price impact"
+  >
     <p
       class="text-p2"
       :class="{ 'text-error-500': isPriceImpactWarning(priceImpact) }"
     >
-      {{ priceImpact !== null ? `${formatNumber(priceImpact, 2, 2)}%` : '-' }}
+      {{ formatNumber(priceImpact, 2, 2) }}%
     </p>
   </SummaryRow>
   <SummaryRow
@@ -59,9 +68,12 @@ const emit = defineEmits<{
       />
     </button>
   </SummaryRow>
-  <SummaryRow label="Routed via">
+  <SummaryRow
+    v-if="routedVia"
+    label="Routed via"
+  >
     <p class="text-p2 text-right">
-      {{ routedVia ?? '-' }}
+      {{ routedVia }}
     </p>
   </SummaryRow>
 </template>

--- a/pages/borrow/[collateral]/[borrow]/index.vue
+++ b/pages/borrow/[collateral]/[borrow]/index.vue
@@ -515,6 +515,7 @@ watch(formTab, () => {
                   />
 
                   <VaultFormInfoBlock
+                    v-if="borrow.borrowSwapEstimatedCollateral.value || borrow.borrowSwapQuoteError.value"
                     :loading="borrow.isBorrowSwapQuoteLoading.value"
                     variant="card"
                   >

--- a/pages/borrow/[collateral]/[borrow]/index.vue
+++ b/pages/borrow/[collateral]/[borrow]/index.vue
@@ -515,7 +515,6 @@ watch(formTab, () => {
                   />
 
                   <VaultFormInfoBlock
-                    v-if="borrow.borrowSwapEstimatedCollateral.value"
                     :loading="borrow.isBorrowSwapQuoteLoading.value"
                     variant="card"
                   >

--- a/pages/lend/[vault]/[subAccount]/withdraw.vue
+++ b/pages/lend/[vault]/[subAccount]/withdraw.vue
@@ -594,6 +594,7 @@ watch(swapSelectedQuote, () => {
               />
 
               <VaultFormInfoBlock
+                v-if="swapEstimatedOutput || swapQuoteError"
                 :loading="isSwapQuoteLoading"
                 variant="card"
               >

--- a/pages/lend/[vault]/[subAccount]/withdraw.vue
+++ b/pages/lend/[vault]/[subAccount]/withdraw.vue
@@ -594,7 +594,6 @@ watch(swapSelectedQuote, () => {
               />
 
               <VaultFormInfoBlock
-                v-if="swapEstimatedOutput"
                 :loading="isSwapQuoteLoading"
                 variant="card"
               >

--- a/pages/lend/[vault]/index.vue
+++ b/pages/lend/[vault]/index.vue
@@ -871,7 +871,6 @@ watch(address, () => {
               />
 
               <VaultFormInfoBlock
-                v-if="swapEstimatedOutput"
                 :loading="isSwapQuoteLoading"
                 variant="card"
               >

--- a/pages/lend/[vault]/index.vue
+++ b/pages/lend/[vault]/index.vue
@@ -871,6 +871,7 @@ watch(address, () => {
               />
 
               <VaultFormInfoBlock
+                v-if="swapEstimatedOutput || swapQuoteError"
                 :loading="isSwapQuoteLoading"
                 variant="card"
               >

--- a/pages/position/[number]/repay.vue
+++ b/pages/position/[number]/repay.vue
@@ -562,7 +562,7 @@ watch(formTab, () => {
                 />
               </SummaryRow>
               <SwapDetailsSummary
-                v-if="walletSwap.needsSwap.value && walletSwap.swapEstimatedOutput.value"
+                v-if="walletSwap.needsSwap.value"
                 :input-display="walletSwap.swapInputDisplay.value"
                 :output-display="walletSwap.swapOutputDisplay.value"
                 :price-impact="walletSwap.swapPriceImpact.value"

--- a/pages/position/[number]/repay.vue
+++ b/pages/position/[number]/repay.vue
@@ -562,7 +562,7 @@ watch(formTab, () => {
                 />
               </SummaryRow>
               <SwapDetailsSummary
-                v-if="walletSwap.needsSwap.value"
+                v-if="walletSwap.needsSwap.value && (walletSwap.swapEstimatedOutput.value || walletSwap.quotes.quoteError.value)"
                 :input-display="walletSwap.swapInputDisplay.value"
                 :output-display="walletSwap.swapOutputDisplay.value"
                 :price-impact="walletSwap.swapPriceImpact.value"

--- a/pages/position/[number]/supply.vue
+++ b/pages/position/[number]/supply.vue
@@ -296,6 +296,7 @@ watch(selectedAsset, async () => {
               />
 
               <VaultFormInfoBlock
+                v-if="form.swapEstimatedOutput.value || form.swapQuoteError.value"
                 :loading="form.isSwapQuoteLoading.value"
                 variant="card"
               >

--- a/pages/position/[number]/supply.vue
+++ b/pages/position/[number]/supply.vue
@@ -296,7 +296,6 @@ watch(selectedAsset, async () => {
               />
 
               <VaultFormInfoBlock
-                v-if="form.swapEstimatedOutput.value"
                 :loading="form.isSwapQuoteLoading.value"
                 variant="card"
               >

--- a/pages/position/[number]/withdraw.vue
+++ b/pages/position/[number]/withdraw.vue
@@ -240,7 +240,6 @@ watch(selectedOutputAsset, () => {
               />
 
               <VaultFormInfoBlock
-                v-if="form.swapEstimatedOutput.value"
                 :loading="form.isSwapQuoteLoading.value"
                 variant="card"
               >

--- a/pages/position/[number]/withdraw.vue
+++ b/pages/position/[number]/withdraw.vue
@@ -240,6 +240,7 @@ watch(selectedOutputAsset, () => {
               />
 
               <VaultFormInfoBlock
+                v-if="form.swapEstimatedOutput.value || form.swapQuoteError.value"
                 :loading="form.isSwapQuoteLoading.value"
                 variant="card"
               >


### PR DESCRIPTION
## Summary
- When a swap quote failed, the slippage tolerance edit button disappeared because `SwapDetailsSummary` was gated behind a quote-success condition (`swapEstimatedOutput`). Users had no way to adjust slippage to retry the quote unless they navigated to the global Settings panel.
- The block now renders on quote success (full details) or quote failure (slippage row only), while staying hidden during loading — preserving the original UX for the happy path.

## Changes
- Widened the `v-if` on 6 pages from `swapEstimatedOutput` to `swapEstimatedOutput || swapQuoteError` so the swap details block also appears when a quote fails.
- Updated `SwapDetailsSummary` to hide data-dependent rows (swap in/out, price impact, routed via) when their values are empty. The slippage tolerance row always renders, so on quote failure only the editable slippage is shown instead of a card full of dashes.
- Affected pages: borrow, position supply, position withdraw, position repay (wallet tab), lend deposit, lend withdraw.

## Test plan
- [ ] On any swap-enabled page (e.g. borrow with "Pay with" a different token), trigger a quote failure (select a token pair with no swap route available)
- [ ] Verify the slippage tolerance row with its edit button appears after the quote fails
- [ ] Verify clicking the edit button opens the slippage settings modal and changes persist
- [ ] Verify the block does NOT flash during quote loading — it should appear only after loading completes
- [ ] Verify successful quotes still show all detail rows (swap in/out, price impact, slippage, routed via)
- [ ] Verify the multiply page and dedicated swap pages (which were not affected) still behave normally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed empty placeholder values from swap detail summaries for cleaner display
  * Swap information containers now display when quote errors occur, providing better error context alongside messages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->