### PR TITLE
refactor: replace governance-limited chip with standalone Limited badge

### DIFF
--- a/components/entities/vault/GovernanceLimitedBadge.vue
+++ b/components/entities/vault/GovernanceLimitedBadge.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import { useModal } from '~/components/ui/composables/useModal'
+import { GovernanceLimitedInfoModal } from '#components'
+
+const { size = 'small' } = defineProps<{
+  size?: 'small' | 'large'
+}>()
+
+const modal = useModal()
+
+const openInfoModal = (event: MouseEvent) => {
+  event.preventDefault()
+  event.stopPropagation()
+  modal.open(GovernanceLimitedInfoModal)
+}
+</script>
+
+<template>
+  <span
+    class="governance-limited-badge inline-flex items-center cursor-pointer"
+    :class="size === 'large'
+      ? 'gap-8 py-8 px-12 rounded-8'
+      : 'gap-4 py-2 px-8 rounded-8 text-p5'"
+    title="This vault has limited risk management"
+    @click="openInfoModal"
+  >
+    <SvgIcon
+      name="pulse"
+      :class="size === 'large' ? '!w-20 !h-20 mr-2' : '!w-14 !h-14'"
+    />
+    Limited
+  </span>
+</template>
+
+<style scoped lang="scss">
+.governance-limited-badge {
+  background-color: rgba(var(--accent-rgb), 0.15);
+  color: var(--accent-600);
+
+  [data-theme="dark"] & {
+    background-color: rgba(var(--accent-rgb), 0.2);
+    color: var(--accent-500);
+  }
+}
+</style>

--- a/components/entities/vault/GovernanceLimitedInfoModal.vue
+++ b/components/entities/vault/GovernanceLimitedInfoModal.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+import { vaultTypeDescriptions } from '~/entities/vault/descriptions'
+
+defineEmits(['close'])
+</script>
+
+<template>
+  <BaseModalWrapper
+    title="Limited Risk Management"
+    @close="$emit('close')"
+  >
+    <div class="flex flex-col gap-16 pt-8">
+      <div class="flex items-center justify-center">
+        <div class="flex items-center justify-center w-48 h-48 rounded-12 bg-accent-100">
+          <SvgIcon
+            name="pulse"
+            class="!w-24 !h-24 text-accent-600"
+          />
+        </div>
+      </div>
+
+      <div class="flex flex-col gap-8">
+        <p class="text-p2 text-content-primary text-center font-medium">
+          Limited Risk Management
+        </p>
+        <p class="text-p3 text-content-secondary text-center">
+          {{ vaultTypeDescriptions.governanceLimited }}
+        </p>
+      </div>
+
+      <UiButton
+        variant="primary"
+        size="large"
+        @click="$emit('close')"
+      >
+        Got it
+      </UiButton>
+    </div>
+  </BaseModalWrapper>
+</template>

--- a/components/entities/vault/SecuritizeVaultItem.vue
+++ b/components/entities/vault/SecuritizeVaultItem.vue
@@ -113,6 +113,7 @@ watchEffect(async () => {
             :name="displayName"
             :is-unverified="isUnverified"
           />
+          <GovernanceLimitedBadge v-if="isGovernanceLimited" />
           <span
             v-if="isGeoBlocked"
             class="inline-flex items-center gap-4 rounded-8 px-8 py-2 bg-warning-100 text-warning-500 text-p5"

--- a/components/entities/vault/VaultBorrowItem.vue
+++ b/components/entities/vault/VaultBorrowItem.vue
@@ -270,6 +270,7 @@ const linkPath = computed(() => ({
               Featured
             </span>
             <KeyringBadge v-if="isKeyring" />
+            <GovernanceLimitedBadge v-if="isAnyGovernanceLimited" />
             <span
               v-if="isGeoBlocked"
               class="inline-flex items-center gap-4 rounded-8 px-8 py-2 bg-warning-100 text-warning-500 text-p5"

--- a/components/entities/vault/VaultItem.vue
+++ b/components/entities/vault/VaultItem.vue
@@ -183,6 +183,7 @@ watchEffect(async () => {
             Featured
           </span>
           <KeyringBadge v-if="isKeyring" />
+          <GovernanceLimitedBadge v-if="isGovernanceLimited" />
           <span
             v-if="isGeoBlocked"
             class="inline-flex items-center gap-4 rounded-8 px-8 py-2 bg-warning-100 text-warning-500 text-p5"

--- a/components/entities/vault/VaultTypeBadges.vue
+++ b/components/entities/vault/VaultTypeBadges.vue
@@ -46,7 +46,7 @@ const governanceType = computed(() => {
   if (!v.governorAdmin) return 'unknown'
   if (v.governorAdmin === zeroAddress) return 'ungoverned'
   if (entities.value.length) {
-    return isGovernanceLimited.value ? 'governanceLimited' : 'governed'
+    return 'governed'
   }
   return 'unknown'
 })
@@ -75,6 +75,10 @@ const isKeyring = computed(() => isVaultKeyring(vaultAddress))
     />
     <KeyringBadge
       v-if="isKeyring && isVerified"
+      size="large"
+    />
+    <GovernanceLimitedBadge
+      v-if="isGovernanceLimited"
       size="large"
     />
   </div>

--- a/components/entities/vault/VaultTypeChip.vue
+++ b/components/entities/vault/VaultTypeChip.vue
@@ -22,7 +22,7 @@ const isVerified = computed(() => {
     return isEarnVaultOwnerVerified(vault as EarnVault)
   }
 
-  // governed, governanceLimited, ungoverned, securitize
+  // governed, ungoverned, securitize
   return isVaultGovernorVerified(vault as Vault)
 })
 
@@ -34,7 +34,6 @@ const icon = computed(() => {
   }
   switch (type) {
     case 'governed':
-    case 'governanceLimited':
     case 'managed':
       return 'bank'
     case 'escrow':
@@ -54,8 +53,6 @@ const label = computed(() => {
   switch (type) {
     case 'governed':
       return 'Governed'
-    case 'governanceLimited':
-      return 'Governed - limited'
     case 'managed':
       return 'Managed'
     case 'escrow':

--- a/components/entities/vault/discovery/DiscoveryMarketCard.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketCard.vue
@@ -168,6 +168,7 @@ const onMaxRoeInfoIconClick = (event: MouseEvent, result: BestMaxRoeResult) => {
               Featured
             </span>
             <KeyringBadge v-if="isKeyring" />
+            <GovernanceLimitedBadge v-if="isGovernanceLimited" />
           </div>
           <div class="text-h5 text-content-primary">
             {{ market.name }}

--- a/components/entities/vault/overview/SecuritizeVaultOverview.vue
+++ b/components/entities/vault/overview/SecuritizeVaultOverview.vue
@@ -249,10 +249,6 @@ const supplyCapPercentageDisplay = computed(() => {
                 class="text-p2 text-content-primary underline"
               >{{ entity.name }}</a>
             </div>
-            <span
-              v-if="isGovernanceLimited"
-              class="text-p3 text-content-tertiary"
-            >Limited risk management</span>
           </div>
           <VaultTypeChip
             v-else-if="!isGovernorVerified"

--- a/components/entities/vault/overview/VaultOverviewBlockGeneral.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockGeneral.vue
@@ -144,10 +144,6 @@ watchEffect(async () => {
                 class="text-p2 text-content-primary"
               >{{ entity.name }}</span>
             </div>
-            <span
-              v-if="isGovernanceLimited"
-              class="text-p3 text-content-tertiary"
-            >Limited risk management</span>
           </div>
           <div v-else>
             -

--- a/composables/borrow/useBorrowForm.ts
+++ b/composables/borrow/useBorrowForm.ts
@@ -674,28 +674,28 @@ export const useBorrowForm = (options: UseBorrowFormOptions) => {
       try {
         plan.value = isSavingCollateral.value
           ? await buildBorrowBySavingPlan(
-            collateralVault.value.address,
-            collateralAmountForPlan,
-            borrowVault.value.address,
-            borrowAmountNano,
-            undefined,
-            undefined,
-            savingCollateral.value?.subAccount,
-          )
+              collateralVault.value.address,
+              collateralAmountForPlan,
+              borrowVault.value.address,
+              borrowAmountNano,
+              undefined,
+              undefined,
+              savingCollateral.value?.subAccount,
+            )
           : await buildBorrowPlan(
-            collateralVault.value.address,
-            collateralVault.value.asset.address,
-            collateralAmountForPlan,
-            borrowVault.value.address,
-            borrowAmountNano,
-            undefined,
-            {
-              includePermit2Call: false,
-              wrappedNativeInfo: isBorrowNativeWrap.value
-                ? { wrappedTokenAddress: resolveWrappedNativeAddress(chainId.value!)!, nativeAmount: collateralAmountForPlan }
-                : undefined,
-            },
-          )
+              collateralVault.value.address,
+              collateralVault.value.asset.address,
+              collateralAmountForPlan,
+              borrowVault.value.address,
+              borrowAmountNano,
+              undefined,
+              {
+                includePermit2Call: false,
+                wrappedNativeInfo: isBorrowNativeWrap.value
+                  ? { wrappedTokenAddress: resolveWrappedNativeAddress(chainId.value!)!, nativeAmount: collateralAmountForPlan }
+                  : undefined,
+              },
+            )
       }
       catch (e) {
         logWarn('borrow/buildPlan', e)
@@ -761,28 +761,28 @@ export const useBorrowForm = (options: UseBorrowFormOptions) => {
         const borrowAmountNano = borrowAmountFixed.value.toFormat({ decimals: Number(borrowVault.value.decimals) }).value
         txPlan = isSavingCollateral.value
           ? await buildBorrowBySavingPlan(
-            collateralVault.value.address,
-            collateralAmountForPlan,
-            borrowVault.value.address,
-            borrowAmountNano,
-            undefined,
-            undefined,
-            savingCollateral.value?.subAccount,
-          )
+              collateralVault.value.address,
+              collateralAmountForPlan,
+              borrowVault.value.address,
+              borrowAmountNano,
+              undefined,
+              undefined,
+              savingCollateral.value?.subAccount,
+            )
           : await buildBorrowPlan(
-            collateralVault.value.address,
-            collateralVault.value.asset.address,
-            collateralAmountForPlan,
-            borrowVault.value.address,
-            borrowAmountNano,
-            undefined,
-            {
-              includePermit2Call: true,
-              wrappedNativeInfo: isBorrowNativeWrap.value
-                ? { wrappedTokenAddress: resolveWrappedNativeAddress(chainId.value!)!, nativeAmount: collateralAmountForPlan }
-                : undefined,
-            },
-          )
+              collateralVault.value.address,
+              collateralVault.value.asset.address,
+              collateralAmountForPlan,
+              borrowVault.value.address,
+              borrowAmountNano,
+              undefined,
+              {
+                includePermit2Call: true,
+                wrappedNativeInfo: isBorrowNativeWrap.value
+                  ? { wrappedTokenAddress: resolveWrappedNativeAddress(chainId.value!)!, nativeAmount: collateralAmountForPlan }
+                  : undefined,
+              },
+            )
       }
       await executeTxPlan(txPlan)
 

--- a/composables/repay/useWalletRepay.ts
+++ b/composables/repay/useWalletRepay.ts
@@ -141,20 +141,20 @@ export const useWalletRepay = (options: UseWalletRepayOptions) => {
       try {
         plan.value = shouldFullRepay
           ? await buildFullRepayPlan(
-            borrowVault.value.address,
-            borrowVault.value.asset.address,
-            amountNano,
-            position.value.subAccount,
-            position.value.collaterals ?? [collateralVault.value.address],
-            { includePermit2Call: false },
-          )
+              borrowVault.value.address,
+              borrowVault.value.asset.address,
+              amountNano,
+              position.value.subAccount,
+              position.value.collaterals ?? [collateralVault.value.address],
+              { includePermit2Call: false },
+            )
           : await buildRepayPlan(
-            borrowVault.value.address,
-            borrowVault.value.asset.address,
-            amountNano,
-            position.value.subAccount,
-            { includePermit2Call: false },
-          )
+              borrowVault.value.address,
+              borrowVault.value.asset.address,
+              amountNano,
+              position.value.subAccount,
+              { includePermit2Call: false },
+            )
       }
       catch (e) {
         logWarn('walletRepay/buildPlan', e)
@@ -196,20 +196,20 @@ export const useWalletRepay = (options: UseWalletRepayOptions) => {
       const isFullRepay = amountNano >= currentDebt || walletRepayPercent.value >= 100
       const txPlan = isFullRepay
         ? await buildFullRepayPlan(
-          borrowVault.value.address,
-          borrowVault.value.asset.address,
-          amountNano,
-          position.value.subAccount,
-          position.value.collaterals ?? [collateralVault.value.address],
-          { includePermit2Call: true },
-        )
+            borrowVault.value.address,
+            borrowVault.value.asset.address,
+            amountNano,
+            position.value.subAccount,
+            position.value.collaterals ?? [collateralVault.value.address],
+            { includePermit2Call: true },
+          )
         : await buildRepayPlan(
-          borrowVault.value.address,
-          borrowVault.value.asset.address,
-          amountNano,
-          position.value.subAccount,
-          { includePermit2Call: true },
-        )
+            borrowVault.value.address,
+            borrowVault.value.asset.address,
+            amountNano,
+            position.value.subAccount,
+            { includePermit2Call: true },
+          )
       await executeTxPlan(txPlan)
 
       modal.close()

--- a/composables/useVaultSearch.ts
+++ b/composables/useVaultSearch.ts
@@ -14,10 +14,10 @@ function sanitizeQuery(raw: string): string {
 export function useVaultSearch<T>(
   getSearchableFields: (item: T) => (string | undefined)[],
 ): {
-    searchQuery: Ref<string>
-    matchesSearch: (item: T) => boolean
-    clearSearch: () => void
-  } {
+  searchQuery: Ref<string>
+  matchesSearch: (item: T) => boolean
+  clearSearch: () => void
+} {
   const searchQuery = ref('')
 
   const matchesSearch = (item: T): boolean => {

--- a/entities/custom.ts
+++ b/entities/custom.ts
@@ -2,21 +2,21 @@
 export const themeHue = 150
 
 // Intrinsic APY sources (data mapping, not deployment config)
-export type IntrinsicApySourceConfig =
-  | { provider: 'defillama', address: string, chainId: number, poolId: string, useSpotApy?: boolean }
-  | { provider: 'pendle', address: string, chainId: number, pendleMarket: string, crossChainSourceChainId?: number }
-  | { provider: 'securitize', address: string, chainId: number, symbol: string, yieldField: 'nav_yield_30d' | 'distribution_yield' }
-  | { provider: 'stablewatch', address: string, chainId: number }
-  | { provider: 'etherfi', address: string, chainId: number }
-  | { provider: 'renzo', address: string, chainId: number, renzoVariant: 'ezETH' | 'pzETH' }
-  | { provider: 'midas', address: string, chainId: number, midasKey: string }
-  | { provider: 'yo', address: string, chainId: number }
-  | { provider: 'spark', address: string, chainId: number }
-  | { provider: 'puffer', address: string, chainId: number }
-  | { provider: 'treehouse', address: string, chainId: number }
-  | { provider: 'ondo', address: string, chainId: number }
-  | { provider: 'benqi', address: string, chainId: number }
-  | { provider: 'avant', address: string, chainId: number }
+export type IntrinsicApySourceConfig
+  = | { provider: 'defillama', address: string, chainId: number, poolId: string, useSpotApy?: boolean }
+    | { provider: 'pendle', address: string, chainId: number, pendleMarket: string, crossChainSourceChainId?: number }
+    | { provider: 'securitize', address: string, chainId: number, symbol: string, yieldField: 'nav_yield_30d' | 'distribution_yield' }
+    | { provider: 'stablewatch', address: string, chainId: number }
+    | { provider: 'etherfi', address: string, chainId: number }
+    | { provider: 'renzo', address: string, chainId: number, renzoVariant: 'ezETH' | 'pzETH' }
+    | { provider: 'midas', address: string, chainId: number, midasKey: string }
+    | { provider: 'yo', address: string, chainId: number }
+    | { provider: 'spark', address: string, chainId: number }
+    | { provider: 'puffer', address: string, chainId: number }
+    | { provider: 'treehouse', address: string, chainId: number }
+    | { provider: 'ondo', address: string, chainId: number }
+    | { provider: 'benqi', address: string, chainId: number }
+    | { provider: 'avant', address: string, chainId: number }
 
 export const intrinsicApySources: readonly IntrinsicApySourceConfig[] = [
   // DefiLlama pools — Ethereum (1)

--- a/entities/txPlan.ts
+++ b/entities/txPlan.ts
@@ -1,10 +1,10 @@
 import type { Address, Abi } from 'viem'
 
-export type TxStepType =
-  | 'approve'
-  | 'permit2-approve'
-  | 'evc-batch'
-  | 'other'
+export type TxStepType
+  = | 'approve'
+    | 'permit2-approve'
+    | 'evc-batch'
+    | 'other'
 
 export interface TxStep {
   type: TxStepType

--- a/entities/vault/fetcher.ts
+++ b/entities/vault/fetcher.ts
@@ -253,10 +253,10 @@ export const fetchSecuritizeVault = async (vaultAddress: string): Promise<Securi
 
   const assetPriceInfo = eulerLensAddresses.value?.utilsLens
     ? await resolveAssetPriceInfo(
-      rpcUrl.value,
-      eulerLensAddresses.value.utilsLens,
-      data.asset as string,
-    )
+        rpcUrl.value,
+        eulerLensAddresses.value.utilsLens,
+        data.asset as string,
+      )
     : undefined
 
   return {
@@ -384,10 +384,10 @@ export const fetchEarnVault = async (vaultAddress: string): Promise<EarnVault> =
 export const fetchVaults = async function* (
   vaultAddresses?: string[],
 ): AsyncGenerator<
-    VaultIteratorResult<Vault>,
-    void,
-    unknown
-  > {
+  VaultIteratorResult<Vault>,
+  void,
+  unknown
+> {
   const { PYTH_HERMES_URL } = useEulerConfig()
   const { client: rpcClient, rpcUrl } = useRpcClient()
   const { eulerLensAddresses, eulerCoreAddresses, chainId } = useEulerAddresses()

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -228,7 +228,9 @@ export default defineNuxtConfig({
             org: 'euler',
             project: 'euler-lite',
             authToken: process.env.SENTRY_AUTH_TOKEN,
-            filesToDeleteAfterUpload: ['**/*.map'],
+            sourcemaps: {
+              filesToDeleteAfterUpload: ['**/*.map'],
+            },
           },
         },
       }

--- a/server/api/sentry-tunnel.post.ts
+++ b/server/api/sentry-tunnel.post.ts
@@ -54,7 +54,7 @@ export default defineEventHandler(async (event) => {
       response = await fetch(buildIngestUrl(sentryDsn), {
         method: 'POST',
         headers: { 'Content-Type': contentType },
-        body,
+        body: body as unknown as BodyInit,
         signal: controller.signal,
       })
     }

--- a/utils/eulerLabelsState.ts
+++ b/utils/eulerLabelsState.ts
@@ -6,19 +6,19 @@ export const isLoading = ref(false)
 // Use a simple object to track loaded state (survives HMR better than ref)
 export const loadState = { chainId: null as number | null, timestamp: 0 }
 
-export const products: Record<string, EulerLabelProduct> = shallowReactive({})
-export const entities: Record<string, EulerLabelEntity> = shallowReactive({})
-export const points: Record<string, EulerLabelPointReward[]> = shallowReactive({})
+export const products = shallowReactive<Record<string, EulerLabelProduct>>({})
+export const entities = shallowReactive<Record<string, EulerLabelEntity>>({})
+export const points = shallowReactive<Record<string, EulerLabelPointReward[]>>({})
 export const earnVaults: Ref<string[]> = ref([]) // string of earn vault addresses
-export const earnVaultBlocks: Record<string, string[]> = shallowReactive({}) // address (lowercase) -> blocked country codes
-export const earnVaultRestrictions: Record<string, string[]> = shallowReactive({}) // address (lowercase) -> restricted country codes
+export const earnVaultBlocks = shallowReactive<Record<string, string[]>>({}) // address (lowercase) -> blocked country codes
+export const earnVaultRestrictions = shallowReactive<Record<string, string[]>>({}) // address (lowercase) -> restricted country codes
 export const featuredEarnVaults: Set<string> = shallowReactive(new Set())
-export const deprecatedEarnVaults: Record<string, string> = shallowReactive({}) // address (lowercase) -> deprecation reason
-export const earnVaultDescriptions: Record<string, string> = shallowReactive({}) // address (lowercase) -> description
-export const earnVaultNotices: Record<string, string> = shallowReactive({}) // address (lowercase) -> notice
+export const deprecatedEarnVaults = shallowReactive<Record<string, string>>({}) // address (lowercase) -> deprecation reason
+export const earnVaultDescriptions = shallowReactive<Record<string, string>>({}) // address (lowercase) -> description
+export const earnVaultNotices = shallowReactive<Record<string, string>>({}) // address (lowercase) -> notice
 export const notExplorableEarnVaults: Set<string> = shallowReactive(new Set())
 // Derived from products - all unique vault addresses across all products
 export const verifiedVaultAddresses: Ref<string[]> = ref([])
-export const oracleAdapters: Record<string, OracleAdapterMeta> = shallowReactive({})
+export const oracleAdapters = shallowReactive<Record<string, OracleAdapterMeta>>({})
 
 export const loadingAdapters = new Set<string>()


### PR DESCRIPTION
## Summary
- Replace the "Governed - limited" vault type chip with a standalone "Limited" badge that follows the same pattern as the keyring "Private" badge
- Governance-limited vaults now show a normal "Governed" chip plus a teal "Limited" badge with a dedicated info modal
- Remove "Limited risk management" text from vault overview Risk Manager sections
- Risk manager dimming (opacity-20) is unchanged

## Changes
- **New:** `GovernanceLimitedBadge.vue` — standalone badge component (pulse icon, accent colors, small/large sizes)
- **New:** `GovernanceLimitedInfoModal.vue` — info modal with governance-limited description
- **Modified:** `VaultTypeBadges.vue` — return `governed` instead of `governanceLimited`; add Limited badge
- **Modified:** `VaultItem.vue`, `VaultBorrowItem.vue`, `DiscoveryMarketCard.vue` — add Limited badge next to Private/Featured badges
- **Modified:** `VaultOverviewBlockGeneral.vue`, `SecuritizeVaultOverview.vue` — remove "Limited risk management" text

## Test plan
- [ ] Find a governance-limited vault in lend list → shows "Governed" chip + "Limited" badge
- [ ] Click the "Limited" badge → modal opens with description
- [ ] Open vault overview → risk managers dimmed, no "Limited risk management" text, "Governed" chip + "Limited" badge in vault type section
- [ ] Check explore page → governance-limited product shows "Limited" badge
- [ ] Check borrow pair with governance-limited vault → "Limited" badge appears

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a clickable "Limited" governance badge across vault listings and detail pages, with an informational modal explaining limited risk management.
* **Bug Fixes / UI**
  * Removed a redundant "Limited risk management" label from risk manager sections to avoid duplicate messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->