### PR TITLE
Feat/exact amount hover tooltip

### DIFF
--- a/components/entities/asset/AssetInput.vue
+++ b/components/entities/asset/AssetInput.vue
@@ -3,7 +3,7 @@ import { formatUnits } from 'viem'
 import type { Vault, SecuritizeVault, VaultAsset, CollateralOption, EarnVault } from '~/entities/vault'
 import { getAssetUsdPrice } from '~/services/pricing/priceProvider'
 import { nanoToValue } from '~/utils/crypto-utils'
-import { compactNumber, formatSmartAmount, trimTrailingZeros } from '~/utils/string-utils'
+import { compactNumber, formatSmartAmount, trimTrailingZeros, formatExactAmount } from '~/utils/string-utils'
 import { ChooseCollateralModal } from '#components'
 import { useModal } from '~/components/ui/composables/useModal'
 
@@ -250,7 +250,12 @@ const openChooseCollateralModal = () => {
         :loading="balanceLoading ?? false"
       >
         <p @click="setMax">
-          <span class="text-content-tertiary">{{ formatSmartAmount(friendlyBalance) }} {{ asset.symbol }}</span> <span
+          <UiExactAmount
+            class="text-content-tertiary"
+            :exact="formatExactAmount(balance ?? 0n, asset?.decimals || 18n, asset.symbol)"
+          >
+            {{ formatSmartAmount(friendlyBalance) }} {{ asset.symbol }}
+          </UiExactAmount> <span
             class="text-accent-500 font-semibold px-4 cursor-pointer select-none text-[12px] leading-[16px]"
           >Max</span> <!-- TODO: button -->
         </p>

--- a/components/entities/asset/AssetInput.vue
+++ b/components/entities/asset/AssetInput.vue
@@ -252,7 +252,7 @@ const openChooseCollateralModal = () => {
         <p @click="setMax">
           <UiExactAmount
             class="text-content-tertiary"
-            :exact="formatExactAmount(balance ?? 0n, asset?.decimals || 18n, asset.symbol)"
+            :exact="formatExactAmount(balance ?? 0n, asset?.decimals ?? 18n, asset.symbol)"
           >
             {{ formatSmartAmount(friendlyBalance) }} {{ asset.symbol }}
           </UiExactAmount> <span

--- a/components/entities/portfolio/PortfolioBorrowItem.vue
+++ b/components/entities/portfolio/PortfolioBorrowItem.vue
@@ -2,7 +2,7 @@
 import { useAccount } from '@wagmi/vue'
 import { getAddress, type Address, type Abi } from 'viem'
 import { logWarn } from '~/utils/errorHandling'
-import { formatNumber, formatCompactUsdValue } from '~/utils/string-utils'
+import { formatNumber, formatCompactUsdValue, formatExactAmount } from '~/utils/string-utils'
 import { nanoToValue, roundAndCompactTokens } from '~/utils/crypto-utils'
 import type { AccountBorrowPosition } from '~/entities/account'
 import { getSubAccountIndex } from '~/entities/account'
@@ -529,13 +529,14 @@ onMounted(() => {
             <div class="text-content-primary text-p3">
               {{ borrowedValueDisplay }}
             </div>
-            <div
+            <UiExactAmount
               v-if="borrowedValueInfo.hasPrice"
               class="text-content-tertiary text-p3"
+              :exact="formatExactAmount(position.borrowed, position.borrow.decimals, position.borrow.asset.symbol)"
             >
               ~ {{ roundAndCompactTokens(position.borrowed, position.borrow.decimals) }}
               {{ position.borrow.asset.symbol }}
-            </div>
+            </UiExactAmount>
           </div>
         </div>
         <div class="flex justify-between">
@@ -544,15 +545,24 @@ onMounted(() => {
           </div>
           <div class="flex justify-between gap-8 text-right">
             <div class="text-content-primary text-p3">
-              {{ collateralValueDisplay }}
+              <template v-if="collateralValue.hasPrice">
+                {{ collateralValueDisplay }}
+              </template>
+              <UiExactAmount
+                v-else
+                :exact="formatExactAmount(collateralItems[0]?.assets ?? 0n, position.collateral.decimals, position.collateral.asset.symbol)"
+              >
+                {{ collateralValueDisplay }}
+              </UiExactAmount>
             </div>
-            <div
+            <UiExactAmount
               v-if="collateralValue.hasPrice"
               class="text-content-tertiary text-p3"
+              :exact="formatExactAmount(collateralItems[0].assets, position.collateral.decimals, position.collateral.asset.symbol)"
             >
               ~ {{ roundAndCompactTokens(collateralItems[0].assets, position.collateral.decimals) }}
               {{ position.collateral.asset.symbol }} {{ collateralItems.length > 1 ? '& others' : '' }}
-            </div>
+            </UiExactAmount>
           </div>
         </div>
         <div class="flex justify-between">

--- a/components/entities/portfolio/PortfolioEarnItem.vue
+++ b/components/entities/portfolio/PortfolioEarnItem.vue
@@ -7,7 +7,7 @@ import { type AccountDepositPosition, getSubAccountIndex } from '~/entities/acco
 import type { EarnVault } from '~/entities/vault'
 import { VaultOverviewModal, VaultSupplyApyModal } from '#components'
 import { useModal } from '~/components/ui/composables/useModal'
-import { formatNumber, formatCompactUsdValue, compactNumber } from '~/utils/string-utils'
+import { formatNumber, formatCompactUsdValue, compactNumber, formatExactAmount } from '~/utils/string-utils'
 import { nanoToValue, roundAndCompactTokens } from '~/utils/crypto-utils'
 
 const { position } = defineProps<{ position: AccountDepositPosition }>()
@@ -183,12 +183,13 @@ const onClick = () => {
             <div class="text-content-primary text-p3">
               {{ supplyValueDisplay }}
             </div>
-            <div
+            <UiExactAmount
               v-if="hasPrice"
               class="text-content-tertiary text-p3"
+              :exact="formatExactAmount(position.assets, vault.asset.decimals, vault.asset.symbol)"
             >
               ~ {{ roundAndCompactTokens(position.assets, vault.asset.decimals) }} {{ vault.asset.symbol }}
-            </div>
+            </UiExactAmount>
           </div>
         </div>
         <div

--- a/components/entities/portfolio/PortfolioSavingItem.vue
+++ b/components/entities/portfolio/PortfolioSavingItem.vue
@@ -5,7 +5,7 @@ import { getUtilisationWarning } from '~/composables/useVaultWarnings'
 import { getAssetUsdValue, formatAssetValue } from '~/services/pricing/priceProvider'
 import { isVaultBlockedByCountry } from '~/composables/useGeoBlock'
 import { isVaultDeprecated, getVaultNotice } from '~/utils/eulerLabelsUtils'
-import { formatNumber, compactNumber, formatCompactUsdValue, formatSmartAmount } from '~/utils/string-utils'
+import { formatNumber, compactNumber, formatCompactUsdValue, formatSmartAmount, formatExactAmount } from '~/utils/string-utils'
 import { nanoToValue, roundAndCompactTokens } from '~/utils/crypto-utils'
 import { type AccountDepositPosition, getSubAccountIndex } from '~/entities/account'
 import { VaultOverviewModal, VaultSupplyApyModal } from '#components'
@@ -195,7 +195,9 @@ const onClick = () => {
           </div>
           <div class="flex justify-between gap-8 text-right">
             <div class="text-content-primary text-p3">
-              {{ formatSmartAmount(assetAmount) }} {{ vault.asset.symbol }}
+              <UiExactAmount :exact="formatExactAmount(position.assets, vault.asset.decimals, vault.asset.symbol)">
+                {{ formatSmartAmount(assetAmount) }} {{ vault.asset.symbol }}
+              </UiExactAmount>
             </div>
           </div>
         </div>
@@ -308,13 +310,14 @@ const onClick = () => {
             <div class="text-content-primary text-p3">
               {{ supplyValueDisplay }}
             </div>
-            <div
+            <UiExactAmount
               v-if="hasPrice"
               class="text-content-tertiary text-p3"
+              :exact="formatExactAmount(position.assets, vault.decimals, vault.asset.symbol)"
             >
               ~ {{ roundAndCompactTokens(position.assets, vault.decimals) }}
               {{ vault.asset.symbol }}
-            </div>
+            </UiExactAmount>
           </div>
         </div>
         <div

--- a/components/entities/swap/SwapDetailsSummary.vue
+++ b/components/entities/swap/SwapDetailsSummary.vue
@@ -17,22 +17,31 @@ const emit = defineEmits<{
 </script>
 
 <template>
-  <SummaryRow label="Swap in">
+  <SummaryRow
+    v-if="inputDisplay"
+    label="Swap in"
+  >
     <p class="text-p2 text-right">
-      {{ inputDisplay ?? '-' }}
+      {{ inputDisplay }}
     </p>
   </SummaryRow>
-  <SummaryRow label="Swap out">
+  <SummaryRow
+    v-if="outputDisplay"
+    label="Swap out"
+  >
     <p class="text-p2 text-right">
-      {{ outputDisplay ?? '-' }}
+      {{ outputDisplay }}
     </p>
   </SummaryRow>
-  <SummaryRow label="Price impact">
+  <SummaryRow
+    v-if="priceImpact !== null"
+    label="Price impact"
+  >
     <p
       class="text-p2"
       :class="{ 'text-error-500': isPriceImpactWarning(priceImpact) }"
     >
-      {{ priceImpact !== null ? `${formatNumber(priceImpact, 2, 2)}%` : '-' }}
+      {{ formatNumber(priceImpact, 2, 2) }}%
     </p>
   </SummaryRow>
   <SummaryRow
@@ -59,9 +68,12 @@ const emit = defineEmits<{
       />
     </button>
   </SummaryRow>
-  <SummaryRow label="Routed via">
+  <SummaryRow
+    v-if="routedVia"
+    label="Routed via"
+  >
     <p class="text-p2 text-right">
-      {{ routedVia ?? '-' }}
+      {{ routedVia }}
     </p>
   </SummaryRow>
 </template>

--- a/components/entities/vault/overview/earn/VaultOverviewEarnBlockExposure.vue
+++ b/components/entities/vault/overview/earn/VaultOverviewEarnBlockExposure.vue
@@ -5,7 +5,7 @@ import { logWarn } from '~/utils/errorHandling'
 import type { EarnVault, EarnVaultStrategyInfo, Vault } from '~/entities/vault'
 import { getAssetUsdValueOrZero } from '~/services/pricing/priceProvider'
 import { useVaultRegistry } from '~/composables/useVaultRegistry'
-import { formatNumber, compactNumber, formatCompactUsdValue } from '~/utils/string-utils'
+import { formatNumber, compactNumber, formatCompactUsdValue, formatExactAmount } from '~/utils/string-utils'
 import { nanoToValue, roundAndCompactTokens } from '~/utils/crypto-utils'
 import { useModal } from '~/components/ui/composables/useModal'
 import { VaultSupplyApyModal } from '#components'
@@ -253,7 +253,9 @@ load()
               <span class="text-content-secondary">({{ compactNumber(getAllocationPercentage(row.exposure), 2) }}%)</span>
             </template>
             <template v-else>
-              {{ getExposureAssetAmount(row.exposure) }}
+              <UiExactAmount :exact="formatExactAmount(row.exposure.allocatedAssets, row.exposure.info.assetDecimals, row.exposure.info.assetSymbol)">
+                {{ getExposureAssetAmount(row.exposure) }}
+              </UiExactAmount>
               <span class="text-content-secondary">({{ compactNumber(getAllocationPercentage(row.exposure), 2) }}%)</span>
             </template>
           </VaultOverviewLabelValue>
@@ -291,7 +293,9 @@ load()
                 {{ formatCompactUsdValue(exposureCapUsdPrices.get(row.exposure.strategy) || 0) }}
               </template>
               <template v-else>
-                {{ roundAndCompactTokens(row.exposure.currentAllocationCap, row.exposure.info.assetDecimals) }} {{ row.exposure.info.assetSymbol }}
+                <UiExactAmount :exact="formatExactAmount(row.exposure.currentAllocationCap, row.exposure.info.assetDecimals, row.exposure.info.assetSymbol)">
+                  {{ roundAndCompactTokens(row.exposure.currentAllocationCap, row.exposure.info.assetDecimals) }} {{ row.exposure.info.assetSymbol }}
+                </UiExactAmount>
               </template>
             </span>
           </VaultOverviewLabelValue>

--- a/components/ui/UiExactAmount.vue
+++ b/components/ui/UiExactAmount.vue
@@ -1,14 +1,39 @@
 <script setup lang="ts">
-defineProps<{
+const props = defineProps<{
   exact: string
 }>()
+
+const copied = ref(false)
+let timer: ReturnType<typeof setTimeout>
+
+function onCopy() {
+  const numericPart = props.exact.replace(/\s+\S+$/, '').replaceAll(',', '')
+  navigator.clipboard.writeText(numericPart)
+  copied.value = true
+  clearTimeout(timer)
+  timer = setTimeout(() => (copied.value = false), 2000)
+}
 </script>
 
 <template>
   <span class="ui-exact-amount">
     <slot />
-    <span class="ui-exact-amount__tip">
+    <span
+      class="ui-exact-amount__tip"
+      @click.stop.prevent
+      @mousedown.stop.prevent
+      @pointerdown.stop.prevent
+    >
       {{ exact }}
+      <button
+        class="ui-exact-amount__copy"
+        @click="onCopy"
+      >
+        <SvgIcon
+          :name="copied ? 'check' : 'copy'"
+          class="!w-14 !h-14"
+        />
+      </button>
     </span>
   </span>
 </template>
@@ -24,7 +49,9 @@ defineProps<{
 
 @media (hover: hover) and (pointer: fine) {
   .ui-exact-amount:hover .ui-exact-amount__tip {
-    display: block;
+    display: flex;
+    align-items: center;
+    gap: 6px;
     position: absolute;
     bottom: calc(100% + 6px);
     left: 50%;
@@ -41,9 +68,37 @@ defineProps<{
     font-weight: 400;
     font-variant-numeric: tabular-nums;
     color: var(--text-primary);
-    pointer-events: none;
     word-break: break-all;
     white-space: nowrap;
+    user-select: all;
+    cursor: text;
+
+    // invisible bridge to cover the gap between trigger and tooltip
+    &::after {
+      content: '';
+      position: absolute;
+      top: 100%;
+      left: 0;
+      width: 100%;
+      height: 6px;
+    }
+  }
+
+  .ui-exact-amount__copy {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+    padding: 0;
+    border: none;
+    background: none;
+    color: var(--text-secondary);
+    cursor: pointer;
+    user-select: none;
+    transition: color 0.15s;
+
+    &:hover {
+      color: var(--text-primary);
+    }
   }
 }
 </style>

--- a/components/ui/UiExactAmount.vue
+++ b/components/ui/UiExactAmount.vue
@@ -1,0 +1,81 @@
+<script setup lang="ts">
+import { offset, flip, shift, useFloating } from '@floating-ui/vue'
+
+const { exact } = defineProps<{
+  exact: string
+}>()
+
+const reference = ref(null)
+const floating = ref(null)
+const isVisible = ref(false)
+
+const { floatingStyles, update } = useFloating(reference, floating, {
+  placement: 'top',
+  middleware: [
+    offset(8),
+    flip({ padding: 8 }),
+    shift({ padding: 8 }),
+  ],
+})
+
+const canHover = typeof window !== 'undefined' && window.matchMedia('(hover: hover)').matches
+
+const onMouseEnter = () => {
+  if (canHover) {
+    isVisible.value = true
+    update()
+  }
+}
+
+const onMouseLeave = () => {
+  if (canHover) {
+    isVisible.value = false
+  }
+}
+</script>
+
+<template>
+  <span
+    ref="reference"
+    class="ui-exact-amount"
+    @mouseenter="onMouseEnter"
+    @mouseleave="onMouseLeave"
+  >
+    <slot />
+    <Transition name="tooltip">
+      <div
+        v-show="isVisible"
+        ref="floating"
+        :style="floatingStyles"
+        class="ui-exact-amount__floating"
+        @click.stop
+      >
+        {{ exact }}
+      </div>
+    </Transition>
+  </span>
+</template>
+
+<style lang="scss">
+.ui-exact-amount {
+  cursor: default;
+
+  &__floating {
+    position: relative;
+    max-width: 500px;
+    width: max-content;
+    padding: 6px 10px;
+    border-radius: 8px;
+    background-color: var(--ui-footnote-floating-background-color);
+    box-shadow: 0 4px 16px var(--ui-footnote-floating-box-shadow-color);
+    z-index: 10;
+    font-size: 13px;
+    line-height: 18px;
+    font-weight: 400;
+    font-variant-numeric: tabular-nums;
+    color: var(--text-primary);
+    pointer-events: none;
+    word-break: break-all;
+  }
+}
+</style>

--- a/components/ui/UiExactAmount.vue
+++ b/components/ui/UiExactAmount.vue
@@ -1,67 +1,34 @@
 <script setup lang="ts">
-import { offset, flip, shift, useFloating } from '@floating-ui/vue'
-
-const { exact } = defineProps<{
+defineProps<{
   exact: string
 }>()
-
-const reference = ref(null)
-const floating = ref(null)
-const isVisible = ref(false)
-
-const { floatingStyles, update } = useFloating(reference, floating, {
-  placement: 'top',
-  middleware: [
-    offset(8),
-    flip({ padding: 8 }),
-    shift({ padding: 8 }),
-  ],
-})
-
-const canHover = typeof window !== 'undefined' && window.matchMedia('(hover: hover)').matches
-
-const onMouseEnter = () => {
-  if (canHover) {
-    isVisible.value = true
-    update()
-  }
-}
-
-const onMouseLeave = () => {
-  if (canHover) {
-    isVisible.value = false
-  }
-}
 </script>
 
 <template>
-  <span
-    ref="reference"
-    class="ui-exact-amount"
-    @mouseenter="onMouseEnter"
-    @mouseleave="onMouseLeave"
-  >
+  <span class="ui-exact-amount">
     <slot />
-    <Transition name="tooltip">
-      <div
-        v-show="isVisible"
-        ref="floating"
-        :style="floatingStyles"
-        class="ui-exact-amount__floating"
-        @click.stop
-      >
-        {{ exact }}
-      </div>
-    </Transition>
+    <span class="ui-exact-amount__tip">
+      {{ exact }}
+    </span>
   </span>
 </template>
 
 <style lang="scss">
 .ui-exact-amount {
-  cursor: default;
+  position: relative;
 
-  &__floating {
-    position: relative;
+  &__tip {
+    display: none;
+  }
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .ui-exact-amount:hover .ui-exact-amount__tip {
+    display: block;
+    position: absolute;
+    bottom: calc(100% + 6px);
+    left: 50%;
+    transform: translateX(-50%);
     max-width: 500px;
     width: max-content;
     padding: 6px 10px;
@@ -76,6 +43,7 @@ const onMouseLeave = () => {
     color: var(--text-primary);
     pointer-events: none;
     word-break: break-all;
+    white-space: nowrap;
   }
 }
 </style>

--- a/pages/borrow/[collateral]/[borrow]/index.vue
+++ b/pages/borrow/[collateral]/[borrow]/index.vue
@@ -515,6 +515,7 @@ watch(formTab, () => {
                   />
 
                   <VaultFormInfoBlock
+                    v-if="borrow.borrowSwapEstimatedCollateral.value || borrow.borrowSwapQuoteError.value"
                     :loading="borrow.isBorrowSwapQuoteLoading.value"
                     variant="card"
                   >

--- a/pages/borrow/[collateral]/[borrow]/index.vue
+++ b/pages/borrow/[collateral]/[borrow]/index.vue
@@ -515,7 +515,6 @@ watch(formTab, () => {
                   />
 
                   <VaultFormInfoBlock
-                    v-if="borrow.borrowSwapEstimatedCollateral.value"
                     :loading="borrow.isBorrowSwapQuoteLoading.value"
                     variant="card"
                   >

--- a/pages/earn/[vault]/[subAccount]/withdraw.vue
+++ b/pages/earn/[vault]/[subAccount]/withdraw.vue
@@ -12,7 +12,7 @@ import {
 import { getSubAccountAddress } from '~/entities/account'
 import { getAssetUsdValueOrZero } from '~/services/pricing/priceProvider'
 import type { TxPlan } from '~/entities/txPlan'
-import { formatNumber, formatSmartAmount } from '~/utils/string-utils'
+import { formatNumber, formatSmartAmount, formatExactAmount } from '~/utils/string-utils'
 import { nanoToValue } from '~/utils/crypto-utils'
 import { isOperationBlocked } from '~/utils/operationGuardRegistry'
 
@@ -309,7 +309,10 @@ watch(amount, () => {
                 v-if="asset"
                 class="text-p2 flex items-center gap-4"
               >
-                {{ formatSmartAmount(nanoToValue(assetsBalance, asset.decimals)) }} <span class="text-p3 text-content-tertiary">{{ asset.symbol }}</span>
+                <UiExactAmount :exact="formatExactAmount(assetsBalance, asset.decimals, asset.symbol)">
+                  {{ formatSmartAmount(nanoToValue(assetsBalance, asset.decimals)) }}
+                  <span class="text-p3 text-content-tertiary">{{ asset.symbol }}</span>
+                </UiExactAmount>
                 <span class="text-p3 text-content-tertiary">&asymp; ${{ formatNumber(assetsBalanceUsd) }}</span>
               </p>
             </SummaryRow>

--- a/pages/lend/[vault]/[subAccount]/withdraw.vue
+++ b/pages/lend/[vault]/[subAccount]/withdraw.vue
@@ -21,7 +21,7 @@ import type { TxPlan } from '~/entities/txPlan'
 import { useSwapQuotesParallel } from '~/composables/useSwapQuotesParallel'
 import { SwapperMode } from '~/entities/swap'
 import { buildSwapRouteItems } from '~/utils/swapRouteItems'
-import { formatNumber, formatSmartAmount } from '~/utils/string-utils'
+import { formatNumber, formatSmartAmount, formatExactAmount } from '~/utils/string-utils'
 import { useSwapPriceImpact } from '~/composables/useSwapPriceImpact'
 import { usePriceImpactGate } from '~/composables/usePriceImpactGate'
 import { nanoToValue } from '~/utils/crypto-utils'
@@ -669,7 +669,10 @@ watch(swapSelectedQuote, () => {
                 v-if="asset"
                 class="text-p2 flex items-center gap-4"
               >
-                {{ formatSmartAmount(nanoToValue(assetsBalance, asset.decimals)) }} <span class="text-p3 text-content-tertiary">{{ asset.symbol }}</span>
+                <UiExactAmount :exact="formatExactAmount(assetsBalance, asset.decimals, asset.symbol)">
+                  {{ formatSmartAmount(nanoToValue(assetsBalance, asset.decimals)) }}
+                  <span class="text-p3 text-content-tertiary">{{ asset.symbol }}</span>
+                </UiExactAmount>
                 <span
                   v-if="!isSecuritizeVaultType"
                   class="text-p3 text-content-tertiary"

--- a/pages/lend/[vault]/[subAccount]/withdraw.vue
+++ b/pages/lend/[vault]/[subAccount]/withdraw.vue
@@ -594,6 +594,7 @@ watch(swapSelectedQuote, () => {
               />
 
               <VaultFormInfoBlock
+                v-if="swapEstimatedOutput || swapQuoteError"
                 :loading="isSwapQuoteLoading"
                 variant="card"
               >

--- a/pages/lend/[vault]/[subAccount]/withdraw.vue
+++ b/pages/lend/[vault]/[subAccount]/withdraw.vue
@@ -594,7 +594,6 @@ watch(swapSelectedQuote, () => {
               />
 
               <VaultFormInfoBlock
-                v-if="swapEstimatedOutput"
                 :loading="isSwapQuoteLoading"
                 variant="card"
               >

--- a/pages/lend/[vault]/index.vue
+++ b/pages/lend/[vault]/index.vue
@@ -871,7 +871,6 @@ watch(address, () => {
               />
 
               <VaultFormInfoBlock
-                v-if="swapEstimatedOutput"
                 :loading="isSwapQuoteLoading"
                 variant="card"
               >

--- a/pages/lend/[vault]/index.vue
+++ b/pages/lend/[vault]/index.vue
@@ -871,6 +871,7 @@ watch(address, () => {
               />
 
               <VaultFormInfoBlock
+                v-if="swapEstimatedOutput || swapQuoteError"
                 :loading="isSwapQuoteLoading"
                 variant="card"
               >

--- a/pages/position/[number]/index.vue
+++ b/pages/position/[number]/index.vue
@@ -21,7 +21,7 @@ import {
 import { type AccountBorrowPosition, isPositionEligibleForLiquidation } from '~/entities/account'
 import type { TxPlan } from '~/entities/txPlan'
 import { formatTtl, nanoToValue, roundAndCompactTokens } from '~/utils/crypto-utils'
-import { formatNumber, formatHealthScore, formatUsdValue, formatCompactUsdValue } from '~/utils/string-utils'
+import { formatNumber, formatHealthScore, formatUsdValue, formatCompactUsdValue, formatExactAmount } from '~/utils/string-utils'
 import { isAnyVaultBlockedByCountry, isVaultRestrictedByCountry } from '~/composables/useGeoBlock'
 import { getVaultNotice } from '~/utils/eulerLabelsUtils'
 import { VaultOverviewModal, OperationReviewModal, VaultSupplyApyModal, VaultBorrowApyModal, VaultNetApyModal, PortfolioRoeModal } from '#components'
@@ -892,17 +892,23 @@ watch([isConnected, isSpyMode], () => {
               </div>
               <div class="flex justify-between gap-8 justify-self-end">
                 <div class="text-neutral-800 text-p3">
-                  {{ borrowMarketValue.hasPrice
-                    ? formatCompactUsdValue(borrowMarketValue.usd)
-                    : `${roundAndCompactTokens(position.borrowed, borrowVault?.decimals ?? 0n)} ${borrowVault?.asset?.symbol}`
-                  }}
+                  <template v-if="borrowMarketValue.hasPrice">
+                    {{ formatCompactUsdValue(borrowMarketValue.usd) }}
+                  </template>
+                  <UiExactAmount
+                    v-else
+                    :exact="formatExactAmount(position.borrowed, borrowVault?.decimals ?? 0n, borrowVault?.asset?.symbol)"
+                  >
+                    {{ roundAndCompactTokens(position.borrowed, borrowVault?.decimals ?? 0n) }} {{ borrowVault?.asset?.symbol }}
+                  </UiExactAmount>
                 </div>
-                <div
+                <UiExactAmount
                   v-if="borrowMarketValue.hasPrice"
                   class="text-neutral-500 text-p3"
+                  :exact="formatExactAmount(position.borrowed, borrowVault?.decimals ?? 0n, borrowVault?.asset?.symbol)"
                 >
                   ~ {{ roundAndCompactTokens(position.borrowed, borrowVault?.decimals ?? 0n) }} {{ borrowVault?.asset?.symbol }}
-                </div>
+                </UiExactAmount>
               </div>
             </div>
             <div class="flex justify-between gap-8 flex-wrap mb-12">
@@ -1057,18 +1063,24 @@ watch([isConnected, isSpyMode], () => {
                 </div>
                 <div class="flex justify-between gap-8 justify-self-end">
                   <div class="text-content-primary text-p3">
-                    {{ collateral.value.hasPrice
-                      ? formatCompactUsdValue(collateral.value.usd)
-                      : `${roundAndCompactTokens(collateral.assets, collateral.vault.decimals)} ${collateral.vault.asset.symbol}`
-                    }}
+                    <template v-if="collateral.value.hasPrice">
+                      {{ formatCompactUsdValue(collateral.value.usd) }}
+                    </template>
+                    <UiExactAmount
+                      v-else
+                      :exact="formatExactAmount(collateral.assets, collateral.vault.decimals, collateral.vault.asset.symbol)"
+                    >
+                      {{ roundAndCompactTokens(collateral.assets, collateral.vault.decimals) }} {{ collateral.vault.asset.symbol }}
+                    </UiExactAmount>
                   </div>
-                  <div
+                  <UiExactAmount
                     v-if="collateral.value.hasPrice"
                     class="text-content-tertiary text-p3"
+                    :exact="formatExactAmount(collateral.assets, collateral.vault.decimals, collateral.vault.asset.symbol)"
                   >
                     ~ {{ roundAndCompactTokens(collateral.assets, collateral.vault.decimals) }}
                     {{ collateral.vault.asset.symbol }}
-                  </div>
+                  </UiExactAmount>
                 </div>
               </div>
               <div class="flex justify-between gap-8 flex-wrap mb-16">

--- a/pages/position/[number]/repay.vue
+++ b/pages/position/[number]/repay.vue
@@ -562,7 +562,7 @@ watch(formTab, () => {
                 />
               </SummaryRow>
               <SwapDetailsSummary
-                v-if="walletSwap.needsSwap.value && walletSwap.swapEstimatedOutput.value"
+                v-if="walletSwap.needsSwap.value"
                 :input-display="walletSwap.swapInputDisplay.value"
                 :output-display="walletSwap.swapOutputDisplay.value"
                 :price-impact="walletSwap.swapPriceImpact.value"

--- a/pages/position/[number]/repay.vue
+++ b/pages/position/[number]/repay.vue
@@ -562,7 +562,7 @@ watch(formTab, () => {
                 />
               </SummaryRow>
               <SwapDetailsSummary
-                v-if="walletSwap.needsSwap.value"
+                v-if="walletSwap.needsSwap.value && (walletSwap.swapEstimatedOutput.value || walletSwap.quotes.quoteError.value)"
                 :input-display="walletSwap.swapInputDisplay.value"
                 :output-display="walletSwap.swapOutputDisplay.value"
                 :price-impact="walletSwap.swapPriceImpact.value"

--- a/pages/position/[number]/supply.vue
+++ b/pages/position/[number]/supply.vue
@@ -296,6 +296,7 @@ watch(selectedAsset, async () => {
               />
 
               <VaultFormInfoBlock
+                v-if="form.swapEstimatedOutput.value || form.swapQuoteError.value"
                 :loading="form.isSwapQuoteLoading.value"
                 variant="card"
               >

--- a/pages/position/[number]/supply.vue
+++ b/pages/position/[number]/supply.vue
@@ -296,7 +296,6 @@ watch(selectedAsset, async () => {
               />
 
               <VaultFormInfoBlock
-                v-if="form.swapEstimatedOutput.value"
                 :loading="form.isSwapQuoteLoading.value"
                 variant="card"
               >

--- a/pages/position/[number]/withdraw.vue
+++ b/pages/position/[number]/withdraw.vue
@@ -240,7 +240,6 @@ watch(selectedOutputAsset, () => {
               />
 
               <VaultFormInfoBlock
-                v-if="form.swapEstimatedOutput.value"
                 :loading="form.isSwapQuoteLoading.value"
                 variant="card"
               >

--- a/pages/position/[number]/withdraw.vue
+++ b/pages/position/[number]/withdraw.vue
@@ -240,6 +240,7 @@ watch(selectedOutputAsset, () => {
               />
 
               <VaultFormInfoBlock
+                v-if="form.swapEstimatedOutput.value || form.swapQuoteError.value"
                 :loading="form.isSwapQuoteLoading.value"
                 variant="card"
               >

--- a/utils/string-utils.ts
+++ b/utils/string-utils.ts
@@ -94,6 +94,32 @@ export const formatCompactUsdValue = (value: string | number = 0, maximumFractio
 }
 
 /**
+ * Format a bigint token amount with full decimal precision for exact-value tooltips.
+ * Trims trailing zeros and adds thousand separators.
+ * e.g. 1234567890000000000n with 18 decimals → "1.23456789"
+ */
+export const formatExactAmount = (amount: bigint, decimals: number | bigint, symbol?: string): string => {
+  if (amount === 0n) return symbol ? `0 ${symbol}` : '0'
+
+  const d = Number(decimals)
+  const divisor = 10n ** BigInt(d)
+  const integerPart = amount / divisor
+  const fractionalPart = amount % divisor
+
+  const formattedInt = integerPart.toLocaleString('en-US')
+
+  if (fractionalPart === 0n) {
+    return symbol ? `${formattedInt} ${symbol}` : formattedInt
+  }
+
+  // Pad fractional part to full decimal width, then trim trailing zeros
+  const fracStr = fractionalPart.toString().padStart(d, '0').replace(/0+$/, '')
+
+  const result = `${formattedInt}.${fracStr}`
+  return symbol ? `${result} ${symbol}` : result
+}
+
+/**
  * Trim trailing zeros from a decimal string while keeping it parseable.
  * Intended for input fields where values are set programmatically.
  * "0.363002000000000000" → "0.363002"


### PR DESCRIPTION
## Summary
- Restore the ability to see full-precision token amounts (all decimal places) by hovering over abbreviated values — a feature from the legacy app that was missing
- Desktop-only: tooltips appear on mouse hover and are completely inert on touch devices

## Changes
- New `UiExactAmount` component using pure CSS `@media (hover: hover) and (pointer: fine)` for reliable desktop-only detection — no JS event listeners, so no iOS Safari double-tap or sticky-hover issues on touch devices
- New `formatExactAmount` utility that does pure bigint arithmetic to format amounts with full decimal precision, avoiding JS `Number` precision loss (which caps at ~15-17 significant digits, not enough for 18-decimal tokens like WETH)
- Applied to: position detail page (borrow/collateral market values), portfolio items (supply value, debt, collateral), vault exposure blocks (allocation amounts/caps), asset input balances, and withdraw page balances

## Test plan
- [ ] Desktop: hover over any approximate token amount (e.g., "~ 1.23 WETH") on the portfolio page — tooltip should show the full-precision value
- [ ] Desktop: hover over token amounts on the position detail page (borrow market value, collateral market value)
- [ ] Desktop: hover over wallet balance in any supply/withdraw form's asset input
- [ ] Desktop: hover over exposure allocation amounts in earn vault overview
- [ ] Mobile: tap on any of the above amounts — no tooltip should appear, no double-tap required for navigation
- [ ] iPad: same as mobile — touch interactions should be completely unaffected

<img width="348" height="143" alt="image" src="https://github.com/user-attachments/assets/3193e59b-7729-4ed3-8c62-dba997252521" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exact-amount tooltips: hoverable displays show full-precision token amounts (including decimals) across portfolio items, vaults, asset inputs and withdraw/earn dialogs, with a copy-to-clipboard action for the exact value.

* **Improvements**
  * Swap info visibility: swap detail cards now also appear when quote retrieval fails, improving visibility into error states and guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->