### PR TITLE
fix: add spy mode support to reward composables

### DIFF
--- a/composables/useBrevis.ts
+++ b/composables/useBrevis.ts
@@ -82,6 +82,10 @@ export const useBrevis = () => {
   const { chainId } = useEulerAddresses()
   const { client: rpcClient } = useRpcClient()
   const { enableIncentra } = useDeployConfig()
+  const { spyAddress } = useSpyMode()
+
+  const effectiveAddress = computed(() => spyAddress.value || wagmiAddress.value || '')
+  const isActive = computed(() => isConnected.value || Boolean(spyAddress.value))
 
   const ensureWalletOnCurrentChain = async () => {
     const targetChainId = chainId.value
@@ -313,14 +317,9 @@ export const useBrevis = () => {
     }
   }
 
-  watch(wagmiAddress, (val, oldVal) => {
-    if (val) {
-      address.value = val
-    }
-    else {
-      address.value = ''
-    }
-    // Force-refresh rewards when the connected wallet changes (skip initial mount)
+  watch(effectiveAddress, (val, oldVal) => {
+    address.value = val || ''
+    // Force-refresh rewards when the effective address changes (skip initial mount)
     if (enableIncentra && oldVal && val && val !== oldVal) {
       loadRewards(true, true)
     }
@@ -337,8 +336,8 @@ export const useBrevis = () => {
     }
   })
 
-  watch(isConnected, (connected) => {
-    if (connected && enableIncentra) {
+  watch(isActive, (active) => {
+    if (active && enableIncentra) {
       if (!isLoaded.value) {
         loadCampaigns()
         loadRewards()
@@ -352,7 +351,7 @@ export const useBrevis = () => {
         }, POLL_INTERVAL_30S_MS)
       }
     }
-    else {
+    else if (!active) {
       userRewards.value = []
       isCampaignsLoading.value = false
       isRewardsLoading.value = false

--- a/composables/useFuul.ts
+++ b/composables/useFuul.ts
@@ -38,6 +38,9 @@ export const useFuul = () => {
   const { client: rpcClient } = useRpcClient()
   const { chainId } = useEulerAddresses()
   const { enableFuul } = useDeployConfig()
+  const { spyAddress } = useSpyMode()
+
+  const effectiveAddress = computed(() => spyAddress.value || wagmiAddress.value || '')
 
   const unclaimedFuulRewards = computed(() =>
     fuulClaimableEntries.value.flatMap(entry => entry.claimable_rewards),
@@ -257,7 +260,7 @@ export const useFuul = () => {
     }
   }
 
-  watch(wagmiAddress, (val, oldVal) => {
+  watch(effectiveAddress, (val, oldVal) => {
     if (val) {
       address.value = val
     }

--- a/composables/useMerkl.ts
+++ b/composables/useMerkl.ts
@@ -298,6 +298,10 @@ export const useMerkl = () => {
   const { writeContractAsync } = useWriteContract()
   const { chainId } = useEulerAddresses()
   const { enableMerkl } = useDeployConfig()
+  const { spyAddress } = useSpyMode()
+
+  const effectiveAddress = computed(() => spyAddress.value || wagmiAddress.value || '')
+  const isActive = computed(() => isConnected.value || Boolean(spyAddress.value))
 
   const ensureWalletOnCurrentChain = async () => {
     const targetChainId = chainId.value
@@ -366,14 +370,9 @@ export const useMerkl = () => {
     }
   }
 
-  watch(wagmiAddress, (val, oldVal) => {
-    if (val) {
-      address.value = val
-    }
-    else {
-      address.value = ''
-    }
-    // Force-refresh rewards when the connected wallet changes (skip initial mount)
+  watch(effectiveAddress, (val, oldVal) => {
+    address.value = val || ''
+    // Force-refresh rewards when the effective address changes (skip initial mount)
     if (enableMerkl && oldVal && val && val !== oldVal && chainId.value) {
       loadRewards(chainId.value, true, true)
     }
@@ -394,9 +393,8 @@ export const useMerkl = () => {
     }
   }, { immediate: true })
 
-  watch([isConnected, chainId], (val, oldVal) => {
-    const [connected, currentChainId] = val
-    const [oldConnected, oldChainId] = oldVal ?? [undefined, undefined]
+  watch([isActive, chainId], ([active, currentChainId], oldVal) => {
+    const [oldActive, oldChainId] = oldVal ?? [undefined, undefined]
 
     if (oldChainId && currentChainId !== oldChainId) {
       isLoaded.value = false
@@ -407,8 +405,8 @@ export const useMerkl = () => {
       cacheState.rewards = { chainId: 0, address: '', timestamp: 0 }
     }
 
-    // Clear user-specific data on disconnect
-    if (oldConnected && !connected) {
+    // Clear user-specific data on deactivation (disconnect + no spy)
+    if (oldActive && !active) {
       rewards.value = []
       isRewardsLoading.value = false
       cacheState.rewards = { chainId: 0, address: '', timestamp: 0 }
@@ -425,14 +423,14 @@ export const useMerkl = () => {
       isLoaded.value = true
     }
 
-    if (enableMerkl && connected && !interval) {
+    if (enableMerkl && active && !interval) {
       interval = setInterval(() => {
         loadRewards(chainId.value, false)
         loadOpportunities(chainId.value, false)
         loadTokens(chainId.value, false)
       }, POLL_INTERVAL_30S_MS)
     }
-    else if (!connected && interval) {
+    else if (!active && interval) {
       clearInterval(interval)
       interval = null
     }

--- a/composables/useREULLocks.ts
+++ b/composables/useREULLocks.ts
@@ -17,6 +17,10 @@ export const useREULLocks = () => {
   const { writeContractAsync } = useWriteContract()
   const { eulerTokenAddresses } = useEulerAddresses()
   const { client: rpcClient } = useRpcClient()
+  const { spyAddress } = useSpyMode()
+
+  const effectiveAddress = computed(() => spyAddress.value || wagmiAddress.value || '')
+  const isActive = computed(() => isConnected.value || Boolean(spyAddress.value))
 
   const reulTokenContractAddress = computed(() => eulerTokenAddresses.value?.rEUL ?? '')
   const eulTokenContractAddress = computed(() => eulerTokenAddresses.value?.EUL ?? '')
@@ -84,25 +88,25 @@ export const useREULLocks = () => {
     }
   }
 
-  watch([isConnected, chainId], ([connected, currentChainId], [_oldConnected, oldChainId]) => {
+  watch([isActive, chainId], ([active, currentChainId], [_oldActive, oldChainId]) => {
     if (oldChainId && currentChainId !== oldChainId) {
       isLoaded.value = false
       locks.value = []
     }
 
-    if (!isLoaded.value && wagmiAddress.value) {
-      loadREULLocksInfo(wagmiAddress.value)
+    if (!isLoaded.value && effectiveAddress.value) {
+      loadREULLocksInfo(effectiveAddress.value)
       isLoaded.value = true
     }
 
-    if (connected && !interval) {
+    if (active && !interval) {
       interval = setInterval(() => {
-        if (wagmiAddress.value) {
-          loadREULLocksInfo(wagmiAddress.value, false)
+        if (effectiveAddress.value) {
+          loadREULLocksInfo(effectiveAddress.value, false)
         }
       }, POLL_INTERVAL_60S_MS)
     }
-    else if (!connected) {
+    else if (!active) {
       locks.value = []
       isLocksLoading.value = false
       if (interval) {
@@ -111,6 +115,16 @@ export const useREULLocks = () => {
       }
     }
   }, { immediate: true })
+
+  // Reload when the effective address changes (e.g. spy address resolves to owner)
+  watch(effectiveAddress, (addr, oldAddr) => {
+    if (oldAddr && addr && addr !== oldAddr) {
+      loadREULLocksInfo(addr)
+    }
+    else if (oldAddr && !addr) {
+      locks.value = []
+    }
+  })
 
   onUnmounted(() => {
     if (interval) {


### PR DESCRIPTION
## Summary
- All four reward composables (`useREULLocks`, `useMerkl`, `useBrevis`, `useFuul`) only fetched data for the connected wallet address, ignoring spy mode (`?spy=` query param) entirely
- Portfolio rewards page showed no/wrong data when viewing another address via spy mode
- Introduces `effectiveAddress` (`spyAddress || wagmiAddress`) for data reads and `isActive` (`isConnected || spyAddress`) as the lifecycle trigger, preserving the original boolean-toggling watcher pattern
- Write operations (claim/unlock) still require the connected wallet to sign

## Test plan
- [ ] Open `/portfolio/rewards?network=1&spy=<address>` without connecting a wallet — all reward sections should load data for the spy address
- [ ] Connect a wallet while in spy mode — rewards should still show spy address data (spy takes priority)
- [ ] Clear spy mode while connected — rewards should switch to the connected wallet's data
- [ ] Verify no excessive RPC/API polling in the network tab (same cadence as normal connected mode)
- [ ] Verify claim/unlock buttons are disabled or require wallet connection in spy mode