### PR TITLE
fix: preserve network query param on post-transaction redirects

### DIFF
--- a/composables/useSwapPageLogic.ts
+++ b/composables/useSwapPageLogic.ts
@@ -84,6 +84,7 @@ export const useSwapPageLogic = (options: UseSwapPageLogicOptions) => {
   const otherAmountField: SwapQuoteAmountField = displayAmountField === 'amountIn' ? 'amountOut' : 'amountIn'
 
   const router = useRouter()
+  const route = useRoute()
   const { isConnected } = useAccount()
   const { executeTxPlan } = useEulerOperations()
   const modal = useModal()
@@ -489,7 +490,7 @@ export const useSwapPageLogic = (options: UseSwapPageLogicOptions) => {
       await executeTxPlan(txPlan)
       modal.close()
       setTimeout(() => {
-        router.replace(redirectPath)
+        router.replace({ path: redirectPath, query: { network: route.query.network } })
       }, 400)
     }
     catch (e) {

--- a/pages/earn/[vault]/[subAccount]/withdraw.vue
+++ b/pages/earn/[vault]/[subAccount]/withdraw.vue
@@ -181,7 +181,7 @@ const send = async () => {
 
     modal.close()
     setTimeout(() => {
-      router.replace('/portfolio/saving')
+      router.replace({ path: '/portfolio/saving', query: { network: route.query.network } })
     }, 400)
   }
   catch (e) {

--- a/pages/earn/[vault]/index.vue
+++ b/pages/earn/[vault]/index.vue
@@ -157,7 +157,7 @@ const send = async () => {
     modal.close()
     await updateEstimates()
     setTimeout(() => {
-      router.replace('/portfolio/saving')
+      router.replace({ path: '/portfolio/saving', query: { network: route.query.network } })
     }, 400)
   }
   catch (e) {

--- a/pages/lend/[vault]/[subAccount]/withdraw.vue
+++ b/pages/lend/[vault]/[subAccount]/withdraw.vue
@@ -414,7 +414,7 @@ const send = async () => {
 
     modal.close()
     setTimeout(() => {
-      router.replace('/portfolio/saving')
+      router.replace({ path: '/portfolio/saving', query: { network: route.query.network } })
     }, 400)
   }
   catch (e) {

--- a/pages/lend/[vault]/index.vue
+++ b/pages/lend/[vault]/index.vue
@@ -481,7 +481,7 @@ const send = async () => {
     modal.close()
     await updateEstimates()
     setTimeout(() => {
-      router.replace('/portfolio/saving')
+      router.replace({ path: '/portfolio/saving', query: { network: route.query.network } })
     }, 400)
   }
   catch (e) {

--- a/pages/position/[number]/borrow/index.vue
+++ b/pages/position/[number]/borrow/index.vue
@@ -292,7 +292,7 @@ const send = async () => {
     modal.close()
     updateBalance()
     setTimeout(() => {
-      router.replace('/portfolio')
+      router.replace({ path: '/portfolio', query: { network: _route.query.network } })
     }, 400)
   }
   catch (e) {

--- a/pages/position/[number]/index.vue
+++ b/pages/position/[number]/index.vue
@@ -604,7 +604,7 @@ const send = async (collateralAddress: string) => {
 
     modal.close()
     setTimeout(() => {
-      router.replace('/portfolio')
+      router.replace({ path: '/portfolio', query: { network: _route.query.network } })
     }, 400)
   }
   catch (e) {

--- a/pages/position/[number]/multiply.vue
+++ b/pages/position/[number]/multiply.vue
@@ -664,7 +664,7 @@ const sendMultiply = async () => {
     modal.close()
     refreshAllPositions(eulerLensAddresses.value, address.value || '')
     setTimeout(() => {
-      router.replace('/portfolio')
+      router.replace({ path: '/portfolio', query: { network: route.query.network } })
     }, 400)
   }
   catch (e) {


### PR DESCRIPTION
All post-transaction redirects used bare path strings without the network query parameter, triggering the network middleware to fire a second redirect. This double-navigation race condition with keep-alive and the out-in page transition could leave the portfolio child page empty and select the wrong tab.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network persistence after transactions. The selected network parameter is now preserved when users are redirected following transaction completion on earn, lend, and position pages, providing a more consistent user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->