### PR TITLE
feat: add InfiniFi intrinsic APY adapter for locked and staked tokens

### DIFF
--- a/composables/useIntrinsicApy.ts
+++ b/composables/useIntrinsicApy.ts
@@ -15,6 +15,7 @@ import { createTreehouseProvider } from '~/services/intrinsicApy/treehouseProvid
 import { createOndoProvider } from '~/services/intrinsicApy/ondoProvider'
 import { createBenqiProvider } from '~/services/intrinsicApy/benqiProvider'
 import { createAvantProvider } from '~/services/intrinsicApy/avantProvider'
+import { createInfinifiProvider } from '~/services/intrinsicApy/infinifiProvider'
 import { logWarn } from '~/utils/errorHandling'
 import { CACHE_TTL_5MIN_MS } from '~/entities/tuning-constants'
 
@@ -41,6 +42,7 @@ const providers: IntrinsicApyProvider[] = [
   createOndoProvider(intrinsicApySources),
   createBenqiProvider(intrinsicApySources),
   createAvantProvider(intrinsicApySources),
+  createInfinifiProvider(intrinsicApySources),
 ]
 
 const mergeResults = (allResults: IntrinsicApyResult[]): Record<string, IntrinsicApyInfo> => {

--- a/entities/custom.ts
+++ b/entities/custom.ts
@@ -52,7 +52,6 @@ export const intrinsicApySources: readonly IntrinsicApySourceConfig[] = [
   { provider: 'defillama', chainId: 1, address: '0xc8CF6D7991f15525488b2A83Df53468D682Ba4B0', poolId: '0f67a08c-3f24-4a4b-963e-541f5a5c0364' },
   { provider: 'defillama', chainId: 1, address: '0xcf62F905562626CfcDD2261162a51fd02Fc9c5b6', poolId: '42523cca-14b0-44f6-95fb-4781069520a5' },
   { provider: 'defillama', chainId: 1, address: '0xd5F7838F5C461fefF7FE49ea5ebaF7728bB0ADfa', poolId: 'b9f2f00a-ba96-4589-a171-dde979a23d87' },
-  { provider: 'defillama', chainId: 1, address: '0xDBDC1Ef57537E34680B898E1FEBD3D68c7389bCB', poolId: '8fa2e60e-365a-41fc-8d50-fadde5041f94' },
   { provider: 'defillama', chainId: 1, address: '0xDcEe70654261AF21C44c093C300eD3Bb97b78192', poolId: '423681e3-4787-40ce-ae43-e9f67c5269b3' },
   { provider: 'defillama', chainId: 1, address: '0xE72B141DF173b999AE7c1aDcbF60Cc9833Ce56a8', poolId: '4e6cd326-72d5-4680-8d2f-3481d50e8bb1' },
   { provider: 'defillama', chainId: 1, address: '0xf1C9acDc66974dFB6dEcB12aA385b9cD01190E38', poolId: '4d01599c-69ae-41a3-bae1-5fab896f04c8' },

--- a/entities/custom.ts
+++ b/entities/custom.ts
@@ -2,21 +2,22 @@
 export const themeHue = 150
 
 // Intrinsic APY sources (data mapping, not deployment config)
-export type IntrinsicApySourceConfig =
-  | { provider: 'defillama', address: string, chainId: number, poolId: string, useSpotApy?: boolean }
-  | { provider: 'pendle', address: string, chainId: number, pendleMarket: string, crossChainSourceChainId?: number }
-  | { provider: 'securitize', address: string, chainId: number, symbol: string, yieldField: 'nav_yield_30d' | 'distribution_yield' }
-  | { provider: 'stablewatch', address: string, chainId: number }
-  | { provider: 'etherfi', address: string, chainId: number }
-  | { provider: 'renzo', address: string, chainId: number, renzoVariant: 'ezETH' | 'pzETH' }
-  | { provider: 'midas', address: string, chainId: number, midasKey: string }
-  | { provider: 'yo', address: string, chainId: number }
-  | { provider: 'spark', address: string, chainId: number }
-  | { provider: 'puffer', address: string, chainId: number }
-  | { provider: 'treehouse', address: string, chainId: number }
-  | { provider: 'ondo', address: string, chainId: number }
-  | { provider: 'benqi', address: string, chainId: number }
-  | { provider: 'avant', address: string, chainId: number }
+export type IntrinsicApySourceConfig
+  = | { provider: 'defillama', address: string, chainId: number, poolId: string, useSpotApy?: boolean }
+    | { provider: 'pendle', address: string, chainId: number, pendleMarket: string, crossChainSourceChainId?: number }
+    | { provider: 'securitize', address: string, chainId: number, symbol: string, yieldField: 'nav_yield_30d' | 'distribution_yield' }
+    | { provider: 'stablewatch', address: string, chainId: number }
+    | { provider: 'etherfi', address: string, chainId: number }
+    | { provider: 'renzo', address: string, chainId: number, renzoVariant: 'ezETH' | 'pzETH' }
+    | { provider: 'midas', address: string, chainId: number, midasKey: string }
+    | { provider: 'yo', address: string, chainId: number }
+    | { provider: 'spark', address: string, chainId: number }
+    | { provider: 'puffer', address: string, chainId: number }
+    | { provider: 'treehouse', address: string, chainId: number }
+    | { provider: 'ondo', address: string, chainId: number }
+    | { provider: 'benqi', address: string, chainId: number }
+    | { provider: 'avant', address: string, chainId: number }
+    | { provider: 'infinifi', address: string, chainId: number, infinifiVariant: 'locked' | 'staked', infinifiLockedKey?: string }
 
 export const intrinsicApySources: readonly IntrinsicApySourceConfig[] = [
   // DefiLlama pools — Ethereum (1)
@@ -261,4 +262,9 @@ export const intrinsicApySources: readonly IntrinsicApySourceConfig[] = [
 
   // Avant — savUSD
   { provider: 'avant', chainId: 43114, address: '0x06d47F3fb376649c3A9Dafe069B3D6E35572219E' },
+
+  // InfiniFi — 4w locked, 13w locked, siUSD staked
+  { provider: 'infinifi', chainId: 1, address: '0x66bCF6151D5558AfB47c38B20663589843156078', infinifiVariant: 'locked', infinifiLockedKey: '0x66bCF6151D5558AfB47c38B20663589843156078' },
+  { provider: 'infinifi', chainId: 1, address: '0xbd3f9814eB946E617f1d774A6762cDbec0bf087A', infinifiVariant: 'locked', infinifiLockedKey: '0xbd3f9814eB946E617f1d774A6762cDbec0bf087A' },
+  { provider: 'infinifi', chainId: 1, address: '0xDBDC1Ef57537E34680B898E1FEBD3D68c7389bCB', infinifiVariant: 'staked' },
 ]

--- a/server/api/intrinsic-apy/[provider].get.ts
+++ b/server/api/intrinsic-apy/[provider].get.ts
@@ -26,6 +26,7 @@ const PROVIDER_URLS: Record<string, string> = {
   yo: 'https://api.yo.xyz/api/v1/vault/stats',
   securitize: 'https://public-feed.securitize.io/asset-stats',
   stablewatch: 'https://api.stablewatch.io/api/pools',
+  infinifi: 'https://eth-api.infinifi.xyz/api/protocol/data',
 }
 
 const PENDLE_API_BASE = 'https://api-v2.pendle.finance/core/v2'

--- a/services/intrinsicApy/infinifiProvider.ts
+++ b/services/intrinsicApy/infinifiProvider.ts
@@ -1,0 +1,49 @@
+import type { IntrinsicApySourceConfig } from '~/entities/custom'
+import type { IntrinsicApyProvider, IntrinsicApyResult } from '~/entities/intrinsic-apy'
+
+type InfinifiSource = Extract<IntrinsicApySourceConfig, { provider: 'infinifi' }>
+
+type InfinifiResponse = {
+  data?: {
+    stats?: {
+      locked?: Record<string, { average7dAPY?: number }>
+      staked?: { average7dAPY?: number }
+    }
+  }
+}
+
+const normalize = (value?: string) => value?.toLowerCase() || ''
+
+export const createInfinifiProvider = (sources: readonly IntrinsicApySourceConfig[]): IntrinsicApyProvider => {
+  const infinifiSources = sources.filter(
+    (s): s is InfinifiSource => s.provider === 'infinifi',
+  )
+
+  return {
+    name: 'InfiniFi',
+
+    async fetch(chainId: number): Promise<IntrinsicApyResult[]> {
+      const chainSources = infinifiSources.filter(s => s.chainId === chainId)
+      if (!chainSources.length) return []
+
+      const data = await $fetch<InfinifiResponse>('/api/intrinsic-apy/infinifi')
+      const stats = data?.data?.stats
+
+      return chainSources.map((source) => {
+        const raw = source.infinifiVariant === 'staked'
+          ? Number(stats?.staked?.average7dAPY ?? 0)
+          : Number(source.infinifiLockedKey ? stats?.locked?.[source.infinifiLockedKey]?.average7dAPY ?? 0 : 0)
+        const apy = raw * 100
+
+        return {
+          address: normalize(source.address),
+          info: {
+            apy,
+            provider: 'InfiniFi',
+            source: 'https://infinifi.xyz',
+          },
+        }
+      })
+    },
+  }
+}


### PR DESCRIPTION
## Summary
- InfiniFi collateral tokens (liUSD-4w, liUSD-13w, siUSD) on Euler borrow markets need intrinsic APY displayed so users can see net yield when borrowing against these positions
- Adds a new intrinsic APY provider that fetches 7-day average APY from the InfiniFi protocol API for locked and staked token variants

## Changes
- New `infinifiProvider.ts` following the custom provider pattern (similar to renzo) since each token has a different APY from a single API endpoint
- Uses `infinifiVariant` discriminator (`locked` | `staked`) to extract the correct APY path from the response: `$.data.stats.locked[address].average7dAPY` for locked tokens, `$.data.stats.staked.average7dAPY` for siUSD
- API returns APY as decimals (e.g. `0.0872`), multiplied by 100 to convert to percentage
- siUSD (`0xDBDC1Ef5...`) also has an existing defillama source; the infinifi provider runs later and takes precedence intentionally

## Test plan
- [ ] Verify `http://localhost:3000/api/intrinsic-apy/infinifi` returns the full InfiniFi protocol data response
- [ ] On Ethereum mainnet borrow page, confirm Net APY for liUSD-13w/USDC reflects ~8.7% collateral yield (Net APY ≈ intrinsic APY − borrow APY)
- [ ] Confirm liUSD-4w/USDC and siUSD/USDC borrow markets similarly show correct net APY
- [ ] Verify no console errors from the provider on other chains where no infinifi sources are configured


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Infinifi is now integrated as an intrinsic APY data source, expanding yield information available to users.
  * APY data from Infinifi's locked and staked variants on Ethereum mainnet are included in yield calculations and shown alongside existing sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->