### PR TITLE
feat: add cyclical notes IRM support for vault overview

### DIFF
--- a/components/entities/vault/overview/VaultOverview.vue
+++ b/components/entities/vault/overview/VaultOverview.vue
@@ -1,10 +1,16 @@
 <script setup lang="ts">
 import type { Vault } from '~/entities/vault'
+import { INTEREST_RATE_MODEL_TYPE } from '~/entities/constants'
 
 const emits = defineEmits<{
   'vault-click': [address: string]
 }>()
 const { vault } = defineProps<{ vault: Vault, desktopOverview?: boolean }>()
+
+const isCyclicalIRM = computed(() => {
+  return Number(vault.irmInfo?.interestRateModelInfo?.interestRateModelType)
+    === INTEREST_RATE_MODEL_TYPE.FIXED_CYCLICAL_BINARY
+})
 </script>
 
 <template>
@@ -29,7 +35,12 @@ const { vault } = defineProps<{ vault: Vault, desktopOverview?: boolean }>()
       @vault-click="(address: string) => emits('vault-click', address)"
     />
 
+    <LazyVaultOverviewBlockCyclicalIRM
+      v-if="isCyclicalIRM"
+      :vault="vault"
+    />
     <LazyVaultOverviewBlockIRM
+      v-else
       :vault="vault"
     />
 

--- a/components/entities/vault/overview/VaultOverviewBlockCyclicalIRM.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockCyclicalIRM.vue
@@ -1,0 +1,398 @@
+<script setup lang="ts">
+import { decodeAbiParameters, formatUnits, zeroAddress, type Hex } from 'viem'
+import { INTEREST_RATE_MODEL_TYPE, FIXED_CYCLICAL_BINARY_IRM_COMPONENTS, SECONDS_IN_YEAR } from '~/entities/constants'
+import type { Vault, SecuritizeVault, CyclicalNoteInfo } from '~/entities/vault'
+import { hasCollateralExposure } from '~/entities/vault'
+import { useVaultRegistry } from '~/composables/useVaultRegistry'
+
+const { vault } = defineProps<{ vault: Vault }>()
+
+const { get: registryGet } = useVaultRegistry()
+
+const isCyclicalIRM = computed(() => {
+  return Number(vault.irmInfo?.interestRateModelInfo?.interestRateModelType)
+    === INTEREST_RATE_MODEL_TYPE.FIXED_CYCLICAL_BINARY
+})
+
+const hasValidIRM = computed(() => {
+  const hasExposure = hasCollateralExposure(
+    vault,
+    addr => registryGet(addr)?.vault as Vault | SecuritizeVault | undefined,
+  )
+  return hasExposure
+    && isCyclicalIRM.value
+    && vault.interestRateModelAddress
+    && vault.interestRateModelAddress !== zeroAddress
+})
+
+const cyclicalInfo = computed((): CyclicalNoteInfo | null => {
+  const params = vault.irmInfo?.interestRateModelInfo?.interestRateModelParams
+  if (!params) return null
+  try {
+    const [decoded] = decodeAbiParameters(
+      [{ type: 'tuple', components: FIXED_CYCLICAL_BINARY_IRM_COMPONENTS }],
+      params as Hex,
+    )
+    return decoded as unknown as CyclicalNoteInfo
+  }
+  catch {
+    return null
+  }
+})
+
+const now = useNow({ interval: 60_000 })
+
+const cycleLength = computed(() => {
+  if (!cyclicalInfo.value) return 0n
+  return cyclicalInfo.value.primaryDuration + cyclicalInfo.value.secondaryDuration
+})
+
+const currentCycleStart = computed(() => {
+  const info = cyclicalInfo.value
+  if (!info || cycleLength.value === 0n) return 0n
+  const nowSec = BigInt(Math.floor(now.value.getTime() / 1000))
+  const elapsed = nowSec - info.startTimestamp
+  const cycleIndex = elapsed / cycleLength.value
+  return info.startTimestamp + cycleIndex * cycleLength.value
+})
+
+const fixedRateStart = computed(() => currentCycleStart.value)
+const fixedRateEnd = computed(() => {
+  if (!cyclicalInfo.value) return 0n
+  return currentCycleStart.value + cyclicalInfo.value.primaryDuration
+})
+const repaymentWindowStart = computed(() => fixedRateEnd.value)
+const repaymentWindowEnd = computed(() => currentCycleStart.value + cycleLength.value)
+
+const elapsedInCycle = computed(() => {
+  const nowSec = BigInt(Math.floor(now.value.getTime() / 1000))
+  const elapsed = nowSec - currentCycleStart.value
+  return elapsed < 0n ? 0n : elapsed
+})
+
+const isInFixedRate = computed(() => {
+  if (!cyclicalInfo.value) return true
+  return elapsedInCycle.value < cyclicalInfo.value.primaryDuration
+})
+
+const cycleLengthDays = computed(() => {
+  if (cycleLength.value === 0n) return 0
+  return Number(cycleLength.value) / 86400
+})
+
+const primaryDurationDays = computed(() => {
+  if (!cyclicalInfo.value) return 0
+  return Number(cyclicalInfo.value.primaryDuration) / 86400
+})
+
+const secondaryDurationDays = computed(() => {
+  if (!cyclicalInfo.value) return 0
+  return Number(cyclicalInfo.value.secondaryDuration) / 86400
+})
+
+const percentComplete = computed(() => {
+  if (cycleLength.value === 0n) return 0
+  return (Number(elapsedInCycle.value) / Number(cycleLength.value)) * 100
+})
+
+const dayInCycle = computed(() => {
+  return Number(elapsedInCycle.value) / 86400
+})
+
+const fixedRatePercent = computed(() => {
+  if (cycleLength.value === 0n) return 0
+  return (Number(cyclicalInfo.value!.primaryDuration) / Number(cycleLength.value)) * 100
+})
+
+const clampedPercent = computed(() => Math.min(Math.max(percentComplete.value, 0), 100))
+
+const fixedFillPercent = computed(() => {
+  return Math.min(clampedPercent.value, fixedRatePercent.value)
+})
+
+const repaymentFillPercent = computed(() => {
+  if (isInFixedRate.value) return 0
+  return clampedPercent.value - fixedRatePercent.value
+})
+
+// SPY (27 decimal, per-second) to APY percentage
+const spyToApy = (spy: bigint): number => {
+  const spyNumber = Number(formatUnits(spy, 27))
+  return (Math.pow(1 + spyNumber, SECONDS_IN_YEAR) - 1) * 100
+}
+
+const fixedBorrowAPY = computed(() => {
+  if (!cyclicalInfo.value) return 0
+  return spyToApy(cyclicalInfo.value.primaryRate)
+})
+
+const repaymentBorrowAPY = computed(() => {
+  if (!cyclicalInfo.value) return 0
+  return spyToApy(cyclicalInfo.value.secondaryRate)
+})
+
+const formatCyclicalDate = (timestamp: bigint): string => {
+  const date = new Date(Number(timestamp) * 1000)
+  const day = date.getDate()
+  const suffix = getDaySuffix(day)
+  const month = date.toLocaleString('en-US', { month: 'short' })
+  const year = date.getFullYear()
+  const hour = date.getHours()
+  const ampm = hour >= 12 ? 'pm' : 'am'
+  const hour12 = hour % 12 || 12
+  const min = date.getMinutes()
+  const timeStr = min === 0 ? `${hour12}${ampm}` : `${hour12}:${String(min).padStart(2, '0')}${ampm}`
+  return `${month} ${day}${suffix}, ${year} ${timeStr}`
+}
+
+const getDaySuffix = (day: number): string => {
+  if (day >= 11 && day <= 13) return 'th'
+  switch (day % 10) {
+    case 1: return 'st'
+    case 2: return 'nd'
+    case 3: return 'rd'
+    default: return 'th'
+  }
+}
+
+// Omit year from end date when it matches the start date
+const formatCyclicalDateShort = (startTimestamp: bigint, endTimestamp: bigint): string => {
+  const startYear = new Date(Number(startTimestamp) * 1000).getFullYear()
+  const endDate = new Date(Number(endTimestamp) * 1000)
+  const day = endDate.getDate()
+  const suffix = getDaySuffix(day)
+  const month = endDate.toLocaleString('en-US', { month: 'short' })
+  const hour = endDate.getHours()
+  const ampm = hour >= 12 ? 'pm' : 'am'
+  const hour12 = hour % 12 || 12
+  const min = endDate.getMinutes()
+  const timeStr = min === 0 ? `${hour12}${ampm}` : `${hour12}:${String(min).padStart(2, '0')}${ampm}`
+  if (endDate.getFullYear() === startYear) {
+    return `${month} ${day}${suffix} ${timeStr}`
+  }
+  return `${month} ${day}${suffix}, ${endDate.getFullYear()} ${timeStr}`
+}
+
+const formatAPY = (apy: number): string => {
+  return apy.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+}
+
+const formatDuration = (days: number): string => {
+  if (days >= 1) {
+    const rounded = Math.round(days)
+    return `${rounded} day${rounded !== 1 ? 's' : ''}`
+  }
+  const hours = Math.round(days * 24)
+  return `${hours} hour${hours !== 1 ? 's' : ''}`
+}
+
+// Progress bar tick marks at 0%, 33%, 66%, 100%
+const progressTicks = computed(() => {
+  const totalDays = cycleLengthDays.value
+  return [
+    { label: `Day 0`, pct: '0%', position: '0%' },
+    { label: `Day ${Math.round(totalDays / 3)}`, pct: '33%', position: '33.33%' },
+    { label: `Day ${Math.round((totalDays * 2) / 3)}`, pct: '66%', position: '66.66%' },
+    { label: `Day ${Math.round(totalDays)}`, pct: '100%', position: '100%' },
+  ]
+})
+
+const phaseLabel = computed(() => {
+  return isInFixedRate.value ? 'Fixed rate period' : 'Repayment window'
+})
+</script>
+
+<template>
+  <div
+    v-if="hasValidIRM && cyclicalInfo"
+    class="bg-surface-secondary rounded-xl flex flex-col gap-16 p-24 shadow-card"
+  >
+    <!-- Header -->
+    <div class="flex items-center gap-8">
+      <p class="text-h3 text-content-primary">
+        Interest rate model
+      </p>
+      <div class="cyclical-chip inline-flex items-center py-4 px-8 rounded-8 text-[13px] font-medium">
+        Cyclical note
+      </div>
+    </div>
+
+    <!-- Current cycle -->
+    <div class="flex flex-col gap-12">
+      <p class="text-p3 text-content-tertiary font-medium uppercase tracking-wide text-[11px]">
+        Current cycle
+      </p>
+      <div class="grid grid-cols-1 sm:grid-cols-3 gap-16">
+        <VaultOverviewLabelValue label="Fixed rate start">
+          <span class="text-p3 text-content-primary">
+            {{ formatCyclicalDate(fixedRateStart) }}
+          </span>
+        </VaultOverviewLabelValue>
+        <VaultOverviewLabelValue label="Fixed rate end">
+          <span class="text-p3 text-content-primary">
+            {{ formatCyclicalDate(fixedRateEnd) }}
+          </span>
+        </VaultOverviewLabelValue>
+        <VaultOverviewLabelValue label="Repayment window">
+          <span class="text-p3 text-content-primary">
+            {{ formatCyclicalDate(repaymentWindowStart) }}<br>– {{ formatCyclicalDateShort(repaymentWindowStart, repaymentWindowEnd) }}
+          </span>
+        </VaultOverviewLabelValue>
+      </div>
+    </div>
+
+    <!-- Parameters -->
+    <div class="flex flex-col gap-12">
+      <p class="text-p3 text-content-tertiary font-medium uppercase tracking-wide text-[11px]">
+        Parameters
+      </p>
+      <div class="grid grid-cols-1 sm:grid-cols-3 gap-16">
+        <VaultOverviewLabelValue label="Cycle length">
+          <span class="text-p3 text-content-primary">
+            {{ formatDuration(primaryDurationDays) }} / {{ formatDuration(secondaryDurationDays) }}
+          </span>
+        </VaultOverviewLabelValue>
+        <VaultOverviewLabelValue label="Fixed APY">
+          <span class="text-p3 text-content-primary">
+            {{ formatAPY(fixedBorrowAPY) }}%
+          </span>
+        </VaultOverviewLabelValue>
+        <VaultOverviewLabelValue label="Repayment APY">
+          <span class="text-p3 text-content-primary">
+            {{ formatAPY(repaymentBorrowAPY) }}%
+          </span>
+        </VaultOverviewLabelValue>
+      </div>
+    </div>
+
+    <!-- Progress -->
+    <div class="flex flex-col gap-12 mt-12">
+      <p class="text-p3 text-content-tertiary font-medium uppercase tracking-wide text-[11px]">
+        Progress
+      </p>
+      <!-- Legend -->
+      <div class="flex items-center gap-16 text-[12px] text-content-secondary">
+        <span class="flex items-center gap-4">
+          <span class="inline-block w-8 h-8 rounded-full bg-accent-500" />
+          Fixed rate period
+        </span>
+        <span class="flex items-center gap-4">
+          <span class="inline-block w-8 h-8 rounded-full cyclical-repayment-dot" />
+          Repayment window
+        </span>
+      </div>
+
+      <!-- Tick labels -->
+      <div class="relative h-16 text-[11px] text-content-tertiary whitespace-nowrap">
+        <span
+          v-for="tick in progressTicks"
+          :key="tick.pct"
+          class="absolute -translate-x-1/2 select-none"
+          :class="{ '!translate-x-0': tick.position === '0%', '!-translate-x-full': tick.position === '100%' }"
+          :style="{ left: tick.position }"
+        >
+          {{ tick.label }} ({{ tick.pct }})
+        </span>
+      </div>
+
+      <!-- Bar -->
+      <div class="cyclical-progress">
+        <div class="cyclical-progress__track">
+          <div
+            class="cyclical-progress__fixed"
+            :style="{ width: `${fixedFillPercent}%` }"
+          />
+          <div
+            v-if="!isInFixedRate"
+            class="cyclical-progress__repayment"
+            :style="{ left: `${fixedRatePercent}%`, width: `${repaymentFillPercent}%` }"
+          />
+          <div
+            class="cyclical-progress__divider"
+            :style="{ left: `${fixedRatePercent}%` }"
+          />
+        </div>
+        <div
+          class="cyclical-progress__cursor"
+          :style="{ left: `${clampedPercent}%` }"
+        />
+      </div>
+
+      <!-- Status text -->
+      <div class="flex justify-between text-[12px]">
+        <span class="text-content-secondary">
+          <span :class="isInFixedRate ? 'text-accent-700' : 'cyclical-repayment-text'">{{ phaseLabel }}</span>
+          day {{ Math.floor(dayInCycle) }} of {{ Math.round(cycleLengthDays) }}
+        </span>
+        <span class="text-content-tertiary">
+          {{ formatAPY(percentComplete) }}% complete
+        </span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.cyclical-chip {
+  background-color: rgba(var(--accent-rgb), 0.15);
+  color: var(--accent-600);
+
+  [data-theme="dark"] & {
+    background-color: rgba(var(--accent-rgb), 0.2);
+    color: var(--accent-500);
+  }
+}
+
+.cyclical-repayment-dot {
+  background-color: var(--warning-500);
+}
+
+.cyclical-repayment-text {
+  color: var(--warning-500);
+}
+
+.cyclical-progress {
+  position: relative;
+  height: 10px;
+
+  &__track {
+    position: relative;
+    height: 100%;
+    border-radius: 100px;
+    background-color: var(--ui-progress-background-color);
+    overflow: hidden;
+  }
+
+  &__fixed {
+    height: 100%;
+    background-color: var(--accent-500);
+  }
+
+  &__repayment {
+    position: absolute;
+    top: 0;
+    height: 100%;
+    background-color: var(--warning-500);
+  }
+
+  &__divider {
+    position: absolute;
+    top: 0;
+    width: 2px;
+    height: 100%;
+    background-color: var(--text-primary);
+    opacity: 0.3;
+    transform: translateX(-50%);
+  }
+
+  &__cursor {
+    position: absolute;
+    top: -2px;
+    width: 3px;
+    height: 14px;
+    background-color: var(--text-primary);
+    border-radius: 2px;
+    transform: translateX(-50%);
+  }
+}
+</style>

--- a/components/entities/vault/overview/VaultOverviewBlockCyclicalIRM.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockCyclicalIRM.vue
@@ -78,11 +78,6 @@ const isInFixedRate = computed(() => {
   return elapsedInCycle.value < cyclicalInfo.value.primaryDuration
 })
 
-const cycleLengthDays = computed(() => {
-  if (cycleLength.value === 0n) return 0
-  return Number(cycleLength.value) / 86400
-})
-
 const primaryDurationDays = computed(() => {
   if (!cyclicalInfo.value) return 0
   return Number(cyclicalInfo.value.primaryDuration) / 86400
@@ -93,29 +88,49 @@ const secondaryDurationDays = computed(() => {
   return Number(cyclicalInfo.value.secondaryDuration) / 86400
 })
 
-const percentComplete = computed(() => {
-  if (cycleLength.value === 0n) return 0
-  return (Number(elapsedInCycle.value) / Number(cycleLength.value)) * 100
+const currentPhaseDurationSec = computed(() => {
+  if (!cyclicalInfo.value) return 0n
+  return isInFixedRate.value
+    ? cyclicalInfo.value.primaryDuration
+    : cyclicalInfo.value.secondaryDuration
 })
 
-const dayInCycle = computed(() => {
-  return Number(elapsedInCycle.value) / 86400
+const currentPhaseDurationDays = computed(() => {
+  return Number(currentPhaseDurationSec.value) / 86400
 })
 
+const elapsedInPhase = computed(() => {
+  if (!cyclicalInfo.value) return 0n
+  if (isInFixedRate.value) return elapsedInCycle.value
+  const elapsed = elapsedInCycle.value - cyclicalInfo.value.primaryDuration
+  return elapsed < 0n ? 0n : elapsed
+})
+
+const dayInPhase = computed(() => {
+  return Number(elapsedInPhase.value) / 86400
+})
+
+// Bar represents the full cycle proportionally. The 100% tick sits at the
+// phase boundary, so fixedRatePercent is the position (in % of bar width)
+// of both the boundary and the end-of-fixed-rate tick.
 const fixedRatePercent = computed(() => {
   if (!cyclicalInfo.value || cycleLength.value === 0n) return 0
   return (Number(cyclicalInfo.value.primaryDuration) / Number(cycleLength.value)) * 100
 })
 
-const clampedPercent = computed(() => Math.min(Math.max(percentComplete.value, 0), 100))
-
-const fixedFillPercent = computed(() => {
-  return Math.min(clampedPercent.value, fixedRatePercent.value)
+const cyclePositionPercent = computed(() => {
+  if (cycleLength.value === 0n) return 0
+  const pct = (Number(elapsedInCycle.value) / Number(cycleLength.value)) * 100
+  return Math.min(Math.max(pct, 0), 100)
 })
+
+const fixedFillPercent = computed(() =>
+  Math.min(cyclePositionPercent.value, fixedRatePercent.value),
+)
 
 const repaymentFillPercent = computed(() => {
   if (isInFixedRate.value) return 0
-  return clampedPercent.value - fixedRatePercent.value
+  return cyclePositionPercent.value - fixedRatePercent.value
 })
 
 // SPY (27 decimal, per-second) to APY percentage
@@ -158,24 +173,6 @@ const getDaySuffix = (day: number): string => {
   }
 }
 
-// Omit year from end date when it matches the start date
-const formatCyclicalDateShort = (startTimestamp: bigint, endTimestamp: bigint): string => {
-  const startYear = new Date(Number(startTimestamp) * 1000).getFullYear()
-  const endDate = new Date(Number(endTimestamp) * 1000)
-  const day = endDate.getDate()
-  const suffix = getDaySuffix(day)
-  const month = endDate.toLocaleString('en-US', { month: 'short' })
-  const hour = endDate.getHours()
-  const ampm = hour >= 12 ? 'pm' : 'am'
-  const hour12 = hour % 12 || 12
-  const min = endDate.getMinutes()
-  const timeStr = min === 0 ? `${hour12}${ampm}` : `${hour12}:${String(min).padStart(2, '0')}${ampm}`
-  if (endDate.getFullYear() === startYear) {
-    return `${month} ${day}${suffix} ${timeStr}`
-  }
-  return `${month} ${day}${suffix}, ${endDate.getFullYear()} ${timeStr}`
-}
-
 const formatPercent = (value: number): string => {
   return value.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
 }
@@ -189,14 +186,15 @@ const formatDuration = (days: number): string => {
   return `${hours} hour${hours !== 1 ? 's' : ''}`
 }
 
-// Progress bar tick marks at 0%, 33%, 66%, 100%
+// Tick marks at 0%, 50%, 100% of the fixed rate period. The 100% mark sits
+// at the phase boundary on the bar, and the repayment portion continues past.
 const progressTicks = computed(() => {
-  const totalDays = cycleLengthDays.value
+  const totalDays = primaryDurationDays.value
+  const fixedEnd = fixedRatePercent.value
   return [
-    { label: `Day 0`, pct: '0%', position: '0%' },
-    { label: `Day ${Math.round(totalDays / 3)}`, pct: '33%', position: '33.33%' },
-    { label: `Day ${Math.round((totalDays * 2) / 3)}`, pct: '66%', position: '66.66%' },
-    { label: `Day ${Math.round(totalDays)}`, pct: '100%', position: '100%' },
+    { label: 'Day 0', pct: '0%', position: '0%' },
+    { label: `Day ${Math.round(totalDays / 2)}`, pct: '50%', position: `${fixedEnd / 2}%` },
+    { label: `Day ${Math.round(totalDays)}`, pct: '100%', position: `${fixedEnd}%` },
   ]
 })
 
@@ -234,22 +232,22 @@ const phaseLabel = computed(() => {
       class="flex flex-col gap-12"
     >
       <p class="text-p3 text-content-tertiary font-medium uppercase tracking-wide text-[11px]">
-        Current cycle
+        Cycle
       </p>
       <div class="grid grid-cols-1 sm:grid-cols-3 gap-16">
-        <VaultOverviewLabelValue label="Fixed rate start">
+        <VaultOverviewLabelValue label="Fixed rate cycle">
           <span class="text-p3 text-content-primary">
-            {{ formatCyclicalDate(fixedRateStart) }}
-          </span>
-        </VaultOverviewLabelValue>
-        <VaultOverviewLabelValue label="Fixed rate end">
-          <span class="text-p3 text-content-primary">
-            {{ formatCyclicalDate(fixedRateEnd) }}
+            {{ formatCyclicalDate(fixedRateStart) }}<br>{{ formatCyclicalDate(fixedRateEnd) }}
           </span>
         </VaultOverviewLabelValue>
         <VaultOverviewLabelValue label="Repayment window">
           <span class="text-p3 text-content-primary">
-            {{ formatCyclicalDate(repaymentWindowStart) }}<br>– {{ formatCyclicalDateShort(repaymentWindowStart, repaymentWindowEnd) }}
+            {{ formatCyclicalDate(repaymentWindowStart) }}<br>{{ formatCyclicalDate(repaymentWindowEnd) }}
+          </span>
+        </VaultOverviewLabelValue>
+        <VaultOverviewLabelValue label="Cycle length">
+          <span class="text-p3 text-content-primary">
+            {{ formatDuration(primaryDurationDays) }} / {{ formatDuration(secondaryDurationDays) }}
           </span>
         </VaultOverviewLabelValue>
       </div>
@@ -261,11 +259,6 @@ const phaseLabel = computed(() => {
         Parameters
       </p>
       <div class="grid grid-cols-1 sm:grid-cols-3 gap-16">
-        <VaultOverviewLabelValue label="Cycle length">
-          <span class="text-p3 text-content-primary">
-            {{ formatDuration(primaryDurationDays) }} / {{ formatDuration(secondaryDurationDays) }}
-          </span>
-        </VaultOverviewLabelValue>
         <VaultOverviewLabelValue label="Fixed APY">
           <span class="text-p3 text-content-primary">
             {{ formatPercent(fixedBorrowAPY) }}%
@@ -305,7 +298,7 @@ const phaseLabel = computed(() => {
           v-for="tick in progressTicks"
           :key="tick.pct"
           class="absolute -translate-x-1/2 select-none"
-          :class="{ '!translate-x-0': tick.position === '0%', '!-translate-x-full': tick.position === '100%' }"
+          :class="{ '!translate-x-0': tick.pct === '0%' }"
           :style="{ left: tick.position }"
         >
           {{ tick.label }} ({{ tick.pct }})
@@ -331,19 +324,13 @@ const phaseLabel = computed(() => {
         </div>
         <div
           class="cyclical-progress__cursor"
-          :style="{ left: `${clampedPercent}%` }"
+          :style="{ left: `${cyclePositionPercent}%` }"
         />
       </div>
 
       <!-- Status text -->
-      <div class="flex justify-between text-[12px]">
-        <span class="text-content-secondary">
-          <span :class="isInFixedRate ? 'text-accent-700' : 'cyclical-repayment-text'">{{ phaseLabel }}</span>
-          day {{ Math.floor(dayInCycle) }} of {{ Math.round(cycleLengthDays) }}
-        </span>
-        <span class="text-content-tertiary">
-          {{ formatPercent(percentComplete) }}% complete
-        </span>
+      <div class="text-[12px] text-content-secondary">
+        {{ phaseLabel }} day {{ Math.floor(dayInPhase) }} of {{ Math.round(currentPhaseDurationDays) }}
       </div>
     </div>
   </div>

--- a/components/entities/vault/overview/VaultOverviewBlockCyclicalIRM.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockCyclicalIRM.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { decodeAbiParameters, formatUnits, zeroAddress, type Hex } from 'viem'
-import { INTEREST_RATE_MODEL_TYPE, FIXED_CYCLICAL_BINARY_IRM_COMPONENTS, SECONDS_IN_YEAR } from '~/entities/constants'
+import { FIXED_CYCLICAL_BINARY_IRM_COMPONENTS, SECONDS_IN_YEAR } from '~/entities/constants'
 import type { Vault, SecuritizeVault, CyclicalNoteInfo } from '~/entities/vault'
 import { hasCollateralExposure } from '~/entities/vault'
 import { useVaultRegistry } from '~/composables/useVaultRegistry'
@@ -9,18 +9,14 @@ const { vault } = defineProps<{ vault: Vault }>()
 
 const { get: registryGet } = useVaultRegistry()
 
-const isCyclicalIRM = computed(() => {
-  return Number(vault.irmInfo?.interestRateModelInfo?.interestRateModelType)
-    === INTEREST_RATE_MODEL_TYPE.FIXED_CYCLICAL_BINARY
-})
-
+// Parent already gates rendering to cyclical IRM vaults via v-if,
+// so this component only checks collateral exposure and IRM address.
 const hasValidIRM = computed(() => {
   const hasExposure = hasCollateralExposure(
     vault,
     addr => registryGet(addr)?.vault as Vault | SecuritizeVault | undefined,
   )
   return hasExposure
-    && isCyclicalIRM.value
     && vault.interestRateModelAddress
     && vault.interestRateModelAddress !== zeroAddress
 })
@@ -33,7 +29,7 @@ const cyclicalInfo = computed((): CyclicalNoteInfo | null => {
       [{ type: 'tuple', components: FIXED_CYCLICAL_BINARY_IRM_COMPONENTS }],
       params as Hex,
     )
-    return decoded as unknown as CyclicalNoteInfo
+    return decoded as CyclicalNoteInfo
   }
   catch {
     return null
@@ -47,9 +43,16 @@ const cycleLength = computed(() => {
   return cyclicalInfo.value.primaryDuration + cyclicalInfo.value.secondaryDuration
 })
 
+const hasStarted = computed(() => {
+  const info = cyclicalInfo.value
+  if (!info) return false
+  const nowSec = BigInt(Math.floor(now.value.getTime() / 1000))
+  return nowSec >= info.startTimestamp
+})
+
 const currentCycleStart = computed(() => {
   const info = cyclicalInfo.value
-  if (!info || cycleLength.value === 0n) return 0n
+  if (!info || cycleLength.value === 0n || !hasStarted.value) return 0n
   const nowSec = BigInt(Math.floor(now.value.getTime() / 1000))
   const elapsed = nowSec - info.startTimestamp
   const cycleIndex = elapsed / cycleLength.value
@@ -100,8 +103,8 @@ const dayInCycle = computed(() => {
 })
 
 const fixedRatePercent = computed(() => {
-  if (cycleLength.value === 0n) return 0
-  return (Number(cyclicalInfo.value!.primaryDuration) / Number(cycleLength.value)) * 100
+  if (!cyclicalInfo.value || cycleLength.value === 0n) return 0
+  return (Number(cyclicalInfo.value.primaryDuration) / Number(cycleLength.value)) * 100
 })
 
 const clampedPercent = computed(() => Math.min(Math.max(percentComplete.value, 0), 100))
@@ -173,8 +176,8 @@ const formatCyclicalDateShort = (startTimestamp: bigint, endTimestamp: bigint): 
   return `${month} ${day}${suffix}, ${endDate.getFullYear()} ${timeStr}`
 }
 
-const formatAPY = (apy: number): string => {
-  return apy.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+const formatPercent = (value: number): string => {
+  return value.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
 }
 
 const formatDuration = (days: number): string => {
@@ -217,8 +220,19 @@ const phaseLabel = computed(() => {
       </div>
     </div>
 
+    <!-- Pre-start notice -->
+    <div
+      v-if="!hasStarted && cyclicalInfo"
+      class="text-p3 text-content-secondary"
+    >
+      First cycle starts {{ formatCyclicalDate(cyclicalInfo.startTimestamp) }}
+    </div>
+
     <!-- Current cycle -->
-    <div class="flex flex-col gap-12">
+    <div
+      v-if="hasStarted"
+      class="flex flex-col gap-12"
+    >
       <p class="text-p3 text-content-tertiary font-medium uppercase tracking-wide text-[11px]">
         Current cycle
       </p>
@@ -254,19 +268,22 @@ const phaseLabel = computed(() => {
         </VaultOverviewLabelValue>
         <VaultOverviewLabelValue label="Fixed APY">
           <span class="text-p3 text-content-primary">
-            {{ formatAPY(fixedBorrowAPY) }}%
+            {{ formatPercent(fixedBorrowAPY) }}%
           </span>
         </VaultOverviewLabelValue>
         <VaultOverviewLabelValue label="Repayment APY">
           <span class="text-p3 text-content-primary">
-            {{ formatAPY(repaymentBorrowAPY) }}%
+            {{ formatPercent(repaymentBorrowAPY) }}%
           </span>
         </VaultOverviewLabelValue>
       </div>
     </div>
 
     <!-- Progress -->
-    <div class="flex flex-col gap-12 mt-12">
+    <div
+      v-if="hasStarted"
+      class="flex flex-col gap-12 mt-12"
+    >
       <p class="text-p3 text-content-tertiary font-medium uppercase tracking-wide text-[11px]">
         Progress
       </p>
@@ -325,7 +342,7 @@ const phaseLabel = computed(() => {
           day {{ Math.floor(dayInCycle) }} of {{ Math.round(cycleLengthDays) }}
         </span>
         <span class="text-content-tertiary">
-          {{ formatAPY(percentComplete) }}% complete
+          {{ formatPercent(percentComplete) }}% complete
         </span>
       </div>
     </div>

--- a/components/entities/vault/overview/VaultOverviewBlockIRM.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockIRM.vue
@@ -73,6 +73,9 @@ const irmTypeLabel = computed(() => {
   else if (modelType === INTEREST_RATE_MODEL_TYPE.ADAPTIVE_CURVE) {
     return 'Adaptive'
   }
+  else if (modelType === INTEREST_RATE_MODEL_TYPE.FIXED_CYCLICAL_BINARY) {
+    return 'Cyclical note'
+  }
   return 'Interest Rate Model'
 })
 

--- a/entities/constants.ts
+++ b/entities/constants.ts
@@ -85,7 +85,16 @@ export const PERMIT2_SIG_WINDOW = 60n * 60n
 export const INTEREST_RATE_MODEL_TYPE = {
   KINK: 1,
   ADAPTIVE_CURVE: 2,
+  FIXED_CYCLICAL_BINARY: 4,
 } as const
+
+export const FIXED_CYCLICAL_BINARY_IRM_COMPONENTS = [
+  { name: 'primaryRate', type: 'uint256' },
+  { name: 'secondaryRate', type: 'uint256' },
+  { name: 'primaryDuration', type: 'uint256' },
+  { name: 'secondaryDuration', type: 'uint256' },
+  { name: 'startTimestamp', type: 'uint256' },
+] as const
 
 export const ORACLE_DETAILED_INFO_COMPONENTS = [
   { name: 'oracle', type: 'address' },

--- a/entities/vault/index.ts
+++ b/entities/vault/index.ts
@@ -6,6 +6,7 @@ export type {
   VaultAsset,
   VaultInterestRateInfo,
   VaultIRMInfo,
+  CyclicalNoteInfo,
   Erc4626Vault,
   SecuritizeVault,
   Vault,

--- a/entities/vault/types.ts
+++ b/entities/vault/types.ts
@@ -45,9 +45,17 @@ export interface VaultInterestRateInfo {
   cash: bigint
   supplyAPY: bigint
 }
+export interface CyclicalNoteInfo {
+  primaryRate: bigint
+  secondaryRate: bigint
+  primaryDuration: bigint
+  secondaryDuration: bigint
+  startTimestamp: bigint
+}
 export interface VaultIRMInfo {
   interestRateModelInfo?: {
     interestRateModelType?: number
+    interestRateModelParams?: string
   }
 }
 export interface Erc4626Vault {


### PR DESCRIPTION
Replace the standard APY chart with a structured display when a vault uses the FIXED_CYCLICAL_BINARY interest rate model type. Shows current cycle dates, fixed/repayment APY parameters, and a two-phase progress bar with period divider. Decodes FixedCyclicalBinaryIRMInfo from the on-chain interestRateModelParams bytes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for cyclical interest-rate models in vault overviews.
  * New cyclical IRM block with visual progress bar, cycle timing, phase/status indicators, and annualized APY displays.
  * Vault overview now conditionally shows the appropriate IRM presentation (including a "Cyclical note" label) based on the vault's interest-rate model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->