### PR TITLE
feat: public /api/public/is-known vault verification endpoint

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -81,6 +81,12 @@ Welcome to the documentation for the Euler Lite project. This documentation is d
 - Country group aliases (EU, EEA, EFTA)
 - UI enforcement across browse, detail, action, and modal pages
 
+### 🌐 [Public API](./public-api.md)
+
+- Publicly reachable endpoints under `/api/public/` (CORS `*`)
+- `GET /api/public/is-known` — verified-vault lookup by address
+- Request/response shape, caching, rate limits, and examples
+
 ## 🎯 Project Overview
 
 **Euler Lite** is a lightweight multi-chain DeFi application that provides lending and borrowing services through the Euler Finance protocol. It supports multiple EVM chains and connects via standard EVM wallets. The application allows users to:

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -27,7 +27,7 @@ See [vault-labels-and-verification.md](./vault-labels-and-verification.md) for h
 | Param       | Type     | Required | Description                                                                 |
 |-------------|----------|----------|-----------------------------------------------------------------------------|
 | `chainId`   | integer  | yes      | EVM chain ID (e.g. `1` for mainnet).                                        |
-| `addresses` | string   | yes      | Comma-separated list of vault addresses. Max 100. Any case accepted.        |
+| `addresses` | string   | yes      | Comma-separated list of vault addresses. Max 100. Lowercase, uppercase, or valid EIP-55 checksum accepted; mixed-case inputs must have a correct checksum. |
 
 ### Response
 
@@ -40,7 +40,7 @@ Status `200`, JSON object mapping each input address (in EIP-55 checksum form) t
 }
 ```
 
-Addresses are normalized via EIP-55 checksum before comparison, so callers may submit lowercase, uppercase, or mixed-case and get the same answer. Keys in the response always use the checksum form.
+Addresses are validated via viem's `isAddress` (strict EIP-55 checks) and normalized to checksum form before comparison. Lowercase and uppercase hex inputs are accepted; mixed-case inputs must already carry a valid EIP-55 checksum or the request is rejected with `400`. Keys in the response always use the checksum form.
 
 ### Errors
 

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -1,0 +1,107 @@
+# Public API
+
+Endpoints under `/api/public/` are intentionally reachable from any origin (no CORS allowlist) and are intended to be consumed by external integrators.
+
+The `/api/public/` path prefix is the contract: any handler placed below it in `server/api/public/` automatically receives `Access-Control-Allow-Origin: *` via `server/middleware/cors.ts`. Do not put internal endpoints under this prefix.
+
+All public endpoints are rate-limited per client IP and return JSON.
+
+---
+
+## `GET /api/public/is-known`
+
+Answers whether a given vault address is considered verified by this app.
+
+"Verified" means the vault is in the app's allowlist used to render markets and resolve unknown-vault prompts — specifically, it appears in one of:
+
+- `products.json` labels under any product's active `vaults[]` (covers both EVK and Securitize vaults, since Securitize vaults are tracked alongside EVK in the same file).
+- `earn-vaults.json` labels as an entry where `deprecated !== true`.
+- The on-chain set returned by `escrowedCollateralPerspective.verifiedArray()` for the chain.
+
+Deprecated vaults (in `products.deprecatedVaults[]` or earn entries with `deprecated: true`) are treated as **not verified**. The `notExplorable` flag does **not** change verification — vaults hidden from Explore are still verified.
+
+See [vault-labels-and-verification.md](./vault-labels-and-verification.md) for how the label sources themselves are structured.
+
+### Request
+
+| Param       | Type     | Required | Description                                                                 |
+|-------------|----------|----------|-----------------------------------------------------------------------------|
+| `chainId`   | integer  | yes      | EVM chain ID (e.g. `1` for mainnet).                                        |
+| `addresses` | string   | yes      | Comma-separated list of vault addresses. Max 100. Any case accepted.        |
+
+### Response
+
+Status `200`, JSON object mapping each input address (in EIP-55 checksum form) to `true` / `false`:
+
+```json
+{
+  "0xAbC…": true,
+  "0xDeF…": false
+}
+```
+
+Addresses are normalized via EIP-55 checksum before comparison, so callers may submit lowercase, uppercase, or mixed-case and get the same answer. Keys in the response always use the checksum form.
+
+### Errors
+
+| Status | Cause                                                                    |
+|--------|--------------------------------------------------------------------------|
+| `400`  | Missing/invalid `chainId`, `chainId` not supported by this deployment, missing `addresses`, >100 addresses, or a malformed address. |
+| `429`  | Rate limit exceeded for this client IP.                                  |
+| `502`  | All upstream sources (labels endpoint, chains config, RPC proxy) failed and no stale cache is available. |
+
+### Caching
+
+The server maintains a per-chain in-memory verified set with a 5-minute TTL and stale-while-revalidate fallback. Back-to-back lookups for the same chain are served from memory. Upstream refreshes happen at most once every 5 minutes per chain.
+
+### Rate limit
+
+100 requests per minute per client IP.
+
+### CORS
+
+`Access-Control-Allow-Origin: *`. Preflight (`OPTIONS`) responds with `204` and `Access-Control-Allow-Methods: GET, OPTIONS`, `Access-Control-Allow-Headers: Content-Type`.
+
+### Examples
+
+Single address:
+
+```bash
+curl 'https://<host>/api/public/is-known?chainId=1&addresses=0x1234567890123456789012345678901234567890'
+```
+
+```json
+{ "0x1234567890123456789012345678901234567890": false }
+```
+
+Batch lookup:
+
+```bash
+curl 'https://<host>/api/public/is-known?chainId=1&addresses=0xAAA…,0xBBB…,0xCCC…'
+```
+
+```json
+{
+  "0xAAA…": true,
+  "0xBBB…": false,
+  "0xCCC…": true
+}
+```
+
+From the browser (verifying CORS):
+
+```js
+const res = await fetch(
+  'https://<host>/api/public/is-known?chainId=1&addresses=0x1234567890123456789012345678901234567890'
+)
+const map = await res.json()
+```
+
+---
+
+## Implementation notes
+
+- Handler: `server/api/public/is-known.get.ts`
+- Verified-set builder + cache: `server/utils/verified-vaults.ts`
+- CORS bypass for the `/api/public/` prefix lives in `server/middleware/cors.ts`.
+- Escrow vaults are read via an `eth_call` to `escrowedCollateralPerspective.verifiedArray()`. The perspective address is looked up from `EulerChains.json` (served by `/api/euler-chains`), and the RPC endpoint is taken from `RPC_URL_HTTP_<chainId>`. Products and earn-vault label files are fetched via internal self-calls to `/api/labels/<file>` to reuse the labels endpoint's own cache and validation.

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -27,7 +27,7 @@ See [vault-labels-and-verification.md](./vault-labels-and-verification.md) for h
 | Param       | Type     | Required | Description                                                                 |
 |-------------|----------|----------|-----------------------------------------------------------------------------|
 | `chainId`   | integer  | yes      | EVM chain ID (e.g. `1` for mainnet).                                        |
-| `addresses` | string   | yes      | Comma-separated list of vault addresses. Max 100. Lowercase, uppercase, or valid EIP-55 checksum accepted; mixed-case inputs must have a correct checksum. |
+| `addresses` | string   | yes      | Comma-separated list of vault addresses. Max 100. Lowercase or valid EIP-55 checksum accepted; mixed-case inputs must have a correct checksum. |
 
 ### Response
 
@@ -40,7 +40,7 @@ Status `200`, JSON object mapping each input address (in EIP-55 checksum form) t
 }
 ```
 
-Addresses are validated via viem's `isAddress` (strict EIP-55 checks) and normalized to checksum form before comparison. Lowercase and uppercase hex inputs are accepted; mixed-case inputs must already carry a valid EIP-55 checksum or the request is rejected with `400`. Keys in the response always use the checksum form.
+Addresses are validated via viem's `isAddress` (strict EIP-55 checks) and normalized to checksum form before comparison. All-lowercase hex inputs are accepted; mixed-case inputs must carry a valid EIP-55 checksum or the request is rejected with `400`. All-uppercase inputs are rejected. Keys in the response always use the checksum form.
 
 ### Errors
 

--- a/docs/vault-labels-and-verification.md
+++ b/docs/vault-labels-and-verification.md
@@ -17,7 +17,7 @@ Labels originate from the [euler-labels](https://github.com/euler-xyz/euler-labe
 | `points.json` | `GET /api/labels/points.json?chainId=X` | `[]` |
 | `earn-vaults.json` | `GET /api/labels/earn-vaults.json?chainId=X` | `[]` |
 
-All label files are optional — any chain may legitimately ship without a given file. When upstream reports the file missing (or is unreachable), the proxy returns the type-appropriate empty payload (`{}` for object-shaped files, `[]` for array-shaped files) with HTTP 200 and caches it for 5 minutes. Non-404 upstream statuses are logged once per refresh so genuine outages stay visible.
+Any chain may legitimately ship without a given file. When upstream reports the file absent (HTTP 404 or 403), the proxy returns the type-appropriate empty payload (`{}` for object-shaped files, `[]` for array-shaped files) with HTTP 200 and caches it for 5 minutes. `earn-vaults.json` and `points.json` are fully optional — any upstream error degrades to the empty payload. `products.json` and `entities.json` are required — non-absent upstream failures (5xx, timeouts) serve stale data when available or return HTTP 502 so clients can show a proper error state.
 
 Oracle adapter metadata is fetched from a separate repository ([oracle-checks](https://github.com/euler-xyz/oracle-checks)) by default, loaded lazily per adapter via `GET /api/oracle-adapter?chainId=X&address=0x...`.
 

--- a/docs/vault-labels-and-verification.md
+++ b/docs/vault-labels-and-verification.md
@@ -10,12 +10,14 @@ Not all vaults on-chain are equal. Some are curated by the Euler UI listing proc
 
 Labels originate from the [euler-labels](https://github.com/euler-xyz/euler-labels) GitHub repository by default. The client never fetches label JSON files directly from GitHub/CDN — all label data is served through **server-side proxy endpoints** that add in-memory caching and stale-fallback. Entity logos are still resolved directly from the labels base URL via `<img>` tags (benefiting from browser HTTP caching). Each supported chain has a directory containing JSON files:
 
-| File | Required | Server endpoint |
-|------|----------|-----------------|
-| `products.json` | Yes | `GET /api/labels/products.json?chainId=X` |
-| `entities.json` | Yes | `GET /api/labels/entities.json?chainId=X` |
-| `points.json` | No | `GET /api/labels/points.json?chainId=X` |
-| `earn-vaults.json` | No | `GET /api/labels/earn-vaults.json?chainId=X` |
+| File | Server endpoint | Empty shape |
+|------|-----------------|-------------|
+| `products.json` | `GET /api/labels/products.json?chainId=X` | `{}` |
+| `entities.json` | `GET /api/labels/entities.json?chainId=X` | `{}` |
+| `points.json` | `GET /api/labels/points.json?chainId=X` | `[]` |
+| `earn-vaults.json` | `GET /api/labels/earn-vaults.json?chainId=X` | `[]` |
+
+All label files are optional — any chain may legitimately ship without a given file. When upstream reports the file missing (or is unreachable), the proxy returns the type-appropriate empty payload (`{}` for object-shaped files, `[]` for array-shaped files) with HTTP 200 and caches it for 5 minutes. Non-404 upstream statuses are logged once per refresh so genuine outages stay visible.
 
 Oracle adapter metadata is fetched from a separate repository ([oracle-checks](https://github.com/euler-xyz/oracle-checks)) by default, loaded lazily per adapter via `GET /api/oracle-adapter?chainId=X&address=0x...`.
 
@@ -356,3 +358,7 @@ These labels appear in address fields across all vault overview types (EVK, Earn
 | `composables/useEulerLabels.ts` | Label fetching, caching, and reactive composables |
 | `composables/useVaultRegistry.ts` | Vault registry with type detection and unknown resolution |
 | `composables/useGeoBlock.ts` | Geo-blocking logic using label block/restricted fields |
+
+## Programmatic verification lookup
+
+External consumers that only need a yes/no answer for a vault address can call the public [`GET /api/public/is-known`](./public-api.md#get-apipublicis-known) endpoint instead of loading the full label set. The endpoint merges `products.json`, `earn-vaults.json`, and the on-chain `escrowedCollateralPerspective` into a single per-chain verified set, excludes deprecated entries, and answers batches of up to 100 addresses per request.

--- a/server/api/labels/[file].get.ts
+++ b/server/api/labels/[file].get.ts
@@ -7,17 +7,15 @@ import { logWarn } from '~/server/utils/log'
 const TIMEOUT_MS = 10_000
 const CACHE_TTL_MS = 300_000
 
-const ALLOWED_FILES = new Set([
-  'products.json',
-  'entities.json',
-  'earn-vaults.json',
-  'points.json',
-])
-
-const OPTIONAL_FILES = new Set([
-  'earn-vaults.json',
-  'points.json',
-])
+// All label files are optional: any chain may legitimately ship without a given
+// file (new chains, test deployments, etc.). Missing files resolve to a
+// type-appropriate empty payload so clients degrade to "no data" instead of 502.
+const EMPTY_SHAPES: Record<string, unknown> = {
+  'products.json': {},
+  'entities.json': {},
+  'earn-vaults.json': [],
+  'points.json': [],
+}
 
 const rateLimiter = createRateLimiter({
   max: 1000,
@@ -88,7 +86,7 @@ export default defineEventHandler(async (event) => {
   rateLimiter.consume(event)
 
   const file = getRouterParam(event, 'file')
-  if (!file || !ALLOWED_FILES.has(file)) {
+  if (!file || !Object.hasOwn(EMPTY_SHAPES, file)) {
     throw createError({ statusCode: 400, statusMessage: 'Invalid file' })
   }
 
@@ -103,17 +101,24 @@ export default defineEventHandler(async (event) => {
   const cached = cache.get(key)
   if (cached) return cached
 
+  const fallback = () => {
+    const stale = cache.getStale(key)
+    if (stale) return stale
+    const empty = EMPTY_SHAPES[file]
+    cache.set(key, empty)
+    return empty
+  }
+
   try {
     const resp = await fetchWithTimeout(getUpstreamUrl(chainId, file), TIMEOUT_MS)
     if (!resp.ok) {
-      if (resp.status === 404 && OPTIONAL_FILES.has(file)) {
-        const stale = cache.getStale(key)
-        if (stale) return stale
-        const empty: unknown[] = []
-        cache.set(key, empty)
-        return empty
+      // 404 is the expected signal for "file not published on this chain".
+      // Other non-2xx statuses (403/5xx from CDNs, etc.) are logged once so
+      // genuine upstream outages stay visible, then degraded the same way.
+      if (resp.status !== 404) {
+        logWarn('labels', `${file} upstream returned ${resp.status} for chain ${chainId}; treating as absent`)
       }
-      throw new Error(`Upstream returned ${resp.status}`)
+      return fallback()
     }
 
     const data: unknown = await resp.json()
@@ -123,10 +128,6 @@ export default defineEventHandler(async (event) => {
   }
   catch (err) {
     logWarn('labels', `Failed to fetch ${file} for chain ${chainId}:`, err instanceof Error ? err.message : err)
-
-    const stale = cache.getStale(key)
-    if (stale) return stale
-
-    throw createError({ statusCode: 502, statusMessage: 'Upstream error' })
+    return fallback()
   }
 })

--- a/server/api/labels/[file].get.ts
+++ b/server/api/labels/[file].get.ts
@@ -7,15 +7,17 @@ import { logWarn } from '~/server/utils/log'
 const TIMEOUT_MS = 10_000
 const CACHE_TTL_MS = 300_000
 
-// All label files are optional: any chain may legitimately ship without a given
-// file (new chains, test deployments, etc.). Missing files resolve to a
-// type-appropriate empty payload so clients degrade to "no data" instead of 502.
+// Shape to use when a file is legitimately absent (404 or upstream failure for
+// optional files). Products and entities are required — upstream failures for
+// those propagate as 502 so clients can show a proper error state.
 const EMPTY_SHAPES: Record<string, unknown> = {
   'products.json': {},
   'entities.json': {},
   'earn-vaults.json': [],
   'points.json': [],
 }
+
+const OPTIONAL_FILES = new Set(['earn-vaults.json', 'points.json'])
 
 const rateLimiter = createRateLimiter({
   max: 1000,
@@ -112,13 +114,15 @@ export default defineEventHandler(async (event) => {
   try {
     const resp = await fetchWithTimeout(getUpstreamUrl(chainId, file), TIMEOUT_MS)
     if (!resp.ok) {
-      // 404 is the expected signal for "file not published on this chain".
-      // Other non-2xx statuses (403/5xx from CDNs, etc.) are logged once so
-      // genuine upstream outages stay visible, then degraded the same way.
-      if (resp.status !== 404) {
-        logWarn('labels', `${file} upstream returned ${resp.status} for chain ${chainId}; treating as absent`)
+      // 404 (and 403 from S3/CDN-style stores) signal "file not published on this chain".
+      const absent = resp.status === 404 || resp.status === 403
+      if (absent || OPTIONAL_FILES.has(file)) {
+        if (!absent) {
+          logWarn('labels', `${file} upstream returned ${resp.status} for chain ${chainId}; treating as absent`)
+        }
+        return fallback()
       }
-      return fallback()
+      throw new Error(`Upstream returned ${resp.status}`)
     }
 
     const data: unknown = await resp.json()
@@ -128,6 +132,12 @@ export default defineEventHandler(async (event) => {
   }
   catch (err) {
     logWarn('labels', `Failed to fetch ${file} for chain ${chainId}:`, err instanceof Error ? err.message : err)
-    return fallback()
+
+    if (OPTIONAL_FILES.has(file)) return fallback()
+
+    const stale = cache.getStale(key)
+    if (stale) return stale
+
+    throw createError({ statusCode: 502, statusMessage: 'Upstream error' })
   }
 })

--- a/server/api/public/is-known.get.ts
+++ b/server/api/public/is-known.get.ts
@@ -1,0 +1,60 @@
+import { createError, getQuery } from 'h3'
+import { getAddress, isAddress } from 'viem'
+import { createRateLimiter } from '~/server/utils/rate-limit'
+import { resolveRpcUrl } from '~/server/utils/rpc'
+import { getVerifiedAddressSet } from '~/server/utils/verified-vaults'
+import { logWarn } from '~/server/utils/log'
+
+const MAX_ADDRESSES = 100
+
+const rateLimiter = createRateLimiter({
+  max: 100,
+  windowMs: 60_000,
+  label: 'public-is-known',
+})
+
+export default defineEventHandler(async (event) => {
+  rateLimiter.consume(event)
+
+  const query = getQuery(event)
+
+  const chainId = Number(query.chainId)
+  if (!Number.isInteger(chainId) || chainId <= 0) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid chainId' })
+  }
+  if (!resolveRpcUrl(chainId)) {
+    throw createError({ statusCode: 400, statusMessage: 'Unsupported chainId' })
+  }
+
+  const raw = typeof query.addresses === 'string' ? query.addresses : ''
+  const parts = raw.split(',').map(s => s.trim()).filter(Boolean)
+  if (parts.length === 0) {
+    throw createError({ statusCode: 400, statusMessage: 'Missing addresses' })
+  }
+  if (parts.length > MAX_ADDRESSES) {
+    throw createError({ statusCode: 400, statusMessage: `Too many addresses (max ${MAX_ADDRESSES})` })
+  }
+
+  const checksumed: string[] = []
+  for (const addr of parts) {
+    if (!isAddress(addr)) {
+      throw createError({ statusCode: 400, statusMessage: `Invalid address: ${addr}` })
+    }
+    checksumed.push(getAddress(addr))
+  }
+
+  let verifiedSet: Set<string>
+  try {
+    verifiedSet = await getVerifiedAddressSet(chainId)
+  }
+  catch (err) {
+    logWarn('public-is-known', `lookup failed for chain ${chainId}:`, err instanceof Error ? err.message : err)
+    throw createError({ statusCode: 502, statusMessage: 'Upstream error' })
+  }
+
+  const response: Record<string, boolean> = {}
+  for (const addr of checksumed) {
+    response[addr] = verifiedSet.has(addr)
+  }
+  return response
+})

--- a/server/api/public/is-known.get.ts
+++ b/server/api/public/is-known.get.ts
@@ -26,7 +26,10 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: 'Unsupported chainId' })
   }
 
-  const raw = typeof query.addresses === 'string' ? query.addresses : ''
+  const rawInput = query.addresses
+  const raw = Array.isArray(rawInput)
+    ? rawInput.filter((v): v is string => typeof v === 'string').join(',')
+    : typeof rawInput === 'string' ? rawInput : ''
   const parts = raw.split(',').map(s => s.trim()).filter(Boolean)
   if (parts.length === 0) {
     throw createError({ statusCode: 400, statusMessage: 'Missing addresses' })

--- a/server/middleware/cors.ts
+++ b/server/middleware/cors.ts
@@ -80,6 +80,18 @@ export default defineEventHandler((event) => {
   // response (including preflights) for one origin to another.
   setResponseHeader(event, 'Vary', 'Origin')
 
+  // Endpoints under /api/public/ are intentionally public.
+  if (url.pathname.startsWith('/api/public/')) {
+    setResponseHeader(event, 'Access-Control-Allow-Origin', '*')
+    setResponseHeader(event, 'Access-Control-Allow-Methods', 'GET, OPTIONS')
+    setResponseHeader(event, 'Access-Control-Allow-Headers', 'Content-Type')
+    if (event.node.req.method === 'OPTIONS') {
+      setResponseHeader(event, 'Access-Control-Max-Age', 86400)
+      return sendNoContent(event)
+    }
+    return
+  }
+
   const origin = event.node.req.headers.origin
 
   if (origin && allowedOrigins.has(origin)) {

--- a/server/utils/fetchWithTimeout.ts
+++ b/server/utils/fetchWithTimeout.ts
@@ -1,8 +1,8 @@
-export async function fetchWithTimeout(url: string, timeoutMs: number): Promise<Response> {
+export async function fetchWithTimeout(url: string, timeoutMs: number, init?: RequestInit): Promise<Response> {
   const controller = new AbortController()
   const timeout = setTimeout(() => controller.abort(), timeoutMs)
   try {
-    return await fetch(url, { signal: controller.signal })
+    return await fetch(url, { ...init, signal: controller.signal })
   }
   finally {
     clearTimeout(timeout)

--- a/server/utils/verified-vaults.ts
+++ b/server/utils/verified-vaults.ts
@@ -1,0 +1,186 @@
+import { decodeFunctionResult, encodeFunctionData, getAddress } from 'viem'
+import { createTtlCache } from './cache'
+import { logWarn } from './log'
+import { resolveRpcUrl } from './rpc'
+
+const CACHE_TTL_MS = 300_000
+
+const VERIFIED_ARRAY_ABI = [{
+  type: 'function',
+  name: 'verifiedArray',
+  stateMutability: 'view',
+  inputs: [],
+  outputs: [{ type: 'address[]' }],
+}] as const
+
+interface ProductsJsonEntry {
+  vaults?: unknown
+  deprecatedVaults?: unknown
+}
+
+interface EarnVaultEntryObject {
+  address?: unknown
+  deprecated?: unknown
+}
+
+interface EulerChainConfig {
+  chainId?: unknown
+  addresses?: {
+    peripheryAddrs?: {
+      escrowedCollateralPerspective?: unknown
+    }
+  }
+}
+
+const cache = createTtlCache<Set<string>>({ ttlMs: CACHE_TTL_MS, maxEntries: 64 })
+const inflight = new Map<number, Promise<Set<string>>>()
+
+function addChecksum(set: Set<string>, value: unknown): void {
+  if (typeof value !== 'string') return
+  try {
+    set.add(getAddress(value))
+  }
+  catch {
+    // Ignore malformed addresses from upstream data.
+  }
+}
+
+async function fetchLabels<T>(chainId: number, file: 'products.json' | 'earn-vaults.json'): Promise<T> {
+  return await $fetch<T>(`/api/labels/${file}`, { query: { chainId } })
+}
+
+async function fetchEulerChains(): Promise<EulerChainConfig[]> {
+  const data = await $fetch<unknown>('/api/euler-chains')
+  return Array.isArray(data) ? data as EulerChainConfig[] : []
+}
+
+async function fetchEscrowAddresses(chainId: number): Promise<string[]> {
+  const rpcUrl = resolveRpcUrl(chainId)
+  if (!rpcUrl) return []
+
+  const chains = await fetchEulerChains()
+  const config = chains.find(c => c.chainId === chainId)
+  const perspective = config?.addresses?.peripheryAddrs?.escrowedCollateralPerspective
+  if (typeof perspective !== 'string' || !perspective.startsWith('0x')) return []
+
+  const callData = encodeFunctionData({ abi: VERIFIED_ARRAY_ABI, functionName: 'verifiedArray' })
+  const payload = JSON.stringify({
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'eth_call',
+    params: [{ to: perspective, data: callData }, 'latest'],
+  })
+
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), 10_000)
+  let response: Response
+  try {
+    response = await fetch(rpcUrl, {
+      method: 'POST',
+      body: payload,
+      headers: { 'content-type': 'application/json' },
+      signal: controller.signal,
+    })
+  }
+  finally {
+    clearTimeout(timeout)
+  }
+
+  if (!response.ok) throw new Error(`Upstream RPC returned ${response.status}`)
+
+  const parsed = await response.json() as { result?: unknown, error?: unknown }
+  if (parsed.error) throw new Error(`Upstream RPC error: ${JSON.stringify(parsed.error)}`)
+  const result = parsed.result
+  if (typeof result !== 'string' || !result.startsWith('0x')) return []
+
+  const decoded = decodeFunctionResult({
+    abi: VERIFIED_ARRAY_ABI,
+    functionName: 'verifiedArray',
+    data: result as `0x${string}`,
+  })
+  return [...decoded]
+}
+
+function collectProductsAddresses(products: Record<string, ProductsJsonEntry>, set: Set<string>): void {
+  for (const product of Object.values(products)) {
+    if (Array.isArray(product.vaults)) {
+      for (const v of product.vaults) addChecksum(set, v)
+    }
+    // product.deprecatedVaults intentionally skipped.
+  }
+}
+
+function collectEarnAddresses(entries: unknown[], set: Set<string>): void {
+  for (const entry of entries) {
+    if (typeof entry === 'string') {
+      addChecksum(set, entry)
+      continue
+    }
+    if (entry && typeof entry === 'object') {
+      const obj = entry as EarnVaultEntryObject
+      if (obj.deprecated === true) continue
+      addChecksum(set, obj.address)
+    }
+  }
+}
+
+async function buildVerifiedSet(chainId: number): Promise<Set<string>> {
+  const set = new Set<string>()
+
+  const [products, earn, escrow] = await Promise.allSettled([
+    fetchLabels<Record<string, ProductsJsonEntry>>(chainId, 'products.json'),
+    fetchLabels<unknown[]>(chainId, 'earn-vaults.json'),
+    fetchEscrowAddresses(chainId),
+  ])
+
+  if (products.status === 'rejected') {
+    const reason = products.reason instanceof Error ? products.reason.message : String(products.reason)
+    throw new Error(`products.json fetch failed: ${reason}`)
+  }
+  collectProductsAddresses(products.value ?? {}, set)
+
+  if (earn.status === 'fulfilled' && Array.isArray(earn.value)) {
+    collectEarnAddresses(earn.value, set)
+  }
+  else if (earn.status === 'rejected') {
+    logWarn('verified-vaults', `earn-vaults fetch failed for chain ${chainId}:`, earn.reason)
+  }
+
+  if (escrow.status === 'fulfilled') {
+    for (const a of escrow.value) addChecksum(set, a)
+  }
+  else {
+    logWarn('verified-vaults', `escrow fetch failed for chain ${chainId}:`, escrow.reason)
+  }
+
+  return set
+}
+
+export async function getVerifiedAddressSet(chainId: number): Promise<Set<string>> {
+  const key = String(chainId)
+  const fresh = cache.get(key)
+  if (fresh) return fresh
+
+  const pending = inflight.get(chainId)
+  if (pending) return pending
+
+  const task = (async () => {
+    try {
+      const set = await buildVerifiedSet(chainId)
+      cache.set(key, set)
+      return set
+    }
+    catch (err) {
+      logWarn('verified-vaults', `Rebuild failed for chain ${chainId}:`, err instanceof Error ? err.message : err)
+      const stale = cache.getStale(key)
+      if (stale) return stale
+      throw err
+    }
+    finally {
+      inflight.delete(chainId)
+    }
+  })()
+
+  inflight.set(chainId, task)
+  return task
+}

--- a/server/utils/verified-vaults.ts
+++ b/server/utils/verified-vaults.ts
@@ -1,5 +1,6 @@
 import { decodeFunctionResult, encodeFunctionData, getAddress } from 'viem'
 import { createTtlCache } from './cache'
+import { fetchWithTimeout } from './fetchWithTimeout'
 import { logWarn } from './log'
 import { resolveRpcUrl } from './rpc'
 
@@ -71,20 +72,11 @@ async function fetchEscrowAddresses(chainId: number): Promise<string[]> {
     params: [{ to: perspective, data: callData }, 'latest'],
   })
 
-  const controller = new AbortController()
-  const timeout = setTimeout(() => controller.abort(), 10_000)
-  let response: Response
-  try {
-    response = await fetch(rpcUrl, {
-      method: 'POST',
-      body: payload,
-      headers: { 'content-type': 'application/json' },
-      signal: controller.signal,
-    })
-  }
-  finally {
-    clearTimeout(timeout)
-  }
+  const response = await fetchWithTimeout(rpcUrl, 10_000, {
+    method: 'POST',
+    body: payload,
+    headers: { 'content-type': 'application/json' },
+  })
 
   if (!response.ok) throw new Error(`Upstream RPC returned ${response.status}`)
 


### PR DESCRIPTION
## Summary

- Adds a new public endpoint `GET /api/public/is-known?chainId=X&addresses=0x…,0x…` that returns `{ [checksumAddress]: boolean }` indicating whether each vault is verified by this app.
- "Verified" merges three sources per chain: `products.json` active vaults (EVK + Securitize), `earn-vaults.json` entries where `deprecated !== true`, and on-chain `escrowedCollateralPerspective.verifiedArray()`. Deprecated vaults are excluded; `notExplorable` vaults stay verified.
- New `/api/public/` path prefix: the CORS middleware sets `Access-Control-Allow-Origin: *` for any file under it. Other endpoints keep the strict allowlist.
- Labels proxy refactor: all four files (`products.json`, `entities.json`, `earn-vaults.json`, `points.json`) are now optional. Missing or unreachable files return a type-appropriate empty payload (`{}` or `[]`) with HTTP 200 instead of 502, so new chains and partial deployments degrade gracefully.

## Implementation

- `server/api/public/is-known.get.ts` — handler with address validation (viem `isAddress`/`getAddress`), 100-address batch cap, rate limit 100/min per IP, chainId allowlist (must have `RPC_URL_HTTP_\<chainId\>` configured).
- `server/utils/verified-vaults.ts` — per-chain verified-set builder with 5-min TTL cache, stale-while-revalidate, and inflight request deduplication. Escrow addresses fetched via a direct eth_call to the configured RPC (perspective address from `EulerChains.json`); labels fetched via internal `$fetch` to reuse the proxy's cache and validation.
- `server/middleware/cors.ts` — public-path branch added ahead of the allowlist check.
- `server/api/labels/[file].get.ts` — removed the required/optional split; `EMPTY_SHAPES` table drives both whitelist validation and fallback payloads.

## DDoS posture

- Per-IP rate limit: 100/60s via the existing `createRateLimiter` (fail-closed on missing `CF-Connecting-IP` in prod).
- chainId must be in the deployment's RPC allowlist (`resolveRpcUrl`) so bogus IDs 400 before any upstream work.
- Per-chain in-memory cache (5-min TTL, max 64 chains) and inflight dedup prevent rebuild stampedes; cold lookups cost exactly one rebuild across concurrent callers.
- Max 100 addresses per request; response bounded to ~5 KB.

## Docs

- New `docs/public-api.md` covering request/response shape, error codes, CORS, caching, rate limit, and curl/JS examples.
- `docs/README.md` index entry added.
- `docs/vault-labels-and-verification.md` cross-references the public endpoint and updates the label-files table to reflect that all files are now optional.

## Test plan

- [x] `curl 'http://localhost:3000/api/public/is-known?chainId=1&addresses=<active-evk>,<deprecated-evk>,<active-earn>,<deprecated-earn>,<escrow>,0x000…01'` returns `true,false,true,false,true,false`
- [x] Batch of 101 addresses returns 400 "Too many addresses"
- [x] Unsupported chainId (e.g. `?chainId=99999`) returns 400 "Unsupported chainId"
- [x] Malformed address returns 400 "Invalid address: 0x…"
- [x] 101st request within 60s from same IP returns 429
- [x] OPTIONS preflight from foreign origin returns 204 with `Access-Control-Allow-Origin: *` and `Access-Control-Allow-Methods: GET, OPTIONS`
- [x] `/api/labels/earn-vaults.json?chainId=130` returns `200 []` (chain without earn labels)
- [x] `/api/labels/products.json?chainId=999999` returns `200 {}` (bogus chain)
- [x] `/api/labels/secrets.json?chainId=1` still 400s (whitelist enforced)
- [x] Existing lend/borrow/explore flows still load correctly on chain 1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public API endpoint for batched verified-address lookup (up to 100 addresses), with permissive CORS, OPTIONS preflight support, per-client rate limiting, strict validation/normalization, and boolean mapping responses.

* **Documentation**
  * Added comprehensive public API docs and README section with endpoint specs, examples, validation rules, caching, and error semantics.

* **Bug Fixes**
  * Label endpoints now return sensible empty payloads for missing/upstream errors and use short caching; verification lookups use a 5-minute cache with stale-while-revalidate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->