### PR TITLE
fix: use formatSmartAmount for swap output display

### DIFF
--- a/composables/useSwapPageLogic.ts
+++ b/composables/useSwapPageLogic.ts
@@ -151,10 +151,7 @@ export const useSwapPageLogic = (options: UseSwapPageLogicOptions) => {
       return
     }
     const formatted = formatUnits(amount, Number(toVault.value.decimals))
-    const numericValue = Number(formatted)
-    toAmount.value = numericValue < 0.01
-      ? formatSignificant(formatted, 3)
-      : formatSignificant(formatted)
+    toAmount.value = formatSmartAmount(formatted)
   }, { immediate: true })
 
   // ── Quote state helpers ────────────────────────────────────────────────

--- a/composables/useSwapPageLogic.ts
+++ b/composables/useSwapPageLogic.ts
@@ -151,7 +151,7 @@ export const useSwapPageLogic = (options: UseSwapPageLogicOptions) => {
       return
     }
     const formatted = formatUnits(amount, Number(toVault.value.decimals))
-    toAmount.value = formatSmartAmount(formatted)
+    toAmount.value = formatSmartAmount(formatted).replace(/,/g, '')
   }, { immediate: true })
 
   // ── Quote state helpers ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `composables/useSwapPageLogic.ts` was formatting the quote-derived `toAmount` with `formatSignificant` (2 sig figs by default, 3 for values <0.01). That collapsed values like `170.053` to `170`, hiding real decimals in the "To" field on all swap pages.
- Switch to `formatSmartAmount`, the helper already used for swap route items (`useSwapPageLogic.ts:376-377`) and repay details (`useRepaySwapDetails.ts:37-38`). It scales precision with magnitude: `≥1000` → 2 decimals, `≥1` → up to 4 decimals, `<1` → enough decimals for 2 significant figures.
- `formatSignificant` itself is untouched; it's still used elsewhere for different purposes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved formatting of swap amounts displayed to users for better precision and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->