### PR TITLE
refactor: inline-kink IRM chart + adaptive APY via UtilsLens

### DIFF
--- a/components/entities/vault/overview/VaultOverviewBlockIRM.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockIRM.vue
@@ -236,6 +236,7 @@ const generateChartDataPoints = (kinkFraction: number | null) => {
   cashData.reverse()
 
   let kinkIndex: number | null = null
+  let kinkInjected = false
   if (kinkFraction !== null && kinkFraction > 0 && kinkFraction < 1) {
     const kinkBorrows = BigInt(Math.floor(kinkFraction * TOTAL))
     const kinkCash = TOTAL_BIG - kinkBorrows
@@ -251,10 +252,11 @@ const generateChartDataPoints = (kinkFraction: number | null) => {
       borrowsData.splice(idx, 0, kinkBorrows)
       cashData.splice(idx, 0, kinkCash)
       kinkIndex = idx
+      kinkInjected = true
     }
   }
 
-  return { cashData, borrowsData, kinkIndex }
+  return { cashData, borrowsData, kinkIndex, kinkInjected }
 }
 
 // Parse APY from bigint (27 decimals) to percentage number
@@ -298,7 +300,7 @@ const fetchIRMData = async (kinkFraction: number | null) => {
   try {
     const client = rpcClient.value!
 
-    const { cashData, borrowsData, kinkIndex } = generateChartDataPoints(kinkFraction)
+    const { cashData, borrowsData, kinkIndex, kinkInjected } = generateChartDataPoints(kinkFraction)
 
     // Fetch general interest rate model info
     const irmData = await client.readContract({
@@ -312,6 +314,7 @@ const fetchIRMData = async (kinkFraction: number | null) => {
     return {
       irmData,
       kinkIndex,
+      kinkInjected,
     }
   }
   catch (error) {
@@ -357,7 +360,7 @@ const renderChart = async () => {
       return
     }
 
-    const { irmData, kinkIndex } = data
+    const { irmData, kinkIndex, kinkInjected } = data
 
     if (adaptiveAPYsPromise) {
       const [minAPY, maxAPY] = await adaptiveAPYsPromise
@@ -378,11 +381,11 @@ const renderChart = async () => {
     const supplyAPYValues: number[] = []
 
     irmData.interestRateInfo.forEach((rate: { borrowAPY: bigint, supplyAPY: bigint }, i: number) => {
-      if (kinkIndex !== null && i === kinkIndex && kinkUtilization !== null) {
+      if (kinkInjected && i === kinkIndex && kinkUtilization !== null) {
         labels.push(kinkUtilization.toFixed(2))
       }
       else {
-        const originalIndex = kinkIndex !== null && i > kinkIndex ? i - 1 : i
+        const originalIndex = kinkInjected && i > kinkIndex! ? i - 1 : i
         labels.push(originalIndex.toFixed(0))
       }
       borrowAPYValues.push(parseAPY(rate.borrowAPY))

--- a/components/entities/vault/overview/VaultOverviewBlockIRM.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockIRM.vue
@@ -32,7 +32,7 @@ import {
   hasCollateralExposure,
 } from '~/entities/vault'
 import { useVaultRegistry } from '~/composables/useVaultRegistry'
-import { eulerVaultLensABI } from '~/entities/euler/abis'
+import { eulerUtilsLensABI, eulerVaultLensABI } from '~/entities/euler/abis'
 
 // Register Chart.js components
 ChartJS.register(
@@ -83,6 +83,11 @@ const MAX_UINT32 = 4_294_967_295
 const chartRateAtZero = ref<number | null>(null)
 const chartRateAtKink = ref<number | null>(null)
 const chartRateAtMax = ref<number | null>(null)
+// Adaptive-only: APY bounds on rate-at-target, computed via UtilsLens.computeAPYs
+// so values match exactly what the vault will accrue (APR × year is the wrong
+// conversion — see AdaptiveCurveIRMParams, baseline uses daily compounding).
+const adaptiveMinRateAPY = ref<number | null>(null)
+const adaptiveMaxRateAPY = ref<number | null>(null)
 
 const formatKinkPercent = (kink: bigint): string => {
   const percent = Number(kink) / MAX_UINT32 * 100
@@ -92,11 +97,6 @@ const formatKinkPercent = (kink: bigint): string => {
 const formatWadPercent = (wad: bigint): string => {
   const percent = Number(formatUnits(wad, 18)) * 100
   return `${percent.toFixed(2)}%`
-}
-
-const formatWadPerSecToApy = (wadPerSec: bigint): string => {
-  const apy = Number(formatUnits(wadPerSec, 18)) * SECONDS_PER_YEAR * 100
-  return `${apy.toFixed(2)}%`
 }
 
 const irmModelType = computed(() => Number(vault.irmInfo?.interestRateModelInfo?.interestRateModelType))
@@ -176,9 +176,9 @@ const irmParamsDisplay = computed<Array<{ label: string, value: string }>>(() =>
   }
   if (decoded.type === 'adaptive') {
     return [
-      { label: 'Target utilization', value: formatWadPercent(decoded.targetUtilization) },
-      { label: 'Min rate', value: formatWadPerSecToApy(decoded.minRateAtTarget) },
-      { label: 'Max rate', value: formatWadPerSecToApy(decoded.maxRateAtTarget) },
+      { label: 'Min rate at kink', value: fmtRate(adaptiveMinRateAPY.value) },
+      { label: 'Max rate at kink', value: fmtRate(adaptiveMaxRateAPY.value) },
+      { label: 'Kink', value: formatWadPercent(decoded.targetUtilization) },
       { label: 'Curve steepness', value: `${Number(formatUnits(decoded.curveSteepness, 18)).toFixed(2)}x` },
       { label: 'Adjustment speed', value: `${(Number(formatUnits(decoded.adjustmentSpeed, 18)) * SECONDS_PER_YEAR).toFixed(1)}x/yr` },
     ]
@@ -262,6 +262,33 @@ const parseAPY = (apy: bigint): number => {
   return Number(formatUnits(apy, 27)) * 100
 }
 
+// Convert a wad-scaled per-second rate into a properly-compounded APY % by
+// round-tripping through UtilsLens.computeAPYs — same math the vault itself
+// uses, so Min/Max rate cells match on-chain accrual for large rates instead
+// of silently collapsing to APR.
+const fetchAdaptiveBorrowAPY = async (wadPerSec: bigint): Promise<number | null> => {
+  const utilsLens = eulerLensAddresses.value?.utilsLens
+  if (!utilsLens || wadPerSec === 0n) {
+    return wadPerSec === 0n ? 0 : null
+  }
+  try {
+    const client = rpcClient.value!
+    const result = await client.readContract({
+      address: utilsLens as Address,
+      abi: eulerUtilsLensABI as Abi,
+      functionName: 'computeAPYs',
+      // cash/borrows don't influence borrowAPY; interestFee only affects supplyAPY.
+      args: [wadPerSec, 1n, 0n, 0n],
+    }) as readonly [bigint, bigint]
+    const [borrowAPY] = result
+    return Number(formatUnits(borrowAPY, 27)) * 100
+  }
+  catch (e) {
+    logWarn('VaultOverviewBlockIRM/fetchAdaptiveBorrowAPY', e)
+    return null
+  }
+}
+
 // Fetch interest rate model data
 const fetchIRMData = async (kinkFraction: number | null) => {
   if (!eulerLensAddresses.value?.vaultLens) {
@@ -310,6 +337,18 @@ const renderChart = async () => {
       : null
     const kinkUtilization = kinkFraction !== null ? kinkFraction * 100 : null
 
+    // Kick off the adaptive-only APY-bound reads in parallel with the curve
+    // fetch so they don't add sequential latency. Reset first so a failed
+    // lookup doesn't leave stale values on the display.
+    adaptiveMinRateAPY.value = null
+    adaptiveMaxRateAPY.value = null
+    const adaptiveAPYsPromise = decoded?.type === 'adaptive'
+      ? Promise.all([
+          fetchAdaptiveBorrowAPY(decoded.minRateAtTarget),
+          fetchAdaptiveBorrowAPY(decoded.maxRateAtTarget),
+        ])
+      : null
+
     const data = await fetchIRMData(kinkFraction)
 
     if (!data || !data.irmData?.interestRateInfo) {
@@ -319,6 +358,12 @@ const renderChart = async () => {
     }
 
     const { irmData, kinkIndex } = data
+
+    if (adaptiveAPYsPromise) {
+      const [minAPY, maxAPY] = await adaptiveAPYsPromise
+      adaptiveMinRateAPY.value = minAPY
+      adaptiveMaxRateAPY.value = maxAPY
+    }
 
     // Read chart colors from CSS variables (theme-aware)
     const colors = getChartColors()

--- a/components/entities/vault/overview/VaultOverviewBlockIRM.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockIRM.vue
@@ -217,20 +217,44 @@ const irmTooltip = computed<{ title: string, text: string } | null>(() => {
   return null
 })
 
-// Generate cash and borrows data points for chart (0-100% utilization)
-const generateChartDataPoints = () => {
+// Generate cash and borrows data points for chart (0-100% utilization).
+// When `kinkFraction` is provided (in 0..1), injects an extra sample at the
+// exact kink so the rendered curve bends there and the annotation + kink-rate
+// readout land on a real data point instead of the nearest integer-percent
+// neighbour. Returns the index of the kink sample, or null when none was added.
+const generateChartDataPoints = (kinkFraction: number | null) => {
   const amountPoints = 100
-  const borrowsData: bigint[] = [BigInt(0)]
+  const TOTAL = 2 ** 32
+  const TOTAL_BIG = BigInt(TOTAL)
+  const borrowsData: bigint[] = [0n]
 
   for (let i = 1; i <= amountPoints; i += 1) {
-    const borrow: bigint = BigInt(Math.floor((i / amountPoints) * 2 ** 32))
-    borrowsData.push(borrow)
+    borrowsData.push(BigInt(Math.floor((i / amountPoints) * TOTAL)))
   }
 
   const cashData = [...borrowsData]
   cashData.reverse()
 
-  return { cashData, borrowsData }
+  let kinkIndex: number | null = null
+  if (kinkFraction !== null && kinkFraction > 0 && kinkFraction < 1) {
+    const kinkBorrows = BigInt(Math.floor(kinkFraction * TOTAL))
+    const kinkCash = TOTAL_BIG - kinkBorrows
+
+    // Keep the arrays sorted by borrows so the plotted line stays monotonic.
+    let idx = borrowsData.findIndex(b => b >= kinkBorrows)
+    if (idx < 0) idx = borrowsData.length
+
+    if (idx < borrowsData.length && borrowsData[idx] === kinkBorrows) {
+      kinkIndex = idx
+    }
+    else {
+      borrowsData.splice(idx, 0, kinkBorrows)
+      cashData.splice(idx, 0, kinkCash)
+      kinkIndex = idx
+    }
+  }
+
+  return { cashData, borrowsData, kinkIndex }
 }
 
 // Parse APY from bigint (27 decimals) to percentage number
@@ -239,7 +263,7 @@ const parseAPY = (apy: bigint): number => {
 }
 
 // Fetch interest rate model data
-const fetchIRMData = async () => {
+const fetchIRMData = async (kinkFraction: number | null) => {
   if (!eulerLensAddresses.value?.vaultLens) {
     return null
   }
@@ -247,7 +271,7 @@ const fetchIRMData = async () => {
   try {
     const client = rpcClient.value!
 
-    const { cashData, borrowsData } = generateChartDataPoints()
+    const { cashData, borrowsData, kinkIndex } = generateChartDataPoints(kinkFraction)
 
     // Fetch general interest rate model info
     const irmData = await client.readContract({
@@ -260,6 +284,7 @@ const fetchIRMData = async () => {
 
     return {
       irmData,
+      kinkIndex,
     }
   }
   catch (error) {
@@ -276,7 +301,16 @@ const renderChart = async () => {
   hasError.value = false
 
   try {
-    const data = await fetchIRMData()
+    // Derive kink utilization (0..1) from decoded params for KINK and KINKY types.
+    // This drives BOTH the annotation line position and the extra sample injected
+    // into the sweep so the curve bends at the exact kink.
+    const decoded = decodedIRMParams.value
+    const kinkFraction = (decoded && (decoded.type === 'kink' || decoded.type === 'kinky'))
+      ? Number(decoded.kink) / MAX_UINT32
+      : null
+    const kinkUtilization = kinkFraction !== null ? kinkFraction * 100 : null
+
+    const data = await fetchIRMData(kinkFraction)
 
     if (!data || !data.irmData?.interestRateInfo) {
       hasError.value = true
@@ -284,42 +318,41 @@ const renderChart = async () => {
       return
     }
 
-    const { irmData } = data
+    const { irmData, kinkIndex } = data
 
     // Read chart colors from CSS variables (theme-aware)
     const colors = getChartColors()
 
-    // Prepare chart data
+    // Prepare chart data. With a kink sample injected, index → utilization is no
+    // longer i/(N-1). Regular samples keep integer-percent labels (so the every-
+    // 10% tick rule still fires). The injected sample gets a two-decimal label
+    // reflecting the exact kink utilization, which deliberately doesn't match
+    // the integer-tick rule — no stray tick at a non-round utilization.
     const labels: string[] = []
     const borrowAPYValues: number[] = []
     const supplyAPYValues: number[] = []
 
     irmData.interestRateInfo.forEach((rate: { borrowAPY: bigint, supplyAPY: bigint }, i: number) => {
-      const utilization = ((i / (irmData.interestRateInfo.length - 1)) * 100).toFixed(0)
-      labels.push(utilization)
+      if (kinkIndex !== null && i === kinkIndex && kinkUtilization !== null) {
+        labels.push(kinkUtilization.toFixed(2))
+      }
+      else {
+        const originalIndex = kinkIndex !== null && i > kinkIndex ? i - 1 : i
+        labels.push(originalIndex.toFixed(0))
+      }
       borrowAPYValues.push(parseAPY(rate.borrowAPY))
       supplyAPYValues.push(parseAPY(rate.supplyAPY))
     })
 
-    // Store key borrow APY values for the params display
+    // Store key borrow APY values for the params display.
     chartRateAtZero.value = borrowAPYValues[0] ?? null
     chartRateAtMax.value = borrowAPYValues[borrowAPYValues.length - 1] ?? null
+    chartRateAtKink.value = kinkIndex !== null
+      ? borrowAPYValues[kinkIndex] ?? null
+      : null
 
     // Current utilization
     const currentUtilization = getVaultUtilization(vault)
-
-    // Derive kink utilization from decoded params for both KINK and KINKY types
-    let kinkUtilization: number | null = null
-    const decoded = decodedIRMParams.value
-    if (decoded && (decoded.type === 'kink' || decoded.type === 'kinky')) {
-      kinkUtilization = Number(decoded.kink) / MAX_UINT32 * 100
-    }
-
-    // Store borrow APY at the kink utilization for the params display
-    if (kinkUtilization !== null) {
-      const kinkIndex = Math.round(kinkUtilization)
-      chartRateAtKink.value = borrowAPYValues[kinkIndex] ?? null
-    }
 
     // Set chart data
     chartData.value = {
@@ -376,7 +409,7 @@ const renderChart = async () => {
       },
     }
 
-    if (kinkUtilization !== null) {
+    if (kinkUtilization !== null && kinkIndex !== null) {
       const labelsAreClose = Math.abs(currentUtilization - kinkUtilization) < 20
       const currentIsLower = currentUtilization <= kinkUtilization
       const yOffset = labelsAreClose ? 24 : 0
@@ -385,10 +418,15 @@ const renderChart = async () => {
         annotations.currentLine.label.yAdjust = yOffset
       }
 
+      // Anchor to the injected sample's label so the line lands exactly on the
+      // kink data point. Using the raw kink percent here would miss the sample
+      // because the category axis positions by label match, not numeric value.
+      const kinkLabel = labels[kinkIndex]
+
       annotations.kinkLine = {
         type: 'line',
-        xMin: kinkUtilization.toFixed(0),
-        xMax: kinkUtilization.toFixed(0),
+        xMin: kinkLabel,
+        xMax: kinkLabel,
         borderColor: colors.lineA,
         borderWidth: 1,
         borderDash: [5, 5],


### PR DESCRIPTION
Stacks on #259.

## Summary

- Inject the decoded kink utilization as an extra sample into the IRM sweep. The kink annotation line and the "Rate at kink" field now land on a real data point instead of being rounded to the nearest integer percent.
- Compute the adaptive IRM min/max rate APYs via `UtilsLens.computeAPYs` so values match on-chain accrual under proper compounding, instead of the `wadPerSec × secondsPerYear` shortcut that silently collapses APR→APY at large rates.
- Rename the adaptive panel labels to kink-centric form: `Min rate → Min rate at kink`, `Max rate → Max rate at kink`, `Target utilization → Kink` (reordered so the kink row sits after the rate rows).

## Why

With only 101 evenly-spaced samples, `kinkUtilization` is rounded via `Math.round()` before indexing into `borrowAPYValues`. On steep Kink / Kinky IRMs (e.g. kink at 90.71%), this means:

- The dashed kink annotation draws at 91% instead of 90.71% — visible ~0.5 pp offset from where the curve actually bends.
- The displayed "Rate at kink" is the APY at the 91% sample, not at the exact kink.

Inserting one extra `(cash, borrows)` pair at the exact kink fraction into the array we already pass to `getVaultInterestRateModelInfo` fixes both, with no additional RPC calls. For the adaptive model, rate-at-target was previously shown as `wadPerSec × 31_557_600 × 100` which is APR, not APY — fine for small rates, increasingly wrong as rates grow. Routing through `UtilsLens.computeAPYs` mirrors the vault's own accrual math.

## Changes

- `components/entities/vault/overview/VaultOverviewBlockIRM.vue`
  - `generateChartDataPoints(kinkFraction)` now splices a kink sample into `cashData` / `borrowsData` at the sorted index and returns `kinkIndex`.
  - `fetchIRMData(kinkFraction)` passes `kinkFraction` through and surfaces `kinkIndex`.
  - `renderChart` derives `kinkFraction` from `decodedIRMParams` up front, reads `chartRateAtKink` from `borrowAPYValues[kinkIndex]`, and anchors the annotation to `labels[kinkIndex]` (two-decimal label so it doesn't trigger the every-10% tick rule).
  - New `fetchAdaptiveBorrowAPY` helper wraps `UtilsLens.computeAPYs`; `adaptiveMinRateAPY` / `adaptiveMaxRateAPY` refs populate the panel values. The obsolete `formatWadPerSecToApy` helper is removed.
  - Adaptive `irmParamsDisplay` rows renamed and reordered.

## Test plan

- [ ] Kink IRM vault: dashed kink line visually aligns with the curve inflection; hover-tooltip at kink utilization shows exact `Utilization: XX.YY%` rather than a rounded integer.
- [ ] Kinky IRM vault: same behaviour as Kink.
- [ ] Adaptive IRM vault: "Min rate at kink" / "Max rate at kink" values match what the vault actually accrues at those rates (spot-check via a high-rate configuration).
- [ ] 10% X-axis ticks still render at 0, 10, …, 100; no stray tick at the kink sample label.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Enhanced Interest Rate Model chart visualization with improved kink point accuracy and precise positioning on charts.

## Updates
- Clarified adaptive IRM parameter display labels for better readability and accuracy in vault overview interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->