### PR TITLE
fix: refresh stale data when wallet address changes

### DIFF
--- a/composables/useAddressScreen.ts
+++ b/composables/useAddressScreen.ts
@@ -15,6 +15,7 @@ export const useAddressScreen = () => {
   const defaultPageRoute = getDefaultPageRoute(enableEarnPage, enableLendPage, enableExplorePage)
   const blockedAddress = ref<string | null>(null)
   const isScreening = ref(false)
+  let screeningGeneration = 0
 
   const showBlockedModal = (address: string) => {
     blockedAddress.value = address
@@ -35,10 +36,14 @@ export const useAddressScreen = () => {
       return false
     }
 
+    const gen = ++screeningGeneration
     isScreening.value = true
     try {
       const vpnIsUsed = await detectVpn()
+      if (gen !== screeningGeneration) return false
+
       const isRestricted = await screenAddress(address, vpnIsUsed)
+      if (gen !== screeningGeneration) return false
 
       if (isRestricted) {
         await disconnect()
@@ -48,7 +53,9 @@ export const useAddressScreen = () => {
       return false
     }
     finally {
-      isScreening.value = false
+      if (gen === screeningGeneration) {
+        isScreening.value = false
+      }
     }
   }
 

--- a/composables/useREULLocks.ts
+++ b/composables/useREULLocks.ts
@@ -112,6 +112,15 @@ export const useREULLocks = () => {
     }
   }, { immediate: true })
 
+  watch(wagmiAddress, (newAddress, oldAddress) => {
+    if (oldAddress && newAddress && newAddress !== oldAddress) {
+      isLoaded.value = false
+      locks.value = []
+      loadREULLocksInfo(newAddress)
+      isLoaded.value = true
+    }
+  })
+
   onUnmounted(() => {
     if (interval) {
       clearInterval(interval)

--- a/composables/useWagmi.ts
+++ b/composables/useWagmi.ts
@@ -1,4 +1,4 @@
-import { useAccount, useAccountEffect, useDisconnect, useBalance, useSwitchChain, useEnsName } from '@wagmi/vue'
+import { useAccount, useDisconnect, useBalance, useSwitchChain, useEnsName } from '@wagmi/vue'
 import { formatUnits, getAddress, isAddress, type Address } from 'viem'
 import { logWarn } from '~/utils/errorHandling'
 import { truncate } from '~/utils/string-utils'
@@ -45,14 +45,6 @@ function initializeWagmi() {
     }
     open()
   }
-
-  useAccountEffect({
-    onConnect: ({ address }) => {
-      if (address) {
-        screenConnectedAddress(address)
-      }
-    },
-  })
 
   watch(wagmiAddress, (address, oldAddress) => {
     if (address && address !== oldAddress) {

--- a/pages/position/[number]/index.vue
+++ b/pages/position/[number]/index.vue
@@ -33,7 +33,7 @@ const _route = useRoute()
 const router = useRouter()
 const modal = useModal()
 const { error } = useToast()
-const { isConnected } = useAccount()
+const { isConnected, address } = useAccount()
 const { isSpyMode } = useSpyMode()
 const { isPositionsLoaded, isPositionsLoading, getPositionBySubAccountIndex } = useEulerAccount()
 const { withIntrinsicBorrowApy, withIntrinsicSupplyApy, getIntrinsicApy, getIntrinsicApyInfo } = useIntrinsicApy()
@@ -689,7 +689,7 @@ const openPairInfoModal = () => {
     },
   })
 }
-watch([isConnected, isSpyMode], () => {
+watch([isConnected, isSpyMode, address], () => {
   load()
 }, { immediate: true })
 </script>


### PR DESCRIPTION
useREULLocks watched [isConnected, chainId] but not the address, so switching wallets on the same chain left old lock data visible. Position detail page had the same gap in its watcher.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed stale position and lock data when switching wallet addresses — the app now clears and reloads data immediately on address change.
  * Prevented a race where overlapping address screenings could prematurely clear screening state.

* **Improvements**
  * Address-screening now synchronizes reliably with the connected address, and screening state persists correctly across rapid address changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->