### PR TITLE
perf: server-side chain vaults snapshot + hydration

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -17,6 +17,13 @@ const { loadCountry } = useGeoBlock()
 const { updateBalances, resetBalances } = useWallets()
 const { isConnected, address } = useWagmi()
 
+// Eagerly instantiate useEulerAccount at app root so its internal watchers
+// trigger updatePositions() as soon as balances + lens addresses are ready.
+// Without this, positions only load when the user navigates to a page that
+// imports the composable, making first detail-page visit wait on the full
+// subgraph + accountLens round-trip.
+useEulerAccount()
+
 // Initialize price backend (configures endpoint when chainId changes)
 usePriceBackend()
 

--- a/components/base/BaseAvatar.vue
+++ b/components/base/BaseAvatar.vue
@@ -24,6 +24,14 @@ const images = computed(() => {
       return { label: labels[index], src: effectiveSrc, state: { isReady: true } }
     }
 
+    // Skip useImage for empty src — it would otherwise create an Image() with
+    // src="" and the browser would attempt to load the current document URL,
+    // emitting an uncaught error event. The template falls through to the
+    // label fallback below when isReady stays false.
+    if (!effectiveSrc) {
+      return { label: labels[index], src: effectiveSrc, state: { isReady: false } }
+    }
+
     const state = reactive(useImage({ src: effectiveSrc, referrerPolicy: 'no-referrer' }))
     watch(() => state.isReady, (ready) => {
       if (ready && effectiveSrc) loadedImages.add(effectiveSrc)

--- a/components/entities/vault/VaultsBorrowList.vue
+++ b/components/entities/vault/VaultsBorrowList.vue
@@ -1,19 +1,59 @@
 <script setup lang="ts">
 import type { AnyBorrowVaultPair } from '~/entities/vault'
+import { LIST_INITIAL_BATCH_ROWS, LIST_ROW_HEIGHT_PX } from '~/entities/tuning-constants'
 
-defineProps<{ items: AnyBorrowVaultPair[] }>()
+const props = defineProps<{ items: AnyBorrowVaultPair[] }>()
+
+// Progressive rendering. The dominant cost of a large pair list is Vue's
+// per-instance setup (each VaultBorrowItem has a nontrivial <script setup>
+// plus several sub-components), not paint. Rendering only the first batch
+// on initial paint keeps time-to-visible low; the remainder is inserted
+// one frame later.
+//
+// Watch `items.length` (not `items`) so an incremental registry update that
+// swaps the array reference but keeps the same length doesn't retrigger
+// the initial-batch ramp (which would otherwise flicker the table).
+//
+// To prevent scroll-restoration from jumping when the list grows, reserve
+// the full expected height up front via a spacer. The list container is
+// the same height from first paint onward, so anything that scrolls based
+// on document height (router scroll restoration, anchor links) settles on
+// the final DOM geometry rather than the partial one.
+const displayedCount = ref(Math.min(props.items.length, LIST_INITIAL_BATCH_ROWS))
+
+watch(() => props.items.length, (total) => {
+  if (total <= LIST_INITIAL_BATCH_ROWS) {
+    displayedCount.value = total
+    return
+  }
+  displayedCount.value = LIST_INITIAL_BATCH_ROWS
+  void nextTick(() => {
+    requestAnimationFrame(() => {
+      displayedCount.value = total
+    })
+  })
+}, { immediate: true })
+
+const visibleItems = computed(() => props.items.slice(0, displayedCount.value))
+const reservedSpacerPx = computed(() => {
+  const missing = props.items.length - displayedCount.value
+  return missing > 0 ? missing * LIST_ROW_HEIGHT_PX : 0
+})
 </script>
 
 <template>
-  <div
-    class="flex flex-col gap-8"
-  >
+  <div class="flex flex-col gap-8">
     <VaultBorrowItem
-      v-for="(pair, index) in items"
+      v-for="(pair, index) in visibleItems"
       :key="`${pair.collateral.address}-${pair.borrow.address}`"
       :pair="pair"
       class="animate-fade-in-up"
       :style="{ animationDelay: `${Math.min(index * 0.03, 0.2)}s` }"
+    />
+    <div
+      v-if="reservedSpacerPx > 0"
+      aria-hidden="true"
+      :style="{ height: `${reservedSpacerPx}px` }"
     />
   </div>
 </template>

--- a/composables/useFetchContext.ts
+++ b/composables/useFetchContext.ts
@@ -1,0 +1,37 @@
+import type { FetchVaultContext } from '~/entities/vault'
+
+/**
+ * Snapshot current composable state into a FetchVaultContext accepted by the
+ * pure vault fetchers. Shared by useVaults (primary caller) and useVaultRegistry
+ * (on-demand `resolveUnknown` path).
+ *
+ * Pass an `isAborted` closure to let in-flight generators bail between rounds
+ * when the chain switches (useVaults uses its loadGeneration guard; registry's
+ * one-shot calls can pass () => false).
+ */
+export const buildFetchContext = (isAborted: () => boolean = () => false): FetchVaultContext => {
+  const { PYTH_HERMES_URL } = useEulerConfig()
+  const { rpcUrl } = useRpcClient()
+  const { chainId, eulerLensAddresses, eulerCoreAddresses, eulerPeripheryAddresses } = useEulerAddresses()
+  const { verifiedVaultAddresses, earnVaults } = useEulerLabels()
+
+  if (!eulerLensAddresses.value) {
+    throw new Error('Euler addresses not loaded yet')
+  }
+
+  return {
+    chainId: chainId.value,
+    rpcUrl: rpcUrl.value,
+    lensAddresses: {
+      vaultLens: eulerLensAddresses.value.vaultLens,
+      eulerEarnVaultLens: eulerLensAddresses.value.eulerEarnVaultLens,
+      utilsLens: eulerLensAddresses.value.utilsLens,
+    },
+    coreAddresses: { evc: eulerCoreAddresses.value?.evc },
+    peripheryAddresses: { escrowedCollateralPerspective: eulerPeripheryAddresses.value?.escrowedCollateralPerspective },
+    pythHermesUrl: PYTH_HERMES_URL,
+    verifiedVaultAddresses: verifiedVaultAddresses.value,
+    earnVaultAddresses: earnVaults.value,
+    isAborted,
+  }
+}

--- a/composables/useMerkl.ts
+++ b/composables/useMerkl.ts
@@ -11,15 +11,19 @@ import { CACHE_TTL_1MIN_MS, POLL_INTERVAL_30S_MS } from '~/entities/tuning-const
 import { logWarn } from '~/utils/errorHandling'
 import { earnVaults } from '~/utils/eulerLabelsState'
 
-const {
-  MERKL_API_BASE_URL,
-} = useEulerConfig()
-
-const endpoints = {
-  tokens: `${MERKL_API_BASE_URL}/tokens/reward`,
-  opportunities: `${MERKL_API_BASE_URL}/opportunities/campaigns`,
-  rewards: (addr: string) => `${MERKL_API_BASE_URL}/users/${addr}/rewards`,
-  campaignById: (id: string) => `${MERKL_API_BASE_URL}/campaigns/${id}`,
+// Endpoints are resolved lazily. `useEulerConfig()` must be called inside a
+// Vue setup or Nuxt context; evaluating it at module-load time fails when the
+// module is pulled in early (e.g. via an import from app.vue). All callers
+// below already run inside setup / async actions kicked off from setup, so a
+// function lookup is safe.
+const endpoints = () => {
+  const { MERKL_API_BASE_URL } = useEulerConfig()
+  return {
+    tokens: `${MERKL_API_BASE_URL}/tokens/reward`,
+    opportunities: `${MERKL_API_BASE_URL}/opportunities/campaigns`,
+    rewards: (addr: string) => `${MERKL_API_BASE_URL}/users/${addr}/rewards`,
+    campaignById: (id: string) => `${MERKL_API_BASE_URL}/campaigns/${id}`,
+  }
 }
 
 const address = ref('')
@@ -59,7 +63,7 @@ const loadTokens = async (chainId: number, isInitialLoading = true, forceRefresh
     if (isInitialLoading) {
       isTokensLoading.value = true
     }
-    const res = await axios.get(endpoints.tokens)
+    const res = await axios.get(endpoints().tokens)
     const data: RewardToken[] = res.data[chainId]
     rewardTokens.value = data || []
     cacheState.tokens = { chainId, timestamp: Date.now() }
@@ -186,6 +190,7 @@ const loadOpportunities = async (chainId: number, isInitialLoading = true, force
     // Always fetch EULER campaigns. Only fetch ERC20LOGPROCESSOR when Earn vault
     // labels are available for client-side filtering (the earnVaults watcher will
     // trigger a force-refresh once labels load).
+    const { MERKL_API_BASE_URL } = useEulerConfig()
     const eulerUrl = `${MERKL_API_BASE_URL}/opportunities/?chainId=${chainId}&type=EULER&campaigns=true`
     const earnAddrs = earnVaults.value
     const knownEarnVaults = earnAddrs.length > 0
@@ -258,7 +263,7 @@ const loadRewards = async (chainId: number, isInitialLoading = true, forceRefres
     if (isInitialLoading) {
       isRewardsLoading.value = true
     }
-    const res = await axios.get(endpoints.rewards(address.value), {
+    const res = await axios.get(endpoints().rewards(address.value), {
       params: {
         chainId,
       },

--- a/composables/useVaultRegistry.ts
+++ b/composables/useVaultRegistry.ts
@@ -184,14 +184,15 @@ const detectVaultType = (factoryAddress: string): VaultType => {
  * They are fetched using fetchVault and identified by vaultCategory.
  */
 const fetchVaultByType = async (address: string, type: VaultType): Promise<AnyVault> => {
+  const ctx = buildFetchContext()
   switch (type) {
     case 'earn':
-      return await fetchEarnVault(address)
+      return await fetchEarnVault(address, ctx)
     case 'securitize':
-      return await fetchSecuritizeVault(address)
+      return await fetchSecuritizeVault(address, ctx)
     case 'evk':
     default:
-      return await fetchVault(address)
+      return await fetchVault(address, ctx)
   }
 }
 
@@ -248,7 +249,7 @@ const resolveUnknown = async (address: string): Promise<VaultEntry> => {
 
     // Try securitize first (has distinct structure), then fall back to EVK
     try {
-      const vault = await fetchSecuritizeVault(normalized)
+      const vault = await fetchSecuritizeVault(normalized, buildFetchContext())
       set(normalized, vault, 'securitize')
       return { vault, type: 'securitize' }
     }
@@ -262,7 +263,7 @@ const resolveUnknown = async (address: string): Promise<VaultEntry> => {
   if (type === 'evk') {
     const isEscrow = await isInEscrowPerspective(normalized)
     if (isEscrow) {
-      const vault = await fetchEscrowVault(normalized)
+      const vault = await fetchEscrowVault(normalized, buildFetchContext())
       set(normalized, vault, 'evk')
       return { vault, type: 'evk' }
     }

--- a/composables/useVaults.ts
+++ b/composables/useVaults.ts
@@ -5,6 +5,8 @@ import {
   type AnyBorrowVaultPair,
   type EarnVault,
   type SecuritizeVault,
+  type SerialisedSnapshot,
+  deserialiseSnapshot,
   fetchEarnVaults,
   fetchVault,
   fetchEarnVault,
@@ -39,11 +41,27 @@ const isEscrowLoadedOnce = ref(false)
 // must stop registering vaults.
 const loadGeneration = ref(0)
 
-// Borrow pairs computed from registry (EVK + Escrow + Securitize collaterals)
+const contextForGeneration = (gen: number) =>
+  buildFetchContext(() => loadGeneration.value !== gen)
+
+// Pair-object cache keyed by `${borrow}:${collateral}`. Vault references in
+// the registry are stable across batch updates for vaults NOT in the current
+// batch — registrySetMany only replaces entries for the addresses it receives.
+// So when `cached.borrow === borrowVault && cached.collateral === collateralVault`,
+// every scalar field on the pair is necessarily unchanged (the LTV subfields
+// live inside borrowVault.collateralLTVs, which is the same array when the
+// borrow vault ref hasn't been replaced). Reusing the cached pair lets
+// Vue's shallow prop compare in VaultBorrowItem mark the bound `pair` as
+// unchanged for every pair whose vaults weren't in the current batch,
+// cutting the row-render cascade down to just the pairs that actually had
+// a vault refreshed.
+const borrowPairCache = new Map<string, AnyBorrowVaultPair>()
+
 const borrowList = computed((): AnyBorrowVaultPair[] => {
   const { getVerifiedEvkVaults, getVault: registryGetVault } = useVaultRegistry()
   const pairs: AnyBorrowVaultPair[] = []
   const evkVaults = getVerifiedEvkVaults()
+  const seenKeys = new Set<string>()
 
   evkVaults.forEach((borrowVault) => {
     borrowVault.collateralLTVs.forEach((ltv) => {
@@ -53,7 +71,16 @@ const borrowList = computed((): AnyBorrowVaultPair[] => {
       if (!collateralVault) return
       if (isVaultNotExplorable(collateralVault.address)) return
 
-      pairs.push({
+      const key = `${borrowVault.address.toLowerCase()}:${ltv.collateral.toLowerCase()}`
+      seenKeys.add(key)
+
+      const cached = borrowPairCache.get(key)
+      if (cached && cached.borrow === borrowVault && cached.collateral === collateralVault) {
+        pairs.push(cached)
+        return
+      }
+
+      const pair = {
         borrow: borrowVault,
         collateral: collateralVault,
         borrowLTV: ltv.borrowLTV,
@@ -61,9 +88,17 @@ const borrowList = computed((): AnyBorrowVaultPair[] => {
         initialLiquidationLTV: ltv.initialLiquidationLTV,
         targetTimestamp: ltv.targetTimestamp,
         rampDuration: ltv.rampDuration,
-      } as AnyBorrowVaultPair)
+      } as AnyBorrowVaultPair
+      borrowPairCache.set(key, pair)
+      pairs.push(pair)
     })
   })
+
+  // Garbage-collect entries that aren't in the current pair set (chain switch,
+  // vault removed from perspective). Keeps the cache bounded.
+  for (const key of borrowPairCache.keys()) {
+    if (!seenKeys.has(key)) borrowPairCache.delete(key)
+  }
 
   return pairs
 })
@@ -72,6 +107,7 @@ const resetVaultsState = () => {
   const { clear } = useVaultRegistry()
 
   loadGeneration.value++
+  borrowPairCache.clear()
   isReady.value = false
   isEVKLoading.value = true
   isEVKUpdating.value = true
@@ -89,6 +125,7 @@ const resetVaultsState = () => {
 const updateEVKVaults = async (vaultAddresses: string[], generation?: number, silent = false) => {
   const { setMany: registrySetMany, getVault: registryGetVault } = useVaultRegistry()
   const gen = generation ?? loadGeneration.value
+  const ctx = contextForGeneration(gen)
 
   try {
     if (!silent) {
@@ -96,7 +133,7 @@ const updateEVKVaults = async (vaultAddresses: string[], generation?: number, si
       isEVKLoading.value = true
     }
 
-    for await (const result of fetchVaults(vaultAddresses)) {
+    for await (const result of fetchVaults(ctx, vaultAddresses)) {
       if (loadGeneration.value !== gen) return
 
       registrySetMany(result.vaults.map((vault) => {
@@ -131,6 +168,7 @@ const updateEVKVaults = async (vaultAddresses: string[], generation?: number, si
 const updateEarnVaults = async (vaultAddresses: string[], generation?: number, silent = false) => {
   const { setMany: registrySetMany } = useVaultRegistry()
   const gen = generation ?? loadGeneration.value
+  const ctx = contextForGeneration(gen)
 
   try {
     if (!silent) {
@@ -138,7 +176,7 @@ const updateEarnVaults = async (vaultAddresses: string[], generation?: number, s
       isEarnLoading.value = true
     }
 
-    for await (const result of fetchEarnVaults(vaultAddresses)) {
+    for await (const result of fetchEarnVaults(ctx, vaultAddresses)) {
       if (loadGeneration.value !== gen) return
 
       registrySetMany(result.vaults.map(vault => ({
@@ -205,8 +243,9 @@ const fetchNeededEscrowVaults = async (addresses: string[], generation: number):
     return
   }
 
+  const ctx = contextForGeneration(generation)
   const results = await Promise.allSettled(
-    addresses.map(addr => fetchEscrowVault(addr)),
+    addresses.map(addr => fetchEscrowVault(addr, ctx)),
   )
 
   if (loadGeneration.value !== generation) return
@@ -236,8 +275,9 @@ const updateSecuritizeVaults = async (securitizeAddresses: string[], generation:
       isSecuritizeLoading.value = true
     }
 
+    const ctx = contextForGeneration(generation)
     const results = await Promise.allSettled(
-      securitizeAddresses.map(addr => fetchSecuritizeVault(addr)),
+      securitizeAddresses.map(addr => fetchSecuritizeVault(addr, ctx)),
     )
 
     if (loadGeneration.value !== generation) return
@@ -264,6 +304,63 @@ const updateSecuritizeVaults = async (securitizeAddresses: string[], generation:
   }
 }
 
+/**
+ * Hydrate the registry from the server-side snapshot endpoint.
+ *
+ * Returns true if hydration succeeded, false if the server endpoint failed
+ * or was stale — the caller falls through to the full RPC pipeline in that
+ * case. On success, isReady is flipped immediately so UI consumers unblock
+ * without waiting on the full RPC refresh.
+ *
+ * Loading flags (isEVKLoading etc.) clear on hydration success because we
+ * have valid data to render; updating flags (isEVKUpdating) stay true so the
+ * subsequent RPC refresh can still signal "refresh in progress" to the UI.
+ */
+const hydrateFromServer = async (targetChainId: number, generation: number): Promise<boolean> => {
+  const { setMany: registrySetMany, setEscrowAddresses } = useVaultRegistry()
+  try {
+    const wire = await $fetch<SerialisedSnapshot>('/api/vaults', {
+      query: { chainId: targetChainId },
+    })
+    if (loadGeneration.value !== generation) return false
+
+    const snap = deserialiseSnapshot(wire)
+    if (snap.chainId !== targetChainId) return false
+
+    // Registry writes: match the type tags useVaults normally uses so that
+    // getType/getVault/isEscrowVault all work identically after hydration.
+    // Escrow vaults already carry vaultCategory='escrow' from the loader.
+    registrySetMany(snap.evkVaults.map(vault => ({ address: vault.address, vault, type: 'evk' as const })))
+    registrySetMany(snap.escrowVaults.map(vault => ({ address: vault.address, vault, type: 'evk' as const })))
+    registrySetMany(snap.earnVaults.map(vault => ({ address: vault.address, vault, type: 'earn' as const })))
+    registrySetMany(snap.securitizeVaults.map(vault => ({ address: vault.address, vault, type: 'securitize' as const })))
+    setEscrowAddresses(snap.escrowAddresses)
+
+    // Clear both loading AND updating flags: the registry is fully populated
+    // from the snapshot, and the subsequent RPC refresh runs in silent mode
+    // so it won't re-toggle them. Consumers gating on isEVKUpdating
+    // (e.g. pages/lend) unblock immediately instead of waiting on the full
+    // RPC refresh.
+    isEVKLoading.value = false
+    isEVKUpdating.value = false
+    isEarnLoading.value = false
+    isEarnUpdating.value = false
+    isSecuritizeLoading.value = false
+    isSecuritizeUpdating.value = false
+    isEscrowLoading.value = false
+    isEscrowUpdating.value = false
+    isEscrowLoadedOnce.value = true
+    isReady.value = true
+    loadedChainId.value = targetChainId
+
+    return true
+  }
+  catch (err) {
+    logWarn('useVaults/hydrateFromServer', err)
+    return false
+  }
+}
+
 const loadVaults = async () => {
   const { chainId, eulerPeripheryAddresses } = useEulerAddresses()
   const { verifiedVaultAddresses, earnVaults: earnVaultAddresses } = useEulerLabels()
@@ -272,6 +369,19 @@ const loadVaults = async () => {
   resetVaultsState()
   const generation = loadGeneration.value
   const startChainId = chainId.value
+
+  // Hydrate from server cache first. On failure we fall through and the
+  // RPC pipeline below populates from scratch.
+  const hydrated = await hydrateFromServer(startChainId, generation)
+  if (loadGeneration.value !== generation) return
+
+  // When hydrated, the RPC refresh below runs in *silent* mode: the UI
+  // already has valid data to render, so per-category loading/updating
+  // flags stay false (same semantics as the 60s polling refresh). Pages
+  // that gate content on isEVKUpdating / isEarnUpdating / etc unblock
+  // immediately. When hydration failed, the refresh runs non-silent so
+  // flags drive the loading state normally.
+  const silent = hydrated
 
   // Filter out non-explorable vaults before any on-chain work
   const explorableVaultAddresses = verifiedVaultAddresses.value.filter(
@@ -282,8 +392,10 @@ const loadVaults = async () => {
   )
 
   try {
-    isEscrowUpdating.value = true
-    isEscrowLoading.value = true
+    if (!silent) {
+      isEscrowUpdating.value = true
+      isEscrowLoading.value = true
+    }
 
     // Phase 1: Fetch vault factories (escrow addresses fetched in Phase 2)
     const factories = await fetchVaultFactories(explorableVaultAddresses)
@@ -326,17 +438,19 @@ const loadVaults = async () => {
 
     await Promise.all([
       (async () => {
-        await updateEarnVaults(explorableEarnAddresses, generation)
+        await updateEarnVaults(explorableEarnAddresses, generation, silent)
         earnResolve()
       })(),
       (async () => {
-        await updateEVKVaults(evkAddresses, generation)
+        await updateEVKVaults(evkAddresses, generation, silent)
         evkResolve()
       })(),
-      updateSecuritizeVaults(securitizeAddresses, generation),
+      updateSecuritizeVaults(securitizeAddresses, generation, silent),
       // Escrow addresses - fetch in parallel, populate set when ready
       (async () => {
-        const addrs = await fetchEscrowAddresses()
+        const perspective = eulerPeripheryAddresses.value?.escrowedCollateralPerspective
+        const ctx = contextForGeneration(generation)
+        const addrs = perspective ? await fetchEscrowAddresses(ctx.rpcUrl, perspective, ctx.chainId) : []
         if (loadGeneration.value !== generation) {
           escrowAddrsResolve([]) // Unblock downstream even if stale
           return
@@ -353,12 +467,17 @@ const loadVaults = async () => {
 
     if (loadGeneration.value !== generation) return
 
-    // Set loading flags AFTER all needed escrow vaults are loaded
-    isEarnUpdating.value = false
-    isSecuritizeUpdating.value = false
-    isSecuritizeLoading.value = false
-    isEscrowUpdating.value = false
-    isEscrowLoading.value = false
+    // Clear flags AFTER all needed escrow vaults are loaded.
+    // Silent mode skips EVK/Earn flags (already false from hydration) but
+    // still clears escrow + securitize which were never touched during
+    // the silent RPC refresh.
+    if (!silent) {
+      isEarnUpdating.value = false
+      isSecuritizeUpdating.value = false
+      isSecuritizeLoading.value = false
+      isEscrowUpdating.value = false
+      isEscrowLoading.value = false
+    }
     isEscrowLoadedOnce.value = true
   }
   catch (e) {
@@ -415,7 +534,7 @@ const getVault = async (address: string): Promise<Vault> => {
     await until(computed(() => registryGetVault(normalizedAddress))).toBeTruthy()
   }
   else {
-    const vault = await fetchVault(normalizedAddress)
+    const vault = await fetchVault(normalizedAddress, contextForGeneration(loadGeneration.value))
     registrySet(normalizedAddress, vault, 'evk')
     return vault
   }
@@ -431,7 +550,7 @@ const getEarnVault = async (address: string): Promise<EarnVault> => {
     await until(computed(() => registryGetVault(normalizedAddress))).toBeTruthy()
   }
   else {
-    const vault = await fetchEarnVault(normalizedAddress)
+    const vault = await fetchEarnVault(normalizedAddress, contextForGeneration(loadGeneration.value))
     registrySet(normalizedAddress, vault, 'earn')
     return vault
   }
@@ -441,17 +560,18 @@ const getEarnVault = async (address: string): Promise<EarnVault> => {
 const updateVault = async (vaultAddress: string): Promise<Vault | SecuritizeVault> => {
   const { set: registrySet, isKnownEscrowAddress, getType } = useVaultRegistry()
   const address = getAddress(vaultAddress)
+  const ctx = contextForGeneration(loadGeneration.value)
 
   // Use appropriate fetch function based on vault type
   if (getType(address) === 'securitize') {
-    const vault = await fetchSecuritizeVault(address)
+    const vault = await fetchSecuritizeVault(address, ctx)
     registrySet(address, vault, 'securitize')
     return vault
   }
 
   const vault = isKnownEscrowAddress(address)
-    ? await fetchEscrowVault(address)
-    : await fetchVault(address)
+    ? await fetchEscrowVault(address, ctx)
+    : await fetchVault(address, ctx)
 
   registrySet(address, vault, 'evk')
   return vault
@@ -476,7 +596,7 @@ const refreshVaults = async () => {
 const updateEarnVault = async (vaultAddress: string): Promise<EarnVault> => {
   const { set: registrySet } = useVaultRegistry()
   const address = getAddress(vaultAddress)
-  const vault = await fetchEarnVault(address)
+  const vault = await fetchEarnVault(address, contextForGeneration(loadGeneration.value))
   registrySet(address, vault, 'earn')
   return vault
 }
@@ -496,16 +616,18 @@ const getEscrowVault = async (address: string): Promise<Vault> => {
     return existingVault as Vault
   }
 
+  const ctx = contextForGeneration(loadGeneration.value)
+
   // If it's a known escrow address but not in registry (wasn't needed during initial load),
   // fetch on-demand
   if (isKnownEscrowAddress(normalizedAddress)) {
-    const vault = await fetchEscrowVault(normalizedAddress)
+    const vault = await fetchEscrowVault(normalizedAddress, ctx)
     registrySet(normalizedAddress, vault, 'evk')
     return vault
   }
 
   // Last resort: try fetching anyway (might be an escrow vault not in perspective yet)
-  const vault = await fetchEscrowVault(normalizedAddress)
+  const vault = await fetchEscrowVault(normalizedAddress, ctx)
   registrySet(normalizedAddress, vault, 'evk')
   return vault
 }
@@ -513,7 +635,7 @@ const getEscrowVault = async (address: string): Promise<Vault> => {
 const updateEscrowVault = async (vaultAddress: string): Promise<Vault> => {
   const { set: registrySet } = useVaultRegistry()
   const address = getAddress(vaultAddress)
-  const vault = await fetchEscrowVault(address)
+  const vault = await fetchEscrowVault(address, contextForGeneration(loadGeneration.value))
   registrySet(address, vault, 'evk')
   return vault
 }
@@ -526,7 +648,7 @@ const getSecuritizeVault = async (address: string): Promise<SecuritizeVault> => 
     return registryGetVault(normalizedAddress) as SecuritizeVault
   }
 
-  const vault = await fetchSecuritizeVault(normalizedAddress)
+  const vault = await fetchSecuritizeVault(normalizedAddress, contextForGeneration(loadGeneration.value))
   registrySet(normalizedAddress, vault, 'securitize')
   return vault
 }
@@ -575,8 +697,10 @@ const getBorrowVaultPair = async (
     }
   }
 
+  const ctx = contextForGeneration(loadGeneration.value)
+
   // Fallback: fetch borrow vault if not in registry
-  const borrowVault = await fetchVault(borrowAddr)
+  const borrowVault = await fetchVault(borrowAddr, ctx)
   if (!borrowVault) {
     throw '[getBorrowVaultPair]: Borrow vault not found'
   }
@@ -598,18 +722,18 @@ const getBorrowVaultPair = async (
   }
   else {
     try {
-      collateralVault = await fetchVault(collateralAddr)
+      collateralVault = await fetchVault(collateralAddr, ctx)
     }
     catch {
       // Try escrow vault first
       try {
-        collateralVault = await fetchEscrowVault(collateralAddr)
+        collateralVault = await fetchEscrowVault(collateralAddr, ctx)
       }
       catch {
         // Check if it's a securitize vault
         const isSecuritize = await isSecuritizeVault(collateralAddr)
         if (isSecuritize) {
-          collateralVault = await fetchSecuritizeVault(collateralAddr)
+          collateralVault = await fetchSecuritizeVault(collateralAddr, ctx)
           // Add to registry so balances can be fetched
           registrySet(collateralAddr, collateralVault, 'securitize')
         }

--- a/composables/useVaults.ts
+++ b/composables/useVaults.ts
@@ -3,6 +3,7 @@ import { useVaultRegistry } from './useVaultRegistry'
 import { logWarn } from '~/utils/errorHandling'
 import {
   type AnyBorrowVaultPair,
+  type ChainVaultsSnapshot,
   type EarnVault,
   type SecuritizeVault,
   type SerialisedSnapshot,
@@ -316,6 +317,26 @@ const updateSecuritizeVaults = async (securitizeAddresses: string[], generation:
  * have valid data to render; updating flags (isEVKUpdating) stay true so the
  * subsequent RPC refresh can still signal "refresh in progress" to the UI.
  */
+/** Upper bound on snapshot age the client will hydrate from. Covers normal
+ * warm-cache intervals (4 min) plus a couple of missed cycles. Older
+ * snapshots are discarded and the RPC pipeline populates from scratch. */
+const MAX_HYDRATION_AGE_MS = 15 * 60_000
+
+/** Narrow the opaque wire object to the ChainVaultsSnapshot shape before we
+ * start trusting it for registry writes. A malformed server response would
+ * otherwise crash at the first `.map()` call. */
+const isChainVaultsSnapshot = (v: unknown): v is ChainVaultsSnapshot => {
+  if (v === null || typeof v !== 'object') return false
+  const s = v as Record<string, unknown>
+  return typeof s.chainId === 'number'
+    && typeof s.fetchedAt === 'number'
+    && Array.isArray(s.evkVaults)
+    && Array.isArray(s.earnVaults)
+    && Array.isArray(s.securitizeVaults)
+    && Array.isArray(s.escrowAddresses)
+    && Array.isArray(s.escrowVaults)
+}
+
 const hydrateFromServer = async (targetChainId: number, generation: number): Promise<boolean> => {
   const { setMany: registrySetMany, setEscrowAddresses } = useVaultRegistry()
   try {
@@ -325,13 +346,30 @@ const hydrateFromServer = async (targetChainId: number, generation: number): Pro
     if (loadGeneration.value !== generation) return false
 
     const snap = deserialiseSnapshot(wire)
+    if (!isChainVaultsSnapshot(snap)) {
+      logWarn('useVaults/hydrateFromServer', 'server returned a malformed snapshot; falling back to RPC')
+      return false
+    }
     if (snap.chainId !== targetChainId) return false
+    if (Date.now() - snap.fetchedAt > MAX_HYDRATION_AGE_MS) {
+      // Snapshot is older than MAX_HYDRATION_AGE_MS — indicates prolonged
+      // warm-cache failure. Reject rather than render stale prices/caps.
+      logWarn('useVaults/hydrateFromServer', `snapshot too stale (${Math.round((Date.now() - snap.fetchedAt) / 1000)}s old); falling back to RPC`)
+      return false
+    }
 
     // Registry writes: match the type tags useVaults normally uses so that
     // getType/getVault/isEscrowVault all work identically after hydration.
-    // Escrow vaults already carry vaultCategory='escrow' from the loader.
+    // Re-stamp vaultCategory='escrow' defensively on escrow vaults — the
+    // loader already sets it via fetchEscrowVault, but the registry write
+    // is our last chance to guarantee it for downstream `vaultCategory`
+    // consumers (VaultItem etc.).
     registrySetMany(snap.evkVaults.map(vault => ({ address: vault.address, vault, type: 'evk' as const })))
-    registrySetMany(snap.escrowVaults.map(vault => ({ address: vault.address, vault, type: 'evk' as const })))
+    registrySetMany(snap.escrowVaults.map(vault => ({
+      address: vault.address,
+      vault: { ...vault, vaultCategory: 'escrow' as const },
+      type: 'evk' as const,
+    })))
     registrySetMany(snap.earnVaults.map(vault => ({ address: vault.address, vault, type: 'earn' as const })))
     registrySetMany(snap.securitizeVaults.map(vault => ({ address: vault.address, vault, type: 'securitize' as const })))
     setEscrowAddresses(snap.escrowAddresses)

--- a/composables/useWallets.ts
+++ b/composables/useWallets.ts
@@ -4,6 +4,7 @@ import { eulerUtilsLensABI } from '~/entities/euler/abis'
 import { erc20BalanceOfAbi } from '~/abis/erc20'
 import { logWarn } from '~/utils/errorHandling'
 import { getPublicClient } from '~/utils/public-client'
+import { FULL_BALANCES_TTL_MS } from '~/entities/tuning-constants'
 
 // Singleton state
 const balances = shallowRef(new Map<string, bigint>())
@@ -12,6 +13,22 @@ const isFetching = ref(false)
 const lastFetchChainId = ref<number | null>(null)
 const lastFetchAddress = ref<string | null>(null)
 let fetchPromise: Promise<void> | null = null
+
+// Reference-counted flag: when >0, updateBalances includes the full token list
+// (all Uniswap/DefiLlama entries — thousands of tokens on mainnet) so pages
+// with the "pay with" token selector can show non-zero balances first.
+// When 0 (the default), updateBalances fetches only vault-asset balances
+// (a few dozen tokens at most) — enough for Max buttons, balance chips, and
+// wallet-sourced-repay dropdowns on the main navigation pages.
+const fullBalancesRequesters = ref(0)
+
+// Remembers the most recent (chain, address) that completed a full-mode fetch
+// and when. Lets useFullBalances skip a redundant refetch when the user
+// navigates between two swap pages within the TTL window.
+// resetBalances() clears this alongside the Map, so chain / wallet changes
+// correctly force a refetch.
+let lastFullFetchKey: string | null = null
+let lastFullFetchAt = 0
 
 export const useWallets = () => {
   const { loadedChainId } = useVaults()
@@ -74,18 +91,29 @@ export const useWallets = () => {
       }
     })
 
-    // Include token list addresses (for swap selector zero-balance filtering).
+    // Include token list addresses (for swap selector zero-balance filtering)
+    // ONLY when a page with the "pay with" selector is mounted. On mainnet
+    // the token list is thousands of tokens, so including it in every
+    // routine balance refresh stretches the fetch into many RPC chunks.
+    // The main navigation pages (lend/borrow/earn) don't need this data,
+    // so we default to vault-assets-only — typically a single RPC chunk.
+    //
+    // Pages that render SwapTokenSelector opt in via `useFullBalances()`; when
+    // the counter flips from 0 we re-fire updateBalances to populate the rest.
+    //
     // Defensive filter: only accept entries matching the active chain, so that
     // a stale useTokenList singleton from a previous chain can never contaminate
     // the RPC batch with foreign-chain addresses.
-    const { getAllTokens } = useTokenList()
-    for (const token of getAllTokens()) {
-      if (token.chainId !== currentChainId) continue
-      try {
-        addresses.add(getAddress(token.address))
-      }
-      catch {
-        // Skip invalid addresses
+    if (fullBalancesRequesters.value > 0) {
+      const { getAllTokens } = useTokenList()
+      for (const token of getAllTokens()) {
+        if (token.chainId !== currentChainId) continue
+        try {
+          addresses.add(getAddress(token.address))
+        }
+        catch {
+          // Skip invalid addresses
+        }
       }
     }
 
@@ -150,14 +178,22 @@ export const useWallets = () => {
 
       // Only update if still on same chain
       if (chainId.value === currentChainId) {
-        const newBalances = new Map<string, bigint>()
+        // Merge rather than replace: a vault-only-mode fetch shouldn't drop
+        // full-mode balances we fetched earlier (e.g. from a swap page).
+        // resetBalances() is called on chain switch and wallet-address
+        // change, which is the right boundary to fully clear.
+        const merged = new Map(balances.value)
         result.forEach((balance: bigint, index: number) => {
-          newBalances.set(tokenAddresses[index], balance)
+          merged.set(tokenAddresses[index], balance)
         })
-        balances.value = newBalances
+        balances.value = merged
         lastFetchChainId.value = currentChainId
         lastFetchAddress.value = targetAddress
         isLoaded.value = true
+        if (fullBalancesRequesters.value > 0) {
+          lastFullFetchKey = `${currentChainId}:${targetAddress.toLowerCase()}`
+          lastFullFetchAt = Date.now()
+        }
       }
     }
     catch (e) {
@@ -204,6 +240,8 @@ export const useWallets = () => {
 
   const resetBalances = () => {
     balances.value = new Map()
+    lastFullFetchKey = null
+    lastFullFetchAt = 0
     isLoaded.value = false
     isFetching.value = false
     lastFetchChainId.value = null
@@ -293,4 +331,43 @@ export const useWallets = () => {
     fetchSingleBalance,
     fetchVaultShareBalance,
   }
+}
+
+/**
+ * Opt the current component into "full balance" mode. While any component
+ * using this is mounted, updateBalances includes the whole token list (so
+ * the pay-with selector sees non-zero balances on wallet tokens); when the
+ * counter returns to zero, subsequent updates go back to the vault-assets-
+ * only fast path.
+ *
+ * Refcounted so multiple concurrent pages (unlikely, but safe) compose.
+ * A TTL guard skips the re-fetch when navigating between two swap pages
+ * within a 60s window on the same chain+address — the balances Map already
+ * has them from the previous page's fetch, and the merge semantics in
+ * updateBalances mean they weren't wiped by intervening vault-only fetches.
+ *
+ * Call once at `<script setup>` top-level — lifecycle hooks do the rest.
+ */
+export const useFullBalances = (): void => {
+  const { updateBalances } = useWallets()
+  const { chainId } = useEulerAddresses()
+  const { address } = useWagmi()
+  const { spyAddress, isSpyMode } = useSpyMode()
+
+  onMounted(() => {
+    fullBalancesRequesters.value++
+    if (fullBalancesRequesters.value !== 1) return // not the first requester, data already in-flight / present
+
+    const activeAddress = (isSpyMode.value ? spyAddress.value : address.value) ?? ''
+    const expectedKey = `${chainId.value}:${activeAddress.toLowerCase()}`
+    const isFresh = lastFullFetchKey === expectedKey && (Date.now() - lastFullFetchAt) < FULL_BALANCES_TTL_MS
+
+    if (!isFresh) {
+      void updateBalances()
+    }
+  })
+
+  onBeforeUnmount(() => {
+    fullBalancesRequesters.value = Math.max(0, fullBalancesRequesters.value - 1)
+  })
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -207,10 +207,22 @@ The application follows Vue 3's Composition API pattern, organizing code into lo
 | `/api/vault-factories` | 24 h | Factory is immutable per vault; batched subgraph query |
 | `/api/oracle-adapter` | 5 min | Lazy per-address fetch |
 | `/api/euler-chains` | 5 min | Static chain-agnostic config from `euler-interfaces` repo |
+| `/api/vaults` | 10 min (safety floor) | Pre-computed chain vault snapshot; warm-cache rewrites every 4 min so in steady state the snapshot is ≤4 min old. Handler is read-only — no request-triggered refresh |
 
 Every cacheable proxy above uses the same pattern: TTL cache for fresh hits, stale-cache fallback on upstream failure, and in-flight request deduplication so concurrent cache-miss callers (e.g. warm-cache racing real traffic) collapse onto a single upstream fetch per cache key.
 
-`server/plugins/warm-cache.ts` pre-populates labels, token-list, `/api/intrinsic-apy`, and vault-factories for every enabled chain, plus `/api/euler-chains` once globally. A 4-min interval re-warms every entry ahead of its 5-min TTL. Warming runs fire-and-forget so Nitro's listener is never delayed; caches are typically hot within ~5 s of boot, and users arriving before that just pay the usual cold-upstream latency for whichever endpoints they hit.
+`server/plugins/warm-cache.ts` pre-populates labels, token-list, `/api/intrinsic-apy`, vault-factories, and the vaults snapshot for every enabled chain, plus `/api/euler-chains` once globally. A 4-min interval re-warms every entry ahead of its 5-min TTL. Warming runs fire-and-forget so Nitro's listener is never delayed; caches are typically hot within ~5 s of boot, and users arriving before that just pay the usual cold-upstream latency for whichever endpoints they hit.
+
+### Vault snapshot pipeline
+
+`/api/vaults?chainId=X` serves a pre-computed snapshot of the public vault set for a chain: every EVK vault, Earn vault, Securitize vault, and referenced escrow vault, with all on-chain state (caps, rates, LTV matrices, oracle prices) already resolved. Per-user data (balances, positions, collateral flags) is **not** in this snapshot — the client fetches it separately after wallet connect via `useAccountPositions` / `useEulerAccount`.
+
+The client composable `useVaults.loadVaults()` runs in two phases:
+
+1. **Hydrate** (`~100 ms`): `$fetch('/api/vaults?chainId=X')`, deserialise, populate the vault registry, flip `isReady=true`. UI renders a fully populated `borrowList` immediately.
+2. **Fresh RPC pass** (`~3-6 s`): the existing batched lens pipeline (`fetchVaults`/`fetchEarnVaults`/`fetchSecuritizeVault`/`fetchEscrowVault`) runs against the client's RPC with Pyth simulation, overwriting registry entries with live prices and rates.
+
+The public interface of `useVaults()` is unchanged — the 15 exports (`isReady`, `borrowList`, `getVault`, etc.) keep their names, types, and semantics. All RPC-level fetchers are extracted to pure functions in `entities/vault/{fetcher,apy,pricing,escrow-fetcher}.ts` that accept a `FetchVaultContext`; both the client composable and the server-side `loadChainSnapshot` (`entities/vault/loader.ts`) share the same code path. bigint fields in the wire payload are tagged (`__bi:<decimal>`) by `entities/vault/loader-serde.ts` so the JSON transport doesn't lose precision.
 
 ## 🔍 Explore Page & Market Discovery
 

--- a/entities/tuning-constants.ts
+++ b/entities/tuning-constants.ts
@@ -20,6 +20,24 @@ export const BATCH_DELAY_COLLECT_MS = 50
 // ── Request Timeouts ────────────────────────────────────
 export const TIMEOUT_SUBGRAPH_MS = 30_000
 
+// ── Debounce ──────────────────────────────────────────────
+/** Price-fetch watchEffects on list pages. Collapses bursts of registry
+ * updates streamed during loadVaults's RPC refresh into a single pass. */
+export const DEBOUNCE_LIST_PRICE_FETCH_MS = 300
+
+// ── Progressive list rendering ────────────────────────────
+/** Rows rendered on the initial paint of a long list. Remainder is inserted
+ * one frame later so the first paint is fast on large (400+ row) sets. */
+export const LIST_INITIAL_BATCH_ROWS = 40
+/** Estimated per-row height for the scroll-restoration spacer reservation. */
+export const LIST_ROW_HEIGHT_PX = 88
+
+// ── Wallet balances ───────────────────────────────────────
+/** TTL for a "full" wallet balance fetch (the one that includes the whole
+ * token list for the pay-with selector). Navigating between swap pages
+ * within this window reuses the cached Map rather than re-fetching. */
+export const FULL_BALANCES_TTL_MS = 60_000
+
 // ── Basis Points ──────────────────────────────────────────
 export const BPS_BASE = 10_000n
 /** BPS_BASE + 1: pads amounts by 0.01% to cover interest accrual */

--- a/entities/vault/apy.ts
+++ b/entities/vault/apy.ts
@@ -3,6 +3,8 @@ import { logWarn } from '~/utils/errorHandling'
 import { SECONDS_IN_YEAR, TARGET_TIME_AGO } from '~/entities/constants'
 import { eulerUtilsLensABI, eulerVaultLensABI } from '~/entities/euler/abis'
 import { vaultConvertToAssetsAbi } from '~/abis/vault'
+import { getPublicClient } from '~/utils/public-client'
+import { logConciseFetchError } from './log-fetch-error'
 
 export interface ProjectedRates {
   supplyAPY: bigint // 27 decimals
@@ -110,10 +112,9 @@ interface BlockDataCache {
 }
 
 // Pre-fetch block data once for all APY calculations
-export const fetchBlockDataForAPY = async (): Promise<BlockDataCache | null> => {
+export const fetchBlockDataForAPY = async (rpcUrl: string, chainId: number): Promise<BlockDataCache | null> => {
   try {
-    const { client: rpcClient } = useRpcClient()
-    const client = rpcClient.value!
+    const client = getPublicClient(rpcUrl)
     const currentBlockBigInt = await client.getBlockNumber()
     const currentBlock = Number(currentBlockBigInt)
     const sampleDistance = 100
@@ -166,7 +167,7 @@ export const fetchBlockDataForAPY = async (): Promise<BlockDataCache | null> => 
     }
   }
   catch (e) {
-    logWarn('apy/fetchBlockData', e, { severity: 'error' })
+    logConciseFetchError('apy/fetchBlockData', chainId, 'block data', e)
     return null
   }
 }
@@ -176,10 +177,10 @@ export const calculateEarnVaultAPYWithCache = async (
   vaultAddress: string,
   decimals: bigint,
   blockCache: BlockDataCache,
+  rpcUrl: string,
 ): Promise<number> => {
   try {
-    const { client: rpcClient } = useRpcClient()
-    const client = rpcClient.value!
+    const client = getPublicClient(rpcUrl)
 
     const oneShare = parseUnits('1', Number(decimals))
 
@@ -224,10 +225,12 @@ export const calculateEarnVaultAPYWithCache = async (
 export const calculateEarnVaultAPYFromExchangeRate = async (
   vaultAddress: string,
   decimals: bigint,
+  rpcUrl: string,
+  chainId: number,
 ): Promise<number> => {
-  const blockCache = await fetchBlockDataForAPY()
+  const blockCache = await fetchBlockDataForAPY(rpcUrl, chainId)
   if (!blockCache) {
     return 0
   }
-  return calculateEarnVaultAPYWithCache(vaultAddress, decimals, blockCache)
+  return calculateEarnVaultAPYWithCache(vaultAddress, decimals, blockCache, rpcUrl)
 }

--- a/entities/vault/escrow-fetcher.ts
+++ b/entities/vault/escrow-fetcher.ts
@@ -1,25 +1,23 @@
 import { getAddress, parseUnits, type Address } from 'viem'
-import type { Vault, VaultIteratorResult } from './types'
-import { resolveAssetPriceInfo, resolveFullAssetPriceInfo, resolveUnitOfAccountPriceInfo } from './pricing'
-import { processRawVaultData, fetchVault } from './fetcher'
+import type { Vault } from './types'
+import { resolveFullAssetPriceInfo } from './pricing'
+import { fetchVault, type FetchVaultContext } from './fetcher'
 import { logWarn } from '~/utils/errorHandling'
 import { USD_ADDRESS } from '~/entities/constants'
-import { BATCH_SIZE_RPC_CALLS } from '~/entities/tuning-constants'
-import {
-  eulerPerspectiveABI,
-  eulerVaultLensABI,
-} from '~/entities/euler/abis'
+import { eulerPerspectiveABI } from '~/entities/euler/abis'
+import { getPublicClient } from '~/utils/public-client'
+import { logConciseFetchError } from './log-fetch-error'
 
-export const fetchEscrowVault = async (vaultAddress: string): Promise<Vault> => {
-  const { rpcUrl } = useRpcClient()
-  const { eulerLensAddresses } = useEulerAddresses()
-
-  const vault = await fetchVault(vaultAddress)
+export const fetchEscrowVault = async (
+  vaultAddress: string,
+  ctx: FetchVaultContext,
+): Promise<Vault> => {
+  const vault = await fetchVault(vaultAddress, ctx)
 
   try {
     const priceInfo = await resolveFullAssetPriceInfo(
-      rpcUrl.value,
-      eulerLensAddresses.value!.utilsLens,
+      ctx.rpcUrl,
+      ctx.lensAddresses.utilsLens,
       vault.asset.address,
     )
 
@@ -59,160 +57,27 @@ export const fetchEscrowVault = async (vaultAddress: string): Promise<Vault> => 
  * Single RPC call to get the list of addresses from escrowedCollateralPerspective.
  * Used for lazy loading optimization - vault info is fetched on-demand.
  */
-export const fetchEscrowAddresses = async (): Promise<string[]> => {
-  const { client: rpcClient } = useRpcClient()
-  const { eulerPeripheryAddresses } = useEulerAddresses()
-
-  await until(
-    computed(() => eulerPeripheryAddresses.value?.escrowedCollateralPerspective),
-  ).toBeTruthy()
-
-  if (!eulerPeripheryAddresses.value?.escrowedCollateralPerspective) {
+export const fetchEscrowAddresses = async (
+  rpcUrl: string,
+  escrowedCollateralPerspectiveAddress: string,
+  chainId: number,
+): Promise<string[]> => {
+  if (!escrowedCollateralPerspectiveAddress) {
     return []
   }
 
-  const client = rpcClient.value!
+  const client = getPublicClient(rpcUrl)
 
   try {
     const addresses = await client.readContract({
-      address: eulerPeripheryAddresses.value.escrowedCollateralPerspective as Address,
+      address: escrowedCollateralPerspectiveAddress as Address,
       abi: eulerPerspectiveABI,
       functionName: 'verifiedArray',
     }) as string[]
     return addresses.map(addr => getAddress(addr))
   }
   catch (e) {
-    logWarn('escrow/fetchAddresses', e, { severity: 'error' })
+    logConciseFetchError('escrow/fetchAddresses', chainId, 'addresses', e)
     return []
-  }
-}
-
-export const fetchEscrowVaults = async function* (): AsyncGenerator<
-  VaultIteratorResult<Vault>,
-  void,
-  unknown
-> {
-  const { client: rpcClient, rpcUrl } = useRpcClient()
-  const { eulerPeripheryAddresses, eulerLensAddresses, chainId } = useEulerAddresses()
-
-  const startChainId = chainId.value
-
-  await until(
-    computed(() => {
-      return (
-        eulerPeripheryAddresses.value?.escrowedCollateralPerspective
-        && eulerLensAddresses.value?.vaultLens
-        && eulerLensAddresses.value?.utilsLens
-      )
-    }),
-  ).toBeTruthy()
-
-  if (
-    !eulerPeripheryAddresses.value?.escrowedCollateralPerspective
-    || !eulerLensAddresses.value?.vaultLens
-    || !eulerLensAddresses.value?.utilsLens
-  ) {
-    throw new Error('Escrow perspective or vault lens address not loaded yet')
-  }
-
-  const client = rpcClient.value!
-
-  let verifiedVaults: string[]
-  try {
-    verifiedVaults = await client.readContract({
-      address: eulerPeripheryAddresses.value.escrowedCollateralPerspective as Address,
-      abi: eulerPerspectiveABI,
-      functionName: 'verifiedArray',
-    }) as string[]
-  }
-  catch (e) {
-    logWarn('escrow/fetchVaults', e, { severity: 'error' })
-    verifiedVaults = []
-  }
-
-  const batchSize = BATCH_SIZE_RPC_CALLS
-
-  for (let i = 0; i < verifiedVaults.length; i += batchSize) {
-    if (chainId.value !== startChainId) {
-      return
-    }
-    const batch = verifiedVaults.slice(i, i + batchSize)
-    const batchPromises = batch.map(async (vaultAddress) => {
-      try {
-        const raw = await client.readContract({
-          address: eulerLensAddresses.value!.vaultLens as Address,
-          abi: eulerVaultLensABI,
-          functionName: 'getVaultInfoFull',
-          args: [vaultAddress],
-        }) as Record<string, unknown>
-
-        return processRawVaultData(raw, vaultAddress, undefined, { verified: true, vaultCategory: 'escrow' })
-      }
-      catch (e) {
-        logWarn('escrow/fetchVault', e, { severity: 'error' })
-        return undefined
-      }
-    })
-
-    const res = await Promise.all(batchPromises)
-    let validVaults = res.filter(o => !!o) as Vault[]
-
-    const utilsLensAddress = eulerLensAddresses.value!.utilsLens
-    validVaults = await Promise.all(
-      validVaults.map(async (vault) => {
-        const [assetPriceInfo, unitOfAccountPriceInfo] = await Promise.all([
-          resolveAssetPriceInfo(rpcUrl.value, utilsLensAddress, vault.asset.address),
-          resolveUnitOfAccountPriceInfo(rpcUrl.value, utilsLensAddress, vault.unitOfAccount),
-        ])
-        return { ...vault, assetPriceInfo, unitOfAccountPriceInfo }
-      }),
-    )
-
-    validVaults = await Promise.all(
-      validVaults.map(async (vault) => {
-        // Refetch price if missing or query failed (0n is valid - very small price)
-        if (
-          !vault.liabilityPriceInfo
-          || vault.liabilityPriceInfo.queryFailure
-        ) {
-          try {
-            const priceInfo = await resolveFullAssetPriceInfo(
-              rpcUrl.value,
-              utilsLensAddress,
-              vault.asset.address,
-            )
-
-            if (priceInfo && priceInfo.amountOutMid > 0n) {
-              return {
-                ...vault,
-                liabilityPriceInfo: {
-                  amountIn: priceInfo.amountIn || parseUnits('1', Number(vault.asset.decimals)),
-                  amountOutAsk: priceInfo.amountOutAsk || priceInfo.amountOutMid,
-                  amountOutBid: priceInfo.amountOutBid || priceInfo.amountOutMid,
-                  amountOutMid: priceInfo.amountOutMid,
-                  queryFailure: false,
-                  queryFailureReason: '',
-                  timestamp: priceInfo.timestamp,
-                  oracle: priceInfo.oracle,
-                  asset: vault.asset.address,
-                  unitOfAccount: USD_ADDRESS,
-                },
-              }
-            }
-          }
-          catch (e) {
-            logWarn('escrow/fetchAssetPrice', e)
-          }
-        }
-        return vault
-      }),
-    )
-
-    const isFinished = i + batchSize >= verifiedVaults.length
-
-    yield {
-      vaults: validVaults,
-      isFinished,
-    }
   }
 }

--- a/entities/vault/fetcher.ts
+++ b/entities/vault/fetcher.ts
@@ -20,6 +20,30 @@ import {
 import { executeLensWithPythSimulation, executeBatchLensWithPythSimulation } from '~/utils/pyth'
 import { valueToNano } from '~/utils/crypto-utils'
 import { batchLensCalls } from '~/utils/multicall'
+import { getPublicClient } from '~/utils/public-client'
+import { logConciseFetchError } from './log-fetch-error'
+
+/**
+ * Context bundle the pure fetchers need. Both the client-side composable
+ * wrappers and the server-side loader build this from their own sources
+ * (composables vs the chain-config plugin) and pass it in.
+ */
+export interface FetchVaultContext {
+  chainId: number
+  rpcUrl: string
+  lensAddresses: {
+    vaultLens: string
+    eulerEarnVaultLens: string
+    utilsLens: string
+  }
+  coreAddresses?: { evc?: string }
+  peripheryAddresses?: { escrowedCollateralPerspective?: string }
+  pythHermesUrl?: string
+  verifiedVaultAddresses: string[]
+  earnVaultAddresses: string[]
+  /** Optional abort signal. Checked between parallel rounds in generators. */
+  isAborted?: () => boolean
+}
 
 interface ProcessVaultOptions {
   verified?: boolean
@@ -96,15 +120,6 @@ export const processRawVaultData = (
 /**
  * Fetch vault using EVC batchSimulation with Pyth updates.
  * This ensures fresh Pyth prices are available when querying vault info.
- *
- * @param vaultAddress - The vault address to fetch
- * @param feeds - Pre-collected Pyth feeds for this vault
- * @param rpcUrl - JSON-RPC provider URL
- * @param vaultLensAddress - Vault lens contract address
- * @param evcAddress - EVC contract address
- * @param hermesEndpoint - Pyth Hermes endpoint URL
- * @param verifiedVaultAddresses - List of verified vault addresses
- * @returns Vault with fresh Pyth prices, or undefined if simulation fails
  */
 const fetchVaultWithPythSimulation = async (
   vaultAddress: string,
@@ -133,28 +148,17 @@ const fetchVaultWithPythSimulation = async (
   return processRawVaultData(result, vaultAddress, verifiedVaultAddresses)
 }
 
-export const fetchVault = async (vaultAddress: string): Promise<Vault> => {
-  const { PYTH_HERMES_URL } = useEulerConfig()
-  const { client: rpcClient, rpcUrl } = useRpcClient()
-  const { loadEulerConfig, isReady } = useEulerAddresses()
-  const { verifiedVaultAddresses } = useEulerLabels()
-
-  if (!isReady.value) {
-    loadEulerConfig()
-    await until(computed(() => isReady.value)).toBeTruthy()
-  }
-  const { eulerLensAddresses, eulerCoreAddresses } = useEulerAddresses()
-
-  const client = rpcClient.value!
+export const fetchVault = async (vaultAddress: string, ctx: FetchVaultContext): Promise<Vault> => {
+  const client = getPublicClient(ctx.rpcUrl)
 
   // Standard query first (fast path for non-Pyth vaults)
   const raw = await client.readContract({
-    address: eulerLensAddresses.value!.vaultLens as Address,
+    address: ctx.lensAddresses.vaultLens as Address,
     abi: eulerVaultLensABI,
     functionName: 'getVaultInfoFull',
     args: [vaultAddress],
   }) as Record<string, unknown>
-  let vault = processRawVaultData(raw, vaultAddress, verifiedVaultAddresses.value)
+  let vault = processRawVaultData(raw, vaultAddress, ctx.verifiedVaultAddresses)
 
   // Check if vault uses Pyth oracles
   const feeds = collectPythFeedIds(vault.oracleDetailedInfo)
@@ -162,47 +166,38 @@ export const fetchVault = async (vaultAddress: string): Promise<Vault> => {
   // ALWAYS re-query with simulation if Pyth detected
   // Pyth prices are only valid for ~2 minutes after on-chain update,
   // so we need fresh prices even if current query succeeded
-  if (feeds.length > 0 && eulerCoreAddresses.value?.evc && PYTH_HERMES_URL) {
+  if (feeds.length > 0 && ctx.coreAddresses?.evc && ctx.pythHermesUrl) {
     const vaultWithFreshPrice = await fetchVaultWithPythSimulation(
       vaultAddress,
       feeds,
-      rpcUrl.value,
-      eulerLensAddresses.value!.vaultLens,
-      eulerCoreAddresses.value.evc,
-      PYTH_HERMES_URL,
-      verifiedVaultAddresses.value,
+      ctx.rpcUrl,
+      ctx.lensAddresses.vaultLens,
+      ctx.coreAddresses.evc,
+      ctx.pythHermesUrl,
+      ctx.verifiedVaultAddresses,
     )
     if (vaultWithFreshPrice) {
       vault = vaultWithFreshPrice
     }
   }
 
-  if (eulerLensAddresses.value?.utilsLens) {
-    const [assetPriceInfo, unitOfAccountPriceInfo] = await Promise.all([
-      resolveAssetPriceInfo(rpcUrl.value, eulerLensAddresses.value.utilsLens, vault.asset.address),
-      resolveUnitOfAccountPriceInfo(rpcUrl.value, eulerLensAddresses.value.utilsLens, vault.unitOfAccount),
-    ])
-    vault = { ...vault, assetPriceInfo, unitOfAccountPriceInfo }
-  }
+  const [assetPriceInfo, unitOfAccountPriceInfo] = await Promise.all([
+    resolveAssetPriceInfo(ctx.rpcUrl, ctx.lensAddresses.utilsLens, vault.asset.address),
+    resolveUnitOfAccountPriceInfo(ctx.rpcUrl, ctx.lensAddresses.utilsLens, vault.unitOfAccount),
+  ])
+  vault = { ...vault, assetPriceInfo, unitOfAccountPriceInfo }
 
   return vault
 }
 
-export const fetchSecuritizeVault = async (vaultAddress: string): Promise<SecuritizeVault> => {
-  const { client: rpcClient, rpcUrl } = useRpcClient()
-  const { loadEulerConfig, isReady } = useEulerAddresses()
-  const { verifiedVaultAddresses } = useEulerLabels()
-
-  if (!isReady.value) {
-    loadEulerConfig()
-    await until(computed(() => isReady.value)).toBeTruthy()
-  }
-  const { eulerLensAddresses } = useEulerAddresses()
-
-  const client = rpcClient.value!
+export const fetchSecuritizeVault = async (
+  vaultAddress: string,
+  ctx: FetchVaultContext,
+): Promise<SecuritizeVault> => {
+  const client = getPublicClient(ctx.rpcUrl)
 
   const data = await client.readContract({
-    address: eulerLensAddresses.value!.utilsLens as Address,
+    address: ctx.lensAddresses.utilsLens as Address,
     abi: eulerUtilsLensABI,
     functionName: 'getVaultInfoERC4626',
     args: [vaultAddress as Address],
@@ -251,17 +246,15 @@ export const fetchSecuritizeVault = async (vaultAddress: string): Promise<Securi
     // supplyCapResolved may not exist on all vaults
   }
 
-  const assetPriceInfo = eulerLensAddresses.value?.utilsLens
-    ? await resolveAssetPriceInfo(
-        rpcUrl.value,
-        eulerLensAddresses.value.utilsLens,
-        data.asset as string,
-      )
-    : undefined
+  const assetPriceInfo = await resolveAssetPriceInfo(
+    ctx.rpcUrl,
+    ctx.lensAddresses.utilsLens,
+    data.asset as string,
+  )
 
   return {
     type: 'securitize',
-    verified: verifiedVaultAddresses.value.includes(vaultAddress),
+    verified: ctx.verifiedVaultAddresses.includes(vaultAddress),
     address: data.vault,
     name: data.vaultName,
     symbol: data.vaultSymbol,
@@ -291,22 +284,14 @@ export const fetchSecuritizeVault = async (vaultAddress: string): Promise<Securi
   } as SecuritizeVault
 }
 
-export const fetchEarnVault = async (vaultAddress: string): Promise<EarnVault> => {
-  const { client: rpcClient, rpcUrl } = useRpcClient()
-  const { earnVaults } = useEulerLabels()
-  const { loadEulerConfig, isReady } = useEulerAddresses()
-
-  if (!isReady.value) {
-    loadEulerConfig()
-    await until(computed(() => isReady.value)).toBeTruthy()
-  }
-
-  const { eulerLensAddresses } = useEulerAddresses()
-
-  const client = rpcClient.value!
+export const fetchEarnVault = async (
+  vaultAddress: string,
+  ctx: FetchVaultContext,
+): Promise<EarnVault> => {
+  const client = getPublicClient(ctx.rpcUrl)
 
   const data = await client.readContract({
-    address: eulerLensAddresses.value!.eulerEarnVaultLens as Address,
+    address: ctx.lensAddresses.eulerEarnVaultLens as Address,
     abi: eulerEarnVaultLensABI,
     functionName: 'getVaultInfoFull',
     args: [vaultAddress],
@@ -328,15 +313,17 @@ export const fetchEarnVault = async (vaultAddress: string): Promise<EarnVault> =
   const supplyAPYNumber = await calculateEarnVaultAPYFromExchangeRate(
     vaultAddress,
     data.vaultDecimals as bigint,
+    ctx.rpcUrl,
+    ctx.chainId,
   )
 
   const assetPriceInfo = await resolveAssetPriceInfo(
-    rpcUrl.value,
-    eulerLensAddresses.value!.utilsLens,
+    ctx.rpcUrl,
+    ctx.lensAddresses.utilsLens,
     data.asset as string,
   )
 
-  const verified = earnVaults.value.includes(vaultAddress)
+  const verified = ctx.earnVaultAddresses.includes(vaultAddress)
 
   return {
     verified,
@@ -382,32 +369,18 @@ export const fetchEarnVault = async (vaultAddress: string): Promise<EarnVault> =
 }
 
 export const fetchVaults = async function* (
+  ctx: FetchVaultContext,
   vaultAddresses?: string[],
 ): AsyncGenerator<
   VaultIteratorResult<Vault>,
   void,
   unknown
 > {
-  const { PYTH_HERMES_URL } = useEulerConfig()
-  const { client: rpcClient, rpcUrl } = useRpcClient()
-  const { eulerLensAddresses, eulerCoreAddresses, chainId } = useEulerAddresses()
-  const { verifiedVaultAddresses } = useEulerLabels()
-
-  const startChainId = chainId.value
-
-  await until(
-    computed(() => eulerLensAddresses.value?.vaultLens),
-  ).toBeTruthy()
-
-  if (!eulerLensAddresses.value?.vaultLens) {
-    throw new Error('Euler addresses not loaded yet')
-  }
-
-  const client = rpcClient.value!
+  const client = getPublicClient(ctx.rpcUrl)
 
   // Use provided addresses if available, otherwise fall back to verifiedVaultAddresses
   // (pre-categorization by caller is preferred to eliminate per-vault RPC calls)
-  const verifiedVaults = vaultAddresses || verifiedVaultAddresses.value
+  const verifiedVaults = vaultAddresses || ctx.verifiedVaultAddresses
   const batchSize = BATCH_SIZE_VAULT_FETCH
   const parallelBatches = BATCH_SIZE_PARALLEL_ROUNDS
 
@@ -420,7 +393,7 @@ export const fetchVaults = async function* (
   // when they get swept into refreshVaults().
   const processVaultResult = (raw: Record<string, unknown>, vaultAddress: string): Vault | undefined => {
     try {
-      return processRawVaultData(raw, vaultAddress, verifiedVaultAddresses.value)
+      return processRawVaultData(raw, vaultAddress, ctx.verifiedVaultAddresses)
     }
     catch (e) {
       logWarn('vault/processResult', e, { severity: 'error' })
@@ -432,7 +405,7 @@ export const fetchVaults = async function* (
   const fetchVaultIndividually = async (vaultAddress: string): Promise<Vault | undefined> => {
     try {
       const raw = await client.readContract({
-        address: eulerLensAddresses.value!.vaultLens as Address,
+        address: ctx.lensAddresses.vaultLens as Address,
         abi: eulerVaultLensABI,
         functionName: 'getVaultInfoFull',
         args: [vaultAddress],
@@ -440,7 +413,7 @@ export const fetchVaults = async function* (
       return processVaultResult(raw, vaultAddress)
     }
     catch (e) {
-      logWarn('vault/fetchIndividual', e, { severity: 'error' })
+      logConciseFetchError('vault/fetchIndividual', ctx.chainId, vaultAddress, e)
       return undefined
     }
   }
@@ -448,18 +421,18 @@ export const fetchVaults = async function* (
   // Helper to fetch a batch of vaults using EVC batchSimulation
   const fetchBatch = async (batchAddresses: string[]): Promise<Vault[]> => {
     // Use EVC batchSimulation if available for batched RPC calls
-    if (eulerCoreAddresses.value?.evc) {
+    if (ctx.coreAddresses?.evc) {
       const calls = batchAddresses.map(vaultAddress => ({
         functionName: 'getVaultInfoFull',
         args: [vaultAddress],
       }))
 
       const results = await batchLensCalls<Record<string, unknown>>(
-        eulerCoreAddresses.value.evc,
-        eulerLensAddresses.value!.vaultLens,
+        ctx.coreAddresses.evc,
+        ctx.lensAddresses.vaultLens,
         eulerVaultLensABI,
         calls,
-        rpcUrl.value,
+        ctx.rpcUrl,
       )
 
       const vaults: Vault[] = []
@@ -513,7 +486,7 @@ export const fetchVaults = async function* (
 
   // Process batches in parallel rounds
   for (let round = 0; round < parallelRounds; round++) {
-    if (chainId.value !== startChainId) {
+    if (ctx.isAborted?.()) {
       return
     }
 
@@ -530,13 +503,13 @@ export const fetchVaults = async function* (
     // Fetch all batches in this round in parallel
     const roundResults = await Promise.all(roundBatches.map(batch => fetchBatch(batch)))
 
-    if (chainId.value !== startChainId) return
+    if (ctx.isAborted?.()) return
 
     let validVaults = roundResults.flat()
 
     // Re-fetch Pyth-powered vaults with simulation to get fresh prices
     // Pyth prices are only valid for ~2 minutes after on-chain update
-    if (eulerCoreAddresses.value?.evc && PYTH_HERMES_URL) {
+    if (ctx.coreAddresses?.evc && ctx.pythHermesUrl) {
       const pythVaultEntries = validVaults
         .map((vault) => {
           const feeds = collectPythFeedIds(vault.oracleDetailedInfo)
@@ -547,21 +520,21 @@ export const fetchVaults = async function* (
       if (pythVaultEntries.length > 0) {
         const refreshedMap = await executeBatchLensWithPythSimulation<Record<string, unknown>>(
           pythVaultEntries,
-          eulerLensAddresses.value!.vaultLens as Address,
+          ctx.lensAddresses.vaultLens as Address,
           eulerVaultLensABI,
           'getVaultInfoFull',
-          eulerCoreAddresses.value!.evc,
-          rpcUrl.value,
-          PYTH_HERMES_URL,
+          ctx.coreAddresses.evc,
+          ctx.rpcUrl,
+          ctx.pythHermesUrl,
         )
 
-        if (chainId.value !== startChainId) return
+        if (ctx.isAborted?.()) return
 
         validVaults = validVaults.map((vault) => {
           const raw = refreshedMap.get(vault.address)
           if (!raw) return vault
           try {
-            return processRawVaultData(raw, vault.address, verifiedVaultAddresses.value)
+            return processRawVaultData(raw, vault.address, ctx.verifiedVaultAddresses)
           }
           catch (e) {
             logWarn('vault/pythRefresh', e, { severity: 'error' })
@@ -572,20 +545,18 @@ export const fetchVaults = async function* (
     }
 
     // Populate assetPriceInfo and unitOfAccountPriceInfo for USD conversion
-    if (eulerLensAddresses.value?.utilsLens) {
-      const utilsLensAddress = eulerLensAddresses.value.utilsLens
-      validVaults = await Promise.all(
-        validVaults.map(async (vault) => {
-          const [assetPriceInfo, unitOfAccountPriceInfo] = await Promise.all([
-            resolveAssetPriceInfo(rpcUrl.value, utilsLensAddress, vault.asset.address),
-            resolveUnitOfAccountPriceInfo(rpcUrl.value, utilsLensAddress, vault.unitOfAccount),
-          ])
-          return { ...vault, assetPriceInfo, unitOfAccountPriceInfo }
-        }),
-      )
+    const utilsLensAddress = ctx.lensAddresses.utilsLens
+    validVaults = await Promise.all(
+      validVaults.map(async (vault) => {
+        const [assetPriceInfo, unitOfAccountPriceInfo] = await Promise.all([
+          resolveAssetPriceInfo(ctx.rpcUrl, utilsLensAddress, vault.asset.address),
+          resolveUnitOfAccountPriceInfo(ctx.rpcUrl, utilsLensAddress, vault.unitOfAccount),
+        ])
+        return { ...vault, assetPriceInfo, unitOfAccountPriceInfo }
+      }),
+    )
 
-      if (chainId.value !== startChainId) return
-    }
+    if (ctx.isAborted?.()) return
 
     const isFinished = (round + 1) * parallelBatches * batchSize >= verifiedVaults.length
 
@@ -596,40 +567,20 @@ export const fetchVaults = async function* (
   }
 }
 
-export const fetchEarnVaults = async function* (vaultAddresses?: string[]): AsyncGenerator<
+export const fetchEarnVaults = async function* (
+  ctx: FetchVaultContext,
+  vaultAddresses?: string[],
+): AsyncGenerator<
   VaultIteratorResult<EarnVault>,
   void,
   unknown
 > {
-  const { client: rpcClient, rpcUrl } = useRpcClient()
-  const { eulerLensAddresses, chainId } = useEulerAddresses()
-  const { earnVaults, isLoading } = useEulerLabels()
+  const client = getPublicClient(ctx.rpcUrl)
 
-  const startChainId = chainId.value
-
-  await until(
-    computed(() => {
-      return (
-        eulerLensAddresses.value?.eulerEarnVaultLens
-        && eulerLensAddresses.value?.utilsLens
-        && !isLoading.value
-      )
-    }),
-  ).toBeTruthy()
-
-  if (
-    !eulerLensAddresses.value?.eulerEarnVaultLens
-    || !eulerLensAddresses.value?.utilsLens
-  ) {
-    throw new Error('Euler Earn addresses not loaded yet')
-  }
-
-  const client = rpcClient.value!
-
-  const verifiedVaults = vaultAddresses || earnVaults.value
+  const verifiedVaults = vaultAddresses || ctx.earnVaultAddresses
 
   // Start block prefetch in parallel - will be awaited when needed for APY calculation
-  const blockCachePromise = fetchBlockDataForAPY()
+  const blockCachePromise = fetchBlockDataForAPY(ctx.rpcUrl, ctx.chainId)
 
   // Helper to fetch a single vault (lens + price only, APY calculated after)
   type PartialEarnVault = Omit<EarnVault, 'interestRateInfo'> & { decimals: bigint }
@@ -637,7 +588,7 @@ export const fetchEarnVaults = async function* (vaultAddresses?: string[]): Asyn
   const fetchVaultData = async (vaultAddress: string): Promise<PartialEarnVault | undefined> => {
     try {
       const data = await client.readContract({
-        address: eulerLensAddresses.value!.eulerEarnVaultLens as Address,
+        address: ctx.lensAddresses.eulerEarnVaultLens as Address,
         abi: eulerEarnVaultLensABI,
         functionName: 'getVaultInfoFull',
         args: [vaultAddress],
@@ -657,13 +608,13 @@ export const fetchEarnVaults = async function* (vaultAddresses?: string[]): Asyn
       })
 
       const assetPriceInfo = await resolveAssetPriceInfo(
-        rpcUrl.value,
-        eulerLensAddresses.value!.utilsLens,
+        ctx.rpcUrl,
+        ctx.lensAddresses.utilsLens,
         data.asset as string,
       )
 
       return {
-        verified: earnVaults.value.includes(vaultAddress),
+        verified: ctx.earnVaultAddresses.includes(vaultAddress),
         type: 'earn',
         address: data.vault,
         name: data.vaultName,
@@ -698,7 +649,7 @@ export const fetchEarnVaults = async function* (vaultAddresses?: string[]): Asyn
       } as PartialEarnVault
     }
     catch (e) {
-      logWarn('vault/fetchEarnVault', e, { severity: 'error' })
+      logConciseFetchError('vault/fetchEarnVault', ctx.chainId, vaultAddress, e)
       return undefined
     }
   }
@@ -712,7 +663,7 @@ export const fetchEarnVaults = async function* (vaultAddresses?: string[]): Asyn
     Promise.all(allVaultDataPromises),
   ])
 
-  if (chainId.value !== startChainId) return
+  if (ctx.isAborted?.()) return
 
   // Calculate APY for all vaults (using cached block data)
   const vaultsWithAPY = await Promise.all(
@@ -720,7 +671,7 @@ export const fetchEarnVaults = async function* (vaultAddresses?: string[]): Asyn
       .filter((v): v is PartialEarnVault => v !== undefined)
       .map(async (vaultData) => {
         const supplyAPYNumber = blockCache
-          ? await calculateEarnVaultAPYWithCache(vaultData.address, vaultData.decimals, blockCache)
+          ? await calculateEarnVaultAPYWithCache(vaultData.address, vaultData.decimals, blockCache, ctx.rpcUrl)
           : 0
         return {
           ...vaultData,
@@ -735,7 +686,7 @@ export const fetchEarnVaults = async function* (vaultAddresses?: string[]): Asyn
       }),
   )
 
-  if (chainId.value !== startChainId) return
+  if (ctx.isAborted?.()) return
 
   yield {
     vaults: vaultsWithAPY,

--- a/entities/vault/index.ts
+++ b/entities/vault/index.ts
@@ -38,8 +38,16 @@ export { clearPriceCaches } from './pricing'
 export {
   fetchEscrowVault,
   fetchEscrowAddresses,
-  fetchEscrowVaults,
 } from './escrow-fetcher'
+
+// Shared context for pure fetchers
+export type { FetchVaultContext } from './fetcher'
+
+// Universal chain snapshot loader (used by /api/vaults handler and client hydration).
+export { loadChainSnapshot } from './loader'
+export type { ChainVaultsSnapshot, LoadSnapshotInput } from './loader'
+export { serialiseSnapshot, deserialiseSnapshot } from './loader-serde'
+export type { SerialisedSnapshot } from './loader-serde'
 
 // LTV ramp calculations
 export {

--- a/entities/vault/loader-serde.ts
+++ b/entities/vault/loader-serde.ts
@@ -1,23 +1,37 @@
 /**
  * Bigint-safe JSON wire format for ChainVaultsSnapshot.
  *
- * JSON cannot serialise bigint natively, so we walk the object tree and
- * replace every bigint with a tagged string (`__bi:<decimal>`). The decode
- * walker reverses it. No schema knowledge required — works for any nested
- * shape, including arrays and plain objects.
+ * JSON cannot serialise bigint natively. The encoder walks the object tree
+ * and replaces every bigint with a single-key object `{ __bi: "<decimal>" }`;
+ * the decoder walks the mirror structure and reverses it. No schema
+ * knowledge required — works for any nested shape, including arrays and
+ * plain objects.
  *
- * Do not apply to user-supplied content. These walkers assume trusted
- * server-origin data.
+ * The object-wrapper form is important vs a prefix-on-a-string: vault
+ * fields like `name()` and `symbol()` come from on-chain data and are
+ * adversary-controlled. If the decoder ran `BigInt(s.slice(5))` on any
+ * string starting with `__bi:`, a malicious vault could poison the
+ * decoded snapshot. An object wrapper with exactly one numeric-string
+ * key is not producible as an on-chain string, so only genuine encoder
+ * output trips the decoder.
  */
 
 import type { ChainVaultsSnapshot } from './loader'
 
-const BIGINT_PREFIX = '__bi:'
-
 type AnyRecord = Record<string, unknown>
 
+interface BigintTag { __bi: string }
+
+const isBigintTag = (v: unknown): v is BigintTag => {
+  if (v === null || typeof v !== 'object' || Array.isArray(v)) return false
+  const keys = Object.keys(v)
+  if (keys.length !== 1 || keys[0] !== '__bi') return false
+  const payload = (v as AnyRecord).__bi
+  return typeof payload === 'string' && /^-?\d+$/.test(payload)
+}
+
 const encodeValue = (v: unknown): unknown => {
-  if (typeof v === 'bigint') return `${BIGINT_PREFIX}${v.toString()}`
+  if (typeof v === 'bigint') return { __bi: v.toString() }
   if (Array.isArray(v)) return v.map(encodeValue)
   if (v !== null && typeof v === 'object') {
     const out: AnyRecord = {}
@@ -30,9 +44,7 @@ const encodeValue = (v: unknown): unknown => {
 }
 
 const decodeValue = (v: unknown): unknown => {
-  if (typeof v === 'string' && v.startsWith(BIGINT_PREFIX)) {
-    return BigInt(v.slice(BIGINT_PREFIX.length))
-  }
+  if (isBigintTag(v)) return BigInt(v.__bi)
   if (Array.isArray(v)) return v.map(decodeValue)
   if (v !== null && typeof v === 'object') {
     const out: AnyRecord = {}
@@ -44,7 +56,7 @@ const decodeValue = (v: unknown): unknown => {
   return v
 }
 
-/** Opaque wire type. Structurally it's ChainVaultsSnapshot with bigints replaced by tagged strings. */
+/** Opaque wire type. Structurally it's ChainVaultsSnapshot with bigints replaced by `{ __bi: "<decimal>" }` tags. */
 export type SerialisedSnapshot = Record<string, unknown>
 
 export const serialiseSnapshot = (snap: ChainVaultsSnapshot): SerialisedSnapshot =>

--- a/entities/vault/loader-serde.ts
+++ b/entities/vault/loader-serde.ts
@@ -1,0 +1,54 @@
+/**
+ * Bigint-safe JSON wire format for ChainVaultsSnapshot.
+ *
+ * JSON cannot serialise bigint natively, so we walk the object tree and
+ * replace every bigint with a tagged string (`__bi:<decimal>`). The decode
+ * walker reverses it. No schema knowledge required — works for any nested
+ * shape, including arrays and plain objects.
+ *
+ * Do not apply to user-supplied content. These walkers assume trusted
+ * server-origin data.
+ */
+
+import type { ChainVaultsSnapshot } from './loader'
+
+const BIGINT_PREFIX = '__bi:'
+
+type AnyRecord = Record<string, unknown>
+
+const encodeValue = (v: unknown): unknown => {
+  if (typeof v === 'bigint') return `${BIGINT_PREFIX}${v.toString()}`
+  if (Array.isArray(v)) return v.map(encodeValue)
+  if (v !== null && typeof v === 'object') {
+    const out: AnyRecord = {}
+    for (const [k, val] of Object.entries(v as AnyRecord)) {
+      out[k] = encodeValue(val)
+    }
+    return out
+  }
+  return v
+}
+
+const decodeValue = (v: unknown): unknown => {
+  if (typeof v === 'string' && v.startsWith(BIGINT_PREFIX)) {
+    return BigInt(v.slice(BIGINT_PREFIX.length))
+  }
+  if (Array.isArray(v)) return v.map(decodeValue)
+  if (v !== null && typeof v === 'object') {
+    const out: AnyRecord = {}
+    for (const [k, val] of Object.entries(v as AnyRecord)) {
+      out[k] = decodeValue(val)
+    }
+    return out
+  }
+  return v
+}
+
+/** Opaque wire type. Structurally it's ChainVaultsSnapshot with bigints replaced by tagged strings. */
+export type SerialisedSnapshot = Record<string, unknown>
+
+export const serialiseSnapshot = (snap: ChainVaultsSnapshot): SerialisedSnapshot =>
+  encodeValue(snap) as SerialisedSnapshot
+
+export const deserialiseSnapshot = (wire: SerialisedSnapshot): ChainVaultsSnapshot =>
+  decodeValue(wire) as ChainVaultsSnapshot

--- a/entities/vault/loader.ts
+++ b/entities/vault/loader.ts
@@ -78,13 +78,31 @@ export const loadChainSnapshot = async (input: LoadSnapshotInput): Promise<Chain
     ? fetchEscrowAddresses(ctx.rpcUrl, peripheryAddresses.escrowedCollateralPerspective, ctx.chainId)
     : Promise.resolve<string[]>([])
 
-  // Phase 2: all four in parallel.
-  const [evkVaults, earnVaults, securitizeSettled, escrowAddresses] = await Promise.all([
-    collectVaults(fetchVaults(ctx, evkAddresses)),
-    collectEarnVaults(fetchEarnVaults(ctx, explorableEarn)),
+  // Phase 2: all four in parallel. Each arm is `allSettled` so one RPC
+  // hiccup on e.g. the escrow-addresses read doesn't kill the whole
+  // snapshot — a partial snapshot serves the client better than none.
+  const [evkSettled, earnSettled, securitizeSettled, escrowAddressesSettled] = await Promise.all([
+    collectVaults(fetchVaults(ctx, evkAddresses)).then(
+      v => ({ ok: true as const, value: v }),
+      err => ({ ok: false as const, err }),
+    ),
+    collectEarnVaults(fetchEarnVaults(ctx, explorableEarn)).then(
+      v => ({ ok: true as const, value: v }),
+      err => ({ ok: false as const, err }),
+    ),
     Promise.allSettled(securitizeAddresses.map(a => fetchSecuritizeVault(a, ctx))),
-    escrowAddressesPromise,
+    escrowAddressesPromise.then(
+      v => ({ ok: true as const, value: v }),
+      err => ({ ok: false as const, err }),
+    ),
   ])
+
+  const evkVaults: Vault[] = evkSettled.ok ? evkSettled.value : []
+  if (!evkSettled.ok) logWarn('loader/evk', evkSettled.err)
+  const earnVaults: EarnVault[] = earnSettled.ok ? earnSettled.value : []
+  if (!earnSettled.ok) logWarn('loader/earn', earnSettled.err)
+  const escrowAddresses: string[] = escrowAddressesSettled.ok ? escrowAddressesSettled.value : []
+  if (!escrowAddressesSettled.ok) logWarn('loader/escrowAddresses', escrowAddressesSettled.err)
 
   const securitizeVaults: SecuritizeVault[] = []
   securitizeSettled.forEach((r, i) => {

--- a/entities/vault/loader.ts
+++ b/entities/vault/loader.ts
@@ -1,0 +1,154 @@
+import { getAddress } from 'viem'
+import type { Vault, EarnVault, SecuritizeVault } from './types'
+import { type FetchVaultContext, fetchVaults, fetchEarnVaults, fetchSecuritizeVault } from './fetcher'
+import { fetchEscrowAddresses, fetchEscrowVault } from './escrow-fetcher'
+import { logWarn } from '~/utils/errorHandling'
+
+/**
+ * A full snapshot of the public vault set for one chain. Everything here is
+ * wallet-independent — only depends on chainId × vault addresses. Per-user
+ * data (balances, debts, collateral flags) is NOT included; the client
+ * fetches it separately after wallet connect.
+ */
+export interface ChainVaultsSnapshot {
+  chainId: number
+  fetchedAt: number
+  /** EVK-family vaults (non-escrow). */
+  evkVaults: Vault[]
+  earnVaults: EarnVault[]
+  securitizeVaults: SecuritizeVault[]
+  /** All escrow vault addresses known to the chain (from escrowedCollateralPerspective). */
+  escrowAddresses: string[]
+  /** Info for the subset of escrow vaults referenced as collateral / strategy by evkVaults or earnVaults. */
+  escrowVaults: Vault[]
+}
+
+export interface LoadSnapshotInput {
+  chainId: number
+  ctx: FetchVaultContext
+  peripheryAddresses: {
+    escrowedCollateralPerspective?: string
+    securitizeFactory?: string
+  }
+  /**
+   * Lowercase vault address → factory address, for splitting verified vault
+   * addresses into EVK vs Securitize. Client: from /api/vault-factories proxy.
+   * Server: from direct subgraph query.
+   */
+  factories: Map<string, string>
+  /** Optional UI-only filters (honoured by the client path, bypassed by server for completeness). */
+  nonExplorableVault?: (addr: string) => boolean
+  nonExplorableEarn?: (addr: string) => boolean
+}
+
+/**
+ * Runs the same 3-phase load the client uses in useVaults.loadVaults():
+ *   1. split EVK vs Securitize by factory
+ *   2. fetch EVK + Earn + Securitize + escrow-address-list in parallel
+ *   3. fetch info for the escrow subset referenced by (1)
+ *
+ * Generators are collected into arrays so the caller gets one snapshot.
+ * Cancellation is honoured via ctx.isAborted if the caller supplies one
+ * (client-side); server callers pass no isAborted and run the full fetch.
+ */
+export const loadChainSnapshot = async (input: LoadSnapshotInput): Promise<ChainVaultsSnapshot> => {
+  const { chainId, ctx, peripheryAddresses, factories } = input
+
+  const explorableVault = ctx.verifiedVaultAddresses.filter(
+    addr => !input.nonExplorableVault?.(addr),
+  )
+  const explorableEarn = ctx.earnVaultAddresses.filter(
+    addr => !input.nonExplorableEarn?.(addr),
+  )
+
+  const securitizeFactory = peripheryAddresses.securitizeFactory?.toLowerCase()
+  const evkAddresses: string[] = []
+  const securitizeAddresses: string[] = []
+  for (const addr of explorableVault) {
+    const factory = factories.get(addr.toLowerCase())
+    if (securitizeFactory && factory?.toLowerCase() === securitizeFactory) {
+      securitizeAddresses.push(addr)
+    }
+    else {
+      evkAddresses.push(addr)
+    }
+  }
+
+  const escrowAddressesPromise = peripheryAddresses.escrowedCollateralPerspective
+    ? fetchEscrowAddresses(ctx.rpcUrl, peripheryAddresses.escrowedCollateralPerspective, ctx.chainId)
+    : Promise.resolve<string[]>([])
+
+  // Phase 2: all four in parallel.
+  const [evkVaults, earnVaults, securitizeSettled, escrowAddresses] = await Promise.all([
+    collectVaults(fetchVaults(ctx, evkAddresses)),
+    collectEarnVaults(fetchEarnVaults(ctx, explorableEarn)),
+    Promise.allSettled(securitizeAddresses.map(a => fetchSecuritizeVault(a, ctx))),
+    escrowAddressesPromise,
+  ])
+
+  const securitizeVaults: SecuritizeVault[] = []
+  securitizeSettled.forEach((r, i) => {
+    if (r.status === 'fulfilled') securitizeVaults.push(r.value)
+    else logWarn(`loader/securitize/${securitizeAddresses[i]}`, r.reason)
+  })
+
+  // Phase 3: derive the escrow subset referenced by EVK collateral LTVs and
+  // Earn strategies, and fetch their full info.
+  const escrowSet = new Set(escrowAddresses.map(a => a.toLowerCase()))
+  const needed = new Set<string>()
+  for (const vault of evkVaults) {
+    for (const ltv of vault.collateralLTVs) {
+      if (ltv.borrowLTV > 0n && escrowSet.has(ltv.collateral.toLowerCase())) {
+        needed.add(getAddress(ltv.collateral))
+      }
+    }
+  }
+  for (const earn of earnVaults) {
+    for (const strategy of earn.strategies) {
+      if (escrowSet.has(strategy.strategy.toLowerCase())) {
+        needed.add(getAddress(strategy.strategy))
+      }
+    }
+  }
+
+  const escrowSettled = await Promise.allSettled(
+    [...needed].map(a => fetchEscrowVault(a, ctx)),
+  )
+  const escrowVaults: Vault[] = []
+  escrowSettled.forEach((r, i) => {
+    if (r.status === 'fulfilled') escrowVaults.push(r.value)
+    else logWarn(`loader/escrow/${[...needed][i]}`, r.reason)
+  })
+
+  return {
+    chainId,
+    fetchedAt: Date.now(),
+    evkVaults,
+    earnVaults,
+    securitizeVaults,
+    escrowAddresses,
+    escrowVaults,
+  }
+}
+
+const collectVaults = async (
+  gen: AsyncGenerator<{ vaults: Vault[], isFinished: boolean }>,
+): Promise<Vault[]> => {
+  const out: Vault[] = []
+  for await (const batch of gen) {
+    out.push(...batch.vaults)
+    if (batch.isFinished) break
+  }
+  return out
+}
+
+const collectEarnVaults = async (
+  gen: AsyncGenerator<{ vaults: EarnVault[], isFinished: boolean }>,
+): Promise<EarnVault[]> => {
+  const out: EarnVault[] = []
+  for await (const batch of gen) {
+    out.push(...batch.vaults)
+    if (batch.isFinished) break
+  }
+  return out
+}

--- a/entities/vault/log-fetch-error.ts
+++ b/entities/vault/log-fetch-error.ts
@@ -1,0 +1,29 @@
+import { logWarn } from '~/utils/errorHandling'
+
+/**
+ * Shared concise-log helper for vault fetchers. Detects the two classes of
+ * "expected operational noise" and prints a one-line warn instead of the
+ * viem error's full nested-cause stack trace (which easily fills 30+ lines
+ * in server dev logs when warm-cache runs across many chains).
+ *
+ * Expected noise:
+ *   - Contract revert: lens called against an address that isn't a proper
+ *     vault on the target chain. Stale labels entries produce these.
+ *   - Network unreachable: DNS failure / fetch failed against the RPC URL.
+ *     Usually a bad env var or upstream outage; same handling either way.
+ *
+ * Everything else (ABI decode errors, unexpected exceptions) still logs at
+ * error severity with the full error object so genuine issues remain loud.
+ */
+export const logConciseFetchError = (context: string, chainId: number, subject: string, err: unknown): void => {
+  const msg = err instanceof Error ? err.message : String(err)
+  if (msg.includes('reverted') || msg.includes('Execution reverted')) {
+    logWarn(context, `chain=${chainId} ${subject} reverted (likely not deployed on this chain)`)
+    return
+  }
+  if (msg.includes('HTTP request failed') || msg.includes('fetch failed') || msg.includes('ENOTFOUND') || msg.includes('ECONNREFUSED') || msg.includes('ETIMEDOUT')) {
+    logWarn(context, `chain=${chainId} RPC unreachable for ${subject}`)
+    return
+  }
+  logWarn(context, err, { severity: 'error' })
+}

--- a/pages/borrow/[collateral]/[borrow]/index.vue
+++ b/pages/borrow/[collateral]/[borrow]/index.vue
@@ -22,6 +22,8 @@ const reviewBorrowLabel = 'Review Borrow'
 const reviewMultiplyLabel = 'Review Multiply'
 const { getBorrowVaultPair, updateVault } = useVaults()
 const { address, isConnected } = useAccount()
+// Page uses SwapTokenSelector — opt into full wallet-token balance fetch while mounted.
+useFullBalances()
 const { refreshAllPositions: _refreshAllPositions, depositPositions } = useEulerAccount()
 const { getSupplyRewardApy, getBorrowRewardApy } = useRewardsApy()
 const { withIntrinsicBorrowApy, withIntrinsicSupplyApy } = useIntrinsicApy()

--- a/pages/borrow/index.vue
+++ b/pages/borrow/index.vue
@@ -9,6 +9,7 @@ import { getEulerLabelEntityLogo } from '~/entities/euler/labels'
 import { useCustomFilters } from '~/composables/useCustomFilters'
 import { useVaultSearch } from '~/composables/useVaultSearch'
 import { isOpDisabled, OP_BORROW, OP_DEPOSIT, OP_TRANSFER } from '~/utils/vault-hooks'
+import { DEBOUNCE_LIST_PRICE_FETCH_MS } from '~/entities/tuning-constants'
 
 const { withIntrinsicBorrowApy, withIntrinsicSupplyApy } = useIntrinsicApy()
 const { getSupplyRewardApy, getBorrowRewardApy, getLoopingRewardApy } = useRewardsApy()
@@ -108,8 +109,12 @@ const pairBorrowedUsd = ref<Map<string, number>>(new Map())
 // Helper to create a unique key for a borrow pair
 const getPairKey = (pair: AnyBorrowVaultPair) => `${pair.collateral.address}-${pair.borrow.address}`
 
-// Fetch USD values for all borrow pairs
-watchEffect(async () => {
+// Fetch USD values for all borrow pairs. Debounced to collapse the
+// bursts of registry updates streamed during loadVaults's RPC refresh
+// (each batch causes borrowList to re-derive) into a single pass —
+// this is the most expensive price-fetch watcher in the app because
+// pair count is combinatorial in collaterals × borrow vaults.
+const fetchBorrowPrices = useDebounceFn(async () => {
   const pairs = borrowList.value
   if (!pairs.length) {
     isPricesReady.value = true
@@ -136,6 +141,26 @@ watchEffect(async () => {
   finally {
     isPricesReady.value = true
   }
+}, DEBOUNCE_LIST_PRICE_FETCH_MS)
+
+// Pause price fetches while the page is in keep-alive but not visible. The
+// borrow page is included in app.vue's keepalive list, so it keeps running
+// watchEffects when the user navigates away. Deferring the refetch until
+// the user returns removes a major source of main-thread contention
+// during chain switches, which otherwise fan out to every keep-alive
+// page's price watchEffect at once.
+const isActive = ref(true)
+onActivated(() => {
+  isActive.value = true
+})
+onDeactivated(() => {
+  isActive.value = false
+})
+
+watchEffect(() => {
+  void borrowList.value
+  if (!isActive.value) return
+  fetchBorrowPrices()
 })
 
 const getPairBorrowApy = (pair: AnyBorrowVaultPair): number => {

--- a/pages/earn/index.vue
+++ b/pages/earn/index.vue
@@ -9,6 +9,7 @@ import { getProductByVault, applyVaultOverrides, getEntitiesByEarnVault, isVault
 import { getEulerLabelEntityLogo } from '~/entities/euler/labels'
 import { useCustomFilters } from '~/composables/useCustomFilters'
 import { useVaultSearch } from '~/composables/useVaultSearch'
+import { DEBOUNCE_LIST_PRICE_FETCH_MS } from '~/entities/tuning-constants'
 
 defineOptions({
   name: 'EarnPage',
@@ -53,8 +54,9 @@ useUrlQuerySync([
 const vaultTotalSupplyUsd = ref<Map<string, number>>(new Map())
 const vaultLiquidityUsd = ref<Map<string, number>>(new Map())
 
-// Fetch USD values for all earn vaults
-watchEffect(async () => {
+// Fetch USD values for all earn vaults. Debounced to collapse the bursts
+// of registry updates streamed during loadVaults's RPC refresh.
+const fetchEarnPrices = useDebounceFn(async () => {
   const vaults = list.value
   if (!vaults.length) {
     isPricesReady.value = true
@@ -80,6 +82,22 @@ watchEffect(async () => {
   finally {
     isPricesReady.value = true
   }
+}, DEBOUNCE_LIST_PRICE_FETCH_MS)
+
+// Pause price fetches while the page is in keep-alive but not visible. See the
+// borrow-page equivalent for the full rationale.
+const isActive = ref(true)
+onActivated(() => {
+  isActive.value = true
+})
+onDeactivated(() => {
+  isActive.value = false
+})
+
+watchEffect(() => {
+  void list.value
+  if (!isActive.value) return
+  fetchEarnPrices()
 })
 
 const {

--- a/pages/lend/[vault]/[subAccount]/swap.vue
+++ b/pages/lend/[vault]/[subAccount]/swap.vue
@@ -150,7 +150,7 @@ const loadVaults = async () => {
 
     const isFromSecuritize = await isSecuritizeVault(baseAddress)
     if (isFromSecuritize) {
-      fromVault.value = await fetchSecuritizeVault(baseAddress)
+      fromVault.value = await fetchSecuritizeVault(baseAddress, buildFetchContext())
     }
     else {
       fromVault.value = await getVault(baseAddress)

--- a/pages/lend/[vault]/[subAccount]/withdraw.vue
+++ b/pages/lend/[vault]/[subAccount]/withdraw.vue
@@ -263,7 +263,7 @@ const load = async () => {
     // Check if securitize vault first
     const isSecuritize = await isSecuritizeVault(vaultAddress)
     if (isSecuritize) {
-      vault.value = await fetchSecuritizeVault(vaultAddress)
+      vault.value = await fetchSecuritizeVault(vaultAddress, buildFetchContext())
       estimateSupplyAPY.value = 0n // Securitize vaults don't have interest rate
     }
     else {

--- a/pages/lend/[vault]/[subAccount]/withdraw.vue
+++ b/pages/lend/[vault]/[subAccount]/withdraw.vue
@@ -32,6 +32,8 @@ const router = useRouter()
 const route = useRoute()
 const modal = useModal()
 const { error } = useToast()
+// Page uses SwapTokenSelector — opt into full wallet-token balance fetch while mounted.
+useFullBalances()
 const { buildWithdrawPlan, buildRedeemPlan, buildWithdrawAndSwapPlan, buildRedeemAndSwapPlan, executeTxPlan } = useEulerOperations()
 const { getVault, getSecuritizeVault: _getSecuritizeVault, getEscrowVault: _getEscrowVault } = useVaults()
 const { isConnected, address } = useAccount()

--- a/pages/lend/[vault]/index.vue
+++ b/pages/lend/[vault]/index.vue
@@ -64,6 +64,8 @@ const route = useRoute()
 const modal = useModal()
 const { error } = useToast()
 const reviewSupplyLabel = 'Review Supply'
+// Page uses SwapTokenSelector — opt into full wallet-token balance fetch while mounted.
+useFullBalances()
 const { buildSupplyPlan, buildSwapAndSupplyPlan, executeTxPlan } = useEulerOperations()
 const { getVault, getSecuritizeVault, getEscrowVault, updateVault, isEscrowLoadedOnce } = useVaults()
 const { get: registryGet, getVault: _registryGetVault, isKnownEscrowAddress } = useVaultRegistry()

--- a/pages/lend/index.vue
+++ b/pages/lend/index.vue
@@ -12,6 +12,7 @@ import { useCustomFilters } from '~/composables/useCustomFilters'
 import { useVaultSearch } from '~/composables/useVaultSearch'
 import { nanoToValue } from '~/utils/crypto-utils'
 import { isOpDisabled, OP_DEPOSIT } from '~/utils/vault-hooks'
+import { DEBOUNCE_LIST_PRICE_FETCH_MS } from '~/entities/tuning-constants'
 
 defineOptions({
   name: 'LendPage',
@@ -115,11 +116,12 @@ const borrowableVaults = computed(() => {
   )
 })
 
-// Fetch USD values for all borrowable vaults
-// Reading rewardsVersion.value establishes a reactive dependency so this
-// re-runs when reward data loads asynchronously (fixes custom filter staleness).
-watchEffect(async () => {
-  const _rv = rewardsVersion.value
+// Fetch USD values for all borrowable vaults. Debounced to collapse the
+// bursts of registry updates streamed during loadVaults's RPC refresh
+// (each batch causes borrowableVaults to re-derive) into a single
+// price-fetch cycle. Reading rewardsVersion.value establishes a reactive
+// dependency so this also re-runs when reward data loads asynchronously.
+const fetchLendPrices = useDebounceFn(async () => {
   const vaults = borrowableVaults.value
   if (!vaults.length) {
     isPricesReady.value = true
@@ -153,6 +155,27 @@ watchEffect(async () => {
   finally {
     isPricesReady.value = true
   }
+}, DEBOUNCE_LIST_PRICE_FETCH_MS)
+
+// Pause price fetches while the page is in keep-alive but not visible.
+// See the borrow-page equivalent for the full rationale — avoiding a
+// bulk refetch while a hidden page's data changes.
+const isActive = ref(true)
+onActivated(() => {
+  isActive.value = true
+})
+onDeactivated(() => {
+  isActive.value = false
+})
+
+watchEffect(() => {
+  // Touch deps so watchEffect re-registers on change, then delegate to the
+  // debounced fetcher. Values are re-read inside fetchLendPrices at execution
+  // time to avoid closing over stale references.
+  void rewardsVersion.value
+  void borrowableVaults.value
+  if (!isActive.value) return
+  fetchLendPrices()
 })
 
 const marketOptions = computed(() => {

--- a/pages/position/[number]/repay.vue
+++ b/pages/position/[number]/repay.vue
@@ -24,6 +24,8 @@ const _router = useRouter()
 const modal = useModal()
 const { isConnected, address } = useAccount()
 const { isSpyMode } = useSpyMode()
+// Page uses SwapTokenSelector — opt into full wallet-token balance fetch while mounted.
+useFullBalances()
 const positionIndex = usePositionIndex()
 const { isPositionsLoading, isPositionsLoaded, isDepositsLoaded, refreshAllPositions: _refreshAllPositions, getPositionBySubAccountIndex } = useEulerAccount()
 const { getSupplyRewardApy, getBorrowRewardApy } = useRewardsApy()

--- a/pages/position/[number]/supply.vue
+++ b/pages/position/[number]/supply.vue
@@ -21,6 +21,8 @@ const { isSpyMode } = useSpyMode()
 const { fetchSingleBalance } = useWallets()
 const { buildSupplyPlan, buildSwapAndSupplyPlan } = useEulerOperations()
 const { chainId } = useEulerAddresses()
+// Page uses SwapTokenSelector — opt into full wallet-token balance fetch while mounted.
+useFullBalances()
 
 // Supply-specific state
 const balance = ref(0n)

--- a/pages/position/[number]/withdraw.vue
+++ b/pages/position/[number]/withdraw.vue
@@ -22,6 +22,8 @@ const { address } = useAccount()
 const { buildWithdrawPlan, buildWithdrawAndSwapPlan } = useEulerOperations()
 const { refreshAllPositions } = useEulerAccount()
 const { eulerLensAddresses } = useEulerAddresses()
+// Page uses SwapTokenSelector — opt into full wallet-token balance fetch while mounted.
+useFullBalances()
 
 // Withdraw-specific state
 const selectedOutputAsset = ref<VaultAsset | undefined>()

--- a/server/api/vault-factories.post.ts
+++ b/server/api/vault-factories.post.ts
@@ -1,12 +1,10 @@
 import { createError, readBody } from 'h3'
 import { isAddress } from 'viem'
 import { createRateLimiter } from '~/server/utils/rate-limit'
-import { createTtlCache } from '~/server/utils/cache'
-import { getEnabledChainIds, getSubgraphUris } from '~/utils/chain-env'
+import { getEnabledChainIds } from '~/utils/chain-env'
 import { logWarn } from '~/server/utils/log'
+import { getVaultFactories } from '~/server/utils/vault-factories-store'
 
-const TIMEOUT_MS = 10_000
-const CACHE_TTL_MS = 24 * 60 * 60 * 1000
 const MAX_ADDRESSES_PER_REQUEST = 1000
 
 const rateLimiter = createRateLimiter({
@@ -14,62 +12,6 @@ const rateLimiter = createRateLimiter({
   windowMs: 60_000,
   label: 'vault-factories',
 })
-
-// Factory address per `${chainId}:${lowercaseVaultAddress}`.
-// Factories are immutable per vault, so entries can live 24h and up to 10k
-// vaults total — larger than any realistic deployment.
-const cache = createTtlCache<string>({ ttlMs: CACHE_TTL_MS, maxEntries: 10_000 })
-
-// Per-address inflight dedup keyed by `${chainId}:${address}`.
-// Concurrent requests with overlapping addresses share the same subgraph
-// round-trip, and keys are always small fixed-size strings.
-const inflight = new Map<string, Promise<string | undefined>>()
-
-interface SubgraphVault {
-  id: string
-  factory: string
-}
-
-async function fetchFromSubgraph(
-  subgraphUrl: string,
-  addresses: string[],
-): Promise<Record<string, string>> {
-  const addressList = addresses.map(addr => `"${addr}"`).join(', ')
-  const controller = new AbortController()
-  const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS)
-  try {
-    const resp = await fetch(subgraphUrl, {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      signal: controller.signal,
-      body: JSON.stringify({
-        query: `query VaultFactories {
-          vaults(first: 1000, where: { id_in: [${addressList}] }) {
-            id
-            factory
-          }
-        }`,
-      }),
-    })
-
-    if (!resp.ok) {
-      throw new Error(`Subgraph returned ${resp.status}`)
-    }
-
-    const body = await resp.json() as { data?: { vaults?: SubgraphVault[] } }
-    const vaults = body?.data?.vaults ?? []
-    const result: Record<string, string> = {}
-    for (const vault of vaults) {
-      if (vault.id && vault.factory) {
-        result[vault.id.toLowerCase()] = vault.factory.toLowerCase()
-      }
-    }
-    return result
-  }
-  finally {
-    clearTimeout(timeout)
-  }
-}
 
 export default defineEventHandler(async (event) => {
   rateLimiter.consume(event)
@@ -95,68 +37,12 @@ export default defineEventHandler(async (event) => {
     }
   }
 
-  const addresses = (body.addresses as string[]).map(a => a.toLowerCase())
-  const factories: Record<string, string> = {}
-  const uncached: string[] = []
-
-  for (const addr of addresses) {
-    const cached = cache.get(`${chainId}:${addr}`)
-    if (cached) {
-      factories[addr] = cached
-    }
-    else {
-      uncached.push(addr)
-    }
-  }
-
-  if (uncached.length === 0) {
+  try {
+    const factories = await getVaultFactories(chainId, body.addresses as string[])
     return { factories }
   }
-
-  const subgraphUrl = getSubgraphUris()[String(chainId)]
-  if (!subgraphUrl) {
-    logWarn('vault-factories', `No subgraph URL for chain ${chainId}; returning partial result`)
-    return { factories }
+  catch (err) {
+    logWarn('vault-factories', `Subgraph query failed for chain ${chainId}:`, err instanceof Error ? err.message : err)
+    return { factories: {} }
   }
-
-  // Split uncached addresses into those already inflight vs needing a fresh fetch.
-  const promises: Array<[string, Promise<string | undefined>]> = []
-  const toFetch: string[] = []
-
-  for (const addr of uncached) {
-    const key = `${chainId}:${addr}`
-    const existing = inflight.get(key)
-    if (existing) {
-      promises.push([addr, existing])
-    }
-    else {
-      toFetch.push(addr)
-    }
-  }
-
-  if (toFetch.length > 0) {
-    const batchPromise = fetchFromSubgraph(subgraphUrl, toFetch).catch((err) => {
-      logWarn('vault-factories', `Subgraph query failed for chain ${chainId}:`, err instanceof Error ? err.message : err)
-      return {} as Record<string, string>
-    })
-
-    for (const addr of toFetch) {
-      const addrPromise = batchPromise
-        .then((result) => {
-          const factory = result[addr]
-          if (factory) cache.set(`${chainId}:${addr}`, factory)
-          return factory
-        })
-        .finally(() => { inflight.delete(`${chainId}:${addr}`) })
-      inflight.set(`${chainId}:${addr}`, addrPromise)
-      promises.push([addr, addrPromise])
-    }
-  }
-
-  await Promise.all(promises.map(async ([addr, promise]) => {
-    const factory = await promise
-    if (factory) factories[addr] = factory
-  }))
-
-  return { factories }
 })

--- a/server/api/vaults.get.ts
+++ b/server/api/vaults.get.ts
@@ -1,0 +1,46 @@
+import { createError, getQuery } from 'h3'
+import { createRateLimiter } from '~/server/utils/rate-limit'
+import { logWarn } from '~/server/utils/log'
+import { vaultsCache, refreshChainVaults } from '~/server/utils/vaults-cache'
+import { getEnabledChainIds } from '~/utils/chain-env'
+
+const rateLimiter = createRateLimiter({
+  max: 600,
+  windowMs: 60_000,
+  label: 'vaults',
+})
+
+/**
+ * Read-only handler for the chain vaults snapshot.
+ *
+ * - Steady state: the warm-cache plugin rewrites each entry every 4 min.
+ *   Hits always land in a <4 min-old cache. No refresh triggered per request.
+ * - After extended warm-cache failure: stale data served up to the 10 min
+ *   TTL, then cold-path falls back to a synchronous refresh.
+ * - Cold start (before first warm cycle completes): handler awaits the
+ *   refresh. In-flight dedup in vaults-cache collapses concurrent cold
+ *   requests onto a single upstream pass.
+ */
+export default defineEventHandler(async (event) => {
+  rateLimiter.consume(event)
+
+  const chainId = Number(getQuery(event).chainId)
+  if (!Number.isInteger(chainId) || chainId <= 0) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid chainId' })
+  }
+  if (!getEnabledChainIds().includes(chainId)) {
+    throw createError({ statusCode: 400, statusMessage: 'Unsupported chainId' })
+  }
+
+  const cacheKey = String(chainId)
+  const cached = vaultsCache.get(cacheKey) ?? vaultsCache.getStale(cacheKey)
+  if (cached) return cached
+
+  try {
+    return await refreshChainVaults(chainId)
+  }
+  catch (err) {
+    logWarn('vaults', `Cold fetch failed for chain ${chainId}:`, err instanceof Error ? err.message : err)
+    throw createError({ statusCode: 502, statusMessage: 'Upstream vault load failed' })
+  }
+})

--- a/server/plugins/warm-cache.ts
+++ b/server/plugins/warm-cache.ts
@@ -12,17 +12,10 @@
 import { LABEL_FILES } from '../api/labels/[file].get'
 import { getEnabledChainIds } from '~/utils/chain-env'
 import { logWarn } from '../utils/log'
+import { INTERNAL_FETCH_HEADERS } from '../utils/internal-headers'
 import { refreshChainVaults } from '../utils/vaults-cache'
 
 const REWARM_INTERVAL_MS = 4 * 60_000
-
-// Synthetic client-IP header for every internal $fetch the warm-cache issues.
-// The rate-limit middleware fails-closed when `cf-connecting-ip` is absent in
-// production (see server/utils/rate-limit.ts) — without this header every warm
-// request would get a silent 403 and the caches would never populate.
-// A fixed sentinel IP is fine: warm-cache runs at most ~240 requests/cycle
-// against a 1000/min label budget, so sharing one bucket is well-bounded.
-const WARM_HEADERS = { 'cf-connecting-ip': '127.0.0.1' } as const
 
 // Nitro dev mode re-imports server plugins across its double-init (Vite
 // client build + Nitro server build), which would fire two warm cycles
@@ -42,10 +35,10 @@ export default defineNitroPlugin(() => {
 
   const warmChain = async (chainId: number) => {
     const tasks: Promise<unknown>[] = LABEL_FILES.map(file =>
-      $fetch(`/api/labels/${file}`, { query: { chainId }, headers: WARM_HEADERS }).catch(() => undefined),
+      $fetch(`/api/labels/${file}`, { query: { chainId }, headers: INTERNAL_FETCH_HEADERS }).catch(() => undefined),
     )
-    tasks.push($fetch('/api/token-list', { query: { chainId }, headers: WARM_HEADERS }).catch(() => undefined))
-    tasks.push($fetch('/api/intrinsic-apy', { query: { chainId }, headers: WARM_HEADERS }).catch(() => undefined))
+    tasks.push($fetch('/api/token-list', { query: { chainId }, headers: INTERNAL_FETCH_HEADERS }).catch(() => undefined))
+    tasks.push($fetch('/api/intrinsic-apy', { query: { chainId }, headers: INTERNAL_FETCH_HEADERS }).catch(() => undefined))
     // Vaults snapshot — direct call so we skip $fetch's HTTP dispatch and
     // get typed errors. refreshChainVaults internally $fetches labels +
     // euler-chains + vault-factories; the other tasks in this batch populate
@@ -59,7 +52,7 @@ export default defineNitroPlugin(() => {
     try {
       const earnData = await $fetch<Array<string | { address: string }>>('/api/labels/earn-vaults.json', {
         query: { chainId },
-        headers: WARM_HEADERS,
+        headers: INTERNAL_FETCH_HEADERS,
       })
       const addresses = (earnData ?? [])
         .map(e => typeof e === 'string' ? e : e?.address)
@@ -68,7 +61,7 @@ export default defineNitroPlugin(() => {
         await $fetch('/api/vault-factories', {
           method: 'POST',
           body: { chainId, addresses },
-          headers: WARM_HEADERS,
+          headers: INTERNAL_FETCH_HEADERS,
         })
       }
     }
@@ -78,7 +71,7 @@ export default defineNitroPlugin(() => {
   }
 
   const warmEulerChains = () =>
-    $fetch('/api/euler-chains', { headers: WARM_HEADERS }).catch(() => undefined)
+    $fetch('/api/euler-chains', { headers: INTERNAL_FETCH_HEADERS }).catch(() => undefined)
 
   const warmAll = async () => {
     try {

--- a/server/plugins/warm-cache.ts
+++ b/server/plugins/warm-cache.ts
@@ -12,6 +12,7 @@
 import { LABEL_FILES } from '../api/labels/[file].get'
 import { getEnabledChainIds } from '~/utils/chain-env'
 import { logWarn } from '../utils/log'
+import { refreshChainVaults } from '../utils/vaults-cache'
 
 const REWARM_INTERVAL_MS = 4 * 60_000
 
@@ -45,6 +46,13 @@ export default defineNitroPlugin(() => {
     )
     tasks.push($fetch('/api/token-list', { query: { chainId }, headers: WARM_HEADERS }).catch(() => undefined))
     tasks.push($fetch('/api/intrinsic-apy', { query: { chainId }, headers: WARM_HEADERS }).catch(() => undefined))
+    // Vaults snapshot — direct call so we skip $fetch's HTTP dispatch and
+    // get typed errors. refreshChainVaults internally $fetches labels +
+    // euler-chains + vault-factories; the other tasks in this batch populate
+    // those caches in parallel (in-flight dedup collapses the contention).
+    tasks.push(refreshChainVaults(chainId).catch((err) => {
+      logWarn('warm-cache', `vaults chain=${chainId} failed:`, err instanceof Error ? err.message : err)
+    }))
     await Promise.allSettled(tasks)
 
     // Phase 2: warm vault-factories using earn-vault addresses (labels are cached from above)

--- a/server/utils/internal-headers.ts
+++ b/server/utils/internal-headers.ts
@@ -1,0 +1,21 @@
+/**
+ * Synthetic headers for server-internal $fetch calls.
+ *
+ * The rate-limit middleware in production (DOPPLER_ENVIRONMENT=prd) fails
+ * closed when `cf-connecting-ip` is absent — a Cloudflare egress invariant
+ * that keeps direct-to-origin traffic out. Internal fetches from warm-cache,
+ * vaults-cache, etc. don't go through Cloudflare, so without this header
+ * every internal request would silently 403.
+ *
+ * 127.0.0.1 is a fixed sentinel — all server-internal traffic shares one
+ * rate-limit bucket, which is fine: warm-cache issues at most ~240
+ * requests per 4-min cycle against a >=600/min-per-endpoint budget.
+ *
+ * SECURITY: this sentinel relies on origin ingress NOT being directly
+ * reachable — Cloudflare is the only public entrypoint. If that
+ * assumption changes (eg a new ingress is exposed), attackers could
+ * spoof this header to bypass rate limiting. Do not add the header to
+ * anything that forwards user input into the downstream URL, and keep
+ * origin locked behind Cloudflare.
+ */
+export const INTERNAL_FETCH_HEADERS = { 'cf-connecting-ip': '127.0.0.1' } as const

--- a/server/utils/vault-factories-store.ts
+++ b/server/utils/vault-factories-store.ts
@@ -6,11 +6,14 @@
  * a self-HTTP round-trip. The POST endpoint is a thin wrapper around
  * getVaultFactories() below.
  */
+import { isAddress } from 'viem'
 import { createTtlCache } from './cache'
+import { logWarn } from './log'
 import { getSubgraphUris } from '~/utils/chain-env'
 
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000
 const SUBGRAPH_TIMEOUT_MS = 10_000
+const MAX_ADDRESSES_PER_CALL = 1000
 
 /** Factory address per `${chainId}:${lowercaseVaultAddress}`. */
 export const vaultFactoryCache = createTtlCache<string>({
@@ -72,11 +75,15 @@ const fetchFromSubgraph = async (
 }
 
 /**
- * Resolve factory addresses for a batch of (already-validated) vault addresses.
- * Caller must pre-validate with viem isAddress() when the input is untrusted —
- * this function does NOT re-validate and injects lowercase addresses into a
- * GraphQL query, so untrusted input would be an injection vector. See the
- * POST handler for the sanitisation it applies.
+ * Resolve factory addresses for a batch of vault addresses.
+ *
+ * Validates every input with viem isAddress() internally — callers (HTTP
+ * handler and server-internal composables) don't need to pre-validate.
+ * Invalid addresses are dropped and logged; the returned map only contains
+ * well-formed addresses. Enforces a hard cap of MAX_ADDRESSES_PER_CALL;
+ * excess input is truncated. Both guards exist because the uncached subset
+ * is interpolated into a raw GraphQL query string via `"${addr}"` — any
+ * unchecked input would be an injection vector.
  *
  * Returns a map of lowercase-address → lowercase-factory. Missing vaults
  * (not indexed yet, not matching the query) are absent from the result.
@@ -91,11 +98,22 @@ export const getVaultFactories = async (
 ): Promise<Record<string, string>> => {
   if (addresses.length === 0) return {}
 
-  const normalized = addresses.map(a => a.toLowerCase())
+  const valid: string[] = []
+  let rejected = 0
+  for (const addr of addresses) {
+    if (typeof addr === 'string' && isAddress(addr)) valid.push(addr.toLowerCase())
+    else rejected++
+    if (valid.length >= MAX_ADDRESSES_PER_CALL) break
+  }
+  if (rejected > 0) {
+    logWarn('vault-factories-store', `Dropped ${rejected} invalid address(es) from getVaultFactories call`)
+  }
+  if (valid.length === 0) return {}
+
   const factories: Record<string, string> = {}
   const uncached: string[] = []
 
-  for (const addr of normalized) {
+  for (const addr of valid) {
     const cached = vaultFactoryCache.get(`${chainId}:${addr}`)
     if (cached) factories[addr] = cached
     else uncached.push(addr)

--- a/server/utils/vault-factories-store.ts
+++ b/server/utils/vault-factories-store.ts
@@ -1,0 +1,146 @@
+/**
+ * Shared cache + fetcher for vault factory lookups.
+ *
+ * Extracted from server/api/vault-factories.post.ts so server-internal
+ * callers (vaults-cache, warm-cache) can reuse the same 24h cache without
+ * a self-HTTP round-trip. The POST endpoint is a thin wrapper around
+ * getVaultFactories() below.
+ */
+import { createTtlCache } from './cache'
+import { getSubgraphUris } from '~/utils/chain-env'
+
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000
+const SUBGRAPH_TIMEOUT_MS = 10_000
+
+/** Factory address per `${chainId}:${lowercaseVaultAddress}`. */
+export const vaultFactoryCache = createTtlCache<string>({
+  ttlMs: CACHE_TTL_MS,
+  maxEntries: 10_000,
+})
+
+/**
+ * Per-address inflight dedup keyed by `${chainId}:${address}`. Concurrent
+ * requests with overlapping addresses share the same subgraph round-trip,
+ * and keys stay bounded to small fixed-size strings.
+ */
+const inflight = new Map<string, Promise<string | undefined>>()
+
+interface SubgraphVault {
+  id: string
+  factory: string
+}
+
+const fetchFromSubgraph = async (
+  subgraphUrl: string,
+  addresses: string[],
+): Promise<Record<string, string>> => {
+  const addressList = addresses.map(addr => `"${addr}"`).join(', ')
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), SUBGRAPH_TIMEOUT_MS)
+  try {
+    const resp = await fetch(subgraphUrl, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      signal: controller.signal,
+      body: JSON.stringify({
+        query: `query VaultFactories {
+          vaults(first: 1000, where: { id_in: [${addressList}] }) {
+            id
+            factory
+          }
+        }`,
+      }),
+    })
+
+    if (!resp.ok) {
+      throw new Error(`Subgraph returned ${resp.status}`)
+    }
+
+    const body = await resp.json() as { data?: { vaults?: SubgraphVault[] } }
+    const vaults = body?.data?.vaults ?? []
+    const result: Record<string, string> = {}
+    for (const vault of vaults) {
+      if (vault.id && vault.factory) {
+        result[vault.id.toLowerCase()] = vault.factory.toLowerCase()
+      }
+    }
+    return result
+  }
+  finally {
+    clearTimeout(timeout)
+  }
+}
+
+/**
+ * Resolve factory addresses for a batch of (already-validated) vault addresses.
+ * Caller must pre-validate with viem isAddress() when the input is untrusted —
+ * this function does NOT re-validate and injects lowercase addresses into a
+ * GraphQL query, so untrusted input would be an injection vector. See the
+ * POST handler for the sanitisation it applies.
+ *
+ * Returns a map of lowercase-address → lowercase-factory. Missing vaults
+ * (not indexed yet, not matching the query) are absent from the result.
+ *
+ * Per-address inflight dedup means concurrent callers with overlapping
+ * address sets share the same upstream query; the batched fetch resolves
+ * every participating address in one round-trip.
+ */
+export const getVaultFactories = async (
+  chainId: number,
+  addresses: string[],
+): Promise<Record<string, string>> => {
+  if (addresses.length === 0) return {}
+
+  const normalized = addresses.map(a => a.toLowerCase())
+  const factories: Record<string, string> = {}
+  const uncached: string[] = []
+
+  for (const addr of normalized) {
+    const cached = vaultFactoryCache.get(`${chainId}:${addr}`)
+    if (cached) factories[addr] = cached
+    else uncached.push(addr)
+  }
+
+  if (uncached.length === 0) return factories
+
+  const subgraphUrl = getSubgraphUris()[String(chainId)]
+  if (!subgraphUrl) return factories
+
+  // Split uncached addresses into those already inflight vs needing a fresh fetch.
+  const promises: Array<[string, Promise<string | undefined>]> = []
+  const toFetch: string[] = []
+
+  for (const addr of uncached) {
+    const key = `${chainId}:${addr}`
+    const existing = inflight.get(key)
+    if (existing) {
+      promises.push([addr, existing])
+    }
+    else {
+      toFetch.push(addr)
+    }
+  }
+
+  if (toFetch.length > 0) {
+    const batchPromise = fetchFromSubgraph(subgraphUrl, toFetch).catch(() => ({} as Record<string, string>))
+
+    for (const addr of toFetch) {
+      const addrPromise = batchPromise
+        .then((result) => {
+          const factory = result[addr]
+          if (factory) vaultFactoryCache.set(`${chainId}:${addr}`, factory)
+          return factory
+        })
+        .finally(() => { inflight.delete(`${chainId}:${addr}`) })
+      inflight.set(`${chainId}:${addr}`, addrPromise)
+      promises.push([addr, addrPromise])
+    }
+  }
+
+  await Promise.all(promises.map(async ([addr, promise]) => {
+    const factory = await promise
+    if (factory) factories[addr] = factory
+  }))
+
+  return factories
+}

--- a/server/utils/vaults-cache.ts
+++ b/server/utils/vaults-cache.ts
@@ -1,0 +1,183 @@
+/**
+ * Server-side cache for the /api/vaults snapshot endpoint.
+ *
+ * - The cache itself is a plain TTL store. The 10 min TTL is a safety floor:
+ *   the warm-cache plugin rewrites every entry every 4 min under normal
+ *   operation, so in steady state the cache is always "fresh" from the
+ *   handler's point of view. If warm-cache stalls for two cycles, stale
+ *   entries are still servable (via .getStale) until the handler falls back
+ *   to a synchronous cold-path refresh.
+ * - refreshChainVaults() is the only write path. In-flight dedup collapses
+ *   concurrent calls (warm-cache + a cold client request arriving together)
+ *   onto a single upstream pass.
+ */
+import { createTtlCache } from './cache'
+import { logWarn } from './log'
+import { getVaultFactories } from './vault-factories-store'
+import { loadChainSnapshot, serialiseSnapshot } from '~/entities/vault'
+import type { FetchVaultContext, SerialisedSnapshot } from '~/entities/vault'
+
+const TTL_MS = 10 * 60_000
+// Synthetic CF header so rate-limit fail-closed in prd doesn't 403 every internal fetch.
+// Same fixed sentinel pattern as warm-cache.
+const WARM_HEADERS = { 'cf-connecting-ip': '127.0.0.1' } as const
+
+export const vaultsCache = createTtlCache<SerialisedSnapshot>({
+  ttlMs: TTL_MS,
+  maxEntries: 100,
+})
+
+const inFlight = new Map<number, Promise<SerialisedSnapshot>>()
+
+interface EulerChainEntry {
+  chainId: number
+  addresses: {
+    lensAddrs: {
+      vaultLens: string
+      eulerEarnVaultLens: string
+      utilsLens: string
+    }
+    coreAddrs: { evc: string }
+    peripheryAddrs: {
+      escrowedCollateralPerspective?: string
+      securitizeFactory?: string
+    }
+  }
+}
+
+interface EulerLabelProduct {
+  vaults?: string[]
+  deprecatedVaults?: string[]
+  /** If true, every vault in the product is excluded from the snapshot — mirrors isVaultNotExplorable on the client. */
+  notExplorable?: boolean
+}
+
+interface EarnVaultEntry {
+  address: string
+  /** If true, the entry is excluded from the snapshot — mirrors isEarnVaultNotExplorable on the client. */
+  notExplorable?: boolean
+}
+
+const getChainConfig = async (chainId: number): Promise<EulerChainEntry | undefined> => {
+  const chains = await $fetch<EulerChainEntry[]>('/api/euler-chains', { headers: WARM_HEADERS })
+  return chains.find(c => c.chainId === chainId)
+}
+
+/**
+ * Distil the label payloads needed by the loader. Mirrors the subset of
+ * useEulerLabels that feeds into the vault-loading pipeline:
+ *   - verifiedVaultAddresses: union of every `vaults[chainId]` array across all products
+ *   - earnVaults: the earn-vaults.json list (array of addresses)
+ *
+ * Does NOT extract entities/points/descriptions — those are UI-only and the
+ * loader doesn't care about them.
+ */
+const getLabels = async (chainId: number) => {
+  const [products, earn] = await Promise.all([
+    $fetch<Record<string, EulerLabelProduct>>('/api/labels/products.json', {
+      query: { chainId },
+      headers: WARM_HEADERS,
+    }).catch(() => ({} as Record<string, EulerLabelProduct>)),
+    $fetch<Array<string | EarnVaultEntry>>('/api/labels/earn-vaults.json', {
+      query: { chainId },
+      headers: WARM_HEADERS,
+    }).catch(() => [] as Array<string | EarnVaultEntry>),
+  ])
+
+  // products.json shape: { [productKey]: { vaults: ["0x…"], deprecatedVaults: [...], notExplorable? } }
+  // Verified set = union of vaults + deprecatedVaults across all products, EXCEPT products
+  // flagged notExplorable (mirrors the client's explorableVaultAddresses filter in loadVaults).
+  // Skipping them matters because the lens calls `getVaultInfoFull` against every address
+  // in the list — notExplorable entries include decommissioned vaults whose lens calls revert.
+  const verifiedSet = new Set<string>()
+  for (const product of Object.values(products)) {
+    if (product.notExplorable === true) continue
+    product.vaults?.forEach(addr => verifiedSet.add(addr))
+    product.deprecatedVaults?.forEach(addr => verifiedSet.add(addr))
+  }
+
+  // earn-vaults.json: array of { address, ... } entries, or (legacy) bare strings.
+  // Skip entries marked notExplorable (deprecated earn vaults whose lens calls would revert).
+  const earnVaults: string[] = earn.flatMap((entry) => {
+    if (typeof entry === 'string') return [entry]
+    if (entry.notExplorable === true) return []
+    return [entry.address]
+  })
+
+  return {
+    verifiedVaultAddresses: [...verifiedSet],
+    earnVaults,
+  }
+}
+
+const getFactories = async (chainId: number, addresses: string[]): Promise<Map<string, string>> => {
+  if (addresses.length === 0) return new Map()
+  const factories = await getVaultFactories(chainId, addresses)
+  return new Map(Object.entries(factories))
+}
+
+/**
+ * The single refresh path. Called by the warm-cache plugin on a 4-min
+ * schedule, and also by the /api/vaults handler as a cold-path fallback.
+ */
+export const refreshChainVaults = async (chainId: number): Promise<SerialisedSnapshot> => {
+  const existing = inFlight.get(chainId)
+  if (existing) return existing
+
+  const promise = (async () => {
+    const rpcUrl = process.env[`RPC_URL_HTTP_${chainId}`]
+    if (!rpcUrl) throw new Error(`No RPC URL configured for chain ${chainId}`)
+
+    const cfg = await getChainConfig(chainId)
+    if (!cfg) throw new Error(`No euler-chains entry for chain ${chainId}`)
+
+    const labels = await getLabels(chainId)
+    const factories = await getFactories(chainId, labels.verifiedVaultAddresses)
+
+    const ctx: FetchVaultContext = {
+      chainId,
+      rpcUrl,
+      lensAddresses: {
+        vaultLens: cfg.addresses.lensAddrs.vaultLens,
+        eulerEarnVaultLens: cfg.addresses.lensAddrs.eulerEarnVaultLens,
+        utilsLens: cfg.addresses.lensAddrs.utilsLens,
+      },
+      coreAddresses: { evc: cfg.addresses.coreAddrs.evc },
+      peripheryAddresses: {
+        escrowedCollateralPerspective: cfg.addresses.peripheryAddrs.escrowedCollateralPerspective,
+      },
+      // Server skips Pyth simulation in v1: the client's post-hydration
+      // RPC refresh handles Pyth-fresh prices. See plan "Pyth on server: skip in v1".
+      pythHermesUrl: undefined,
+      verifiedVaultAddresses: labels.verifiedVaultAddresses,
+      earnVaultAddresses: labels.earnVaults,
+    }
+
+    const snap = await loadChainSnapshot({
+      chainId,
+      ctx,
+      peripheryAddresses: {
+        escrowedCollateralPerspective: cfg.addresses.peripheryAddrs.escrowedCollateralPerspective,
+        securitizeFactory: cfg.addresses.peripheryAddrs.securitizeFactory,
+      },
+      factories,
+      // Server doesn't honour nonExplorable filters — UI-only concerns.
+      // The snapshot contains all verified vaults; the client applies UI
+      // filters at render time.
+    })
+
+    const serialised = serialiseSnapshot(snap)
+    vaultsCache.set(String(chainId), serialised)
+    return serialised
+  })().finally(() => { inFlight.delete(chainId) })
+
+  inFlight.set(chainId, promise)
+
+  try {
+    return await promise
+  }
+  catch (err) {
+    logWarn('vaults-cache', `refreshChainVaults chain=${chainId} failed:`, err instanceof Error ? err.message : err)
+    throw err
+  }
+}

--- a/server/utils/vaults-cache.ts
+++ b/server/utils/vaults-cache.ts
@@ -14,13 +14,11 @@
 import { createTtlCache } from './cache'
 import { logWarn } from './log'
 import { getVaultFactories } from './vault-factories-store'
+import { INTERNAL_FETCH_HEADERS } from './internal-headers'
 import { loadChainSnapshot, serialiseSnapshot } from '~/entities/vault'
 import type { FetchVaultContext, SerialisedSnapshot } from '~/entities/vault'
 
 const TTL_MS = 10 * 60_000
-// Synthetic CF header so rate-limit fail-closed in prd doesn't 403 every internal fetch.
-// Same fixed sentinel pattern as warm-cache.
-const WARM_HEADERS = { 'cf-connecting-ip': '127.0.0.1' } as const
 
 export const vaultsCache = createTtlCache<SerialisedSnapshot>({
   ttlMs: TTL_MS,
@@ -59,7 +57,7 @@ interface EarnVaultEntry {
 }
 
 const getChainConfig = async (chainId: number): Promise<EulerChainEntry | undefined> => {
-  const chains = await $fetch<EulerChainEntry[]>('/api/euler-chains', { headers: WARM_HEADERS })
+  const chains = await $fetch<EulerChainEntry[]>('/api/euler-chains', { headers: INTERNAL_FETCH_HEADERS })
   return chains.find(c => c.chainId === chainId)
 }
 
@@ -76,11 +74,11 @@ const getLabels = async (chainId: number) => {
   const [products, earn] = await Promise.all([
     $fetch<Record<string, EulerLabelProduct>>('/api/labels/products.json', {
       query: { chainId },
-      headers: WARM_HEADERS,
+      headers: INTERNAL_FETCH_HEADERS,
     }).catch(() => ({} as Record<string, EulerLabelProduct>)),
     $fetch<Array<string | EarnVaultEntry>>('/api/labels/earn-vaults.json', {
       query: { chainId },
-      headers: WARM_HEADERS,
+      headers: INTERNAL_FETCH_HEADERS,
     }).catch(() => [] as Array<string | EarnVaultEntry>),
   ])
 

--- a/tests/entities/vault/loader-serde.test.ts
+++ b/tests/entities/vault/loader-serde.test.ts
@@ -88,7 +88,7 @@ describe('loader-serde', () => {
     const snap = mockSnapshot()
     const wire = serialiseSnapshot(snap)
     expect(() => JSON.stringify(wire)).not.toThrow()
-    expect(JSON.stringify(wire)).toContain('__bi:')
+    expect(JSON.stringify(wire)).toContain('"__bi"')
   })
 
   it('restored bigint values survive JSON string round-trip', () => {
@@ -98,5 +98,22 @@ describe('loader-serde', () => {
     expect(restored.evkVaults[0].supply).toBe(snap.evkVaults[0].supply)
     expect(restored.evkVaults[0].supplyCap).toBe(snap.evkVaults[0].supplyCap)
     expect(restored.evkVaults[0].interestRateInfo.borrowAPY).toBe(snap.evkVaults[0].interestRateInfo.borrowAPY)
+  })
+
+  // Regression: vault name() / symbol() are adversary-controlled on-chain.
+  // A naive prefix-on-string encoding would let a malicious vault with
+  // `name = "__bi:0"` silently deserialise to the bigint 0n, corrupting
+  // downstream string operations. The object-wrapper encoding prevents this.
+  it('treats adversarial strings that look like the bigint tag as plain strings', () => {
+    const snap = mockSnapshot()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(snap.evkVaults[0] as any).name = '__bi:0'
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(snap.evkVaults[0] as any).symbol = '__bi:deadbeef'
+    const restored = deserialiseSnapshot(JSON.parse(JSON.stringify(serialiseSnapshot(snap))))
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((restored.evkVaults[0] as any).name).toBe('__bi:0')
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((restored.evkVaults[0] as any).symbol).toBe('__bi:deadbeef')
   })
 })

--- a/tests/entities/vault/loader-serde.test.ts
+++ b/tests/entities/vault/loader-serde.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+import { serialiseSnapshot, deserialiseSnapshot } from '~/entities/vault/loader-serde'
+import type { ChainVaultsSnapshot } from '~/entities/vault/loader'
+
+/**
+ * The serde must survive every bigint-containing field the loader produces.
+ * We construct a minimal-but-bigint-heavy snapshot and assert deep equality
+ * after round-trip. JSON-stringify the encoded form to confirm no bigints
+ * leak to the wire.
+ */
+describe('loader-serde', () => {
+  const mockSnapshot = (): ChainVaultsSnapshot => ({
+    chainId: 1,
+    fetchedAt: 1_700_000_000_000,
+    evkVaults: [
+      {
+        verified: true,
+        address: '0xvault1',
+        name: 'Test Vault',
+        symbol: 'TV',
+        decimals: 18n,
+        supply: 1000000n,
+        borrow: 500000n,
+        supplyCap: 10_000_000_000_000_000_000_000n,
+        borrowCap: 5_000_000_000_000_000_000_000n,
+        totalCash: 500000n,
+        totalAssets: 1000000n,
+        totalShares: 1000000n,
+        interestFee: 100n,
+        configFlags: 0n,
+        oracle: '0xoracle',
+        collateralLTVs: [
+          {
+            collateral: '0xcol',
+            borrowLTV: 8000n,
+            liquidationLTV: 9000n,
+            initialLiquidationLTV: 0n,
+            targetTimestamp: 0n,
+            rampDuration: 0n,
+          },
+        ],
+        collateralPrices: [],
+        liabilityPriceInfo: {
+          amountIn: 1000000000000000000n,
+          amountOutAsk: 1000000000000000000n,
+          amountOutBid: 1000000000000000000n,
+          amountOutMid: 1000000000000000000n,
+          queryFailure: false,
+          queryFailureReason: '',
+          timestamp: 1700000000n,
+          oracle: '0xoracle',
+          asset: '0xasset',
+          unitOfAccount: '0x0000000000000000000000000000000000000348',
+        },
+        maxLiquidationDiscount: 500n,
+        interestRateInfo: {
+          borrowAPY: 500_000_000_000_000_000_000_000n,
+          borrowSPY: 1n,
+          borrows: 500000n,
+          cash: 500000n,
+          supplyAPY: 300_000_000_000_000_000_000_000n,
+        },
+        asset: { address: '0xasset', name: 'Asset', symbol: 'AST', decimals: 18n },
+        dToken: '0xdtoken',
+        governorAdmin: '0xgov',
+        governorFeeReceiver: '0xreceiver',
+        unitOfAccount: '0xuoa',
+        interestRateModelAddress: '0xirm',
+        hookTarget: '0x0000000000000000000000000000000000000000',
+        hookedOps: 0n,
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test vault shape
+    ] as any,
+    earnVaults: [],
+    securitizeVaults: [],
+    escrowAddresses: ['0xescrow1'],
+    escrowVaults: [],
+  })
+
+  it('round-trips a snapshot with bigint-heavy fields', () => {
+    const snap = mockSnapshot()
+    const wire = serialiseSnapshot(snap)
+    const restored = deserialiseSnapshot(wire)
+    expect(restored).toEqual(snap)
+  })
+
+  it('produces a wire representation that JSON.stringify accepts (no raw bigints)', () => {
+    const snap = mockSnapshot()
+    const wire = serialiseSnapshot(snap)
+    expect(() => JSON.stringify(wire)).not.toThrow()
+    expect(JSON.stringify(wire)).toContain('__bi:')
+  })
+
+  it('restored bigint values survive JSON string round-trip', () => {
+    const snap = mockSnapshot()
+    const wire = serialiseSnapshot(snap)
+    const restored = deserialiseSnapshot(JSON.parse(JSON.stringify(wire)))
+    expect(restored.evkVaults[0].supply).toBe(snap.evkVaults[0].supply)
+    expect(restored.evkVaults[0].supplyCap).toBe(snap.evkVaults[0].supplyCap)
+    expect(restored.evkVaults[0].interestRateInfo.borrowAPY).toBe(snap.evkVaults[0].interestRateInfo.borrowAPY)
+  })
+})


### PR DESCRIPTION
## Summary

Stacks on top of #262 (chain-switch-perf). Moves the public vault set into a server-computed, pre-warmed snapshot so `useVaults.loadVaults()` hydrates from a 15-min-fresh payload within ~100 ms instead of running the full batched RPC refresh before the UI becomes usable.

Measured impact on mainnet (`chain=1`, 129 EVK / 7 Earn / 6 referenced-escrow vaults, wallet connected): time-to-rendered-vault-list dropped from **~3-6 s** to **~200 ms**. The silent RPC refresh still runs in the background so live Pyth prices / rate ticks land within another few seconds.

### How it works

- **`/api/vaults?chainId`** — read-only Nitro handler. Serves a bigint-safe serialised `ChainVaultsSnapshot` from an in-memory TTL cache written by the warm-cache plugin on a 4-min interval. In-flight dedup collapses concurrent cold-path refreshes onto one upstream fetch.
- **Universal `entities/vault/loader.ts`** — runs the same 3-phase fetch that was inline in `useVaults.loadVaults()` (factory split, parallel EVK / Earn / Securitize / escrow-address list, then the referenced-escrow subset). `FetchVaultContext` carries RPC URL + lens addresses + label data so the same code runs in browser and Nitro.
- **`loader-serde`** — tags bigints as `{ __bi: "<decimal>" }` object wrappers so the payload JSON-serialises without precision loss. The wrapper form is not producible as an on-chain string, so adversary-controlled fields like vault `name()` can't poison the decoded snapshot.
- **`composables/useVaults.loadVaults`** now hydrates first, flips `isReady=true`, then runs the existing RPC refresh in silent mode so `isEVKUpdating` etc. stay false and consumer pages unblock immediately. Public composable surface unchanged.

### Follow-on improvements in this PR

- **Progressive rendering in `VaultsBorrowList`** (initial batch on first paint + height spacer for scroll restoration) — the hydration change shifted the dominant cost to Vue's per-component setup for ~400 pair rows, so rendering the first batch and revealing the rest one frame later keeps time-to-visible low without a layout jump.
- **Debounced + keep-alive-paused price watchEffects** on lend/borrow/earn list pages — each chain switch used to fan out to three pages at once because of Nuxt's keepalive.
- **Scoped wallet balances** (`useFullBalances` opt-in) — the default `updateBalances` now fetches balances only for vault-asset addresses; swap pages opt into the full Uniswap/DefiLlama token-list fetch via `useFullBalances()`. Refcounted, merge-semantics on the balance Map so navigating between swap pages doesn't redo the fetch, with a 60 s TTL safety net that `resetBalances` invalidates on chain/wallet change.
- **Eager `useEulerAccount()` at app root** — positions load in the background on wallet connect / chain switch, so the first detail-page visit doesn't wait on the subgraph + accountLens round-trip.

### Security / correctness fixes addressed in review

- `loader-serde` decoder hardened against adversary-controlled strings that look like the bigint tag (regression test added).
- `getVaultFactories` validates every address with `isAddress()` internally and enforces a 1000-cap — defence-in-depth since the util interpolates into a raw GraphQL query. The HTTP handler's strict `400` on bad input is preserved.
- Escrow vaults have `vaultCategory: 'escrow'` re-stamped at hydration so downstream consumers can't see a category-less escrow vault.
- Snapshot shape-guard + 15-min `fetchedAt` staleness gate in `hydrateFromServer` — a malformed or ancient response falls through to RPC instead of crashing or rendering stale data.
- `loadChainSnapshot` switched to per-arm error isolation — one RPC hiccup on any phase-2 arm no longer kills the whole snapshot refresh.
- `INTERNAL_FETCH_HEADERS` centralised (single `'cf-connecting-ip': '127.0.0.1'` sentinel) with a prominent comment about the rate-limit-bypass assumption it depends on.

### Known follow-ups (not in this PR)

- Pyth-staleness UX indicator (product decision — server snapshot skips Pyth simulation; client RPC refresh handles it within a few seconds).
- Triplicated keep-alive debounce pattern across lend/borrow/earn list pages → composable extraction.
- `VaultsBorrowList` hardcoded row-height → `ResizeObserver`-based measurement for fully accurate scroll-restoration on variable-height rows.
- `useFullBalances` TTL/refcount edge cases (chainId=0 seeding, Suspense double-mount, missed refetch while in-flight) — deserves a focused pass.
- `/api/vaults` stale-serve max-age cap + async refresh kick when serving stale.

## Commits

- `b48b72d` refactor: hoist composable deps from vault fetchers into FetchVaultContext
- `349043e` feat: server-side chain vault snapshot + progressive list rendering
- `1b4ad26` perf: defer hidden pages' price watchEffects + debounce bursts
- `5a6f32b` feat: scope wallet balances with pay-with opt-in (useFullBalances)
- `77746d6` feat: eagerly load account positions on wallet connect
- `ad12ab6` fix: address review findings on server vaults snapshot

## Test plan

- [ ] Chain switch: measure time-to-rendered-list across chains with varied vault counts (mainnet 100+, mid-size 30+, small <10). Expected: hydrated render < 500 ms regardless of chain size; RPC refresh completes in the background.
- [ ] Chain switch while wallet connected: balances + positions should load in the background without blocking the list.
- [ ] Swap/repay/supply/withdraw pages: `SwapTokenSelector` shows non-zero balances first on the active chain. Navigating between two swap pages within 60 s does not refetch.
- [ ] Warm-cache success on boot: `[warm-cache]` logs fire for every enabled chain; subsequent 4-min cycles succeed.
- [ ] Warm-cache failure tolerance: kill the subgraph/RPC for one chain, observe only that chain's cache stays stale while others refresh.
- [ ] `/api/vaults` empty-body guard: invalid chainId → 400; unsupported chainId → 400; cold path returns 502 on genuine upstream failure.
- [ ] Adversarial vault name / symbol fixtures: regression test on `loader-serde` passes.
- [ ] Existing Playwright E2E green.