### PR TITLE
fix: wire SENTRY_AUTH_TOKEN into Docker build for source map uploads

### DIFF
--- a/.github/workflows/build-push-deploy-stage.yaml
+++ b/.github/workflows/build-push-deploy-stage.yaml
@@ -55,6 +55,8 @@ jobs:
           platforms: linux/amd64
           load: true
           tags: euler-lite
+          build-args: |
+            SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/build-push-image.yaml
+++ b/.github/workflows/build-push-image.yaml
@@ -53,7 +53,7 @@ jobs:
           ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
         run: |
           FULL_IMAGE="$REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
-          docker build --platform linux/amd64 -t euler-lite .
+          docker build --platform linux/amd64 --build-arg SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }} -t euler-lite .
           docker tag euler-lite "$FULL_IMAGE"
           docker tag euler-lite "$REGISTRY/$ECR_REPOSITORY:latest"
           docker push "$FULL_IMAGE"

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,10 @@ WORKDIR /usr/src/app
 COPY package.json package-lock.json ./
 RUN npm ci
 COPY . .
+
+# Sentry source-map upload (build-time only; token never reaches production stage)
+ARG SENTRY_AUTH_TOKEN
+
 RUN npm run build
 
 # Download Doppler CLI (binary only, no package manager install)

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -3,11 +3,12 @@ import * as Sentry from '@sentry/nuxt'
 // useRuntimeConfig() at module top-level is intentional here.
 // @sentry/nuxt processes this file as a client-entry hook before the Nuxt
 // app boots, and guarantees it runs in a context where useRuntimeConfig() is available.
-const { public: { sentryDsn } } = useRuntimeConfig()
+const { public: { sentryDsn, appUrl } } = useRuntimeConfig()
 
 if (sentryDsn) {
   Sentry.init({
     dsn: sentryDsn,
+    environment: appUrl?.includes('stage') ? 'staging' : 'production',
     tunnel: '/api/sentry-tunnel',
     tracesSampleRate: 0.2,
     replaysOnErrorSampleRate: 1.0,


### PR DESCRIPTION
The token was configured but never passed through to the Docker build, so nuxt.config.ts conditions gating source map generation and upload always evaluated to false.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build and deployment now support passing an additional authentication token into the container build process.
  * Improved error reporting configuration so the app sets Sentry's environment (staging vs production) based on the app URL at runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->