### PR TITLE
fix: allow deep-linking to non-explorable products on explore page

### DIFF
--- a/components/entities/vault/overview/SecuritizeVaultOverview.vue
+++ b/components/entities/vault/overview/SecuritizeVaultOverview.vue
@@ -17,6 +17,7 @@ import { useModal } from '~/components/ui/composables/useModal'
 import { VaultSupplyApyModal } from '#components'
 
 const { vault } = defineProps<{ vault: SecuritizeVault, desktopOverview?: boolean }>()
+const route = useRoute()
 const { enableEntityBranding: enableEntityBrandingDisplay, enableVaultType: enableVaultTypeDisplay } = useDeployConfig()
 
 const { client: rpcClient } = useRpcClient()
@@ -215,7 +216,7 @@ const supplyCapPercentageDisplay = computed(() => {
         <VaultOverviewLabelValue label="Market">
           <NuxtLink
             v-if="marketProductKey"
-            :to="{ name: 'explore-market', params: { market: marketProductKey } }"
+            :to="{ name: 'explore-market', params: { market: marketProductKey }, query: { network: route.query.network } }"
             class="text-p2 text-content-primary hover:text-accent-600 underline transition-colors"
           >
             {{ product.name }}

--- a/components/entities/vault/overview/VaultOverviewBlockGeneral.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockGeneral.vue
@@ -9,6 +9,7 @@ import { isVaultBlockedByCountry } from '~/composables/useGeoBlock'
 import { autoLink } from '~/utils/autoLink'
 
 const { vault } = defineProps<{ vault: Vault }>()
+const route = useRoute()
 const { enableEntityBranding: enableEntityBrandingDisplay, enableVaultType: enableVaultTypeDisplay } = useDeployConfig()
 
 const { borrowList, isVaultGovernorVerified } = useVaults()
@@ -99,7 +100,7 @@ watchEffect(async () => {
         <VaultOverviewLabelValue label="Market">
           <NuxtLink
             v-if="marketProductKey"
-            :to="{ name: 'explore-market', params: { market: marketProductKey } }"
+            :to="{ name: 'explore-market', params: { market: marketProductKey }, query: { network: route.query.network } }"
             class="text-p2 text-content-primary hover:text-accent-600 underline transition-colors"
           >
             {{ product.name }}

--- a/composables/useMarketGroups.ts
+++ b/composables/useMarketGroups.ts
@@ -472,7 +472,8 @@ export const useMarketGroups = () => {
     try {
       return await resolveGroupTVL(augmented)
     }
-    catch {
+    catch (e) {
+      logWarn(`useMarketGroups/fetchMarketGroupOnDemand/resolveGroupTVL [${productKey}]`, e)
       return augmented
     }
   }

--- a/composables/useMarketGroups.ts
+++ b/composables/useMarketGroups.ts
@@ -1,4 +1,4 @@
-import type { Vault } from '~/entities/vault'
+import { fetchVaults, type Vault } from '~/entities/vault'
 import { logWarn } from '~/utils/errorHandling'
 import type { EulerLabelEntity, EulerLabelProduct } from '~/entities/euler/labels'
 import type { MarketGroup, MarketGroupMetrics, CuratorGroup } from '~/entities/lend-discovery'
@@ -428,6 +428,55 @@ export const useMarketGroups = () => {
     )
   }
 
+  /** Fetch a market group on demand for non-explorable products accessed via direct URL */
+  const fetchMarketGroupOnDemand = async (productKey: string): Promise<MarketGroup | null> => {
+    const product = products[productKey]
+    if (!product) return null
+
+    const allAddresses = [...product.vaults, ...(product.deprecatedVaults || [])]
+    if (allAddresses.length === 0) return null
+
+    const memberVaults: Vault[] = []
+
+    try {
+      for await (const result of fetchVaults(allAddresses)) {
+        memberVaults.push(...result.vaults)
+        if (result.isFinished) break
+      }
+    }
+    catch (e) {
+      logWarn('useMarketGroups/fetchMarketGroupOnDemand', e)
+    }
+
+    if (memberVaults.length === 0) return null
+
+    const entityKeys = Array.isArray(product.entity) ? product.entity : [product.entity]
+    const curatorKey = entityKeys[0] || undefined
+    const curator = curatorKey ? entities[curatorKey] : undefined
+
+    const group: MarketGroup = {
+      id: productKey,
+      name: product.name,
+      source: 'product',
+      curator,
+      curatorKey,
+      vaults: memberVaults,
+      externalCollateral: [],
+      metrics: computeMetricsSync(memberVaults),
+    }
+
+    // Augment with collateral graph using registry vaults + fetched vaults
+    const registryVaults = getAll().map(entry => entry.vault)
+    const [augmented] = augmentWithCollateralGraph([group], [...registryVaults, ...memberVaults])
+
+    try {
+      return await resolveGroupTVL(augmented)
+    }
+    catch {
+      return augmented
+    }
+  }
+
   return {
     allVaults,
     marketGroups,
@@ -435,5 +484,6 @@ export const useMarketGroups = () => {
     curatorGroups,
     isResolvingTVL,
     getGroupForVault,
+    fetchMarketGroupOnDemand,
   }
 }

--- a/pages/explore/[market].vue
+++ b/pages/explore/[market].vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { useMarketGroups } from '~/composables/useMarketGroups'
+import type { MarketGroup } from '~/entities/lend-discovery'
 
 defineOptions({
   name: 'ExploreMarketPage',
@@ -8,17 +9,58 @@ defineOptions({
 const route = useRoute()
 const marketKey = computed(() => route.params.market as string)
 
-const { marketGroups, isResolvingTVL } = useMarketGroups()
+const { marketGroups, isResolvingTVL, fetchMarketGroupOnDemand } = useMarketGroups()
 const { isEVKUpdating, isEarnUpdating, isSecuritizeUpdating, isEscrowUpdating } = useVaults()
 
-const isLoading = computed(() =>
+const isVaultsLoading = computed(() =>
   isEVKUpdating.value || isEarnUpdating.value || isSecuritizeUpdating.value || isEscrowUpdating.value
   || isResolvingTVL.value,
 )
 
-const market = computed(() =>
+// Regular market from pre-loaded groups
+const indexedMarket = computed(() =>
   marketGroups.value.find(g => g.id === marketKey.value),
 )
+
+// On-demand market for non-explorable products accessed via direct URL
+const onDemandMarket = ref<MarketGroup | null>(null)
+const isLoadingOnDemand = ref(false)
+let onDemandRunId = 0
+
+watch(
+  [indexedMarket, isVaultsLoading, marketKey],
+  async ([found, loading, key]) => {
+    // If the market appeared in regular groups, clear on-demand data
+    if (found) {
+      onDemandMarket.value = null
+      return
+    }
+
+    // Skip while vaults are still loading, or no key — keep stale data visible
+    if (loading || !key) return
+
+    // Skip if already loaded for this key
+    if (onDemandMarket.value?.id === key) return
+
+    const runId = ++onDemandRunId
+    isLoadingOnDemand.value = true
+    try {
+      const result = await fetchMarketGroupOnDemand(key)
+      if (runId === onDemandRunId) {
+        onDemandMarket.value = result
+      }
+    }
+    finally {
+      if (runId === onDemandRunId) {
+        isLoadingOnDemand.value = false
+      }
+    }
+  },
+  { immediate: true },
+)
+
+const market = computed(() => indexedMarket.value || onDemandMarket.value)
+const isLoading = computed(() => isVaultsLoading.value || isLoadingOnDemand.value)
 </script>
 
 <template>


### PR DESCRIPTION
Products with notExplorable: true had their vaults filtered out during initial load, making direct URLs like /explore/apostro-resolv return "Market not found". Add on-demand vault fetching in the explore market page that bypasses the global filter when accessed via direct URL, while keeping non-explorable products hidden from the explore listing.

- Add fetchMarketGroupOnDemand to useMarketGroups composable
- Fetch vaults on demand with collateral graph augmentation and TVL
- Add race guard and dedup to prevent redundant RPC calls on refresh
- Preserve network query param in vault overview market links

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * On-demand loading of market group data when not preloaded, improving responsiveness and reducing initial page load.

* **Improvements**
  * Preserves the selected network query when navigating to market pages for consistent context.
  * Better loading state handling and safeguards against out-of-order fetch results for more reliable data presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->