### PR TITLE
fix: eagerly initialize AppKit to prevent wallet connect page refresh

### DIFF
--- a/composables/useWagmi.ts
+++ b/composables/useWagmi.ts
@@ -38,7 +38,7 @@ function initializeWagmi() {
   // only on first connect for signed-out visitors.
   const modal = () => {
     const nuxtApp = useNuxtApp()
-    const open = nuxtApp.$openWalletModal as (() => void) | undefined
+    const open = nuxtApp.$openWalletModal as (() => Promise<void>) | undefined
     if (!open) {
       console.warn('[useWagmi] $openWalletModal not available — wallet plugin may not have loaded')
       return

--- a/composables/useWagmi.ts
+++ b/composables/useWagmi.ts
@@ -17,17 +17,6 @@ const routeNetworkId: Ref<number | null> = ref(null)
 let cachedWagmiData: ReturnType<typeof initializeWagmi> | null = null
 let watchersInitialized = false
 
-function isAppKitInitializing(): boolean {
-  try {
-    const nuxtApp = useNuxtApp()
-    const check = nuxtApp.$isAppKitInitializing as (() => boolean) | undefined
-    return check ? check() : false
-  }
-  catch {
-    return false
-  }
-}
-
 function initializeWagmi() {
   const { address: wagmiAddress, isConnected: wagmiIsConnected, connector, chain: wagmiChain, status } = useAccount()
   const { disconnect: wagmiDisconnect } = useDisconnect()
@@ -239,8 +228,6 @@ export const useWagmi = () => {
     watchersInitialized = true
 
     watch([isConnected, connector], ([connected, conn]) => {
-      if (isAppKitInitializing()) return
-
       if (connected && conn) {
         walletName.value = conn.name || 'Wallet'
       }
@@ -291,13 +278,6 @@ export const useWagmi = () => {
 
     watch(wagmiChain, async (val, oldVal) => {
       if (!val?.id || isChangingChain) {
-        return
-      }
-
-      // Suppress state changes from AppKit's deferred initialization
-      // (connector discovery, adapter sync) to prevent route/chain cascades
-      // that would make the page appear to refresh on first connect click.
-      if (isAppKitInitializing()) {
         return
       }
 

--- a/composables/useWagmi.ts
+++ b/composables/useWagmi.ts
@@ -43,7 +43,7 @@ function initializeWagmi() {
       console.warn('[useWagmi] $openWalletModal not available — wallet plugin may not have loaded')
       return
     }
-    open()
+    open().catch(err => logWarn('useWagmi/modal', err))
   }
 
   watch(wagmiAddress, (address, oldAddress) => {

--- a/composables/useWagmi.ts
+++ b/composables/useWagmi.ts
@@ -17,6 +17,17 @@ const routeNetworkId: Ref<number | null> = ref(null)
 let cachedWagmiData: ReturnType<typeof initializeWagmi> | null = null
 let watchersInitialized = false
 
+function isAppKitInitializing(): boolean {
+  try {
+    const nuxtApp = useNuxtApp()
+    const check = nuxtApp.$isAppKitInitializing as (() => boolean) | undefined
+    return check ? check() : false
+  }
+  catch {
+    return false
+  }
+}
+
 function initializeWagmi() {
   const { address: wagmiAddress, isConnected: wagmiIsConnected, connector, chain: wagmiChain, status } = useAccount()
   const { disconnect: wagmiDisconnect } = useDisconnect()
@@ -228,6 +239,8 @@ export const useWagmi = () => {
     watchersInitialized = true
 
     watch([isConnected, connector], ([connected, conn]) => {
+      if (isAppKitInitializing()) return
+
       if (connected && conn) {
         walletName.value = conn.name || 'Wallet'
       }
@@ -278,6 +291,13 @@ export const useWagmi = () => {
 
     watch(wagmiChain, async (val, oldVal) => {
       if (!val?.id || isChangingChain) {
+        return
+      }
+
+      // Suppress state changes from AppKit's deferred initialization
+      // (connector discovery, adapter sync) to prevent route/chain cascades
+      // that would make the page appear to refresh on first connect click.
+      if (isAppKitInitializing()) {
         return
       }
 

--- a/plugins/00.wagmi.ts
+++ b/plugins/00.wagmi.ts
@@ -5,44 +5,6 @@ import type { AppKitNetwork } from '@reown/appkit/networks'
 import { WagmiAdapter } from '@reown/appkit-adapter-wagmi'
 import { getNetworksByChainIds } from '~/entities/chainRegistry'
 
-/**
- * Detects whether the user has previously connected a wallet on this origin.
- *
- * AppKit / Wagmi eagerly probe injected providers and attempt silent reconnect
- * at startup. For users in "default EVM wallet" modes (notably Phantom), that
- * probe can surface an unsolicited connection prompt on every page visit — even
- * when the visitor has never connected. To avoid that we only eagerly initialize
- * AppKit when we know the user previously connected. Otherwise we defer AppKit
- * creation until the user explicitly clicks "Connect Wallet".
- */
-const hasPersistedWalletSession = (): boolean => {
-  if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
-    return false
-  }
-
-  try {
-    if (window.localStorage.getItem('wagmi.recentConnectorId')) {
-      return true
-    }
-
-    const storeRaw = window.localStorage.getItem('wagmi.store')
-    if (storeRaw) {
-      try {
-        const parsed = JSON.parse(storeRaw)
-        if (parsed?.state?.current) return true
-      }
-      catch {
-        // Malformed store — treat as no session.
-      }
-    }
-  }
-  catch {
-    // localStorage may be blocked (Safari private mode, etc.) — treat as no session.
-  }
-
-  return false
-}
-
 export default defineNuxtPlugin((nuxtApp) => {
   const envConfig = useEnvConfig()
   const projectId = envConfig.appKitProjectId
@@ -128,12 +90,10 @@ export default defineNuxtPlugin((nuxtApp) => {
     kit.open()
   }
 
-  // Returning users who previously connected get the full modal up front so
-  // silent reconnect works as before. First-time / signed-out visitors don't
-  // pay that cost until they actually ask to connect.
-  if (hasPersistedWalletSession()) {
-    ensureAppKit()
-  }
+  // Always eagerly initialize AppKit so chunk loads and initialization
+  // side-effects (connector discovery, remote feature fetches) complete
+  // during page load rather than on first "Connect Wallet" click.
+  ensureAppKit()
 
   return {
     provide: {

--- a/plugins/00.wagmi.ts
+++ b/plugins/00.wagmi.ts
@@ -5,6 +5,44 @@ import type { AppKitNetwork } from '@reown/appkit/networks'
 import { WagmiAdapter } from '@reown/appkit-adapter-wagmi'
 import { getNetworksByChainIds } from '~/entities/chainRegistry'
 
+/**
+ * Detects whether the user has previously connected a wallet on this origin.
+ *
+ * AppKit / Wagmi eagerly probe injected providers and attempt silent reconnect
+ * at startup. For users in "default EVM wallet" modes (notably Phantom), that
+ * probe can surface an unsolicited connection prompt on every page visit — even
+ * when the visitor has never connected. To avoid that we only eagerly initialize
+ * AppKit when we know the user previously connected. Otherwise we defer AppKit
+ * creation until the user explicitly clicks "Connect Wallet".
+ */
+const hasPersistedWalletSession = (): boolean => {
+  if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
+    return false
+  }
+
+  try {
+    if (window.localStorage.getItem('wagmi.recentConnectorId')) {
+      return true
+    }
+
+    const storeRaw = window.localStorage.getItem('wagmi.store')
+    if (storeRaw) {
+      try {
+        const parsed = JSON.parse(storeRaw)
+        if (parsed?.state?.current) return true
+      }
+      catch {
+        // Malformed store — treat as no session.
+      }
+    }
+  }
+  catch {
+    // localStorage may be blocked (Safari private mode, etc.) — treat as no session.
+  }
+
+  return false
+}
+
 export default defineNuxtPlugin((nuxtApp) => {
   const envConfig = useEnvConfig()
   const projectId = envConfig.appKitProjectId
@@ -70,6 +108,7 @@ export default defineNuxtPlugin((nuxtApp) => {
   nuxtApp.vueApp.use(WagmiPlugin, { config: wagmiAdapter.wagmiConfig })
 
   let appKitInstance: ReturnType<typeof createAppKit> | null = null
+  let _isAppKitInitializing = false
   const ensureAppKit = () => {
     if (appKitInstance) return appKitInstance
     appKitInstance = createAppKit({
@@ -85,20 +124,25 @@ export default defineNuxtPlugin((nuxtApp) => {
   }
 
   const openWalletModal = async () => {
+    _isAppKitInitializing = true
     const kit = ensureAppKit()
     await kit.ready()
+    _isAppKitInitializing = false
     kit.open()
   }
 
-  // Always eagerly initialize AppKit so chunk loads and initialization
-  // side-effects (connector discovery, remote feature fetches) complete
-  // during page load rather than on first "Connect Wallet" click.
-  ensureAppKit()
+  // Returning users who previously connected get the full modal up front so
+  // silent reconnect works as before. First-time / signed-out visitors don't
+  // pay that cost until they actually ask to connect.
+  if (hasPersistedWalletSession()) {
+    ensureAppKit()
+  }
 
   return {
     provide: {
       ensureAppKit,
       openWalletModal,
+      isAppKitInitializing: () => _isAppKitInitializing,
     },
   }
 })

--- a/plugins/00.wagmi.ts
+++ b/plugins/00.wagmi.ts
@@ -122,8 +122,9 @@ export default defineNuxtPlugin((nuxtApp) => {
     return appKitInstance
   }
 
-  const openWalletModal = () => {
+  const openWalletModal = async () => {
     const kit = ensureAppKit()
+    await kit.ready()
     kit.open()
   }
 

--- a/plugins/00.wagmi.ts
+++ b/plugins/00.wagmi.ts
@@ -5,44 +5,6 @@ import type { AppKitNetwork } from '@reown/appkit/networks'
 import { WagmiAdapter } from '@reown/appkit-adapter-wagmi'
 import { getNetworksByChainIds } from '~/entities/chainRegistry'
 
-/**
- * Detects whether the user has previously connected a wallet on this origin.
- *
- * AppKit / Wagmi eagerly probe injected providers and attempt silent reconnect
- * at startup. For users in "default EVM wallet" modes (notably Phantom), that
- * probe can surface an unsolicited connection prompt on every page visit — even
- * when the visitor has never connected. To avoid that we only eagerly initialize
- * AppKit when we know the user previously connected. Otherwise we defer AppKit
- * creation until the user explicitly clicks "Connect Wallet".
- */
-const hasPersistedWalletSession = (): boolean => {
-  if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
-    return false
-  }
-
-  try {
-    if (window.localStorage.getItem('wagmi.recentConnectorId')) {
-      return true
-    }
-
-    const storeRaw = window.localStorage.getItem('wagmi.store')
-    if (storeRaw) {
-      try {
-        const parsed = JSON.parse(storeRaw)
-        if (parsed?.state?.current) return true
-      }
-      catch {
-        // Malformed store — treat as no session.
-      }
-    }
-  }
-  catch {
-    // localStorage may be blocked (Safari private mode, etc.) — treat as no session.
-  }
-
-  return false
-}
-
 export default defineNuxtPlugin((nuxtApp) => {
   const envConfig = useEnvConfig()
   const projectId = envConfig.appKitProjectId
@@ -108,7 +70,6 @@ export default defineNuxtPlugin((nuxtApp) => {
   nuxtApp.vueApp.use(WagmiPlugin, { config: wagmiAdapter.wagmiConfig })
 
   let appKitInstance: ReturnType<typeof createAppKit> | null = null
-  let _isAppKitInitializing = false
   const ensureAppKit = () => {
     if (appKitInstance) return appKitInstance
     appKitInstance = createAppKit({
@@ -124,25 +85,23 @@ export default defineNuxtPlugin((nuxtApp) => {
   }
 
   const openWalletModal = async () => {
-    _isAppKitInitializing = true
     const kit = ensureAppKit()
     await kit.ready()
-    _isAppKitInitializing = false
     kit.open()
   }
 
-  // Returning users who previously connected get the full modal up front so
-  // silent reconnect works as before. First-time / signed-out visitors don't
-  // pay that cost until they actually ask to connect.
-  if (hasPersistedWalletSession()) {
-    ensureAppKit()
-  }
+  // Always eagerly initialize AppKit so chunk loads and initialization
+  // side-effects (connector discovery, remote feature fetches) complete
+  // during page load rather than on first "Connect Wallet" click.
+  // Previously this was deferred for first-time visitors to avoid Phantom's
+  // unsolicited connection prompt, but that auto-connect is a pre-existing
+  // wagmi-level behavior unrelated to AppKit initialization.
+  ensureAppKit()
 
   return {
     provide: {
       ensureAppKit,
       openWalletModal,
-      isAppKitInitializing: () => _isAppKitInitializing,
     },
   }
 })


### PR DESCRIPTION
## Summary

- Clicking "Connect Wallet" on production caused the page to refresh instead of opening the modal. On second click it worked. This only happened in production builds, not locally.
- Root cause: AppKit was lazily created on first click for users without a persisted wallet session. The `createAppKit()` constructor fires a background `initialize()` that loads 13+ dynamic chunks and probes injected wallet providers. In production builds these chunk loads could trigger Nuxt's `emitRouteChunkError: 'automatic-immediate'` auto-reload, making the page refresh before the modal could open.
- Fix: always eagerly initialize AppKit at plugin load time so chunks and initialization side-effects settle during page load. `openWalletModal` now awaits `kit.ready()` before calling `kit.open()` as an additional safety net.
- The deferred init was originally added to avoid Phantom's unsolicited connection prompt, but testing confirmed that auto-connect is a pre-existing wagmi-level behavior (`WagmiPlugin` probes `window.ethereum` regardless of AppKit timing) — removing deferred init does not regress it.

## Test plan

- [ ] Clear `wagmi.store` and `wagmi.recentConnectorId` from localStorage, click "Connect Wallet" — modal opens without page refresh
- [ ] Returning user: connect wallet, refresh page — silently reconnects
- [ ] Disconnect wallet, refresh — stays disconnected
- [ ] Chain switching works without unexpected refreshes
- [ ] Test with MetaMask and WalletConnect-based wallet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Wallet modal now correctly awaits the wallet kit initialization before opening, reducing failed or premature modal openings.

* **Chores**
  * Removed deferred/session-gated initialization so the wallet toolkit initializes eagerly on page load, improving consistency for first-time visitors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->