### PR TITLE
feat/switch prod deploy trigger from master push to tag-based

### DIFF
--- a/.github/workflows/build-push-deploy-prod.yaml
+++ b/.github/workflows/build-push-deploy-prod.yaml
@@ -1,9 +1,14 @@
 name: Build, Push & Deploy (prod)
 on:
   workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'ECR image tag to deploy (defaults to "latest")'
+        required: false
+        default: 'latest'
   push:
-    branches:
-      - master
+    tags:
+      - 'v*'
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -13,22 +18,31 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build-push:
-    name: Build & Push Image
-    if: github.ref == 'refs/heads/master'
+  build-push-deploy:
+    name: Build, Push & Deploy
     runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write
-    outputs:
-      image_tag: ${{ steps.generate-tag.outputs.image_tag }}
     steps:
+      # ── Build & Push (tag push only) ──
       - name: Check out repository code
+        if: github.event_name == 'push'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.ref }}
+          fetch-depth: 0
+
+      - name: Verify tag is on master
+        if: github.event_name == 'push'
+        run: |
+          if ! git merge-base --is-ancestor "${{ github.sha }}" origin/master; then
+            echo "::error::Tag does not point to a commit on master. Aborting."
+            exit 1
+          fi
 
       - name: Generate image tag
+        if: github.event_name == 'push'
         id: generate-tag
         run: |
           TIMESTAMP=$(date -u +'%H%M_%d%m%Y')
@@ -37,20 +51,24 @@ jobs:
           echo "image_tag=${IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "Generated image tag: ${IMAGE_TAG}"
 
-      - name: Configure AWS credentials
+      - name: Configure AWS credentials (ECR push)
+        if: github.event_name == 'push'
         uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN_PUSH_IMAGE }}
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Login to Amazon ECR
+        if: github.event_name == 'push'
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2.1.2
 
       - name: Set up Docker Buildx
+        if: github.event_name == 'push'
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Build, tag, and push docker image to Amazon ECR
+        if: github.event_name == 'push'
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
@@ -64,14 +82,17 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  deploy:
-    name: Deploy to ECS
-    needs: build-push
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-    steps:
-      - name: Configure AWS credentials
+      # ── Deploy ──
+      - name: Resolve image tag
+        id: resolve-tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "image_tag=${{ inputs.image_tag }}" >> $GITHUB_OUTPUT
+          else
+            echo "image_tag=${{ steps.generate-tag.outputs.image_tag }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Configure AWS credentials (ECS deploy)
         uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
@@ -91,7 +112,7 @@ jobs:
         with:
           task-definition: task-definition.json
           container-name: ${{ secrets.ECS_CONTAINER_NAME }}
-          image: ${{ secrets.ECR_REGISTRY }}/${{ secrets.ECR_REPOSITORY }}:${{ needs.build-push.outputs.image_tag }}
+          image: ${{ secrets.ECR_REGISTRY }}/${{ secrets.ECR_REPOSITORY }}:${{ steps.resolve-tag.outputs.image_tag }}
 
       - name: Deploy new task definition to ECS
         uses: aws-actions/amazon-ecs-deploy-task-definition@fc8fc60f3a60ffd500fcb13b209c59d221ac8c8c # v2.6.1


### PR DESCRIPTION
## Summary
- Production was deploying on every push to master, with no manual gate. This switches the trigger to `v*` tag pushes so deployments are explicit and intentional.
- Manual deploy via `workflow_dispatch` is preserved with an optional `image_tag` input for rollbacks or re-deploys without rebuilding.

## Changes
- Removed `push.branches: [master]` trigger, replaced with `push.tags: ['v*']`
- Collapsed the two-job (build-push + deploy) structure into a single job — build steps are gated with `if: github.event_name == 'push'`, deploy steps run unconditionally
- Added ancestry check (`git merge-base --is-ancestor`) to verify the tagged commit is on master before building
- `workflow_dispatch` now accepts an `image_tag` input (defaults to `latest`) and skips the build, deploying an existing ECR image directly

## Test plan
- [ ] Push a `v*` tag on a master commit — should build, push, and deploy
- [ ] Push a `v*` tag on a non-master commit — should fail at the ancestry check
- [ ] Trigger `workflow_dispatch` with default `latest` — should skip build and deploy the latest ECR image
- [ ] Trigger `workflow_dispatch` with a specific image tag — should deploy that image
- [ ] Push to master — should not trigger this workflow at all

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped version to 1.0.1
  * Enhanced deployment workflow to support manual and tag-based releases with improved validation and consolidated build/deploy process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->