### PR TITLE
fix: address review findings from pre-merge

### DIFF
--- a/components/entities/portfolio/PortfolioBorrowItem.vue
+++ b/components/entities/portfolio/PortfolioBorrowItem.vue
@@ -550,7 +550,7 @@ onMounted(() => {
               </template>
               <UiExactAmount
                 v-else
-                :exact="formatExactAmount(collateralItems[0]?.assets ?? 0n, position.collateral.decimals, position.collateral.asset.symbol)"
+                :exact="formatExactAmount(collateralItems[0]?.assets ?? position.supplied, position.collateral.decimals, position.collateral.asset.symbol)"
               >
                 {{ collateralValueDisplay }}
               </UiExactAmount>
@@ -558,9 +558,9 @@ onMounted(() => {
             <UiExactAmount
               v-if="collateralValue.hasPrice"
               class="text-content-tertiary text-p3"
-              :exact="formatExactAmount(collateralItems[0]?.assets ?? 0n, position.collateral.decimals, position.collateral.asset.symbol)"
+              :exact="formatExactAmount(collateralItems[0]?.assets ?? position.supplied, position.collateral.decimals, position.collateral.asset.symbol)"
             >
-              ~ {{ roundAndCompactTokens(collateralItems[0]?.assets ?? 0n, position.collateral.decimals) }}
+              ~ {{ roundAndCompactTokens(collateralItems[0]?.assets ?? position.supplied, position.collateral.decimals) }}
               {{ position.collateral.asset.symbol }} {{ collateralItems.length > 1 ? '& others' : '' }}
             </UiExactAmount>
           </div>

--- a/components/entities/portfolio/PortfolioBorrowItem.vue
+++ b/components/entities/portfolio/PortfolioBorrowItem.vue
@@ -181,7 +181,7 @@ watchEffect(() => {
 const collateralValueDisplay = computed(() => {
   return collateralValue.value.hasPrice
     ? formatCompactUsdValue(collateralValue.value.usd)
-    : `${roundAndCompactTokens(collateralItems.value[0]?.assets ?? 0n, BigInt(position.collateral.decimals))} ${position.collateral.asset.symbol}`
+    : `${roundAndCompactTokens(collateralItems.value[0]?.assets ?? position.supplied, BigInt(position.collateral.decimals))} ${position.collateral.asset.symbol}`
 })
 
 const borrowedValueInfo = ref<{ display: string, hasPrice: boolean }>({ display: '-', hasPrice: false })

--- a/composables/useBrevis.ts
+++ b/composables/useBrevis.ts
@@ -359,7 +359,9 @@ export const useBrevis = () => {
 
       // Trigger immediate reload so users don't wait up to 60s for the
       // poll interval to repopulate data after a chain switch.
-      if (enableIncentra && val) {
+      // Only mark isLoaded when active, so the isActive watcher still
+      // fires the initial fetch on reconnect.
+      if (enableIncentra && isActive.value && val) {
         loadCampaigns()
         loadRewards()
         isLoaded.value = true

--- a/composables/useBrevis.ts
+++ b/composables/useBrevis.ts
@@ -356,6 +356,14 @@ export const useBrevis = () => {
       cacheState.campaigns.timestamp = 0
       cacheState.rewards.timestamp = 0
       cacheState.rewards.address = ''
+
+      // Trigger immediate reload so users don't wait up to 60s for the
+      // poll interval to repopulate data after a chain switch.
+      if (enableIncentra && val) {
+        loadCampaigns()
+        loadRewards()
+        isLoaded.value = true
+      }
     }
   })
 

--- a/composables/useFuul.ts
+++ b/composables/useFuul.ts
@@ -9,6 +9,7 @@ import type { TxPlan } from '~/entities/txPlan'
 import { CACHE_TTL_1MIN_MS, POLL_INTERVAL_60S_MS } from '~/entities/tuning-constants'
 import { logWarn } from '~/utils/errorHandling'
 import { createInFlightDedup } from '~/utils/in-flight'
+import { createRaceGuard } from '~/utils/race-guard'
 
 const address = ref('')
 
@@ -24,9 +25,8 @@ const isClaimableLoading = ref(true)
 let publicInterval: NodeJS.Timeout | null = null
 let userInterval: NodeJS.Timeout | null = null
 let subscriberCount = 0
-let latestClaimableRequestId = 0
-
-let latestIncentivesRequestId = 0
+const incentivesGuard = createRaceGuard()
+const claimableGuard = createRaceGuard()
 
 const cacheState = {
   campaigns: { chainId: 0, timestamp: 0 },
@@ -86,7 +86,7 @@ export const useFuul = () => {
       return
     }
 
-    const requestId = ++latestIncentivesRequestId
+    const generation = incentivesGuard.next()
 
     try {
       if (isInitialLoading) {
@@ -98,7 +98,7 @@ export const useFuul = () => {
       // /claimable-rewards stays direct below since it's wallet-specific.
       const proxyData = await fetchFuulProxy(currentChainId)
 
-      if (requestId !== latestIncentivesRequestId) return
+      if (incentivesGuard.isStale(generation)) return
 
       const campaignMap = new Map<string, RewardCampaign[]>()
 
@@ -171,7 +171,7 @@ export const useFuul = () => {
       return
     }
 
-    const requestId = ++latestClaimableRequestId
+    const generation = claimableGuard.next()
     const capturedAddress = address.value
 
     try {
@@ -188,7 +188,7 @@ export const useFuul = () => {
         }),
       ])
 
-      if (requestId !== latestClaimableRequestId) return
+      if (claimableGuard.isStale(generation)) return
 
       fuulClaimableEntries.value = [
         ...(Array.isArray(eulerRes.data) ? eulerRes.data : []),
@@ -200,7 +200,7 @@ export const useFuul = () => {
       logWarn('fuul/claimable-rewards', e)
     }
     finally {
-      if (requestId === latestClaimableRequestId) {
+      if (!claimableGuard.isStale(generation)) {
         isClaimableLoading.value = false
       }
     }
@@ -286,7 +286,7 @@ export const useFuul = () => {
     }
     else {
       address.value = ''
-      latestClaimableRequestId++
+      claimableGuard.next()
       fuulClaimableEntries.value = []
       isClaimableLoading.value = false
       cacheState.claimable = { timestamp: 0, address: '', chainId: 0 }

--- a/composables/useFuul.ts
+++ b/composables/useFuul.ts
@@ -26,6 +26,8 @@ let userInterval: NodeJS.Timeout | null = null
 let subscriberCount = 0
 let latestClaimableRequestId = 0
 
+let latestIncentivesRequestId = 0
+
 const cacheState = {
   campaigns: { chainId: 0, timestamp: 0 },
   claimable: { timestamp: 0, address: '', chainId: 0 },
@@ -84,6 +86,8 @@ export const useFuul = () => {
       return
     }
 
+    const requestId = ++latestIncentivesRequestId
+
     try {
       if (isInitialLoading) {
         isCampaignsLoading.value = true
@@ -93,6 +97,8 @@ export const useFuul = () => {
       // protocol queries (euler + euler-looping) and returns a combined shape.
       // /claimable-rewards stays direct below since it's wallet-specific.
       const proxyData = await fetchFuulProxy(currentChainId)
+
+      if (requestId !== latestIncentivesRequestId) return
 
       const campaignMap = new Map<string, RewardCampaign[]>()
 

--- a/composables/useWallets.ts
+++ b/composables/useWallets.ts
@@ -49,9 +49,12 @@ export const useWallets = () => {
       return
     }
 
-    // Capture chainId up-front so we can (a) filter out stale cross-chain
-    // token-list entries and (b) discard results if the chain changes mid-fetch.
+    // Capture chainId and full-balance mode up-front so we can (a) filter out
+    // stale cross-chain token-list entries, (b) discard results if the chain
+    // changes mid-fetch, and (c) only stamp lastFullFetchKey when the fetch
+    // actually included the full token list (not when the mode flipped mid-flight).
     const currentChainId = chainId.value
+    const wasFullMode = fullBalancesRequesters.value > 0
 
     // Guard: the vault registry must hold vaults for THIS chain. Checking
     // `isReady` alone is not enough — on chain switch, `eulerLensAddresses`
@@ -190,7 +193,7 @@ export const useWallets = () => {
         lastFetchChainId.value = currentChainId
         lastFetchAddress.value = targetAddress
         isLoaded.value = true
-        if (fullBalancesRequesters.value > 0) {
+        if (wasFullMode) {
           lastFullFetchKey = `${currentChainId}:${targetAddress.toLowerCase()}`
           lastFullFetchAt = Date.now()
         }

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -86,7 +86,7 @@ External metadata (contract addresses, labels, oracle checks) is fetched through
 | `GET /api/token-list?chainId=X` | Euler API + Uniswap + DefiLlama + Merkl reward-tokens | 5 min | `EULER_API_URL`, `NUXT_PUBLIC_CONFIG_UNISWAP_TOKEN_LIST_URL`, `NUXT_PUBLIC_CONFIG_DEFILLAMA_TOKEN_LIST_URL` |
 | `GET /api/vault-categories?chainId=X[&address=0x…]` | Subgraph vaults query (paginated, capped at 10k per chain) + escrow perspective RPC | 5 min | `NUXT_PUBLIC_SUBGRAPH_URI_<chainId>` |
 | `GET /api/intrinsic-apy?chainId=X` | Every intrinsic-APY source for chain as `{ [addr]: info }` | 5 min (per upstream) | Provider-specific upstreams (DefiLlama, Pendle, Securitize, etc.) |
-| `GET /api/rewards/{merkl,brevis,fuul}?chainId=X` | Merkl / Brevis / Fuul public campaigns | 5 min | Hardcoded provider URLs |
+| `GET /api/rewards/{merkl,brevis,fuul}?chainId=X` | Merkl / Incentra / Fuul public campaigns | 5 min | Hardcoded provider URLs |
 | `GET /api/vaults?chainId=X` | Pre-computed chain vault snapshot | 10 min (safety floor) | — |
 | `GET /api/pyth/updates?ids[]=...` | Pyth Hermes (`/v2/updates/price/latest`) | No cache | `PYTH_HERMES_URL` (server-only) |
 

--- a/server/api/rewards/merkl.get.ts
+++ b/server/api/rewards/merkl.get.ts
@@ -58,31 +58,38 @@ export default defineEventHandler(async (event) => {
 
   const chainId = resolveChainId(event)
 
-  try {
-    const [euler, multi, erc20] = await Promise.all([
-      resolveOpportunity(chainId, 'EULER'),
-      resolveOpportunity(chainId, 'MULTILENDBORROW'),
-      resolveOpportunity(chainId, 'ERC20LOGPROCESSOR'),
-    ])
+  const results = await Promise.allSettled([
+    resolveOpportunity(chainId, 'EULER'),
+    resolveOpportunity(chainId, 'MULTILENDBORROW'),
+    resolveOpportunity(chainId, 'ERC20LOGPROCESSOR'),
+  ])
 
-    // Clients poll in lockstep — letting Cloudflare short-circuit the repeat
-    // polls between warm cycles skips Nitro entirely for most hits.
-    setResponseHeader(event, 'Cache-Control', 'public, max-age=30, stale-while-revalidate=30')
+  const euler = results[0].status === 'fulfilled' ? results[0].value : []
+  const multi = results[1].status === 'fulfilled' ? results[1].value : []
+  const erc20 = results[2].status === 'fulfilled' ? results[2].value : []
 
-    return {
-      opportunities: {
-        euler,
-        multilendborrow: multi,
-        erc20logprocessor: erc20,
-      },
+  // Log individual failures but don't fail the whole response
+  for (const [i, type] of MERKL_TYPES.entries()) {
+    if (results[i].status === 'rejected') {
+      logWarn('rewards-merkl', `${type} failed chain=${chainId}:`, results[i].reason instanceof Error ? results[i].reason.message : results[i].reason)
     }
   }
-  catch (err) {
-    if (err && typeof err === 'object' && 'statusCode' in err) {
-      throw err
-    }
-    logWarn('rewards-merkl', `cold fetch failed chain=${chainId}:`, err instanceof Error ? err.message : err)
+
+  // Only fail if all three subtypes failed — partial data is better than none
+  if (results.every(r => r.status === 'rejected')) {
     throw createError({ statusCode: 502, statusMessage: 'Merkl upstream error' })
+  }
+
+  // Clients poll in lockstep — letting Cloudflare short-circuit the repeat
+  // polls between warm cycles skips Nitro entirely for most hits.
+  setResponseHeader(event, 'Cache-Control', 'public, max-age=30, stale-while-revalidate=30')
+
+  return {
+    opportunities: {
+      euler,
+      multilendborrow: multi,
+      erc20logprocessor: erc20,
+    },
   }
 })
 

--- a/server/api/rewards/merkl.get.ts
+++ b/server/api/rewards/merkl.get.ts
@@ -70,8 +70,9 @@ export default defineEventHandler(async (event) => {
 
   // Log individual failures but don't fail the whole response
   for (const [i, type] of MERKL_TYPES.entries()) {
-    if (results[i].status === 'rejected') {
-      logWarn('rewards-merkl', `${type} failed chain=${chainId}:`, results[i].reason instanceof Error ? results[i].reason.message : results[i].reason)
+    const result = results[i]
+    if (result.status === 'rejected') {
+      logWarn('rewards-merkl', `${type} failed chain=${chainId}:`, result.reason instanceof Error ? result.reason.message : result.reason)
     }
   }
 


### PR DESCRIPTION
FIXES ALL WARRENTED FIXES FROM https://github.com/euler-xyz/euler-lite/pull/285 's CODE REVIEW

## Summary

- Use `Promise.allSettled` in Merkl proxy so one failing subtype does not block the other two from returning data
- Add request-generation guard in `useFuul` via `createRaceGuard` to prevent stale chain responses from overwriting data after a chain switch
- Capture full-balance mode at fetch start in `useWallets` so the `lastFullFetchKey` stamp only applies when the fetch actually included the full token list
- Fix collateral value display in `PortfolioBorrowItem` to fall back to `position.supplied` instead of `0n` when price or asset data is missing
- Immediately reload Brevis campaigns and rewards on chain switch, with `isActive` guard to prevent premature `isLoaded` flag
- Rename "Brevis" to "Incentra" in server endpoint docs