### PR TITLE
hotfix: bypass geo-gate for internal fetches (v1.1.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-app",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/server/middleware/geo-gate.ts
+++ b/server/middleware/geo-gate.ts
@@ -1,10 +1,21 @@
 import { createError, getRequestURL } from 'h3'
 import { SANCTIONED_COUNTRIES } from '~/entities/country-constants'
+import { isInternalRequest } from '~/server/utils/internal-headers'
 
 export default defineEventHandler((event) => {
   // Only gate API routes
   const url = getRequestURL(event)
   if (!url.pathname.startsWith('/api/')) {
+    return
+  }
+
+  // Internal server-to-server $fetch calls (warm-cache, vaults-cache) skip
+  // geo-gating — they never traversed Cloudflare and have no cf-ipcountry,
+  // which would otherwise fail-closed and 451 every internal fetch. The
+  // loopback cf-connecting-ip sentinel is the same signal the rate-limiter
+  // uses to identify internal traffic; both rely on origin being locked
+  // behind CF (see internal-headers.ts).
+  if (isInternalRequest(event)) {
     return
   }
 

--- a/server/utils/internal-headers.ts
+++ b/server/utils/internal-headers.ts
@@ -1,21 +1,36 @@
+import type { H3Event } from 'h3'
+
 /**
  * Synthetic headers for server-internal $fetch calls.
  *
  * The rate-limit middleware in production (DOPPLER_ENVIRONMENT=prd) fails
  * closed when `cf-connecting-ip` is absent — a Cloudflare egress invariant
- * that keeps direct-to-origin traffic out. Internal fetches from warm-cache,
- * vaults-cache, etc. don't go through Cloudflare, so without this header
- * every internal request would silently 403.
+ * that keeps direct-to-origin traffic out. The geo-gate middleware
+ * likewise fails closed when `cf-ipcountry` is absent. Internal fetches
+ * from warm-cache, vaults-cache, etc. don't go through Cloudflare, so
+ * without these headers every internal request would be 403'd or 451'd.
  *
- * 127.0.0.1 is a fixed sentinel — all server-internal traffic shares one
- * rate-limit bucket, which is fine: warm-cache issues at most ~240
- * requests per 5-min cycle against a >=600/min-per-endpoint budget.
+ * `cf-connecting-ip` is a fixed loopback sentinel that downstream
+ * middleware also uses to identify internal traffic (see isInternalRequest
+ * below) — all server-internal traffic shares one rate-limit bucket, which
+ * is fine: warm-cache issues at most ~240 requests per 5-min cycle
+ * against a >=600/min-per-endpoint budget.
  *
  * SECURITY: this sentinel relies on origin ingress NOT being directly
  * reachable — Cloudflare is the only public entrypoint. If that
  * assumption changes (eg a new ingress is exposed), attackers could
- * spoof this header to bypass rate limiting. Do not add the header to
- * anything that forwards user input into the downstream URL, and keep
- * origin locked behind Cloudflare.
+ * spoof these headers to bypass rate limiting AND geo-blocking. Do not
+ * add the headers to anything that forwards user input into the
+ * downstream URL, and keep origin locked behind Cloudflare.
  */
 export const INTERNAL_FETCH_HEADERS = { 'cf-connecting-ip': '127.0.0.1' } as const
+
+/**
+ * True when the incoming request bears the loopback `cf-connecting-ip`
+ * sentinel set by `INTERNAL_FETCH_HEADERS`. Middleware uses this to
+ * bypass geo/rate checks for warm-cache → `/api/*` traffic that never
+ * traversed Cloudflare. Relies on the same origin-locked-behind-CF
+ * security invariant noted above.
+ */
+export const isInternalRequest = (event: H3Event): boolean =>
+  event.node.req.headers['cf-connecting-ip'] === '127.0.0.1'

--- a/tests/server/internal-request.test.ts
+++ b/tests/server/internal-request.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Regression tests for the internal-request sentinel.
+ *
+ * Server-internal $fetch calls (warm-cache, vaults-cache, etc.) do not
+ * traverse Cloudflare, so they have no `cf-ipcountry` or real
+ * `cf-connecting-ip`. Both the geo-gate and rate-limit middlewares
+ * fail-closed when those headers are missing. INTERNAL_FETCH_HEADERS
+ * stamps a loopback `cf-connecting-ip: 127.0.0.1` that downstream
+ * middleware recognises via `isInternalRequest` to bypass those checks.
+ *
+ * If this contract breaks — the sentinel stops being set, the helper
+ * stops recognising it, or a middleware forgets to consult the helper —
+ * every internal API→API call 502s/451s in prod. One such regression
+ * already shipped once (internal `/api/vaults` → `/api/euler-chains`
+ * 451'd by geo-gate). Lock it down.
+ */
+import { describe, it, expect } from 'vitest'
+import type { H3Event } from 'h3'
+import { INTERNAL_FETCH_HEADERS, isInternalRequest } from '~/server/utils/internal-headers'
+
+const eventWithHeaders = (headers: Record<string, string | undefined>): H3Event =>
+  ({ node: { req: { headers } } }) as unknown as H3Event
+
+describe('INTERNAL_FETCH_HEADERS', () => {
+  it('sets cf-connecting-ip to the loopback sentinel', () => {
+    expect(INTERNAL_FETCH_HEADERS['cf-connecting-ip']).toBe('127.0.0.1')
+  })
+})
+
+describe('isInternalRequest', () => {
+  it('returns true when cf-connecting-ip matches the sentinel', () => {
+    const event = eventWithHeaders({ 'cf-connecting-ip': '127.0.0.1' })
+    expect(isInternalRequest(event)).toBe(true)
+  })
+
+  it('returns true for requests decorated with INTERNAL_FETCH_HEADERS', () => {
+    // End-to-end contract: whatever INTERNAL_FETCH_HEADERS sets must be
+    // what isInternalRequest recognises.
+    const event = eventWithHeaders({ ...INTERNAL_FETCH_HEADERS })
+    expect(isInternalRequest(event)).toBe(true)
+  })
+
+  it('returns false when cf-connecting-ip is absent', () => {
+    const event = eventWithHeaders({})
+    expect(isInternalRequest(event)).toBe(false)
+  })
+
+  it('returns false for any other IP', () => {
+    expect(isInternalRequest(eventWithHeaders({ 'cf-connecting-ip': '203.0.113.1' }))).toBe(false)
+    expect(isInternalRequest(eventWithHeaders({ 'cf-connecting-ip': '::1' }))).toBe(false)
+    expect(isInternalRequest(eventWithHeaders({ 'cf-connecting-ip': '127.0.0.2' }))).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

- Prod `/api/vaults` is returning 502 because its internal `$fetch` to `/api/euler-chains` (via `vaults-cache.getChainConfig`) is being 451'd by the `geo-gate` middleware. Internal fetches never traverse Cloudflare, so they carry no `cf-ipcountry` header — the middleware's fail-closed branch fires.
- Fix: the existing `INTERNAL_FETCH_HEADERS` loopback `cf-connecting-ip: 127.0.0.1` sentinel (already relied on by the rate limiter) now also signals "skip geo-gating" via a new `isInternalRequest()` helper. Same origin-locked-behind-CF security invariant that `internal-headers.ts` already documents.
- Adds a focused regression test (`tests/server/internal-request.test.ts`) so this contract can't silently break again — the helper/sentinel wiring is covered end-to-end.
- Bumps `package.json` to `1.1.1` so the `v1.1.1` tag has matching metadata.

### Evidence from prod (betterstack)
```
[geo-gate] Blocked: country undetermined { cfCountry: 'absent', path: '/api/euler-chains' }
```

### Why only /api/vaults
Other proxy endpoints hit real external upstreams (DefiLlama, Merkl, labels repo, etc.) and don't fan out through other internal `/api/*` routes. `/api/vaults`'s `refreshChainVaults` is the only handler that internal-`$fetch`es into the app's own `/api/euler-chains` and `/api/labels/*` — which is why everything else works while this one 502s.

### Deployment
After merge:
```
git tag v1.1.1 <master_sha_after_merge>
git push origin v1.1.1
```
Tag push triggers `build-push-deploy-prod.yaml`, which builds/pushes the image and rolls the ECS service.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npx vitest run tests/server/` — 38 tests passing (added 5)
- [ ] After tag + deploy: verify `/api/vaults?chainId=1` returns 200 (warm-cache populates cache, handler serves cached snapshot)
- [ ] Verify `[geo-gate] Blocked: country undetermined` lines disappear for internal `path` values in logs
- [ ] Verify external user traffic is still geo-gated (non-loopback `cf-connecting-ip` falls through the new bypass)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released patch version 1.1.1
  * Enhanced internal request handling for improved server reliability
  * Added regression test coverage for internal request validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->