### PR TITLE
Fix OKX wallet simulation warning on multi-step transactions

### DIFF
--- a/composables/useEulerOperations/execution.ts
+++ b/composables/useEulerOperations/execution.ts
@@ -8,11 +8,26 @@ import { applyOperationGuards } from '~/utils/operationGuardRegistry'
 
 const OKX_POST_APPROVE_DELAY_MS = 3000
 
-const isOkxWallet = (connector?: { id?: string, name?: string }) => {
+const isOkxWallet = async (connector?: { id?: string, name?: string, getProvider?: () => Promise<unknown> }) => {
   if (!connector) return false
   const id = connector.id?.toLowerCase() ?? ''
   const name = connector.name?.toLowerCase() ?? ''
-  return id === 'okx' || name.includes('okx')
+  if (id === 'okx' || name.includes('okx')) return true
+
+  // When OKX connects via WalletConnect, the connector itself is generic.
+  // The actual wallet name is in the WC session peer metadata.
+  if (id === 'walletconnect' && connector.getProvider) {
+    try {
+      const provider = await connector.getProvider() as { session?: { peer?: { metadata?: { name?: string } } } }
+      const peerName = provider?.session?.peer?.metadata?.name?.toLowerCase() ?? ''
+      return peerName.includes('okx')
+    }
+    catch {
+      return false
+    }
+  }
+
+  return false
 }
 
 export const createExecutionHelpers = (ctx: OperationsContext, allowanceHelpers: AllowanceHelpers) => {
@@ -59,7 +74,7 @@ export const createExecutionHelpers = (ctx: OperationsContext, allowanceHelpers:
       // OKX wallet's simulation backend lags behind on-chain state after approvals.
       // Without a delay, the next step's preview shows "unable to decode asset changes".
       const isApproveStep = step.type === 'approve' || step.type === 'permit2-approve'
-      if (isApproveStep && isOkxWallet(getAccount(ctx.config).connector)) {
+      if (isApproveStep && await isOkxWallet(getAccount(ctx.config).connector)) {
         await new Promise(resolve => setTimeout(resolve, OKX_POST_APPROVE_DELAY_MS))
       }
     }

--- a/composables/useEulerOperations/execution.ts
+++ b/composables/useEulerOperations/execution.ts
@@ -1,10 +1,19 @@
 import type { Address, Hash, Hex, StateOverride } from 'viem'
-import { simulateContract } from '@wagmi/vue/actions'
+import { getAccount, simulateContract } from '@wagmi/vue/actions'
 import type { OperationsContext, AllowanceHelpers } from './types'
 import type { TxPlan } from '~/entities/txPlan'
 import { catchToFallback } from '~/utils/errorHandling'
 import { isNonBlockingSimulationError } from '~/utils/tx-errors'
 import { applyOperationGuards } from '~/utils/operationGuardRegistry'
+
+const OKX_POST_APPROVE_DELAY_MS = 3000
+
+const isOkxWallet = (connector?: { id?: string, name?: string }) => {
+  if (!connector) return false
+  const id = connector.id?.toLowerCase() ?? ''
+  const name = connector.name?.toLowerCase() ?? ''
+  return id === 'okx' || name.includes('okx')
+}
 
 export const createExecutionHelpers = (ctx: OperationsContext, allowanceHelpers: AllowanceHelpers) => {
   const { triggerPortfolioRefresh } = usePortfolioRefresh()
@@ -46,6 +55,13 @@ export const createExecutionHelpers = (ctx: OperationsContext, allowanceHelpers:
 
       lastHash = txHash
       await waitForTxReceipt(txHash)
+
+      // OKX wallet's simulation backend lags behind on-chain state after approvals.
+      // Without a delay, the next step's preview shows "unable to decode asset changes".
+      const isApproveStep = step.type === 'approve' || step.type === 'permit2-approve'
+      if (isApproveStep && isOkxWallet(getAccount(ctx.config).connector)) {
+        await new Promise(resolve => setTimeout(resolve, OKX_POST_APPROVE_DELAY_MS))
+      }
     }
 
     triggerPortfolioRefresh()


### PR DESCRIPTION
## Summary
- OKX wallet's simulation backend lags behind on-chain state after approval transactions are mined, causing an "unable to decode asset changes" warning on the subsequent batch step
- Adds a 3-second post-approve delay exclusively for OKX wallet connections (injected and WalletConnect) to let the simulation backend sync
- No impact on other wallets — the delay is gated on connector id/name matching "okx"

## Test plan
- [x] Tested with OKX wallet (injected) — revoked AERO approval, re-deposited, warning no longer appears
- [x] Verified delay only triggers for OKX by checking connector detection logic
- [ ] Verify no regression on non-OKX wallets (MetaMask, Rabby, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved transaction execution reliability for OKX wallet users by adding a short delay after approval steps to reduce race conditions.
  * Extended handling to cover both standard approval and permit2-approval flows.
  * Transaction simulation and behavior for other wallet types remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->