### PR TITLE
fix: tag-based stage deploy and harden deployment workflows

### DIFF
--- a/.github/workflows/build-push-deploy-prod.yaml
+++ b/.github/workflows/build-push-deploy-prod.yaml
@@ -98,10 +98,15 @@ jobs:
           BUILD_TAG: ${{ steps.generate-tag.outputs.image_tag }}
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "image_tag=$INPUT_TAG" >> $GITHUB_OUTPUT
+            TAG="$INPUT_TAG"
           else
-            echo "image_tag=$BUILD_TAG" >> $GITHUB_OUTPUT
+            TAG="$BUILD_TAG"
           fi
+          if ! echo "$TAG" | grep -qE '^[a-zA-Z0-9_.-]+$'; then
+            echo "::error::Invalid image tag: must match [a-zA-Z0-9_.-]+"
+            exit 1
+          fi
+          echo "image_tag=$TAG" >> $GITHUB_OUTPUT
 
       - name: Configure AWS credentials (ECS deploy)
         uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0

--- a/.github/workflows/build-push-deploy-prod.yaml
+++ b/.github/workflows/build-push-deploy-prod.yaml
@@ -9,6 +9,8 @@ on:
   push:
     tags:
       - 'v*'
+      - '!v*-rc*'
+      - '!v*-beta*'
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true

--- a/.github/workflows/build-push-deploy-prod.yaml
+++ b/.github/workflows/build-push-deploy-prod.yaml
@@ -85,11 +85,14 @@ jobs:
       # ── Deploy ──
       - name: Resolve image tag
         id: resolve-tag
+        env:
+          INPUT_TAG: ${{ inputs.image_tag }}
+          BUILD_TAG: ${{ steps.generate-tag.outputs.image_tag }}
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "image_tag=${{ inputs.image_tag }}" >> $GITHUB_OUTPUT
+            echo "image_tag=$INPUT_TAG" >> $GITHUB_OUTPUT
           else
-            echo "image_tag=${{ steps.generate-tag.outputs.image_tag }}" >> $GITHUB_OUTPUT
+            echo "image_tag=$BUILD_TAG" >> $GITHUB_OUTPUT
           fi
 
       - name: Configure AWS credentials (ECS deploy)

--- a/.github/workflows/build-push-deploy-prod.yaml
+++ b/.github/workflows/build-push-deploy-prod.yaml
@@ -83,6 +83,14 @@ jobs:
           cache-to: type=gha,mode=max
 
       # ── Deploy ──
+      - name: Verify dispatch is from master
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          if [ "${{ github.ref }}" != "refs/heads/master" ]; then
+            echo "::error::workflow_dispatch must be run from the master branch."
+            exit 1
+          fi
+
       - name: Resolve image tag
         id: resolve-tag
         env:

--- a/.github/workflows/build-push-deploy-stage.yaml
+++ b/.github/workflows/build-push-deploy-stage.yaml
@@ -128,10 +128,15 @@ jobs:
           BUILD_TAG: ${{ needs.build-push.outputs.image_tag }}
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "image_tag=$INPUT_TAG" >> $GITHUB_OUTPUT
+            TAG="$INPUT_TAG"
           else
-            echo "image_tag=$BUILD_TAG" >> $GITHUB_OUTPUT
+            TAG="$BUILD_TAG"
           fi
+          if ! echo "$TAG" | grep -qE '^[a-zA-Z0-9_.-]+$'; then
+            echo "::error::Invalid image tag: must match [a-zA-Z0-9_.-]+"
+            exit 1
+          fi
+          echo "image_tag=$TAG" >> $GITHUB_OUTPUT
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0

--- a/.github/workflows/build-push-deploy-stage.yaml
+++ b/.github/workflows/build-push-deploy-stage.yaml
@@ -115,11 +115,14 @@ jobs:
     steps:
       - name: Resolve image tag
         id: resolve-tag
+        env:
+          INPUT_TAG: ${{ inputs.image_tag }}
+          BUILD_TAG: ${{ needs.build-push.outputs.image_tag }}
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "image_tag=${{ inputs.image_tag }}" >> $GITHUB_OUTPUT
+            echo "image_tag=$INPUT_TAG" >> $GITHUB_OUTPUT
           else
-            echo "image_tag=${{ needs.build-push.outputs.image_tag }}" >> $GITHUB_OUTPUT
+            echo "image_tag=$BUILD_TAG" >> $GITHUB_OUTPUT
           fi
 
       - name: Configure AWS credentials

--- a/.github/workflows/build-push-deploy-stage.yaml
+++ b/.github/workflows/build-push-deploy-stage.yaml
@@ -1,9 +1,16 @@
 name: Build, Push & Deploy (stage)
 on:
   workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'ECR image tag to deploy (defaults to "latest")'
+        required: false
+        default: 'latest'
   push:
-    branches:
-      - development
+    tags:
+      - 'rc*'
+      - 'beta*'
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
@@ -14,6 +21,7 @@ concurrency:
 jobs:
   build-push:
     name: Build & Push Image
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -25,6 +33,14 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.ref }}
+          fetch-depth: 0
+
+      - name: Verify tag is on development
+        run: |
+          if ! git merge-base --is-ancestor "${{ github.sha }}" origin/development; then
+            echo "::error::Tag does not point to a commit on development. Aborting."
+            exit 1
+          fi
 
       - name: Generate image tag
         id: generate-tag
@@ -91,11 +107,21 @@ jobs:
 
   deploy:
     name: Deploy to ECS
+    if: always() && (needs.build-push.result == 'success' || (github.event_name == 'workflow_dispatch' && needs.build-push.result == 'skipped'))
     needs: build-push
     runs-on: ubuntu-latest
     permissions:
       id-token: write
     steps:
+      - name: Resolve image tag
+        id: resolve-tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "image_tag=${{ inputs.image_tag }}" >> $GITHUB_OUTPUT
+          else
+            echo "image_tag=${{ needs.build-push.outputs.image_tag }}" >> $GITHUB_OUTPUT
+          fi
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
@@ -116,7 +142,7 @@ jobs:
         with:
           task-definition: task-definition.json
           container-name: ${{ secrets.ECS_CONTAINER_NAME_STAGE }}
-          image: ${{ secrets.ECR_REGISTRY }}/${{ secrets.ECR_REPOSITORY }}:${{ needs.build-push.outputs.image_tag }}
+          image: ${{ secrets.ECR_REGISTRY }}/${{ secrets.ECR_REPOSITORY }}:${{ steps.resolve-tag.outputs.image_tag }}
 
       - name: Deploy new task definition to ECS
         uses: aws-actions/amazon-ecs-deploy-task-definition@fc8fc60f3a60ffd500fcb13b209c59d221ac8c8c # v2.6.1

--- a/.github/workflows/build-push-deploy-stage.yaml
+++ b/.github/workflows/build-push-deploy-stage.yaml
@@ -113,6 +113,14 @@ jobs:
     permissions:
       id-token: write
     steps:
+      - name: Verify dispatch is from development
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          if [ "${{ github.ref }}" != "refs/heads/development" ]; then
+            echo "::error::workflow_dispatch must be run from the development branch."
+            exit 1
+          fi
+
       - name: Resolve image tag
         id: resolve-tag
         env:

--- a/.github/workflows/build-push-deploy-stage.yaml
+++ b/.github/workflows/build-push-deploy-stage.yaml
@@ -8,8 +8,8 @@ on:
         default: 'latest'
   push:
     tags:
-      - 'rc*'
-      - 'beta*'
+      - 'v*-rc*'
+      - 'v*-beta*'
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true

--- a/.github/workflows/build-push-deploy-stage.yaml
+++ b/.github/workflows/build-push-deploy-stage.yaml
@@ -3,9 +3,8 @@ on:
   workflow_dispatch:
     inputs:
       image_tag:
-        description: 'ECR image tag to deploy (defaults to "latest")'
-        required: false
-        default: 'latest'
+        description: 'ECR image tag to deploy'
+        required: true
   push:
     tags:
       - 'v*-rc*'


### PR DESCRIPTION
## Summary

- Stage deployments now trigger on `v*-rc*`/`v*-beta*` tags (e.g. `v1.0.0-rc.1`) instead of every push to `development`, matching the tag-based pattern used for production
- Prod `v*` pattern explicitly excludes `-rc`/`-beta` suffixes so both workflows never fire for the same tag
- Adds branch ancestry verification to ensure tagged commits are actually on `development`
- Adds `workflow_dispatch` with an `image_tag` input for deploy-only reruns of an existing image
- **Security:** Fixes script injection vector in both prod and stage workflows — `inputs.image_tag` was interpolated directly into shell scripts via `${{ }}`, now routed through env vars so values are never parsed as shell syntax
- **Security:** Restricts `workflow_dispatch` to target branch only — stage must be dispatched from `development`, prod from `master`. Prevents accidental deploys from feature branches
- **Security:** Validates image tag format against `[a-zA-Z0-9_.-]+` before writing to workflow outputs. Rejects newlines, spaces, or special characters that could corrupt step outputs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Manual deployment trigger with a customizable image tag input (default "latest").

* **Improvements**
  * CI now runs builds for tagged releases and supports prerelease tags for non-prod; production excludes prerelease tags.
  * Deploy flow gated so manual dispatches and pushes behave appropriately; build runs only on push.
  * Resolved image tag is selected and validated before deployment.
  * Full-history checkout and commit ancestry verification added.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->