### PR TITLE
Fix deprecated banner missing in vault and pair information modals

### DIFF
--- a/components/entities/vault/overview/SecuritizeVaultOverview.vue
+++ b/components/entities/vault/overview/SecuritizeVaultOverview.vue
@@ -40,7 +40,7 @@ const marketProductKey = computed(() => getProductKeyByVault(vault.address))
 const isDeprecated = computed(() => {
   return product.deprecatedVaults?.includes(vaultAddress.value) ?? false
 })
-const deprecationReason = computed(() => isDeprecated.value ? product.deprecationReason : '')
+const deprecationReason = computed(() => isDeprecated.value ? product.deprecationReason || '' : '')
 const isRestricted = computed(() => isVaultBlockedByCountry(vault.address))
 
 const shortenAddress = (address: string) => {
@@ -167,30 +167,10 @@ const supplyCapPercentageDisplay = computed(() => {
         Overview
       </p>
       <div class="flex flex-col items-start gap-24">
-        <div
+        <VaultDeprecationBanner
           v-if="isDeprecated"
-          class="w-full rounded-12 p-16 bg-warning-100 text-warning-500"
-        >
-          <div class="flex items-center gap-8">
-            <SvgIcon
-              name="warning"
-              class="!w-20 !h-20 flex-shrink-0"
-            />
-            <!-- eslint-disable vue/no-v-html -- trusted label content -->
-            <p
-              v-if="deprecationReason"
-              class="text-p3 text-warning-500 auto-link"
-              v-html="autoLink(deprecationReason)"
-            />
-            <!-- eslint-enable vue/no-v-html -->
-            <p
-              v-else
-              class="text-p3 text-warning-500"
-            >
-              This vault has been deprecated.
-            </p>
-          </div>
-        </div>
+          :reason="deprecationReason"
+        />
         <div
           v-if="isRestricted"
           class="w-full rounded-12 p-16 bg-warning-100 text-warning-500"

--- a/components/entities/vault/overview/SecuritizeVaultOverview.vue
+++ b/components/entities/vault/overview/SecuritizeVaultOverview.vue
@@ -168,7 +168,7 @@ const supplyCapPercentageDisplay = computed(() => {
       </p>
       <div class="flex flex-col items-start gap-24">
         <div
-          v-if="isDeprecated && deprecationReason"
+          v-if="isDeprecated"
           class="w-full rounded-12 p-16 bg-warning-100 text-warning-500"
         >
           <div class="flex items-center gap-8">
@@ -178,10 +178,17 @@ const supplyCapPercentageDisplay = computed(() => {
             />
             <!-- eslint-disable vue/no-v-html -- trusted label content -->
             <p
+              v-if="deprecationReason"
               class="text-p3 text-warning-500 auto-link"
               v-html="autoLink(deprecationReason)"
             />
             <!-- eslint-enable vue/no-v-html -->
+            <p
+              v-else
+              class="text-p3 text-warning-500"
+            >
+              This vault has been deprecated.
+            </p>
           </div>
         </div>
         <div

--- a/components/entities/vault/overview/VaultDeprecationBanner.vue
+++ b/components/entities/vault/overview/VaultDeprecationBanner.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import { autoLink } from '~/utils/autoLink'
+
+defineProps<{ reason: string }>()
+</script>
+
+<template>
+  <div class="w-full rounded-12 p-16 bg-warning-100 text-warning-500">
+    <div class="flex items-center gap-8">
+      <SvgIcon
+        name="warning"
+        class="!w-20 !h-20 flex-shrink-0"
+      />
+      <!-- eslint-disable vue/no-v-html -- deprecationReason is validated server-side in server/api/labels/[file].get.ts -->
+      <p
+        v-if="reason"
+        class="text-p3 text-warning-500 auto-link"
+        v-html="autoLink(reason)"
+      />
+      <!-- eslint-enable vue/no-v-html -->
+      <p
+        v-else
+        class="text-p3 text-warning-500"
+      >
+        This vault has been deprecated.
+      </p>
+    </div>
+  </div>
+</template>

--- a/components/entities/vault/overview/VaultOverviewBlockGeneral.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockGeneral.vue
@@ -25,7 +25,7 @@ const description = computed(() => {
 const isDeprecated = computed(() => {
   return product.deprecatedVaults?.includes(vaultAddress.value) ?? false
 })
-const deprecationReason = computed(() => isDeprecated.value ? product.deprecationReason : '')
+const deprecationReason = computed(() => isDeprecated.value ? product.deprecationReason || '' : '')
 const isRestricted = computed(() => isVaultBlockedByCountry(vault.address))
 const isGovernorVerified = computed(() => isVaultGovernorVerified(vault))
 const isGovernanceLimited = computed(() => product.isGovernanceLimited && isGovernorVerified.value)
@@ -54,30 +54,10 @@ watchEffect(async () => {
       Overview
     </p>
     <div class="flex flex-col gap-20">
-      <div
+      <VaultDeprecationBanner
         v-if="isDeprecated"
-        class="w-full rounded-12 p-16 bg-warning-100 text-warning-500"
-      >
-        <div class="flex items-center gap-8">
-          <SvgIcon
-            name="warning"
-            class="!w-20 !h-20 flex-shrink-0"
-          />
-          <!-- eslint-disable vue/no-v-html -- trusted label content -->
-          <p
-            v-if="deprecationReason"
-            class="text-p3 text-warning-500 auto-link"
-            v-html="autoLink(deprecationReason)"
-          />
-          <!-- eslint-enable vue/no-v-html -->
-          <p
-            v-else
-            class="text-p3 text-warning-500"
-          >
-            This vault has been deprecated.
-          </p>
-        </div>
-      </div>
+        :reason="deprecationReason"
+      />
       <div
         v-if="isRestricted"
         class="w-full rounded-12 p-16 bg-warning-100 text-warning-500"

--- a/components/entities/vault/overview/VaultOverviewBlockGeneral.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockGeneral.vue
@@ -55,7 +55,7 @@ watchEffect(async () => {
     </p>
     <div class="flex flex-col gap-20">
       <div
-        v-if="isDeprecated && deprecationReason"
+        v-if="isDeprecated"
         class="w-full rounded-12 p-16 bg-warning-100 text-warning-500"
       >
         <div class="flex items-center gap-8">
@@ -65,10 +65,17 @@ watchEffect(async () => {
           />
           <!-- eslint-disable vue/no-v-html -- trusted label content -->
           <p
+            v-if="deprecationReason"
             class="text-p3 text-warning-500 auto-link"
             v-html="autoLink(deprecationReason)"
           />
           <!-- eslint-enable vue/no-v-html -->
+          <p
+            v-else
+            class="text-p3 text-warning-500"
+          >
+            This vault has been deprecated.
+          </p>
         </div>
       </div>
       <div

--- a/components/entities/vault/overview/earn/VaultOverviewEarnBlockGeneral.vue
+++ b/components/entities/vault/overview/earn/VaultOverviewEarnBlockGeneral.vue
@@ -47,7 +47,7 @@ const feeDisplay = computed(() => {
     </p>
     <div class="flex flex-col gap-20">
       <div
-        v-if="isDeprecated && deprecationReason"
+        v-if="isDeprecated"
         class="w-full rounded-12 p-16 bg-warning-100 text-warning-500"
       >
         <div class="flex items-center gap-8">
@@ -57,10 +57,17 @@ const feeDisplay = computed(() => {
           />
           <!-- eslint-disable vue/no-v-html -- trusted label content -->
           <p
+            v-if="deprecationReason"
             class="text-p3 text-warning-500 auto-link"
             v-html="autoLink(deprecationReason)"
           />
           <!-- eslint-enable vue/no-v-html -->
+          <p
+            v-else
+            class="text-p3 text-warning-500"
+          >
+            This vault has been deprecated.
+          </p>
         </div>
       </div>
       <div

--- a/components/entities/vault/overview/earn/VaultOverviewEarnBlockGeneral.vue
+++ b/components/entities/vault/overview/earn/VaultOverviewEarnBlockGeneral.vue
@@ -46,30 +46,10 @@ const feeDisplay = computed(() => {
       Overview
     </p>
     <div class="flex flex-col gap-20">
-      <div
+      <VaultDeprecationBanner
         v-if="isDeprecated"
-        class="w-full rounded-12 p-16 bg-warning-100 text-warning-500"
-      >
-        <div class="flex items-center gap-8">
-          <SvgIcon
-            name="warning"
-            class="!w-20 !h-20 flex-shrink-0"
-          />
-          <!-- eslint-disable vue/no-v-html -- trusted label content -->
-          <p
-            v-if="deprecationReason"
-            class="text-p3 text-warning-500 auto-link"
-            v-html="autoLink(deprecationReason)"
-          />
-          <!-- eslint-enable vue/no-v-html -->
-          <p
-            v-else
-            class="text-p3 text-warning-500"
-          >
-            This vault has been deprecated.
-          </p>
-        </div>
-      </div>
+        :reason="deprecationReason"
+      />
       <div
         v-if="isRestricted"
         class="w-full rounded-12 p-16 bg-warning-100 text-warning-500"


### PR DESCRIPTION
## Summary
- A vault flagged as deprecated (e.g. MEV Capital Sonic Cluster USDC) shows a `Deprecated` chip on the portfolio/market card but nothing about deprecation inside the vault information modal or the per-asset tabs of the pair information modal.
- Root cause: the single-vault overview blocks gate the warning banner on both `isDeprecated` AND a non-empty `deprecationReason`. When a product lists a vault as deprecated without configuring a reason string, the banner is suppressed. On full pages the missing banner is masked by the `Deprecated` chip rendered in `VaultLabelsAndAssets`, but modals have no such header.

## Changes
- Drop the `deprecationReason` requirement in the three single-vault overview blocks (`VaultOverviewBlockGeneral`, `earn/VaultOverviewEarnBlockGeneral`, `SecuritizeVaultOverview`).
- Render the configured `deprecationReason` when present, otherwise fall back to a generic "This vault has been deprecated." message. This mirrors the pattern already used by `VaultOverviewPairBlockGeneral`, keeping the full pages and all modals consistent.

## Test plan
- [ ] Open the portfolio `Direct lending` card for MEV Capital Sonic Cluster USDC on Sonic, click through to the vault information modal, and confirm the yellow deprecation banner is visible in the Overview section.
- [ ] On a pair where either side is deprecated, open the pair information modal and switch to the collateral and borrow sub-tabs; confirm the banner appears in each.
- [ ] Repeat on the full `/lend/:vault` page and the `/borrow/:collateral/:borrow` page to confirm no visual regression (header chip + body banner both show).
- [ ] Verify a deprecated vault that *does* have a `deprecationReason` configured still renders the reason text (not the generic fallback).
- [ ] Smoke-check a non-deprecated vault to ensure no banner appears.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a dedicated deprecation banner component to display vault deprecation notices and fallback messaging.

* **Bug Fixes**
  * Deprecation warnings now appear for all vaults marked deprecated, even when no specific reason is provided; custom reasons are still shown when present.

* **Refactor**
  * Moved deprecation display and link-rendering logic into the new banner for consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->