### PR TITLE
feat: Cyclical note badge for cyclical-IRM vaults

### DIFF
--- a/components/entities/vault/CyclicalNoteBadge.vue
+++ b/components/entities/vault/CyclicalNoteBadge.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import { useModal } from '~/components/ui/composables/useModal'
+import { CyclicalNoteInfoModal } from '#components'
+
+const { size = 'small' } = defineProps<{
+  size?: 'small' | 'large'
+}>()
+
+const modal = useModal()
+
+const openInfoModal = (event: MouseEvent) => {
+  event.preventDefault()
+  event.stopPropagation()
+  modal.open(CyclicalNoteInfoModal)
+}
+</script>
+
+<template>
+  <span
+    class="cyclical-note-badge inline-flex items-center cursor-pointer"
+    :class="size === 'large'
+      ? 'gap-8 py-8 px-12 rounded-8'
+      : 'gap-4 py-2 px-8 rounded-8 text-p5'"
+    title="Fixed-rate vault with recurring cycles"
+    @click="openInfoModal"
+  >
+    <SvgIcon
+      name="refresh"
+      :class="size === 'large' ? '!w-20 !h-20 mr-2' : '!w-14 !h-14'"
+    />
+    Cyclical note
+  </span>
+</template>
+
+<style scoped lang="scss">
+.cyclical-note-badge {
+  background-color: rgba(var(--accent-rgb), 0.15);
+  color: var(--accent-600);
+
+  [data-theme="dark"] & {
+    background-color: rgba(var(--accent-rgb), 0.2);
+    color: var(--accent-500);
+  }
+}
+</style>

--- a/components/entities/vault/CyclicalNoteBadge.vue
+++ b/components/entities/vault/CyclicalNoteBadge.vue
@@ -16,7 +16,8 @@ const openInfoModal = (event: MouseEvent) => {
 </script>
 
 <template>
-  <span
+  <button
+    type="button"
     class="cyclical-note-badge inline-flex items-center cursor-pointer"
     :class="size === 'large'
       ? 'gap-8 py-8 px-12 rounded-8'
@@ -29,11 +30,12 @@ const openInfoModal = (event: MouseEvent) => {
       :class="size === 'large' ? '!w-20 !h-20 mr-2' : '!w-14 !h-14'"
     />
     Cyclical note
-  </span>
+  </button>
 </template>
 
 <style scoped lang="scss">
 .cyclical-note-badge {
+  border: 0;
   background-color: rgba(var(--accent-rgb), 0.15);
   color: var(--accent-600);
 

--- a/components/entities/vault/CyclicalNoteInfoModal.vue
+++ b/components/entities/vault/CyclicalNoteInfoModal.vue
@@ -1,7 +1,5 @@
 <script setup lang="ts">
 defineEmits<{ close: [] }>()
-
-const LEARN_MORE_URL = 'https://hackmd.io/@46qaiep5S3W5Kif6afqAFg/ByDllQt5xl'
 </script>
 
 <template>
@@ -66,19 +64,6 @@ const LEARN_MORE_URL = 'https://hackmd.io/@46qaiep5S3W5Kif6afqAFg/ByDllQt5xl'
           </p>
         </div>
       </div>
-
-      <a
-        :href="LEARN_MORE_URL"
-        target="_blank"
-        rel="noopener noreferrer"
-        class="flex items-center justify-center gap-4 text-p3 text-accent-600 hover:underline"
-      >
-        Learn more
-        <SvgIcon
-          name="arrow-top-right"
-          class="!w-14 !h-14"
-        />
-      </a>
 
       <UiButton
         variant="primary"

--- a/components/entities/vault/CyclicalNoteInfoModal.vue
+++ b/components/entities/vault/CyclicalNoteInfoModal.vue
@@ -1,0 +1,92 @@
+<script setup lang="ts">
+defineEmits(['close'])
+
+const LEARN_MORE_URL = 'https://hackmd.io/@46qaiep5S3W5Kif6afqAFg/ByDllQt5xl'
+</script>
+
+<template>
+  <BaseModalWrapper
+    title="Cyclical Note"
+    @close="$emit('close')"
+  >
+    <div class="flex flex-col gap-16 pt-8">
+      <div class="flex items-center justify-center">
+        <div class="flex items-center justify-center w-48 h-48 rounded-12 bg-accent-100">
+          <SvgIcon
+            name="refresh"
+            class="!w-24 !h-24 text-accent-600"
+          />
+        </div>
+      </div>
+
+      <div class="flex flex-col gap-8">
+        <p class="text-p2 text-content-primary text-center font-medium">
+          Fixed rates with recurring cycles
+        </p>
+        <p class="text-p3 text-content-secondary text-center">
+          Cyclical Notes offer borrowers a fixed interest rate for most of the cycle, followed by a short repayment window with a sharply higher rate to incentivise repayment. Lenders earn an elevated, predictable yield in exchange for reduced withdrawal flexibility.
+        </p>
+      </div>
+
+      <div class="flex flex-col gap-8 p-12 rounded-12 bg-surface-secondary">
+        <div class="flex items-start gap-8">
+          <SvgIcon
+            name="check-circle"
+            class="!w-16 !h-16 text-accent-600 mt-2 shrink-0"
+          />
+          <p class="text-p3 text-content-secondary">
+            Borrowers pay a fixed rate during the cycle and can repay at any time without penalty
+          </p>
+        </div>
+        <div class="flex items-start gap-8">
+          <SvgIcon
+            name="check-circle"
+            class="!w-16 !h-16 text-accent-600 mt-2 shrink-0"
+          />
+          <p class="text-p3 text-content-secondary">
+            Lenders can only withdraw when liquidity is available, typically at the end of each cycle
+          </p>
+        </div>
+        <div class="flex items-start gap-8">
+          <SvgIcon
+            name="check-circle"
+            class="!w-16 !h-16 text-accent-600 mt-2 shrink-0"
+          />
+          <p class="text-p3 text-content-secondary">
+            The rate rises sharply during the repayment window, creating an incentive to repay and a structured exit point for lenders
+          </p>
+        </div>
+        <div class="flex items-start gap-8">
+          <SvgIcon
+            name="check-circle"
+            class="!w-16 !h-16 text-accent-600 mt-2 shrink-0"
+          />
+          <p class="text-p3 text-content-secondary">
+            Cycles repeat indefinitely — no manual rollover is required
+          </p>
+        </div>
+      </div>
+
+      <a
+        :href="LEARN_MORE_URL"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="flex items-center justify-center gap-4 text-p3 text-accent-600 hover:underline"
+      >
+        Learn more
+        <SvgIcon
+          name="arrow-top-right"
+          class="!w-14 !h-14"
+        />
+      </a>
+
+      <UiButton
+        variant="primary"
+        size="large"
+        @click="$emit('close')"
+      >
+        Got it
+      </UiButton>
+    </div>
+  </BaseModalWrapper>
+</template>

--- a/components/entities/vault/CyclicalNoteInfoModal.vue
+++ b/components/entities/vault/CyclicalNoteInfoModal.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-defineEmits(['close'])
+defineEmits<{ close: [] }>()
 
 const LEARN_MORE_URL = 'https://hackmd.io/@46qaiep5S3W5Kif6afqAFg/ByDllQt5xl'
 </script>

--- a/components/entities/vault/VaultBorrowItem.vue
+++ b/components/entities/vault/VaultBorrowItem.vue
@@ -2,7 +2,7 @@
 import { getAddress } from 'viem'
 import { formatNumber, compactNumber, formatCompactUsdValue } from '~/utils/string-utils'
 import { nanoToValue } from '~/utils/crypto-utils'
-import { type AnyBorrowVaultPair, type Vault, getVaultUtilization } from '~/entities/vault'
+import { type AnyBorrowVaultPair, type Vault, getVaultUtilization, isCyclicalNoteVault } from '~/entities/vault'
 import { getUtilisationWarning, getBorrowCapWarning } from '~/composables/useVaultWarnings'
 import { formatAssetValue } from '~/services/pricing/priceProvider'
 import { getMaxMultiplier, getMaxRoe } from '~/utils/leverage'
@@ -94,6 +94,7 @@ const isPairEffectivelyBlocked = computed(() => {
 
 const isFeatured = computed(() => isVaultFeatured(pair.collateral.address) || isVaultFeatured(pair.borrow.address))
 const isKeyring = computed(() => isVaultKeyring(pair.collateral.address) || isVaultKeyring(pair.borrow.address))
+const isCyclicalNote = computed(() => isCyclicalNoteVault(pair.borrow))
 
 const isAnyDeprecated = computed(() => {
   const collateralAddr = getAddress(pair.collateral.address)
@@ -271,6 +272,7 @@ const linkPath = computed(() => ({
             </span>
             <KeyringBadge v-if="isKeyring" />
             <GovernanceLimitedBadge v-if="isAnyGovernanceLimited" />
+            <CyclicalNoteBadge v-if="isCyclicalNote" />
             <span
               v-if="isGeoBlocked"
               class="inline-flex items-center gap-4 rounded-8 px-8 py-2 bg-warning-100 text-warning-500 text-p5"

--- a/components/entities/vault/VaultItem.vue
+++ b/components/entities/vault/VaultItem.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useAccount } from '@wagmi/vue'
 import { getAddress } from 'viem'
-import { getVaultUtilization, getCurrentLiquidationLTV, type Vault } from '~/entities/vault'
+import { getVaultUtilization, getCurrentLiquidationLTV, isCyclicalNoteVault, type Vault } from '~/entities/vault'
 import { getUtilisationWarning, getSupplyCapWarning } from '~/composables/useVaultWarnings'
 import { formatAssetValue } from '~/services/pricing/priceProvider'
 import { useEulerProductOfVault, useEulerEntitiesOfVault } from '~/composables/useEulerLabels'
@@ -86,6 +86,7 @@ const utilization = computed(() => getVaultUtilization(vault))
 const isGeoBlocked = computed(() => isVaultBlockedByCountry(vault.address))
 const isFeatured = computed(() => isVaultFeatured(vault.address))
 const isKeyring = computed(() => isVaultKeyring(vault.address))
+const isCyclicalNote = computed(() => isCyclicalNoteVault(vault))
 const utilisationWarning = computed(() => getUtilisationWarning(vault, 'lend'))
 const supplyCapWarning = computed(() => getSupplyCapWarning(vault))
 const statsGridCols = computed(() => {
@@ -184,6 +185,7 @@ watchEffect(async () => {
           </span>
           <KeyringBadge v-if="isKeyring" />
           <GovernanceLimitedBadge v-if="isGovernanceLimited" />
+          <CyclicalNoteBadge v-if="isCyclicalNote" />
           <span
             v-if="isGeoBlocked"
             class="inline-flex items-center gap-4 rounded-8 px-8 py-2 bg-warning-100 text-warning-500 text-p5"

--- a/components/entities/vault/VaultTypeBadges.vue
+++ b/components/entities/vault/VaultTypeBadges.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { zeroAddress } from 'viem'
 import type { Vault, EarnVault } from '~/entities/vault'
+import { isCyclicalNoteVault } from '~/entities/vault'
 import { isVaultKeyring, getEntitiesByVault, getEntitiesByEarnVault } from '~/utils/eulerLabelsUtils'
 import { useEulerProductOfVault } from '~/composables/useEulerLabels'
 
@@ -57,6 +58,11 @@ const extraType = computed(() => {
 })
 
 const isKeyring = computed(() => isVaultKeyring(vaultAddress))
+
+const isCyclicalNote = computed(() => {
+  if (!vault.value || isEarn.value) return false
+  return isCyclicalNoteVault(vault.value as Vault)
+})
 </script>
 
 <template>
@@ -79,6 +85,10 @@ const isKeyring = computed(() => isVaultKeyring(vaultAddress))
     />
     <GovernanceLimitedBadge
       v-if="isGovernanceLimited"
+      size="large"
+    />
+    <CyclicalNoteBadge
+      v-if="isCyclicalNote"
       size="large"
     />
   </div>

--- a/components/entities/vault/discovery/DiscoveryMarketCard.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketCard.vue
@@ -11,7 +11,6 @@ import {
   findVault,
   type BestMaxRoeResult,
 } from '~/utils/discoveryCalculations'
-import { isVaultKeyring } from '~/utils/eulerLabelsUtils'
 import { getMaxMultiplier, getMaxRoe } from '~/utils/leverage'
 import { useModal } from '~/components/ui/composables/useModal'
 import { VaultMaxRoeModal } from '#components'
@@ -33,14 +32,6 @@ const modal = useModal()
 const isGovernanceLimited = computed(() =>
   props.market.source === 'product' && !!products[props.market.id]?.isGovernanceLimited,
 )
-
-const isKeyring = computed(() => {
-  if (props.market.source === 'product' && products[props.market.id]?.keyring) return true
-  return props.market.vaults.some((v) => {
-    const addr = 'address' in v ? v.address : ''
-    return addr && isVaultKeyring(addr)
-  })
-})
 
 const getProductDescription = (market: MarketGroup): string => {
   if (market.source !== 'product') return ''
@@ -167,7 +158,6 @@ const onMaxRoeInfoIconClick = (event: MouseEvent, result: BestMaxRoeResult) => {
               />
               Featured
             </span>
-            <KeyringBadge v-if="isKeyring" />
             <GovernanceLimitedBadge v-if="isGovernanceLimited" />
           </div>
           <div class="text-h5 text-content-primary">

--- a/components/entities/vault/discovery/DiscoveryMarketGraph.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketGraph.vue
@@ -10,7 +10,9 @@ import {
   getGraphConnectedAddresses,
   isNodeRampingDown,
   isExternalCollateral,
+  findVault,
 } from '~/utils/discoveryCalculations'
+import { isCyclicalNoteVault } from '~/entities/vault'
 
 const props = defineProps<{
   market: MarketGroup
@@ -38,6 +40,10 @@ const isGraphEdgeHighlighted = (fromAddr: string, toAddr: string): boolean => {
     fromAddr === props.selectedNodeAddress
     || toAddr === props.selectedNodeAddress
   )
+}
+
+const isNodeCyclicalNote = (address: string): boolean => {
+  return isCyclicalNoteVault(findVault(props.market, address))
 }
 </script>
 
@@ -255,6 +261,23 @@ const isGraphEdgeHighlighted = (fromAddr: string, toAddr: string): boolean => {
               :d="`M${node.x + 9} ${node.y - 12.5} l-2.5 1 v2.2 c0 1.5 1 2.5 2.5 3 c1.5 -0.5 2.5 -1.5 2.5 -3 v-2.2 z`"
               fill="white"
             />
+          </g>
+          <!-- Cyclical note badge -->
+          <g v-else-if="isNodeCyclicalNote(node.address)">
+            <circle
+              :cx="node.x + 9"
+              :cy="node.y - 9"
+              r="6"
+              style="fill: var(--accent-500)"
+            />
+            <text
+              :x="node.x + 9"
+              :y="node.y - 5.8"
+              text-anchor="middle"
+              fill="white"
+              font-size="9"
+              font-weight="700"
+            >↻</text>
           </g>
           <!-- Asset label -->
           <text

--- a/components/entities/vault/overview/VaultOverview.vue
+++ b/components/entities/vault/overview/VaultOverview.vue
@@ -1,16 +1,12 @@
 <script setup lang="ts">
-import type { Vault } from '~/entities/vault'
-import { INTEREST_RATE_MODEL_TYPE } from '~/entities/constants'
+import { type Vault, isCyclicalNoteVault } from '~/entities/vault'
 
 const emits = defineEmits<{
   'vault-click': [address: string]
 }>()
 const { vault } = defineProps<{ vault: Vault, desktopOverview?: boolean }>()
 
-const isCyclicalIRM = computed(() => {
-  return Number(vault.irmInfo?.interestRateModelInfo?.interestRateModelType)
-    === INTEREST_RATE_MODEL_TYPE.FIXED_CYCLICAL_BINARY
-})
+const isCyclicalIRM = computed(() => isCyclicalNoteVault(vault))
 </script>
 
 <template>

--- a/entities/vault/index.ts
+++ b/entities/vault/index.ts
@@ -89,4 +89,5 @@ export {
   getMaxWithdraw,
   getUtilization,
   getVaultUtilization,
+  isCyclicalNoteVault,
 } from './utils'

--- a/entities/vault/utils.ts
+++ b/entities/vault/utils.ts
@@ -6,6 +6,13 @@ import {
   vaultMaxWithdrawAbi,
   vaultPreviewWithdrawAbi,
 } from '~/abis/vault'
+import { INTEREST_RATE_MODEL_TYPE } from '~/entities/constants'
+
+export const isCyclicalNoteVault = (vault: unknown): boolean => {
+  const type = (vault as { irmInfo?: { interestRateModelInfo?: { interestRateModelType?: number } } } | null | undefined)
+    ?.irmInfo?.interestRateModelInfo?.interestRateModelType
+  return Number(type) === INTEREST_RATE_MODEL_TYPE.FIXED_CYCLICAL_BINARY
+}
 
 export const getBorrowVaultsByMap = (vaultsMap: Map<string, Vault>) => {
   const arr: BorrowVaultPair[] = []

--- a/entities/vault/utils.ts
+++ b/entities/vault/utils.ts
@@ -8,10 +8,12 @@ import {
 } from '~/abis/vault'
 import { INTEREST_RATE_MODEL_TYPE } from '~/entities/constants'
 
-export const isCyclicalNoteVault = (vault: unknown): boolean => {
-  const type = (vault as { irmInfo?: { interestRateModelInfo?: { interestRateModelType?: number } } } | null | undefined)
-    ?.irmInfo?.interestRateModelInfo?.interestRateModelType
-  return Number(type) === INTEREST_RATE_MODEL_TYPE.FIXED_CYCLICAL_BINARY
+export const isCyclicalNoteVault = (
+  vault: Vault | SecuritizeVault | null | undefined,
+): boolean => {
+  if (!vault || !('irmInfo' in vault)) return false
+  const type = vault.irmInfo?.interestRateModelInfo?.interestRateModelType
+  return typeof type === 'number' && type === INTEREST_RATE_MODEL_TYPE.FIXED_CYCLICAL_BINARY
 }
 
 export const getBorrowVaultsByMap = (vaultsMap: Map<string, Vault>) => {

--- a/tests/entities/vault/utils.test.ts
+++ b/tests/entities/vault/utils.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
-import { getUtilization, getVaultUtilization, getBorrowVaultsByMap } from '~/entities/vault/utils'
-import type { Vault } from '~/entities/vault/types'
+import { INTEREST_RATE_MODEL_TYPE } from '~/entities/constants'
+import { getUtilization, getVaultUtilization, getBorrowVaultsByMap, isCyclicalNoteVault } from '~/entities/vault/utils'
+import type { Vault, SecuritizeVault } from '~/entities/vault/types'
 
 describe('getUtilization', () => {
   it('returns 0 when totalAssets is zero', () => {
@@ -107,5 +108,60 @@ describe('getBorrowVaultsByMap', () => {
     const map = new Map([['0xA', vault]])
     // Collateral vault not in map → pair.collateral is undefined → filtered
     expect(getBorrowVaultsByMap(map)).toEqual([])
+  })
+})
+
+describe('isCyclicalNoteVault', () => {
+  it('returns true for EVK vaults using the fixed cyclical IRM', () => {
+    const vault = {
+      irmInfo: {
+        interestRateModelInfo: {
+          interestRateModelType: INTEREST_RATE_MODEL_TYPE.FIXED_CYCLICAL_BINARY,
+        },
+      },
+    } as Vault
+
+    expect(isCyclicalNoteVault(vault)).toBe(true)
+  })
+
+  it('returns false for non-cyclical EVK vaults', () => {
+    const vault = {
+      irmInfo: {
+        interestRateModelInfo: {
+          interestRateModelType: INTEREST_RATE_MODEL_TYPE.KINK,
+        },
+      },
+    } as Vault
+
+    expect(isCyclicalNoteVault(vault)).toBe(false)
+  })
+
+  it('returns false for securitize vaults and missing vault data', () => {
+    const securitizeVault = {
+      type: 'securitize',
+    } as SecuritizeVault
+
+    expect(isCyclicalNoteVault(securitizeVault)).toBe(false)
+    expect(isCyclicalNoteVault(null)).toBe(false)
+    expect(isCyclicalNoteVault(undefined)).toBe(false)
+  })
+
+  it('returns false when the IRM type is missing or not numeric', () => {
+    const missingType = {
+      irmInfo: {
+        interestRateModelInfo: {},
+      },
+    } as Vault
+
+    const stringType = {
+      irmInfo: {
+        interestRateModelInfo: {
+          interestRateModelType: `${INTEREST_RATE_MODEL_TYPE.FIXED_CYCLICAL_BINARY}` as unknown as number,
+        },
+      },
+    } as Vault
+
+    expect(isCyclicalNoteVault(missingType)).toBe(false)
+    expect(isCyclicalNoteVault(stringType)).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary

Surface vaults using the new Fixed Cyclical Binary IRM via a dedicated **Cyclical note** chip in the lend and borrow tables, on the vault overview page, and as a per-node icon in the discovery graph — so users can learn a vault is cyclical without having to drill into its IRM block.

## Changes

- `isCyclicalNoteVault(vault)` helper in `entities/vault/utils.ts` (checks `irmInfo.interestRateModelInfo.interestRateModelType === FIXED_CYCLICAL_BINARY`)
- `CyclicalNoteBadge.vue` — same shape/size conventions as `KeyringBadge` / `GovernanceLimitedBadge`
- `CyclicalNoteInfoModal.vue` — explains fixed-rate cycles / repayment window / lender-withdrawal behavior
- Wired into `VaultItem` (lend table), `VaultBorrowItem` (borrow table) and `VaultTypeBadges` (vault overview)
- `DiscoveryMarketGraph.vue` — per-node ↻ indicator on cyclical vaults, mirroring how the Private shield marks keyring vaults
- `DiscoveryMarketCard.vue` — dropped the market-level Private chip (graph icon + per-table Private badge already cover this; keeps the rule symmetric with how we surface Cyclical note — which is intentionally **not** shown at market level)

## Test plan

- [ ] Lend table: `Cyclical note` chip renders next to `Private` / `Limited` / `Featured` / `Deprecated` on a cyclical vault row
- [ ] Borrow table: chip renders when the borrow side uses the cyclical IRM
- [ ] Vault overview page: chip renders in the header (both EVK vault and securitize paths unaffected)
- [ ] Chip click opens the info modal; "Learn more" link opens the hackmd doc in a new tab
- [ ] Discovery graph: cyclical vault nodes get the accent-500 ↻ marker; still reuses keyring shield priority where applicable
- [ ] Discovery card: Private chip no longer shown at market level; Limited chip still shown when the product is limited
- [ ] No regression on non-cyclical (kink/adaptive/kinky) vaults — no badge, no graph marker

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a clickable "Cyclical note" badge (small/large, dark-theme aware) shown on vault listings, overview, and market graph nodes for applicable vaults. Clicking opens an informational modal with explanation, checklist, “Got it” action and a “Learn more” link.

* **Removed**
  * Removed the keyring badge from discovery market card displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->