### PR TITLE
fix: verified race on direct navigation to earn/securitize vault pages

### DIFF
--- a/composables/useEulerLabels.ts
+++ b/composables/useEulerLabels.ts
@@ -9,6 +9,7 @@ import { CACHE_TTL_5MIN_MS } from '~/entities/tuning-constants'
 import { normalizeAddress } from '~/utils/normalizeAddress'
 import {
   isLoading,
+  isReady,
   loadState,
   products,
   entities,
@@ -87,9 +88,11 @@ export const useEulerLabels = () => {
         && loadState.chainId === chainId
         && Object.keys(products).length > 0
         && (now - loadState.timestamp) < CACHE_TTL_5MIN_MS) {
+        isReady.value = true
         return
       }
 
+      isReady.value = false
       isLoading.value = true
 
       Object.keys(products).forEach(key => delete products[key])
@@ -190,11 +193,13 @@ export const useEulerLabels = () => {
     }
     finally {
       isLoading.value = false
+      isReady.value = true
     }
   }
 
   return {
     isLoading,
+    isReady,
     verifiedVaultAddresses,
     products,
     entities,

--- a/pages/earn/[vault]/index.vue
+++ b/pages/earn/[vault]/index.vue
@@ -20,6 +20,7 @@ const modal = useModal()
 const { error } = useToast()
 const { buildSupplyPlan, executeTxPlan } = useEulerOperations()
 const { getEarnVault, updateEarnVault } = useVaults()
+const { isReady: isLabelsReady } = useEulerLabels()
 const { isConnected, address } = useAccount()
 const { fetchSingleBalance } = useWallets()
 const { runSimulation, simulationError, clearSimulationError } = useTxPlanSimulation()
@@ -53,6 +54,12 @@ const fetchBalance = async () => {
 // Non-blocking to avoid Suspense + pageTransition crash on direct navigation
 ;(async () => {
   try {
+    // Wait for labels so `verified` is set correctly on direct navigation.
+    // Otherwise getEarnVault falls through to a direct fetch with empty
+    // earnVaultAddresses and returns verified: false.
+    if (!isLabelsReady.value) {
+      await until(isLabelsReady).toBe(true)
+    }
     vault.value = await getEarnVault(vaultAddress)
     asset.value = vault.value?.asset
 

--- a/pages/lend/[vault]/index.vue
+++ b/pages/lend/[vault]/index.vue
@@ -69,6 +69,7 @@ const reviewSupplyLabel = 'Review Supply'
 useFullBalances()
 const { buildSupplyPlan, buildSwapAndSupplyPlan, executeTxPlan } = useEulerOperations()
 const { getVault, getSecuritizeVault, getEscrowVault, updateVault, isEscrowLoadedOnce } = useVaults()
+const { isReady: isLabelsReady } = useEulerLabels()
 const { get: registryGet, getVault: _registryGetVault, isKnownEscrowAddress } = useVaultRegistry()
 const { isConnected, address } = useAccount()
 const { chainId } = useEulerAddresses()
@@ -161,6 +162,12 @@ const needsRefresh = (v: Vault | undefined): boolean => {
   const isSecuritize = await isSecuritizeVault(vaultAddress)
 
   if (isSecuritize) {
+    // Wait for labels so `verified` is set correctly on direct navigation.
+    // Otherwise getSecuritizeVault falls through to a direct fetch with
+    // empty verifiedVaultAddresses and returns verified: false.
+    if (!isLabelsReady.value) {
+      await until(isLabelsReady).toBe(true)
+    }
     securitizeVault.value = await getSecuritizeVault(vaultAddress)
   }
   else {
@@ -172,9 +179,13 @@ const needsRefresh = (v: Vault | undefined): boolean => {
       if (registryEntry?.type === 'evk') {
         evkVault.value = registryEntry.vault as Vault
       }
-      // Escrow vaults haven't loaded yet - wait for them
-      else if (!isEscrowLoadedOnce.value) {
-        await until(isEscrowLoadedOnce).toBe(true)
+      else {
+        // Wait for labels (so `verified` is set correctly) AND for the escrow
+        // address set (so isKnownEscrowAddress can dispatch) before resolving.
+        await Promise.all([
+          isLabelsReady.value ? null : until(isLabelsReady).toBe(true),
+          isEscrowLoadedOnce.value ? null : until(isEscrowLoadedOnce).toBe(true),
+        ])
         const entryAfterLoad = registryGet(normalizedAddress)
         if (entryAfterLoad?.type === 'evk') {
           evkVault.value = entryAfterLoad.vault as Vault
@@ -185,14 +196,6 @@ const needsRefresh = (v: Vault | undefined): boolean => {
         else {
           evkVault.value = await getVault(vaultAddress)
         }
-      }
-      // Escrow vaults loaded - check if known escrow address
-      else if (isKnownEscrowAddress(normalizedAddress)) {
-        evkVault.value = await getEscrowVault(vaultAddress) as Vault
-      }
-      // Regular vault
-      else {
-        evkVault.value = await getVault(vaultAddress)
       }
 
       // Load any collateral vaults that aren't already in registry

--- a/utils/eulerLabelsState.ts
+++ b/utils/eulerLabelsState.ts
@@ -2,6 +2,7 @@ import type { EulerLabelEntity, EulerLabelProduct, EulerLabelPointReward } from 
 import type { OracleAdapterMeta } from '~/entities/oracle'
 
 export const isLoading = ref(false)
+export const isReady = ref(false)
 
 // Use a simple object to track loaded state (survives HMR better than ref)
 export const loadState = { chainId: null as number | null, timestamp: 0 }


### PR DESCRIPTION
## Summary
- Direct navigation to an Earn vault page (and, latently, to a Securitize vault page) could render the vault as unverified because `getEarnVault` / `getSecuritizeVault` would fall through to a direct fetch with an empty labels context, yielding `verified: false`.
- Gate the Earn and Securitize vault page IIFEs on a new `useEulerLabels().isReady` signal so they wait for labels to load before resolving the vault. Internal navigation is unaffected (the flag is already true).
- The EVK branch of the Lend page now explicitly waits on both `isLabelsReady` and `isEscrowLoadedOnce` (in parallel) instead of relying on the transitive `loadLabels → loadVaults` ordering in `app.vue`.

## Test plan
- [x] Reload directly on an Earn vault page (e.g. `/earn/0x8bF41Ad2b816F7c220b22F4BCD63fC2A35Ab4247?network=8453`); the unverified disclaimer modal should NOT appear for a verified vault.
- [ ] Reload directly on a verified Securitize vault page; the unverified disclaimer modal should NOT appear.
- [x] Reload directly on a verified EVK vault page; the page should still render correctly with no regression.
- [x] Reload directly on an escrow EVK collateral page; still verified, no regression.
- [x] Reload directly on a genuinely unverified vault of each type; disclaimer modal should still appear as before.
- [x] Navigate from the in-app Earn/Lend lists to each vault type; no delay regressions on the already-loaded path.
- [x] Switch chains while on a vault page; labels refetch, `isReady` resets and re-flips when done.