### PR TITLE
feat: warn when vault-sourced repay lacks liquidity

### DIFF
--- a/composables/repay/useCollateralSwapRepay.ts
+++ b/composables/repay/useCollateralSwapRepay.ts
@@ -21,7 +21,7 @@ import { nanoToValue, valueToNano } from '~/utils/crypto-utils'
 import { normalizeAddressOrEmpty } from '~/utils/accountPositionHelpers'
 import { createRaceGuard } from '~/utils/race-guard'
 import { findBlockingDisabledOp, OP_REPAY, OP_REPAY_WITH_SHARES, OP_SKIM, OP_TRANSFER, OP_WITHDRAW, type PlannedOp } from '~/utils/vault-hooks'
-import { getPlanHookDisabledWarning } from '~/composables/useVaultWarnings'
+import { getPlanHookDisabledWarning, getUtilisationWarning, type VaultWarning } from '~/composables/useVaultWarnings'
 
 interface UseCollateralSwapRepayOptions {
   position: Ref<AccountBorrowPosition | undefined>
@@ -253,6 +253,13 @@ export const useCollateralSwapRepay = (options: UseCollateralSwapRepayOptions) =
     return getSwapInputAmount(q, core.direction.value)
   })
   const isInsufficientSource = computed(() => requiredInput.value > 0n && requiredInput.value > sourceBalance.value)
+  const isInsufficientVaultLiquidity = computed(() =>
+    requiredInput.value > 0n && requiredInput.value > (sourceVault.value?.totalCash || 0n),
+  )
+  const liquidityWarning = computed<VaultWarning | null>(() => {
+    if (!sourceVault.value) return null
+    return getUtilisationWarning(sourceVault.value, 'repay')
+  })
 
   // --- Submit disabled ---
   const isSubmitDisabled = computed(() => {
@@ -261,6 +268,7 @@ export const useCollateralSwapRepay = (options: UseCollateralSwapRepayOptions) =
     if (!sourceVault.value || !borrowVault.value) return true
     if (!core.debtAmount.value && !core.amount.value) return true
     if (isInsufficientSource.value) return true
+    if (isInsufficientVaultLiquidity.value) return true
     if (core.isSameAsset.value) {
       if (isHealthInsufficient.value) return true
       return false
@@ -278,6 +286,9 @@ export const useCollateralSwapRepay = (options: UseCollateralSwapRepayOptions) =
     }
     if (isInsufficientSource.value) {
       return 'Insufficient collateral balance to cover the required swap amount.'
+    }
+    if (isInsufficientVaultLiquidity.value) {
+      return 'Not enough liquidity in the collateral vault.'
     }
     if (isHealthInsufficient.value) {
       return 'This swap will not restore account health. Repay the full debt from your wallet instead.'
@@ -506,6 +517,7 @@ export const useCollateralSwapRepay = (options: UseCollateralSwapRepayOptions) =
     isSubmitDisabled,
     disabledReason,
     hookWarning,
+    liquidityWarning,
     isRepayExceedsDebt: core.isRepayExceedsDebt,
     // Handlers
     onAmountInput: core.onAmountInput,

--- a/composables/repay/useSavingsRepay.ts
+++ b/composables/repay/useSavingsRepay.ts
@@ -19,7 +19,7 @@ import { getSwapInputAmount } from '~/composables/useEulerOperations/swaps/verif
 import { nanoToValue, valueToNano } from '~/utils/crypto-utils'
 import { createRaceGuard } from '~/utils/race-guard'
 import { findBlockingDisabledOp, OP_REPAY_WITH_SHARES, OP_SKIM, OP_TRANSFER, OP_WITHDRAW, type PlannedOp } from '~/utils/vault-hooks'
-import { getPlanHookDisabledWarning } from '~/composables/useVaultWarnings'
+import { getPlanHookDisabledWarning, getUtilisationWarning, type VaultWarning } from '~/composables/useVaultWarnings'
 
 interface UseSavingsRepayOptions {
   position: Ref<AccountBorrowPosition | undefined>
@@ -197,6 +197,13 @@ export const useSavingsRepay = (options: UseSavingsRepayOptions) => {
     return getSwapInputAmount(q, core.direction.value)
   })
   const isInsufficientSource = computed(() => requiredInput.value > 0n && requiredInput.value > sourceBalance.value)
+  const isInsufficientVaultLiquidity = computed(() =>
+    requiredInput.value > 0n && requiredInput.value > (sourceVault.value?.totalCash || 0n),
+  )
+  const liquidityWarning = computed<VaultWarning | null>(() => {
+    if (!sourceVault.value) return null
+    return getUtilisationWarning(sourceVault.value, 'repay')
+  })
 
   // --- Submit disabled ---
   const isSubmitDisabled = computed(() => {
@@ -206,6 +213,7 @@ export const useSavingsRepay = (options: UseSavingsRepayOptions) => {
     if (!core.debtAmount.value && !core.amount.value) return true
     if (core.isRepayExceedsDebt.value) return true
     if (isInsufficientSource.value) return true
+    if (isInsufficientVaultLiquidity.value) return true
     if (core.isSameAsset.value) return false
     if (core.quotes.quoteError.value) return true
     if (!core.quotes.selectedQuote.value) return true
@@ -218,6 +226,9 @@ export const useSavingsRepay = (options: UseSavingsRepayOptions) => {
     }
     if (isInsufficientSource.value) {
       return 'Insufficient savings balance to cover the required swap amount.'
+    }
+    if (isInsufficientVaultLiquidity.value) {
+      return 'Not enough liquidity in the savings vault.'
     }
     return undefined
   })
@@ -436,6 +447,7 @@ export const useSavingsRepay = (options: UseSavingsRepayOptions) => {
     isSubmitDisabled,
     disabledReason,
     hookWarning,
+    liquidityWarning,
     isRepayExceedsDebt: core.isRepayExceedsDebt,
     // Handlers
     onAmountInput: core.onAmountInput,

--- a/composables/useVaultWarnings.ts
+++ b/composables/useVaultWarnings.ts
@@ -57,11 +57,11 @@ const utilisationMessages: Record<WarningContext, Record<'high' | 'critical', { 
   repay: {
     high: {
       title: 'High utilisation',
-      message: 'Utilisation is high on this collateral market. Available cash is limited, so repaying with collateral may be constrained.',
+      message: 'Utilisation is high on this collateral market. Available liquidity is limited, so repaying with collateral may be constrained.',
     },
     critical: {
       title: 'Critical utilisation',
-      message: 'Utilisation is critically high on this collateral market. Available cash is near zero, so repaying with collateral may fail.',
+      message: 'Utilisation is critically high on this collateral market. Available liquidity is near zero, so repaying with collateral may fail.',
     },
   },
   general: {

--- a/composables/useVaultWarnings.ts
+++ b/composables/useVaultWarnings.ts
@@ -19,7 +19,7 @@ import {
 } from '~/utils/vault-hooks'
 
 export type WarningLevel = 'info' | 'high' | 'critical'
-export type WarningContext = 'lend' | 'borrow' | 'general'
+export type WarningContext = 'lend' | 'borrow' | 'repay' | 'general'
 
 export interface VaultWarning {
   level: WarningLevel
@@ -52,6 +52,16 @@ const utilisationMessages: Record<WarningContext, Record<'high' | 'critical', { 
     critical: {
       title: 'Critical utilisation',
       message: 'Utilisation is critically high. Interest rates are very elevated. Available liquidity is near zero.',
+    },
+  },
+  repay: {
+    high: {
+      title: 'High utilisation',
+      message: 'Utilisation is high on this collateral market. Available cash is limited, so repaying with collateral may be constrained.',
+    },
+    critical: {
+      title: 'Critical utilisation',
+      message: 'Utilisation is critically high on this collateral market. Available cash is near zero, so repaying with collateral may fail.',
     },
   },
   general: {

--- a/pages/position/[number]/repay.vue
+++ b/pages/position/[number]/repay.vue
@@ -538,8 +538,6 @@ watch(formTab, () => {
                 :description="simulationError"
                 size="compact"
               />
-
-              <VaultWarningBanner :warnings="[collateral.liquidityWarning.value]" />
             </div>
 
             <VaultFormInfoBlock
@@ -713,6 +711,8 @@ watch(formTab, () => {
                 :description="simulationError"
                 size="compact"
               />
+
+              <VaultWarningBanner :warnings="[collateral.liquidityWarning.value]" />
             </div>
 
             <VaultFormInfoBlock

--- a/pages/position/[number]/repay.vue
+++ b/pages/position/[number]/repay.vue
@@ -538,6 +538,8 @@ watch(formTab, () => {
                 :description="simulationError"
                 size="compact"
               />
+
+              <VaultWarningBanner :warnings="[collateral.liquidityWarning.value]" />
             </div>
 
             <VaultFormInfoBlock

--- a/pages/position/[number]/repay.vue
+++ b/pages/position/[number]/repay.vue
@@ -886,6 +886,8 @@ watch(formTab, () => {
                 :description="simulationError"
                 size="compact"
               />
+
+              <VaultWarningBanner :warnings="[savings.liquidityWarning.value]" />
             </div>
 
             <VaultFormInfoBlock


### PR DESCRIPTION
## Summary
- Prevent vault-sourced repay submissions when the selected source vault does not have enough liquidity for the withdrawal.
- Surface proactive utilisation warnings on the collateral and savings repay forms so users can see liquidity risk before they submit.

## Changes
- Compare the slippage-aware required input against the selected source vault total cash for both collateral repay and savings repay, then disable submit with a clear liquidity reason when it would exceed available liquidity.
- Add a repay-specific utilisation warning context that keeps the existing warning thresholds while using copy tailored to withdrawing a repay source from a vault.
- Render the liquidity warning in the existing vault warning banner area on the collateral and savings repay forms.

## Test plan
- [x] npx eslint composables/useVaultWarnings.ts composables/repay/useCollateralSwapRepay.ts composables/repay/useSavingsRepay.ts pages/position/[number]/repay.vue
- [x] Smoke tested /position/2/repay?network=42161 in spy mode, switched to From collateral, and verified the collateral repay form renders.
- [x] Force-rendered the warning locally to verify the real VaultWarningBanner path and corrected it to render only under the relevant vault-sourced tab.
- [ ] npm run typecheck: currently blocked by an existing unrelated TypeScript error in composables/useMarketGroups.ts around fetchVault context arguments.
- [ ] Full submit-path manual QA with a connected wallet and terms accepted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Liquidity warning banner added to repay tabs to surface repay-specific utilisation alerts.
  * New dedicated messaging for high and critical repay utilisation states.

* **Bug Fixes**
  * Repayment flow now prevents submission when the source vault lacks sufficient liquidity and shows a clear disabled reason.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->