### PR TITLE
refactor: simplify 1h APY block lookup for earn vaults

### DIFF
--- a/entities/vault/apy.ts
+++ b/entities/vault/apy.ts
@@ -103,68 +103,44 @@ export const getRoe = (
   return netYield / equity
 }
 
-// Cached block data for APY calculations (shared across all vaults)
 interface BlockDataCache {
-  currentBlock: number
-  currentBlockData: { number: bigint, timestamp: bigint }
   oneHourAgoBlock: number
-  oneHourAgoBlockData: { number: bigint, timestamp: bigint }
+  timeElapsedSeconds: number
 }
 
-// Pre-fetch block data once for all APY calculations
+const SAMPLE_DISTANCE = 10_000
+
 export const fetchBlockDataForAPY = async (rpcUrl: string, chainId: number): Promise<BlockDataCache | null> => {
   try {
     const client = getPublicClient(rpcUrl)
-    const currentBlockBigInt = await client.getBlockNumber()
-    const currentBlock = Number(currentBlockBigInt)
-    const sampleDistance = 100
+    const currentBlock = Number(await client.getBlockNumber())
+    const sampleDistance = Math.min(SAMPLE_DISTANCE, currentBlock)
 
-    // Estimate oneHourAgoBlock upfront using typical block times
-    // This allows all 3 getBlock calls to run in parallel
-    // We'll refine the estimate after getting actual block data
-    const estimatedBlockTime = 12 // Conservative estimate (Ethereum mainnet)
-    const estimatedBlocksPerHour = Math.floor(TARGET_TIME_AGO / estimatedBlockTime)
-    const estimatedOneHourAgoBlock = Math.max(0, currentBlock - estimatedBlocksPerHour)
+    if (sampleDistance === 0) {
+      return null
+    }
 
-    // Fetch all 3 blocks in parallel
-    const [currentBlockData, sampleBlockData, estimatedOneHourAgoBlockData] = await Promise.all([
+    const [currentBlockData, sampleBlockData] = await Promise.all([
       client.getBlock({ blockNumber: BigInt(currentBlock) }),
       client.getBlock({ blockNumber: BigInt(currentBlock - sampleDistance) }),
-      client.getBlock({ blockNumber: BigInt(estimatedOneHourAgoBlock) }),
     ])
 
     if (!currentBlockData || !sampleBlockData) {
       return null
     }
 
-    // Calculate actual block time and refine if needed
     const timeDiff = Number(currentBlockData.timestamp - sampleBlockData.timestamp)
     const avgBlockTime = timeDiff / sampleDistance
 
-    if (avgBlockTime === 0) {
+    if (avgBlockTime <= 0) {
       return null
     }
 
-    const blocksPerHour = Math.floor(TARGET_TIME_AGO / avgBlockTime)
-    const actualOneHourAgoBlock = Math.max(0, currentBlock - blocksPerHour)
+    const blocksPerHour = Math.round(TARGET_TIME_AGO / avgBlockTime)
+    const oneHourAgoBlock = Math.max(0, currentBlock - blocksPerHour)
+    const timeElapsedSeconds = blocksPerHour * avgBlockTime
 
-    // If estimate was close enough, use the already-fetched block data
-    // Otherwise fetch the correct block (rare case)
-    let oneHourAgoBlockData = estimatedOneHourAgoBlockData
-    if (actualOneHourAgoBlock !== estimatedOneHourAgoBlock) {
-      oneHourAgoBlockData = await client.getBlock({ blockNumber: BigInt(actualOneHourAgoBlock) })
-    }
-
-    if (!oneHourAgoBlockData) {
-      return null
-    }
-
-    return {
-      currentBlock,
-      currentBlockData,
-      oneHourAgoBlock: actualOneHourAgoBlock,
-      oneHourAgoBlockData,
-    }
+    return { oneHourAgoBlock, timeElapsedSeconds }
   }
   catch (e) {
     logConciseFetchError('apy/fetchBlockData', chainId, 'block data', e)
@@ -172,7 +148,6 @@ export const fetchBlockDataForAPY = async (rpcUrl: string, chainId: number): Pro
   }
 }
 
-// Calculate APY using cached block data (only 2 RPC calls per vault instead of 6)
 export const calculateEarnVaultAPYWithCache = async (
   vaultAddress: string,
   decimals: bigint,
@@ -200,18 +175,12 @@ export const calculateEarnVaultAPYWithCache = async (
       }) as Promise<bigint>,
     ])
 
-    if (oneHourAgoRate === 0n) {
-      return 0
-    }
-
-    const timeElapsed = Number(blockCache.currentBlockData.timestamp - blockCache.oneHourAgoBlockData.timestamp)
-
-    if (timeElapsed === 0) {
+    if (oneHourAgoRate === 0n || blockCache.timeElapsedSeconds <= 0) {
       return 0
     }
 
     const rateChange = Number(currentRate - oneHourAgoRate) / Number(oneHourAgoRate)
-    const apy = ((rateChange * SECONDS_IN_YEAR) / timeElapsed) * 100
+    const apy = ((rateChange * SECONDS_IN_YEAR) / blockCache.timeElapsedSeconds) * 100
 
     return Number.isFinite(apy) ? apy : 0
   }


### PR DESCRIPTION
## Summary
- Rewrites `fetchBlockDataForAPY` in `entities/vault/apy.ts` to sample 10k blocks and derive `oneHourAgoBlock` + `timeElapsedSeconds` in a single straight-line pass.
- Drops the 12s-block guess, the speculative parallel prefetch of the estimated 1h-ago block, and the fallback `getBlock` call that always fired on fast L2s.
- Uses the computed `timeElapsedSeconds` (blocksPerHour × avgBlockTime) as the APY annualization denominator instead of fetching the 1h-ago block's real timestamp.

## Why
- The previous two-phase estimate-then-refine lookup assumed 12s blocks (Ethereum mainnet-ish) and always paid an extra `getBlock` round-trip on any chain with faster blocks (Base, Arbitrum).
- The old 100-block sample produced a noisy `avgBlockTime` on fast L2s (~25s of history on Arbitrum). A 10k sample covers ~33h on mainnet, ~5.5h on Base, ~42min on Arbitrum — all fine and statistically much smoother.
- Net: 2 `getBlock` calls per page load on every chain (was 3 or 4), smaller cache shape, no branching on estimate accuracy.

## Tradeoff
`timeElapsedSeconds` is now derived from `avgBlockTime` rather than the 1h-ago block's real timestamp. If block production rate across the past hour diverges meaningfully from the sample window the annualized APY has a proportional bias, but with a 10k-block sample the sample window dominates and the bias is small in practice.

## Test plan
- [x] `npm run test:run tests/entities/vault/apy.test.ts` — 12/12 pass
- [x] `npm run typecheck` — no new errors (one pre-existing error in `useMarketGroups.ts` unrelated to this change)
- [x] `npx eslint entities/vault/apy.ts` — clean
- [x] Manual smoke test on `/earn` and `/earn/[vault]` on mainnet and at least one fast-block chain (Base/Arbitrum) — confirm "1h" APY badge renders sensible, non-`NaN` values and the network tab shows exactly 2 `getBlock` calls per page load

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized APY calculation logic through improved block-time sampling and caching mechanisms for enhanced accuracy and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->