### PR TITLE
fix: ramping node fix

### DIFF
--- a/components/entities/vault/overview/VaultOverviewBlockBorrow.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockBorrow.vue
@@ -10,6 +10,7 @@ import {
 } from '~/entities/vault'
 import { useModal } from '~/components/ui/composables/useModal'
 import { useVaultRegistry } from '~/composables/useVaultRegistry'
+import { logWarn } from '~/utils/errorHandling'
 import { VaultRampDownModal } from '#components'
 
 const modal = useModal()
@@ -30,10 +31,25 @@ const onRampDownInfoIconClick = (event: MouseEvent, pair: LTVRampConfig) => {
   })
 }
 
+const warnedUnresolved = new Set<string>()
+
 const allCollateralPairs = computed(() =>
   getCollateralExposurePairs(
     vault,
-    addr => registryGet(addr)?.vault as Vault | SecuritizeVault | undefined,
+    (addr) => {
+      const entry = registryGet(addr)
+      if (!entry?.vault) {
+        const key = addr.toLowerCase()
+        if (!warnedUnresolved.has(key)) {
+          warnedUnresolved.add(key)
+          logWarn(
+            'vault-overview/missing-collateral',
+            `Vault ${vault.address} references unresolved collateral ${addr}`,
+          )
+        }
+      }
+      return entry?.vault as Vault | SecuritizeVault | undefined
+    },
   ),
 )
 </script>

--- a/components/entities/vault/overview/VaultOverviewBlockBorrow.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockBorrow.vue
@@ -31,8 +31,10 @@ const onRampDownInfoIconClick = (event: MouseEvent, pair: LTVRampConfig) => {
   })
 }
 
-// Module-scope dedupe so we warn at most once per missing collateral address
-// across recomputes (and across SFC instances on the client).
+// Module-scope dedupe so we warn at most once per (vault, missing-collateral)
+// pair across recomputes and SFC instances. Mirrors the dedupe in
+// composables/useMarketGroups.ts so a curator can spot the same gap reported
+// by either site without one suppressing the other.
 const warnedUnresolved = new Set<string>()
 
 const allCollateralPairs = computed(() =>
@@ -41,7 +43,7 @@ const allCollateralPairs = computed(() =>
     (addr) => {
       const entry = registryGet(addr)
       if (!entry?.vault) {
-        const key = addr.toLowerCase()
+        const key = `${vault.address.toLowerCase()}:${addr.toLowerCase()}`
         if (!warnedUnresolved.has(key)) {
           warnedUnresolved.add(key)
           logWarn(

--- a/components/entities/vault/overview/VaultOverviewBlockBorrow.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockBorrow.vue
@@ -31,6 +31,8 @@ const onRampDownInfoIconClick = (event: MouseEvent, pair: LTVRampConfig) => {
   })
 }
 
+// Module-scope dedupe so we warn at most once per missing collateral address
+// across recomputes (and across SFC instances on the client).
 const warnedUnresolved = new Set<string>()
 
 const allCollateralPairs = computed(() =>

--- a/composables/useMarketGroups.ts
+++ b/composables/useMarketGroups.ts
@@ -97,6 +97,10 @@ const buildProductGroups = (
 
 // -- Step 2: Augment with Collateral Graph --
 
+// Module-scope dedupe so we warn at most once per (vault → missing-collateral)
+// pair across recomputes.
+const warnedMissingCollateral = new Set<string>()
+
 const augmentWithCollateralGraph = (
   groups: MarketGroup[],
   allVaults: AnyVault[],
@@ -116,14 +120,27 @@ const augmentWithCollateralGraph = (
     const seenExternal = new Set<string>()
 
     for (const vault of group.vaults) {
+      const vaultAddr = getVaultAddress(vault)
       const collateralAddrs = getCollateralAddresses(vault)
       for (const colAddr of collateralAddrs) {
         const normalized = colAddr.toLowerCase()
-        if (!groupAddresses.has(normalized) && !seenExternal.has(normalized)) {
-          const externalVault = vaultMap.get(normalized)
-          if (externalVault) {
-            externalCollateral.push(externalVault)
-            seenExternal.add(normalized)
+        if (groupAddresses.has(normalized) || seenExternal.has(normalized)) continue
+        const externalVault = vaultMap.get(normalized)
+        if (externalVault) {
+          externalCollateral.push(externalVault)
+          seenExternal.add(normalized)
+        }
+        else {
+          // Curator referenced a collateral vault that isn't loaded into the
+          // registry — silently dropping it would hide the relationship from
+          // every discovery view. Warn once per pair so the gap is visible.
+          const key = `${vaultAddr.toLowerCase()}:${normalized}`
+          if (!warnedMissingCollateral.has(key)) {
+            warnedMissingCollateral.add(key)
+            logWarn(
+              'useMarketGroups/missing-collateral',
+              `Group "${group.name}": vault ${vaultAddr} references unresolved collateral ${colAddr}`,
+            )
           }
         }
       }

--- a/composables/useVaults.ts
+++ b/composables/useVaults.ts
@@ -15,6 +15,7 @@ import {
   fetchSecuritizeVault,
   fetchVaults,
   clearPriceCaches,
+  isLiveCollateralEdge,
   type Vault,
 } from '~/entities/vault'
 import { fetchChainVaultCategories, isSecuritizeVault, resetVaultCategoryCache } from '~/entities/vault/factory'
@@ -212,10 +213,12 @@ const extractNeededEscrowAddresses = (): string[] => {
   const { getEvkVaults, getEarnVaults, isKnownEscrowAddress } = useVaultRegistry()
   const needed = new Set<string>()
 
-  // 1. Escrow vaults used as collateral in EVK vaults
+  // 1. Escrow vaults used as collateral in EVK vaults — include any live edge,
+  //    not just borrowable ones, so escrows mid-liquidation-LTV-ramp (where
+  //    borrowLTV is already 0) still get fetched and shown in discovery.
   getEvkVaults().forEach((vault) => {
     vault.collateralLTVs.forEach((ltv) => {
-      if (ltv.borrowLTV > 0n && isKnownEscrowAddress(ltv.collateral)) {
+      if (isLiveCollateralEdge(ltv) && isKnownEscrowAddress(ltv.collateral)) {
         needed.add(getAddress(ltv.collateral))
       }
     })

--- a/entities/vault/collateral-exposure.ts
+++ b/entities/vault/collateral-exposure.ts
@@ -38,6 +38,11 @@ export type CollateralVaultResolver
  * deposits are actively backing borrows on *this* vault. This errs on the side
  * of showing the IRM chart (false positive) rather than hiding it (false
  * negative), and matches the heuristic used by the original inline code.
+ *
+ * Distinct from {@link isLiveCollateralEdge} (in `./ltv`), which is the
+ * edge-level predicate used by discovery views — it does not have access to
+ * the collateral vault object, treats `borrowLTV > 0` as sufficient on its
+ * own, and is intentionally broader.
  */
 const isLiveExposure = (
   ltv: VaultCollateralLTV,

--- a/entities/vault/index.ts
+++ b/entities/vault/index.ts
@@ -57,6 +57,7 @@ export type { SerialisedSnapshot } from './loader-serde'
 export {
   getCurrentLiquidationLTV,
   isLiquidationLTVRamping,
+  isLiveCollateralEdge,
   getRampTimeRemaining,
 } from './ltv'
 

--- a/entities/vault/ltv.ts
+++ b/entities/vault/ltv.ts
@@ -3,6 +3,9 @@ import type { VaultCollateralLTV } from './types'
 /** Shared LTV ramp config fields used by both VaultCollateralLTV and BorrowVaultPair */
 export type LTVRampConfig = Pick<VaultCollateralLTV, 'liquidationLTV' | 'initialLiquidationLTV' | 'targetTimestamp' | 'rampDuration'>
 
+/** A collateral edge with both borrow side and liquidation-ramp config — covers VaultCollateralLTV. */
+export type CollateralEdgeConfig = LTVRampConfig & Pick<VaultCollateralLTV, 'borrowLTV'>
+
 /**
  * Calculate the current liquidation LTV, taking into account ramping.
  * When liquidation LTV is lowered, it ramps down linearly from initialLiquidationLTV
@@ -38,6 +41,22 @@ export const isLiquidationLTVRamping = (ltv: LTVRampConfig, nowSeconds?: bigint)
   // Ramping down if: not yet at target timestamp AND target is less than initial (ramping DOWN)
   return now < ltv.targetTimestamp && ltv.liquidationLTV < ltv.initialLiquidationLTV
 }
+
+/**
+ * Is this collateral edge still "live" from the protocol's perspective?
+ *
+ * True if either:
+ * - the edge accepts new borrows (borrowLTV > 0), or
+ * - the current (interpolated) liquidation LTV is still > 0 — i.e. positions
+ *   opened before the ramp are still being wound down rather than fully closed.
+ *
+ * Use this everywhere the UI asks "should this collateral relationship be visible
+ * / loaded / counted?". An LTV ramp-down sets borrowLTV to 0 immediately while
+ * liquidation LTV ramps over time, so a `borrowLTV > 0` check alone drops live
+ * mid-ramp edges (escrows, etc.) from discovery.
+ */
+export const isLiveCollateralEdge = (ltv: CollateralEdgeConfig, nowSeconds?: bigint): boolean =>
+  ltv.borrowLTV > 0n || getCurrentLiquidationLTV(ltv, nowSeconds) > 0n
 
 /**
  * Get the time remaining until ramping completes (in seconds)

--- a/entities/vault/ltv.ts
+++ b/entities/vault/ltv.ts
@@ -54,6 +54,11 @@ export const isLiquidationLTVRamping = (ltv: LTVRampConfig, nowSeconds?: bigint)
  * / loaded / counted?". An LTV ramp-down sets borrowLTV to 0 immediately while
  * liquidation LTV ramps over time, so a `borrowLTV > 0` check alone drops live
  * mid-ramp edges (escrows, etc.) from discovery.
+ *
+ * This is the **edge-level** predicate (no collateral vault object available).
+ * For the borrow-side overview block, see `isLiveExposure` in
+ * `./collateral-exposure` — it additionally checks the collateral vault's
+ * `totalAssets`, so the two predicates are deliberately not equivalent.
  */
 export const isLiveCollateralEdge = (ltv: CollateralEdgeConfig, nowSeconds?: bigint): boolean =>
   ltv.borrowLTV > 0n || getCurrentLiquidationLTV(ltv, nowSeconds) > 0n

--- a/tests/entities/vault/ltv.test.ts
+++ b/tests/entities/vault/ltv.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect } from 'vitest'
 import {
   getCurrentLiquidationLTV,
   isLiquidationLTVRamping,
+  isLiveCollateralEdge,
   getRampTimeRemaining,
+  type CollateralEdgeConfig,
   type LTVRampConfig,
 } from '~/entities/vault/ltv'
 
@@ -11,6 +13,12 @@ const makeLtv = (overrides: Partial<LTVRampConfig> = {}): LTVRampConfig => ({
   initialLiquidationLTV: 9000n, // started at 90%
   targetTimestamp: 2000n, // completes at t=2000
   rampDuration: 1000n, // takes 1000 seconds
+  ...overrides,
+})
+
+const makeEdge = (overrides: Partial<CollateralEdgeConfig> = {}): CollateralEdgeConfig => ({
+  ...makeLtv(),
+  borrowLTV: 7500n,
   ...overrides,
 })
 
@@ -90,6 +98,33 @@ describe('isLiquidationLTVRamping', () => {
   it('returns false when LTV equals initial (no change)', () => {
     const ltv = makeLtv({ liquidationLTV: 9000n, initialLiquidationLTV: 9000n })
     expect(isLiquidationLTVRamping(ltv, 1500n)).toBe(false)
+  })
+})
+
+describe('isLiveCollateralEdge', () => {
+  it('is live when borrowLTV > 0 and liquidation LTV is non-zero', () => {
+    expect(isLiveCollateralEdge(makeEdge(), 1500n)).toBe(true)
+  })
+
+  it('is live mid-ramp even when borrowLTV is already 0', () => {
+    // The exact case the bug fix addresses: curator started LTV ramp-down,
+    // borrowLTV is zeroed immediately, liquidation LTV is still > 0 mid-ramp.
+    const edge = makeEdge({ borrowLTV: 0n, liquidationLTV: 0n })
+    expect(getCurrentLiquidationLTV(edge, 1500n)).toBeGreaterThan(0n)
+    expect(isLiveCollateralEdge(edge, 1500n)).toBe(true)
+  })
+
+  it('is not live once both borrowLTV and the ramped liquidation LTV are 0', () => {
+    const edge = makeEdge({ borrowLTV: 0n, liquidationLTV: 0n })
+    // now=3000 > target=2000 → ramp complete
+    expect(isLiveCollateralEdge(edge, 3000n)).toBe(false)
+  })
+
+  it('is live when borrowLTV > 0 even after the liquidation ramp has completed at zero', () => {
+    // Defensive: shouldn't happen on chain (you can't borrow against a 0 liq
+    // LTV), but the predicate is symmetric — borrow alone keeps it live.
+    const edge = makeEdge({ borrowLTV: 1n, liquidationLTV: 0n })
+    expect(isLiveCollateralEdge(edge, 3000n)).toBe(true)
   })
 })
 

--- a/tests/utils/discovery-calculations.test.ts
+++ b/tests/utils/discovery-calculations.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { getCollateralMatrix, isNodeRampingDown } from '~/utils/discoveryCalculations'
+import { getActiveExternalCollateral, getCollateralMatrix, isNodeRampingDown } from '~/utils/discoveryCalculations'
 import type { MarketGroup } from '~/entities/lend-discovery'
 import type { Vault, VaultCollateralLTV } from '~/entities/vault/types'
 
@@ -31,10 +31,10 @@ const makeVault = (address: string, collateralLTVs: VaultCollateralLTV[]): Vault
     asset: { address, symbol: 'TST' },
   }) as unknown as Vault
 
-const makeMarket = (vaults: Vault[]): MarketGroup =>
+const makeMarket = (vaults: Vault[], externalCollateral: Vault[] = []): MarketGroup =>
   ({
     vaults,
-    externalCollateral: [],
+    externalCollateral,
   }) as unknown as MarketGroup
 
 describe('isNodeRampingDown', () => {
@@ -97,5 +97,34 @@ describe('getCollateralMatrix', () => {
     const market = makeMarket([phasedOutVault, collateralVault])
 
     expect(getCollateralMatrix(market)).toBeNull()
+  })
+})
+
+describe('getActiveExternalCollateral', () => {
+  it('keeps an external collateral vault visible while the borrow vault is ramping it out', () => {
+    const borrowVault = makeVault('0xBorrow', [
+      makeLtv({ collateral: '0xExternal', borrowLTV: 0n }),
+    ])
+    const externalVault = makeVault('0xExternal', [])
+    const market = makeMarket([borrowVault], [externalVault])
+
+    const active = getActiveExternalCollateral(market)
+    expect(active.map(v => (v as Vault).address)).toContain('0xExternal')
+  })
+
+  it('drops an external collateral once the relationship is fully ramped out', () => {
+    const borrowVault = makeVault('0xBorrow', [
+      makeLtv({
+        collateral: '0xExternal',
+        borrowLTV: 0n,
+        liquidationLTV: 0n,
+        initialLiquidationLTV: 8500n,
+        targetTimestamp: nowSeconds - 1n,
+      }),
+    ])
+    const externalVault = makeVault('0xExternal', [])
+    const market = makeMarket([borrowVault], [externalVault])
+
+    expect(getActiveExternalCollateral(market)).toEqual([])
   })
 })

--- a/tests/utils/discovery-calculations.test.ts
+++ b/tests/utils/discovery-calculations.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from 'vitest'
+import { getCollateralMatrix, isNodeRampingDown } from '~/utils/discoveryCalculations'
+import type { MarketGroup } from '~/entities/lend-discovery'
+import type { Vault, VaultCollateralLTV } from '~/entities/vault/types'
+
+vi.mock('~/entities/euler/labels', () => ({
+  getEulerLabelEntityLogo: () => undefined,
+}))
+
+vi.mock('~/utils/eulerLabelsUtils', () => ({
+  getEntitiesByVault: () => [],
+  isVaultDeprecated: () => false,
+}))
+
+const nowSeconds = BigInt(Math.floor(Date.now() / 1000))
+
+const makeLtv = (overrides: Partial<VaultCollateralLTV> = {}): VaultCollateralLTV => ({
+  collateral: '0xCollateral',
+  borrowLTV: 0n,
+  liquidationLTV: 7000n,
+  initialLiquidationLTV: 8500n,
+  targetTimestamp: nowSeconds + 1000n,
+  rampDuration: 2000n,
+  ...overrides,
+})
+
+const makeVault = (address: string, collateralLTVs: VaultCollateralLTV[]): Vault =>
+  ({
+    address,
+    collateralLTVs,
+    asset: { address, symbol: 'TST' },
+  }) as unknown as Vault
+
+const makeMarket = (vaults: Vault[]): MarketGroup =>
+  ({
+    vaults,
+    externalCollateral: [],
+  }) as unknown as MarketGroup
+
+describe('isNodeRampingDown', () => {
+  it('marks the vault whose own collateral LTV is ramping down after borrow LTV is zeroed', () => {
+    const borrowVault = makeVault('0xBorrow', [makeLtv({ collateral: '0xCollateral' })])
+    const collateralVault = makeVault('0xCollateral', [])
+    const market = makeMarket([borrowVault, collateralVault])
+
+    expect(isNodeRampingDown(market, '0xBorrow')).toBe(true)
+  })
+
+  it('does not mark a collateral vault just because another vault is ramping against it', () => {
+    const borrowVault = makeVault('0xBorrow', [makeLtv({ collateral: '0xCollateral' })])
+    const collateralVault = makeVault('0xCollateral', [])
+    const market = makeMarket([borrowVault, collateralVault])
+
+    expect(isNodeRampingDown(market, '0xCollateral')).toBe(false)
+  })
+
+  it('does not mark completed or upward LTV changes as ramping down', () => {
+    const vault = makeVault('0xBorrow', [
+      makeLtv({
+        liquidationLTV: 9000n,
+        initialLiquidationLTV: 8500n,
+      }),
+      makeLtv({
+        targetTimestamp: nowSeconds - 1n,
+      }),
+    ])
+    const market = makeMarket([vault])
+
+    expect(isNodeRampingDown(market, '0xBorrow')).toBe(false)
+  })
+})
+
+describe('getCollateralMatrix', () => {
+  it('keeps a vault as a matrix column while its liquidation LTV is still ramping down', () => {
+    const borrowVault = makeVault('0xBorrow', [makeLtv({ collateral: '0xCollateral', borrowLTV: 0n })])
+    const collateralVault = makeVault('0xCollateral', [])
+    const market = makeMarket([borrowVault, collateralVault])
+
+    const matrix = getCollateralMatrix(market)
+
+    expect(matrix).not.toBeNull()
+    expect(matrix!.columns.map(col => col.address)).toContain('0xborrow')
+    expect(matrix!.rows.map(row => row.address)).toContain('0xcollateral')
+  })
+
+  it('drops a vault from matrix columns once all of its collateral relationships are fully ramped out', () => {
+    const phasedOutVault = makeVault('0xBorrow', [
+      makeLtv({
+        collateral: '0xCollateral',
+        borrowLTV: 0n,
+        liquidationLTV: 0n,
+        initialLiquidationLTV: 8500n,
+        targetTimestamp: nowSeconds - 1n,
+      }),
+    ])
+    const collateralVault = makeVault('0xCollateral', [])
+    const market = makeMarket([phasedOutVault, collateralVault])
+
+    expect(getCollateralMatrix(market)).toBeNull()
+  })
+})

--- a/utils/discoveryCalculations.ts
+++ b/utils/discoveryCalculations.ts
@@ -469,8 +469,11 @@ export const isNodeRampingDown = (market: MarketGroup, address: string): boolean
   const normalized = address.toLowerCase()
   for (const v of market.vaults) {
     if (!isVaultType(v)) continue
+    if (!hasBorrowableLTV(v)) continue
     for (const ltv of v.collateralLTVs) {
-      if (ltv.collateral.toLowerCase() === normalized && isLiquidationLTVRamping(ltv)) return true
+      if (ltv.collateral.toLowerCase() === normalized && isLiquidationLTVRamping(ltv)) {
+        return true
+      }
     }
   }
   return false

--- a/utils/discoveryCalculations.ts
+++ b/utils/discoveryCalculations.ts
@@ -186,6 +186,10 @@ export const getMiniDiagram = (market: MarketGroup): MiniDiagramData => {
       const colAddr = ltv.collateral.toLowerCase()
       if (!vaultByAddr.has(colAddr)) continue
       const liabAddr = vault.address.toLowerCase()
+      // directedEdges drives the borrowable-pair count rendered next to the
+      // graph — only currently borrowable edges count. displayEdges drives
+      // graph rendering and includes mid-ramp edges so a winding-down
+      // collateral remains visually connected.
       if (ltv.borrowLTV > 0n) {
         directedEdges.add(`${colAddr}:${liabAddr}`)
       }

--- a/utils/discoveryCalculations.ts
+++ b/utils/discoveryCalculations.ts
@@ -128,18 +128,27 @@ export const getBorrowableVaults = (market: MarketGroup): Vault[] =>
 export const getNonBorrowableMemberVaults = (market: MarketGroup): Vault[] =>
   market.vaults.filter(isVaultType).filter(v => !hasBorrowableLTV(v))
 
+const hasLiveDiscoveryColumn = (vault: Vault): boolean =>
+  vault.collateralLTVs.some(ltv => getCurrentLiquidationLTV(ltv) > 0n)
+
+const getDiscoveryColumnVaults = (market: MarketGroup): Vault[] =>
+  market.vaults.filter(isVaultType).filter(hasLiveDiscoveryColumn)
+
+const getDiscoveryRowOnlyVaults = (market: MarketGroup): Vault[] =>
+  market.vaults.filter(isVaultType).filter(v => !hasLiveDiscoveryColumn(v))
+
 export const isExternalCollateral = (market: MarketGroup, address: string): boolean => {
   const normalized = address.toLowerCase()
   return market.externalCollateral.some(v => getVaultAddress(v).toLowerCase() === normalized)
 }
 
 export const getActiveExternalCollateral = (market: MarketGroup): AnyVault[] => {
-  const borrowableVaults = getBorrowableVaults(market)
+  const columnVaults = getDiscoveryColumnVaults(market)
   return market.externalCollateral.filter((ext) => {
     const extAddr = getVaultAddress(ext).toLowerCase()
-    return borrowableVaults.some(v =>
+    return columnVaults.some(v =>
       v.collateralLTVs.some(ltv =>
-        ltv.collateral.toLowerCase() === extAddr && ltv.liquidationLTV > 0n,
+        ltv.collateral.toLowerCase() === extAddr && getCurrentLiquidationLTV(ltv) > 0n,
       ),
     )
   })
@@ -250,8 +259,8 @@ export const getMiniDiagram = (market: MarketGroup): MiniDiagramData => {
 // ============================================================
 
 export const getCollateralMatrix = (market: MarketGroup): CollateralMatrixData | null => {
-  const borrowable = getBorrowableVaults(market)
-  const nonBorrowable = getNonBorrowableMemberVaults(market)
+  const borrowable = getDiscoveryColumnVaults(market)
+  const nonBorrowable = getDiscoveryRowOnlyVaults(market)
   const external = getActiveExternalCollateral(market)
 
   const knownAddresses = new Set<string>()
@@ -467,16 +476,11 @@ export const getGraphConnectedAddresses = (diagram: MiniDiagramData, address: st
 
 export const isNodeRampingDown = (market: MarketGroup, address: string): boolean => {
   const normalized = address.toLowerCase()
-  for (const v of market.vaults) {
-    if (!isVaultType(v)) continue
-    if (!hasBorrowableLTV(v)) continue
-    for (const ltv of v.collateralLTVs) {
-      if (ltv.collateral.toLowerCase() === normalized && isLiquidationLTVRamping(ltv)) {
-        return true
-      }
-    }
-  }
-  return false
+  const vault = market.vaults
+    .filter(isVaultType)
+    .find(v => v.address.toLowerCase() === normalized)
+
+  return vault?.collateralLTVs.some(ltv => isLiquidationLTVRamping(ltv)) ?? false
 }
 
 // ============================================================

--- a/utils/discoveryCalculations.ts
+++ b/utils/discoveryCalculations.ts
@@ -2,7 +2,7 @@ import type { MarketGroup, MiniDiagramData, MiniNode, MiniEdge } from '~/entitie
 import type { Vault, SecuritizeVault, VaultCollateralLTV } from '~/entities/vault'
 import type { AnyVault } from '~/composables/useVaultRegistry'
 import type { EulerLabelEntity } from '~/entities/euler/labels'
-import { getCurrentLiquidationLTV, isLiquidationLTVRamping } from '~/entities/vault'
+import { isLiquidationLTVRamping, isLiveCollateralEdge } from '~/entities/vault'
 import { getEulerLabelEntityLogo } from '~/entities/euler/labels'
 import { getEntitiesByVault, isVaultDeprecated } from '~/utils/eulerLabelsUtils'
 import { nanoToValue } from '~/utils/crypto-utils'
@@ -129,7 +129,7 @@ export const getNonBorrowableMemberVaults = (market: MarketGroup): Vault[] =>
   market.vaults.filter(isVaultType).filter(v => !hasBorrowableLTV(v))
 
 const hasLiveDiscoveryColumn = (vault: Vault): boolean =>
-  vault.collateralLTVs.some(ltv => getCurrentLiquidationLTV(ltv) > 0n)
+  vault.collateralLTVs.some(ltv => isLiveCollateralEdge(ltv))
 
 const getDiscoveryColumnVaults = (market: MarketGroup): Vault[] =>
   market.vaults.filter(isVaultType).filter(hasLiveDiscoveryColumn)
@@ -148,7 +148,7 @@ export const getActiveExternalCollateral = (market: MarketGroup): AnyVault[] => 
     const extAddr = getVaultAddress(ext).toLowerCase()
     return columnVaults.some(v =>
       v.collateralLTVs.some(ltv =>
-        ltv.collateral.toLowerCase() === extAddr && getCurrentLiquidationLTV(ltv) > 0n,
+        ltv.collateral.toLowerCase() === extAddr && isLiveCollateralEdge(ltv),
       ),
     )
   })
@@ -189,7 +189,7 @@ export const getMiniDiagram = (market: MarketGroup): MiniDiagramData => {
       if (ltv.borrowLTV > 0n) {
         directedEdges.add(`${colAddr}:${liabAddr}`)
       }
-      if (getCurrentLiquidationLTV(ltv) > 0n) {
+      if (isLiveCollateralEdge(ltv)) {
         displayEdges.add(`${colAddr}:${liabAddr}`)
         connectedAddresses.add(colAddr)
         connectedAddresses.add(liabAddr)
@@ -276,7 +276,7 @@ export const getCollateralMatrix = (market: MarketGroup): CollateralMatrixData |
 
   for (const vault of borrowable) {
     for (const ltv of vault.collateralLTVs) {
-      if (getCurrentLiquidationLTV(ltv) <= 0n) continue
+      if (!isLiveCollateralEdge(ltv)) continue
       const colAddr = ltv.collateral.toLowerCase()
       if (!knownAddresses.has(colAddr)) continue
 


### PR DESCRIPTION
**Summary**
Fix LTV ramping in discovery so vaults that have started a liquidation-LTV ramp stay visible everywhere they should — graph, matrix, and the per-vault "Collateral exposure" block.

**Why**
When a curator starts an LTV ramp-down (e.g. Prime → wstETH escrow), the borrow LTV drops to 0 immediately while the liquidation LTV ramps over the configured window. Previously the lazy escrow loader excluded any collateral whose `borrowLTV` was 0, so the affected escrow was never fetched into the registry — and every downstream consumer (graph, matrix, per-vault "Collateral exposure" block) silently dropped the relationship. The discovery-side filters compounded the issue by also keying on the target liquidation LTV instead of the current ramped value.

**What changed**
- New shared predicate `isLiveCollateralEdge(ltv)` in `entities/vault/ltv.ts` — true if `borrowLTV > 0` OR the current ramped liquidation LTV > 0. Single source of truth for "is this collateral relationship still live".
- Loader fix in `composables/useVaults.ts` (`extractNeededEscrowAddresses`): use the new predicate so escrows under a live-but-ramping liquidation LTV are fetched into the registry.
- Discovery fixes in `utils/discoveryCalculations.ts`: `hasLiveDiscoveryColumn`, `getActiveExternalCollateral`, `getMiniDiagram`, and `getCollateralMatrix` all use the shared predicate so display tracks loader behaviour.
- Graph node ramping detection re-aligned to the borrowable vault's perspective (kept from prior commit; verified against existing tests).
- Diagnostic `logWarn` calls when a collateral address can't be resolved in `useMarketGroups.augmentWithCollateralGraph` or in the `VaultOverviewBlockBorrow` resolver — deduped per (vault, collateral) pair so future curator gaps surface visibly instead of disappearing.
- Regression tests for `getActiveExternalCollateral` mid-ramp and post-ramp, plus full unit coverage on the new `isLiveCollateralEdge` helper.

**Validation**
- `npm run test:run` — full suite (433 tests) passes.
- `npm run test:run -- tests/entities/vault/ltv.test.ts tests/utils/discovery-calculations.test.ts` — targeted.
- Manual smoke against Prime: with wstETH escrow mid-ramp, expect the escrow node visible in the graph, present in the matrix, and the "Collateral exposure" tile rendered with the current liquidation LTV on the WETH vault page.

**Prime sanity check**
- XAUt and TBILL remain row-only and don't get column treatment or graph arrows.
- wstETH (or any other collateral) under an active liquidation-LTV ramp now stays in graph + matrix + collateral-exposure block until the ramp completes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests covering collateral discovery, live-edge/ramp visibility, and related ramp-out scenarios.

* **Refactor**
  * Discovery logic updated so mid-ramp collateral relationships and associated escrows remain visible during discovery.
  * Ramping-down detection narrowed to specific vaults for clearer results and improved efficiency.

* **Bug Fixes**
  * Deduplicated warnings when collateral references cannot be resolved to reduce noisy logs.

* **Documentation**
  * Clarified distinction between edge-level and vault-level live-collateral checks in comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->