### PR TITLE
fix: fix spy mode balance lookup for native-token deposit flows.

### DIFF
--- a/composables/useWagmi.ts
+++ b/composables/useWagmi.ts
@@ -22,6 +22,8 @@ function initializeWagmi() {
   const { disconnect: wagmiDisconnect } = useDisconnect()
   const { switchChain } = useSwitchChain()
   const { screenConnectedAddress, resetScreeningCache } = useAddressScreen()
+  const { spyAddress } = useSpyMode()
+  const { chainId: appChainId } = useEulerAddresses()
 
   const chainId = computed(() => wagmiChain.value?.id)
 
@@ -29,8 +31,22 @@ function initializeWagmi() {
     address: wagmiAddress,
     chainId: chainId.value,
   })
+
+  // Balance follows spy mode when active: queries the spy-target's balance on
+  // the app's current chain (not the wallet's), so the header always matches
+  // the portfolio being viewed. Falls back to the connected wallet otherwise.
+  const balanceAddress = computed<Address | undefined>(() => {
+    if (spyAddress.value) return spyAddress.value as Address
+    return wagmiAddress.value
+  })
+  const balanceChainId = computed(() => {
+    if (spyAddress.value) return appChainId.value || undefined
+    return undefined
+  })
+
   const { data: balanceData, isLoading: isLoadingBalance, refetch: refetchBalance } = useBalance({
-    address: wagmiAddress,
+    address: balanceAddress,
+    chainId: balanceChainId,
   })
 
   // AppKit may be deferred-initialized (see plugins/00.wagmi.ts). Route

--- a/composables/useWagmi.ts
+++ b/composables/useWagmi.ts
@@ -22,8 +22,6 @@ function initializeWagmi() {
   const { disconnect: wagmiDisconnect } = useDisconnect()
   const { switchChain } = useSwitchChain()
   const { screenConnectedAddress, resetScreeningCache } = useAddressScreen()
-  const { spyAddress } = useSpyMode()
-  const { chainId: appChainId } = useEulerAddresses()
 
   const chainId = computed(() => wagmiChain.value?.id)
 
@@ -31,22 +29,8 @@ function initializeWagmi() {
     address: wagmiAddress,
     chainId: chainId.value,
   })
-
-  // Balance follows spy mode when active: queries the spy-target's balance on
-  // the app's current chain (not the wallet's), so the header always matches
-  // the portfolio being viewed. Falls back to the connected wallet otherwise.
-  const balanceAddress = computed<Address | undefined>(() => {
-    if (spyAddress.value) return spyAddress.value as Address
-    return wagmiAddress.value
-  })
-  const balanceChainId = computed(() => {
-    if (spyAddress.value) return appChainId.value || undefined
-    return undefined
-  })
-
   const { data: balanceData, isLoading: isLoadingBalance, refetch: refetchBalance } = useBalance({
-    address: balanceAddress,
-    chainId: balanceChainId,
+    address: wagmiAddress,
   })
 
   // AppKit may be deferred-initialized (see plugins/00.wagmi.ts). Route

--- a/composables/useWallets.ts
+++ b/composables/useWallets.ts
@@ -120,8 +120,9 @@ export const useWallets = () => {
       }
     }
 
+    const includesNativeCurrency = addresses.delete(zeroAddress)
     const tokenAddresses = [...addresses] as Address[]
-    if (!tokenAddresses.length) {
+    if (!tokenAddresses.length && !includesNativeCurrency) {
       isLoaded.value = true
       return
     }
@@ -136,6 +137,17 @@ export const useWallets = () => {
     try {
       const targetAddress = balanceAddress.value as Address
       const client = getPublicClient(rpcUrl.value)
+      const nativeBalancePromise = includesNativeCurrency
+        ? client.getBalance({ address: targetAddress }).catch((e) => {
+            logWarn('wallets/nativeBalance', e, {
+              data: {
+                chainId: currentChainId,
+                target: targetAddress,
+              },
+            })
+            return 0n
+          })
+        : Promise.resolve<bigint | undefined>(undefined)
 
       // Fetch balances via lens in chunks to stay within gas limits
       // All chunks fire concurrently so viem's HTTP transport batches them into fewer requests
@@ -145,38 +157,41 @@ export const useWallets = () => {
         chunks.push(tokenAddresses.slice(i, i + LENS_BATCH_SIZE))
       }
 
-      const chunkResults = await Promise.all(
-        chunks.map(async (batch, chunkIndex) => {
-          try {
-            return await client.readContract({
-              address: utilsLensAddress,
-              abi: eulerUtilsLensABI,
-              functionName: 'tokenBalances',
-              args: [targetAddress, batch],
-            }) as bigint[]
-          }
-          catch (e) {
-            logWarn(
-              'wallets/batchFetch',
-              `Lens tokenBalances failed, using zero fallback`,
-              {
-                data: {
-                  chainId: currentChainId,
-                  lens: utilsLensAddress,
-                  target: targetAddress,
-                  totalTokens: tokenAddresses.length,
-                  chunkIndex,
-                  chunkCount: chunks.length,
-                  chunkSize: batch.length,
-                  sampleTokens: batch.slice(0, 3),
-                  error: e,
+      const [chunkResults, nativeBalance] = await Promise.all([
+        Promise.all(
+          chunks.map(async (batch, chunkIndex) => {
+            try {
+              return await client.readContract({
+                address: utilsLensAddress,
+                abi: eulerUtilsLensABI,
+                functionName: 'tokenBalances',
+                args: [targetAddress, batch],
+              }) as bigint[]
+            }
+            catch (e) {
+              logWarn(
+                'wallets/batchFetch',
+                `Lens tokenBalances failed, using zero fallback`,
+                {
+                  data: {
+                    chainId: currentChainId,
+                    lens: utilsLensAddress,
+                    target: targetAddress,
+                    totalTokens: tokenAddresses.length,
+                    chunkIndex,
+                    chunkCount: chunks.length,
+                    chunkSize: batch.length,
+                    sampleTokens: batch.slice(0, 3),
+                    error: e,
+                  },
                 },
-              },
-            )
-            return batch.map(() => 0n)
-          }
-        }),
-      )
+              )
+              return batch.map(() => 0n)
+            }
+          }),
+        ),
+        nativeBalancePromise,
+      ])
       const result = chunkResults.flat()
 
       // Only update if still on same chain
@@ -189,6 +204,9 @@ export const useWallets = () => {
         result.forEach((balance: bigint, index: number) => {
           merged.set(tokenAddresses[index], balance)
         })
+        if (nativeBalance !== undefined) {
+          merged.set(zeroAddress, nativeBalance)
+        }
         balances.value = merged
         lastFetchChainId.value = currentChainId
         lastFetchAddress.value = targetAddress


### PR DESCRIPTION
## Summary
Fixes spy mode balance lookup for native-token deposit flows.

When viewing as a spy address and choosing to deposit native ETH/native token through a wrapped-native flow (for example ETH → WETH), the deposit form could show the wrong native balance or `0`. The affected UI path uses `useWallets()` / `SwapTokenSelector`, not `useWagmi()`.

## Fix
- Reverted the earlier `useWagmi()` balance change because it targeted the wrong layer.
- Keep `useWagmi()` as connected-wallet state.
- In `useWallets()`, split native currency (`zeroAddress`) out of the ERC-20/lens `tokenBalances` batch.
- Fetch native balance with `client.getBalance({ address: balanceAddress })`.
- Merge the result back into the balance map under `zeroAddress`, so `SwapTokenSelector` and deposit `AssetInput` use the spy target’s native balance when spy mode is active.

## Test plan
- [x] Open a WETH/native-wrap supply form with no `spy` param
  - Select **Pay with ETH/native token**
  - Balance uses the connected wallet’s native balance
- [x] Open the same flow in spy mode, e.g. `/position/1/supply?collateral=0xEE074ceB44adA094391B9C71A7Fb8ba6962D492c&network=42161&spy=0x80DE5fBe9238F5F8F22860675a523c56215844B6`
  - Select **Pay with ETH**
  - Balance uses the spy address’s ETH balance
- [x] Enter more than the spy address’s ETH balance
  - Form shows “Not enough balance”
- [x] Toggle spy mode off
  - Pay-with-native balance reverts to connected wallet context

## Verification
- [x] `npx eslint composables/useWallets.ts composables/useWagmi.ts`
