### PR TITLE
fix: use lens-computed availableAssets for earn vault stats

### DIFF
--- a/components/entities/vault/overview/earn/VaultOverviewEarnBlockStats.vue
+++ b/components/entities/vault/overview/earn/VaultOverviewEarnBlockStats.vue
@@ -9,11 +9,8 @@ import { VaultSupplyApyModal } from '#components'
 const { vault } = defineProps<{ vault: EarnVault }>()
 
 const modal = useModal()
-const { getVault } = useVaults()
 const { getIntrinsicApy, getIntrinsicApyInfo } = useIntrinsicApy()
 const { getSupplyRewardApy, getSupplyRewardCampaigns, hasSupplyRewards } = useRewardsApy()
-
-const availableLiquidityOfStrategies = ref(0n)
 
 const rewardSupplyAPY = computed(() => getSupplyRewardApy(vault.address))
 
@@ -27,19 +24,9 @@ watchEffect(async () => {
 const availableLiquidityDisplay = ref('-')
 
 watchEffect(async () => {
-  const price = await formatAssetValue(availableLiquidityOfStrategies.value, vault, 'off-chain')
+  const price = await formatAssetValue(vault.availableAssets, vault, 'off-chain')
   availableLiquidityDisplay.value = price.hasPrice ? formatCompactUsdValue(price.usdValue) : price.display
 })
-
-const load = async () => {
-  vault.strategies.forEach(async (strategy) => {
-    const vlt = await getVault(strategy.info.vault)
-    const liquidity = vlt.supply - vlt.borrow
-    availableLiquidityOfStrategies.value += strategy.allocatedAssets - (liquidity < strategy.allocatedAssets ? strategy.allocatedAssets - liquidity : 0n)
-  })
-}
-
-load()
 
 const onSupplyInfoIconClick = () => {
   modal.open(VaultSupplyApyModal, {


### PR DESCRIPTION
## Problem

Visiting an earn vault page threw an uncaught promise error when any of its strategies wasn't backed by an EVK vault:

```
Uncaught (in promise) Error: [getVault] Address is a securitize vault, use getSecuritizeVault instead
    at getVault (useVaults.ts:587:1)
    at async VaultOverviewEarnBlockStats.vue:42:6
```

**Chain of causes:**

1. `VaultOverviewEarnBlockStats.vue` was computing *Available liquidity* by iterating `vault.strategies` and calling `getVault(strategy.info.vault)` per strategy, then summing `min(allocatedAssets, supply - borrow)`.
2. `getVault` is EVK-only — it throws if the registry classifies the address as Securitize or Earn.
3. For strategies whose underlying vault isn't in the Euler subgraph (third-party ERC-4626 vaults like Morpho, Yearn, etc.), `resolveUnknown` falls back to `fetchSecuritizeVault`, which uses the generic `utilsLens.getVaultInfoERC4626` call. That succeeds on *any* ERC-4626, so the registry ends up tagging the vault as `'securitize'` even though it isn't. Next `getVault` call: bang, uncaught throw that also killed the rest of the liquidity calc.

## Fix

`EulerEarnVaultLens` already computes this number on-chain:

```solidity
strategy.availableAssets = vault.maxWithdrawFromStrategy(strategy);
result.availableAssets   += strategies[i].availableAssets;
```

Switch `VaultOverviewEarnBlockStats.vue` to `vault.availableAssets` directly. Drops the per-strategy loop entirely.

### Improvements

- **Works for any strategy type** — no more dependence on classifying the underlying as EVK.
- **Zero extra RPC calls** — the value is already on the earn vault object from the initial lens call.
- **Strictly more accurate** — `maxWithdrawFromStrategy` respects earn-vault fees, hooks, paused strategies, and withdrawal-queue constraints that the client-side `min(allocated, supply - borrow)` formula couldn't see.
- **No error-handling needed** — nothing to throw.

Root-cause fix for the registry's Securitize-misclassification is deliberately **not** in scope — the correct fix there is broader (narrow the fallback, or introduce a new 'other-erc4626' type) and the earn-stats issue is solved better by not depending on the registry at all for this calculation.

## Test plan

- [x] Open an earn vault page whose strategies include only EVK underlyings — *Available liquidity* matches the previous value (within the small difference introduced by `maxWithdrawFromStrategy`'s extra accounting).
- [ ] Open an earn vault page whose strategies include a non-EVK ERC-4626 (e.g. the case on Plasma that triggered the bug) — no uncaught promise error; *Available liquidity* renders.
- [x] DevTools → Network: confirm the earn page no longer issues per-strategy lens calls from the Statistics block.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified available liquidity calculation in the vault earnings overview component, removing unnecessary async operations and state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->