### PR TITLE
Fix spy mode position flows

### DIFF
--- a/components/entities/vault/form/VaultFormSubmit.vue
+++ b/components/entities/vault/form/VaultFormSubmit.vue
@@ -46,7 +46,7 @@ const { floatingStyles, update } = useFloating(reference, floating, {
 })
 
 const needToSwitchChain = computed(() => {
-  return isConnected.value && chainId.value !== _chainId.value
+  return !isSpyMode.value && isConnected.value && chainId.value !== _chainId.value
 })
 const hasActiveSession = computed(() => isConnected.value || isSpyMode.value)
 const _disabled = computed(() => {

--- a/components/entities/vault/form/VaultFormSubmit.vue
+++ b/components/entities/vault/form/VaultFormSubmit.vue
@@ -23,6 +23,7 @@ interface KeyringGuardState {
 
 const props = defineProps<{ disabled?: boolean, loading?: boolean, disabledReason?: string, disabledReasonVariant?: DisabledReasonVariant }>()
 const { isConnected } = useAccount()
+const { isSpyMode } = useSpyMode()
 const { chainId: _chainId } = useEulerAddresses()
 const { chainId, switchChain, connect } = useWagmi()
 const modal = useModal()
@@ -47,6 +48,7 @@ const { floatingStyles, update } = useFloating(reference, floating, {
 const needToSwitchChain = computed(() => {
   return isConnected.value && chainId.value !== _chainId.value
 })
+const hasActiveSession = computed(() => isConnected.value || isSpyMode.value)
 const _disabled = computed(() => {
   if (isOperationBlocked.value) return true
   return props.disabled && !needToSwitchChain.value
@@ -87,7 +89,7 @@ const onClick = (e: Event) => {
     switchChain({ chainId: _chainId.value })
     return
   }
-  if (!isConnected.value) {
+  if (!hasActiveSession.value) {
     e.preventDefault()
     connect()
     return
@@ -188,7 +190,7 @@ const openTermsModal = () => {
         <template v-if="needToSwitchChain">
           Switch chain
         </template>
-        <slot v-else-if="isConnected" />
+        <slot v-else-if="hasActiveSession" />
         <template v-else>
           Connect wallet
         </template>

--- a/composables/useAccountPositions.ts
+++ b/composables/useAccountPositions.ts
@@ -47,6 +47,7 @@ const borrowPositions = computed(() => {
   if (isShowAllPositions.value) return _allBorrowPositions.value
   return _allBorrowPositions.value.filter(p => p.borrow.verified && p.collateral.verified)
 })
+const allBorrowPositions = computed(() => _allBorrowPositions.value)
 const depositPositions = computed(() => {
   if (isShowAllPositions.value) return _allDepositPositions.value
   return _allDepositPositions.value.filter(p => p.vault.verified)
@@ -557,6 +558,7 @@ const clearPositions = () => {
 }
 
 export const useAccountPositions = () => ({
+  allBorrowPositions,
   depositPositions,
   borrowPositions,
   collateralUsageSet,

--- a/composables/useEulerAccount.ts
+++ b/composables/useEulerAccount.ts
@@ -12,6 +12,7 @@ import { fetchAccountPositions, type SubgraphPositionEntry } from '~/utils/subgr
 import { logWarn } from '~/utils/errorHandling'
 
 const {
+  allBorrowPositions,
   depositPositions,
   borrowPositions,
   isPositionsLoading,
@@ -138,7 +139,7 @@ export const useEulerAccount = () => {
     const owner = portfolioAddress.value || address.value
     if (!owner) return undefined
 
-    return borrowPositions.value.find((position) => {
+    return allBorrowPositions.value.find((position) => {
       try {
         const ownerBigInt = BigInt(getAddress(owner))
         const subAccountBigInt = BigInt(getAddress(position.subAccount))

--- a/composables/useShowAllHint.ts
+++ b/composables/useShowAllHint.ts
@@ -2,6 +2,7 @@ import { useAccount } from '@wagmi/vue'
 import { SHOW_ALL_HINT_DISMISSED_KEY } from '~/entities/constants'
 
 const dismissed = useLocalStorage<boolean>(SHOW_ALL_HINT_DISMISSED_KEY, false)
+const spyDismissed = ref(false)
 
 export const useShowAllHint = () => {
   const {
@@ -20,22 +21,35 @@ export const useShowAllHint = () => {
   )
 
   const shouldShowHint = computed(() => {
-    return isConnected.value
-      && !isSpyMode.value
+    return (isConnected.value || isSpyMode.value)
       && isPositionsLoaded.value
       && isDepositsLoaded.value
       && hasHiddenPositions.value
-      && !dismissed.value
+      && !(isSpyMode.value ? spyDismissed.value : dismissed.value)
       && !isShowAllPositions.value
   })
 
   const dismissHint = () => {
+    if (isSpyMode.value) {
+      spyDismissed.value = true
+      return
+    }
     dismissed.value = true
   }
 
   watch(isShowAllPositions, (newVal) => {
+    if (newVal && isSpyMode.value) {
+      spyDismissed.value = true
+      return
+    }
     if (newVal && !dismissed.value) {
       dismissed.value = true
+    }
+  })
+
+  watch(isSpyMode, (newVal, oldVal) => {
+    if (newVal && !oldVal) {
+      spyDismissed.value = false
     }
   })
 

--- a/pages/portfolio/index.vue
+++ b/pages/portfolio/index.vue
@@ -3,9 +3,11 @@ import { useAccount } from '@wagmi/vue'
 import { getSubAccountIndex } from '~/entities/account'
 
 const { isConnected, address } = useAccount()
+const { isSpyMode } = useSpyMode()
 const { borrowPositions, isPositionsLoaded, portfolioAddress } = useEulerAccount()
 const { isReady } = useVaults()
 
+const hasActiveSession = computed(() => isConnected.value || isSpyMode.value)
 const ownerAddress = computed(() => portfolioAddress.value || address.value || '')
 
 const sortedBorrowPositions = computed(() => {
@@ -32,7 +34,7 @@ const sortedBorrowPositions = computed(() => {
       class="flex flex-1 p-8 rounded-12 border border-line-default bg-card"
     >
       <div
-        v-if="isConnected && (!isPositionsLoaded || (!isReady && sortedBorrowPositions.length === 0))"
+        v-if="hasActiveSession && (!isPositionsLoaded || (!isReady && sortedBorrowPositions.length === 0))"
         class="flex flex-1 justify-center items-center"
       >
         <UiLoader class="text-neutral-500 my-8" />
@@ -46,7 +48,7 @@ const sortedBorrowPositions = computed(() => {
           <div class="flex w-48 h-48 justify-center items-center rounded-12 bg-neutral-100">
             <SvgIcon name="search" />
           </div>
-          <template v-if="isConnected">
+          <template v-if="hasActiveSession">
             You don't have positions yet
           </template>
           <template v-else>


### PR DESCRIPTION
## Summary
- Fix spy mode so disconnected users can still move through supported operation flows without being bounced to wallet connect.
- Resolve deep-linked positions from the full account position set so hidden or unverified positions can still be opened directly.
- Show the hidden-position hint in spy mode without persisting its dismissal across sessions.

## Changes
- Treat spy mode as an active session in the shared submit CTA and in the portfolio positions empty state.
- Add an unfiltered borrow-position view for subaccount lookup while keeping the visible portfolio list filtered by verification state.
- Keep the normal localStorage-backed dismissal behavior for the hidden-position hint, but use an in-memory dismissal flag while spy mode is active.

## Test plan
- [x] Manually verify spy mode shows `Viewing as ...` and no longer shows top-level `Connect wallet` CTAs.
- [x] Manually verify the example deep link no longer lands on `Position not found`.
- [x] Manually verify spy mode can progress through operation flows up to the final confirmation boundary.
- [ ] Re-check the hidden-position hint in spy mode with an address that reliably has hidden positions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Spy mode is now treated as an active session, enabling connected-state UI, loading, and empty-state content without wallet connection
  * Hint visibility and dismissal behave correctly for spy mode users

* **New Features**
  * Full list of borrow positions is now exposed for account views
  * Position lookups now consider the complete set of borrow positions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->