### PR TITLE
fix: keep primary multiply collateral selectable

### DIFF
--- a/composables/borrow/useMultiplyForm.ts
+++ b/composables/borrow/useMultiplyForm.ts
@@ -138,7 +138,7 @@ export const useMultiplyForm = (options: UseMultiplyFormOptions) => {
 
   // --- Collateral options ---
   const { collateralOptions: multiplyCollateralOptions, collateralVaults: multiplyCollateralVaults } = useMultiplyCollateralOptions({
-    currentVault: multiplySupplyVault,
+    primaryCollateralVault: multiplyLongVault,
     liabilityVault: multiplyShortVault,
   })
 

--- a/composables/useMultiplyCollateralOptions.ts
+++ b/composables/useMultiplyCollateralOptions.ts
@@ -4,6 +4,7 @@ import { useVaultRegistry } from '~/composables/useVaultRegistry'
 import type { CollateralOption, Vault } from '~/entities/vault'
 import { buildCollateralOption, computeSupplyApy } from '~/utils/collateralOptions'
 import { useReactiveMap } from '~/composables/useReactiveMap'
+import { shouldIncludeWalletCollateral } from '~/utils/collateralFilters'
 
 type CollateralItem = {
   vault: Vault
@@ -11,10 +12,10 @@ type CollateralItem = {
 }
 
 export const useMultiplyCollateralOptions = ({
-  currentVault,
+  primaryCollateralVault,
   liabilityVault,
 }: {
-  currentVault: Ref<Vault | undefined>
+  primaryCollateralVault: Ref<Vault | undefined>
   liabilityVault?: Ref<Vault | undefined>
 }) => {
   const { getVault } = useVaultRegistry()
@@ -23,9 +24,9 @@ export const useMultiplyCollateralOptions = ({
   const { withIntrinsicSupplyApy, version: intrinsicVersion } = useIntrinsicApy()
   const { getSupplyRewardApy, version: rewardsVersion } = useRewardsApy()
 
-  const currentVaultAddress = computed(() => {
-    const current = currentVault.value
-    return current ? getAddress(current.address) : ''
+  const primaryCollateralAddress = computed(() => {
+    const primary = primaryCollateralVault.value
+    return primary ? getAddress(primary.address) : ''
   })
 
   const walletItemsInput = computed(() => {
@@ -42,9 +43,11 @@ export const useMultiplyCollateralOptions = ({
         if (!vault) return
 
         const balance = getBalance(vault.asset.address as Address)
-        const isCurrent = currentVaultAddress.value
-          && getAddress(vault.address) === currentVaultAddress.value
-        if (!balance && !isCurrent) return
+        if (!shouldIncludeWalletCollateral({
+          balance,
+          vaultAddress: vault.address as Address,
+          primaryCollateralAddress: primaryCollateralAddress.value as Address | '',
+        })) return
 
         items.push({ vault, balance })
       })

--- a/tests/composables/useMultiplyCollateralOptions.test.ts
+++ b/tests/composables/useMultiplyCollateralOptions.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import type { Address } from 'viem'
+import { shouldIncludeWalletCollateral } from '~/utils/collateralFilters'
+
+const PRIMARY = '0x1111111111111111111111111111111111111111' as Address
+const SECONDARY = '0x2222222222222222222222222222222222222222' as Address
+
+describe('shouldIncludeWalletCollateral', () => {
+  it('keeps positive wallet balances', () => {
+    expect(shouldIncludeWalletCollateral({
+      balance: 1n,
+      vaultAddress: SECONDARY,
+      primaryCollateralAddress: PRIMARY,
+    })).toBe(true)
+  })
+
+  it('keeps the primary collateral wallet option with a zero balance', () => {
+    expect(shouldIncludeWalletCollateral({
+      balance: 0n,
+      vaultAddress: PRIMARY,
+      primaryCollateralAddress: PRIMARY,
+    })).toBe(true)
+  })
+
+  it('filters zero-balance non-primary wallet options', () => {
+    expect(shouldIncludeWalletCollateral({
+      balance: 0n,
+      vaultAddress: SECONDARY,
+      primaryCollateralAddress: PRIMARY,
+    })).toBe(false)
+  })
+})

--- a/utils/collateralFilters.ts
+++ b/utils/collateralFilters.ts
@@ -1,0 +1,13 @@
+import { getAddress, type Address } from 'viem'
+
+export function shouldIncludeWalletCollateral({
+  balance,
+  vaultAddress,
+  primaryCollateralAddress,
+}: {
+  balance: bigint
+  vaultAddress: Address
+  primaryCollateralAddress: Address | ''
+}) {
+  return balance > 0n || (!!primaryCollateralAddress && getAddress(vaultAddress) === primaryCollateralAddress)
+}


### PR DESCRIPTION
## Summary
- keep the market's primary collateral selectable in the multiply collateral picker even when its wallet balance is zero
- prevent the source selector from collapsing to a single option after switching away from the market's default collateral

## Changes
- pass the market's primary collateral into the multiply collateral option builder instead of the currently selected source
- extract the zero-balance wallet inclusion rule into a small helper so the primary collateral remains pinned while other zero-balance wallet options stay filtered
- add focused coverage for the wallet-collateral filter behavior

## Test plan
- [ ] open the multiply flow on a market whose default collateral wallet balance is zero
- [ ] switch to another available collateral source and confirm the selector can still reopen with the market's primary collateral listed
- [ ] run `npm run test:run -- tests/composables/useMultiplyCollateralOptions.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated collateral selection logic in the multiply form to use the long vault as the primary reference point
  * Improved collateral filtering to more accurately determine which assets to display based on wallet balance and vault matching

* **Tests**
  * Added comprehensive test coverage for collateral filtering scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->