### PR TITLE
fix: relabel multiply summary positions

### DIFF
--- a/pages/borrow/[collateral]/[borrow]/index.vue
+++ b/pages/borrow/[collateral]/[borrow]/index.vue
@@ -728,7 +728,7 @@ watch(formTab, () => {
                     <AssetInput
                       v-model="multiply.multiplyLongAmount.value"
                       :desc="multiply.multiplyLongProduct.name"
-                      label="Long"
+                      label="Additional collateral"
                       :asset="multiply.multiplyLongVault.value.asset"
                       :vault="(multiply.multiplyLongVault.value as Vault)"
                       :readonly="true"
@@ -737,7 +737,7 @@ watch(formTab, () => {
                     <AssetInput
                       v-model="multiply.multiplyShortAmount.value"
                       :desc="multiply.multiplyShortProduct.name"
-                      label="Short"
+                      label="Debt"
                       :asset="multiply.multiplyShortVault.value.asset"
                       :vault="multiply.multiplyShortVault.value"
                       :readonly="true"

--- a/pages/position/[number]/multiply.vue
+++ b/pages/position/[number]/multiply.vue
@@ -827,7 +827,7 @@ watch([multiplyMinMultiplier, multiplyMaxMultiplier], ([min, max]) => {
             <AssetInput
               v-model="multiplyLongAmount"
               :desc="multiplyLongProduct.name"
-              label="Long"
+              label="Additional collateral"
               :asset="multiplyLongVault.asset"
               :vault="(multiplyLongVault as Vault)"
               :readonly="true"
@@ -836,7 +836,7 @@ watch([multiplyMinMultiplier, multiplyMaxMultiplier], ([min, max]) => {
             <AssetInput
               v-model="multiplyShortAmount"
               :desc="multiplyShortProduct.name"
-              label="Short"
+              label="Debt"
               :asset="multiplyShortVault.asset"
               :vault="multiplyShortVault"
               :readonly="true"


### PR DESCRIPTION
## Summary
- rename the multiply summary cards to match what the displayed values actually represent
- remove the ambiguity of "Long" and "Short" in flows where margin and collateral assets can differ

## Changes
- update the existing-position multiply page to show `Additional collateral` and `Debt`
- update the borrow multiply flow to use the same labels so both entry points stay aligned
- leave the underlying amounts and USD values unchanged; this is a UI-copy-only update

## Test plan
- [ ] Open `/position/:number/multiply` and confirm the summary cards read `Additional collateral` and `Debt`
- [ ] Open `/borrow/:collateral/:borrow` and confirm the same labels appear there
- [ ] Verify the amounts and USD values shown in both cards are unchanged from before
- [ ] Run `npx eslint 'pages/position/[number]/multiply.vue' 'pages/borrow/[collateral]/[borrow]/index.vue'`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated form field labels in multiply operations for improved clarity. Long-side fields now display "Additional collateral" instead of "Long", and short-side fields now display "Debt" instead of "Short".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->