### PR TITLE
fix: use first-parent history check in deploy tag guards

### DIFF
--- a/.github/workflows/build-push-deploy-prod.yaml
+++ b/.github/workflows/build-push-deploy-prod.yaml
@@ -38,8 +38,8 @@ jobs:
       - name: Verify tag is on master
         if: github.event_name == 'push'
         run: |
-          if ! git merge-base --is-ancestor "${{ github.sha }}" origin/master; then
-            echo "::error::Tag does not point to a commit on master. Aborting."
+          if ! git log --first-parent --format=%H origin/master | grep -q "^${{ github.sha }}$"; then
+            echo "::error::Tag does not point to a commit on master's first-parent history. Aborting."
             exit 1
           fi
 

--- a/.github/workflows/build-push-deploy-stage.yaml
+++ b/.github/workflows/build-push-deploy-stage.yaml
@@ -36,8 +36,8 @@ jobs:
 
       - name: Verify tag is on development
         run: |
-          if ! git merge-base --is-ancestor "${{ github.sha }}" origin/development; then
-            echo "::error::Tag does not point to a commit on development. Aborting."
+          if ! git log --first-parent --format=%H origin/development | grep -q "^${{ github.sha }}$"; then
+            echo "::error::Tag does not point to a commit on development's first-parent history. Aborting."
             exit 1
           fi
 


### PR DESCRIPTION
The --is-ancestor check was too permissive — it allowed tags on any merged feature branch commit to pass the guard and trigger deploys. Replace with git log --first-parent to ensure the tagged commit is on the mainline of development/master, not a side branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated validation logic in production and staging deployment workflows to improve verification of commit history integrity during the deployment process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->