### PR TITLE
Fix repay stablecoin slippage context

### DIFF
--- a/components/entities/swap/SlippageSettings.vue
+++ b/components/entities/swap/SlippageSettings.vue
@@ -145,14 +145,14 @@ defineExpose({ savePending })
           v-for="option in slippagePresets"
           :key="option.value"
           type="button"
-          :class="['ui-select__chip', { 'ui-select__chip--active': isPresetActive(option.value) }]"
+          :class="['slippage-settings__chip', { 'slippage-settings__chip--active': isPresetActive(option.value) }]"
           @click="onPresetSelect(option.value)"
         >
           {{ option.label }}
         </button>
         <button
           type="button"
-          :class="['ui-select__chip', { 'ui-select__chip--active': customChipActive }]"
+          :class="['slippage-settings__chip', { 'slippage-settings__chip--active': customChipActive }]"
           @click="onCustomChipClick"
         >
           <span v-if="isCustomSelected && !isCustomInputVisible">
@@ -212,3 +212,45 @@ defineExpose({ savePending })
     </div>
   </div>
 </template>
+
+<style scoped lang="scss">
+.slippage-settings__chip {
+  display: inline-flex;
+  align-items: center;
+  min-height: 36px;
+  gap: 8px;
+  padding: 6px 14px;
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 500;
+  color: var(--text-primary);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  border-radius: 100px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: all 0.15s ease;
+  box-shadow: var(--ui-input-shadow);
+
+  &:hover {
+    color: var(--accent-600);
+    border-color: var(--border-emphasis);
+    background: var(--bg-surface-elevated);
+  }
+
+  &--active {
+    font-weight: 600;
+    color: var(--ui-select-chip-active-color);
+    background: var(--ui-select-chip-active-background-color);
+    border-color: transparent;
+    box-shadow: var(--accent-shadow-md);
+
+    &:hover {
+      color: var(--ui-select-chip-active-color);
+      background: var(--accent-600);
+      border-color: transparent;
+      box-shadow: var(--accent-shadow-lg);
+    }
+  }
+}
+</style>

--- a/composables/repay/useWalletSwapRepay.ts
+++ b/composables/repay/useWalletSwapRepay.ts
@@ -32,6 +32,7 @@ interface UseWalletSwapRepayOptions {
   plan: Ref<TxPlan | null>
   isSubmitting: Ref<boolean>
   isPreparing: Ref<boolean>
+  slippage: Readonly<Ref<number>>
   clearSimulationError: () => void
   runSimulation: (plan: TxPlan) => Promise<boolean>
   netAPY: Ref<number>
@@ -51,6 +52,7 @@ export const useWalletSwapRepay = (options: UseWalletSwapRepayOptions) => {
     plan,
     isSubmitting,
     isPreparing,
+    slippage,
     clearSimulationError,
     runSimulation,
     netAPY,
@@ -69,10 +71,6 @@ export const useWalletSwapRepay = (options: UseWalletSwapRepayOptions) => {
   const { eulerLensAddresses, chainId } = useEulerAddresses()
   const { isConnected, address } = useAccount()
   const { fetchSingleBalance } = useWallets()
-  const { slippage } = useSlippage({
-    fromSymbol: () => selectedAsset.value?.symbol,
-    toSymbol: () => borrowVault.value?.asset.symbol,
-  })
   const { getVault: registryGetVault } = useVaultRegistry()
 
   // --- State ---

--- a/pages/position/[number]/repay.vue
+++ b/pages/position/[number]/repay.vue
@@ -38,7 +38,7 @@ const { slippage } = useSlippage({
   fromSymbol: () => {
     if (formTab.value === 'wallet') return walletSwap.selectedAsset.value?.symbol
     if (formTab.value === 'savings') return savings.sourceVault.value?.asset.symbol
-    return collateralVault.value?.asset.symbol
+    return collateral.sourceVault.value?.asset.symbol
   },
   toSymbol: () => borrowVault.value?.asset.symbol,
 })
@@ -147,6 +147,7 @@ const walletSwap = useWalletSwapRepay({
   plan,
   isSubmitting,
   isPreparing,
+  slippage,
   clearSimulationError,
   runSimulation,
   netAPY,


### PR DESCRIPTION
## Summary
- Share the repay page slippage state with the wallet swap repay flow so stablecoin defaults are not overwritten by a second context writer.
- Use the active collateral source vault when computing repay slippage defaults.
- Keep slippage preset chips styled locally so the modal does not depend on `UiSelect` styles being loaded elsewhere.

## Changes
- Removed the internal slippage context writer from wallet swap repay.
- Passed the page-owned slippage ref into wallet, collateral, and savings repay swap paths.
- Replaced borrowed `ui-select__chip` classes in slippage settings with local chip styles that match the app control patterns.

## Test plan
- [x] `npm run test:run` (22 files, 426 tests)
- [x] `npx eslint composables/repay/useWalletSwapRepay.ts pages/position/[number]/repay.vue`
- [x] `npx eslint components/entities/swap/SlippageSettings.vue`
- [x] `git diff --check`
- [x] Manual: From collateral stable-to-stable repay (`USD₮0` collateral into `USDC` debt) shows `0.05%` slippage tolerance.
- [x] Manual: switching away from From collateral and back keeps the stable-to-stable collateral tab at `0.05%`, confirming the wallet swap flow no longer overwrites the active tab context.
- [x] Manual: From wallet non-stable swap repay (`thBILL` into `USDC`) shows normal `0.3%` slippage tolerance.
- [x] Manual: From savings non-stable swap repay (`thBILL` into `USDC`) shows normal `0.3%` slippage tolerance.
- [x] Manual: Slippage settings modal preset buttons render as styled chips instead of plain text.
- [ ] Manual: From savings stable-to-stable not tested; it uses the same page-owned slippage ref path as collateral.
- [ ] `npm run typecheck` (currently blocked by unrelated `composables/useMarketGroups.ts:442` error)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Slippage handling in the repay workflow now requires an explicit, caller-provided slippage value instead of being auto-initialized.
  * Collateral asset resolution in the repay flow has been refined for more accurate source-token selection.

* **Style**
  * Slippage option buttons received updated, scoped styling with distinct active and hover states for clearer selection feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->