### PR TITLE
feat: add config, stats, and oracle views to explore matrix

### DIFF
--- a/components/entities/vault/discovery/DiscoveryMarketAccordion.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketAccordion.vue
@@ -83,13 +83,16 @@ const setExpandedView = (marketId: string, mode: ExpandedViewMode) => {
 
 const vaultUsdCache = ref<Map<string, VaultUsdCacheEntry>>(new Map())
 
+const formatUsdOrDisplay = (p: { hasPrice: boolean, usdValue: number, display: string }) =>
+  p.hasPrice ? formatCompactUsdValue(p.usdValue) : p.display
+
 const loadVaultUsdValues = async (market: MarketGroup) => {
   const newEntries = new Map(vaultUsdCache.value)
   const allVaults = [...market.vaults, ...market.externalCollateral.filter(isMatrixCompatibleVault)]
 
   await Promise.all(
     allVaults.map(async (vault) => {
-      const addr = getVaultAddress(vault)
+      const addr = getVaultAddress(vault).toLowerCase()
       if (!addr || newEntries.has(addr)) return
       const totalAssets = 'totalAssets' in vault ? vault.totalAssets as bigint : 0n
       const supply = 'supply' in vault ? vault.supply as bigint : totalAssets
@@ -98,34 +101,19 @@ const loadVaultUsdValues = async (market: MarketGroup) => {
       const borrowCapRaw = 'borrowCap' in vault ? vault.borrowCap as bigint : maxUint256
 
       const liquidity = supply >= borrow ? supply - borrow : 0n
-      const supplyCapAmount = supplyCapRaw >= maxUint256 ? 0n : supplyCapRaw
-      const borrowCapAmount = borrowCapRaw >= maxUint256 ? 0n : borrowCapRaw
+      const supplyCapHasPrice = supplyCapRaw > 0n && supplyCapRaw < maxUint256
+      const borrowCapHasPrice = borrowCapRaw > 0n && borrowCapRaw < maxUint256
 
       const [supplyPrice, borrowPrice, liquidityPrice, supplyCapPrice, borrowCapPrice] = await Promise.all([
         formatAssetValue(totalAssets, vault, 'off-chain'),
         formatAssetValue(borrow, vault, 'off-chain'),
         formatAssetValue(liquidity, vault, 'off-chain'),
-        supplyCapAmount > 0n
-          ? formatAssetValue(supplyCapAmount, vault, 'off-chain')
-          : Promise.resolve({ hasPrice: false, usdValue: 0, display: '$0' }),
-        borrowCapAmount > 0n
-          ? formatAssetValue(borrowCapAmount, vault, 'off-chain')
-          : Promise.resolve({ hasPrice: false, usdValue: 0, display: '$0' }),
+        supplyCapHasPrice ? formatAssetValue(supplyCapRaw, vault, 'off-chain') : null,
+        borrowCapHasPrice ? formatAssetValue(borrowCapRaw, vault, 'off-chain') : null,
       ])
 
-      const formatUsdOrDisplay = (p: { hasPrice: boolean, usdValue: number, display: string }) =>
-        p.hasPrice ? formatCompactUsdValue(p.usdValue) : p.display
-
-      const supplyCapStr = supplyCapRaw >= maxUint256
-        ? '∞'
-        : supplyCapRaw === 0n
-          ? '$0'
-          : formatUsdOrDisplay(supplyCapPrice)
-      const borrowCapStr = borrowCapRaw >= maxUint256
-        ? '∞'
-        : borrowCapRaw === 0n
-          ? '$0'
-          : formatUsdOrDisplay(borrowCapPrice)
+      const capDisplay = (rawCap: bigint, price: typeof supplyPrice | null) =>
+        rawCap >= maxUint256 ? '∞' : rawCap === 0n ? '$0' : price ? formatUsdOrDisplay(price) : '—'
 
       newEntries.set(addr, {
         supply: formatUsdOrDisplay(supplyPrice),
@@ -134,10 +122,10 @@ const loadVaultUsdValues = async (market: MarketGroup) => {
         borrowUsd: borrowPrice.hasPrice ? borrowPrice.usdValue : 0,
         liquidity: formatUsdOrDisplay(liquidityPrice),
         liquidityUsd: liquidityPrice.hasPrice ? liquidityPrice.usdValue : 0,
-        supplyCap: supplyCapStr,
-        supplyCapUsd: supplyCapRaw >= maxUint256 || !supplyCapPrice.hasPrice ? undefined : supplyCapPrice.usdValue,
-        borrowCap: borrowCapStr,
-        borrowCapUsd: borrowCapRaw >= maxUint256 || !borrowCapPrice.hasPrice ? undefined : borrowCapPrice.usdValue,
+        supplyCap: capDisplay(supplyCapRaw, supplyCapPrice),
+        supplyCapUsd: supplyCapPrice?.hasPrice ? supplyCapPrice.usdValue : undefined,
+        borrowCap: capDisplay(borrowCapRaw, borrowCapPrice),
+        borrowCapUsd: borrowCapPrice?.hasPrice ? borrowCapPrice.usdValue : undefined,
       })
     }),
   )
@@ -573,7 +561,6 @@ onMounted(() => {
             <!-- Matrix View: Config / Stats attribute matrix -->
             <DiscoveryMarketAttributeMatrix
               v-else-if="attributeMatrixMap.get(market.id)"
-              :market="market"
               :data="attributeMatrixMap.get(market.id)!"
               :usd-cache="vaultUsdCache"
               :selected-header="selectedMatrixHeader?.marketId === market.id ? { address: selectedMatrixHeader.address, axis: selectedMatrixHeader.axis } : null"

--- a/components/entities/vault/discovery/DiscoveryMarketAccordion.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketAccordion.vue
@@ -10,15 +10,16 @@ import {
   getMiniDiagram,
   getCollateralMatrix,
   findVault,
-  DOT_METRIC_OPTIONS,
   getAttributeMatrix,
   isMatrixCompatibleVault,
+  formatCapDisplay,
+  isAttributeMatrixView,
+  MATRIX_VIEW_OPTIONS,
   type CollateralMatrixData,
   type DotMetric,
   type ExpandedViewMode,
-  type MatrixVariant,
   type AttributeMatrixData,
-  type AttributeMatrixMode,
+  type MatrixViewId,
   type VaultUsdCacheEntry,
 } from '~/utils/discoveryCalculations'
 
@@ -112,9 +113,6 @@ const loadVaultUsdValues = async (market: MarketGroup) => {
         borrowCapHasPrice ? formatAssetValue(borrowCapRaw, vault, 'off-chain') : null,
       ])
 
-      const capDisplay = (rawCap: bigint, price: typeof supplyPrice | null) =>
-        rawCap >= maxUint256 ? '∞' : rawCap === 0n ? '$0' : price ? formatUsdOrDisplay(price) : '—'
-
       newEntries.set(addr, {
         supply: formatUsdOrDisplay(supplyPrice),
         supplyUsd: supplyPrice.hasPrice ? supplyPrice.usdValue : 0,
@@ -122,9 +120,9 @@ const loadVaultUsdValues = async (market: MarketGroup) => {
         borrowUsd: borrowPrice.hasPrice ? borrowPrice.usdValue : 0,
         liquidity: formatUsdOrDisplay(liquidityPrice),
         liquidityUsd: liquidityPrice.hasPrice ? liquidityPrice.usdValue : 0,
-        supplyCap: capDisplay(supplyCapRaw, supplyCapPrice),
+        supplyCap: formatCapDisplay(supplyCapRaw, supplyCapPrice ? formatUsdOrDisplay(supplyCapPrice) : null).display,
         supplyCapUsd: supplyCapPrice?.hasPrice ? supplyCapPrice.usdValue : undefined,
-        borrowCap: capDisplay(borrowCapRaw, borrowCapPrice),
+        borrowCap: formatCapDisplay(borrowCapRaw, borrowCapPrice ? formatUsdOrDisplay(borrowCapPrice) : null).display,
         borrowCapUsd: borrowCapPrice?.hasPrice ? borrowCapPrice.usdValue : undefined,
       })
     }),
@@ -139,21 +137,33 @@ const onToggle = (market: MarketGroup) => {
   if (!wasExpanded) loadVaultUsdValues(market)
 }
 
-// -- Metric selector --
+// -- Matrix view selector (single dropdown spans Stats, Configuration,
+// Oracles, and the four numeric pair metrics) --
 
-const dotMetric = ref<DotMetric>('net-apy')
-const metricDropdownOpen = ref(false)
+const matrixView = ref<MatrixViewId>('stats')
+const matrixDropdownOpen = ref(false)
 
-// -- Matrix variant (LTV pairs / Config / Stats) --
+const matrixVariant = computed(() => isAttributeMatrixView(matrixView.value) ? matrixView.value : 'pairs')
+const dotMetric = computed<DotMetric>(() => {
+  if (isAttributeMatrixView(matrixView.value)) return 'net-apy' // unused for attribute matrices
+  return matrixView.value
+})
 
-const matrixVariant = ref<MatrixVariant>('pairs')
-
-const setMatrixVariant = (variant: MatrixVariant) => {
-  if (matrixVariant.value === variant) return
-  matrixVariant.value = variant
-  // Clear selections that don't apply to the new variant.
-  selectedCell.value = null
-  selectedMatrixHeader.value = null
+const setMatrixView = (view: MatrixViewId) => {
+  if (matrixView.value === view) {
+    matrixDropdownOpen.value = false
+    return
+  }
+  const wasAttribute = isAttributeMatrixView(matrixView.value)
+  const isAttribute = isAttributeMatrixView(view)
+  matrixView.value = view
+  matrixDropdownOpen.value = false
+  // Clear selections when crossing the attribute / pair boundary — pair
+  // selections (cell) don't map to attribute matrices and vice versa.
+  if (wasAttribute !== isAttribute) {
+    selectedCell.value = null
+    selectedMatrixHeader.value = null
+  }
 }
 
 // -- Precomputed matrix map --
@@ -168,10 +178,9 @@ const matrixMap = computed((): Map<string, CollateralMatrixData | null> => {
 
 const attributeMatrixMap = computed((): Map<string, AttributeMatrixData> => {
   const result = new Map<string, AttributeMatrixData>()
-  if (matrixVariant.value === 'pairs') return result
-  const mode = matrixVariant.value as AttributeMatrixMode
+  if (!isAttributeMatrixView(matrixView.value)) return result
   for (const market of props.markets) {
-    result.set(market.id, getAttributeMatrix(market, mode))
+    result.set(market.id, getAttributeMatrix(market, matrixView.value))
   }
   return result
 })
@@ -365,7 +374,7 @@ const hasSelection = (market: MarketGroup): boolean => {
 
 onMounted(() => {
   const onClick = () => {
-    metricDropdownOpen.value = false
+    matrixDropdownOpen.value = false
   }
   window.addEventListener('click', onClick)
   onUnmounted(() => {
@@ -464,72 +473,42 @@ onMounted(() => {
                 </button>
               </div>
 
-              <!-- Matrix sub-mode toggle (matrix view only) -->
+              <!-- Unified matrix view dropdown (matrix view only).
+                   Stats / Configuration sit at the top, then Oracles, then
+                   the existing pair metrics. Selecting Stats/Configuration
+                   swaps in the attribute matrix; everything else uses the
+                   pair matrix with the corresponding dotMetric. -->
               <div
                 v-if="getExpandedView(market.id) === 'matrix'"
-                class="flex rounded-[100px] border border-line-default overflow-hidden"
-              >
-                <button
-                  class="flex items-center gap-4 min-h-36 py-6 px-12 cursor-pointer transition-all text-p3"
-                  :class="matrixVariant === 'pairs'
-                    ? 'bg-accent-300/20 text-accent-700 font-medium'
-                    : 'bg-surface text-content-secondary hover:bg-surface-secondary'"
-                  @click.stop="setMatrixVariant('pairs')"
-                >
-                  LTV pairs
-                </button>
-                <button
-                  class="flex items-center gap-4 min-h-36 py-6 px-12 cursor-pointer transition-all text-p3 border-l border-line-default"
-                  :class="matrixVariant === 'stats'
-                    ? 'bg-accent-300/20 text-accent-700 font-medium'
-                    : 'bg-surface text-content-secondary hover:bg-surface-secondary'"
-                  @click.stop="setMatrixVariant('stats')"
-                >
-                  Stats
-                </button>
-                <button
-                  class="flex items-center gap-4 min-h-36 py-6 px-12 cursor-pointer transition-all text-p3 border-l border-line-default"
-                  :class="matrixVariant === 'config'
-                    ? 'bg-accent-300/20 text-accent-700 font-medium'
-                    : 'bg-surface text-content-secondary hover:bg-surface-secondary'"
-                  @click.stop="setMatrixVariant('config')"
-                >
-                  Configuration
-                </button>
-              </div>
-
-              <!-- Metric dropdown (LTV pairs only) -->
-              <div
-                v-if="getExpandedView(market.id) === 'matrix' && matrixVariant === 'pairs'"
                 class="relative"
               >
                 <div
                   class="ui-select__field"
-                  @click.stop="metricDropdownOpen = !metricDropdownOpen"
+                  @click.stop="matrixDropdownOpen = !matrixDropdownOpen"
                 >
                   <UiIcon
                     name="filter"
                     class="ui-select__icon"
                   />
-                  <span class="ui-select__text">{{ DOT_METRIC_OPTIONS.find(o => o.id === dotMetric)?.label }}</span>
+                  <span class="ui-select__text">{{ MATRIX_VIEW_OPTIONS.find(o => o.id === matrixView)?.label }}</span>
                   <UiIcon
                     name="arrow-down"
                     class="ui-select__arrow"
-                    :style="metricDropdownOpen ? 'transform: rotate(180deg)' : ''"
+                    :style="matrixDropdownOpen ? 'transform: rotate(180deg)' : ''"
                   />
                 </div>
                 <div
-                  v-if="metricDropdownOpen"
-                  class="absolute left-0 top-full mt-4 z-30 bg-surface border border-line-default rounded-12 shadow-card py-4 min-w-[160px]"
+                  v-if="matrixDropdownOpen"
+                  class="absolute left-0 top-full mt-4 z-30 bg-surface border border-line-default rounded-12 shadow-card py-4 min-w-[180px]"
                 >
                   <button
-                    v-for="option in DOT_METRIC_OPTIONS"
+                    v-for="option in MATRIX_VIEW_OPTIONS"
                     :key="option.id"
                     class="w-full text-left px-14 py-6 text-p3 cursor-pointer transition-colors"
-                    :class="dotMetric === option.id
+                    :class="matrixView === option.id
                       ? 'text-accent-700 bg-accent-300/20 font-medium'
                       : 'text-content-secondary hover:bg-surface-secondary'"
-                    @click.stop="dotMetric = option.id; metricDropdownOpen = false"
+                    @click.stop="setMatrixView(option.id)"
                   >
                     {{ option.label }}
                   </button>

--- a/components/entities/vault/discovery/DiscoveryMarketAccordion.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketAccordion.vue
@@ -493,7 +493,7 @@ onMounted(() => {
                 </div>
                 <div
                   v-if="matrixDropdownOpen"
-                  class="absolute left-0 top-full mt-4 z-30 bg-surface border border-line-default rounded-12 shadow-card py-4 min-w-[180px]"
+                  class="absolute left-0 top-full mt-4 z-50 bg-surface border border-line-default rounded-12 shadow-card py-4 min-w-[180px]"
                 >
                   <button
                     v-for="option in MATRIX_VIEW_OPTIONS"

--- a/components/entities/vault/discovery/DiscoveryMarketAccordion.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketAccordion.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { maxUint256 } from 'viem'
 import type { MarketGroup } from '~/entities/lend-discovery'
 import type { Vault, SecuritizeVault, AnyBorrowVaultPair } from '~/entities/vault'
 import { formatCompactUsdValue } from '~/utils/string-utils'
@@ -10,9 +11,15 @@ import {
   getCollateralMatrix,
   findVault,
   DOT_METRIC_OPTIONS,
+  getAttributeMatrix,
+  isMatrixCompatibleVault,
   type CollateralMatrixData,
   type DotMetric,
   type ExpandedViewMode,
+  type MatrixVariant,
+  type AttributeMatrixData,
+  type AttributeMatrixMode,
+  type VaultUsdCacheEntry,
 } from '~/utils/discoveryCalculations'
 
 const props = defineProps<{
@@ -74,25 +81,63 @@ const setExpandedView = (marketId: string, mode: ExpandedViewMode) => {
 
 // -- Per-vault USD values (loaded on expand) --
 
-const vaultUsdCache = ref<Map<string, { supply: string, liquidity: string, supplyUsd: number }>>(new Map())
+const vaultUsdCache = ref<Map<string, VaultUsdCacheEntry>>(new Map())
 
 const loadVaultUsdValues = async (market: MarketGroup) => {
   const newEntries = new Map(vaultUsdCache.value)
+  const allVaults = [...market.vaults, ...market.externalCollateral.filter(isMatrixCompatibleVault)]
 
   await Promise.all(
-    market.vaults.map(async (vault) => {
+    allVaults.map(async (vault) => {
       const addr = getVaultAddress(vault)
       if (!addr || newEntries.has(addr)) return
       const totalAssets = 'totalAssets' in vault ? vault.totalAssets as bigint : 0n
       const supply = 'supply' in vault ? vault.supply as bigint : totalAssets
       const borrow = 'borrow' in vault ? vault.borrow as bigint : 0n
-      const supplyPrice = await formatAssetValue(totalAssets, vault, 'off-chain')
+      const supplyCapRaw = 'supplyCap' in vault ? vault.supplyCap as bigint : maxUint256
+      const borrowCapRaw = 'borrowCap' in vault ? vault.borrowCap as bigint : maxUint256
+
       const liquidity = supply >= borrow ? supply - borrow : 0n
-      const liquidityPrice = await formatAssetValue(liquidity, vault, 'off-chain')
+      const supplyCapAmount = supplyCapRaw >= maxUint256 ? 0n : supplyCapRaw
+      const borrowCapAmount = borrowCapRaw >= maxUint256 ? 0n : borrowCapRaw
+
+      const [supplyPrice, borrowPrice, liquidityPrice, supplyCapPrice, borrowCapPrice] = await Promise.all([
+        formatAssetValue(totalAssets, vault, 'off-chain'),
+        formatAssetValue(borrow, vault, 'off-chain'),
+        formatAssetValue(liquidity, vault, 'off-chain'),
+        supplyCapAmount > 0n
+          ? formatAssetValue(supplyCapAmount, vault, 'off-chain')
+          : Promise.resolve({ hasPrice: false, usdValue: 0, display: '$0' }),
+        borrowCapAmount > 0n
+          ? formatAssetValue(borrowCapAmount, vault, 'off-chain')
+          : Promise.resolve({ hasPrice: false, usdValue: 0, display: '$0' }),
+      ])
+
+      const formatUsdOrDisplay = (p: { hasPrice: boolean, usdValue: number, display: string }) =>
+        p.hasPrice ? formatCompactUsdValue(p.usdValue) : p.display
+
+      const supplyCapStr = supplyCapRaw >= maxUint256
+        ? '∞'
+        : supplyCapRaw === 0n
+          ? '$0'
+          : formatUsdOrDisplay(supplyCapPrice)
+      const borrowCapStr = borrowCapRaw >= maxUint256
+        ? '∞'
+        : borrowCapRaw === 0n
+          ? '$0'
+          : formatUsdOrDisplay(borrowCapPrice)
+
       newEntries.set(addr, {
-        supply: supplyPrice.hasPrice ? formatCompactUsdValue(supplyPrice.usdValue) : supplyPrice.display,
-        liquidity: liquidityPrice.hasPrice ? formatCompactUsdValue(liquidityPrice.usdValue) : liquidityPrice.display,
+        supply: formatUsdOrDisplay(supplyPrice),
         supplyUsd: supplyPrice.hasPrice ? supplyPrice.usdValue : 0,
+        borrow: formatUsdOrDisplay(borrowPrice),
+        borrowUsd: borrowPrice.hasPrice ? borrowPrice.usdValue : 0,
+        liquidity: formatUsdOrDisplay(liquidityPrice),
+        liquidityUsd: liquidityPrice.hasPrice ? liquidityPrice.usdValue : 0,
+        supplyCap: supplyCapStr,
+        supplyCapUsd: supplyCapRaw >= maxUint256 || !supplyCapPrice.hasPrice ? undefined : supplyCapPrice.usdValue,
+        borrowCap: borrowCapStr,
+        borrowCapUsd: borrowCapRaw >= maxUint256 || !borrowCapPrice.hasPrice ? undefined : borrowCapPrice.usdValue,
       })
     }),
   )
@@ -111,12 +156,34 @@ const onToggle = (market: MarketGroup) => {
 const dotMetric = ref<DotMetric>('net-apy')
 const metricDropdownOpen = ref(false)
 
+// -- Matrix variant (LTV pairs / Config / Stats) --
+
+const matrixVariant = ref<MatrixVariant>('pairs')
+
+const setMatrixVariant = (variant: MatrixVariant) => {
+  if (matrixVariant.value === variant) return
+  matrixVariant.value = variant
+  // Clear selections that don't apply to the new variant.
+  selectedCell.value = null
+  selectedMatrixHeader.value = null
+}
+
 // -- Precomputed matrix map --
 
 const matrixMap = computed((): Map<string, CollateralMatrixData | null> => {
   const result = new Map<string, CollateralMatrixData | null>()
   for (const market of props.markets) {
     result.set(market.id, getCollateralMatrix(market))
+  }
+  return result
+})
+
+const attributeMatrixMap = computed((): Map<string, AttributeMatrixData> => {
+  const result = new Map<string, AttributeMatrixData>()
+  if (matrixVariant.value === 'pairs') return result
+  const mode = matrixVariant.value as AttributeMatrixMode
+  for (const market of props.markets) {
+    result.set(market.id, getAttributeMatrix(market, mode))
   }
   return result
 })
@@ -409,9 +476,43 @@ onMounted(() => {
                 </button>
               </div>
 
-              <!-- Metric dropdown (matrix view only) -->
+              <!-- Matrix sub-mode toggle (matrix view only) -->
               <div
                 v-if="getExpandedView(market.id) === 'matrix'"
+                class="flex rounded-[100px] border border-line-default overflow-hidden"
+              >
+                <button
+                  class="flex items-center gap-4 min-h-36 py-6 px-12 cursor-pointer transition-all text-p3"
+                  :class="matrixVariant === 'pairs'
+                    ? 'bg-accent-300/20 text-accent-700 font-medium'
+                    : 'bg-surface text-content-secondary hover:bg-surface-secondary'"
+                  @click.stop="setMatrixVariant('pairs')"
+                >
+                  LTV pairs
+                </button>
+                <button
+                  class="flex items-center gap-4 min-h-36 py-6 px-12 cursor-pointer transition-all text-p3 border-l border-line-default"
+                  :class="matrixVariant === 'config'
+                    ? 'bg-accent-300/20 text-accent-700 font-medium'
+                    : 'bg-surface text-content-secondary hover:bg-surface-secondary'"
+                  @click.stop="setMatrixVariant('config')"
+                >
+                  Config
+                </button>
+                <button
+                  class="flex items-center gap-4 min-h-36 py-6 px-12 cursor-pointer transition-all text-p3 border-l border-line-default"
+                  :class="matrixVariant === 'stats'
+                    ? 'bg-accent-300/20 text-accent-700 font-medium'
+                    : 'bg-surface text-content-secondary hover:bg-surface-secondary'"
+                  @click.stop="setMatrixVariant('stats')"
+                >
+                  Stats
+                </button>
+              </div>
+
+              <!-- Metric dropdown (LTV pairs only) -->
+              <div
+                v-if="getExpandedView(market.id) === 'matrix' && matrixVariant === 'pairs'"
                 class="relative"
               >
                 <div
@@ -457,15 +558,25 @@ onMounted(() => {
               @select-node="toggleGraphNode(market.id, $event)"
             />
 
-            <!-- Matrix View -->
+            <!-- Matrix View: LTV pairs -->
             <DiscoveryMarketMatrix
-              v-else
+              v-else-if="matrixVariant === 'pairs'"
               :market="market"
               :matrix="matrix"
               :dot-metric="dotMetric"
               :selected-cell="selectedCell?.marketId === market.id ? { collateralAddr: selectedCell.collateralAddr, liabilityAddr: selectedCell.liabilityAddr } : null"
               :selected-header="selectedMatrixHeader?.marketId === market.id ? { address: selectedMatrixHeader.address, axis: selectedMatrixHeader.axis } : null"
               @select-cell="(col: string, lia: string) => onCellClick(market.id, col, lia)"
+              @select-header="(addr: string, axis: 'row' | 'column') => toggleMatrixHeader(market.id, addr, axis)"
+            />
+
+            <!-- Matrix View: Config / Stats attribute matrix -->
+            <DiscoveryMarketAttributeMatrix
+              v-else-if="attributeMatrixMap.get(market.id)"
+              :market="market"
+              :data="attributeMatrixMap.get(market.id)!"
+              :usd-cache="vaultUsdCache"
+              :selected-header="selectedMatrixHeader?.marketId === market.id ? { address: selectedMatrixHeader.address, axis: selectedMatrixHeader.axis } : null"
               @select-header="(addr: string, axis: 'row' | 'column') => toggleMatrixHeader(market.id, addr, axis)"
             />
 

--- a/components/entities/vault/discovery/DiscoveryMarketAccordion.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketAccordion.vue
@@ -480,21 +480,21 @@ onMounted(() => {
                 </button>
                 <button
                   class="flex items-center gap-4 min-h-36 py-6 px-12 cursor-pointer transition-all text-p3 border-l border-line-default"
-                  :class="matrixVariant === 'config'
-                    ? 'bg-accent-300/20 text-accent-700 font-medium'
-                    : 'bg-surface text-content-secondary hover:bg-surface-secondary'"
-                  @click.stop="setMatrixVariant('config')"
-                >
-                  Config
-                </button>
-                <button
-                  class="flex items-center gap-4 min-h-36 py-6 px-12 cursor-pointer transition-all text-p3 border-l border-line-default"
                   :class="matrixVariant === 'stats'
                     ? 'bg-accent-300/20 text-accent-700 font-medium'
                     : 'bg-surface text-content-secondary hover:bg-surface-secondary'"
                   @click.stop="setMatrixVariant('stats')"
                 >
                   Stats
+                </button>
+                <button
+                  class="flex items-center gap-4 min-h-36 py-6 px-12 cursor-pointer transition-all text-p3 border-l border-line-default"
+                  :class="matrixVariant === 'config'
+                    ? 'bg-accent-300/20 text-accent-700 font-medium'
+                    : 'bg-surface text-content-secondary hover:bg-surface-secondary'"
+                  @click.stop="setMatrixVariant('config')"
+                >
+                  Configuration
                 </button>
               </div>
 

--- a/components/entities/vault/discovery/DiscoveryMarketAccordion.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketAccordion.vue
@@ -154,16 +154,10 @@ const setMatrixView = (view: MatrixViewId) => {
     matrixDropdownOpen.value = false
     return
   }
-  const wasAttribute = isAttributeMatrixView(matrixView.value)
-  const isAttribute = isAttributeMatrixView(view)
   matrixView.value = view
   matrixDropdownOpen.value = false
-  // Clear selections when crossing the attribute / pair boundary — pair
-  // selections (cell) don't map to attribute matrices and vice versa.
-  if (wasAttribute !== isAttribute) {
-    selectedCell.value = null
-    selectedMatrixHeader.value = null
-  }
+  selectedCell.value = null
+  selectedMatrixHeader.value = null
 }
 
 // -- Precomputed matrix map --

--- a/components/entities/vault/discovery/DiscoveryMarketAttributeMatrix.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketAttributeMatrix.vue
@@ -132,6 +132,7 @@ const isAttributeColumnHighlighted = (attributeId: string): boolean =>
               v-for="col in attributeColumns"
               :key="col.attribute.id"
               class="text-center py-6 px-8 min-w-[80px] transition-colors border-b border-r border-white/[0.04]"
+              :class="(isVaultRowHighlighted(vault.address) || isAttributeColumnHighlighted(col.attribute.id)) ? '!bg-white/[0.06]' : ''"
               :style="{ backgroundColor: cellBgColor(col, col.cells[vaultIdx]) }"
               @mouseenter="hoveredCell = { vaultAddr: vault.address, attributeId: col.attribute.id }"
               @mouseleave="hoveredCell = null"

--- a/components/entities/vault/discovery/DiscoveryMarketAttributeMatrix.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketAttributeMatrix.vue
@@ -1,0 +1,204 @@
+<script setup lang="ts">
+import type { MarketGroup } from '~/entities/lend-discovery'
+import type { Vault } from '~/entities/vault'
+import {
+  type AttributeMatrixData,
+  type AttributeCell,
+  type AttributeMatrixColumn,
+  type AttributeRow,
+  type VaultUsdCacheEntry,
+  buildAttributeRowCells,
+  getAttributeRowColor,
+} from '~/utils/discoveryCalculations'
+import { getEntitiesByVault } from '~/utils/eulerLabelsUtils'
+import { getEulerLabelEntityLogo } from '~/entities/euler/labels'
+import { useModal } from '~/components/ui/composables/useModal'
+import { VaultHooksInfoModal } from '#components'
+
+const props = defineProps<{
+  market: MarketGroup
+  data: AttributeMatrixData
+  usdCache: Map<string, VaultUsdCacheEntry>
+  selectedHeader: { address: string, axis: 'row' | 'column' } | null
+}>()
+
+defineEmits<{
+  selectHeader: [address: string, axis: 'row' | 'column']
+}>()
+
+const modal = useModal()
+const { isVaultGovernorVerified } = useVaults()
+
+interface RowComputed {
+  row: AttributeRow
+  cells: AttributeCell[]
+  min: number
+  max: number
+}
+
+const rowsComputed = computed<RowComputed[]>(() =>
+  props.data.rows.map((row) => {
+    const cells = buildAttributeRowCells(row, props.data.columns, props.usdCache)
+    let min = Infinity
+    let max = -Infinity
+    for (const c of cells) {
+      if (c.numeric === undefined || !Number.isFinite(c.numeric)) continue
+      if (c.numeric < min) min = c.numeric
+      if (c.numeric > max) max = c.numeric
+    }
+    if (!Number.isFinite(min)) {
+      min = 0
+      max = 0
+    }
+    return { row, cells, min, max }
+  }),
+)
+
+const cellBgColor = (
+  rowComputed: RowComputed,
+  cell: AttributeCell,
+): string => getAttributeRowColor(cell.numeric, rowComputed.min, rowComputed.max, rowComputed.row.direction)
+
+const onHooksClick = (col: AttributeMatrixColumn) => {
+  modal.open(VaultHooksInfoModal, { props: { vault: col.vault as Vault } })
+}
+
+const entitiesFor = (col: AttributeMatrixColumn) => getEntitiesByVault(col.vault as Vault)
+const isGovernorKnown = (col: AttributeMatrixColumn) => isVaultGovernorVerified(col.vault as Vault)
+</script>
+
+<template>
+  <div class="px-16 pb-12 flex items-center justify-center">
+    <div
+      class="relative max-h-[60vh] overflow-auto rounded-8 border border-line-subtle p-12"
+    >
+      <table class="border-collapse">
+        <thead class="sticky top-0 z-20 bg-surface">
+          <tr>
+            <th
+              class="text-left text-p5 text-content-muted font-normal py-6 pr-10 pl-6 sticky left-0 bg-surface z-30 border-b border-r border-white/[0.04]"
+            >
+              <span>Attribute</span>
+            </th>
+            <th
+              v-for="col in data.columns"
+              :key="col.address"
+              class="text-center text-p4 font-medium py-6 px-8 whitespace-nowrap border-b border-r border-white/[0.04] cursor-pointer transition-colors"
+              :class="
+                selectedHeader?.address === col.address
+                  && selectedHeader?.axis === 'column'
+                  ? 'text-accent-500 !bg-accent-500/10'
+                  : 'text-content-primary hover:bg-white/[0.04]'
+              "
+              @click.stop="$emit('selectHeader', col.address, 'column')"
+            >
+              <div class="flex flex-col items-center gap-2">
+                <AssetAvatar
+                  :asset="{ address: col.assetAddress, symbol: col.symbol }"
+                  size="16"
+                />
+                {{ col.symbol }}
+              </div>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            v-for="rc in rowsComputed"
+            :key="rc.row.id"
+          >
+            <td
+              class="text-p4 font-medium py-6 pr-10 pl-6 whitespace-nowrap sticky left-0 z-10 bg-surface border-b border-r border-white/[0.04] text-content-primary"
+            >
+              <span :title="rc.row.tooltip">{{ rc.row.label }}</span>
+            </td>
+            <td
+              v-for="(cell, colIdx) in rc.cells"
+              :key="data.columns[colIdx].address"
+              class="text-center py-6 px-8 min-w-[80px] transition-colors border-b border-r border-white/[0.04]"
+              :style="{ backgroundColor: cellBgColor(rc, cell) }"
+            >
+              <!-- capProgress: number + radial -->
+              <template v-if="cell.kind === 'capProgress'">
+                <div
+                  class="inline-flex items-center justify-center gap-6 text-p5 text-content-secondary whitespace-nowrap"
+                  :title="cell.hint"
+                >
+                  <span>{{ cell.display }}</span>
+                  <UiRadialProgress
+                    v-if="!cell.capUncapped && cell.capPercent !== undefined"
+                    :value="cell.capPercent"
+                    :max="100"
+                    class="shrink-0"
+                  />
+                </div>
+              </template>
+
+              <!-- governor: entity logos + names, or unknown chip -->
+              <template v-else-if="cell.kind === 'governor'">
+                <template v-if="isGovernorKnown(data.columns[colIdx]) && entitiesFor(data.columns[colIdx]).length">
+                  <div class="inline-flex items-center justify-center gap-6 flex-wrap">
+                    <div
+                      v-for="(entity, idx) in entitiesFor(data.columns[colIdx])"
+                      :key="idx"
+                      class="inline-flex items-center gap-4"
+                    >
+                      <BaseAvatar
+                        :label="entity.name"
+                        :src="getEulerLabelEntityLogo(entity.logo)"
+                        class="icon--16"
+                      />
+                      <span class="text-p5 text-content-primary whitespace-nowrap">{{ entity.name }}</span>
+                    </div>
+                  </div>
+                </template>
+                <template v-else>
+                  <VaultTypeChip
+                    :vault="data.columns[colIdx].vault"
+                    type="unknown"
+                    class="inline-flex !py-2 !px-6 !text-p5"
+                  />
+                </template>
+              </template>
+
+              <!-- hooks: text + optional clickable info icon -->
+              <template v-else-if="cell.kind === 'hooks'">
+                <button
+                  v-if="cell.hookable"
+                  type="button"
+                  class="inline-flex items-center justify-center gap-4 text-p5 text-content-primary hover:text-accent-500 cursor-pointer transition-colors"
+                  @click.stop="onHooksClick(data.columns[colIdx])"
+                >
+                  <span>{{ cell.display }}</span>
+                  <SvgIcon
+                    name="info-circle"
+                    class="!w-12 !h-12 shrink-0"
+                  />
+                </button>
+                <span
+                  v-else
+                  class="text-p5 text-content-secondary"
+                >{{ cell.display }}</span>
+              </template>
+
+              <!-- text (default) -->
+              <template v-else>
+                <span
+                  class="text-p5 text-content-secondary whitespace-nowrap"
+                  :title="cell.hint"
+                >{{ cell.display }}</span>
+              </template>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <p
+    v-if="!selectedHeader"
+    class="text-h6 text-content-primary text-center leading-relaxed px-16 pb-12"
+  >
+    Tap a column header to see lending/borrowing options below.
+  </p>
+</template>

--- a/components/entities/vault/discovery/DiscoveryMarketAttributeMatrix.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketAttributeMatrix.vue
@@ -81,11 +81,11 @@ const isAttributeColumnHighlighted = (attributeId: string): boolean =>
     <div
       class="relative max-h-[60vh] overflow-auto rounded-8 border border-line-subtle px-12 pb-12 pt-0"
     >
-      <table class="border-collapse">
-        <thead class="sticky top-0 z-20 bg-surface">
+      <table class="border-separate border-spacing-0">
+        <thead class="sticky top-0 z-30 bg-surface">
           <tr>
             <th
-              class="text-left text-p5 text-content-muted font-normal py-6 pr-10 pl-6 sticky left-0 bg-surface z-30 border-b border-r border-white/[0.04]"
+              class="text-left text-p5 text-content-muted font-normal py-6 pr-10 pl-6 sticky left-0 bg-surface z-40 border-b border-r border-white/[0.04]"
             >
               <div class="flex flex-col leading-tight">
                 <span>Attribute &#8594;</span>
@@ -95,7 +95,7 @@ const isAttributeColumnHighlighted = (attributeId: string): boolean =>
             <th
               v-for="col in attributeColumns"
               :key="col.attribute.id"
-              class="text-center text-p4 text-content-secondary font-medium py-6 px-8 whitespace-nowrap border-b border-r border-white/[0.04] transition-colors"
+              class="text-center text-p4 text-content-secondary font-medium py-6 px-8 whitespace-nowrap bg-surface border-b border-r border-white/[0.04] transition-colors"
               :class="isAttributeColumnHighlighted(col.attribute.id) ? '!bg-white/[0.06] text-content-primary' : ''"
             >
               <span :title="col.attribute.tooltip">{{ col.attribute.label }}</span>

--- a/components/entities/vault/discovery/DiscoveryMarketAttributeMatrix.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketAttributeMatrix.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import type { MarketGroup } from '~/entities/lend-discovery'
 import type { Vault } from '~/entities/vault'
 import {
   type AttributeMatrixData,
@@ -9,6 +8,7 @@ import {
   type VaultUsdCacheEntry,
   buildAttributeRowCells,
   getAttributeRowColor,
+  isVaultType,
 } from '~/utils/discoveryCalculations'
 import { getEntitiesByVault } from '~/utils/eulerLabelsUtils'
 import { getEulerLabelEntityLogo } from '~/entities/euler/labels'
@@ -16,7 +16,6 @@ import { useModal } from '~/components/ui/composables/useModal'
 import { VaultHooksInfoModal } from '#components'
 
 const props = defineProps<{
-  market: MarketGroup
   data: AttributeMatrixData
   usdCache: Map<string, VaultUsdCacheEntry>
   selectedHeader: { address: string, axis: 'row' | 'column' } | null
@@ -27,7 +26,6 @@ defineEmits<{
 }>()
 
 const modal = useModal()
-const { isVaultGovernorVerified } = useVaults()
 
 interface RowComputed {
   row: AttributeRow
@@ -60,11 +58,13 @@ const cellBgColor = (
 ): string => getAttributeRowColor(cell.numeric, rowComputed.min, rowComputed.max, rowComputed.row.direction)
 
 const onHooksClick = (col: AttributeMatrixColumn) => {
-  modal.open(VaultHooksInfoModal, { props: { vault: col.vault as Vault } })
+  if (!isVaultType(col.vault)) return
+  modal.open(VaultHooksInfoModal, { props: { vault: col.vault } })
 }
 
+// Governor entities resolve via the vault's governorAdmin address, which exists
+// on both Vault and SecuritizeVault — the helper only reads that one field.
 const entitiesFor = (col: AttributeMatrixColumn) => getEntitiesByVault(col.vault as Vault)
-const isGovernorKnown = (col: AttributeMatrixColumn) => isVaultGovernorVerified(col.vault as Vault)
 </script>
 
 <template>
@@ -136,7 +136,7 @@ const isGovernorKnown = (col: AttributeMatrixColumn) => isVaultGovernorVerified(
 
               <!-- governor: entity logos + names, or unknown chip -->
               <template v-else-if="cell.kind === 'governor'">
-                <template v-if="isGovernorKnown(data.columns[colIdx]) && entitiesFor(data.columns[colIdx]).length">
+                <template v-if="entitiesFor(data.columns[colIdx]).length">
                   <div class="inline-flex items-center justify-center gap-6 flex-wrap">
                     <div
                       v-for="(entity, idx) in entitiesFor(data.columns[colIdx])"

--- a/components/entities/vault/discovery/DiscoveryMarketAttributeMatrix.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketAttributeMatrix.vue
@@ -27,16 +27,19 @@ defineEmits<{
 
 const modal = useModal()
 
-interface RowComputed {
-  row: AttributeRow
-  cells: AttributeCell[]
+// Each AttributeRow renders as a *table column*; each vault renders as a *table row*.
+// We pre-compute one entry per attribute with the per-attribute cells (one per vault)
+// and the min/max range needed for the heatmap.
+interface AttributeColumn {
+  attribute: AttributeRow
+  cells: AttributeCell[] // index aligned to data.columns (vaults)
   min: number
   max: number
 }
 
-const rowsComputed = computed<RowComputed[]>(() =>
-  props.data.rows.map((row) => {
-    const cells = buildAttributeRowCells(row, props.data.columns, props.usdCache)
+const attributeColumns = computed<AttributeColumn[]>(() =>
+  props.data.rows.map((attribute) => {
+    const cells = buildAttributeRowCells(attribute, props.data.columns, props.usdCache)
     let min = Infinity
     let max = -Infinity
     for (const c of cells) {
@@ -48,23 +51,21 @@ const rowsComputed = computed<RowComputed[]>(() =>
       min = 0
       max = 0
     }
-    return { row, cells, min, max }
+    return { attribute, cells, min, max }
   }),
 )
 
-const cellBgColor = (
-  rowComputed: RowComputed,
-  cell: AttributeCell,
-): string => getAttributeRowColor(cell.numeric, rowComputed.min, rowComputed.max, rowComputed.row.direction)
+const cellBgColor = (column: AttributeColumn, cell: AttributeCell): string =>
+  getAttributeRowColor(cell.numeric, column.min, column.max, column.attribute.direction)
 
-const onHooksClick = (col: AttributeMatrixColumn) => {
-  if (!isVaultType(col.vault)) return
-  modal.open(VaultHooksInfoModal, { props: { vault: col.vault } })
+const onHooksClick = (vault: AttributeMatrixColumn) => {
+  if (!isVaultType(vault.vault)) return
+  modal.open(VaultHooksInfoModal, { props: { vault: vault.vault } })
 }
 
 // Governor entities resolve via the vault's governorAdmin address, which exists
 // on both Vault and SecuritizeVault — the helper only reads that one field.
-const entitiesFor = (col: AttributeMatrixColumn) => getEntitiesByVault(col.vault as Vault)
+const entitiesFor = (vault: AttributeMatrixColumn) => getEntitiesByVault(vault.vault as Vault)
 </script>
 
 <template>
@@ -78,56 +79,57 @@ const entitiesFor = (col: AttributeMatrixColumn) => getEntitiesByVault(col.vault
             <th
               class="text-left text-p5 text-content-muted font-normal py-6 pr-10 pl-6 sticky left-0 bg-surface z-30 border-b border-r border-white/[0.04]"
             >
-              <span>Attribute</span>
+              <span>Vault</span>
             </th>
             <th
-              v-for="col in data.columns"
-              :key="col.address"
-              class="text-center text-p4 font-medium py-6 px-8 whitespace-nowrap border-b border-r border-white/[0.04] cursor-pointer transition-colors"
-              :class="
-                selectedHeader?.address === col.address
-                  && selectedHeader?.axis === 'column'
-                  ? 'text-accent-500 !bg-accent-500/10'
-                  : 'text-content-primary hover:bg-white/[0.04]'
-              "
-              @click.stop="$emit('selectHeader', col.address, 'column')"
+              v-for="col in attributeColumns"
+              :key="col.attribute.id"
+              class="text-center text-p4 text-content-secondary font-medium py-6 px-8 whitespace-nowrap border-b border-r border-white/[0.04]"
             >
-              <div class="flex flex-col items-center gap-2">
-                <AssetAvatar
-                  :asset="{ address: col.assetAddress, symbol: col.symbol }"
-                  size="16"
-                />
-                {{ col.symbol }}
-              </div>
+              <span :title="col.attribute.tooltip">{{ col.attribute.label }}</span>
             </th>
           </tr>
         </thead>
         <tbody>
           <tr
-            v-for="rc in rowsComputed"
-            :key="rc.row.id"
+            v-for="(vault, vaultIdx) in data.columns"
+            :key="vault.address"
           >
             <td
-              class="text-p4 font-medium py-6 pr-10 pl-6 whitespace-nowrap sticky left-0 z-10 bg-surface border-b border-r border-white/[0.04] text-content-primary"
+              class="text-p4 font-medium py-6 pr-10 pl-6 whitespace-nowrap sticky left-0 z-10 bg-surface border-b border-r border-white/[0.04] cursor-pointer transition-colors"
+              :class="
+                selectedHeader?.address === vault.address
+                  && selectedHeader?.axis === 'row'
+                  ? 'text-accent-500 !bg-accent-500/10'
+                  : 'text-content-primary hover:bg-white/[0.04]'
+              "
+              @click.stop="$emit('selectHeader', vault.address, 'row')"
             >
-              <span :title="rc.row.tooltip">{{ rc.row.label }}</span>
+              <div class="flex items-center gap-4">
+                <AssetAvatar
+                  class="shrink-0"
+                  :asset="{ address: vault.assetAddress, symbol: vault.symbol }"
+                  size="16"
+                />
+                {{ vault.symbol }}
+              </div>
             </td>
             <td
-              v-for="(cell, colIdx) in rc.cells"
-              :key="data.columns[colIdx].address"
+              v-for="col in attributeColumns"
+              :key="col.attribute.id"
               class="text-center py-6 px-8 min-w-[80px] transition-colors border-b border-r border-white/[0.04]"
-              :style="{ backgroundColor: cellBgColor(rc, cell) }"
+              :style="{ backgroundColor: cellBgColor(col, col.cells[vaultIdx]) }"
             >
               <!-- capProgress: number + radial -->
-              <template v-if="cell.kind === 'capProgress'">
+              <template v-if="col.cells[vaultIdx].kind === 'capProgress'">
                 <div
                   class="inline-flex items-center justify-center gap-6 text-p5 text-content-secondary whitespace-nowrap"
-                  :title="cell.hint"
+                  :title="col.cells[vaultIdx].hint"
                 >
-                  <span>{{ cell.display }}</span>
+                  <span>{{ col.cells[vaultIdx].display }}</span>
                   <UiRadialProgress
-                    v-if="!cell.capUncapped && cell.capPercent !== undefined"
-                    :value="cell.capPercent"
+                    v-if="!col.cells[vaultIdx].capUncapped && col.cells[vaultIdx].capPercent !== undefined"
+                    :value="col.cells[vaultIdx].capPercent!"
                     :max="100"
                     class="shrink-0"
                   />
@@ -135,11 +137,11 @@ const entitiesFor = (col: AttributeMatrixColumn) => getEntitiesByVault(col.vault
               </template>
 
               <!-- governor: entity logos + names, or unknown chip -->
-              <template v-else-if="cell.kind === 'governor'">
-                <template v-if="entitiesFor(data.columns[colIdx]).length">
+              <template v-else-if="col.cells[vaultIdx].kind === 'governor'">
+                <template v-if="entitiesFor(vault).length">
                   <div class="inline-flex items-center justify-center gap-6 flex-wrap">
                     <div
-                      v-for="(entity, idx) in entitiesFor(data.columns[colIdx])"
+                      v-for="(entity, idx) in entitiesFor(vault)"
                       :key="idx"
                       class="inline-flex items-center gap-4"
                     >
@@ -154,7 +156,7 @@ const entitiesFor = (col: AttributeMatrixColumn) => getEntitiesByVault(col.vault
                 </template>
                 <template v-else>
                   <VaultTypeChip
-                    :vault="data.columns[colIdx].vault"
+                    :vault="vault.vault"
                     type="unknown"
                     class="inline-flex !py-2 !px-6 !text-p5"
                   />
@@ -162,14 +164,14 @@ const entitiesFor = (col: AttributeMatrixColumn) => getEntitiesByVault(col.vault
               </template>
 
               <!-- hooks: text + optional clickable info icon -->
-              <template v-else-if="cell.kind === 'hooks'">
+              <template v-else-if="col.cells[vaultIdx].kind === 'hooks'">
                 <button
-                  v-if="cell.hookable"
+                  v-if="col.cells[vaultIdx].hookable"
                   type="button"
                   class="inline-flex items-center justify-center gap-4 text-p5 text-content-primary hover:text-accent-500 cursor-pointer transition-colors"
-                  @click.stop="onHooksClick(data.columns[colIdx])"
+                  @click.stop="onHooksClick(vault)"
                 >
-                  <span>{{ cell.display }}</span>
+                  <span>{{ col.cells[vaultIdx].display }}</span>
                   <SvgIcon
                     name="info-circle"
                     class="!w-12 !h-12 shrink-0"
@@ -178,15 +180,15 @@ const entitiesFor = (col: AttributeMatrixColumn) => getEntitiesByVault(col.vault
                 <span
                   v-else
                   class="text-p5 text-content-secondary"
-                >{{ cell.display }}</span>
+                >{{ col.cells[vaultIdx].display }}</span>
               </template>
 
               <!-- text (default) -->
               <template v-else>
                 <span
                   class="text-p5 text-content-secondary whitespace-nowrap"
-                  :title="cell.hint"
-                >{{ cell.display }}</span>
+                  :title="col.cells[vaultIdx].hint"
+                >{{ col.cells[vaultIdx].display }}</span>
               </template>
             </td>
           </tr>
@@ -199,6 +201,6 @@ const entitiesFor = (col: AttributeMatrixColumn) => getEntitiesByVault(col.vault
     v-if="!selectedHeader"
     class="text-h6 text-content-primary text-center leading-relaxed px-16 pb-12"
   >
-    Tap a column header to see lending/borrowing options below.
+    Tap a vault row to see lending/borrowing options below.
   </p>
 </template>

--- a/components/entities/vault/discovery/DiscoveryMarketAttributeMatrix.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketAttributeMatrix.vue
@@ -79,7 +79,10 @@ const entitiesFor = (vault: AttributeMatrixColumn) => getEntitiesByVault(vault.v
             <th
               class="text-left text-p5 text-content-muted font-normal py-6 pr-10 pl-6 sticky left-0 bg-surface z-30 border-b border-r border-white/[0.04]"
             >
-              <span>Vault</span>
+              <div class="flex flex-col leading-tight">
+                <span>Attribute &#8594;</span>
+                <span>Vault &#8595;</span>
+              </div>
             </th>
             <th
               v-for="col in attributeColumns"

--- a/components/entities/vault/discovery/DiscoveryMarketAttributeMatrix.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketAttributeMatrix.vue
@@ -62,9 +62,18 @@ const onHooksClick = (vault: AttributeMatrixColumn) => {
   modal.open(VaultHooksInfoModal, { props: { vault: vault.vault } })
 }
 
-// Governor entities resolve via the vault's governorAdmin address, which exists
-// on both Vault and SecuritizeVault — the helper only reads that one field.
 const entitiesFor = (vault: AttributeMatrixColumn) => getEntitiesByVault(vault.vault)
+
+// Hover state — used to highlight the matching vault row label and attribute
+// column header so users can scan from a cell back to its labels.
+const hoveredCell = ref<{ vaultAddr: string, attributeId: string } | null>(null)
+
+const isVaultRowHighlighted = (vaultAddr: string): boolean =>
+  hoveredCell.value?.vaultAddr === vaultAddr
+  || (props.selectedHeader?.axis === 'row' && props.selectedHeader.address === vaultAddr)
+
+const isAttributeColumnHighlighted = (attributeId: string): boolean =>
+  hoveredCell.value?.attributeId === attributeId
 </script>
 
 <template>
@@ -86,7 +95,8 @@ const entitiesFor = (vault: AttributeMatrixColumn) => getEntitiesByVault(vault.v
             <th
               v-for="col in attributeColumns"
               :key="col.attribute.id"
-              class="text-center text-p4 text-content-secondary font-medium py-6 px-8 whitespace-nowrap border-b border-r border-white/[0.04]"
+              class="text-center text-p4 text-content-secondary font-medium py-6 px-8 whitespace-nowrap border-b border-r border-white/[0.04] transition-colors"
+              :class="isAttributeColumnHighlighted(col.attribute.id) ? '!bg-white/[0.06] text-content-primary' : ''"
             >
               <span :title="col.attribute.tooltip">{{ col.attribute.label }}</span>
             </th>
@@ -103,7 +113,9 @@ const entitiesFor = (vault: AttributeMatrixColumn) => getEntitiesByVault(vault.v
                 selectedHeader?.address === vault.address
                   && selectedHeader?.axis === 'row'
                   ? 'text-accent-500 !bg-accent-500/10'
-                  : 'text-content-primary hover:bg-white/[0.04]'
+                  : isVaultRowHighlighted(vault.address)
+                    ? 'text-content-primary !bg-white/[0.06]'
+                    : 'text-content-primary hover:bg-white/[0.04]'
               "
               @click.stop="$emit('selectHeader', vault.address, 'row')"
             >
@@ -121,6 +133,8 @@ const entitiesFor = (vault: AttributeMatrixColumn) => getEntitiesByVault(vault.v
               :key="col.attribute.id"
               class="text-center py-6 px-8 min-w-[80px] transition-colors border-b border-r border-white/[0.04]"
               :style="{ backgroundColor: cellBgColor(col, col.cells[vaultIdx]) }"
+              @mouseenter="hoveredCell = { vaultAddr: vault.address, attributeId: col.attribute.id }"
+              @mouseleave="hoveredCell = null"
             >
               <!-- capProgress: number + radial -->
               <template v-if="col.cells[vaultIdx].kind === 'capProgress'">

--- a/components/entities/vault/discovery/DiscoveryMarketAttributeMatrix.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketAttributeMatrix.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import type { Vault } from '~/entities/vault'
 import {
   type AttributeMatrixData,
   type AttributeCell,
@@ -65,7 +64,7 @@ const onHooksClick = (vault: AttributeMatrixColumn) => {
 
 // Governor entities resolve via the vault's governorAdmin address, which exists
 // on both Vault and SecuritizeVault — the helper only reads that one field.
-const entitiesFor = (vault: AttributeMatrixColumn) => getEntitiesByVault(vault.vault as Vault)
+const entitiesFor = (vault: AttributeMatrixColumn) => getEntitiesByVault(vault.vault)
 </script>
 
 <template>

--- a/components/entities/vault/discovery/DiscoveryMarketAttributeMatrix.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketAttributeMatrix.vue
@@ -79,7 +79,7 @@ const isAttributeColumnHighlighted = (attributeId: string): boolean =>
 <template>
   <div class="px-16 pb-12 flex items-center justify-center">
     <div
-      class="relative max-h-[60vh] overflow-auto rounded-8 border border-line-subtle p-12"
+      class="relative max-h-[60vh] overflow-auto rounded-8 border border-line-subtle px-12 pb-12 pt-0"
     >
       <table class="border-collapse">
         <thead class="sticky top-0 z-20 bg-surface">

--- a/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
@@ -49,7 +49,7 @@ const {
   hasSupplyRewards,
   hasBorrowRewards,
 } = useRewardsApy()
-const { oracleAdapters, loadOracleAdapter } = useEulerLabels()
+const { oracleAdapters, loadAllOracleAdapters } = useEulerLabels()
 const { chainId } = useEulerAddresses()
 
 const hoveredCell = ref<{
@@ -175,22 +175,14 @@ const cellOracleAdapters = computed((): Map<string, OracleAdapterEntry[]> => {
   return result
 })
 
+// Bulk-load adapter metadata for the chain whenever the oracle metric is the
+// active view. Heavy call; deferred to first oracle-mode render and cached
+// per-chain by useEulerLabels.
 watch(
-  [cellOracleAdapters, chainId],
-  async ([map, currentChainId]) => {
-    if (!currentChainId || map.size === 0) return
-    const seen = new Set<string>()
-    const toLoad: OracleAdapterEntry[] = []
-    for (const adapters of map.values()) {
-      for (const a of adapters) {
-        if (a.name === 'ERC4626Vault') continue
-        const key = a.oracle.toLowerCase()
-        if (seen.has(key)) continue
-        seen.add(key)
-        toLoad.push(a)
-      }
-    }
-    await Promise.all(toLoad.map(a => loadOracleAdapter(currentChainId, a.oracle)))
+  [() => props.dotMetric, chainId],
+  ([metric, currentChainId]) => {
+    if (metric !== 'oracle' || !currentChainId) return
+    void loadAllOracleAdapters(currentChainId)
   },
   { immediate: true },
 )

--- a/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
@@ -595,7 +595,7 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
                     <SvgIcon
                       v-if="isAdapterPriceFailed(adapter)"
                       name="warning"
-                      class="absolute -bottom-1 -right-1 !w-10 !h-10 text-error-500"
+                      class="absolute -bottom-1 -right-1 !w-10 !h-10 text-warning-500"
                       title="getQuote reverted"
                     />
                   </button>
@@ -633,7 +633,7 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
                       <SvgIcon
                         v-if="isAdapterPriceFailed(adapter)"
                         name="warning"
-                        class="absolute -bottom-1 -right-1 !w-10 !h-10 text-error-500"
+                        class="absolute -bottom-1 -right-1 !w-10 !h-10 text-warning-500"
                         title="getQuote reverted"
                       />
                     </button>

--- a/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
@@ -166,7 +166,10 @@ const cellOracleAdapters = computed((): Map<string, OracleAdapterEntry[]> => {
   for (const row of props.matrix.rows) skipERC4626Bases.add(row.address.toLowerCase())
 
   for (const [colAddr, rowCells] of props.matrix.cells) {
-    for (const [liabAddr] of rowCells) {
+    for (const [liabAddr, cell] of rowCells) {
+      // Belt-and-braces — getCollateralMatrix already filters LLTV>0 cells,
+      // but enforce again here so the invariant is explicit at the consumer.
+      if (getCurrentLiquidationLTV(cell.ltv) <= 0n) continue
       const collateral = findVault(props.market, colAddr)
       const liability = findVault(props.market, liabAddr)
       if (!collateral || !liability) continue
@@ -183,6 +186,25 @@ const cellOracleAdapters = computed((): Map<string, OracleAdapterEntry[]> => {
       })
       if (adapters.length) result.set(`${colAddr}:${liabAddr}`, adapters)
     }
+  }
+  return result
+})
+
+// Per-borrow-vault asset oracle: resolves the borrow vault's own asset against
+// its unit of account. Same set repeated across every cell in a column, so we
+// surface it once as a header row instead.
+const columnAssetOracleAdapters = computed((): Map<string, OracleAdapterEntry[]> => {
+  const result = new Map<string, OracleAdapterEntry[]>()
+  if (props.dotMetric !== 'oracle') return result
+  for (const col of props.matrix.columns) {
+    const liability = findVault(props.market, col.address)
+    if (!liability || !isVaultType(liability) || !liability.oracleDetailedInfo) continue
+    const adapters = collectOracleAdapters(liability.oracleDetailedInfo, 3, {
+      base: liability.asset.address as Address,
+      quote: liability.unitOfAccount as Address,
+      leafOnly: true,
+    })
+    if (adapters.length) result.set(col.address, adapters)
   }
   return result
 })
@@ -237,6 +259,12 @@ const enrichAdapter = (adapter: OracleAdapterEntry): AdapterView => {
 
 const getCellAdapterViews = (collateralAddr: string, liabilityAddr: string): AdapterView[] => {
   const list = cellOracleAdapters.value.get(`${collateralAddr}:${liabilityAddr}`)
+  if (!list) return []
+  return list.map(enrichAdapter)
+}
+
+const getColumnAssetAdapterViews = (liabilityAddr: string): AdapterView[] => {
+  const list = columnAssetOracleAdapters.value.get(liabilityAddr)
   if (!list) return []
   return list.map(enrichAdapter)
 }
@@ -315,6 +343,54 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
           </tr>
         </thead>
         <tbody>
+          <!-- Oracle metric: per-column asset oracle row (vault asset -> UoA).
+               Lifted out of cells because it's identical for every row in a
+               given column. -->
+          <tr
+            v-if="dotMetric === 'oracle'"
+          >
+            <td
+              class="text-p5 italic text-content-tertiary py-6 pr-10 pl-6 whitespace-nowrap sticky left-0 z-10 bg-surface border-b-2 border-r border-line-subtle"
+            >
+              Asset
+            </td>
+            <td
+              v-for="col in matrix.columns"
+              :key="`asset-${col.address}`"
+              class="text-center py-6 px-8 min-w-[56px] border-b-2 border-r border-line-subtle bg-white/[0.02]"
+            >
+              <div
+                v-if="getColumnAssetAdapterViews(col.address).length"
+                class="inline-flex items-center justify-center gap-4 flex-wrap"
+              >
+                <button
+                  v-for="adapter in getColumnAssetAdapterViews(col.address)"
+                  :key="adapter.oracle"
+                  type="button"
+                  class="relative inline-flex items-center justify-center cursor-pointer"
+                  :title="adapter.provider"
+                  @click.stop="onAdapterClick(adapter, $event)"
+                >
+                  <BaseAvatar
+                    v-if="adapter.logo"
+                    :src="adapter.logo"
+                    :label="adapter.name"
+                    class="icon--16"
+                  />
+                  <SvgIcon
+                    v-else
+                    name="question-circle"
+                    class="!w-16 !h-16 text-content-tertiary"
+                  />
+                  <span
+                    v-if="adapter.checksStatus === 'warning' || adapter.checksStatus === 'negative'"
+                    class="absolute -top-1 -right-1 w-6 h-6 rounded-full"
+                    :class="adapter.checksStatus === 'negative' ? 'bg-error-500' : 'bg-warning-500'"
+                  />
+                </button>
+              </div>
+            </td>
+          </tr>
           <tr
             v-for="row in matrix.rows"
             :key="row.address"
@@ -486,70 +562,84 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
     Tap a cell, row, or column header to see lending/borrowing options below.
   </p>
 
-  <!-- Oracle adapter tooltip -->
+  <!-- Oracle adapter tooltip — mirrors VaultOverviewBlockOracleAdapters card layout -->
   <Teleport to="body">
     <div
       v-if="tooltipAdapter"
-      class="fixed z-[9999] bg-surface-secondary border border-line-subtle rounded-xl p-12 shadow-card overflow-y-auto"
+      class="fixed z-[9999] bg-surface-secondary border border-line-subtle rounded-xl p-16 shadow-card overflow-y-auto flex flex-col gap-12"
       :style="[tooltipStyle, { width: `${TOOLTIP_WIDTH}px` }]"
       @click.stop
     >
-      <div class="flex items-center justify-between gap-8 mb-8">
-        <div class="flex items-center gap-8">
-          <BaseAvatar
-            v-if="tooltipAdapter.logo"
-            :src="tooltipAdapter.logo"
-            :label="tooltipAdapter.name"
-            class="icon--20"
-          />
-          <SvgIcon
-            v-else
-            name="question-circle"
-            class="!w-20 !h-20 text-content-tertiary"
-          />
-          <span class="text-p2 text-content-primary font-medium">{{ tooltipAdapter.provider || 'Unknown' }}</span>
+      <!-- Header: oracle label / pair + address & close -->
+      <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-4 sm:gap-8">
+        <div class="text-p2 text-content-primary font-medium">
+          <template v-if="tooltipAdapter.label">
+            {{ tooltipAdapter.label.primary }}
+            <span
+              v-if="tooltipAdapter.label.suffix"
+              class="text-content-tertiary ml-2"
+            >{{ tooltipAdapter.label.suffix }}</span>
+          </template>
+          <template v-else>
+            Oracle
+          </template>
         </div>
-        <button
-          type="button"
-          class="text-content-muted hover:text-content-secondary cursor-pointer"
-          aria-label="Close"
-          @click.stop="closeTooltip"
-        >
-          <SvgIcon
-            name="close"
-            class="!w-14 !h-14"
-          />
-        </button>
-      </div>
-      <div class="flex flex-col gap-8 text-p3">
-        <div class="flex flex-col gap-2">
-          <span class="text-content-tertiary">Oracle</span>
+        <div class="flex items-center gap-8 flex-shrink-0">
           <NuxtLink
             :to="explorerLink(tooltipAdapter.oracle)"
             target="_blank"
-            class="text-accent-600 underline hover:text-accent-500"
+            class="text-accent-600 underline cursor-pointer hover:text-accent-500 text-p3"
             @click.stop
           >
-            {{ tooltipAdapter.label?.primary ?? truncate(tooltipAdapter.oracle, 6) }}
-            <span
-              v-if="tooltipAdapter.label?.suffix"
-              class="text-content-tertiary ml-2"
-            >{{ tooltipAdapter.label.suffix }}</span>
+            {{ truncate(tooltipAdapter.oracle, 6) }}
           </NuxtLink>
+          <button
+            type="button"
+            class="text-content-muted hover:text-content-secondary cursor-pointer"
+            aria-label="Close"
+            @click.stop="closeTooltip"
+          >
+            <SvgIcon
+              name="close"
+              class="!w-14 !h-14"
+            />
+          </button>
         </div>
-        <div
-          v-if="tooltipAdapter.methodology"
-          class="flex flex-col gap-2"
-        >
+      </div>
+
+      <!-- Provider / Methodology / Checks grid -->
+      <div class="grid grid-cols-2 gap-12 text-p3">
+        <div class="flex flex-col gap-4">
+          <span class="text-content-tertiary">Provider</span>
+          <div class="flex items-center gap-8">
+            <BaseAvatar
+              v-if="tooltipAdapter.logo"
+              :src="tooltipAdapter.logo"
+              :label="tooltipAdapter.name"
+              class="icon--20"
+            />
+            <SvgIcon
+              v-else
+              name="question-circle"
+              class="!w-20 !h-20 text-content-tertiary"
+            />
+            <span class="text-content-primary">{{ tooltipAdapter.provider || 'Unknown' }}</span>
+          </div>
+        </div>
+        <div class="flex flex-col gap-4">
           <span class="text-content-tertiary">Methodology</span>
-          <span class="text-content-primary">{{ tooltipAdapter.methodology }}</span>
+          <span class="text-content-primary">{{ tooltipAdapter.methodology || 'Unknown' }}</span>
         </div>
-        <div
-          v-if="tooltipAdapter.checks?.length"
-          class="flex flex-col gap-2"
-        >
+        <div class="flex flex-col gap-4 col-span-2">
           <span class="text-content-tertiary">Checks</span>
-          <span class="flex items-center gap-6">
+          <span
+            v-if="!tooltipAdapter.checks?.length"
+            class="text-content-secondary"
+          >N/A</span>
+          <span
+            v-else
+            class="flex items-center gap-6"
+          >
             <span
               class="inline-block w-8 h-8 rounded-full flex-shrink-0"
               :class="{
@@ -564,27 +654,29 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
             </span>
           </span>
         </div>
+      </div>
+
+      <!-- Failed checks detail -->
+      <div
+        v-if="tooltipAdapter.failedChecks.length"
+        class="flex flex-col gap-6 border-t border-line-subtle pt-12 text-p3"
+      >
         <div
-          v-if="tooltipAdapter.failedChecks.length"
-          class="flex flex-col gap-6 border-t border-line-subtle pt-8"
+          v-for="(check, i) in tooltipAdapter.failedChecks"
+          :key="`${check.id}-${i}`"
+          class="flex items-start gap-8"
         >
-          <div
-            v-for="(check, i) in tooltipAdapter.failedChecks"
-            :key="`${check.id}-${i}`"
-            class="flex items-start gap-6"
-          >
-            <SvgIcon
-              name="warning"
-              class="!w-14 !h-14 mt-1 flex-shrink-0"
-              :class="{
-                'text-error-500': check.severity === OracleAdapterCheckSeverity.High,
-                'text-warning-500': check.severity !== OracleAdapterCheckSeverity.High,
-              }"
-            />
-            <div>
-              <span class="text-content-primary font-medium">{{ check.id }}: </span>
-              <span class="text-content-secondary">{{ check.message }}</span>
-            </div>
+          <SvgIcon
+            name="warning"
+            class="!w-16 !h-16 mt-1 flex-shrink-0"
+            :class="{
+              'text-error-500': check.severity === OracleAdapterCheckSeverity.High,
+              'text-warning-500': check.severity !== OracleAdapterCheckSeverity.High,
+            }"
+          />
+          <div>
+            <span class="text-content-primary font-medium">{{ check.id }}: </span>
+            <span class="text-content-secondary">{{ check.message }}</span>
           </div>
         </div>
       </div>

--- a/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
@@ -2,6 +2,7 @@
 import type { CSSProperties } from 'vue'
 import type { Address } from 'viem'
 import type { MarketGroup } from '~/entities/lend-discovery'
+import type { Vault, SecuritizeVault } from '~/entities/vault'
 import { nanoToValue } from '~/utils/crypto-utils'
 import { getMaxMultiplier, getMaxRoe } from '~/utils/leverage'
 import {
@@ -26,7 +27,8 @@ import {
 } from '~/entities/oracle'
 import { getOracleProviderLogo } from '~/entities/oracle-providers'
 import { getExplorerLink } from '~/utils/block-explorer'
-import { truncate } from '~/utils/string-utils'
+import { truncate, formatNumber } from '~/utils/string-utils'
+import { useOracleAdapterPrices } from '~/composables/useOracleAdapterPrices'
 
 const props = defineProps<{
   market: MarketGroup
@@ -224,6 +226,8 @@ watch(
 interface AdapterView {
   oracle: string
   name: string
+  base: string
+  quote: string
   provider: string
   methodology?: string
   logo?: string
@@ -242,6 +246,8 @@ const enrichAdapter = (adapter: OracleAdapterEntry): AdapterView => {
   return {
     oracle: adapter.oracle,
     name,
+    base: adapter.base,
+    quote: adapter.quote,
     provider,
     methodology: meta?.methodology || (isERC4626 ? 'Exchange Rate' : undefined),
     logo: getOracleProviderLogo(provider, name),
@@ -270,18 +276,59 @@ const getColumnAssetAdapterViews = (liabilityAddr: string): AdapterView[] => {
 }
 
 const TOOLTIP_WIDTH = 360
-const tooltipAdapter = ref<AdapterView | null>(null)
-const tooltipStyle = ref<CSSProperties>({})
 
-const closeTooltip = () => {
-  tooltipAdapter.value = null
+interface TooltipContext {
+  view: AdapterView
+  sourceVault: Vault
+  collateralVault: Vault | SecuritizeVault | null
 }
 
-const onAdapterClick = (adapter: AdapterView, event: MouseEvent) => {
-  if (tooltipAdapter.value?.oracle === adapter.oracle) {
-    closeTooltip()
-    return
-  }
+const tooltipContext = ref<TooltipContext | null>(null)
+const tooltipAdapter = computed(() => tooltipContext.value?.view ?? null)
+const tooltipStyle = ref<CSSProperties>({})
+
+// Lazy price fetch — only the currently-open tooltip's adapter is in the
+// list, so the borrow page's batch query runs once per tooltip open and
+// nothing else.
+const tooltipAdapters = computed<OracleAdapterEntry[]>(() => {
+  const ctx = tooltipContext.value
+  if (!ctx) return []
+  return [{
+    oracle: ctx.view.oracle as Address,
+    name: ctx.view.name,
+    base: ctx.view.base as Address,
+    quote: ctx.view.quote as Address,
+  }]
+})
+const tooltipSourceVaults = computed<Vault[]>(() => {
+  const ctx = tooltipContext.value
+  return ctx ? [ctx.sourceVault] : []
+})
+const tooltipCollateralVaults = computed<(Vault | SecuritizeVault)[]>(() => {
+  const ctx = tooltipContext.value
+  return ctx?.collateralVault ? [ctx.collateralVault] : []
+})
+
+const { prices: tooltipPrices, isLoading: tooltipPriceLoading } = useOracleAdapterPrices(
+  tooltipAdapters,
+  tooltipSourceVaults,
+  tooltipCollateralVaults,
+)
+
+const tooltipPriceText = computed((): string | null => {
+  const adapters = tooltipAdapters.value
+  if (!adapters.length) return null
+  const key = `${adapters[0].oracle.toLowerCase()}:${adapters[0].base.toLowerCase()}:${adapters[0].quote.toLowerCase()}`
+  const info = tooltipPrices.value.get(key)
+  if (!info?.success) return null
+  return formatNumber(info.rate, 4)
+})
+
+const closeTooltip = () => {
+  tooltipContext.value = null
+}
+
+const positionTooltip = (event: MouseEvent) => {
   const rect = (event.currentTarget as HTMLElement).getBoundingClientRect()
   const left = Math.max(8, Math.min(rect.left, window.innerWidth - TOOLTIP_WIDTH - 16))
   const spaceBelow = Math.max(160, window.innerHeight - rect.bottom - 16)
@@ -290,7 +337,46 @@ const onAdapterClick = (adapter: AdapterView, event: MouseEvent) => {
   tooltipStyle.value = flipUp
     ? { top: `${rect.top - 8}px`, left: `${left}px`, transform: 'translateY(-100%)', maxHeight: `${spaceAbove}px` }
     : { top: `${rect.bottom + 8}px`, left: `${left}px`, transform: 'none', maxHeight: `${spaceBelow}px` }
-  tooltipAdapter.value = adapter
+}
+
+const onCellAdapterClick = (
+  view: AdapterView,
+  event: MouseEvent,
+  collateralAddr: string,
+  liabilityAddr: string,
+) => {
+  if (tooltipContext.value?.view.oracle === view.oracle) {
+    closeTooltip()
+    return
+  }
+  const liability = findVault(props.market, liabilityAddr)
+  const collateral = findVault(props.market, collateralAddr)
+  if (!liability || !isVaultType(liability)) return
+  positionTooltip(event)
+  tooltipContext.value = {
+    view,
+    sourceVault: liability,
+    collateralVault: collateral && collateral.address.toLowerCase() !== liabilityAddr.toLowerCase() ? collateral : null,
+  }
+}
+
+const onAssetAdapterClick = (
+  view: AdapterView,
+  event: MouseEvent,
+  liabilityAddr: string,
+) => {
+  if (tooltipContext.value?.view.oracle === view.oracle) {
+    closeTooltip()
+    return
+  }
+  const liability = findVault(props.market, liabilityAddr)
+  if (!liability || !isVaultType(liability)) return
+  positionTooltip(event)
+  tooltipContext.value = {
+    view,
+    sourceVault: liability,
+    collateralVault: null,
+  }
 }
 
 const onDocumentClick = () => closeTooltip()
@@ -343,54 +429,6 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
           </tr>
         </thead>
         <tbody>
-          <!-- Oracle metric: per-column asset oracle row (vault asset -> UoA).
-               Lifted out of cells because it's identical for every row in a
-               given column. -->
-          <tr
-            v-if="dotMetric === 'oracle'"
-          >
-            <td
-              class="text-p5 italic text-content-tertiary py-6 pr-10 pl-6 whitespace-nowrap sticky left-0 z-10 bg-surface border-b-2 border-r border-line-subtle"
-            >
-              Asset
-            </td>
-            <td
-              v-for="col in matrix.columns"
-              :key="`asset-${col.address}`"
-              class="text-center py-6 px-8 min-w-[56px] border-b-2 border-r border-line-subtle bg-white/[0.02]"
-            >
-              <div
-                v-if="getColumnAssetAdapterViews(col.address).length"
-                class="inline-flex items-center justify-center gap-4 flex-wrap"
-              >
-                <button
-                  v-for="adapter in getColumnAssetAdapterViews(col.address)"
-                  :key="adapter.oracle"
-                  type="button"
-                  class="relative inline-flex items-center justify-center cursor-pointer"
-                  :title="adapter.provider"
-                  @click.stop="onAdapterClick(adapter, $event)"
-                >
-                  <BaseAvatar
-                    v-if="adapter.logo"
-                    :src="adapter.logo"
-                    :label="adapter.name"
-                    class="icon--16"
-                  />
-                  <SvgIcon
-                    v-else
-                    name="question-circle"
-                    class="!w-16 !h-16 text-content-tertiary"
-                  />
-                  <span
-                    v-if="adapter.checksStatus === 'warning' || adapter.checksStatus === 'negative'"
-                    class="absolute -top-1 -right-1 w-6 h-6 rounded-full"
-                    :class="adapter.checksStatus === 'negative' ? 'bg-error-500' : 'bg-warning-500'"
-                  />
-                </button>
-              </div>
-            </td>
-          </tr>
           <tr
             v-for="row in matrix.rows"
             :key="row.address"
@@ -470,7 +508,44 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
                   && $emit('selectCell', row.address, col.address)
               "
             >
-              <template v-if="matrix.cells.get(row.address)?.get(col.address)">
+              <!-- Diagonal in oracle mode: surface the borrow vault's own
+                   asset -> UoA oracle (same for every cell in the column,
+                   so we show it once on the self-row instead of repeating). -->
+              <template
+                v-if="dotMetric === 'oracle'
+                  && row.address === col.address
+                  && getColumnAssetAdapterViews(col.address).length"
+              >
+                <div class="inline-flex items-center justify-center gap-4 flex-wrap">
+                  <button
+                    v-for="adapter in getColumnAssetAdapterViews(col.address)"
+                    :key="adapter.oracle"
+                    type="button"
+                    class="relative inline-flex items-center justify-center cursor-pointer"
+                    :title="adapter.provider"
+                    @click.stop="onAssetAdapterClick(adapter, $event, col.address)"
+                  >
+                    <BaseAvatar
+                      v-if="adapter.logo"
+                      :src="adapter.logo"
+                      :label="adapter.name"
+                      class="icon--16"
+                    />
+                    <SvgIcon
+                      v-else
+                      name="question-circle"
+                      class="!w-16 !h-16 text-content-tertiary"
+                    />
+                    <span
+                      v-if="adapter.checksStatus === 'warning' || adapter.checksStatus === 'negative'"
+                      class="absolute -top-1 -right-1 w-6 h-6 rounded-full"
+                      :class="adapter.checksStatus === 'negative' ? 'bg-error-500' : 'bg-warning-500'"
+                    />
+                  </button>
+                </div>
+              </template>
+
+              <template v-else-if="matrix.cells.get(row.address)?.get(col.address)">
                 <!-- Oracle metric: render adapter logos -->
                 <template v-if="dotMetric === 'oracle'">
                   <div class="inline-flex items-center justify-center gap-4 flex-wrap">
@@ -480,7 +555,7 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
                       type="button"
                       class="relative inline-flex items-center justify-center cursor-pointer"
                       :title="adapter.provider"
-                      @click.stop="onAdapterClick(adapter, $event)"
+                      @click.stop="onCellAdapterClick(adapter, $event, row.address, col.address)"
                     >
                       <BaseAvatar
                         v-if="adapter.logo"
@@ -607,7 +682,7 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
         </div>
       </div>
 
-      <!-- Provider / Methodology / Checks grid -->
+      <!-- Provider / Methodology / Checks / Price grid (mirrors borrow page) -->
       <div class="grid grid-cols-2 gap-12 text-p3">
         <div class="flex flex-col gap-4">
           <span class="text-content-tertiary">Provider</span>
@@ -630,7 +705,7 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
           <span class="text-content-tertiary">Methodology</span>
           <span class="text-content-primary">{{ tooltipAdapter.methodology || 'Unknown' }}</span>
         </div>
-        <div class="flex flex-col gap-4 col-span-2">
+        <div class="flex flex-col gap-4">
           <span class="text-content-tertiary">Checks</span>
           <span
             v-if="!tooltipAdapter.checks?.length"
@@ -653,6 +728,27 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
               <template v-else>{{ tooltipAdapter.failedChecks.length }} failed</template>
             </span>
           </span>
+        </div>
+        <div class="flex flex-col gap-4">
+          <span class="text-content-tertiary">Price</span>
+          <span
+            v-if="tooltipPriceLoading"
+            class="text-content-secondary animate-pulse"
+          >...</span>
+          <span
+            v-else-if="tooltipPriceText === null"
+            class="flex items-center text-warning-500"
+          >
+            <SvgIcon
+              name="warning"
+              class="mr-2 !w-16 !h-16"
+            />
+            Unknown
+          </span>
+          <span
+            v-else
+            class="text-content-primary"
+          >{{ tooltipPriceText }}</span>
         </div>
       </div>
 

--- a/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
@@ -176,9 +176,9 @@ const cellOracleAdapters = computed((): Map<string, OracleAdapterEntry[]> => {
 })
 
 watch(
-  cellOracleAdapters,
-  async (map) => {
-    if (!chainId.value || map.size === 0) return
+  [cellOracleAdapters, chainId],
+  async ([map, currentChainId]) => {
+    if (!currentChainId || map.size === 0) return
     const seen = new Set<string>()
     const toLoad: OracleAdapterEntry[] = []
     for (const adapters of map.values()) {
@@ -190,7 +190,7 @@ watch(
         toLoad.push(a)
       }
     }
-    await Promise.all(toLoad.map(a => loadOracleAdapter(chainId.value, a.oracle)))
+    await Promise.all(toLoad.map(a => loadOracleAdapter(currentChainId, a.oracle)))
   },
   { immediate: true },
 )
@@ -251,9 +251,9 @@ const onAdapterClick = (adapter: AdapterView, event: MouseEvent) => {
     return
   }
   const rect = (event.currentTarget as HTMLElement).getBoundingClientRect()
-  const left = Math.min(rect.left, window.innerWidth - TOOLTIP_WIDTH - 16)
-  const spaceBelow = window.innerHeight - rect.bottom - 16
-  const spaceAbove = rect.top - 16
+  const left = Math.max(8, Math.min(rect.left, window.innerWidth - TOOLTIP_WIDTH - 16))
+  const spaceBelow = Math.max(160, window.innerHeight - rect.bottom - 16)
+  const spaceAbove = Math.max(160, rect.top - 16)
   const flipUp = spaceAbove > spaceBelow
   tooltipStyle.value = flipUp
     ? { top: `${rect.top - 8}px`, left: `${left}px`, transform: 'translateY(-100%)', maxHeight: `${spaceAbove}px` }

--- a/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
@@ -446,11 +446,11 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
     <div
       class="relative max-h-[50vh] overflow-auto rounded-8 border border-line-subtle px-12 pb-12 pt-0"
     >
-      <table class="border-collapse">
-        <thead class="sticky top-0 z-20 bg-surface">
+      <table class="border-separate border-spacing-0">
+        <thead class="sticky top-0 z-30 bg-surface">
           <tr>
             <th
-              class="text-left text-p5 text-content-muted font-normal py-6 pr-10 pl-6 sticky left-0 bg-surface z-30 border-b border-r border-white/[0.04]"
+              class="text-left text-p5 text-content-muted font-normal py-6 pr-10 pl-6 sticky left-0 bg-surface z-40 border-b border-r border-white/[0.04]"
             >
               <div class="flex flex-col leading-tight">
                 <span>Liability &#8594;</span>
@@ -460,7 +460,7 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
             <th
               v-for="col in matrix.columns"
               :key="col.address"
-              class="text-center text-p4 font-medium py-6 px-8 whitespace-nowrap border-b border-r border-white/[0.04] cursor-pointer transition-colors"
+              class="text-center text-p4 font-medium py-6 px-8 whitespace-nowrap bg-surface border-b border-r border-white/[0.04] cursor-pointer transition-colors"
               :class="
                 selectedHeader?.address === col.address
                   && selectedHeader?.axis === 'column'

--- a/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
@@ -60,6 +60,17 @@ const hoveredCell = ref<{
   liabilityAddr: string
 } | null>(null)
 
+// Row/column highlighting helpers — make it easy to scan a cell back to its
+// row label and column header. A row is "highlighted" when it owns either
+// the hovered cell or the currently selected cell; same for columns.
+const isRowHighlighted = (rowAddr: string): boolean =>
+  hoveredCell.value?.collateralAddr === rowAddr
+  || props.selectedCell?.collateralAddr === rowAddr
+
+const isColumnHighlighted = (colAddr: string): boolean =>
+  hoveredCell.value?.liabilityAddr === colAddr
+  || props.selectedCell?.liabilityAddr === colAddr
+
 const computeEnhancedApys = (
   cell: MatrixCell,
   collateralAddr: string,
@@ -419,7 +430,9 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
                 selectedHeader?.address === col.address
                   && selectedHeader?.axis === 'column'
                   ? 'text-accent-500 !bg-accent-500/10'
-                  : 'text-content-primary hover:bg-white/[0.04]'
+                  : isColumnHighlighted(col.address)
+                    ? 'text-content-primary !bg-white/[0.06]'
+                    : 'text-content-primary hover:bg-white/[0.04]'
               "
               @click.stop="$emit('selectHeader', col.address, 'column')"
             >
@@ -444,9 +457,11 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
                 selectedHeader?.address === row.address
                   && selectedHeader?.axis === 'row'
                   ? 'text-accent-500 !bg-accent-500/10'
-                  : row.category === 'external'
-                    ? 'text-content-tertiary hover:bg-white/[0.04]'
-                    : 'text-content-primary hover:bg-white/[0.04]'
+                  : isRowHighlighted(row.address)
+                    ? (row.category === 'external' ? 'text-content-tertiary !bg-white/[0.06]' : 'text-content-primary !bg-white/[0.06]')
+                    : (row.category === 'external'
+                      ? 'text-content-tertiary hover:bg-white/[0.04]'
+                      : 'text-content-primary hover:bg-white/[0.04]')
               "
               @click.stop="$emit('selectHeader', row.address, 'row')"
             >
@@ -500,13 +515,7 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
                   };
                 })()
               "
-              @mouseenter="
-                matrix.cells.get(row.address)?.get(col.address)
-                  && (hoveredCell = {
-                    collateralAddr: row.address,
-                    liabilityAddr: col.address,
-                  })
-              "
+              @mouseenter="hoveredCell = { collateralAddr: row.address, liabilityAddr: col.address }"
               @mouseleave="hoveredCell = null"
               @click.stop="
                 matrix.cells.get(row.address)?.get(col.address)

--- a/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
@@ -444,7 +444,7 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
 <template>
   <div class="px-16 pb-12 flex items-center justify-center">
     <div
-      class="relative max-h-[50vh] overflow-auto rounded-8 border border-line-subtle p-12"
+      class="relative max-h-[50vh] overflow-auto rounded-8 border border-line-subtle px-12 pb-12 pt-0"
     >
       <table class="border-collapse">
         <thead class="sticky top-0 z-20 bg-surface">

--- a/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
@@ -13,6 +13,7 @@ import {
   getCurrentLiquidationLTV,
   getVaultUtilization,
   isVaultType,
+  isMatrixCompatibleVault,
   type CollateralMatrixData,
   type MatrixCell,
   type DotMetric,
@@ -168,20 +169,17 @@ const cellOracleAdapters = computed((): Map<string, OracleAdapterEntry[]> => {
   for (const row of props.matrix.rows) skipERC4626Bases.add(row.address.toLowerCase())
 
   for (const [colAddr, rowCells] of props.matrix.cells) {
-    for (const [liabAddr, cell] of rowCells) {
-      // Belt-and-braces — getCollateralMatrix already filters LLTV>0 cells,
-      // but enforce again here so the invariant is explicit at the consumer.
-      if (getCurrentLiquidationLTV(cell.ltv) <= 0n) continue
+    for (const [liabAddr] of rowCells) {
       const collateral = findVault(props.market, colAddr)
       const liability = findVault(props.market, liabAddr)
       if (!collateral || !liability) continue
+      if (!isMatrixCompatibleVault(collateral)) continue
       if (!isVaultType(liability) || !liability.oracleDetailedInfo) continue
       // The borrow vault's oracle resolves the collateral *vault* (eToken)
       // address against its unit of account — not the collateral's underlying
       // asset. Mirrors VaultOverviewBlockOracleAdapters' collateralVaults path.
-      const collateralAddr = (isVaultType(collateral) ? collateral.address : (collateral as { address: string }).address)
       const adapters = collectOracleAdapters(liability.oracleDetailedInfo, 3, {
-        base: collateralAddr as Address,
+        base: collateral.address as Address,
         quote: liability.unitOfAccount as Address,
         leafOnly: true,
         skipERC4626Bases,
@@ -211,9 +209,11 @@ const columnAssetOracleAdapters = computed((): Map<string, OracleAdapterEntry[]>
   return result
 })
 
-// Bulk-load adapter metadata for the chain whenever the oracle metric is the
-// active view. Heavy call; deferred to first oracle-mode render and cached
-// per-chain by useEulerLabels.
+// Bulk-load adapter metadata for the chain. Heavy call (1+ MB JSON); the
+// `metric !== 'oracle'` guard short-circuits the immediate run on mount and
+// every re-evaluation while a non-oracle metric is selected — so the network
+// request only fires the first time the user picks the Oracles view.
+// loadAllOracleAdapters is per-chain idempotent (cached by useEulerLabels).
 watch(
   [() => props.dotMetric, chainId],
   ([metric, currentChainId]) => {
@@ -224,10 +224,10 @@ watch(
 )
 
 interface AdapterView {
-  oracle: string
+  oracle: Address
   name: string
-  base: string
-  quote: string
+  base: Address
+  quote: Address
   provider: string
   methodology?: string
   logo?: string
@@ -294,10 +294,10 @@ const tooltipAdapters = computed<OracleAdapterEntry[]>(() => {
   const ctx = tooltipContext.value
   if (!ctx) return []
   return [{
-    oracle: ctx.view.oracle as Address,
+    oracle: ctx.view.oracle,
     name: ctx.view.name,
-    base: ctx.view.base as Address,
-    quote: ctx.view.quote as Address,
+    base: ctx.view.base,
+    quote: ctx.view.quote,
   }]
 })
 const tooltipSourceVaults = computed<Vault[]>(() => {
@@ -379,6 +379,11 @@ const onAssetAdapterClick = (
   }
 }
 
+// Document-level bubble-phase listener — `@click.stop` on every logo button
+// and on the tooltip itself prevents this from firing for in-tooltip clicks
+// or for clicks on other adapter triggers. That keeps "click same logo to
+// close" working (vueuse's onClickOutside attaches in capture phase, which
+// would short-circuit the toggle behaviour).
 const onDocumentClick = () => closeTooltip()
 onMounted(() => {
   document.addEventListener('click', onDocumentClick)
@@ -682,7 +687,7 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
         </div>
       </div>
 
-      <!-- Provider / Methodology / Checks / Price grid (mirrors borrow page) -->
+      <!-- Provider / Methodology / Price / Checks grid (mirrors borrow page) -->
       <div class="grid grid-cols-2 gap-12 text-p3">
         <div class="flex flex-col gap-4">
           <span class="text-content-tertiary">Provider</span>
@@ -704,6 +709,27 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
         <div class="flex flex-col gap-4">
           <span class="text-content-tertiary">Methodology</span>
           <span class="text-content-primary">{{ tooltipAdapter.methodology || 'Unknown' }}</span>
+        </div>
+        <div class="flex flex-col gap-4">
+          <span class="text-content-tertiary">Price</span>
+          <span
+            v-if="tooltipPriceLoading"
+            class="text-content-secondary animate-pulse"
+          >...</span>
+          <span
+            v-else-if="tooltipPriceText === null"
+            class="flex items-center text-warning-500"
+          >
+            <SvgIcon
+              name="warning"
+              class="mr-2 !w-16 !h-16"
+            />
+            Unknown
+          </span>
+          <span
+            v-else
+            class="text-content-primary"
+          >{{ tooltipPriceText }}</span>
         </div>
         <div class="flex flex-col gap-4">
           <span class="text-content-tertiary">Checks</span>
@@ -728,27 +754,6 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
               <template v-else>{{ tooltipAdapter.failedChecks.length }} failed</template>
             </span>
           </span>
-        </div>
-        <div class="flex flex-col gap-4">
-          <span class="text-content-tertiary">Price</span>
-          <span
-            v-if="tooltipPriceLoading"
-            class="text-content-secondary animate-pulse"
-          >...</span>
-          <span
-            v-else-if="tooltipPriceText === null"
-            class="flex items-center text-warning-500"
-          >
-            <SvgIcon
-              name="warning"
-              class="mr-2 !w-16 !h-16"
-            />
-            Unknown
-          </span>
-          <span
-            v-else
-            class="text-content-primary"
-          >{{ tooltipPriceText }}</span>
         </div>
       </div>
 

--- a/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import type { CSSProperties } from 'vue'
+import type { Address } from 'viem'
 import type { MarketGroup } from '~/entities/lend-discovery'
 import { nanoToValue } from '~/utils/crypto-utils'
 import { getMaxMultiplier, getMaxRoe } from '~/utils/leverage'
@@ -9,11 +11,22 @@ import {
   isLiquidationLTVRamping,
   getCurrentLiquidationLTV,
   getVaultUtilization,
+  isVaultType,
   type CollateralMatrixData,
   type MatrixCell,
   type DotMetric,
   type EnhancedCellApys,
 } from '~/utils/discoveryCalculations'
+import {
+  collectOracleAdapters,
+  getChecksStatus,
+  OracleAdapterCheckSeverity,
+  type OracleAdapterEntry,
+  type OracleAdapterCheck,
+} from '~/entities/oracle'
+import { getOracleProviderLogo } from '~/entities/oracle-providers'
+import { getExplorerLink } from '~/utils/block-explorer'
+import { truncate } from '~/utils/string-utils'
 
 const props = defineProps<{
   market: MarketGroup
@@ -36,6 +49,8 @@ const {
   hasSupplyRewards,
   hasBorrowRewards,
 } = useRewardsApy()
+const { oracleAdapters, loadOracleAdapter } = useEulerLabels()
+const { chainId } = useEulerAddresses()
 
 const hoveredCell = ref<{
   collateralAddr: string
@@ -123,6 +138,7 @@ const shouldShowSparkles = (
 }
 
 const metricRange = computed((): { min: number, max: number } => {
+  if (props.dotMetric === 'oracle') return { min: 0, max: 0 }
   let min = Infinity
   let max = -Infinity
   for (const [rowAddr, cols] of props.matrix.cells) {
@@ -136,6 +152,124 @@ const metricRange = computed((): { min: number, max: number } => {
   }
   return Number.isFinite(min) ? { min, max } : { min: 0, max: 0 }
 })
+
+// ── Oracle metric: per-cell adapter list + tooltip ────────────────────────────
+
+const cellOracleAdapters = computed((): Map<string, OracleAdapterEntry[]> => {
+  const result = new Map<string, OracleAdapterEntry[]>()
+  if (props.dotMetric !== 'oracle') return result
+  for (const [colAddr, rowCells] of props.matrix.cells) {
+    for (const [liabAddr] of rowCells) {
+      const collateral = findVault(props.market, colAddr)
+      const liability = findVault(props.market, liabAddr)
+      if (!collateral || !liability) continue
+      if (!isVaultType(liability) || !liability.oracleDetailedInfo) continue
+      const adapters = collectOracleAdapters(liability.oracleDetailedInfo, 3, {
+        base: collateral.asset.address as Address,
+        quote: liability.unitOfAccount as Address,
+        leafOnly: true,
+      })
+      if (adapters.length) result.set(`${colAddr}:${liabAddr}`, adapters)
+    }
+  }
+  return result
+})
+
+watch(
+  cellOracleAdapters,
+  async (map) => {
+    if (!chainId.value || map.size === 0) return
+    const seen = new Set<string>()
+    const toLoad: OracleAdapterEntry[] = []
+    for (const adapters of map.values()) {
+      for (const a of adapters) {
+        if (a.name === 'ERC4626Vault') continue
+        const key = a.oracle.toLowerCase()
+        if (seen.has(key)) continue
+        seen.add(key)
+        toLoad.push(a)
+      }
+    }
+    await Promise.all(toLoad.map(a => loadOracleAdapter(chainId.value, a.oracle)))
+  },
+  { immediate: true },
+)
+
+interface AdapterView {
+  oracle: string
+  name: string
+  provider: string
+  methodology?: string
+  logo?: string
+  label?: { primary: string, suffix?: string }
+  checks?: OracleAdapterCheck[]
+  checksStatus: 'positive' | 'warning' | 'negative' | null
+  failedChecks: OracleAdapterCheck[]
+}
+
+const enrichAdapter = (adapter: OracleAdapterEntry): AdapterView => {
+  const meta = oracleAdapters[adapter.oracle.toLowerCase()]
+  const isERC4626 = adapter.name === 'ERC4626Vault'
+  const provider = meta?.provider || adapter.name
+  const name = meta?.name || adapter.name
+  const checks = meta?.checks
+  return {
+    oracle: adapter.oracle,
+    name,
+    provider,
+    methodology: meta?.methodology || (isERC4626 ? 'Exchange Rate' : undefined),
+    logo: getOracleProviderLogo(provider, name),
+    label: meta?.label
+      ? {
+          primary: meta.label.split('(')[0].trimEnd(),
+          suffix: meta.label.includes('(') ? meta.label.slice(meta.label.indexOf('(')).trim() : undefined,
+        }
+      : undefined,
+    checks,
+    checksStatus: getChecksStatus(checks),
+    failedChecks: checks?.filter(c => !c.pass) ?? [],
+  }
+}
+
+const getCellAdapterViews = (collateralAddr: string, liabilityAddr: string): AdapterView[] => {
+  const list = cellOracleAdapters.value.get(`${collateralAddr}:${liabilityAddr}`)
+  if (!list) return []
+  return list.map(enrichAdapter)
+}
+
+const TOOLTIP_WIDTH = 360
+const tooltipAdapter = ref<AdapterView | null>(null)
+const tooltipStyle = ref<CSSProperties>({})
+
+const closeTooltip = () => {
+  tooltipAdapter.value = null
+}
+
+const onAdapterClick = (adapter: AdapterView, event: MouseEvent) => {
+  if (tooltipAdapter.value?.oracle === adapter.oracle) {
+    closeTooltip()
+    return
+  }
+  const rect = (event.currentTarget as HTMLElement).getBoundingClientRect()
+  const left = Math.min(rect.left, window.innerWidth - TOOLTIP_WIDTH - 16)
+  const spaceBelow = window.innerHeight - rect.bottom - 16
+  const spaceAbove = rect.top - 16
+  const flipUp = spaceAbove > spaceBelow
+  tooltipStyle.value = flipUp
+    ? { top: `${rect.top - 8}px`, left: `${left}px`, transform: 'translateY(-100%)', maxHeight: `${spaceAbove}px` }
+    : { top: `${rect.bottom + 8}px`, left: `${left}px`, transform: 'none', maxHeight: `${spaceBelow}px` }
+  tooltipAdapter.value = adapter
+}
+
+const onDocumentClick = () => closeTooltip()
+onMounted(() => {
+  document.addEventListener('click', onDocumentClick)
+})
+onUnmounted(() => {
+  document.removeEventListener('click', onDocumentClick)
+})
+
+const explorerLink = (address: string) => getExplorerLink(address, chainId.value, true)
 </script>
 
 <template>
@@ -257,7 +391,42 @@ const metricRange = computed((): { min: number, max: number } => {
               "
             >
               <template v-if="matrix.cells.get(row.address)?.get(col.address)">
-                <div class="inline-flex items-center justify-center gap-2">
+                <!-- Oracle metric: render adapter logos -->
+                <template v-if="dotMetric === 'oracle'">
+                  <div class="inline-flex items-center justify-center gap-4 flex-wrap">
+                    <button
+                      v-for="adapter in getCellAdapterViews(row.address, col.address)"
+                      :key="adapter.oracle"
+                      type="button"
+                      class="relative inline-flex items-center justify-center cursor-pointer"
+                      :title="adapter.provider"
+                      @click.stop="onAdapterClick(adapter, $event)"
+                    >
+                      <BaseAvatar
+                        v-if="adapter.logo"
+                        :src="adapter.logo"
+                        :label="adapter.name"
+                        class="icon--16"
+                      />
+                      <SvgIcon
+                        v-else
+                        name="question-circle"
+                        class="!w-16 !h-16 text-content-tertiary"
+                      />
+                      <span
+                        v-if="adapter.checksStatus === 'warning' || adapter.checksStatus === 'negative'"
+                        class="absolute -top-1 -right-1 w-6 h-6 rounded-full"
+                        :class="adapter.checksStatus === 'negative' ? 'bg-error-500' : 'bg-warning-500'"
+                      />
+                    </button>
+                  </div>
+                </template>
+
+                <!-- Numeric metrics: original rendering -->
+                <div
+                  v-else
+                  class="inline-flex items-center justify-center gap-2"
+                >
                   <SvgIcon
                     v-if="
                       dotMetric === 'lltv'
@@ -312,4 +481,109 @@ const metricRange = computed((): { min: number, max: number } => {
   >
     Tap a cell, row, or column header to see lending/borrowing options below.
   </p>
+
+  <!-- Oracle adapter tooltip -->
+  <Teleport to="body">
+    <div
+      v-if="tooltipAdapter"
+      class="fixed z-[9999] bg-surface-secondary border border-line-subtle rounded-xl p-12 shadow-card overflow-y-auto"
+      :style="[tooltipStyle, { width: `${TOOLTIP_WIDTH}px` }]"
+      @click.stop
+    >
+      <div class="flex items-center justify-between gap-8 mb-8">
+        <div class="flex items-center gap-8">
+          <BaseAvatar
+            v-if="tooltipAdapter.logo"
+            :src="tooltipAdapter.logo"
+            :label="tooltipAdapter.name"
+            class="icon--20"
+          />
+          <SvgIcon
+            v-else
+            name="question-circle"
+            class="!w-20 !h-20 text-content-tertiary"
+          />
+          <span class="text-p2 text-content-primary font-medium">{{ tooltipAdapter.provider || 'Unknown' }}</span>
+        </div>
+        <button
+          type="button"
+          class="text-content-muted hover:text-content-secondary cursor-pointer"
+          aria-label="Close"
+          @click.stop="closeTooltip"
+        >
+          <SvgIcon
+            name="close"
+            class="!w-14 !h-14"
+          />
+        </button>
+      </div>
+      <div class="flex flex-col gap-8 text-p3">
+        <div class="flex flex-col gap-2">
+          <span class="text-content-tertiary">Oracle</span>
+          <NuxtLink
+            :to="explorerLink(tooltipAdapter.oracle)"
+            target="_blank"
+            class="text-accent-600 underline hover:text-accent-500"
+            @click.stop
+          >
+            {{ tooltipAdapter.label?.primary ?? truncate(tooltipAdapter.oracle, 6) }}
+            <span
+              v-if="tooltipAdapter.label?.suffix"
+              class="text-content-tertiary ml-2"
+            >{{ tooltipAdapter.label.suffix }}</span>
+          </NuxtLink>
+        </div>
+        <div
+          v-if="tooltipAdapter.methodology"
+          class="flex flex-col gap-2"
+        >
+          <span class="text-content-tertiary">Methodology</span>
+          <span class="text-content-primary">{{ tooltipAdapter.methodology }}</span>
+        </div>
+        <div
+          v-if="tooltipAdapter.checks?.length"
+          class="flex flex-col gap-2"
+        >
+          <span class="text-content-tertiary">Checks</span>
+          <span class="flex items-center gap-6">
+            <span
+              class="inline-block w-8 h-8 rounded-full flex-shrink-0"
+              :class="{
+                'bg-success-500': tooltipAdapter.checksStatus === 'positive',
+                'bg-warning-500': tooltipAdapter.checksStatus === 'warning',
+                'bg-error-500': tooltipAdapter.checksStatus === 'negative',
+              }"
+            />
+            <span class="text-content-primary">
+              <template v-if="tooltipAdapter.checksStatus === 'positive'">{{ tooltipAdapter.checks.length }} passed</template>
+              <template v-else>{{ tooltipAdapter.failedChecks.length }} failed</template>
+            </span>
+          </span>
+        </div>
+        <div
+          v-if="tooltipAdapter.failedChecks.length"
+          class="flex flex-col gap-6 border-t border-line-subtle pt-8"
+        >
+          <div
+            v-for="(check, i) in tooltipAdapter.failedChecks"
+            :key="`${check.id}-${i}`"
+            class="flex items-start gap-6"
+          >
+            <SvgIcon
+              name="warning"
+              class="!w-14 !h-14 mt-1 flex-shrink-0"
+              :class="{
+                'text-error-500': check.severity === OracleAdapterCheckSeverity.High,
+                'text-warning-500': check.severity !== OracleAdapterCheckSeverity.High,
+              }"
+            />
+            <div>
+              <span class="text-content-primary font-medium">{{ check.id }}: </span>
+              <span class="text-content-secondary">{{ check.message }}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </Teleport>
 </template>

--- a/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
@@ -158,16 +158,28 @@ const metricRange = computed((): { min: number, max: number } => {
 const cellOracleAdapters = computed((): Map<string, OracleAdapterEntry[]> => {
   const result = new Map<string, OracleAdapterEntry[]>()
   if (props.dotMetric !== 'oracle') return result
+
+  // Skip the ERC4626 wrapper adapter for any address that already appears
+  // as a collateral row — the matrix already names the collateral, so the
+  // wrapper-to-underlying hop is noise in the cell.
+  const skipERC4626Bases = new Set<string>()
+  for (const row of props.matrix.rows) skipERC4626Bases.add(row.address.toLowerCase())
+
   for (const [colAddr, rowCells] of props.matrix.cells) {
     for (const [liabAddr] of rowCells) {
       const collateral = findVault(props.market, colAddr)
       const liability = findVault(props.market, liabAddr)
       if (!collateral || !liability) continue
       if (!isVaultType(liability) || !liability.oracleDetailedInfo) continue
+      // The borrow vault's oracle resolves the collateral *vault* (eToken)
+      // address against its unit of account — not the collateral's underlying
+      // asset. Mirrors VaultOverviewBlockOracleAdapters' collateralVaults path.
+      const collateralAddr = (isVaultType(collateral) ? collateral.address : (collateral as { address: string }).address)
       const adapters = collectOracleAdapters(liability.oracleDetailedInfo, 3, {
-        base: collateral.asset.address as Address,
+        base: collateralAddr as Address,
         quote: liability.unitOfAccount as Address,
         leafOnly: true,
+        skipERC4626Bases,
       })
       if (adapters.length) result.set(`${colAddr}:${liabAddr}`, adapters)
     }

--- a/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
@@ -298,42 +298,77 @@ const tooltipContext = ref<TooltipContext | null>(null)
 const tooltipAdapter = computed(() => tooltipContext.value?.view ?? null)
 const tooltipStyle = ref<CSSProperties>({})
 
-// Lazy price fetch — only the currently-open tooltip's adapter is in the
-// list, so the borrow page's batch query runs once per tooltip open and
-// nothing else.
-const tooltipAdapters = computed<OracleAdapterEntry[]>(() => {
-  const ctx = tooltipContext.value
-  if (!ctx) return []
-  return [{
-    oracle: ctx.view.oracle,
-    name: ctx.view.name,
-    base: ctx.view.base,
-    quote: ctx.view.quote,
-  }]
-})
-const tooltipSourceVaults = computed<Vault[]>(() => {
-  const ctx = tooltipContext.value
-  return ctx ? [ctx.sourceVault] : []
-})
-const tooltipCollateralVaults = computed<(Vault | SecuritizeVault)[]>(() => {
-  const ctx = tooltipContext.value
-  return ctx?.collateralVault ? [ctx.collateralVault] : []
+// Single matrix-wide price fetch — when oracle mode is active we
+// dedup-collect every adapter currently shown (per-pair + per-column-asset)
+// and run them through one batchSimulation. The tooltip then reads its
+// price from the same map, and every logo can show a warning marker if
+// its getQuote reverted.
+const adapterKeyOf = (a: OracleAdapterEntry) =>
+  `${a.oracle.toLowerCase()}:${a.base.toLowerCase()}:${a.quote.toLowerCase()}`
+
+const allOracleAdapters = computed<OracleAdapterEntry[]>(() => {
+  if (props.dotMetric !== 'oracle') return []
+  const seen = new Map<string, OracleAdapterEntry>()
+  const ingest = (lists: Iterable<OracleAdapterEntry[]>) => {
+    for (const list of lists) {
+      for (const a of list) {
+        const key = adapterKeyOf(a)
+        if (!seen.has(key)) seen.set(key, a)
+      }
+    }
+  }
+  ingest(cellOracleAdapters.value.values())
+  ingest(columnAssetOracleAdapters.value.values())
+  return [...seen.values()]
 })
 
-const { prices: tooltipPrices, isLoading: tooltipPriceLoading } = useOracleAdapterPrices(
-  tooltipAdapters,
-  tooltipSourceVaults,
-  tooltipCollateralVaults,
+const oraclePriceSourceVaults = computed<Vault[]>(() => {
+  if (props.dotMetric !== 'oracle') return []
+  const seen = new Map<string, Vault>()
+  for (const col of props.matrix.columns) {
+    const liability = findVault(props.market, col.address)
+    if (liability && isVaultType(liability)) {
+      seen.set(liability.address.toLowerCase(), liability)
+    }
+  }
+  return [...seen.values()]
+})
+
+const oraclePriceCollateralVaults = computed<(Vault | SecuritizeVault)[]>(() => {
+  if (props.dotMetric !== 'oracle') return []
+  const seen = new Map<string, Vault | SecuritizeVault>()
+  for (const row of props.matrix.rows) {
+    const v = findVault(props.market, row.address)
+    if (v && isMatrixCompatibleVault(v)) {
+      seen.set(row.address.toLowerCase(), v)
+    }
+  }
+  return [...seen.values()]
+})
+
+const { prices: oraclePrices, isLoading: oraclePricesLoading } = useOracleAdapterPrices(
+  allOracleAdapters,
+  oraclePriceSourceVaults,
+  oraclePriceCollateralVaults,
 )
 
+const isAdapterPriceFailed = (adapter: { oracle: string, base: string, quote: string }): boolean => {
+  if (oraclePricesLoading.value) return false
+  const key = `${adapter.oracle.toLowerCase()}:${adapter.base.toLowerCase()}:${adapter.quote.toLowerCase()}`
+  const info = oraclePrices.value.get(key)
+  return info ? !info.success : false
+}
+
 const tooltipPriceText = computed((): string | null => {
-  const adapters = tooltipAdapters.value
-  if (!adapters.length) return null
-  const key = `${adapters[0].oracle.toLowerCase()}:${adapters[0].base.toLowerCase()}:${adapters[0].quote.toLowerCase()}`
-  const info = tooltipPrices.value.get(key)
+  const ctx = tooltipContext.value
+  if (!ctx) return null
+  const key = `${ctx.view.oracle.toLowerCase()}:${ctx.view.base.toLowerCase()}:${ctx.view.quote.toLowerCase()}`
+  const info = oraclePrices.value.get(key)
   if (!info?.success) return null
   return formatNumber(info.rate, 4)
 })
+
+const tooltipPriceLoading = computed(() => oraclePricesLoading.value && !oraclePrices.value.size)
 
 const closeTooltip = () => {
   tooltipContext.value = null
@@ -482,11 +517,13 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
                 selectedCell?.collateralAddr === row.address
                   && selectedCell?.liabilityAddr === col.address
                   ? '!bg-accent-500/20'
-                  : row.address === col.address
-                    ? 'bg-white/[0.03]'
-                    : '',
+                  : (isRowHighlighted(row.address) || isColumnHighlighted(col.address))
+                    ? '!bg-white/[0.06]'
+                    : row.address === col.address
+                      ? 'bg-white/[0.03]'
+                      : '',
                 matrix.cells.get(row.address)?.get(col.address)
-                  ? 'cursor-pointer hover:bg-white/[0.06]'
+                  ? 'cursor-pointer'
                   : '',
               ]"
               :style="
@@ -555,6 +592,12 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
                       class="absolute -top-1 -right-1 w-6 h-6 rounded-full"
                       :class="adapter.checksStatus === 'negative' ? 'bg-error-500' : 'bg-warning-500'"
                     />
+                    <SvgIcon
+                      v-if="isAdapterPriceFailed(adapter)"
+                      name="warning"
+                      class="absolute -bottom-1 -right-1 !w-10 !h-10 text-error-500"
+                      title="getQuote reverted"
+                    />
                   </button>
                 </div>
               </template>
@@ -586,6 +629,12 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
                         v-if="adapter.checksStatus === 'warning' || adapter.checksStatus === 'negative'"
                         class="absolute -top-1 -right-1 w-6 h-6 rounded-full"
                         :class="adapter.checksStatus === 'negative' ? 'bg-error-500' : 'bg-warning-500'"
+                      />
+                      <SvgIcon
+                        v-if="isAdapterPriceFailed(adapter)"
+                        name="warning"
+                        class="absolute -bottom-1 -right-1 !w-10 !h-10 text-error-500"
+                        title="getQuote reverted"
                       />
                     </button>
                   </div>

--- a/components/entities/vault/overview/VaultOverviewBlockRiskParameters.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockRiskParameters.vue
@@ -3,8 +3,8 @@ import { maxUint256, type Address } from 'viem'
 import { formatNumber, compactNumber, formatCompactUsdValue } from '~/utils/string-utils'
 import { nanoToValue } from '~/utils/crypto-utils'
 import { vaultConvertToAssetsAbi } from '~/abis/vault'
-import type { Vault } from '~/entities/vault'
-import { getSupplyCapPercentage, getBorrowCapPercentage } from '~/composables/useVaultWarnings'
+import { type Vault, getSupplyCapPercentage, getBorrowCapPercentage } from '~/entities/vault'
+import { CFG_DONT_SOCIALIZE_DEBT } from '~/entities/constants'
 import { formatAssetValue } from '~/services/pricing/priceProvider'
 import {
   decodeHookedOps,
@@ -163,7 +163,7 @@ const openHooksModal = () => {
       </VaultOverviewLabelValue>
       <VaultOverviewLabelValue
         v-if="isBorrowable"
-        :value="vault.configFlags === 0n ? 'Yes' : 'No'"
+        :value="(vault.configFlags & CFG_DONT_SOCIALIZE_DEBT) === 0n ? 'Yes' : 'No'"
         orientation="horizontal"
       >
         <template #label>

--- a/composables/useEulerLabels.ts
+++ b/composables/useEulerLabels.ts
@@ -25,6 +25,8 @@ import {
   verifiedVaultAddresses,
   oracleAdapters,
   loadingAdapters,
+  bulkLoadedAdapterChains,
+  pendingBulkAdapterLoads,
 } from '~/utils/eulerLabelsState'
 import {
   normalizeProducts,
@@ -71,6 +73,36 @@ const loadOracleAdapters = async (chainId: number, addresses?: string[]) => {
   await Promise.all(addresses.map(addr => loadOracleAdapter(chainId, addr)))
 }
 
+// Bulk-load every adapter known for a chain via the all.json upstream.
+// Heavy call (KBs of JSON, hundreds of adapters) — caller decides when to invoke.
+// Concurrent callers share one in-flight request; subsequent calls within the
+// same session are no-ops once the chain is loaded.
+const loadAllOracleAdapters = async (chainId: number): Promise<void> => {
+  if (!Number.isInteger(chainId) || chainId <= 0) return
+  if (bulkLoadedAdapterChains.has(chainId)) return
+
+  const inflight = pendingBulkAdapterLoads.get(chainId)
+  if (inflight) return inflight
+
+  const promise = (async () => {
+    try {
+      const res = await axios.get('/api/oracle-adapters', { params: { chainId } })
+      const meta = normalizeOracleAdapters(res.data)
+      safeAssign(oracleAdapters, meta)
+      bulkLoadedAdapterChains.add(chainId)
+    }
+    catch (err) {
+      logWarn('useEulerLabels', `Failed to bulk-load oracle adapters for chain ${chainId}: ${err instanceof Error ? err.message : String(err)}`)
+    }
+    finally {
+      pendingBulkAdapterLoads.delete(chainId)
+    }
+  })()
+
+  pendingBulkAdapterLoads.set(chainId, promise)
+  return promise
+}
+
 export const useEulerLabels = () => {
   const loadLabels = async (forceRefresh = false) => {
     try {
@@ -99,6 +131,7 @@ export const useEulerLabels = () => {
       Object.keys(entities).forEach(key => delete entities[key])
       Object.keys(points).forEach(key => delete points[key])
       Object.keys(oracleAdapters).forEach(key => delete oracleAdapters[key])
+      bulkLoadedAdapterChains.clear()
       Object.keys(earnVaultBlocks).forEach(key => delete earnVaultBlocks[key])
       Object.keys(earnVaultRestrictions).forEach(key => delete earnVaultRestrictions[key])
       Object.keys(deprecatedEarnVaults).forEach(key => delete deprecatedEarnVaults[key])
@@ -209,6 +242,7 @@ export const useEulerLabels = () => {
     loadLabels,
     loadOracleAdapter,
     loadOracleAdapters,
+    loadAllOracleAdapters,
   }
 }
 

--- a/composables/useEulerLabels.ts
+++ b/composables/useEulerLabels.ts
@@ -74,12 +74,15 @@ const loadOracleAdapters = async (chainId: number, addresses?: string[]) => {
 }
 
 // Bulk-load every adapter known for a chain via the all.json upstream.
-// Heavy call (KBs of JSON, hundreds of adapters) — caller decides when to invoke.
-// Concurrent callers share one in-flight request; subsequent calls within the
-// same session are no-ops once the chain is loaded.
+// Heavy call (~1 MB JSON, hundreds of adapters) — caller decides when to invoke.
+// Concurrent callers share one in-flight request; cached payloads are
+// considered fresh for CACHE_TTL_5MIN_MS, after which the next call refetches
+// (matches the labels load cadence so adapter checks don't drift).
 const loadAllOracleAdapters = async (chainId: number): Promise<void> => {
   if (!Number.isInteger(chainId) || chainId <= 0) return
-  if (bulkLoadedAdapterChains.has(chainId)) return
+
+  const loadedAt = bulkLoadedAdapterChains.get(chainId)
+  if (loadedAt !== undefined && (Date.now() - loadedAt) < CACHE_TTL_5MIN_MS) return
 
   const inflight = pendingBulkAdapterLoads.get(chainId)
   if (inflight) return inflight
@@ -89,7 +92,7 @@ const loadAllOracleAdapters = async (chainId: number): Promise<void> => {
       const res = await axios.get('/api/oracle-adapters', { params: { chainId } })
       const meta = normalizeOracleAdapters(res.data)
       safeAssign(oracleAdapters, meta)
-      bulkLoadedAdapterChains.add(chainId)
+      bulkLoadedAdapterChains.set(chainId, Date.now())
     }
     catch (err) {
       logWarn('useEulerLabels', `Failed to bulk-load oracle adapters for chain ${chainId}: ${err instanceof Error ? err.message : String(err)}`)

--- a/composables/useMarketGroups.ts
+++ b/composables/useMarketGroups.ts
@@ -6,6 +6,7 @@ import type { AnyVault } from '~/composables/useVaultRegistry'
 import { getVaultUtilization } from '~/entities/vault'
 import { getAssetUsdValueOrZero } from '~/services/pricing/priceProvider'
 import { isVaultNotExplorable, isVaultFeatured } from '~/utils/eulerLabelsUtils'
+import { buildFetchContext } from '~/composables/useFetchContext'
 
 // -- Helpers --
 
@@ -456,7 +457,8 @@ export const useMarketGroups = () => {
     const memberVaults: Vault[] = []
 
     try {
-      for await (const result of fetchVaults(allAddresses)) {
+      const ctx = buildFetchContext()
+      for await (const result of fetchVaults(ctx, allAddresses)) {
         memberVaults.push(...result.vaults)
         if (result.isFinished) break
       }

--- a/composables/useVaultWarnings.ts
+++ b/composables/useVaultWarnings.ts
@@ -1,5 +1,4 @@
-import { maxUint256 } from 'viem'
-import { getVaultUtilization, type Vault } from '~/entities/vault'
+import { getVaultUtilization, getSupplyCapPercentage, getBorrowCapPercentage, type Vault } from '~/entities/vault'
 import {
   findBlockingDisabledOp,
   getOpMeta,
@@ -88,25 +87,9 @@ const getCapLevel = (percentage: number): WarningLevel | null => {
   return null
 }
 
-const bigintPercentage = (numerator: bigint, denominator: bigint): number => {
-  const scale = 10n ** 2n
-  const fraction = (numerator * scale * 100n) / denominator
-  const whole = fraction / scale
-  const remainder = fraction % scale
-  return parseFloat(`${whole}.${remainder.toString().padStart(2, '0')}`)
-}
-
-export const getSupplyCapPercentage = (vault: Vault): number => {
-  if (vault.supplyCap >= maxUint256) return 0
-  if (vault.supplyCap === 0n) return vault.supply > 0n ? 100 : 0
-  return bigintPercentage(vault.supply, vault.supplyCap)
-}
-
-export const getBorrowCapPercentage = (vault: Vault): number => {
-  if (vault.borrowCap >= maxUint256) return 0
-  if (vault.borrowCap === 0n) return vault.borrow > 0n ? 100 : 0
-  return bigintPercentage(vault.borrow, vault.borrowCap)
-}
+// Re-export cap helpers from entities/vault so existing call sites that
+// imported them from useVaultWarnings still work after the move.
+export { getSupplyCapPercentage, getBorrowCapPercentage } from '~/entities/vault'
 
 export const getUtilisationWarning = (
   vault: Vault,

--- a/entities/constants.ts
+++ b/entities/constants.ts
@@ -89,6 +89,11 @@ export const INTEREST_RATE_MODEL_TYPE = {
   FIXED_CYCLICAL_BINARY: 4,
 } as const
 
+// EVK Vault.configFlags is a bitmask. CFG_DONT_SOCIALIZE_DEBT is the only
+// publicly-defined bit today (0x01) — when set, bad debt is left in the vault
+// rather than being shared across depositors via share-price reduction.
+export const CFG_DONT_SOCIALIZE_DEBT = 1n
+
 export const KINK_IRM_COMPONENTS = [
   { name: 'baseRate', type: 'uint256' },
   { name: 'slope1', type: 'uint256' },

--- a/entities/vault/index.ts
+++ b/entities/vault/index.ts
@@ -89,5 +89,7 @@ export {
   getMaxWithdraw,
   getUtilization,
   getVaultUtilization,
+  getSupplyCapPercentage,
+  getBorrowCapPercentage,
   isCyclicalNoteVault,
 } from './utils'

--- a/entities/vault/utils.ts
+++ b/entities/vault/utils.ts
@@ -1,4 +1,4 @@
-import type { Address } from 'viem'
+import { maxUint256, type Address } from 'viem'
 import type { Vault, SecuritizeVault, BorrowVaultPair } from './types'
 import {
   vaultConvertToAssetsAbi,
@@ -129,4 +129,24 @@ export const getUtilization = (totalAssets: bigint, totalBorrow: bigint): number
 
 export const getVaultUtilization = (vault: Vault | SecuritizeVault): number => {
   return getUtilization(vault.totalAssets, vault.borrow)
+}
+
+const bigintPercentage = (numerator: bigint, denominator: bigint): number => {
+  const scale = 10n ** 2n
+  const fraction = (numerator * scale * 100n) / denominator
+  const whole = fraction / scale
+  const remainder = fraction % scale
+  return parseFloat(`${whole}.${remainder.toString().padStart(2, '0')}`)
+}
+
+export const getSupplyCapPercentage = (vault: Vault): number => {
+  if (vault.supplyCap >= maxUint256) return 0
+  if (vault.supplyCap === 0n) return vault.supply > 0n ? 100 : 0
+  return bigintPercentage(vault.supply, vault.supplyCap)
+}
+
+export const getBorrowCapPercentage = (vault: Vault): number => {
+  if (vault.borrowCap >= maxUint256) return 0
+  if (vault.borrowCap === 0n) return vault.borrow > 0n ? 100 : 0
+  return bigintPercentage(vault.borrow, vault.borrowCap)
 }

--- a/server/api/oracle-adapters.get.ts
+++ b/server/api/oracle-adapters.get.ts
@@ -41,10 +41,11 @@ export default defineEventHandler(async (event) => {
   try {
     const resp = await fetchWithTimeout(getUpstreamUrl(chainId))
     if (!resp.ok) {
-      if (resp.status === 404) {
-        cache.set(key, [])
-        return []
-      }
+      // Don't cache the empty fallback for 404 (or any non-OK status). A
+      // missing/transient upstream response would otherwise pin every client
+      // to the empty array for the full TTL window — better to let the next
+      // request retry quickly.
+      if (resp.status === 404) return []
       throw new Error(`Upstream returned ${resp.status}`)
     }
 
@@ -58,6 +59,8 @@ export default defineEventHandler(async (event) => {
     const stale = cache.getStale(key)
     if (stale !== undefined) return stale
 
+    // Same reasoning as the 404 branch: don't pollute the cache with an empty
+    // array on transient failures.
     return []
   }
 })

--- a/server/api/oracle-adapters.get.ts
+++ b/server/api/oracle-adapters.get.ts
@@ -1,0 +1,63 @@
+import { createError, getQuery } from 'h3'
+import { createRateLimiter } from '~/server/utils/rate-limit'
+import { createTtlCache } from '~/server/utils/cache'
+import { fetchWithTimeout } from '~/server/utils/fetchWithTimeout'
+import { logWarn } from '~/server/utils/log'
+
+const CACHE_TTL_MS = 300_000
+
+const rateLimiter = createRateLimiter({
+  max: 60,
+  windowMs: 60_000,
+  label: 'oracle-adapters',
+})
+
+const cache = createTtlCache<unknown>({ ttlMs: CACHE_TTL_MS, maxEntries: 50 })
+
+function getUpstreamUrl(chainId: number): string {
+  const baseUrl = (process.env.NUXT_PUBLIC_CONFIG_ORACLE_CHECKS_BASE_URL || '').trim().replace(/\/+$/, '')
+  if (baseUrl) {
+    return `${baseUrl}/${chainId}/adapters/all.json`
+  }
+
+  const repo = process.env.NUXT_PUBLIC_CONFIG_ORACLE_CHECKS_REPO || 'euler-xyz/oracle-checks'
+  return `https://raw.githubusercontent.com/${repo}/refs/heads/master/data/${chainId}/adapters/all.json`
+}
+
+export default defineEventHandler(async (event) => {
+  rateLimiter.consume(event)
+
+  const query = getQuery(event)
+  const chainId = Number(query.chainId)
+  if (!Number.isInteger(chainId) || chainId <= 0) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid chainId' })
+  }
+
+  const key = `${chainId}`
+
+  const cached = cache.get(key)
+  if (cached !== undefined) return cached
+
+  try {
+    const resp = await fetchWithTimeout(getUpstreamUrl(chainId))
+    if (!resp.ok) {
+      if (resp.status === 404) {
+        cache.set(key, [])
+        return []
+      }
+      throw new Error(`Upstream returned ${resp.status}`)
+    }
+
+    const data: unknown = await resp.json()
+    cache.set(key, data)
+    return data
+  }
+  catch (err) {
+    logWarn('oracle-adapters', `Failed to fetch all.json for chain ${chainId}:`, err instanceof Error ? err.message : err)
+
+    const stale = cache.getStale(key)
+    if (stale !== undefined) return stale
+
+    return []
+  }
+})

--- a/tests/utils/discovery-calculations.test.ts
+++ b/tests/utils/discovery-calculations.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it, vi } from 'vitest'
-import { getActiveExternalCollateral, getCollateralMatrix, isNodeRampingDown } from '~/utils/discoveryCalculations'
+import {
+  STATS_ROWS,
+  buildAttributeRowCells,
+  getActiveExternalCollateral,
+  getAttributeRowColor,
+  getCollateralMatrix,
+  isNodeRampingDown,
+  type VaultUsdCacheEntry,
+} from '~/utils/discoveryCalculations'
 import type { MarketGroup } from '~/entities/lend-discovery'
 import type { Vault, VaultCollateralLTV } from '~/entities/vault/types'
 
@@ -126,5 +134,63 @@ describe('getActiveExternalCollateral', () => {
     const market = makeMarket([borrowVault], [externalVault])
 
     expect(getActiveExternalCollateral(market)).toEqual([])
+  })
+})
+
+describe('attribute stats matrix', () => {
+  it('emits numeric values and directional rows for heatmap rendering', () => {
+    const vault = {
+      ...makeVault('0xStats', []),
+      supply: 400n,
+      borrow: 500n,
+      totalAssets: 1000n,
+      supplyCap: 1000n,
+      borrowCap: 1000n,
+      interestRateInfo: {
+        supplyAPY: 5n * 10n ** 25n,
+        borrowAPY: 12n * 10n ** 25n,
+      },
+    } as Vault
+    const usd: VaultUsdCacheEntry = {
+      supply: '$1K',
+      supplyUsd: 1000,
+      borrow: '$500',
+      borrowUsd: 500,
+      liquidity: '$500',
+      liquidityUsd: 500,
+      supplyCap: '$1K',
+      supplyCapUsd: 1000,
+      borrowCap: '$1K',
+      borrowCapUsd: 1000,
+    }
+
+    const columns = [{ address: vault.address.toLowerCase(), symbol: 'TST', assetAddress: vault.asset.address, vault }]
+    const usdCache = new Map([[vault.address.toLowerCase(), usd]])
+    const byRow = new Map(STATS_ROWS.map(row => [
+      row.id,
+      { row, cell: buildAttributeRowCells(row, columns, usdCache)[0] },
+    ]))
+
+    expect(byRow.get('totalSupply')!.row.direction).toBe('higher-better')
+    expect(byRow.get('totalSupply')!.cell.numeric).toBe(1000)
+    expect(byRow.get('totalBorrow')!.row.direction).toBe('lower-better')
+    expect(byRow.get('totalBorrow')!.cell.numeric).toBe(500)
+    expect(byRow.get('liquidity')!.row.direction).toBe('higher-better')
+    expect(byRow.get('liquidity')!.cell.numeric).toBe(500)
+    expect(byRow.get('utilization')!.row.direction).toBe('lower-better')
+    expect(byRow.get('utilization')!.cell.numeric).toBe(50)
+    expect(byRow.get('supplyCapUsage')!.row.direction).toBe('lower-better')
+    expect(byRow.get('supplyCapUsage')!.cell.numeric).toBe(40)
+    expect(byRow.get('borrowCapUsage')!.row.direction).toBe('lower-better')
+    expect(byRow.get('borrowCapUsage')!.cell.numeric).toBe(50)
+    expect(byRow.get('supplyApy')!.row.direction).toBe('higher-better')
+    expect(byRow.get('supplyApy')!.cell.numeric).toBe(5)
+    expect(byRow.get('borrowApy')!.row.direction).toBe('lower-better')
+    expect(byRow.get('borrowApy')!.cell.numeric).toBe(12)
+  })
+
+  it('colors higher-better rows green at the high end and lower-better rows red at the high end', () => {
+    expect(getAttributeRowColor(100, 0, 100, 'higher-better')).toContain('hsla(145')
+    expect(getAttributeRowColor(100, 0, 100, 'lower-better')).toContain('hsla(0')
   })
 })

--- a/utils/discoveryCalculations.ts
+++ b/utils/discoveryCalculations.ts
@@ -1,12 +1,16 @@
+import { maxUint256 } from 'viem'
 import type { MarketGroup, MiniDiagramData, MiniNode, MiniEdge } from '~/entities/lend-discovery'
 import type { Vault, SecuritizeVault, VaultCollateralLTV } from '~/entities/vault'
 import type { AnyVault } from '~/composables/useVaultRegistry'
 import type { EulerLabelEntity } from '~/entities/euler/labels'
-import { getCurrentLiquidationLTV, isLiquidationLTVRamping } from '~/entities/vault'
+import { getCurrentLiquidationLTV, isLiquidationLTVRamping, getVaultUtilization } from '~/entities/vault'
 import { getEulerLabelEntityLogo } from '~/entities/euler/labels'
 import { getEntitiesByVault, isVaultDeprecated } from '~/utils/eulerLabelsUtils'
 import { nanoToValue } from '~/utils/crypto-utils'
-import { formatNumber } from '~/utils/string-utils'
+import { formatNumber, compactNumber } from '~/utils/string-utils'
+import { decodeHookedOps, formatHookedOpsSummary, isVaultEffectivelyPaused } from '~/utils/vault-hooks'
+import { getSupplyCapPercentage, getBorrowCapPercentage } from '~/composables/useVaultWarnings'
+import { INTEREST_RATE_MODEL_TYPE } from '~/entities/constants'
 
 // ============================================================
 // Types & Constants
@@ -43,7 +47,7 @@ export interface EnhancedCellApys {
   utilization: number
 }
 
-export type DotMetric = 'bltv' | 'lltv' | 'net-apy' | 'roe' | 'multiplier'
+export type DotMetric = 'bltv' | 'lltv' | 'net-apy' | 'roe' | 'multiplier' | 'oracle'
 
 export interface DotMetricOption {
   id: DotMetric
@@ -57,9 +61,13 @@ export const DOT_METRIC_OPTIONS: DotMetricOption[] = [
   { id: 'multiplier', label: 'Multiplier', higherIsBetter: false },
   { id: 'bltv', label: 'Borrow LTV', higherIsBetter: false },
   { id: 'lltv', label: 'Liquidation LTV', higherIsBetter: false },
+  { id: 'oracle', label: 'Oracle', higherIsBetter: false },
 ]
 
 export type ExpandedViewMode = 'graph' | 'matrix'
+
+export type MatrixVariant = 'pairs' | 'config' | 'stats'
+export type AttributeMatrixMode = 'config' | 'stats'
 
 // ============================================================
 // Vault Type Guards & Accessors
@@ -374,6 +382,8 @@ export const formatMetricValue = (value: number, metric: DotMetric): string => {
   switch (metric) {
     case 'multiplier':
       return `${formatNumber(value, 1, 1)}x`
+    case 'oracle':
+      return ''
     default:
       return `${formatNumber(value, 1, 1)}%`
   }
@@ -513,8 +523,381 @@ export const getCellBgColor = (value: number, metric: DotMetric, min: number, ma
     case 'net-apy':
     case 'roe':
       return getDivergingColor(value, min, max)
+    case 'oracle':
+      return 'transparent'
   }
 }
 
 // Re-export vault helpers for convenience
 export { isLiquidationLTVRamping, getCurrentLiquidationLTV, getVaultUtilization } from '~/entities/vault'
+
+// ============================================================
+// Attribute Matrix (Configuration & Stats)
+// ============================================================
+
+const isSecuritizeVault = (v: AnyVault): v is SecuritizeVault =>
+  'type' in v && (v as { type?: string }).type === 'securitize'
+
+export const isMatrixCompatibleVault = (v: AnyVault): v is Vault | SecuritizeVault =>
+  isVaultType(v) || isSecuritizeVault(v)
+
+export interface VaultUsdCacheEntry {
+  supply: string
+  supplyUsd: number
+  borrow: string
+  borrowUsd: number
+  liquidity: string
+  liquidityUsd: number
+  supplyCap: string
+  supplyCapUsd: number | undefined
+  borrowCap: string
+  borrowCapUsd: number | undefined
+}
+
+export type AttributeDirection = 'higher-better' | 'lower-better' | 'neutral'
+
+export interface AttributeCell {
+  display: string
+  numeric?: number
+  hint?: string
+  kind?: 'text' | 'capProgress' | 'governor' | 'hooks'
+  capPercent?: number
+  capUncapped?: boolean
+  hookable?: boolean
+}
+
+export interface AttributeRow {
+  id: string
+  label: string
+  tooltip?: string
+  direction: AttributeDirection
+  getValue: (vault: Vault | SecuritizeVault, usd: VaultUsdCacheEntry | undefined) => AttributeCell
+}
+
+export interface AttributeMatrixColumn {
+  address: string
+  symbol: string
+  assetAddress: string
+  vault: Vault | SecuritizeVault
+}
+
+export interface AttributeMatrixData {
+  rows: AttributeRow[]
+  columns: AttributeMatrixColumn[]
+}
+
+const getTotalAssets = (vault: Vault | SecuritizeVault): bigint =>
+  (vault.totalAssets ?? 0n) as bigint
+
+const isEscrow = (v: Vault | SecuritizeVault): boolean =>
+  isVaultType(v) && v.vaultCategory === 'escrow'
+
+export const getAttributeMatrixColumns = (market: MarketGroup): AttributeMatrixColumn[] => {
+  const memberEvk: Vault[] = []
+  const memberSecuritize: SecuritizeVault[] = []
+  for (const v of market.vaults) {
+    if (isVaultType(v)) memberEvk.push(v)
+    else if (isSecuritizeVault(v)) memberSecuritize.push(v)
+  }
+  const externalSecuritize: SecuritizeVault[] = []
+  const seenExternal = new Set<string>()
+  for (const v of market.externalCollateral) {
+    if (!isSecuritizeVault(v)) continue
+    const addr = getVaultAddress(v).toLowerCase()
+    if (seenExternal.has(addr)) continue
+    seenExternal.add(addr)
+    externalSecuritize.push(v)
+  }
+
+  memberEvk.sort((a, b) => (getTotalAssets(b) > getTotalAssets(a) ? 1 : -1))
+  memberSecuritize.sort((a, b) => (getTotalAssets(b) > getTotalAssets(a) ? 1 : -1))
+  externalSecuritize.sort((a, b) => (getTotalAssets(b) > getTotalAssets(a) ? 1 : -1))
+
+  const toCol = (vault: Vault | SecuritizeVault): AttributeMatrixColumn => ({
+    address: getVaultAddress(vault).toLowerCase(),
+    symbol: vault.asset.symbol,
+    assetAddress: vault.asset.address,
+    vault,
+  })
+
+  return [
+    ...memberEvk.map(toCol),
+    ...memberSecuritize.map(toCol),
+    ...externalSecuritize.map(toCol),
+  ]
+}
+
+const NA_CELL: AttributeCell = { display: '—', kind: 'text' }
+
+const formatCapDisplay = (
+  rawCap: bigint,
+  usdEntry: { capStr: string, capUsd: number | undefined } | undefined,
+): { display: string, hint?: string } => {
+  if (rawCap >= maxUint256) return { display: '∞' }
+  if (rawCap === 0n) return { display: '$0' }
+  if (!usdEntry) return { display: '…' }
+  return { display: usdEntry.capStr }
+}
+
+const getIrmTypeLabel = (t: number | undefined): string => {
+  if (t === INTEREST_RATE_MODEL_TYPE.KINK) return 'Kink'
+  if (t === INTEREST_RATE_MODEL_TYPE.ADAPTIVE_CURVE) return 'Adaptive'
+  if (t === INTEREST_RATE_MODEL_TYPE.KINKY) return 'Kinky'
+  if (t === INTEREST_RATE_MODEL_TYPE.FIXED_CYCLICAL_BINARY) return 'Cyclical'
+  return '—'
+}
+
+const formatCapPercentDisplay = (pct: number, uncapped: boolean): string => {
+  if (uncapped) return '—'
+  return `${compactNumber(pct, 2)}%`
+}
+
+const supplyApyPercent = (vault: Vault | SecuritizeVault): number =>
+  Number(nanoToValue(vault.interestRateInfo.supplyAPY, 25)) * 100
+
+const borrowApyPercent = (vault: Vault | SecuritizeVault): number =>
+  Number(nanoToValue(vault.interestRateInfo.borrowAPY, 25)) * 100
+
+export const CONFIG_ROWS: AttributeRow[] = [
+  {
+    id: 'supplyCap',
+    label: 'Supply cap',
+    direction: 'lower-better',
+    getValue: (vault, usd) => {
+      const rawCap = vault.supplyCap
+      const uncapped = rawCap >= maxUint256
+      const { display } = formatCapDisplay(rawCap, usd ? { capStr: usd.supplyCap, capUsd: usd.supplyCapUsd } : undefined)
+      const pct = uncapped ? 0 : getSupplyCapPercentage(vault as Vault)
+      return {
+        display,
+        kind: 'capProgress',
+        capPercent: pct,
+        capUncapped: uncapped,
+        numeric: uncapped ? undefined : pct,
+      }
+    },
+  },
+  {
+    id: 'borrowCap',
+    label: 'Borrow cap',
+    direction: 'lower-better',
+    getValue: (vault, usd) => {
+      if (!isVaultType(vault)) return NA_CELL
+      if (isEscrow(vault)) return NA_CELL
+      const rawCap = vault.borrowCap
+      const uncapped = rawCap >= maxUint256
+      const { display } = formatCapDisplay(rawCap, usd ? { capStr: usd.borrowCap, capUsd: usd.borrowCapUsd } : undefined)
+      const pct = getBorrowCapPercentage(vault)
+      return {
+        display,
+        kind: 'capProgress',
+        capPercent: pct,
+        capUncapped: uncapped,
+        numeric: uncapped ? undefined : pct,
+      }
+    },
+  },
+  {
+    id: 'maxLiqDiscount',
+    label: 'Max liquidation discount',
+    direction: 'neutral',
+    getValue: (vault) => {
+      if (!isVaultType(vault) || isEscrow(vault)) return NA_CELL
+      const pct = Number(vault.maxLiquidationDiscount / 100n)
+      return { display: `${pct}%`, kind: 'text', numeric: pct }
+    },
+  },
+  {
+    id: 'interestFee',
+    label: 'Interest fee',
+    direction: 'neutral',
+    getValue: (vault) => {
+      if (!isVaultType(vault) || isEscrow(vault)) return NA_CELL
+      const pct = Number(nanoToValue(vault.interestFee, 2))
+      return { display: `${formatNumber(pct)}%`, kind: 'text', numeric: pct }
+    },
+  },
+  {
+    id: 'badDebtSocialised',
+    label: 'Bad debt socialised',
+    direction: 'lower-better',
+    getValue: (vault) => {
+      if (!isVaultType(vault) || isEscrow(vault)) return NA_CELL
+      const yes = vault.configFlags === 0n
+      return { display: yes ? 'Yes' : 'No', kind: 'text', numeric: yes ? 0 : 1 }
+    },
+  },
+  {
+    id: 'irmType',
+    label: 'Interest rate model',
+    direction: 'neutral',
+    getValue: (vault) => {
+      if (!isVaultType(vault) || isEscrow(vault)) return NA_CELL
+      const t = vault.irmInfo?.interestRateModelInfo?.interestRateModelType
+      const label = getIrmTypeLabel(typeof t === 'number' ? t : undefined)
+      return { display: label, kind: 'text', hint: vault.interestRateModelAddress }
+    },
+  },
+  {
+    id: 'governor',
+    label: 'Governor',
+    direction: 'neutral',
+    getValue: vault => ({
+      display: vault.governorAdmin,
+      kind: 'governor',
+      hint: vault.governorAdmin,
+    }),
+  },
+  {
+    id: 'hooks',
+    label: 'Hooks',
+    direction: 'neutral',
+    getValue: (vault) => {
+      if (!isVaultType(vault)) return NA_CELL
+      const paused = isVaultEffectivelyPaused(vault)
+      const display = paused
+        ? 'Paused'
+        : vault.hookedOps === 0n
+          ? 'None'
+          : formatHookedOpsSummary(decodeHookedOps(vault.hookedOps))
+      return {
+        display,
+        kind: 'hooks',
+        hookable: vault.hookedOps !== 0n,
+      }
+    },
+  },
+]
+
+export const STATS_ROWS: AttributeRow[] = [
+  {
+    id: 'totalSupply',
+    label: 'Total supply',
+    direction: 'higher-better',
+    getValue: (_vault, usd) => ({
+      display: usd ? usd.supply : '…',
+      kind: 'text',
+      numeric: usd?.supplyUsd,
+    }),
+  },
+  {
+    id: 'totalBorrow',
+    label: 'Total borrows',
+    direction: 'neutral',
+    getValue: (vault, usd) => {
+      if (!isVaultType(vault) || isEscrow(vault)) return NA_CELL
+      return {
+        display: usd ? usd.borrow : '…',
+        kind: 'text',
+        numeric: usd?.borrowUsd,
+      }
+    },
+  },
+  {
+    id: 'liquidity',
+    label: 'Available liquidity',
+    direction: 'higher-better',
+    getValue: (vault, usd) => {
+      if (!isVaultType(vault) || isEscrow(vault)) return NA_CELL
+      return {
+        display: usd ? usd.liquidity : '…',
+        kind: 'text',
+        numeric: usd?.liquidityUsd,
+      }
+    },
+  },
+  {
+    id: 'utilization',
+    label: 'Utilization',
+    direction: 'lower-better',
+    getValue: (vault) => {
+      if (!isVaultType(vault) || isEscrow(vault)) return NA_CELL
+      const pct = getVaultUtilization(vault)
+      return { display: `${formatNumber(pct, 2)}%`, kind: 'text', numeric: pct }
+    },
+  },
+  {
+    id: 'supplyCapUsage',
+    label: 'Supply cap usage',
+    direction: 'lower-better',
+    getValue: (vault) => {
+      if (!isVaultType(vault)) return NA_CELL
+      const uncapped = vault.supplyCap >= maxUint256
+      const pct = getSupplyCapPercentage(vault)
+      return {
+        display: formatCapPercentDisplay(pct, uncapped),
+        kind: 'capProgress',
+        capPercent: pct,
+        capUncapped: uncapped,
+        numeric: uncapped ? undefined : pct,
+      }
+    },
+  },
+  {
+    id: 'borrowCapUsage',
+    label: 'Borrow cap usage',
+    direction: 'lower-better',
+    getValue: (vault) => {
+      if (!isVaultType(vault) || isEscrow(vault)) return NA_CELL
+      const uncapped = vault.borrowCap >= maxUint256
+      const pct = getBorrowCapPercentage(vault)
+      return {
+        display: formatCapPercentDisplay(pct, uncapped),
+        kind: 'capProgress',
+        capPercent: pct,
+        capUncapped: uncapped,
+        numeric: uncapped ? undefined : pct,
+      }
+    },
+  },
+  {
+    id: 'supplyApy',
+    label: 'Supply APY',
+    direction: 'higher-better',
+    getValue: (vault) => {
+      if (!isVaultType(vault) || isEscrow(vault)) return NA_CELL
+      const pct = supplyApyPercent(vault)
+      return { display: `${formatNumber(pct, 2)}%`, kind: 'text', numeric: pct }
+    },
+  },
+  {
+    id: 'borrowApy',
+    label: 'Borrow APY',
+    direction: 'neutral',
+    getValue: (vault) => {
+      if (!isVaultType(vault) || isEscrow(vault)) return NA_CELL
+      const pct = borrowApyPercent(vault)
+      return { display: `${formatNumber(pct, 2)}%`, kind: 'text', numeric: pct }
+    },
+  },
+]
+
+export const getAttributeMatrix = (
+  market: MarketGroup,
+  mode: AttributeMatrixMode,
+): AttributeMatrixData => ({
+  rows: mode === 'config' ? CONFIG_ROWS : STATS_ROWS,
+  columns: getAttributeMatrixColumns(market),
+})
+
+export const buildAttributeRowCells = (
+  row: AttributeRow,
+  columns: AttributeMatrixColumn[],
+  usdCache: Map<string, VaultUsdCacheEntry>,
+): AttributeCell[] =>
+  columns.map(col => row.getValue(col.vault, usdCache.get(col.address)))
+
+export const getAttributeRowColor = (
+  value: number | undefined,
+  min: number,
+  max: number,
+  direction: AttributeDirection,
+): string => {
+  if (direction === 'neutral') return 'transparent'
+  if (value === undefined || !Number.isFinite(value)) return 'transparent'
+  if (min === max) return 'transparent'
+  const normalized = ((value - min) / (max - min)) * 100
+  const clamped = Math.max(0, Math.min(100, normalized))
+  if (direction === 'lower-better') return getLtvColor(clamped)
+  return getLtvColor(100 - clamped)
+}

--- a/utils/discoveryCalculations.ts
+++ b/utils/discoveryCalculations.ts
@@ -619,12 +619,9 @@ const isEscrow = (v: Vault | SecuritizeVault): boolean =>
 const compareSymbolAsc = (a: Vault | SecuritizeVault, b: Vault | SecuritizeVault): number =>
   a.asset.symbol.localeCompare(b.asset.symbol, undefined, { sensitivity: 'base' })
 
-export const getAttributeMatrixColumns = (
-  market: MarketGroup,
-  options: { includeExternal?: boolean } = {},
-): AttributeMatrixColumn[] => {
-  const includeExternal = options.includeExternal ?? true
-
+// Both Configuration and Stats matrices show only the curated product — external
+// collateral belongs to other governance and adds noise either way.
+export const getAttributeMatrixColumns = (market: MarketGroup): AttributeMatrixColumn[] => {
   const memberEvk: Vault[] = []
   const memberSecuritize: SecuritizeVault[] = []
   for (const v of market.vaults) {
@@ -642,30 +639,7 @@ export const getAttributeMatrixColumns = (
     vault,
   })
 
-  if (!includeExternal) {
-    return [...memberEvk.map(toCol), ...memberSecuritize.map(toCol)]
-  }
-
-  const externalEvk: Vault[] = []
-  const externalSecuritize: SecuritizeVault[] = []
-  const seenExternal = new Set<string>()
-  for (const v of market.externalCollateral) {
-    const addr = getVaultAddress(v).toLowerCase()
-    if (!addr || seenExternal.has(addr)) continue
-    seenExternal.add(addr)
-    if (isVaultType(v)) externalEvk.push(v)
-    else if (isSecuritizeVault(v)) externalSecuritize.push(v)
-  }
-
-  externalEvk.sort(compareSymbolAsc)
-  externalSecuritize.sort(compareSymbolAsc)
-
-  return [
-    ...memberEvk.map(toCol),
-    ...memberSecuritize.map(toCol),
-    ...externalEvk.map(toCol),
-    ...externalSecuritize.map(toCol),
-  ]
+  return [...memberEvk.map(toCol), ...memberSecuritize.map(toCol)]
 }
 
 const NA_CELL: AttributeCell = { display: '—', kind: 'text' }
@@ -918,10 +892,7 @@ export const getAttributeMatrix = (
   mode: AttributeMatrixMode,
 ): AttributeMatrixData => ({
   rows: mode === 'config' ? CONFIG_ROWS : STATS_ROWS,
-  // Config view focuses on the curated product — externals belong to other
-  // governance and add noise. Stats view keeps externals so risk managers can
-  // compare TVL/APY against linked collateral pools.
-  columns: getAttributeMatrixColumns(market, { includeExternal: mode !== 'config' }),
+  columns: getAttributeMatrixColumns(market),
 })
 
 export const buildAttributeRowCells = (

--- a/utils/discoveryCalculations.ts
+++ b/utils/discoveryCalculations.ts
@@ -586,19 +586,11 @@ export interface AttributeMatrixData {
   columns: AttributeMatrixColumn[]
 }
 
-const getTotalAssets = (vault: Vault | SecuritizeVault): bigint =>
-  (vault.totalAssets ?? 0n) as bigint
-
 const isEscrow = (v: Vault | SecuritizeVault): boolean =>
   isVaultType(v) && v.vaultCategory === 'escrow'
 
-const compareTotalAssetsDesc = (a: Vault | SecuritizeVault, b: Vault | SecuritizeVault): number => {
-  const ta = getTotalAssets(a)
-  const tb = getTotalAssets(b)
-  if (tb > ta) return 1
-  if (tb < ta) return -1
-  return 0
-}
+const compareSymbolAsc = (a: Vault | SecuritizeVault, b: Vault | SecuritizeVault): number =>
+  a.asset.symbol.localeCompare(b.asset.symbol, undefined, { sensitivity: 'base' })
 
 export const getAttributeMatrixColumns = (
   market: MarketGroup,
@@ -613,8 +605,8 @@ export const getAttributeMatrixColumns = (
     else if (isSecuritizeVault(v)) memberSecuritize.push(v)
   }
 
-  memberEvk.sort(compareTotalAssetsDesc)
-  memberSecuritize.sort(compareTotalAssetsDesc)
+  memberEvk.sort(compareSymbolAsc)
+  memberSecuritize.sort(compareSymbolAsc)
 
   const toCol = (vault: Vault | SecuritizeVault): AttributeMatrixColumn => ({
     address: getVaultAddress(vault).toLowerCase(),
@@ -638,8 +630,8 @@ export const getAttributeMatrixColumns = (
     else if (isSecuritizeVault(v)) externalSecuritize.push(v)
   }
 
-  externalEvk.sort(compareTotalAssetsDesc)
-  externalSecuritize.sort(compareTotalAssetsDesc)
+  externalEvk.sort(compareSymbolAsc)
+  externalSecuritize.sort(compareSymbolAsc)
 
   return [
     ...memberEvk.map(toCol),
@@ -689,15 +681,8 @@ export const CONFIG_ROWS: AttributeRow[] = [
     direction: 'neutral',
     getValue: (vault, usd) => {
       const rawCap = vault.supplyCap
-      const uncapped = rawCap >= maxUint256
       const { display } = formatCapDisplay(rawCap, usd ? { capStr: usd.supplyCap, capUsd: usd.supplyCapUsd } : undefined)
-      const pct = uncapped ? 0 : getSupplyCapPercentage(vault as Vault)
-      return {
-        display,
-        kind: 'capProgress',
-        capPercent: pct,
-        capUncapped: uncapped,
-      }
+      return { display, kind: 'text' }
     },
   },
   {
@@ -708,45 +693,8 @@ export const CONFIG_ROWS: AttributeRow[] = [
       if (!isVaultType(vault)) return NA_CELL
       if (isEscrow(vault)) return NA_CELL
       const rawCap = vault.borrowCap
-      const uncapped = rawCap >= maxUint256
       const { display } = formatCapDisplay(rawCap, usd ? { capStr: usd.borrowCap, capUsd: usd.borrowCapUsd } : undefined)
-      const pct = getBorrowCapPercentage(vault)
-      return {
-        display,
-        kind: 'capProgress',
-        capPercent: pct,
-        capUncapped: uncapped,
-      }
-    },
-  },
-  {
-    id: 'maxLiqDiscount',
-    label: 'Max liquidation discount',
-    direction: 'neutral',
-    getValue: (vault) => {
-      if (!isVaultType(vault) || isEscrow(vault)) return NA_CELL
-      const pct = Number(vault.maxLiquidationDiscount / 100n)
-      return { display: `${pct}%`, kind: 'text', numeric: pct }
-    },
-  },
-  {
-    id: 'interestFee',
-    label: 'Interest fee',
-    direction: 'neutral',
-    getValue: (vault) => {
-      if (!isVaultType(vault) || isEscrow(vault)) return NA_CELL
-      const pct = Number(nanoToValue(vault.interestFee, 2))
-      return { display: `${formatNumber(pct)}%`, kind: 'text', numeric: pct }
-    },
-  },
-  {
-    id: 'badDebtSocialised',
-    label: 'Bad debt socialised',
-    direction: 'lower-better',
-    getValue: (vault) => {
-      if (!isVaultType(vault) || isEscrow(vault)) return NA_CELL
-      const yes = vault.configFlags === 0n
-      return { display: yes ? 'Yes' : 'No', kind: 'text', numeric: yes ? 0 : 1 }
+      return { display, kind: 'text' }
     },
   },
   {
@@ -761,14 +709,45 @@ export const CONFIG_ROWS: AttributeRow[] = [
     },
   },
   {
+    id: 'interestFee',
+    label: 'Interest fee',
+    direction: 'neutral',
+    getValue: (vault) => {
+      if (!isVaultType(vault) || isEscrow(vault)) return NA_CELL
+      const pct = Number(nanoToValue(vault.interestFee, 2))
+      return { display: `${formatNumber(pct)}%`, kind: 'text' }
+    },
+  },
+  {
+    id: 'maxLiqDiscount',
+    label: 'Max liquidation discount',
+    direction: 'neutral',
+    getValue: (vault) => {
+      if (!isVaultType(vault) || isEscrow(vault)) return NA_CELL
+      const pct = Number(vault.maxLiquidationDiscount / 100n)
+      return { display: `${pct}%`, kind: 'text' }
+    },
+  },
+  {
+    id: 'badDebtSocialised',
+    label: 'Bad debt socialization',
+    direction: 'neutral',
+    getValue: (vault) => {
+      if (!isVaultType(vault) || isEscrow(vault)) return NA_CELL
+      const yes = vault.configFlags === 0n
+      return { display: yes ? 'Yes' : 'No', kind: 'text' }
+    },
+  },
+  {
     id: 'hooks',
-    label: 'Hooks',
+    label: 'Hooked operations',
     direction: 'neutral',
     getValue: (vault) => {
       if (!isVaultType(vault)) return NA_CELL
-      const paused = isVaultEffectivelyPaused(vault)
-      const display = paused
-        ? 'Paused'
+      // 'All' when every user-facing op is hooked (full disable). Specific
+      // op summary otherwise. 'None' when no ops are hooked.
+      const display = isVaultEffectivelyPaused(vault)
+        ? 'All'
         : vault.hookedOps === 0n
           ? 'None'
           : formatHookedOpsSummary(decodeHookedOps(vault.hookedOps))

--- a/utils/discoveryCalculations.ts
+++ b/utils/discoveryCalculations.ts
@@ -691,8 +691,13 @@ const getIrmTypeLabel = (t: number | undefined): string => {
   return '—'
 }
 
-const formatCapPercentDisplay = (pct: number, uncapped: boolean): string => {
+const formatCapPercentDisplay = (pct: number, uncapped: boolean, exceeded: boolean): string => {
   if (uncapped) return '—'
+  // Both the supply > supplyCap case and the supplyCap === 0n / supply > 0n
+  // edge case (where getSupplyCapPercentage clamps to 100) collapse to one
+  // visual signal: '>100%'. Without this, an exceeded cap was displayed as
+  // exactly 100%, which read as 'at cap' rather than 'over'.
+  if (exceeded || pct > 100) return '>100%'
   return `${compactNumber(pct, 2)}%`
 }
 
@@ -856,8 +861,11 @@ export const STATS_ROWS: AttributeRow[] = [
       if (!isVaultType(vault)) return NA_CELL
       const uncapped = vault.supplyCap >= maxUint256
       const pct = getSupplyCapPercentage(vault)
+      // Edge case: supplyCap === 0 with supply > 0 — the percentage helper
+      // clamps to 100, but conceptually any deposit against a 0 cap is over.
+      const exceeded = vault.supplyCap === 0n && vault.supply > 0n
       return {
-        display: formatCapPercentDisplay(pct, uncapped),
+        display: formatCapPercentDisplay(pct, uncapped, exceeded),
         kind: 'capProgress',
         capPercent: pct,
         capUncapped: uncapped,
@@ -872,8 +880,9 @@ export const STATS_ROWS: AttributeRow[] = [
       if (!isVaultType(vault) || isEscrow(vault)) return NA_CELL
       const uncapped = vault.borrowCap >= maxUint256
       const pct = getBorrowCapPercentage(vault)
+      const exceeded = vault.borrowCap === 0n && vault.borrow > 0n
       return {
-        display: formatCapPercentDisplay(pct, uncapped),
+        display: formatCapPercentDisplay(pct, uncapped, exceeded),
         kind: 'capProgress',
         capPercent: pct,
         capUncapped: uncapped,

--- a/utils/discoveryCalculations.ts
+++ b/utils/discoveryCalculations.ts
@@ -61,7 +61,7 @@ export const DOT_METRIC_OPTIONS: DotMetricOption[] = [
   { id: 'multiplier', label: 'Multiplier', higherIsBetter: false },
   { id: 'bltv', label: 'Borrow LTV', higherIsBetter: false },
   { id: 'lltv', label: 'Liquidation LTV', higherIsBetter: false },
-  { id: 'oracle', label: 'Oracle', higherIsBetter: false },
+  { id: 'oracle', label: 'Oracles', higherIsBetter: false },
 ]
 
 export type ExpandedViewMode = 'graph' | 'matrix'

--- a/utils/discoveryCalculations.ts
+++ b/utils/discoveryCalculations.ts
@@ -600,13 +600,33 @@ const compareTotalAssetsDesc = (a: Vault | SecuritizeVault, b: Vault | Securitiz
   return 0
 }
 
-export const getAttributeMatrixColumns = (market: MarketGroup): AttributeMatrixColumn[] => {
+export const getAttributeMatrixColumns = (
+  market: MarketGroup,
+  options: { includeExternal?: boolean } = {},
+): AttributeMatrixColumn[] => {
+  const includeExternal = options.includeExternal ?? true
+
   const memberEvk: Vault[] = []
   const memberSecuritize: SecuritizeVault[] = []
   for (const v of market.vaults) {
     if (isVaultType(v)) memberEvk.push(v)
     else if (isSecuritizeVault(v)) memberSecuritize.push(v)
   }
+
+  memberEvk.sort(compareTotalAssetsDesc)
+  memberSecuritize.sort(compareTotalAssetsDesc)
+
+  const toCol = (vault: Vault | SecuritizeVault): AttributeMatrixColumn => ({
+    address: getVaultAddress(vault).toLowerCase(),
+    symbol: vault.asset.symbol,
+    assetAddress: vault.asset.address,
+    vault,
+  })
+
+  if (!includeExternal) {
+    return [...memberEvk.map(toCol), ...memberSecuritize.map(toCol)]
+  }
+
   const externalEvk: Vault[] = []
   const externalSecuritize: SecuritizeVault[] = []
   const seenExternal = new Set<string>()
@@ -618,17 +638,8 @@ export const getAttributeMatrixColumns = (market: MarketGroup): AttributeMatrixC
     else if (isSecuritizeVault(v)) externalSecuritize.push(v)
   }
 
-  memberEvk.sort(compareTotalAssetsDesc)
-  memberSecuritize.sort(compareTotalAssetsDesc)
   externalEvk.sort(compareTotalAssetsDesc)
   externalSecuritize.sort(compareTotalAssetsDesc)
-
-  const toCol = (vault: Vault | SecuritizeVault): AttributeMatrixColumn => ({
-    address: getVaultAddress(vault).toLowerCase(),
-    symbol: vault.asset.symbol,
-    assetAddress: vault.asset.address,
-    vault,
-  })
 
   return [
     ...memberEvk.map(toCol),
@@ -663,17 +674,19 @@ const formatCapPercentDisplay = (pct: number, uncapped: boolean): string => {
   return `${compactNumber(pct, 2)}%`
 }
 
+// nanoToValue(supplyAPY, 25) already returns a percentage value (e.g. 5.2 for
+// 5.2%) — matches VaultOverviewBlockStats. No further scaling needed.
 const supplyApyPercent = (vault: Vault | SecuritizeVault): number =>
-  Number(nanoToValue(vault.interestRateInfo.supplyAPY, 25)) * 100
+  Number(nanoToValue(vault.interestRateInfo.supplyAPY, 25))
 
 const borrowApyPercent = (vault: Vault | SecuritizeVault): number =>
-  Number(nanoToValue(vault.interestRateInfo.borrowAPY, 25)) * 100
+  Number(nanoToValue(vault.interestRateInfo.borrowAPY, 25))
 
 export const CONFIG_ROWS: AttributeRow[] = [
   {
     id: 'supplyCap',
     label: 'Supply cap',
-    direction: 'lower-better',
+    direction: 'neutral',
     getValue: (vault, usd) => {
       const rawCap = vault.supplyCap
       const uncapped = rawCap >= maxUint256
@@ -684,14 +697,13 @@ export const CONFIG_ROWS: AttributeRow[] = [
         kind: 'capProgress',
         capPercent: pct,
         capUncapped: uncapped,
-        numeric: uncapped ? undefined : pct,
       }
     },
   },
   {
     id: 'borrowCap',
     label: 'Borrow cap',
-    direction: 'lower-better',
+    direction: 'neutral',
     getValue: (vault, usd) => {
       if (!isVaultType(vault)) return NA_CELL
       if (isEscrow(vault)) return NA_CELL
@@ -704,7 +716,6 @@ export const CONFIG_ROWS: AttributeRow[] = [
         kind: 'capProgress',
         capPercent: pct,
         capUncapped: uncapped,
-        numeric: uncapped ? undefined : pct,
       }
     },
   },
@@ -750,16 +761,6 @@ export const CONFIG_ROWS: AttributeRow[] = [
     },
   },
   {
-    id: 'governor',
-    label: 'Governor',
-    direction: 'neutral',
-    getValue: vault => ({
-      display: vault.governorAdmin,
-      kind: 'governor',
-      hint: vault.governorAdmin,
-    }),
-  },
-  {
     id: 'hooks',
     label: 'Hooks',
     direction: 'neutral',
@@ -778,17 +779,26 @@ export const CONFIG_ROWS: AttributeRow[] = [
       }
     },
   },
+  {
+    id: 'governor',
+    label: 'Governor',
+    direction: 'neutral',
+    getValue: vault => ({
+      display: vault.governorAdmin,
+      kind: 'governor',
+      hint: vault.governorAdmin,
+    }),
+  },
 ]
 
 export const STATS_ROWS: AttributeRow[] = [
   {
     id: 'totalSupply',
     label: 'Total supply',
-    direction: 'higher-better',
+    direction: 'neutral',
     getValue: (_vault, usd) => ({
       display: usd ? usd.supply : '…',
       kind: 'text',
-      numeric: usd?.supplyUsd,
     }),
   },
   {
@@ -800,37 +810,35 @@ export const STATS_ROWS: AttributeRow[] = [
       return {
         display: usd ? usd.borrow : '…',
         kind: 'text',
-        numeric: usd?.borrowUsd,
       }
     },
   },
   {
     id: 'liquidity',
     label: 'Available liquidity',
-    direction: 'higher-better',
+    direction: 'neutral',
     getValue: (vault, usd) => {
       if (!isVaultType(vault) || isEscrow(vault)) return NA_CELL
       return {
         display: usd ? usd.liquidity : '…',
         kind: 'text',
-        numeric: usd?.liquidityUsd,
       }
     },
   },
   {
     id: 'utilization',
     label: 'Utilization',
-    direction: 'lower-better',
+    direction: 'neutral',
     getValue: (vault) => {
       if (!isVaultType(vault) || isEscrow(vault)) return NA_CELL
       const pct = getVaultUtilization(vault)
-      return { display: `${formatNumber(pct, 2)}%`, kind: 'text', numeric: pct }
+      return { display: `${formatNumber(pct, 2)}%`, kind: 'text' }
     },
   },
   {
     id: 'supplyCapUsage',
     label: 'Supply cap usage',
-    direction: 'lower-better',
+    direction: 'neutral',
     getValue: (vault) => {
       if (!isVaultType(vault)) return NA_CELL
       const uncapped = vault.supplyCap >= maxUint256
@@ -840,14 +848,13 @@ export const STATS_ROWS: AttributeRow[] = [
         kind: 'capProgress',
         capPercent: pct,
         capUncapped: uncapped,
-        numeric: uncapped ? undefined : pct,
       }
     },
   },
   {
     id: 'borrowCapUsage',
     label: 'Borrow cap usage',
-    direction: 'lower-better',
+    direction: 'neutral',
     getValue: (vault) => {
       if (!isVaultType(vault) || isEscrow(vault)) return NA_CELL
       const uncapped = vault.borrowCap >= maxUint256
@@ -857,18 +864,17 @@ export const STATS_ROWS: AttributeRow[] = [
         kind: 'capProgress',
         capPercent: pct,
         capUncapped: uncapped,
-        numeric: uncapped ? undefined : pct,
       }
     },
   },
   {
     id: 'supplyApy',
     label: 'Supply APY',
-    direction: 'higher-better',
+    direction: 'neutral',
     getValue: (vault) => {
       if (!isVaultType(vault) || isEscrow(vault)) return NA_CELL
       const pct = supplyApyPercent(vault)
-      return { display: `${formatNumber(pct, 2)}%`, kind: 'text', numeric: pct }
+      return { display: `${formatNumber(pct, 2)}%`, kind: 'text' }
     },
   },
   {
@@ -878,7 +884,7 @@ export const STATS_ROWS: AttributeRow[] = [
     getValue: (vault) => {
       if (!isVaultType(vault) || isEscrow(vault)) return NA_CELL
       const pct = borrowApyPercent(vault)
-      return { display: `${formatNumber(pct, 2)}%`, kind: 'text', numeric: pct }
+      return { display: `${formatNumber(pct, 2)}%`, kind: 'text' }
     },
   },
 ]
@@ -888,7 +894,10 @@ export const getAttributeMatrix = (
   mode: AttributeMatrixMode,
 ): AttributeMatrixData => ({
   rows: mode === 'config' ? CONFIG_ROWS : STATS_ROWS,
-  columns: getAttributeMatrixColumns(market),
+  // Config view focuses on the curated product — externals belong to other
+  // governance and add noise. Stats view keeps externals so risk managers can
+  // compare TVL/APY against linked collateral pools.
+  columns: getAttributeMatrixColumns(market, { includeExternal: mode !== 'config' }),
 })
 
 export const buildAttributeRowCells = (

--- a/utils/discoveryCalculations.ts
+++ b/utils/discoveryCalculations.ts
@@ -3,14 +3,19 @@ import type { MarketGroup, MiniDiagramData, MiniNode, MiniEdge } from '~/entitie
 import type { Vault, SecuritizeVault, VaultCollateralLTV } from '~/entities/vault'
 import type { AnyVault } from '~/composables/useVaultRegistry'
 import type { EulerLabelEntity } from '~/entities/euler/labels'
-import { getCurrentLiquidationLTV, isLiquidationLTVRamping, getVaultUtilization } from '~/entities/vault'
+import {
+  getCurrentLiquidationLTV,
+  isLiquidationLTVRamping,
+  getVaultUtilization,
+  getSupplyCapPercentage,
+  getBorrowCapPercentage,
+} from '~/entities/vault'
 import { getEulerLabelEntityLogo } from '~/entities/euler/labels'
 import { getEntitiesByVault, isVaultDeprecated } from '~/utils/eulerLabelsUtils'
 import { nanoToValue } from '~/utils/crypto-utils'
 import { formatNumber, compactNumber } from '~/utils/string-utils'
 import { decodeHookedOps, formatHookedOpsSummary, isVaultEffectivelyPaused } from '~/utils/vault-hooks'
-import { getSupplyCapPercentage, getBorrowCapPercentage } from '~/composables/useVaultWarnings'
-import { INTEREST_RATE_MODEL_TYPE } from '~/entities/constants'
+import { INTEREST_RATE_MODEL_TYPE, CFG_DONT_SOCIALIZE_DEBT } from '~/entities/constants'
 
 // ============================================================
 // Types & Constants
@@ -68,6 +73,28 @@ export type ExpandedViewMode = 'graph' | 'matrix'
 
 export type MatrixVariant = 'pairs' | 'config' | 'stats'
 export type AttributeMatrixMode = 'config' | 'stats'
+
+// Unified matrix-view selector. Wraps both attribute matrices (stats / config)
+// and pair-matrix metric variants (oracle + numeric metrics). Order is the
+// order shown in the dropdown.
+export type MatrixViewId = AttributeMatrixMode | DotMetric
+export interface MatrixViewOption {
+  id: MatrixViewId
+  label: string
+}
+export const MATRIX_VIEW_OPTIONS: MatrixViewOption[] = [
+  { id: 'stats', label: 'Stats' },
+  { id: 'config', label: 'Configuration' },
+  { id: 'oracle', label: 'Oracles' },
+  { id: 'net-apy', label: 'Net APY' },
+  { id: 'roe', label: 'Max ROE' },
+  { id: 'multiplier', label: 'Multiplier' },
+  { id: 'bltv', label: 'Borrow LTV' },
+  { id: 'lltv', label: 'Liquidation LTV' },
+]
+
+export const isAttributeMatrixView = (id: MatrixViewId): id is AttributeMatrixMode =>
+  id === 'stats' || id === 'config'
 
 // ============================================================
 // Vault Type Guards & Accessors
@@ -643,14 +670,17 @@ export const getAttributeMatrixColumns = (
 
 const NA_CELL: AttributeCell = { display: '—', kind: 'text' }
 
-const formatCapDisplay = (
+// Shared cap renderer used by both the attribute matrix (CONFIG_ROWS) and the
+// USD cache loader in DiscoveryMarketAccordion. `formatted` is the pre-built
+// USD or asset-amount string when available; the boundary cases (uncapped /
+// zero cap) win regardless of whether the formatted string is supplied.
+export const formatCapDisplay = (
   rawCap: bigint,
-  usdEntry: { capStr: string, capUsd: number | undefined } | undefined,
+  formatted: string | null | undefined,
 ): { display: string, hint?: string } => {
   if (rawCap >= maxUint256) return { display: '∞' }
   if (rawCap === 0n) return { display: '$0' }
-  if (!usdEntry) return { display: '…' }
-  return { display: usdEntry.capStr }
+  return { display: formatted ?? '…' }
 }
 
 const getIrmTypeLabel = (t: number | undefined): string => {
@@ -681,7 +711,7 @@ export const CONFIG_ROWS: AttributeRow[] = [
     direction: 'neutral',
     getValue: (vault, usd) => {
       const rawCap = vault.supplyCap
-      const { display } = formatCapDisplay(rawCap, usd ? { capStr: usd.supplyCap, capUsd: usd.supplyCapUsd } : undefined)
+      const { display } = formatCapDisplay(rawCap, usd?.supplyCap)
       return { display, kind: 'text' }
     },
   },
@@ -693,7 +723,7 @@ export const CONFIG_ROWS: AttributeRow[] = [
       if (!isVaultType(vault)) return NA_CELL
       if (isEscrow(vault)) return NA_CELL
       const rawCap = vault.borrowCap
-      const { display } = formatCapDisplay(rawCap, usd ? { capStr: usd.borrowCap, capUsd: usd.borrowCapUsd } : undefined)
+      const { display } = formatCapDisplay(rawCap, usd?.borrowCap)
       return { display, kind: 'text' }
     },
   },
@@ -734,7 +764,11 @@ export const CONFIG_ROWS: AttributeRow[] = [
     direction: 'neutral',
     getValue: (vault) => {
       if (!isVaultType(vault) || isEscrow(vault)) return NA_CELL
-      const yes = vault.configFlags === 0n
+      // Bitmask check — bad-debt socialisation is on when the
+      // CFG_DONT_SOCIALIZE_DEBT bit is *not* set. configFlags may carry
+      // other bits in the future, so testing strict equality against 0n
+      // would silently flip to "No" when an unrelated flag is enabled.
+      const yes = (vault.configFlags & CFG_DONT_SOCIALIZE_DEBT) === 0n
       return { display: yes ? 'Yes' : 'No', kind: 'text' }
     },
   },
@@ -851,6 +885,8 @@ export const STATS_ROWS: AttributeRow[] = [
     label: 'Supply APY',
     direction: 'neutral',
     getValue: (vault) => {
+      // Securitize vaults' interestRateInfo is documented as zero-valued,
+      // so we'd render "0.00%" — avoid that misleading display.
       if (!isVaultType(vault) || isEscrow(vault)) return NA_CELL
       const pct = supplyApyPercent(vault)
       return { display: `${formatNumber(pct, 2)}%`, kind: 'text' }

--- a/utils/discoveryCalculations.ts
+++ b/utils/discoveryCalculations.ts
@@ -592,6 +592,14 @@ const getTotalAssets = (vault: Vault | SecuritizeVault): bigint =>
 const isEscrow = (v: Vault | SecuritizeVault): boolean =>
   isVaultType(v) && v.vaultCategory === 'escrow'
 
+const compareTotalAssetsDesc = (a: Vault | SecuritizeVault, b: Vault | SecuritizeVault): number => {
+  const ta = getTotalAssets(a)
+  const tb = getTotalAssets(b)
+  if (tb > ta) return 1
+  if (tb < ta) return -1
+  return 0
+}
+
 export const getAttributeMatrixColumns = (market: MarketGroup): AttributeMatrixColumn[] => {
   const memberEvk: Vault[] = []
   const memberSecuritize: SecuritizeVault[] = []
@@ -599,19 +607,21 @@ export const getAttributeMatrixColumns = (market: MarketGroup): AttributeMatrixC
     if (isVaultType(v)) memberEvk.push(v)
     else if (isSecuritizeVault(v)) memberSecuritize.push(v)
   }
+  const externalEvk: Vault[] = []
   const externalSecuritize: SecuritizeVault[] = []
   const seenExternal = new Set<string>()
   for (const v of market.externalCollateral) {
-    if (!isSecuritizeVault(v)) continue
     const addr = getVaultAddress(v).toLowerCase()
-    if (seenExternal.has(addr)) continue
+    if (!addr || seenExternal.has(addr)) continue
     seenExternal.add(addr)
-    externalSecuritize.push(v)
+    if (isVaultType(v)) externalEvk.push(v)
+    else if (isSecuritizeVault(v)) externalSecuritize.push(v)
   }
 
-  memberEvk.sort((a, b) => (getTotalAssets(b) > getTotalAssets(a) ? 1 : -1))
-  memberSecuritize.sort((a, b) => (getTotalAssets(b) > getTotalAssets(a) ? 1 : -1))
-  externalSecuritize.sort((a, b) => (getTotalAssets(b) > getTotalAssets(a) ? 1 : -1))
+  memberEvk.sort(compareTotalAssetsDesc)
+  memberSecuritize.sort(compareTotalAssetsDesc)
+  externalEvk.sort(compareTotalAssetsDesc)
+  externalSecuritize.sort(compareTotalAssetsDesc)
 
   const toCol = (vault: Vault | SecuritizeVault): AttributeMatrixColumn => ({
     address: getVaultAddress(vault).toLowerCase(),
@@ -623,6 +633,7 @@ export const getAttributeMatrixColumns = (market: MarketGroup): AttributeMatrixC
   return [
     ...memberEvk.map(toCol),
     ...memberSecuritize.map(toCol),
+    ...externalEvk.map(toCol),
     ...externalSecuritize.map(toCol),
   ]
 }
@@ -643,7 +654,7 @@ const getIrmTypeLabel = (t: number | undefined): string => {
   if (t === INTEREST_RATE_MODEL_TYPE.KINK) return 'Kink'
   if (t === INTEREST_RATE_MODEL_TYPE.ADAPTIVE_CURVE) return 'Adaptive'
   if (t === INTEREST_RATE_MODEL_TYPE.KINKY) return 'Kinky'
-  if (t === INTEREST_RATE_MODEL_TYPE.FIXED_CYCLICAL_BINARY) return 'Cyclical'
+  if (t === INTEREST_RATE_MODEL_TYPE.FIXED_CYCLICAL_BINARY) return 'Cyclical note'
   return '—'
 }
 

--- a/utils/discoveryCalculations.ts
+++ b/utils/discoveryCalculations.ts
@@ -798,20 +798,22 @@ export const STATS_ROWS: AttributeRow[] = [
   {
     id: 'totalSupply',
     label: 'Total supply',
-    direction: 'neutral',
+    direction: 'higher-better',
     getValue: (_vault, usd) => ({
       display: usd ? usd.supply : '…',
+      numeric: usd?.supplyUsd,
       kind: 'text',
     }),
   },
   {
     id: 'totalBorrow',
     label: 'Total borrows',
-    direction: 'neutral',
+    direction: 'lower-better',
     getValue: (vault, usd) => {
       if (!isVaultType(vault) || isEscrow(vault)) return NA_CELL
       return {
         display: usd ? usd.borrow : '…',
+        numeric: usd?.borrowUsd,
         kind: 'text',
       }
     },
@@ -819,11 +821,12 @@ export const STATS_ROWS: AttributeRow[] = [
   {
     id: 'liquidity',
     label: 'Available liquidity',
-    direction: 'neutral',
+    direction: 'higher-better',
     getValue: (vault, usd) => {
       if (!isVaultType(vault) || isEscrow(vault)) return NA_CELL
       return {
         display: usd ? usd.liquidity : '…',
+        numeric: usd?.liquidityUsd,
         kind: 'text',
       }
     },
@@ -831,17 +834,17 @@ export const STATS_ROWS: AttributeRow[] = [
   {
     id: 'utilization',
     label: 'Utilization',
-    direction: 'neutral',
+    direction: 'lower-better',
     getValue: (vault) => {
       if (!isVaultType(vault) || isEscrow(vault)) return NA_CELL
       const pct = getVaultUtilization(vault)
-      return { display: `${formatNumber(pct, 2)}%`, kind: 'text' }
+      return { display: `${formatNumber(pct, 2)}%`, numeric: pct, kind: 'text' }
     },
   },
   {
     id: 'supplyCapUsage',
     label: 'Supply cap usage',
-    direction: 'neutral',
+    direction: 'lower-better',
     getValue: (vault) => {
       if (!isVaultType(vault)) return NA_CELL
       const uncapped = vault.supplyCap >= maxUint256
@@ -851,6 +854,7 @@ export const STATS_ROWS: AttributeRow[] = [
       const exceeded = vault.supplyCap === 0n && vault.supply > 0n
       return {
         display: formatCapPercentDisplay(pct, uncapped, exceeded),
+        numeric: uncapped ? undefined : pct,
         kind: 'capProgress',
         capPercent: pct,
         capUncapped: uncapped,
@@ -860,7 +864,7 @@ export const STATS_ROWS: AttributeRow[] = [
   {
     id: 'borrowCapUsage',
     label: 'Borrow cap usage',
-    direction: 'neutral',
+    direction: 'lower-better',
     getValue: (vault) => {
       if (!isVaultType(vault) || isEscrow(vault)) return NA_CELL
       const uncapped = vault.borrowCap >= maxUint256
@@ -868,6 +872,7 @@ export const STATS_ROWS: AttributeRow[] = [
       const exceeded = vault.borrowCap === 0n && vault.borrow > 0n
       return {
         display: formatCapPercentDisplay(pct, uncapped, exceeded),
+        numeric: uncapped ? undefined : pct,
         kind: 'capProgress',
         capPercent: pct,
         capUncapped: uncapped,
@@ -877,23 +882,23 @@ export const STATS_ROWS: AttributeRow[] = [
   {
     id: 'supplyApy',
     label: 'Supply APY',
-    direction: 'neutral',
+    direction: 'higher-better',
     getValue: (vault) => {
       // Securitize vaults' interestRateInfo is documented as zero-valued,
       // so we'd render "0.00%" — avoid that misleading display.
       if (!isVaultType(vault) || isEscrow(vault)) return NA_CELL
       const pct = supplyApyPercent(vault)
-      return { display: `${formatNumber(pct, 2)}%`, kind: 'text' }
+      return { display: `${formatNumber(pct, 2)}%`, numeric: pct, kind: 'text' }
     },
   },
   {
     id: 'borrowApy',
     label: 'Borrow APY',
-    direction: 'neutral',
+    direction: 'lower-better',
     getValue: (vault) => {
       if (!isVaultType(vault) || isEscrow(vault)) return NA_CELL
       const pct = borrowApyPercent(vault)
-      return { display: `${formatNumber(pct, 2)}%`, kind: 'text' }
+      return { display: `${formatNumber(pct, 2)}%`, numeric: pct, kind: 'text' }
     },
   },
 ]

--- a/utils/eulerLabelsState.ts
+++ b/utils/eulerLabelsState.ts
@@ -23,3 +23,9 @@ export const verifiedVaultAddresses: Ref<string[]> = ref([])
 export const oracleAdapters = shallowReactive<Record<string, OracleAdapterMeta>>({})
 
 export const loadingAdapters = new Set<string>()
+
+// Per-chain bulk-load state for the oracle-adapters all.json fetch.
+// loadedChains tracks chains for which we already have the bulk payload;
+// pendingBulkLoads holds in-flight promises so concurrent callers share a request.
+export const bulkLoadedAdapterChains = new Set<number>()
+export const pendingBulkAdapterLoads = new Map<number, Promise<void>>()

--- a/utils/eulerLabelsState.ts
+++ b/utils/eulerLabelsState.ts
@@ -25,7 +25,8 @@ export const oracleAdapters = shallowReactive<Record<string, OracleAdapterMeta>>
 export const loadingAdapters = new Set<string>()
 
 // Per-chain bulk-load state for the oracle-adapters all.json fetch.
-// loadedChains tracks chains for which we already have the bulk payload;
-// pendingBulkLoads holds in-flight promises so concurrent callers share a request.
-export const bulkLoadedAdapterChains = new Set<number>()
+// loadedAt tracks when we last loaded the bulk payload per chain so we can
+// time-bound staleness. pendingBulkLoads holds in-flight promises so
+// concurrent callers share a request.
+export const bulkLoadedAdapterChains = new Map<number, number>()
 export const pendingBulkAdapterLoads = new Map<number, Promise<void>>()

--- a/utils/eulerLabelsUtils.ts
+++ b/utils/eulerLabelsUtils.ts
@@ -4,7 +4,7 @@ import {
   eulerLabelProductEmpty,
   type EulerLabelVaultOverride,
 } from '~/entities/euler/labels'
-import type { EarnVault, Vault } from '~/entities/vault'
+import type { EarnVault } from '~/entities/vault'
 import { type OracleAdapterMeta, OracleAdapterCheckSeverity } from '~/entities/oracle'
 import { normalizeAddress } from '~/utils/normalizeAddress'
 import {
@@ -276,7 +276,10 @@ export const isProductKeyring = (productKey: string): boolean => {
   return products[productKey]?.keyring === true
 }
 
-export const getEntitiesByVault = (vault: Vault) => {
+// Widened to Vault | SecuritizeVault — both expose governorAdmin: string and
+// the helper only reads that one field. Callers from the discovery matrix
+// pass either type without casting.
+export const getEntitiesByVault = (vault: { governorAdmin: string }) => {
   const arr: EulerLabelEntity[] = []
   Object.values(entities).forEach((entity) => {
     if (Object.keys(entity.addresses).includes(vault.governorAdmin)) {


### PR DESCRIPTION
## Summary

Risk managers complain that exploring vault configuration on the explore page takes too many clicks. The matrix only showed pair-wise LTV metrics; everything else required opening each vault overview one at a time.

This PR adds two new sub-modes to the matrix and a new oracle metric for the existing pair matrix.

## What's new

**Sub-toggle inside the Matrix view: `LTV pairs | Config | Stats`.** The metric dropdown only appears for `LTV pairs`. Earn vaults are excluded from the config/stats matrices in v1 (different shape — separate exploration).

### Configuration matrix
Rows × vault columns. Rows: supply cap, borrow cap, max liquidation discount, interest fee, bad debt socialised, IRM type, governor, hooks.
- Cap rows display USD value + radial-progress indicator (reuses `UiRadialProgress` from the vault overview).
- Governor cell renders entity logos via `getEntitiesByVault` + `BaseAvatar`, falling back to `<VaultTypeChip type="unknown">` when the governor doesn't match a known entity.
- Hooks cell shows the summary text; when `hookedOps !== 0n` it becomes a button that opens `VaultHooksInfoModal`.

### Stats matrix
Rows: total supply, total borrows, available liquidity, utilization, supply cap usage, borrow cap usage, supply APY, borrow APY.
- Per-row heatmap via the existing `getLtvColor` ramp. Direction-aware: utilisation and cap usage glow red toward 100; supply/liquidity/APY glow green at the high end.
- Cap-usage rows also render a radial-progress indicator alongside the percentage.

### Oracle metric on the LTV pair matrix
- New `Oracle` option in the metric dropdown.
- Each cell shows the adapter provider logos for the (collateral, liability) pair, using `collectOracleAdapters` and `getOracleProviderLogo` — the same data already shown on the borrow pair page.
- Logos carry a small check-status dot (warning / negative).
- Click a logo to open a tooltip with provider, methodology, oracle address, and a breakdown of failed checks. Click outside to close.

## Implementation notes

- `utils/discoveryCalculations.ts` got the new attribute-matrix types (`MatrixVariant`, `AttributeMatrixData`, `AttributeRow`, `AttributeCell`, `VaultUsdCacheEntry`), the `CONFIG_ROWS` / `STATS_ROWS` definitions, and `getAttributeRowColor`.
- New component `DiscoveryMarketAttributeMatrix.vue` (transposed layout: rows = attributes, cols = vaults). Cell renderer dispatches on `cell.kind` (`text` / `capProgress` / `governor` / `hooks`).
- `DiscoveryMarketMatrix.vue` extended with the oracle metric and tooltip; numeric metrics are unchanged.
- `DiscoveryMarketAccordion.vue` now manages `matrixVariant`, swaps the matrix component conditionally, and clears stale selections on variant change. `vaultUsdCache` is widened to include borrow / supplyCap / borrowCap USD values so the cells can render synchronously.
- Column-header click reuses the existing `selectedMatrixHeader` flow, so the cards-below panel works in all three matrix variants.

## Test plan

- [ ] Open `/explore` and expand a market with several EVK + Securitize vaults
- [x] In Matrix view, toggle between `LTV pairs`, `Config`, and `Stats` and confirm:
  - [x] Selections clear when toggling and there are no stale highlights
  - [ ] Metric dropdown only shows under `LTV pairs`
  - [ ] Securitize / escrow vaults render `—` for inapplicable rows (borrow cap, utilisation, APYs)
  - [ ] Cap rows show `∞` when uncapped; radial indicator hidden in that case
  - [ ] Governor row: known entities show logos + name; unknown shows the warning chip
  - [ ] Hooks row: clicking a non-`None` cell opens `VaultHooksInfoModal`
- [x] In Stats:
  - [x] Heatmap reads correctly — high utilisation / cap usage red, high APY / liquidity green
- [x] In LTV pairs, select `Oracle`:
  - [x] Cells render provider logos; empty cells stay blank
  - [x] Clicking a logo opens the tooltip; clicking outside closes it
  - [ ] Tooltip surfaces failed checks with severity colours
- [ ] Click a vault column header in any variant — cards-below panel renders the same VaultItem + borrow pairs as in LTV mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Attribute matrix view for exploring vault configs, caps, governors and hooks; unified matrix view selector with mode-specific behavior.
  * Oracle mode showing adapter buttons with rich tooltips (price, checks, explorer links) and lazy adapter loading.
  * Server endpoint to serve adapter metadata with caching for faster loads.

* **Improvements**
  * Broader per-vault USD pricing coverage and concurrent pricing loads.
  * More precise cap-percentage calculations (two-decimal).

* **Bug Fixes**
  * Bad-debt socialisation indicator now reads the correct config flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->