### PR TITLE
feat: lazy-resolve off-label collateral vaults

### DIFF
--- a/composables/useMarketGroups.ts
+++ b/composables/useMarketGroups.ts
@@ -456,8 +456,7 @@ export const useMarketGroups = () => {
     const memberVaults: Vault[] = []
 
     try {
-      const ctx = buildFetchContext()
-      for await (const result of fetchVaults(ctx, allAddresses)) {
+      for await (const result of fetchVaults(allAddresses)) {
         memberVaults.push(...result.vaults)
         if (result.isFinished) break
       }

--- a/composables/useMarketGroups.ts
+++ b/composables/useMarketGroups.ts
@@ -456,7 +456,8 @@ export const useMarketGroups = () => {
     const memberVaults: Vault[] = []
 
     try {
-      for await (const result of fetchVaults(allAddresses)) {
+      const ctx = buildFetchContext()
+      for await (const result of fetchVaults(ctx, allAddresses)) {
         memberVaults.push(...result.vaults)
         if (result.isFinished) break
       }

--- a/composables/useVaults.ts
+++ b/composables/useVaults.ts
@@ -317,11 +317,12 @@ const fetchUnresolvedCollaterals = async (addresses: string[], generation: numbe
 
   if (loadGeneration.value !== generation) return
 
+  // Bulk loaders short-circuit on empty input, so call unconditionally.
   await Promise.all([
-    evkAddrs.length ? updateEVKVaults(evkAddrs, generation, true) : null,
-    earnAddrs.length ? updateEarnVaults(earnAddrs, generation, true) : null,
-    securitizeAddrs.length ? updateSecuritizeVaults(securitizeAddrs, generation, true) : null,
-    escrowAddrs.length ? fetchNeededEscrowVaults(escrowAddrs, generation) : null,
+    updateEVKVaults(evkAddrs, generation, true),
+    updateEarnVaults(earnAddrs, generation, true),
+    updateSecuritizeVaults(securitizeAddrs, generation, true),
+    fetchNeededEscrowVaults(escrowAddrs, generation),
   ])
 }
 
@@ -568,10 +569,10 @@ const loadVaults = async () => {
     // member vaults, so a resolved off-label vault is a leaf in those views;
     // any second-hop unknowns will surface as diagnostic warns and resolve
     // on the next loadVaults cycle.
-    const { getEvkVaults: getEvkForUnresolved, has: registryHasForUnresolved } = useVaultRegistry()
+    const { getEvkVaults, has: registryHas } = useVaultRegistry()
     const unresolvedAddresses = extractUnresolvedCollateralAddresses(
-      getEvkForUnresolved(),
-      registryHasForUnresolved,
+      getEvkVaults(),
+      registryHas,
     ).filter(addr => !isVaultNotExplorable(addr))
     await fetchUnresolvedCollaterals(unresolvedAddresses, generation)
 

--- a/composables/useVaults.ts
+++ b/composables/useVaults.ts
@@ -42,6 +42,7 @@ const isEscrowLoadedOnce = ref(false)
 // Incremented in resetVaultsState(); any async operation capturing an older generation
 // must stop registering vaults.
 const loadGeneration = ref(0)
+const MAX_LAZY_COLLATERAL_RESOLVE_PASSES = 4
 
 const contextForGeneration = (gen: number) =>
   buildFetchContext(() => loadGeneration.value !== gen)
@@ -326,6 +327,30 @@ const fetchUnresolvedCollaterals = async (addresses: string[], generation: numbe
   ])
 }
 
+const resolveUnresolvedCollateralGraph = async (generation: number): Promise<void> => {
+  const { getEvkVaults, has: registryHas } = useVaultRegistry()
+  const attempted = new Set<string>()
+
+  for (let pass = 0; pass < MAX_LAZY_COLLATERAL_RESOLVE_PASSES; pass++) {
+    if (loadGeneration.value !== generation) return
+
+    const unresolvedAddresses = extractUnresolvedCollateralAddresses(
+      getEvkVaults(),
+      registryHas,
+    ).filter((addr) => {
+      if (isVaultNotExplorable(addr)) return false
+      const key = addr.toLowerCase()
+      if (attempted.has(key)) return false
+      attempted.add(key)
+      return true
+    })
+
+    if (!unresolvedAddresses.length) return
+
+    await fetchUnresolvedCollaterals(unresolvedAddresses, generation)
+  }
+}
+
 const updateSecuritizeVaults = async (securitizeAddresses: string[], generation: number, silent = false) => {
   const { setMany: registrySetMany } = useVaultRegistry()
 
@@ -561,20 +586,13 @@ const loadVaults = async () => {
 
     if (loadGeneration.value !== generation) return
 
-    // After bulk loaders + escrow lazy-fetch settle, sweep up any collateral
-    // address referenced by a member vault that isn't yet in the registry.
-    // These are typically EVK vaults that exist on chain but aren't part of
-    // any product label — without this, discovery views silently drop the
-    // relationship. Single pass is enough: discovery views iterate only
-    // member vaults, so a resolved off-label vault is a leaf in those views;
-    // any second-hop unknowns will surface as diagnostic warns and resolve
-    // on the next loadVaults cycle.
-    const { getEvkVaults, has: registryHas } = useVaultRegistry()
-    const unresolvedAddresses = extractUnresolvedCollateralAddresses(
-      getEvkVaults(),
-      registryHas,
-    ).filter(addr => !isVaultNotExplorable(addr))
-    await fetchUnresolvedCollaterals(unresolvedAddresses, generation)
+    // After bulk loaders + escrow lazy-fetch settle, sweep up collateral
+    // addresses referenced by loaded EVK vaults that are not yet in the
+    // registry. These are typically EVK vaults that exist on chain but are
+    // not part of any product label. Resolve in bounded passes so newly
+    // loaded off-label vaults can contribute their own live collateral edges
+    // without risking an unbounded crawl.
+    await resolveUnresolvedCollateralGraph(generation)
 
     if (loadGeneration.value !== generation) return
 

--- a/composables/useVaults.ts
+++ b/composables/useVaults.ts
@@ -267,77 +267,64 @@ const fetchNeededEscrowVaults = async (addresses: string[], generation: number):
   registrySetMany(entries)
 }
 
-const UNRESOLVED_COLLATERAL_CONCURRENCY = 8
-
 /**
  * Lazy-resolve collateral addresses that aren't covered by the bulk loaders.
  *
  * `fetchChainVaultCategories` already ran earlier in this `loadVaults` call
  * and populated the per-address category cache, so `fetchVaultCategory` is a
- * cache hit for every address indexed by the subgraph. We dispatch each
- * address directly to its dedicated lens — no escrow-perspective probe and
- * no securitize-then-EVK guessing — and only fall back to the registry's
- * `resolveUnknown` for the rare brand-new deployment whose category endpoint
- * returns `null`.
+ * cache hit for every address indexed by the subgraph. We group addresses
+ * by category and hand each group to the existing bulk loader for that type
+ * (`updateEVKVaults` / `updateEarnVaults` / `updateSecuritizeVaults` /
+ * `fetchNeededEscrowVaults`) — same multicall batching, same registry-write
+ * path, no parallel implementation. `silent=true` keeps loading flags
+ * untouched since this runs after the initial reveal.
  *
- * Bounded concurrency keeps this from fanning out into hundreds of parallel
- * lens reads on markets that reference many off-label collaterals.
+ * Brand-new deployments not yet indexed by the subgraph (category === null)
+ * fall back to the registry's `getOrFetch` / `resolveUnknown`, which is the
+ * only path that needs the legacy probe-and-guess.
  */
 const fetchUnresolvedCollaterals = async (addresses: string[], generation: number): Promise<void> => {
-  const { setMany: registrySetMany, getOrFetch } = useVaultRegistry()
+  const { getOrFetch } = useVaultRegistry()
   if (!addresses.length || loadGeneration.value !== generation) return
 
-  const ctx = contextForGeneration(generation)
+  const evkAddrs: string[] = []
+  const earnAddrs: string[] = []
+  const securitizeAddrs: string[] = []
+  const escrowAddrs: string[] = []
+  const unknownAddrs: string[] = []
 
-  for (let i = 0; i < addresses.length; i += UNRESOLVED_COLLATERAL_CONCURRENCY) {
-    if (loadGeneration.value !== generation) return
-    const batch = addresses.slice(i, i + UNRESOLVED_COLLATERAL_CONCURRENCY)
+  await Promise.allSettled(addresses.map(async (addr) => {
+    const category = await fetchVaultCategory(addr)
+    switch (category) {
+      case 'escrow':
+        escrowAddrs.push(addr)
+        break
+      case 'evk':
+        evkAddrs.push(addr)
+        break
+      case 'earn':
+        earnAddrs.push(addr)
+        break
+      case 'securitize':
+        securitizeAddrs.push(addr)
+        break
+      default:
+        unknownAddrs.push(addr)
+        break
+    }
+  }))
 
-    const settled = await Promise.allSettled(batch.map(async (addr) => {
-      const category = await fetchVaultCategory(addr)
-      if (loadGeneration.value !== generation) return null
+  if (loadGeneration.value !== generation) return
 
-      switch (category) {
-        case 'escrow': {
-          const vault = await fetchEscrowVault(addr, ctx)
-          return { address: vault.address, vault, type: 'evk' as const }
-        }
-        case 'evk': {
-          const vault = await fetchVault(addr, ctx)
-          return { address: vault.address, vault, type: 'evk' as const }
-        }
-        case 'earn': {
-          const vault = await fetchEarnVault(addr, ctx)
-          return { address: vault.address, vault, type: 'earn' as const }
-        }
-        case 'securitize': {
-          const vault = await fetchSecuritizeVault(addr, ctx)
-          return { address: vault.address, vault, type: 'securitize' as const }
-        }
-        default: {
-          // Subgraph hasn't indexed this address yet (brand-new deployment).
-          // Fall back to the registry's resolveUnknown — it caches the
-          // entry itself, so we just await and skip the manual setMany.
-          await getOrFetch(addr)
-          return null
-        }
-      }
-    }))
-
-    if (loadGeneration.value !== generation) return
-
-    const entries = settled
-      .map((r) => {
-        if (r.status === 'rejected') {
-          logWarn('useVaults/fetchUnresolvedCollaterals', r.reason)
-          return null
-        }
-        return r.value
-      })
-      .filter((entry): entry is { address: string, vault: Vault | EarnVault | SecuritizeVault, type: 'evk' | 'earn' | 'securitize' } => entry !== null)
-
-    if (entries.length) registrySetMany(entries)
-  }
+  await Promise.all([
+    evkAddrs.length ? updateEVKVaults(evkAddrs, generation, true) : null,
+    earnAddrs.length ? updateEarnVaults(earnAddrs, generation, true) : null,
+    securitizeAddrs.length ? updateSecuritizeVaults(securitizeAddrs, generation, true) : null,
+    escrowAddrs.length ? fetchNeededEscrowVaults(escrowAddrs, generation) : null,
+    unknownAddrs.length
+      ? Promise.allSettled(unknownAddrs.map(addr => getOrFetch(addr)))
+      : null,
+  ])
 }
 
 const updateSecuritizeVaults = async (securitizeAddresses: string[], generation: number, silent = false) => {

--- a/composables/useVaults.ts
+++ b/composables/useVaults.ts
@@ -19,7 +19,7 @@ import {
   isLiveCollateralEdge,
   type Vault,
 } from '~/entities/vault'
-import { fetchChainVaultCategories, isSecuritizeVault, resetVaultCategoryCache } from '~/entities/vault/factory'
+import { fetchChainVaultCategories, fetchVaultCategory, isSecuritizeVault, resetVaultCategoryCache } from '~/entities/vault/factory'
 import { getProductByVault, isVaultNotExplorable, isEarnVaultNotExplorable } from '~/utils/eulerLabelsUtils'
 import { getEulerRouterGovernor } from '~/entities/oracle'
 
@@ -268,72 +268,75 @@ const fetchNeededEscrowVaults = async (addresses: string[], generation: number):
 }
 
 const UNRESOLVED_COLLATERAL_CONCURRENCY = 8
-// Total addresses resolved per loadVaults call. Defends against pathological
-// product labels that reference hundreds of off-label collaterals — a
-// well-formed product should resolve in well under this cap.
-const UNRESOLVED_COLLATERAL_MAX_TOTAL = 64
-// Hop limit for the fixed-point sweep. A newly-resolved off-label vault may
-// itself reference further off-label collaterals; we re-extract until no new
-// addresses appear, but cap the depth to keep loadVaults bounded.
-const UNRESOLVED_COLLATERAL_MAX_HOPS = 3
 
 /**
  * Lazy-resolve collateral addresses that aren't covered by the bulk loaders.
- * Uses {@link useVaultRegistry.getOrFetch} (which routes through
- * `/api/vault-categories` + escrow-perspective probe + EVK/Securitize lens
- * fallback) so the call site doesn't need to know the vault type.
+ *
+ * `fetchChainVaultCategories` already ran earlier in this `loadVaults` call
+ * and populated the per-address category cache, so `fetchVaultCategory` is a
+ * cache hit for every address indexed by the subgraph. We dispatch each
+ * address directly to its dedicated lens — no escrow-perspective probe and
+ * no securitize-then-EVK guessing — and only fall back to the registry's
+ * `resolveUnknown` for the rare brand-new deployment whose category endpoint
+ * returns `null`.
  *
  * Bounded concurrency keeps this from fanning out into hundreds of parallel
  * lens reads on markets that reference many off-label collaterals.
  */
 const fetchUnresolvedCollaterals = async (addresses: string[], generation: number): Promise<void> => {
-  const { getOrFetch } = useVaultRegistry()
+  const { setMany: registrySetMany, getOrFetch } = useVaultRegistry()
   if (!addresses.length || loadGeneration.value !== generation) return
+
+  const ctx = contextForGeneration(generation)
 
   for (let i = 0; i < addresses.length; i += UNRESOLVED_COLLATERAL_CONCURRENCY) {
     if (loadGeneration.value !== generation) return
     const batch = addresses.slice(i, i + UNRESOLVED_COLLATERAL_CONCURRENCY)
-    await Promise.allSettled(batch.map(addr => getOrFetch(addr)))
-  }
-}
 
-/**
- * Run the lazy-resolve sweep to a fixed point: each newly-resolved EVK vault
- * may bring its own collateral edges, which can reference further off-label
- * vaults. Repeat the (extract → fetch) pair until extract returns empty or
- * the hop / total caps trip.
- */
-const resolveUnknownCollateralsToFixedPoint = async (generation: number): Promise<void> => {
-  const { getEvkVaults, has: registryHas } = useVaultRegistry()
-  let resolvedSoFar = 0
+    const settled = await Promise.allSettled(batch.map(async (addr) => {
+      const category = await fetchVaultCategory(addr)
+      if (loadGeneration.value !== generation) return null
 
-  for (let hop = 0; hop < UNRESOLVED_COLLATERAL_MAX_HOPS; hop++) {
+      switch (category) {
+        case 'escrow': {
+          const vault = await fetchEscrowVault(addr, ctx)
+          return { address: vault.address, vault, type: 'evk' as const }
+        }
+        case 'evk': {
+          const vault = await fetchVault(addr, ctx)
+          return { address: vault.address, vault, type: 'evk' as const }
+        }
+        case 'earn': {
+          const vault = await fetchEarnVault(addr, ctx)
+          return { address: vault.address, vault, type: 'earn' as const }
+        }
+        case 'securitize': {
+          const vault = await fetchSecuritizeVault(addr, ctx)
+          return { address: vault.address, vault, type: 'securitize' as const }
+        }
+        default: {
+          // Subgraph hasn't indexed this address yet (brand-new deployment).
+          // Fall back to the registry's resolveUnknown — it caches the
+          // entry itself, so we just await and skip the manual setMany.
+          await getOrFetch(addr)
+          return null
+        }
+      }
+    }))
+
     if (loadGeneration.value !== generation) return
 
-    const next = extractUnresolvedCollateralAddresses(getEvkVaults(), registryHas)
-      .filter(addr => !isVaultNotExplorable(addr))
-    if (!next.length) return
+    const entries = settled
+      .map((r) => {
+        if (r.status === 'rejected') {
+          logWarn('useVaults/fetchUnresolvedCollaterals', r.reason)
+          return null
+        }
+        return r.value
+      })
+      .filter((entry): entry is { address: string, vault: Vault | EarnVault | SecuritizeVault, type: 'evk' | 'earn' | 'securitize' } => entry !== null)
 
-    const remaining = UNRESOLVED_COLLATERAL_MAX_TOTAL - resolvedSoFar
-    if (remaining <= 0) {
-      logWarn(
-        'useVaults/resolveUnknownCollaterals',
-        `total cap (${UNRESOLVED_COLLATERAL_MAX_TOTAL}) reached at hop ${hop} with ${next.length} addresses still unresolved`,
-      )
-      return
-    }
-
-    const batch = next.length > remaining ? next.slice(0, remaining) : next
-    await fetchUnresolvedCollaterals(batch, generation)
-    resolvedSoFar += batch.length
-
-    if (next.length > batch.length) {
-      logWarn(
-        'useVaults/resolveUnknownCollaterals',
-        `truncated lazy-resolve at hop ${hop}: ${next.length - batch.length} addresses skipped after total cap`,
-      )
-      return
-    }
+    if (entries.length) registrySetMany(entries)
   }
 }
 
@@ -576,11 +579,16 @@ const loadVaults = async () => {
     // address referenced by a member vault that isn't yet in the registry.
     // These are typically EVK vaults that exist on chain but aren't part of
     // any product label — without this, discovery views silently drop the
-    // relationship. The registry's getOrFetch routes through the standard
-    // category resolver, so escrow / securitize / EVK are all handled.
-    // Iterates to a fixed point: a newly-resolved off-label vault may itself
-    // reference further off-label collaterals.
-    await resolveUnknownCollateralsToFixedPoint(generation)
+    // relationship. Single pass is enough: discovery views iterate only
+    // member vaults, so a resolved off-label vault is a leaf in those views;
+    // any second-hop unknowns will surface as diagnostic warns and resolve
+    // on the next loadVaults cycle.
+    const { getEvkVaults: getEvkForUnresolved, has: registryHasForUnresolved } = useVaultRegistry()
+    const unresolvedAddresses = extractUnresolvedCollateralAddresses(
+      getEvkForUnresolved(),
+      registryHasForUnresolved,
+    ).filter(addr => !isVaultNotExplorable(addr))
+    await fetchUnresolvedCollaterals(unresolvedAddresses, generation)
 
     if (loadGeneration.value !== generation) return
 

--- a/composables/useVaults.ts
+++ b/composables/useVaults.ts
@@ -42,7 +42,6 @@ const isEscrowLoadedOnce = ref(false)
 // Incremented in resetVaultsState(); any async operation capturing an older generation
 // must stop registering vaults.
 const loadGeneration = ref(0)
-const MAX_LAZY_COLLATERAL_RESOLVE_PASSES = 4
 
 const contextForGeneration = (gen: number) =>
   buildFetchContext(() => loadGeneration.value !== gen)
@@ -327,30 +326,6 @@ const fetchUnresolvedCollaterals = async (addresses: string[], generation: numbe
   ])
 }
 
-const resolveUnresolvedCollateralGraph = async (generation: number): Promise<void> => {
-  const { getEvkVaults, has: registryHas } = useVaultRegistry()
-  const attempted = new Set<string>()
-
-  for (let pass = 0; pass < MAX_LAZY_COLLATERAL_RESOLVE_PASSES; pass++) {
-    if (loadGeneration.value !== generation) return
-
-    const unresolvedAddresses = extractUnresolvedCollateralAddresses(
-      getEvkVaults(),
-      registryHas,
-    ).filter((addr) => {
-      if (isVaultNotExplorable(addr)) return false
-      const key = addr.toLowerCase()
-      if (attempted.has(key)) return false
-      attempted.add(key)
-      return true
-    })
-
-    if (!unresolvedAddresses.length) return
-
-    await fetchUnresolvedCollaterals(unresolvedAddresses, generation)
-  }
-}
-
 const updateSecuritizeVaults = async (securitizeAddresses: string[], generation: number, silent = false) => {
   const { setMany: registrySetMany } = useVaultRegistry()
 
@@ -586,13 +561,20 @@ const loadVaults = async () => {
 
     if (loadGeneration.value !== generation) return
 
-    // After bulk loaders + escrow lazy-fetch settle, sweep up collateral
-    // addresses referenced by loaded EVK vaults that are not yet in the
-    // registry. These are typically EVK vaults that exist on chain but are
-    // not part of any product label. Resolve in bounded passes so newly
-    // loaded off-label vaults can contribute their own live collateral edges
-    // without risking an unbounded crawl.
-    await resolveUnresolvedCollateralGraph(generation)
+    // After bulk loaders + escrow lazy-fetch settle, sweep up any collateral
+    // address referenced by a member vault that isn't yet in the registry.
+    // These are typically EVK vaults that exist on chain but aren't part of
+    // any product label — without this, discovery views silently drop the
+    // relationship. Single pass is enough: discovery views iterate only
+    // member vaults, so a resolved off-label vault is a leaf in those views;
+    // any second-hop unknowns will surface as diagnostic warns and resolve
+    // on the next loadVaults cycle.
+    const { getEvkVaults, has: registryHas } = useVaultRegistry()
+    const unresolvedAddresses = extractUnresolvedCollateralAddresses(
+      getEvkVaults(),
+      registryHas,
+    ).filter(addr => !isVaultNotExplorable(addr))
+    await fetchUnresolvedCollaterals(unresolvedAddresses, generation)
 
     if (loadGeneration.value !== generation) return
 

--- a/composables/useVaults.ts
+++ b/composables/useVaults.ts
@@ -279,19 +279,19 @@ const fetchNeededEscrowVaults = async (addresses: string[], generation: number):
  * path, no parallel implementation. `silent=true` keeps loading flags
  * untouched since this runs after the initial reveal.
  *
- * Brand-new deployments not yet indexed by the subgraph (category === null)
- * fall back to the registry's `getOrFetch` / `resolveUnknown`, which is the
- * only path that needs the legacy probe-and-guess.
+ * Addresses the subgraph has not indexed (category === null) are skipped —
+ * a probe-and-guess fallback would misidentify brand-new escrows as plain
+ * EVK, and the next `loadVaults` cycle picks them up once the subgraph
+ * catches up. The diagnostic warns in `useMarketGroups` and
+ * `VaultOverviewBlockBorrow` surface the gap in the meantime.
  */
 const fetchUnresolvedCollaterals = async (addresses: string[], generation: number): Promise<void> => {
-  const { getOrFetch } = useVaultRegistry()
   if (!addresses.length || loadGeneration.value !== generation) return
 
   const evkAddrs: string[] = []
   const earnAddrs: string[] = []
   const securitizeAddrs: string[] = []
   const escrowAddrs: string[] = []
-  const unknownAddrs: string[] = []
 
   await Promise.allSettled(addresses.map(async (addr) => {
     const category = await fetchVaultCategory(addr)
@@ -309,7 +309,8 @@ const fetchUnresolvedCollaterals = async (addresses: string[], generation: numbe
         securitizeAddrs.push(addr)
         break
       default:
-        unknownAddrs.push(addr)
+        // Subgraph hasn't indexed this address — skip and let the next
+        // loadVaults cycle pick it up once the category endpoint warms.
         break
     }
   }))
@@ -321,9 +322,6 @@ const fetchUnresolvedCollaterals = async (addresses: string[], generation: numbe
     earnAddrs.length ? updateEarnVaults(earnAddrs, generation, true) : null,
     securitizeAddrs.length ? updateSecuritizeVaults(securitizeAddrs, generation, true) : null,
     escrowAddrs.length ? fetchNeededEscrowVaults(escrowAddrs, generation) : null,
-    unknownAddrs.length
-      ? Promise.allSettled(unknownAddrs.map(addr => getOrFetch(addr)))
-      : null,
   ])
 }
 

--- a/composables/useVaults.ts
+++ b/composables/useVaults.ts
@@ -268,6 +268,14 @@ const fetchNeededEscrowVaults = async (addresses: string[], generation: number):
 }
 
 const UNRESOLVED_COLLATERAL_CONCURRENCY = 8
+// Total addresses resolved per loadVaults call. Defends against pathological
+// product labels that reference hundreds of off-label collaterals — a
+// well-formed product should resolve in well under this cap.
+const UNRESOLVED_COLLATERAL_MAX_TOTAL = 64
+// Hop limit for the fixed-point sweep. A newly-resolved off-label vault may
+// itself reference further off-label collaterals; we re-extract until no new
+// addresses appear, but cap the depth to keep loadVaults bounded.
+const UNRESOLVED_COLLATERAL_MAX_HOPS = 3
 
 /**
  * Lazy-resolve collateral addresses that aren't covered by the bulk loaders.
@@ -286,6 +294,46 @@ const fetchUnresolvedCollaterals = async (addresses: string[], generation: numbe
     if (loadGeneration.value !== generation) return
     const batch = addresses.slice(i, i + UNRESOLVED_COLLATERAL_CONCURRENCY)
     await Promise.allSettled(batch.map(addr => getOrFetch(addr)))
+  }
+}
+
+/**
+ * Run the lazy-resolve sweep to a fixed point: each newly-resolved EVK vault
+ * may bring its own collateral edges, which can reference further off-label
+ * vaults. Repeat the (extract → fetch) pair until extract returns empty or
+ * the hop / total caps trip.
+ */
+const resolveUnknownCollateralsToFixedPoint = async (generation: number): Promise<void> => {
+  const { getEvkVaults, has: registryHas } = useVaultRegistry()
+  let resolvedSoFar = 0
+
+  for (let hop = 0; hop < UNRESOLVED_COLLATERAL_MAX_HOPS; hop++) {
+    if (loadGeneration.value !== generation) return
+
+    const next = extractUnresolvedCollateralAddresses(getEvkVaults(), registryHas)
+      .filter(addr => !isVaultNotExplorable(addr))
+    if (!next.length) return
+
+    const remaining = UNRESOLVED_COLLATERAL_MAX_TOTAL - resolvedSoFar
+    if (remaining <= 0) {
+      logWarn(
+        'useVaults/resolveUnknownCollaterals',
+        `total cap (${UNRESOLVED_COLLATERAL_MAX_TOTAL}) reached at hop ${hop} with ${next.length} addresses still unresolved`,
+      )
+      return
+    }
+
+    const batch = next.length > remaining ? next.slice(0, remaining) : next
+    await fetchUnresolvedCollaterals(batch, generation)
+    resolvedSoFar += batch.length
+
+    if (next.length > batch.length) {
+      logWarn(
+        'useVaults/resolveUnknownCollaterals',
+        `truncated lazy-resolve at hop ${hop}: ${next.length - batch.length} addresses skipped after total cap`,
+      )
+      return
+    }
   }
 }
 
@@ -530,12 +578,9 @@ const loadVaults = async () => {
     // any product label — without this, discovery views silently drop the
     // relationship. The registry's getOrFetch routes through the standard
     // category resolver, so escrow / securitize / EVK are all handled.
-    const { getEvkVaults: getEvkForUnresolved, has: registryHasForUnresolved } = useVaultRegistry()
-    const unresolvedCollateralAddresses = extractUnresolvedCollateralAddresses(
-      getEvkForUnresolved(),
-      registryHasForUnresolved,
-    )
-    await fetchUnresolvedCollaterals(unresolvedCollateralAddresses, generation)
+    // Iterates to a fixed point: a newly-resolved off-label vault may itself
+    // reference further off-label collaterals.
+    await resolveUnknownCollateralsToFixedPoint(generation)
 
     if (loadGeneration.value !== generation) return
 

--- a/composables/useVaults.ts
+++ b/composables/useVaults.ts
@@ -15,6 +15,7 @@ import {
   fetchSecuritizeVault,
   fetchVaults,
   clearPriceCaches,
+  extractUnresolvedCollateralAddresses,
   isLiveCollateralEdge,
   type Vault,
 } from '~/entities/vault'
@@ -266,6 +267,28 @@ const fetchNeededEscrowVaults = async (addresses: string[], generation: number):
   registrySetMany(entries)
 }
 
+const UNRESOLVED_COLLATERAL_CONCURRENCY = 8
+
+/**
+ * Lazy-resolve collateral addresses that aren't covered by the bulk loaders.
+ * Uses {@link useVaultRegistry.getOrFetch} (which routes through
+ * `/api/vault-categories` + escrow-perspective probe + EVK/Securitize lens
+ * fallback) so the call site doesn't need to know the vault type.
+ *
+ * Bounded concurrency keeps this from fanning out into hundreds of parallel
+ * lens reads on markets that reference many off-label collaterals.
+ */
+const fetchUnresolvedCollaterals = async (addresses: string[], generation: number): Promise<void> => {
+  const { getOrFetch } = useVaultRegistry()
+  if (!addresses.length || loadGeneration.value !== generation) return
+
+  for (let i = 0; i < addresses.length; i += UNRESOLVED_COLLATERAL_CONCURRENCY) {
+    if (loadGeneration.value !== generation) return
+    const batch = addresses.slice(i, i + UNRESOLVED_COLLATERAL_CONCURRENCY)
+    await Promise.allSettled(batch.map(addr => getOrFetch(addr)))
+  }
+}
+
 const updateSecuritizeVaults = async (securitizeAddresses: string[], generation: number, silent = false) => {
   const { setMany: registrySetMany } = useVaultRegistry()
 
@@ -498,6 +521,21 @@ const loadVaults = async () => {
         await fetchNeededEscrowVaults(neededEscrowAddresses, generation)
       }),
     ])
+
+    if (loadGeneration.value !== generation) return
+
+    // After bulk loaders + escrow lazy-fetch settle, sweep up any collateral
+    // address referenced by a member vault that isn't yet in the registry.
+    // These are typically EVK vaults that exist on chain but aren't part of
+    // any product label — without this, discovery views silently drop the
+    // relationship. The registry's getOrFetch routes through the standard
+    // category resolver, so escrow / securitize / EVK are all handled.
+    const { getEvkVaults: getEvkForUnresolved, has: registryHasForUnresolved } = useVaultRegistry()
+    const unresolvedCollateralAddresses = extractUnresolvedCollateralAddresses(
+      getEvkForUnresolved(),
+      registryHasForUnresolved,
+    )
+    await fetchUnresolvedCollaterals(unresolvedCollateralAddresses, generation)
 
     if (loadGeneration.value !== generation) return
 

--- a/entities/vault/collateral-discovery.ts
+++ b/entities/vault/collateral-discovery.ts
@@ -22,14 +22,20 @@ export const extractUnresolvedCollateralAddresses = (
   isInRegistry: (address: string) => boolean,
   nowSeconds?: bigint,
 ): string[] => {
+  // Snapshot the clock once so all edges see the same "now" — without this,
+  // two edges in the same vault could be evaluated with millisecond-different
+  // values across a ramp boundary. Defaulting here keeps the documented
+  // contract ("we don't fetch fully ramped-out edges") tight.
+  const now = nowSeconds ?? BigInt(Math.floor(Date.now() / 1000))
   const unresolved = new Set<string>()
   evkVaults.forEach((vault) => {
     vault.collateralLTVs.forEach((ltv) => {
-      if (!isLiveCollateralEdge(ltv, nowSeconds)) return
+      if (!isLiveCollateralEdge(ltv, now)) return
       const addr = ltv.collateral
       if (addr === zeroAddress) return
-      if (isInRegistry(addr)) return
-      unresolved.add(getAddress(addr))
+      const normalised = getAddress(addr)
+      if (isInRegistry(normalised)) return
+      unresolved.add(normalised)
     })
   })
   return [...unresolved]

--- a/entities/vault/collateral-discovery.ts
+++ b/entities/vault/collateral-discovery.ts
@@ -1,0 +1,36 @@
+import { getAddress, zeroAddress } from 'viem'
+import type { Vault } from './types'
+import { isLiveCollateralEdge } from './ltv'
+
+/**
+ * Pure helper: from a list of EVK vaults, return the unique set of
+ * collateral addresses that are referenced by *live* edges but are NOT
+ * present in the registry yet.
+ *
+ * "Live" matches the {@link isLiveCollateralEdge} contract — non-zero
+ * borrow LTV OR non-zero current ramped liquidation LTV. We don't fetch
+ * collaterals for fully ramped-out edges.
+ *
+ * Addresses are normalised via `getAddress` so the caller can hand them
+ * straight to the registry without re-normalising.
+ *
+ * Extracted from `composables/useVaults.ts` so the resolution logic is
+ * testable in isolation from the reactive registry.
+ */
+export const extractUnresolvedCollateralAddresses = (
+  evkVaults: readonly Vault[],
+  isInRegistry: (address: string) => boolean,
+  nowSeconds?: bigint,
+): string[] => {
+  const unresolved = new Set<string>()
+  evkVaults.forEach((vault) => {
+    vault.collateralLTVs.forEach((ltv) => {
+      if (!isLiveCollateralEdge(ltv, nowSeconds)) return
+      const addr = ltv.collateral
+      if (addr === zeroAddress) return
+      if (isInRegistry(addr)) return
+      unresolved.add(getAddress(addr))
+    })
+  })
+  return [...unresolved]
+}

--- a/entities/vault/index.ts
+++ b/entities/vault/index.ts
@@ -61,6 +61,10 @@ export {
   getRampTimeRemaining,
 } from './ltv'
 
+// Collateral discovery (find addresses referenced as live collateral but
+// not yet resolved into the registry).
+export { extractUnresolvedCollateralAddresses } from './collateral-discovery'
+
 // Collateral exposure (borrow-side pair derivation)
 export {
   getCollateralExposurePairs,

--- a/tests/entities/vault/collateral-discovery.test.ts
+++ b/tests/entities/vault/collateral-discovery.test.ts
@@ -90,21 +90,49 @@ describe('extractUnresolvedCollateralAddresses', () => {
   })
 
   it('deduplicates collaterals shared across multiple vaults', () => {
+    const upperA = `0x${ADDR_A.slice(2).toUpperCase()}`
     const a = makeVault([makeLtv({ collateral: ADDR_A })])
-    const b = makeVault([makeLtv({ collateral: ADDR_A.toUpperCase().replace('0X', '0x') })])
+    const b = makeVault([makeLtv({ collateral: upperA })])
     const result = extractUnresolvedCollateralAddresses([a, b], () => false, NOW)
     expect(lower(result)).toEqual([ADDR_A.toLowerCase()])
   })
 
   it('treats registry membership case-insensitively', () => {
-    const vault = makeVault([
-      makeLtv({ collateral: ADDR_A.toUpperCase().replace('0X', '0x') }),
-    ])
+    const upperA = `0x${ADDR_A.slice(2).toUpperCase()}`
+    const vault = makeVault([makeLtv({ collateral: upperA })])
     const result = extractUnresolvedCollateralAddresses(
       [vault],
       inRegistry(ADDR_A),
       NOW,
     )
     expect(result).toEqual([])
+  })
+
+  it('snapshots time once so mid-evaluation Date.now() jitter cannot move ramp boundaries', () => {
+    // Edge with a borderline ramp: targetTimestamp exactly NOW means the ramp
+    // is complete, edge is dead. If the helper called Date.now() per-edge
+    // and the wall-clock advanced mid-loop the second edge could see now+ε
+    // and still be dead — but we want a single snapshot.
+    const vault = makeVault([
+      makeLtv({
+        collateral: ADDR_A,
+        borrowLTV: 0n,
+        liquidationLTV: 0n,
+        initialLiquidationLTV: 9000n,
+        targetTimestamp: NOW,
+        rampDuration: 1000n,
+      }),
+      makeLtv({
+        collateral: ADDR_B,
+        borrowLTV: 0n,
+        liquidationLTV: 0n,
+        initialLiquidationLTV: 9000n,
+        targetTimestamp: NOW + 100n,
+        rampDuration: 1000n,
+      }),
+    ])
+    const result = extractUnresolvedCollateralAddresses([vault], () => false, NOW)
+    // First edge dead at NOW; second still mid-ramp.
+    expect(lower(result)).toEqual([ADDR_B.toLowerCase()])
   })
 })

--- a/tests/entities/vault/collateral-discovery.test.ts
+++ b/tests/entities/vault/collateral-discovery.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest'
+import { extractUnresolvedCollateralAddresses } from '~/entities/vault/collateral-discovery'
+import type { Vault, VaultCollateralLTV } from '~/entities/vault/types'
+
+const NOW = 1500n
+
+const ADDR_A = '0x000000000000000000000000000000000000c0a1'
+const ADDR_B = '0x000000000000000000000000000000000000c0a2'
+const ZERO = '0x0000000000000000000000000000000000000000'
+
+const makeLtv = (overrides: Partial<VaultCollateralLTV> = {}): VaultCollateralLTV => ({
+  collateral: ADDR_A,
+  borrowLTV: 7500n,
+  liquidationLTV: 8000n,
+  initialLiquidationLTV: 9000n,
+  targetTimestamp: 2000n,
+  rampDuration: 1000n,
+  ...overrides,
+})
+
+const makeVault = (collateralLTVs: VaultCollateralLTV[]): Vault =>
+  ({ collateralLTVs }) as unknown as Vault
+
+const inRegistry = (...addrs: string[]) => {
+  const set = new Set(addrs.map(a => a.toLowerCase()))
+  return (addr: string) => set.has(addr.toLowerCase())
+}
+
+const lower = (xs: string[]) => xs.map(x => x.toLowerCase()).sort()
+
+describe('extractUnresolvedCollateralAddresses', () => {
+  it('returns addresses referenced as live collateral but not in the registry', () => {
+    const vault = makeVault([
+      makeLtv({ collateral: ADDR_A }),
+      makeLtv({ collateral: ADDR_B }),
+    ])
+    const result = extractUnresolvedCollateralAddresses([vault], () => false, NOW)
+    expect(lower(result)).toEqual([ADDR_A, ADDR_B].map(a => a.toLowerCase()).sort())
+  })
+
+  it('skips collaterals already present in the registry', () => {
+    const vault = makeVault([
+      makeLtv({ collateral: ADDR_A }),
+      makeLtv({ collateral: ADDR_B }),
+    ])
+    const result = extractUnresolvedCollateralAddresses(
+      [vault],
+      inRegistry(ADDR_A),
+      NOW,
+    )
+    expect(lower(result)).toEqual([ADDR_B.toLowerCase()])
+  })
+
+  it('skips fully ramped-out edges (no need to fetch a collateral the UI will hide)', () => {
+    const vault = makeVault([
+      makeLtv({
+        collateral: ADDR_A,
+        borrowLTV: 0n,
+        liquidationLTV: 0n,
+        initialLiquidationLTV: 9000n,
+        targetTimestamp: 100n, // ramp completed before NOW=1500
+        rampDuration: 50n,
+      }),
+    ])
+    const result = extractUnresolvedCollateralAddresses([vault], () => false, NOW)
+    expect(result).toEqual([])
+  })
+
+  it('keeps mid-ramp edges (borrowLTV=0, liquidation LTV still > 0)', () => {
+    const vault = makeVault([
+      makeLtv({
+        collateral: ADDR_A,
+        borrowLTV: 0n,
+        liquidationLTV: 0n, // target 0
+        initialLiquidationLTV: 9000n,
+        targetTimestamp: 2000n, // ramp not yet finished at NOW=1500
+        rampDuration: 1000n,
+      }),
+    ])
+    const result = extractUnresolvedCollateralAddresses([vault], () => false, NOW)
+    expect(lower(result)).toEqual([ADDR_A.toLowerCase()])
+  })
+
+  it('skips the zero address', () => {
+    const vault = makeVault([
+      makeLtv({ collateral: ZERO }),
+    ])
+    const result = extractUnresolvedCollateralAddresses([vault], () => false, NOW)
+    expect(result).toEqual([])
+  })
+
+  it('deduplicates collaterals shared across multiple vaults', () => {
+    const a = makeVault([makeLtv({ collateral: ADDR_A })])
+    const b = makeVault([makeLtv({ collateral: ADDR_A.toUpperCase().replace('0X', '0x') })])
+    const result = extractUnresolvedCollateralAddresses([a, b], () => false, NOW)
+    expect(lower(result)).toEqual([ADDR_A.toLowerCase()])
+  })
+
+  it('treats registry membership case-insensitively', () => {
+    const vault = makeVault([
+      makeLtv({ collateral: ADDR_A.toUpperCase().replace('0X', '0x') }),
+    ])
+    const result = extractUnresolvedCollateralAddresses(
+      [vault],
+      inRegistry(ADDR_A),
+      NOW,
+    )
+    expect(result).toEqual([])
+  })
+})


### PR DESCRIPTION
**Summary**
Stop dropping off-label collateral vaults from Euler Lite discovery. After the bulk loaders + escrow lazy-fetch settle, scan all member EVK vaults for *live* collateral edges and feed any address not yet in the registry through the existing per-category bulk loaders.

**Why**
`verifiedVaultAddresses` is built exclusively from product labels (`euler-labels`). Any EVK vault that exists on chain but isn't listed under any product is invisible to the bulk EVK loader — and when a labeled borrow vault references it as collateral, every downstream view silently drops the relationship:

- `useMarketGroups.augmentWithCollateralGraph` can't add it to `externalCollateral` (no entry in `vaultMap`)
- `getCollateralExposurePairs` skips the pair when the resolver returns `undefined`
- the matrix and graph have no row/cell to render

The diagnostic `logWarn`s added in PR #309 surface the gaps; this PR fixes them by resolving the missing addresses lazily.

**Resolution path**
By the time the lazy-resolve pass runs, `fetchChainVaultCategories` has already populated the per-address category cache earlier in the same `loadVaults` call. So `fetchVaultCategory(addr)` is a cache hit for every address indexed by the subgraph, and we can group addresses by category and hand each group to the existing bulk loader for that type — same multicall batching, same registry-write path, no parallel implementation:

| `fetchVaultCategory(addr)` returns | dispatched to |
|---|---|
| `'escrow'` | `fetchNeededEscrowVaults` |
| `'evk'` | `updateEVKVaults` (multicall lens generator) |
| `'earn'` | `updateEarnVaults` (multicall lens generator) |
| `'securitize'` | `updateSecuritizeVaults` |
| `null` (subgraph hasn't indexed) | **skipped** — diagnostic warn fires; the next `loadVaults` cycle resolves it once the subgraph catches up |

The bulk loaders are invoked with `silent=true` so loading flags stay untouched (this runs after the initial reveal). Skipping null-category addresses avoids the legacy probe-and-guess path that misidentifies brand-new escrows as plain EVK.

**What changed**
- New pure helper `extractUnresolvedCollateralAddresses(evkVaults, isInRegistry, nowSeconds?)` in `entities/vault/collateral-discovery.ts` — returns the unique set of collateral addresses referenced by *live* edges (`isLiveCollateralEdge`) but not in the registry. Skips zero address. Snapshots the clock once. Tested in isolation.
- `composables/useVaults.ts`: after the existing `Promise.all(...)` for EVK / Earn / Securitize / escrow loaders, run a lazy-resolve pass that categorises every unknown via `fetchVaultCategory`, groups by category, and delegates to the existing bulk loaders. Generation guard preserved so chain switches abort cleanly. Non-explorable addresses are filtered out before fetching.
- Single-pass (not fixed-point): discovery views (matrix, graph, collateral-exposure block) iterate only product-member vaults, so a newly resolved off-label vault is a leaf in those views. Any second-hop unknowns will produce diagnostic warns and resolve on the next `loadVaults` cycle.
- Unit coverage in `tests/entities/vault/collateral-discovery.test.ts`: live unknown collaterals are surfaced, registry hits are skipped, fully ramped-out edges are excluded, mid-ramp edges are kept, zero address skipped, dedupe across vaults, case-insensitive registry membership, snapshotted-clock contract pinned.

**Validation**
- `npm run test:run` — full suite (441 tests) passes.
- `npm run test:run -- tests/entities/vault/collateral-discovery.test.ts` — 8/8 pass.
- Manual smoke (post-merge of #309 + this): on a product whose borrowable vault references an EVK vault not in any product label, expect the collateral to resolve and appear in the matrix/graph/exposure block within one load cycle.

**Stacked on**
PR #309 (`feature/eul4-147-ramping-node-fix`) — depends on the shared `isLiveCollateralEdge` predicate introduced there. Base will be re-targeted to `development` once #309 merges.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated collateral discovery that identifies and resolves unregistered collateral addresses referenced by vaults during loading.
  * Implemented lazy loading of collateral assets to improve efficiency and performance.

* **Tests**
  * Added comprehensive test coverage for collateral address extraction and resolution logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->