### PR TITLE
Fix stable selection of best swap quote

### DIFF
--- a/composables/useSwapQuotesParallel.ts
+++ b/composables/useSwapQuotesParallel.ts
@@ -38,16 +38,30 @@ export const useSwapQuotesParallel = (options: SwapQuotesParallelOptions) => {
   const sortedQuoteCards = computed(() =>
     sortQuoteCards(quoteCards.value, options.amountField, options.compare),
   )
-  const bestQuote = computed(() => sortedQuoteCards.value[0]?.quote || null)
+  const bestQuoteCard = computed(() => sortedQuoteCards.value[0] || null)
+  const bestQuote = computed(() => bestQuoteCard.value?.quote || null)
   const bestAmount = computed(() => getQuoteAmount(bestQuote.value, options.amountField))
-  const selectedQuote = computed(() => {
+  const selectedQuoteCard = computed(() => {
     if (!selectedProvider.value) {
       return null
     }
     const match = quoteCards.value.find(card => card.provider === selectedProvider.value)
-    return match?.quote || null
+    return match || null
   })
-  const effectiveQuote = computed(() => selectedQuote.value || bestQuote.value)
+  const selectedQuote = computed(() => selectedQuoteCard.value?.quote || null)
+  const effectiveQuoteCard = computed<SwapQuoteCard | null>((previous) => {
+    const next = selectedQuoteCard.value || bestQuoteCard.value
+    if (
+      previous
+      && next
+      && previous.provider === next.provider
+      && previous.quote === next.quote
+    ) {
+      return previous
+    }
+    return next
+  })
+  const effectiveQuote = computed(() => effectiveQuoteCard.value?.quote || null)
   const statusLabel = computed(() => {
     if (!providersCount.value) {
       return null
@@ -186,6 +200,9 @@ export const useSwapQuotesParallel = (options: SwapQuotesParallelOptions) => {
   }
 
   const selectProvider = (provider: string) => {
+    if (selectedProvider.value === provider) {
+      return
+    }
     selectedProvider.value = provider
   }
 

--- a/tests/composables/useSwapQuotesParallel.test.ts
+++ b/tests/composables/useSwapQuotesParallel.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { computed, nextTick, ref, watch } from 'vue'
+import type { SwapApiQuote } from '~/entities/swap'
+import { useSwapQuotesParallel } from '~/composables/useSwapQuotesParallel'
+
+const makeQuote = (amountIn: string, amountOut: string): SwapApiQuote =>
+  ({ amountIn, amountOut }) as SwapApiQuote
+
+const requestParams = {
+  tokenIn: '0x0000000000000000000000000000000000000001',
+  tokenOut: '0x0000000000000000000000000000000000000002',
+  accountIn: '0x0000000000000000000000000000000000000003',
+  accountOut: '0x0000000000000000000000000000000000000004',
+  amount: 100n,
+  vaultIn: '0x0000000000000000000000000000000000000005',
+  receiver: '0x0000000000000000000000000000000000000006',
+} as const satisfies Parameters<ReturnType<typeof useSwapQuotesParallel>['requestQuotes']>[0]
+
+const flushPromises = () => new Promise(resolve => setTimeout(resolve, 0))
+
+describe('useSwapQuotesParallel', () => {
+  let getSwapProviders: ReturnType<typeof vi.fn>
+  let getSwapQuotes: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    getSwapProviders = vi.fn()
+    getSwapQuotes = vi.fn()
+
+    vi.stubGlobal('ref', ref)
+    vi.stubGlobal('computed', computed)
+    vi.stubGlobal('watch', watch)
+    vi.stubGlobal('useSwapApi', () => ({
+      getSwapProviders,
+      getSwapQuotes,
+    }))
+  })
+
+  it('keeps effectiveQuote stable when selecting the current best provider', async () => {
+    const firstQuote = makeQuote('100', '200')
+    getSwapProviders.mockResolvedValue(['first'])
+    getSwapQuotes.mockResolvedValue([firstQuote])
+
+    const quotes = useSwapQuotesParallel({ amountField: 'amountOut', compare: 'max' })
+    await quotes.requestQuotes(requestParams)
+    await flushPromises()
+    await nextTick()
+
+    const changes: Array<SwapApiQuote | null> = []
+    watch(quotes.effectiveQuote, quote => changes.push(quote))
+
+    quotes.selectProvider('first')
+    await nextTick()
+
+    expect(quotes.selectedProvider.value).toBe('first')
+    expect(quotes.selectedQuote.value).toBe(quotes.effectiveQuote.value)
+    expect(changes).toEqual([])
+  })
+
+  it('updates effectiveQuote when selecting a non-best provider', async () => {
+    const bestQuote = makeQuote('100', '300')
+    const otherQuote = makeQuote('100', '200')
+    getSwapProviders.mockResolvedValue(['best', 'other'])
+    getSwapQuotes.mockImplementation(({ provider }: { provider: string }) =>
+      Promise.resolve([provider === 'best' ? bestQuote : otherQuote]),
+    )
+
+    const quotes = useSwapQuotesParallel({ amountField: 'amountOut', compare: 'max' })
+    await quotes.requestQuotes(requestParams)
+    await flushPromises()
+    await nextTick()
+
+    const changes: Array<SwapApiQuote | null> = []
+    watch(quotes.effectiveQuote, quote => changes.push(quote))
+
+    quotes.selectProvider('other')
+    await nextTick()
+
+    expect(quotes.selectedProvider.value).toBe('other')
+    expect(quotes.effectiveQuote.value?.amountOut).toBe('200')
+    expect(changes).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
## Summary
- Prevent selecting the already-best swap route from notifying quote watchers as though the effective quote changed.
- Preserve normal route selection behavior when choosing a different provider.

## Changes
- Track selected and best quote cards separately so the effective quote remains referentially stable when the provider and quote are unchanged.
- Make repeated provider selection idempotent.
- Add regression coverage for selecting the current best provider and for selecting a non-best provider.

## Test plan
- [x] npm run test:run -- tests/composables/useSwapQuotesParallel.test.ts tests/utils/swap-quotes.test.ts
- [x] Manual smoke: wallet, collateral, and savings repay route selection does not refresh the swap API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved swap quote selection logic to prevent redundant state updates.

* **Tests**
  * Added test coverage for swap quote selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->