### PR TITLE
Fix swap quote slippage validation

### DIFF
--- a/components/entities/swap/SwapDetailsSummary.vue
+++ b/components/entities/swap/SwapDetailsSummary.vue
@@ -2,11 +2,12 @@
 import { isPriceImpactWarning, isSlippageWarning } from '~/utils/priceImpact'
 import { formatNumber } from '~/utils/string-utils'
 
-defineProps<{
+const props = defineProps<{
   inputDisplay: string | null
   outputDisplay: string | null
   priceImpact: number | null
   slippage: number
+  quoteSlippage?: number | null
   routedVia: string | null
   multipliedPriceImpact?: number | null
 }>()
@@ -14,6 +15,20 @@ defineProps<{
 const emit = defineEmits<{
   (e: 'openSlippageSettings'): void
 }>()
+
+const SLIPPAGE_DIFF_TOLERANCE = 0.005
+
+const slippageDiffers = computed(() =>
+  props.quoteSlippage !== null
+  && props.quoteSlippage !== undefined
+  && Math.abs(props.quoteSlippage - props.slippage) >= SLIPPAGE_DIFF_TOLERANCE,
+)
+
+const quoteSlippageLabel = computed(() =>
+  props.quoteSlippage !== null && props.quoteSlippage !== undefined
+    ? formatNumber(props.quoteSlippage, 2, 0)
+    : '',
+)
 </script>
 
 <template>
@@ -68,6 +83,12 @@ const emit = defineEmits<{
           class="!w-16 !h-16 text-accent-600"
         />
       </button>
+      <span
+        v-if="slippageDiffers"
+        class="text-p4 text-warning-500 text-right"
+      >
+        Quote applies {{ quoteSlippageLabel }}% slippage
+      </span>
     </div>
   </SummaryRow>
   <SummaryRow

--- a/composables/borrow/useBorrowForm.ts
+++ b/composables/borrow/useBorrowForm.ts
@@ -29,6 +29,7 @@ import { useSwapPriceImpact } from '~/composables/useSwapPriceImpact'
 import { buildSwapRouteItems } from '~/utils/swapRouteItems'
 import { formatSmartAmount, trimTrailingZeros } from '~/utils/string-utils'
 import { nanoToValue } from '~/utils/crypto-utils'
+import { computeQuoteSlippage } from '~/utils/swapQuotes'
 import { isOperationBlocked } from '~/utils/operationGuardRegistry'
 import type { TxPlan } from '~/entities/txPlan'
 import { getPlanHookDisabledWarning, getUtilisationWarning, getBorrowCapWarning, getSupplyCapWarning } from '~/composables/useVaultWarnings'
@@ -125,6 +126,7 @@ export const useBorrowForm = (options: UseBorrowFormOptions) => {
     requestQuotes: requestBorrowSwapQuotes,
     selectProvider: selectBorrowSwapQuote,
   } = useSwapQuotesParallel({ amountField: 'amountOut', compare: 'max' })
+  const borrowSwapQuoteSlippage = computed(() => computeQuoteSlippage(borrowSwapEffectiveQuote.value))
 
   // --- Form state ---
   const ltv = ref(0)
@@ -598,6 +600,7 @@ export const useBorrowForm = (options: UseBorrowFormOptions) => {
       borrowVaultAddress: borrowVault.value.address as Address,
       borrowAmount: borrowAmountNano,
       swapQuote: quote,
+      requestedSlippage: borrowSwapSlippage.value,
       subAccount,
       includePermit2Call: planOptions.includePermit2Call,
       wrappedNativeInfo: isNative && wrappedAddress
@@ -948,6 +951,7 @@ export const useBorrowForm = (options: UseBorrowFormOptions) => {
     borrowSwapInputDisplay,
     borrowSwapOutputDisplay,
     borrowSwapRoutedVia,
+    borrowSwapQuoteSlippage,
     borrowSwapPriceImpact,
     borrowSwapRouteItems,
 

--- a/composables/borrow/useMultiplyForm.ts
+++ b/composables/borrow/useMultiplyForm.ts
@@ -38,7 +38,7 @@ import { useSwapQuotesParallel } from '~/composables/useSwapQuotesParallel'
 import { useEulerProductOfVault } from '~/composables/useEulerLabels'
 import { findBlockingDisabledOp, OP_BORROW, OP_DEPOSIT, OP_SKIM, OP_TRANSFER, type PlannedOp } from '~/utils/vault-hooks'
 
-type MultiplyPlanParams = {
+type MultiplyPlanParamsCommon = {
   supplyVaultAddress: string
   supplyAssetAddress: string
   supplyAmount: bigint
@@ -48,11 +48,12 @@ type MultiplyPlanParams = {
   longAssetAddress: string
   borrowVaultAddress: string
   debtAmount: bigint
-  quote?: SwapApiQuote
-  requestedSlippage?: number
   swapperMode: SwapperMode
   subAccount: string
 }
+type MultiplyPlanParams
+  = | (MultiplyPlanParamsCommon & { quote: SwapApiQuote, requestedSlippage: number })
+    | (MultiplyPlanParamsCommon & { quote?: undefined, requestedSlippage?: never })
 
 export interface UseMultiplyFormOptions {
   pair: Ref<AnyBorrowVaultPair | undefined>
@@ -773,7 +774,7 @@ export const useMultiplyForm = (options: UseMultiplyFormOptions) => {
         return
       }
 
-      const planParams: MultiplyPlanParams = {
+      const baseParams: MultiplyPlanParamsCommon = {
         supplyVaultAddress: multiplySupplyVault.value.address,
         supplyAssetAddress: multiplySupplyVault.value.asset.address,
         supplyAmount: supplyAmountNano,
@@ -783,11 +784,12 @@ export const useMultiplyForm = (options: UseMultiplyFormOptions) => {
         longAssetAddress: multiplyLongVault.value.asset.address,
         borrowVaultAddress: multiplyShortVault.value.address,
         debtAmount,
-        quote: quote || undefined,
-        requestedSlippage: multiplySlippage.value,
         swapperMode: SwapperMode.EXACT_IN,
         subAccount,
       }
+      const planParams: MultiplyPlanParams = quote
+        ? { ...baseParams, quote, requestedSlippage: multiplySlippage.value }
+        : baseParams
       multiplyPlanParams.value = planParams
 
       try {

--- a/composables/borrow/useMultiplyForm.ts
+++ b/composables/borrow/useMultiplyForm.ts
@@ -27,6 +27,7 @@ import { buildSwapRouteItems } from '~/utils/swapRouteItems'
 import { formatSmartAmount, trimTrailingZeros } from '~/utils/string-utils'
 import { nanoToValue } from '~/utils/crypto-utils'
 import { computeMultipliedPriceImpact } from '~/utils/priceImpact'
+import { computeQuoteSlippage } from '~/utils/swapQuotes'
 import { calculateRoe, computeNextHealth, computeLiquidationPrice } from '~/utils/repayUtils'
 import { computeMaxMultiplier, computeMinMultiplier, computeWeightedSupplyApy, computeLeverageDebt } from '~/utils/multiply-math'
 import type { TxPlan } from '~/entities/txPlan'
@@ -48,6 +49,7 @@ type MultiplyPlanParams = {
   borrowVaultAddress: string
   debtAmount: bigint
   quote?: SwapApiQuote
+  requestedSlippage?: number
   swapperMode: SwapperMode
   subAccount: string
 }
@@ -118,6 +120,7 @@ export const useMultiplyForm = (options: UseMultiplyFormOptions) => {
     requestQuotes: requestMultiplyQuotes,
     selectProvider: selectMultiplyQuote,
   } = useSwapQuotesParallel({ amountField: 'amountOut', compare: 'max' })
+  const multiplyQuoteSlippage = computed(() => computeQuoteSlippage(multiplyEffectiveQuote.value))
 
   // --- Form state ---
   const multiplyInputAmount = ref('')
@@ -781,6 +784,7 @@ export const useMultiplyForm = (options: UseMultiplyFormOptions) => {
         borrowVaultAddress: multiplyShortVault.value.address,
         debtAmount,
         quote: quote || undefined,
+        requestedSlippage: multiplySlippage.value,
         swapperMode: SwapperMode.EXACT_IN,
         subAccount,
       }
@@ -979,6 +983,7 @@ export const useMultiplyForm = (options: UseMultiplyFormOptions) => {
     isMultiplyQuoteLoading,
     multiplyQuoteError,
     multiplyQuotesStatusLabel,
+    multiplyQuoteSlippage,
     selectMultiplyQuote,
 
     // USD values

--- a/composables/position/useCollateralForm.ts
+++ b/composables/position/useCollateralForm.ts
@@ -34,6 +34,7 @@ import { useSwapPriceImpact } from '~/composables/useSwapPriceImpact'
 import { usePriceImpactGate } from '~/composables/usePriceImpactGate'
 import { formatSmartAmount } from '~/utils/string-utils'
 import { nanoToValue } from '~/utils/crypto-utils'
+import { computeQuoteSlippage } from '~/utils/swapQuotes'
 import { normalizeAddressOrEmpty } from '~/utils/accountPositionHelpers'
 import { isOpDisabled, OP_DEPOSIT, OP_WITHDRAW } from '~/utils/vault-hooks'
 import { getHookDisabledWarning } from '~/composables/useVaultWarnings'
@@ -82,6 +83,7 @@ export interface UseCollateralFormOptions {
   buildSwapPlan: (quote: SwapApiQuote, ctx: {
     vaultAddress: string
     amountNano: bigint
+    slippage: number
     subAccount?: string
     includePermit2Call?: boolean
   }) => Promise<TxPlan>
@@ -160,6 +162,7 @@ export const useCollateralForm = (options: UseCollateralFormOptions) => {
     requestQuotes: requestSwapQuotes,
     selectProvider: selectSwapQuote,
   } = useSwapQuotesParallel({ amountField: 'amountOut', compare: 'max' })
+  const swapQuoteSlippage = computed(() => computeQuoteSlippage(swapEffectiveQuote.value))
 
   // --- Position/vault computeds ---
   const position = computed(() => getPositionBySubAccountIndex(+positionIndex))
@@ -588,6 +591,7 @@ export const useCollateralForm = (options: UseCollateralFormOptions) => {
             plan.value = await options.buildSwapPlan(swapEffectiveQuote.value, {
               vaultAddress: collateralVault.value.address,
               amountNano: valueToNano(amount.value || '0', asset.value.decimals),
+              slippage: swapSlippage.value,
               subAccount: position.value?.subAccount,
               includePermit2Call: false,
             })
@@ -649,6 +653,7 @@ export const useCollateralForm = (options: UseCollateralFormOptions) => {
         txPlan = await options.buildSwapPlan(quote, {
           vaultAddress: collateralVault.value.address,
           amountNano: valueToNano(amount.value || '0', asset.value.decimals),
+          slippage: swapSlippage.value,
           subAccount: position.value?.subAccount,
         })
       }
@@ -763,6 +768,7 @@ export const useCollateralForm = (options: UseCollateralFormOptions) => {
     swapSelectedProvider,
     swapSelectedQuote,
     swapEffectiveQuote,
+    swapQuoteSlippage,
     swapProvidersCount,
     isSwapQuoteLoading,
     swapQuoteError,

--- a/composables/repay/useCollateralSwapRepay.ts
+++ b/composables/repay/useCollateralSwapRepay.ts
@@ -20,6 +20,7 @@ import { getSwapInputAmount } from '~/composables/useEulerOperations/swaps/verif
 import { nanoToValue, valueToNano } from '~/utils/crypto-utils'
 import { normalizeAddressOrEmpty } from '~/utils/accountPositionHelpers'
 import { createRaceGuard } from '~/utils/race-guard'
+import { computeQuoteSlippage } from '~/utils/swapQuotes'
 import { findBlockingDisabledOp, OP_REPAY, OP_REPAY_WITH_SHARES, OP_SKIM, OP_TRANSFER, OP_WITHDRAW, type PlannedOp } from '~/utils/vault-hooks'
 import { getPlanHookDisabledWarning } from '~/composables/useVaultWarnings'
 
@@ -128,6 +129,7 @@ export const useCollateralSwapRepay = (options: UseCollateralSwapRepayOptions) =
     borrowVault,
     direction: core.direction,
   })
+  const quoteSlippage = computed(() => computeQuoteSlippage(core.quotes.effectiveQuote.value, core.direction.value))
 
   // --- APYs ---
   const collateralSupplyApy = computed(() => {
@@ -368,6 +370,7 @@ export const useCollateralSwapRepay = (options: UseCollateralSwapRepayOptions) =
       return buildSwapFullRepayPlan({
         quote: core.quotes.selectedQuote.value,
         swapperMode: swapMode,
+        requestedSlippage: slippage.value,
         targetDebt,
         currentDebt,
         liabilityVault: borrowVault.value.address,
@@ -380,6 +383,7 @@ export const useCollateralSwapRepay = (options: UseCollateralSwapRepayOptions) =
       quote: core.quotes.selectedQuote.value,
       swapperMode: swapMode,
       isRepay: true,
+      requestedSlippage: slippage.value,
       targetDebt,
       currentDebt,
       liabilityVault: borrowVault.value.address,
@@ -497,6 +501,7 @@ export const useCollateralSwapRepay = (options: UseCollateralSwapRepayOptions) =
     // Swap details
     currentPrice: details.currentPrice,
     summary: details.summary,
+    quoteSlippage,
     priceImpact: details.priceImpact,
     leveragedPriceImpact: details.leveragedPriceImpact,
     routedVia: details.routedVia,

--- a/composables/repay/useSavingsRepay.ts
+++ b/composables/repay/useSavingsRepay.ts
@@ -18,6 +18,7 @@ import { useRepayHealthMetrics } from '~/composables/repay/useRepayHealthMetrics
 import { getSwapInputAmount } from '~/composables/useEulerOperations/swaps/verify'
 import { nanoToValue, valueToNano } from '~/utils/crypto-utils'
 import { createRaceGuard } from '~/utils/race-guard'
+import { computeQuoteSlippage } from '~/utils/swapQuotes'
 import { findBlockingDisabledOp, OP_REPAY_WITH_SHARES, OP_SKIM, OP_TRANSFER, OP_WITHDRAW, type PlannedOp } from '~/utils/vault-hooks'
 import { getPlanHookDisabledWarning } from '~/composables/useVaultWarnings'
 
@@ -107,6 +108,7 @@ export const useSavingsRepay = (options: UseSavingsRepayOptions) => {
     borrowVault,
     direction: core.direction,
   })
+  const quoteSlippage = computed(() => computeQuoteSlippage(core.quotes.effectiveQuote.value, core.direction.value))
 
   // --- Savings-specific computeds ---
   const collateralAmountAfter = computed(() => {
@@ -290,6 +292,7 @@ export const useSavingsRepay = (options: UseSavingsRepayOptions) => {
       return buildSwapFullRepayPlan({
         quote: core.quotes.selectedQuote.value,
         swapperMode: swapMode,
+        requestedSlippage: slippage.value,
         targetDebt,
         currentDebt,
         liabilityVault: borrowVault.value.address,
@@ -302,6 +305,7 @@ export const useSavingsRepay = (options: UseSavingsRepayOptions) => {
       quote: core.quotes.selectedQuote.value,
       swapperMode: swapMode,
       isRepay: true,
+      requestedSlippage: slippage.value,
       targetDebt,
       currentDebt,
       liabilityVault: borrowVault.value.address,
@@ -427,6 +431,7 @@ export const useSavingsRepay = (options: UseSavingsRepayOptions) => {
     // Swap details
     currentPrice: details.currentPrice,
     summary: details.summary,
+    quoteSlippage,
     priceImpact: details.priceImpact,
     leveragedPriceImpact: details.leveragedPriceImpact,
     routedVia: details.routedVia,

--- a/composables/repay/useWalletSwapRepay.ts
+++ b/composables/repay/useWalletSwapRepay.ts
@@ -18,6 +18,7 @@ import { amountToPercent, percentToAmountNano } from '~/utils/repayUtils'
 import { SwapperMode } from '~/entities/swap'
 import { createRaceGuard } from '~/utils/race-guard'
 import { buildSwapRouteItems } from '~/utils/swapRouteItems'
+import { computeQuoteSlippage } from '~/utils/swapQuotes'
 import { useSwapPriceImpact } from '~/composables/useSwapPriceImpact'
 import { useSwapRepayQuotes } from '~/composables/repay/useSwapRepayQuotes'
 import { getSwapInputAmount } from '~/composables/useEulerOperations/swaps/verify'
@@ -86,6 +87,7 @@ export const useWalletSwapRepay = (options: UseWalletSwapRepayOptions) => {
 
   // --- Swap quotes (dual-direction) ---
   const quotes = useSwapRepayQuotes({ direction })
+  const quoteSlippage = computed(() => computeQuoteSlippage(quotes.effectiveQuote.value, direction.value))
 
   // --- Derived ---
   const needsSwap = computed(() => {
@@ -619,6 +621,14 @@ export const useWalletSwapRepay = (options: UseWalletSwapRepayOptions) => {
     }
   })
 
+  watch(slippage, () => {
+    if (formTab.value !== 'wallet' || !needsSwap.value) return
+    clearSimulationError()
+    quotes.reset()
+    resetDerivedState()
+    requestQuote()
+  })
+
   // --- Watch quote changes → sync opposite field + estimates ---
   watch([quotes.effectiveQuote, direction], () => {
     if (formTab.value !== 'wallet' || !needsSwap.value) return
@@ -675,6 +685,7 @@ export const useWalletSwapRepay = (options: UseWalletSwapRepayOptions) => {
       inputTokenAddress: (wrappedAddress || selectedAsset.value.address) as Address,
       inputAmount,
       quote: quotes.selectedQuote.value,
+      requestedSlippage: slippage.value,
       borrowVaultAddress: borrowVault.value.address as Address,
       subAccount: (position.value.subAccount || address.value || zeroAddress) as Address,
       enabledCollaterals: position.value.collaterals ?? [collateralVault.value.address],
@@ -799,6 +810,7 @@ export const useWalletSwapRepay = (options: UseWalletSwapRepayOptions) => {
     swapInputDisplay,
     swapOutputDisplay,
     swapRoutedVia,
+    quoteSlippage,
     swapPriceImpact,
     swapRouteItems,
     isFullRepay,

--- a/composables/useEulerOperations/swaps/cross-asset.ts
+++ b/composables/useEulerOperations/swaps/cross-asset.ts
@@ -21,6 +21,7 @@ export const createCrossAssetSwapBuilders = (
     quote,
     swapperMode,
     isRepay,
+    requestedSlippage,
     targetDebt = 0n,
     currentDebt = 0n,
     enableCollateral = false,
@@ -32,6 +33,7 @@ export const createCrossAssetSwapBuilders = (
     quote: SwapApiQuote
     swapperMode: SwapperMode
     isRepay: boolean
+    requestedSlippage: number
     targetDebt?: bigint
     currentDebt?: bigint
     enableCollateral?: boolean
@@ -61,7 +63,7 @@ export const createCrossAssetSwapBuilders = (
       throw new Error('Swap amount is zero')
     }
 
-    const verifierData = buildSwapVerifierData({ quote, swapperMode, isRepay, targetDebt, currentDebt })
+    const verifierData = buildSwapVerifierData({ quote, swapperMode, isRepay, requestedSlippage, targetDebt, currentDebt })
 
     if (verifierData.toLowerCase() !== quote.verify.verifierData.toLowerCase()) {
       logWarn('swap', 'SwapVerifier data mismatch')
@@ -180,6 +182,7 @@ export const createCrossAssetSwapBuilders = (
     quote,
     swapperMode = SwapperMode.EXACT_IN,
     isRepay = false,
+    requestedSlippage,
     targetDebt = 0n,
     currentDebt = 0n,
     enableCollateral = false,
@@ -191,6 +194,7 @@ export const createCrossAssetSwapBuilders = (
     quote: SwapApiQuote
     swapperMode?: SwapperMode
     isRepay?: boolean
+    requestedSlippage: number
     targetDebt?: bigint
     currentDebt?: bigint
     enableCollateral?: boolean
@@ -201,6 +205,7 @@ export const createCrossAssetSwapBuilders = (
   }): Promise<TxPlan> => {
     const { evcCalls, evcAddress: _evcAddress, totalValue: _totalValue } = await buildSwapEvcCalls({
       quote, swapperMode, isRepay, targetDebt, currentDebt,
+      requestedSlippage,
       enableCollateral, disableCollateral, liabilityVault, enabledCollaterals, isDebtSwap,
     })
 
@@ -216,6 +221,7 @@ export const createCrossAssetSwapBuilders = (
   const buildSwapFullRepayPlan = async ({
     quote,
     swapperMode = SwapperMode.EXACT_IN,
+    requestedSlippage,
     targetDebt = 0n,
     currentDebt = 0n,
     liabilityVault,
@@ -224,6 +230,7 @@ export const createCrossAssetSwapBuilders = (
   }: {
     quote: SwapApiQuote
     swapperMode?: SwapperMode
+    requestedSlippage: number
     targetDebt?: bigint
     currentDebt?: bigint
     liabilityVault?: string
@@ -240,6 +247,7 @@ export const createCrossAssetSwapBuilders = (
 
     const { evcCalls } = await buildSwapEvcCalls({
       quote, swapperMode, isRepay: true, targetDebt, currentDebt,
+      requestedSlippage,
       liabilityVault, enabledCollaterals,
     })
 

--- a/composables/useEulerOperations/swaps/supply-borrow.ts
+++ b/composables/useEulerOperations/swaps/supply-borrow.ts
@@ -25,12 +25,14 @@ export const createSupplyBorrowSwapBuilders = (
     inputTokenAddress,
     inputAmount,
     quote,
+    requestedSlippage,
     includePermit2Call = true,
     wrappedNativeInfo,
   }: {
     inputTokenAddress: Address
     inputAmount: bigint
     quote: SwapApiQuote
+    requestedSlippage: number
     includePermit2Call?: boolean
     wrappedNativeInfo?: { wrappedTokenAddress: Address, nativeAmount: bigint }
   }): Promise<TxPlan> => {
@@ -95,7 +97,7 @@ export const createSupplyBorrowSwapBuilders = (
       throw new Error('Swap verifier type mismatch')
     }
 
-    const verifierData = buildSwapVerifierData({ quote, swapperMode: SwapperMode.EXACT_IN, isRepay: false })
+    const verifierData = buildSwapVerifierData({ quote, swapperMode: SwapperMode.EXACT_IN, isRepay: false, requestedSlippage })
     if (verifierData.toLowerCase() !== quote.verify.verifierData.toLowerCase()) {
       logWarn('swap-supply', 'SwapVerifier data mismatch')
       throw new Error('SwapVerifier data mismatch')
@@ -127,6 +129,7 @@ export const createSupplyBorrowSwapBuilders = (
     borrowVaultAddress,
     borrowAmount: borrowAmountParam,
     swapQuote,
+    requestedSlippage,
     subAccount,
     enabledCollaterals,
     includePermit2Call = true,
@@ -138,6 +141,7 @@ export const createSupplyBorrowSwapBuilders = (
     borrowVaultAddress: Address
     borrowAmount: bigint
     swapQuote: SwapApiQuote
+    requestedSlippage: number
     subAccount?: string
     enabledCollaterals?: string[]
     includePermit2Call?: boolean
@@ -209,7 +213,7 @@ export const createSupplyBorrowSwapBuilders = (
       throw new Error('Swap verifier type mismatch')
     }
 
-    const verifierData = buildSwapVerifierData({ quote: swapQuote, swapperMode: SwapperMode.EXACT_IN, isRepay: false })
+    const verifierData = buildSwapVerifierData({ quote: swapQuote, swapperMode: SwapperMode.EXACT_IN, isRepay: false, requestedSlippage })
     if (verifierData.toLowerCase() !== swapQuote.verify.verifierData.toLowerCase()) {
       logWarn('swap-borrow', 'SwapVerifier data mismatch')
       throw new Error('SwapVerifier data mismatch')
@@ -280,12 +284,14 @@ export const createSupplyBorrowSwapBuilders = (
     vaultAddress: vaultAddr,
     assetsAmount,
     quote,
+    requestedSlippage,
     subAccount,
     options = {},
   }: {
     vaultAddress: Address
     assetsAmount: bigint
     quote: SwapApiQuote
+    requestedSlippage: number
     subAccount?: string
     options?: { includePythUpdate?: boolean, liabilityVault?: string, enabledCollaterals?: string[] }
   }): Promise<TxPlan> => {
@@ -331,7 +337,7 @@ export const createSupplyBorrowSwapBuilders = (
       throw new Error('Swap verifier type mismatch')
     }
 
-    const verifierData = buildSwapVerifierData({ quote, swapperMode: SwapperMode.EXACT_IN, isRepay: false })
+    const verifierData = buildSwapVerifierData({ quote, swapperMode: SwapperMode.EXACT_IN, isRepay: false, requestedSlippage })
     if (verifierData.toLowerCase() !== quote.verify.verifierData.toLowerCase()) {
       logWarn('swap-withdraw', 'SwapVerifier data mismatch')
       throw new Error('SwapVerifier data mismatch')
@@ -368,12 +374,14 @@ export const createSupplyBorrowSwapBuilders = (
     vaultAddress: vaultAddr,
     sharesAmount,
     quote,
+    requestedSlippage,
     subAccount,
     options = {},
   }: {
     vaultAddress: Address
     sharesAmount: bigint
     quote: SwapApiQuote
+    requestedSlippage: number
     subAccount?: string
     options?: { includePythUpdate?: boolean, liabilityVault?: string, enabledCollaterals?: string[] }
   }): Promise<TxPlan> => {
@@ -419,7 +427,7 @@ export const createSupplyBorrowSwapBuilders = (
       throw new Error('Swap verifier type mismatch')
     }
 
-    const redeemVerifierData = buildSwapVerifierData({ quote, swapperMode: SwapperMode.EXACT_IN, isRepay: false })
+    const redeemVerifierData = buildSwapVerifierData({ quote, swapperMode: SwapperMode.EXACT_IN, isRepay: false, requestedSlippage })
     if (redeemVerifierData.toLowerCase() !== quote.verify.verifierData.toLowerCase()) {
       logWarn('swap-redeem', 'SwapVerifier data mismatch')
       throw new Error('SwapVerifier data mismatch')
@@ -457,6 +465,7 @@ export const createSupplyBorrowSwapBuilders = (
     inputTokenAddress,
     inputAmount,
     quote,
+    requestedSlippage,
     borrowVaultAddress,
     subAccount,
     enabledCollaterals,
@@ -470,6 +479,7 @@ export const createSupplyBorrowSwapBuilders = (
     inputTokenAddress: Address
     inputAmount: bigint
     quote: SwapApiQuote
+    requestedSlippage: number
     borrowVaultAddress: Address
     subAccount: Address
     enabledCollaterals?: string[]
@@ -495,7 +505,7 @@ export const createSupplyBorrowSwapBuilders = (
       throw new Error('Swap verifier type mismatch')
     }
 
-    const verifierData = buildSwapVerifierData({ quote, swapperMode, isRepay: true, targetDebt, currentDebt })
+    const verifierData = buildSwapVerifierData({ quote, swapperMode, isRepay: true, requestedSlippage, targetDebt, currentDebt })
     if (verifierData.toLowerCase() !== quote.verify.verifierData.toLowerCase()) {
       logWarn('swap-repay', 'SwapVerifier data mismatch')
       throw new Error('SwapVerifier data mismatch')

--- a/composables/useEulerOperations/swaps/verify.ts
+++ b/composables/useEulerOperations/swaps/verify.ts
@@ -3,6 +3,37 @@ import { adjustForInterest } from '../helpers'
 import { swapVerifierAbi } from '~/entities/euler/abis'
 import { type SwapApiQuote, SwapperMode, SwapVerificationType } from '~/entities/swap'
 
+const MAX_SLIPPAGE = 50
+const SLIPPAGE_DIVERGENCE_NUMERATOR = 10_001n
+const SLIPPAGE_DIVERGENCE_DENOMINATOR = 10_000n
+
+type SwapQuoteSlippageValidationContext = {
+  actualSlippage: string
+  expectedAmount: bigint
+  field: 'amountInMax' | 'amountOutMin'
+  mode: 'input' | 'output'
+  quote: SwapApiQuote
+  quoteSlippage: number | undefined
+  requestedSlippage: number
+}
+
+type SwapQuoteSlippageLogSummary = {
+  actualSlippage: string
+  amountIn: string
+  amountInMax: string
+  amountOut: string
+  amountOutMin: string
+  checkedAmount: string
+  expectedAmount: string
+  field: 'amountInMax' | 'amountOutMin'
+  mode: 'input' | 'output'
+  quoteSlippage?: string
+  requestedSlippage: string
+  route?: string
+  status: 'failed' | 'passed'
+  fullQuote?: SwapApiQuote
+}
+
 export const getSwapInputAmount = (quote: SwapApiQuote, swapperMode: SwapperMode) => {
   const amountIn = BigInt(quote.amountIn || 0)
   const amountInMax = BigInt(quote.amountInMax || 0)
@@ -10,19 +41,199 @@ export const getSwapInputAmount = (quote: SwapApiQuote, swapperMode: SwapperMode
   return amountInMax > 0n ? amountInMax : amountIn
 }
 
+export function validateSwapQuoteSlippageData(
+  request: { slippage?: number, swapperMode?: SwapperMode },
+  quote: SwapApiQuote,
+): void {
+  const { slippage } = request
+
+  if (
+    slippage === undefined
+    || !Number.isFinite(slippage)
+    || slippage > MAX_SLIPPAGE
+    || slippage < 0
+  ) {
+    throw new Error('Valid slippage between 0 and 50% must be provided for swap')
+  }
+
+  if (request.swapperMode === SwapperMode.TARGET_DEBT) {
+    const amountIn = BigInt(quote.amountIn)
+    const amountInMax = BigInt(quote.amountInMax)
+    const expectedAmountInMax = applySlippageToInputWithDivergence(amountIn, slippage)
+    const validationContext = {
+      actualSlippage: calculateInputSlippagePercent(amountIn, amountInMax),
+      expectedAmount: expectedAmountInMax,
+      field: 'amountInMax' as const,
+      mode: 'input' as const,
+      quote,
+      quoteSlippage: quote.slippage,
+      requestedSlippage: slippage,
+    }
+
+    if (amountInMax > expectedAmountInMax) {
+      logSwapQuoteSlippageValidation('failed', validationContext)
+      throw new Error('Swap quote amountInMax exceeds requested slippage')
+    }
+
+    logSwapQuoteSlippageValidation('passed', validationContext)
+    return
+  }
+
+  const amountOut = BigInt(quote.amountOut)
+  const amountOutMin = BigInt(quote.amountOutMin)
+  const expectedAmountOutMin = applySlippageToOutputWithDivergence(amountOut, slippage)
+  const validationContext = {
+    actualSlippage: calculateOutputSlippagePercent(amountOut, amountOutMin),
+    expectedAmount: expectedAmountOutMin,
+    field: 'amountOutMin' as const,
+    mode: 'output' as const,
+    quote,
+    quoteSlippage: quote.slippage,
+    requestedSlippage: slippage,
+  }
+
+  if (amountOutMin < expectedAmountOutMin) {
+    logSwapQuoteSlippageValidation('failed', validationContext)
+    throw new Error('Swap quote amountOutMin exceeds requested slippage')
+  }
+
+  logSwapQuoteSlippageValidation('passed', validationContext)
+}
+
+export function applySlippageToOutput(amount: bigint, slippage: number): bigint {
+  const { slippageUnits, denominator } = parseSlippagePercent(slippage)
+  return (amount * (denominator - slippageUnits)) / denominator
+}
+
+export function applySlippageToInput(amount: bigint, slippage: number): bigint {
+  const { slippageUnits, denominator } = parseSlippagePercent(slippage)
+  return (amount * (denominator + slippageUnits) + denominator - 1n) / denominator
+}
+
+function applySlippageToOutputWithDivergence(amount: bigint, slippage: number): bigint {
+  const { slippageUnits, denominator } = parseSlippagePercent(slippage)
+  const adjustedDenominator = denominator * SLIPPAGE_DIVERGENCE_DENOMINATOR
+  const adjustedSlippageUnits = slippageUnits * SLIPPAGE_DIVERGENCE_NUMERATOR
+
+  return (amount * (adjustedDenominator - adjustedSlippageUnits)) / adjustedDenominator
+}
+
+function applySlippageToInputWithDivergence(amount: bigint, slippage: number): bigint {
+  const { slippageUnits, denominator } = parseSlippagePercent(slippage)
+  const adjustedDenominator = denominator * SLIPPAGE_DIVERGENCE_DENOMINATOR
+  const adjustedSlippageUnits = slippageUnits * SLIPPAGE_DIVERGENCE_NUMERATOR
+
+  return (amount * (adjustedDenominator + adjustedSlippageUnits) + adjustedDenominator - 1n) / adjustedDenominator
+}
+
+function parseSlippagePercent(slippage: number): {
+  slippageUnits: bigint
+  denominator: bigint
+} {
+  const slippageString = slippage.toLocaleString('en-US', {
+    useGrouping: false,
+    maximumFractionDigits: 20,
+  })
+  const [whole = '0', fraction = ''] = slippageString.split('.')
+  const scale = 10n ** BigInt(fraction.length)
+  const slippageUnits = BigInt(whole) * scale + BigInt(fraction || '0')
+
+  return {
+    slippageUnits,
+    denominator: 100n * scale,
+  }
+}
+
+function calculateOutputSlippagePercent(amountOut: bigint, amountOutMin: bigint): string {
+  if (amountOut <= 0n) return 'unavailable'
+
+  return formatPercentRatio(amountOut - amountOutMin, amountOut)
+}
+
+function calculateInputSlippagePercent(amountIn: bigint, amountInMax: bigint): string {
+  if (amountIn <= 0n) return 'unavailable'
+
+  return formatPercentRatio(amountInMax - amountIn, amountIn)
+}
+
+function formatPercentRatio(numerator: bigint, denominator: bigint): string {
+  const scale = 10_000n
+  const scaledPercent = (numerator * 100n * scale) / denominator
+  const whole = scaledPercent / scale
+  const fraction = (scaledPercent % scale).toString().padStart(4, '0')
+
+  return `${whole}.${fraction}%`
+}
+
+function logSwapQuoteSlippageValidation(
+  status: 'failed' | 'passed',
+  {
+    actualSlippage,
+    expectedAmount,
+    field,
+    mode,
+    quote,
+    quoteSlippage,
+    requestedSlippage,
+  }: SwapQuoteSlippageValidationContext,
+) {
+  const payload: SwapQuoteSlippageLogSummary = {
+    actualSlippage,
+    amountIn: quote.amountIn,
+    amountInMax: quote.amountInMax,
+    amountOut: quote.amountOut,
+    amountOutMin: quote.amountOutMin,
+    checkedAmount: quote[field],
+    expectedAmount: expectedAmount.toString(),
+    field,
+    mode,
+    quoteSlippage: quoteSlippage === undefined ? undefined : `${quoteSlippage}%`,
+    requestedSlippage: `${requestedSlippage}%`,
+    route: quote.route?.map(item => item.providerName).join(', ') || undefined,
+    status,
+  }
+
+  if (isDevRuntime() && shouldLogFullSwapQuote()) {
+    payload.fullQuote = quote
+  }
+
+  if (status === 'failed') {
+    console.warn('[swapQuoteSlippage] Swap quote exceeds requested slippage', payload)
+    return
+  }
+
+  if (!isDevRuntime()) return
+
+  // eslint-disable-next-line no-console
+  console.info('[swapQuoteSlippage] Swap quote slippage validation', payload)
+}
+
+function isDevRuntime() {
+  return import.meta.env?.DEV === true
+}
+
+function shouldLogFullSwapQuote() {
+  if (typeof localStorage === 'undefined' || typeof localStorage.getItem !== 'function') return false
+  return localStorage.getItem('debug-swap-quotes') === 'true'
+}
+
 export const buildSwapVerifierData = ({
   quote,
   swapperMode,
   isRepay,
+  requestedSlippage,
   targetDebt = 0n,
   currentDebt = 0n,
 }: {
   quote: SwapApiQuote
   swapperMode: SwapperMode
   isRepay: boolean
+  requestedSlippage: number
   targetDebt?: bigint
   currentDebt?: bigint
 }) => {
+  validateSwapQuoteSlippageData({ slippage: requestedSlippage, swapperMode }, quote)
+
   let functionName: 'verifyAmountMinAndSkim' | 'verifyAmountMinAndTransfer' | 'verifyDebtMax'
   let amount: bigint
 

--- a/composables/useEulerOperations/swaps/verify.ts
+++ b/composables/useEulerOperations/swaps/verify.ts
@@ -1,11 +1,15 @@
 import { encodeFunctionData } from 'viem'
 import { adjustForInterest } from '../helpers'
 import { swapVerifierAbi } from '~/entities/euler/abis'
+import { MAX_SLIPPAGE } from '~/entities/constants'
 import { type SwapApiQuote, SwapperMode, SwapVerificationType } from '~/entities/swap'
+import { logWarn } from '~/utils/errorHandling'
 
-const MAX_SLIPPAGE = 50
-const SLIPPAGE_DIVERGENCE_NUMERATOR = 10_001n
-const SLIPPAGE_DIVERGENCE_DENOMINATOR = 10_000n
+// Absolute extra slippage (in percentage points) the validator forgives to absorb
+// BigInt rounding between the swap API and the SDK. Must stay strictly below
+// SLIPPAGE_DIFF_TOLERANCE in SwapDetailsSummary so the user-facing warning never
+// fires on a quote the validator has accepted.
+const VALIDATION_DIVERGENCE_TOLERANCE_PP = 0.001
 
 type SwapQuoteSlippageValidationContext = {
   actualSlippage: string
@@ -57,8 +61,8 @@ export function validateSwapQuoteSlippageData(
   }
 
   if (request.swapperMode === SwapperMode.TARGET_DEBT) {
-    const amountIn = BigInt(quote.amountIn)
-    const amountInMax = BigInt(quote.amountInMax)
+    const amountIn = BigInt(quote.amountIn || 0)
+    const amountInMax = BigInt(quote.amountInMax || 0)
     const expectedAmountInMax = applySlippageToInputWithDivergence(amountIn, slippage)
     const validationContext = {
       actualSlippage: calculateInputSlippagePercent(amountIn, amountInMax),
@@ -79,8 +83,8 @@ export function validateSwapQuoteSlippageData(
     return
   }
 
-  const amountOut = BigInt(quote.amountOut)
-  const amountOutMin = BigInt(quote.amountOutMin)
+  const amountOut = BigInt(quote.amountOut || 0)
+  const amountOutMin = BigInt(quote.amountOutMin || 0)
   const expectedAmountOutMin = applySlippageToOutputWithDivergence(amountOut, slippage)
   const validationContext = {
     actualSlippage: calculateOutputSlippagePercent(amountOut, amountOutMin),
@@ -111,19 +115,11 @@ export function applySlippageToInput(amount: bigint, slippage: number): bigint {
 }
 
 function applySlippageToOutputWithDivergence(amount: bigint, slippage: number): bigint {
-  const { slippageUnits, denominator } = parseSlippagePercent(slippage)
-  const adjustedDenominator = denominator * SLIPPAGE_DIVERGENCE_DENOMINATOR
-  const adjustedSlippageUnits = slippageUnits * SLIPPAGE_DIVERGENCE_NUMERATOR
-
-  return (amount * (adjustedDenominator - adjustedSlippageUnits)) / adjustedDenominator
+  return applySlippageToOutput(amount, slippage + VALIDATION_DIVERGENCE_TOLERANCE_PP)
 }
 
 function applySlippageToInputWithDivergence(amount: bigint, slippage: number): bigint {
-  const { slippageUnits, denominator } = parseSlippagePercent(slippage)
-  const adjustedDenominator = denominator * SLIPPAGE_DIVERGENCE_DENOMINATOR
-  const adjustedSlippageUnits = slippageUnits * SLIPPAGE_DIVERGENCE_NUMERATOR
-
-  return (amount * (adjustedDenominator + adjustedSlippageUnits) + adjustedDenominator - 1n) / adjustedDenominator
+  return applySlippageToInput(amount, slippage + VALIDATION_DIVERGENCE_TOLERANCE_PP)
 }
 
 function parseSlippagePercent(slippage: number): {
@@ -193,19 +189,13 @@ function logSwapQuoteSlippageValidation(
     status,
   }
 
+  if (status !== 'failed') return
+
   if (isDevRuntime() && shouldLogFullSwapQuote()) {
     payload.fullQuote = quote
   }
 
-  if (status === 'failed') {
-    console.warn('[swapQuoteSlippage] Swap quote exceeds requested slippage', payload)
-    return
-  }
-
-  if (!isDevRuntime()) return
-
-  // eslint-disable-next-line no-console
-  console.info('[swapQuoteSlippage] Swap quote slippage validation', payload)
+  logWarn('swapQuoteSlippage', 'Swap quote exceeds requested slippage', { data: payload })
 }
 
 function isDevRuntime() {

--- a/composables/useEulerOperations/vault.ts
+++ b/composables/useEulerOperations/vault.ts
@@ -1,11 +1,12 @@
 import type { Address, Hash } from 'viem'
 import { encodeFunctionData, getAddress } from 'viem'
+import { buildSwapVerifierData, getSwapInputAmount } from './swaps/verify'
 import type { OperationsContext, OperationHelpers, Permit2Helpers, AllowanceHelpers } from './types'
 import { erc20ApproveAbi, erc20TransferAbi } from '~/abis/erc20'
 import { evcEnableCollateralAbi, evcEnableControllerAbi } from '~/abis/evc'
 import { vaultBorrowAbi, vaultDepositAbi, vaultPreviewWithdrawAbi, vaultRedeemAbi, vaultWithdrawAbi } from '~/abis/vault'
 import { SaHooksBuilder } from '~/entities/saHooksSDK'
-import { swapperAbi, swapVerifierAbi } from '~/entities/euler/abis'
+import { swapperAbi } from '~/entities/euler/abis'
 import { convertSaHooksToEVCCalls, type EVCCall } from '~/utils/evc-converter'
 import { getNewSubAccount } from '~/entities/account'
 import { buildCollateralCleanupCalls } from '~/utils/collateral-cleanup'
@@ -405,6 +406,7 @@ export const createVaultBuilders = (
     borrowVaultAddress,
     debtAmount,
     quote,
+    requestedSlippage,
     swapperMode = SwapperMode.EXACT_IN,
     subAccount,
     includePermit2Call = true,
@@ -421,6 +423,7 @@ export const createVaultBuilders = (
     borrowVaultAddress: string
     debtAmount: bigint
     quote?: SwapApiQuote
+    requestedSlippage?: number
     swapperMode?: SwapperMode
     subAccount?: string
     includePermit2Call?: boolean
@@ -548,15 +551,11 @@ export const createVaultBuilders = (
       data: hooks.getDataForCall(evcAddress, 'enableCollateral', [subAccountAddr, supplyVaultAddr]) as Hash,
     }
 
-    const getSwapInputAmount = (q: SwapApiQuote, mode: SwapperMode) => {
-      const amountIn = BigInt(q.amountIn || 0)
-      const amountInMax = BigInt(q.amountInMax || 0)
-      if (mode === SwapperMode.EXACT_IN) return amountIn
-      return amountInMax > 0n ? amountInMax : amountIn
-    }
-
     if (hasSwap) {
       assertSwapperVerifierAllowed(quote!.verify.verifierAddress, ctx.eulerPeripheryAddresses.value!.swapVerifier)
+      if (requestedSlippage === undefined) {
+        throw new Error('Valid slippage between 0 and 50% must be provided for swap')
+      }
     }
 
     const borrowRecipient = hasSwap ? quote!.swap.swapperAddress : userAddr
@@ -588,49 +587,11 @@ export const createVaultBuilders = (
         throw new Error('Swap quote account mismatch')
       }
 
-      const buildSwapVerifierData = ({
-        q,
-        mode,
-        isRepay,
-        targetDebt = 0n,
-        currentDebt = 0n,
-      }: {
-        q: SwapApiQuote
-        mode: SwapperMode
-        isRepay: boolean
-        targetDebt?: bigint
-        currentDebt?: bigint
-      }) => {
-        let functionName: 'verifyAmountMinAndSkim' | 'verifyDebtMax'
-        let amount: bigint
-
-        if (isRepay) {
-          functionName = 'verifyDebtMax'
-          if (mode === SwapperMode.TARGET_DEBT) {
-            amount = targetDebt
-          }
-          else {
-            amount = currentDebt - BigInt(q.amountOutMin || 0)
-            if (amount < 0n) amount = 0n
-            amount = helpers.adjustForInterest(amount)
-          }
-        }
-        else {
-          functionName = 'verifyAmountMinAndSkim'
-          amount = BigInt(q.amountOutMin || 0)
-        }
-
-        return encodeFunctionData({
-          abi: swapVerifierAbi,
-          functionName,
-          args: [q.verify.vault, q.verify.account, amount, BigInt(q.verify.deadline || 0)],
-        })
-      }
-
       const verifierData = buildSwapVerifierData({
-        q: quote!,
-        mode: swapperMode,
+        quote: quote!,
+        swapperMode,
         isRepay: false,
+        requestedSlippage: requestedSlippage!,
       })
       if (verifierData.toLowerCase() !== quote!.verify.verifierData.toLowerCase()) {
         logWarn('multiply', 'SwapVerifier data mismatch')

--- a/composables/useEulerOperations/vault.ts
+++ b/composables/useEulerOperations/vault.ts
@@ -395,24 +395,7 @@ export const createVaultBuilders = (
     }
   }
 
-  const buildMultiplyPlan = async ({
-    supplyVaultAddress,
-    supplyAssetAddress,
-    supplyAmount,
-    supplySharesAmount,
-    supplyIsSavings = false,
-    longVaultAddress,
-    longAssetAddress,
-    borrowVaultAddress,
-    debtAmount,
-    quote,
-    requestedSlippage,
-    swapperMode = SwapperMode.EXACT_IN,
-    subAccount,
-    includePermit2Call = true,
-    enabledCollaterals,
-    enabledController,
-  }: {
+  type BuildMultiplyPlanCommon = {
     supplyVaultAddress: string
     supplyAssetAddress: string
     supplyAmount: bigint
@@ -422,14 +405,41 @@ export const createVaultBuilders = (
     longAssetAddress: string
     borrowVaultAddress: string
     debtAmount: bigint
-    quote?: SwapApiQuote
-    requestedSlippage?: number
     swapperMode?: SwapperMode
     subAccount?: string
     includePermit2Call?: boolean
     enabledCollaterals?: string[]
     enabledController?: string
-  }): Promise<TxPlan> => {
+  }
+  // Discriminated on `quote`: when a swap quote is present, requestedSlippage is
+  // statically required so the call site cannot reach the swap-verifier branch
+  // without the slippage that buildSwapVerifierData uses to validate it.
+  type BuildMultiplyPlanArgs
+    = | (BuildMultiplyPlanCommon & { quote: SwapApiQuote, requestedSlippage: number })
+      | (BuildMultiplyPlanCommon & { quote?: undefined, requestedSlippage?: never })
+
+  const buildMultiplyPlan = async (args: BuildMultiplyPlanArgs): Promise<TxPlan> => {
+    const {
+      supplyVaultAddress,
+      supplyAssetAddress,
+      supplyAmount,
+      supplySharesAmount,
+      supplyIsSavings = false,
+      longVaultAddress,
+      longAssetAddress,
+      borrowVaultAddress,
+      debtAmount,
+      swapperMode = SwapperMode.EXACT_IN,
+      subAccount,
+      includePermit2Call = true,
+      enabledCollaterals,
+      enabledController,
+    } = args
+    // Capture once so the discriminated narrowing (quote present ⇒ requestedSlippage:number)
+    // survives the rest of the function body.
+    const swapInfo = args.quote
+      ? { quote: args.quote, requestedSlippage: args.requestedSlippage }
+      : null
     if (!ctx.address.value || !ctx.eulerCoreAddresses.value || !ctx.eulerPeripheryAddresses.value) {
       throw new Error('Wallet not connected or addresses not available')
     }
@@ -443,8 +453,7 @@ export const createVaultBuilders = (
     const evcAddress = ctx.eulerCoreAddresses.value.evc as Address
 
     const subAccountAddr = (subAccount || await getNewSubAccount(ctx.address.value)) as Address
-    const hasSwap = !!quote
-    const borrowDepositAmount = hasSwap ? 0n : debtAmount
+    const borrowDepositAmount = swapInfo ? 0n : debtAmount
     const isSameVault = supplyVaultAddr.toLowerCase() === longVaultAddr.toLowerCase()
     const isSupplySavings = Boolean(supplyIsSavings)
     const shouldDepositSupply = !isSupplySavings
@@ -551,15 +560,12 @@ export const createVaultBuilders = (
       data: hooks.getDataForCall(evcAddress, 'enableCollateral', [subAccountAddr, supplyVaultAddr]) as Hash,
     }
 
-    if (hasSwap) {
-      assertSwapperVerifierAllowed(quote!.verify.verifierAddress, ctx.eulerPeripheryAddresses.value!.swapVerifier)
-      if (requestedSlippage === undefined) {
-        throw new Error('Valid slippage between 0 and 50% must be provided for swap')
-      }
+    if (swapInfo) {
+      assertSwapperVerifierAllowed(swapInfo.quote.verify.verifierAddress, ctx.eulerPeripheryAddresses.value!.swapVerifier)
     }
 
-    const borrowRecipient = hasSwap ? quote!.swap.swapperAddress : userAddr
-    const borrowAmount = hasSwap ? getSwapInputAmount(quote!, swapperMode) : debtAmount
+    const borrowRecipient = swapInfo ? swapInfo.quote.swap.swapperAddress : userAddr
+    const borrowAmount = swapInfo ? getSwapInputAmount(swapInfo.quote, swapperMode) : debtAmount
     if (borrowAmount <= 0n) {
       throw new Error('Borrow amount is zero')
     }
@@ -579,39 +585,40 @@ export const createVaultBuilders = (
     }
     evcCalls.push(borrowCall)
 
-    if (hasSwap) {
-      if (quote!.verify.type !== SwapVerificationType.SkimMin) {
+    if (swapInfo) {
+      const { quote, requestedSlippage } = swapInfo
+      if (quote.verify.type !== SwapVerificationType.SkimMin) {
         throw new Error('Swap verifier type mismatch')
       }
-      if (quote!.accountIn.toLowerCase() !== subAccountAddr.toLowerCase()) {
+      if (quote.accountIn.toLowerCase() !== subAccountAddr.toLowerCase()) {
         throw new Error('Swap quote account mismatch')
       }
 
       const verifierData = buildSwapVerifierData({
-        quote: quote!,
+        quote,
         swapperMode,
         isRepay: false,
-        requestedSlippage: requestedSlippage!,
+        requestedSlippage,
       })
-      if (verifierData.toLowerCase() !== quote!.verify.verifierData.toLowerCase()) {
+      if (verifierData.toLowerCase() !== quote.verify.verifierData.toLowerCase()) {
         logWarn('multiply', 'SwapVerifier data mismatch')
         throw new Error('SwapVerifier data mismatch')
       }
 
       evcCalls.push({
-        targetContract: quote!.swap.swapperAddress,
-        onBehalfOfAccount: quote!.accountIn as Address,
+        targetContract: quote.swap.swapperAddress,
+        onBehalfOfAccount: quote.accountIn as Address,
         value: 0n,
         data: encodeFunctionData({
           abi: swapperAbi,
           functionName: 'multicall',
-          args: [quote!.swap.multicallItems.map(item => item.data)],
+          args: [quote.swap.multicallItems.map(item => item.data)],
         }),
       })
 
       evcCalls.push({
-        targetContract: quote!.verify.verifierAddress,
-        onBehalfOfAccount: quote!.verify.account,
+        targetContract: quote.verify.verifierAddress,
+        onBehalfOfAccount: quote.verify.account,
         value: 0n,
         data: verifierData,
       })

--- a/composables/useSwapPageLogic.ts
+++ b/composables/useSwapPageLogic.ts
@@ -9,10 +9,11 @@ import { getAssetUsdValue } from '~/services/pricing/priceProvider'
 import { useEulerProductOfVault } from '~/composables/useEulerLabels'
 import { isAnyVaultBlockedByCountry, getVaultTags } from '~/composables/useGeoBlock'
 import { useSwapQuotesParallel } from '~/composables/useSwapQuotesParallel'
-import { getQuoteAmount, type SwapQuoteAmountField, type SwapQuoteCompare } from '~/utils/swapQuotes'
+import { computeQuoteSlippage, getQuoteAmount, type SwapQuoteAmountField, type SwapQuoteCompare } from '~/utils/swapQuotes'
 import { buildSwapRouteItems } from '~/utils/swapRouteItems'
 import type { SwapApiRequestInput } from '~/composables/useSwapApi'
 import type { TxPlan } from '~/entities/txPlan'
+import { SwapperMode } from '~/entities/swap'
 import { useModal } from '~/components/ui/composables/useModal'
 import { useToast } from '~/components/ui/composables/useToast'
 import { isSameUnderlyingAsset, isSameVault as isSameVaultCheck } from '~/utils/vault-utils'
@@ -118,6 +119,10 @@ export const useSwapPageLogic = (options: UseSwapPageLogicOptions) => {
     requestQuotes,
     selectProvider,
   } = useSwapQuotesParallel({ amountField, compare })
+  const quoteSlippage = computed(() => computeQuoteSlippage(
+    effectiveQuote.value,
+    amountField === 'amountIn' ? SwapperMode.TARGET_DEBT : SwapperMode.EXACT_IN,
+  ))
 
   // ── Vault products & price invert ──────────────────────────────────────
   const fromProduct = useEulerProductOfVault(computed(() => fromVault.value?.address || ''))
@@ -519,6 +524,7 @@ export const useSwapPageLogic = (options: UseSwapPageLogicOptions) => {
     isQuoteLoading,
     quoteError,
     quotesStatusLabel,
+    quoteSlippage,
     selectProvider,
 
     // Vault identity

--- a/entities/constants.ts
+++ b/entities/constants.ts
@@ -63,7 +63,7 @@ export const DEFAULT_SLIPPAGE = 0.3
 export const DEFAULT_STABLECOIN_SLIPPAGE = 0.05
 export const SLIPPAGE_EXPIRY_MS = 24 * 60 * 60 * 1000
 export const SLIPPAGE_TIMESTAMP_STORAGE_KEY = 'swap-slippage-set-at'
-export const MIN_SLIPPAGE = 0
+export const MIN_SLIPPAGE = 0.01
 export const MAX_SLIPPAGE = 50
 export const HIGH_SLIPPAGE_THRESHOLD = 5
 

--- a/pages/borrow/[collateral]/[borrow]/index.vue
+++ b/pages/borrow/[collateral]/[borrow]/index.vue
@@ -548,6 +548,7 @@ watch(formTab, () => {
                       :output-display="borrow.borrowSwapOutputDisplay.value"
                       :price-impact="borrow.borrowSwapPriceImpact.value"
                       :slippage="borrow.borrowSwapSlippage.value"
+                      :quote-slippage="borrow.borrowSwapQuoteSlippage.value"
                       :routed-via="borrow.borrowSwapRoutedVia.value"
                       @open-slippage-settings="openSlippageSettings"
                     />
@@ -852,6 +853,7 @@ watch(formTab, () => {
                         :output-display="multiply.multiplySwapSummary.value?.to ?? null"
                         :price-impact="multiply.multiplyPriceImpact.value"
                         :slippage="multiply.multiplySlippage.value"
+                        :quote-slippage="multiply.multiplyQuoteSlippage.value"
                         :routed-via="multiply.multiplyRoutedVia.value"
                         :multiplied-price-impact="multiply.multipliedPriceImpact.value"
                         @open-slippage-settings="openSlippageSettings"

--- a/pages/lend/[vault]/[subAccount]/swap.vue
+++ b/pages/lend/[vault]/[subAccount]/swap.vue
@@ -123,6 +123,7 @@ const swap = useSwapPageLogic({
       quote: selectedQuote.value,
       swapperMode: SwapperMode.EXACT_IN,
       isRepay: false,
+      requestedSlippage: slippage.value,
       targetDebt: 0n,
       currentDebt: 0n,
     })
@@ -138,7 +139,7 @@ const {
   isGeoBlocked, reviewSwapDisabled, reviewSwapLabel, simulationError,
   isQuoteLoading, quoteError, quotesStatusLabel, selectedProvider, selectedQuote,
   fromProduct, toProduct, currentPrice, swapSummary, priceImpact, routedVia,
-  swapRouteItems, swapRouteEmptyMessage,
+  quoteSlippage, swapRouteItems, swapRouteEmptyMessage,
   selectProvider, onFromInput, onToVaultChange, onRefreshQuotes, submit, openSlippageSettings,
 } = swap
 
@@ -322,6 +323,7 @@ watch([() => route.params.vault, () => route.query.to], () => {
                 :output-display="swapSummary?.to ?? null"
                 :price-impact="priceImpact"
                 :slippage="slippage"
+                :quote-slippage="quoteSlippage"
                 :routed-via="routedVia"
                 @open-slippage-settings="openSlippageSettings"
               />

--- a/pages/lend/[vault]/[subAccount]/withdraw.vue
+++ b/pages/lend/[vault]/[subAccount]/withdraw.vue
@@ -21,6 +21,7 @@ import type { TxPlan } from '~/entities/txPlan'
 import { useSwapQuotesParallel } from '~/composables/useSwapQuotesParallel'
 import { SwapperMode } from '~/entities/swap'
 import { buildSwapRouteItems } from '~/utils/swapRouteItems'
+import { computeQuoteSlippage } from '~/utils/swapQuotes'
 import { formatNumber, formatSmartAmount, formatExactAmount } from '~/utils/string-utils'
 import { useSwapPriceImpact } from '~/composables/useSwapPriceImpact'
 import { usePriceImpactGate } from '~/composables/usePriceImpactGate'
@@ -107,6 +108,7 @@ const {
   requestQuotes: requestSwapQuotes,
   selectProvider: selectSwapQuote,
 } = useSwapQuotesParallel({ amountField: 'amountOut', compare: 'max' })
+const swapQuoteSlippage = computed(() => computeQuoteSlippage(swapEffectiveQuote.value))
 
 const rewardApy = computed(() => getSupplyRewardApy(vault.value?.address || ''))
 const amountFixed = computed(() => {
@@ -340,6 +342,7 @@ const submit = async () => {
               vaultAddress: vaultAddress as Address,
               sharesAmount: sharesBalance.value,
               quote: swapSelectedQuote.value,
+              requestedSlippage: swapSlippage.value,
               subAccount: subAccount.value,
             })
           }
@@ -348,6 +351,7 @@ const submit = async () => {
               vaultAddress: vaultAddress as Address,
               assetsAmount: amountFixed.value.value,
               quote: swapSelectedQuote.value,
+              requestedSlippage: swapSlippage.value,
               subAccount: subAccount.value,
             })
           }
@@ -408,6 +412,7 @@ const send = async () => {
           vaultAddress: vaultAddress as Address,
           sharesAmount: sharesBalance.value,
           quote,
+          requestedSlippage: swapSlippage.value,
           subAccount: subAccount.value,
         })
       }
@@ -416,6 +421,7 @@ const send = async () => {
           vaultAddress: vaultAddress as Address,
           assetsAmount: amountFixed.value.value,
           quote,
+          requestedSlippage: swapSlippage.value,
           subAccount: subAccount.value,
         })
       }
@@ -618,6 +624,7 @@ watch(swapSelectedQuote, () => {
                   :output-display="swapOutputDisplay"
                   :price-impact="swapPriceImpact"
                   :slippage="swapSlippage"
+                  :quote-slippage="swapQuoteSlippage"
                   :routed-via="swapRoutedVia"
                   @open-slippage-settings="openSlippageSettings"
                 />

--- a/pages/lend/[vault]/index.vue
+++ b/pages/lend/[vault]/index.vue
@@ -18,6 +18,7 @@ import { useVaultRegistry } from '~/composables/useVaultRegistry'
 import { useSwapQuotesParallel } from '~/composables/useSwapQuotesParallel'
 import { type SwapApiQuote, SwapperMode } from '~/entities/swap'
 import { buildSwapRouteItems } from '~/utils/swapRouteItems'
+import { computeQuoteSlippage } from '~/utils/swapQuotes'
 import VaultFormInfoBlock from '~/components/entities/vault/form/VaultFormInfoBlock.vue'
 import VaultFormSubmit from '~/components/entities/vault/form/VaultFormSubmit.vue'
 import SecuritizeVaultOverview from '~/components/entities/vault/overview/SecuritizeVaultOverview.vue'
@@ -129,6 +130,7 @@ const {
   requestQuotes: requestSwapQuotes,
   selectProvider: selectSwapQuote,
 } = useSwapQuotesParallel({ amountField: 'amountOut', compare: 'max' })
+const swapQuoteSlippage = computed(() => computeQuoteSlippage(swapEffectiveQuote.value))
 
 // Vault data - only one will be populated based on type
 const evkVault: Ref<Vault | undefined> = ref(undefined)
@@ -392,6 +394,7 @@ const buildSwapSupplyPlanFromQuote = async (quote: SwapApiQuote, options: { incl
     inputTokenAddress: (wrappedAddress || selectedAsset.value.address) as Address,
     inputAmount,
     quote,
+    requestedSlippage: swapSlippage.value,
     includePermit2Call: options.includePermit2Call,
     wrappedNativeInfo: isNative && wrappedAddress
       ? { wrappedTokenAddress: wrappedAddress, nativeAmount: inputAmount }
@@ -897,6 +900,7 @@ watch(address, () => {
                   :output-display="swapOutputDisplay"
                   :price-impact="swapPriceImpact"
                   :slippage="swapSlippage"
+                  :quote-slippage="swapQuoteSlippage"
                   :routed-via="swapRoutedVia"
                   @open-slippage-settings="openSlippageSettings"
                 />

--- a/pages/position/[number]/borrow/swap.vue
+++ b/pages/position/[number]/borrow/swap.vue
@@ -224,6 +224,7 @@ const swap = useSwapPageLogic({
       quote: selectedQuote.value,
       swapperMode: SwapperMode.TARGET_DEBT,
       isRepay: true,
+      requestedSlippage: slippage.value,
       isDebtSwap: true,
       targetDebt: 0n,
       currentDebt: currentDebt.value,
@@ -251,7 +252,7 @@ const {
   isGeoBlocked, reviewSwapDisabled, reviewSwapLabel, simulationError,
   isQuoteLoading, quoteError, quotesStatusLabel, selectedProvider, selectedQuote,
   fromProduct, toProduct, swapPriceInvert, currentPrice, swapSummary, priceImpact, routedVia,
-  swapRouteItems, swapRouteEmptyMessage,
+  quoteSlippage, swapRouteItems, swapRouteEmptyMessage,
   selectProvider, onFromInput: _onFromInput, onRefreshQuotes, submit, openSlippageSettings,
   normalizeAddress, clearSimulationError, requestQuote,
 } = swap
@@ -551,6 +552,7 @@ const onToVaultChange = (selectedIndex: number) => {
               :output-display="swapSummary?.to ?? null"
               :price-impact="priceImpact"
               :slippage="slippage"
+              :quote-slippage="quoteSlippage"
               :routed-via="routedVia"
               @open-slippage-settings="openSlippageSettings"
             />

--- a/pages/position/[number]/collateral/swap.vue
+++ b/pages/position/[number]/collateral/swap.vue
@@ -150,6 +150,7 @@ const swap = useSwapPageLogic({
       quote: selectedQuote.value,
       swapperMode: SwapperMode.EXACT_IN,
       isRepay: false,
+      requestedSlippage: slippage.value,
       targetDebt: 0n,
       currentDebt: 0n,
       enableCollateral: true,
@@ -184,7 +185,7 @@ const {
   isGeoBlocked, reviewSwapDisabled, reviewSwapLabel, simulationError,
   isQuoteLoading, quoteError, quotesStatusLabel, selectedProvider, selectedQuote,
   fromProduct, toProduct, swapPriceInvert, currentPrice, swapSummary, priceImpact, routedVia,
-  swapRouteItems, swapRouteEmptyMessage,
+  quoteSlippage, swapRouteItems, swapRouteEmptyMessage,
   selectProvider, onFromInput, onRefreshQuotes, submit, openSlippageSettings,
   normalizeAddress, clearSimulationError, resetQuoteState,
 } = swap
@@ -663,6 +664,7 @@ const nextLiquidationPrice = computed(() => {
               :output-display="swapSummary?.to ?? null"
               :price-impact="priceImpact"
               :slippage="slippage"
+              :quote-slippage="quoteSlippage"
               :routed-via="routedVia"
               @open-slippage-settings="openSlippageSettings"
             />

--- a/pages/position/[number]/multiply.vue
+++ b/pages/position/[number]/multiply.vue
@@ -9,6 +9,7 @@ import type { AccountBorrowPosition } from '~/entities/account'
 import type { Vault, VaultAsset } from '~/entities/vault'
 import { getAssetUsdValue, getAssetOraclePrice, getCollateralOraclePrice, conservativePriceRatioNumber } from '~/services/pricing/priceProvider'
 import { computeMultipliedPriceImpact } from '~/utils/priceImpact'
+import { computeQuoteSlippage } from '~/utils/swapQuotes'
 import { usePriceImpactGate } from '~/composables/usePriceImpactGate'
 import { useEulerProductOfVault } from '~/composables/useEulerLabels'
 import { isAnyVaultBlockedByCountry, isVaultRestrictedByCountry } from '~/composables/useGeoBlock'
@@ -55,6 +56,7 @@ type MultiplyPlanParams = {
   borrowVaultAddress: string
   debtAmount: bigint
   quote?: SwapApiQuote
+  requestedSlippage?: number
   swapperMode: SwapperMode
   subAccount: string
 }
@@ -96,6 +98,7 @@ const {
   requestQuotes: requestMultiplyQuotes,
   selectProvider: selectMultiplyQuote,
 } = useSwapQuotesParallel({ amountField: 'amountOut', compare: 'max' })
+const multiplyQuoteSlippage = computed(() => computeQuoteSlippage(multiplyEffectiveQuote.value))
 
 const multiplyLongVault = computed(() => position.value?.collateral)
 const multiplyShortVault = computed(() => position.value?.borrow)
@@ -597,6 +600,7 @@ const submitMultiply = async () => {
         borrowVaultAddress: multiplyShortVault.value.address,
         debtAmount,
         quote: quote || undefined,
+        requestedSlippage: multiplySlippage.value,
         swapperMode: SwapperMode.EXACT_IN,
         subAccount,
       }
@@ -622,14 +626,19 @@ const submitMultiply = async () => {
         }
       }
 
+      const reviewBorrowAmount = trimTrailingZeros(formatUnits(debtAmount, Number(multiplyShortVault.value.asset.decimals)))
+      const reviewSwapToAmount = quote
+        ? trimTrailingZeros(formatUnits(BigInt(quote.amountOut || 0), Number(multiplyLongVault.value.asset.decimals)))
+        : undefined
+
       modal.open(OperationReviewModal, {
         props: {
           type: 'borrow',
           asset: multiplyShortVault.value.asset,
-          amount: multiplyShortAmount.value || formatUnits(debtAmount, Number(multiplyShortVault.value.asset.decimals)),
+          amount: reviewBorrowAmount,
           plan: plan.value || undefined,
           swapToAsset: quote ? multiplyLongVault.value.asset : undefined,
-          swapToAmount: quote ? multiplyLongAmount.value : undefined,
+          swapToAmount: reviewSwapToAmount,
           subAccount,
           submittingLabel: 'Submitting...',
           onConfirm: async () => {
@@ -948,6 +957,7 @@ watch([multiplyMinMultiplier, multiplyMaxMultiplier], ([min, max]) => {
               :output-display="multiplySwapSummary?.to ?? null"
               :price-impact="multiplyPriceImpact"
               :slippage="multiplySlippage"
+              :quote-slippage="multiplyQuoteSlippage"
               :routed-via="multiplyRoutedVia"
               :multiplied-price-impact="multipliedPriceImpact"
               @open-slippage-settings="openSlippageSettings"

--- a/pages/position/[number]/multiply.vue
+++ b/pages/position/[number]/multiply.vue
@@ -45,7 +45,7 @@ const openSlippageSettings = () => {
   modal.open(SlippageSettingsModal)
 }
 
-type MultiplyPlanParams = {
+type MultiplyPlanParamsCommon = {
   supplyVaultAddress: string
   supplyAssetAddress: string
   supplyAmount: bigint
@@ -55,11 +55,12 @@ type MultiplyPlanParams = {
   longAssetAddress: string
   borrowVaultAddress: string
   debtAmount: bigint
-  quote?: SwapApiQuote
-  requestedSlippage?: number
   swapperMode: SwapperMode
   subAccount: string
 }
+type MultiplyPlanParams
+  = | (MultiplyPlanParamsCommon & { quote: SwapApiQuote, requestedSlippage: number })
+    | (MultiplyPlanParamsCommon & { quote?: undefined, requestedSlippage?: never })
 
 const priceInvert = usePriceInvert(
   () => multiplyShortVault.value?.asset.symbol,
@@ -591,7 +592,7 @@ const submitMultiply = async () => {
         return
       }
 
-      const nextPlanParams: MultiplyPlanParams = {
+      const baseParams: MultiplyPlanParamsCommon = {
         supplyVaultAddress: multiplySupplyVault.value.address,
         supplyAssetAddress: multiplySupplyVault.value.asset.address,
         supplyAmount: 0n,
@@ -599,11 +600,12 @@ const submitMultiply = async () => {
         longAssetAddress: multiplyLongVault.value.asset.address,
         borrowVaultAddress: multiplyShortVault.value.address,
         debtAmount,
-        quote: quote || undefined,
-        requestedSlippage: multiplySlippage.value,
         swapperMode: SwapperMode.EXACT_IN,
         subAccount,
       }
+      const nextPlanParams: MultiplyPlanParams = quote
+        ? { ...baseParams, quote, requestedSlippage: multiplySlippage.value }
+        : baseParams
       planParams.value = nextPlanParams
 
       try {

--- a/pages/position/[number]/repay.vue
+++ b/pages/position/[number]/repay.vue
@@ -608,6 +608,7 @@ watch(formTab, () => {
                 :output-display="walletSwap.swapOutputDisplay.value"
                 :price-impact="walletSwap.swapPriceImpact.value"
                 :slippage="slippage"
+                :quote-slippage="walletSwap.quoteSlippage.value"
                 :routed-via="walletSwap.swapRoutedVia.value"
                 @open-slippage-settings="openSlippageSettings"
               />
@@ -789,6 +790,7 @@ watch(formTab, () => {
                 :output-display="collateral.summary.value?.to ?? null"
                 :price-impact="collateral.priceImpact.value"
                 :slippage="slippage"
+                :quote-slippage="collateral.quoteSlippage.value"
                 :routed-via="collateral.routedVia.value"
                 @open-slippage-settings="openSlippageSettings"
               />
@@ -962,6 +964,7 @@ watch(formTab, () => {
                 :output-display="savings.summary.value?.to ?? null"
                 :price-impact="savings.priceImpact.value"
                 :slippage="slippage"
+                :quote-slippage="savings.quoteSlippage.value"
                 :routed-via="savings.routedVia.value"
                 @open-slippage-settings="openSlippageSettings"
               />

--- a/pages/position/[number]/supply.vue
+++ b/pages/position/[number]/supply.vue
@@ -96,7 +96,7 @@ const form = useCollateralForm({
     })
   },
 
-  buildSwapPlan: async (quote: SwapApiQuote, { includePermit2Call }) => {
+  buildSwapPlan: async (quote: SwapApiQuote, { slippage, includePermit2Call }) => {
     if (!selectedAsset.value || !form.collateralVault.value) {
       throw new Error('No selected asset or vault')
     }
@@ -110,6 +110,7 @@ const form = useCollateralForm({
       inputTokenAddress: (wrappedAddress || selectedAsset.value.address) as Address,
       inputAmount,
       quote,
+      requestedSlippage: slippage,
       includePermit2Call,
       wrappedNativeInfo: isNative && wrappedAddress
         ? { wrappedTokenAddress: wrappedAddress, nativeAmount: inputAmount }
@@ -319,6 +320,7 @@ watch(selectedAsset, async () => {
                   :output-display="form.swapOutputDisplay.value"
                   :price-impact="form.swapPriceImpact.value"
                   :slippage="form.swapSlippage.value"
+                  :quote-slippage="form.swapQuoteSlippage.value"
                   :routed-via="form.swapRoutedVia.value"
                   @open-slippage-settings="form.openSlippageSettings"
                 />

--- a/pages/position/[number]/withdraw.vue
+++ b/pages/position/[number]/withdraw.vue
@@ -88,12 +88,13 @@ const form = useCollateralForm({
     )
   },
 
-  buildSwapPlan: async (quote: SwapApiQuote, { vaultAddress, amountNano, subAccount }) => {
+  buildSwapPlan: async (quote: SwapApiQuote, { vaultAddress, amountNano, slippage, subAccount }) => {
     const hasBorrows = (form.position.value?.borrowed || 0n) > 0n
     return buildWithdrawAndSwapPlan({
       vaultAddress: vaultAddress as Address,
       assetsAmount: amountNano,
       quote,
+      requestedSlippage: slippage,
       subAccount,
       options: {
         includePythUpdate: hasBorrows,
@@ -263,6 +264,7 @@ watch(selectedOutputAsset, () => {
                   :output-display="form.swapOutputDisplay.value"
                   :price-impact="form.swapPriceImpact.value"
                   :slippage="form.swapSlippage.value"
+                  :quote-slippage="form.swapQuoteSlippage.value"
                   :routed-via="form.swapRoutedVia.value"
                   @open-slippage-settings="form.openSlippageSettings"
                 />

--- a/tests/utils/swap-quotes.test.ts
+++ b/tests/utils/swap-quotes.test.ts
@@ -4,11 +4,18 @@ import {
   sortQuoteCards,
   pickBestQuote,
   getQuoteDiffPct,
+  computeQuoteSlippage,
 } from '~/utils/swapQuotes'
-import type { SwapApiQuote } from '~/entities/swap'
+import { type SwapApiQuote, SwapperMode } from '~/entities/swap'
 
 const makeQuote = (amountIn: string, amountOut: string): SwapApiQuote =>
   ({ amountIn, amountOut }) as SwapApiQuote
+
+const makeSlippageQuote = (amountOut: string, amountOutMin: string): SwapApiQuote =>
+  ({ amountOut, amountOutMin }) as SwapApiQuote
+
+const makeTargetDebtSlippageQuote = (amountIn: string, amountInMax: string): SwapApiQuote =>
+  ({ amountIn, amountInMax }) as SwapApiQuote
 
 describe('getQuoteAmount', () => {
   it('returns 0n for null quote', () => {
@@ -132,5 +139,71 @@ describe('getQuoteDiffPct', () => {
   it('returns null when quote is better than best in max mode', () => {
     // quoteAmount=200 > bestAmount=100 => diff = 100-200 = -100 <= 0 => null
     expect(getQuoteDiffPct(200n, 100n, 'max')).toBeNull()
+  })
+})
+
+describe('computeQuoteSlippage', () => {
+  it('returns null for null quote', () => {
+    expect(computeQuoteSlippage(null)).toBeNull()
+  })
+
+  it('returns null when amountOut is zero', () => {
+    expect(computeQuoteSlippage(makeSlippageQuote('0', '95'))).toBeNull()
+  })
+
+  it('returns null when amountOutMin is missing', () => {
+    expect(computeQuoteSlippage({ amountOut: '100' } as SwapApiQuote)).toBeNull()
+  })
+
+  it('returns null when amountOutMin is invalid', () => {
+    expect(computeQuoteSlippage(makeSlippageQuote('100', 'invalid'))).toBeNull()
+  })
+
+  it('returns 100 when amountOutMin is zero', () => {
+    expect(computeQuoteSlippage(makeSlippageQuote('100', '0'))).toBe(100)
+  })
+
+  it('returns 0 when amountOutMin matches amountOut', () => {
+    expect(computeQuoteSlippage(makeSlippageQuote('100', '100'))).toBe(0)
+  })
+
+  it('returns null when amountOutMin is greater than amountOut', () => {
+    expect(computeQuoteSlippage(makeSlippageQuote('100', '101'))).toBeNull()
+  })
+
+  it('derives the quote slippage percentage from amountOut and amountOutMin', () => {
+    expect(computeQuoteSlippage(makeSlippageQuote('1000', '995'))).toBe(0.5)
+  })
+
+  it('rounds down to basis-point precision', () => {
+    expect(computeQuoteSlippage(makeSlippageQuote('3333', '3300'))).toBe(0.99)
+  })
+
+  it('derives target debt quote slippage from amountIn and amountInMax', () => {
+    expect(computeQuoteSlippage(
+      makeTargetDebtSlippageQuote('1000', '1005'),
+      SwapperMode.TARGET_DEBT,
+    )).toBe(0.5)
+  })
+
+  it('returns 0 when target debt amountInMax matches amountIn', () => {
+    expect(computeQuoteSlippage(
+      makeTargetDebtSlippageQuote('1000', '1000'),
+      SwapperMode.TARGET_DEBT,
+    )).toBe(0)
+  })
+
+  it('returns null when target debt amountInMax is below amountIn', () => {
+    expect(computeQuoteSlippage(
+      makeTargetDebtSlippageQuote('1000', '999'),
+      SwapperMode.TARGET_DEBT,
+    )).toBeNull()
+  })
+
+  it('returns null when target debt amountInMax is missing', () => {
+    expect(computeQuoteSlippage(
+      { amountIn: '1000' } as SwapApiQuote,
+      SwapperMode.TARGET_DEBT,
+    )).toBeNull()
   })
 })

--- a/tests/utils/swap-slippage-validation.test.ts
+++ b/tests/utils/swap-slippage-validation.test.ts
@@ -48,7 +48,8 @@ describe('swap quote slippage validation', () => {
     ).toThrow('amountOutMin exceeds requested slippage')
 
     expect(warnSpy).toHaveBeenCalledWith(
-      '[swapQuoteSlippage] Swap quote exceeds requested slippage',
+      '[swapQuoteSlippage]',
+      'Swap quote exceeds requested slippage',
       expect.objectContaining({
         actualSlippage: '0.6315%',
         checkedAmount: '944',
@@ -59,8 +60,8 @@ describe('swap quote slippage validation', () => {
         route: 'test-provider',
       }),
     )
-    expect(warnSpy.mock.calls[0]?.[1]).not.toHaveProperty('quote')
-    expect(warnSpy.mock.calls[0]?.[1]).not.toHaveProperty('fullQuote')
+    expect(warnSpy.mock.calls[0]?.[2]).not.toHaveProperty('quote')
+    expect(warnSpy.mock.calls[0]?.[2]).not.toHaveProperty('fullQuote')
   })
 
   it('rejects amountInMax above requested slippage for target debt', () => {
@@ -74,7 +75,8 @@ describe('swap quote slippage validation', () => {
     ).toThrow('amountInMax exceeds requested slippage')
 
     expect(warnSpy).toHaveBeenCalledWith(
-      '[swapQuoteSlippage] Swap quote exceeds requested slippage',
+      '[swapQuoteSlippage]',
+      'Swap quote exceeds requested slippage',
       expect.objectContaining({
         actualSlippage: '0.7000%',
         checkedAmount: '1007',
@@ -85,59 +87,73 @@ describe('swap quote slippage validation', () => {
         route: 'test-provider',
       }),
     )
-    expect(warnSpy.mock.calls[0]?.[1]).not.toHaveProperty('quote')
-    expect(warnSpy.mock.calls[0]?.[1]).not.toHaveProperty('fullQuote')
+    expect(warnSpy.mock.calls[0]?.[2]).not.toHaveProperty('quote')
+    expect(warnSpy.mock.calls[0]?.[2]).not.toHaveProperty('fullQuote')
   })
 
-  it('allows output slippage up to the monorepo divergence allowance', () => {
-    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {})
+  it('allows output slippage up to the validator divergence tolerance', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
+    // At slippage 0.5%, validator forgives up to +0.001pp absolute, so a quote
+    // with amountOutMin = floor(2_000_000 * (1 - 0.00501)) = 1989980 must pass.
     expect(() =>
       validateSwapQuoteSlippageData(
         { slippage: 0.5, swapperMode: SwapperMode.EXACT_IN },
-        makeQuote({ amountOut: '2000000', amountOutMin: '1989999' }),
+        makeQuote({ amountOut: '2000000', amountOutMin: '1989980' }),
       ),
     ).not.toThrow()
 
-    expect(infoSpy).toHaveBeenCalledWith(
-      '[swapQuoteSlippage] Swap quote slippage validation',
-      expect.objectContaining({
-        actualSlippage: '0.5000%',
-        checkedAmount: '1989999',
-        expectedAmount: '1989999',
-        field: 'amountOutMin',
-        requestedSlippage: '0.5%',
-        route: 'test-provider',
-        status: 'passed',
-      }),
-    )
-    expect(infoSpy.mock.calls[0]?.[1]).not.toHaveProperty('quote')
-    expect(infoSpy.mock.calls[0]?.[1]).not.toHaveProperty('fullQuote')
+    // One wei below the boundary must fail.
+    expect(() =>
+      validateSwapQuoteSlippageData(
+        { slippage: 0.5, swapperMode: SwapperMode.EXACT_IN },
+        makeQuote({ amountOut: '2000000', amountOutMin: '1989979' }),
+      ),
+    ).toThrow('amountOutMin exceeds requested slippage')
+
+    expect(warnSpy).toHaveBeenCalledTimes(1)
   })
 
-  it('allows input slippage up to the monorepo divergence allowance', () => {
-    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {})
+  it('allows input slippage up to the validator divergence tolerance', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
+    // At slippage 0.5%, validator forgives up to +0.001pp absolute, so a quote
+    // with amountInMax = floor(2_000_000 * (1 + 0.00501)) = 2010020 must pass.
     expect(() =>
       validateSwapQuoteSlippageData(
         { slippage: 0.5, swapperMode: SwapperMode.TARGET_DEBT },
-        makeQuote({ amountIn: '2000000', amountInMax: '2010001' }),
+        makeQuote({ amountIn: '2000000', amountInMax: '2010020' }),
       ),
     ).not.toThrow()
 
-    expect(infoSpy).toHaveBeenCalledWith(
-      '[swapQuoteSlippage] Swap quote slippage validation',
-      expect.objectContaining({
-        actualSlippage: '0.5000%',
-        checkedAmount: '2010001',
-        expectedAmount: '2010001',
-        field: 'amountInMax',
-        requestedSlippage: '0.5%',
-        route: 'test-provider',
-        status: 'passed',
-      }),
-    )
-    expect(infoSpy.mock.calls[0]?.[1]).not.toHaveProperty('quote')
-    expect(infoSpy.mock.calls[0]?.[1]).not.toHaveProperty('fullQuote')
+    // One wei above the boundary must fail.
+    expect(() =>
+      validateSwapQuoteSlippageData(
+        { slippage: 0.5, swapperMode: SwapperMode.TARGET_DEBT },
+        makeQuote({ amountIn: '2000000', amountInMax: '2010021' }),
+      ),
+    ).toThrow('amountInMax exceeds requested slippage')
+
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps validator tolerance below SwapDetailsSummary warning threshold at MAX_SLIPPAGE', () => {
+    // SLIPPAGE_DIFF_TOLERANCE in SwapDetailsSummary is 0.005pp. The validator
+    // must allow strictly less so a quote it accepts never trips the user-facing
+    // warning. At MAX_SLIPPAGE = 50%, the validator forgives 0.001pp → boundary
+    // amountOutMin = floor(2_000_000 * (1 - 0.50001)) = 999_980.
+    expect(() =>
+      validateSwapQuoteSlippageData(
+        { slippage: 50, swapperMode: SwapperMode.EXACT_IN },
+        makeQuote({ amountOut: '2000000', amountOutMin: '999980' }),
+      ),
+    ).not.toThrow()
+
+    expect(() =>
+      validateSwapQuoteSlippageData(
+        { slippage: 50, swapperMode: SwapperMode.EXACT_IN },
+        makeQuote({ amountOut: '2000000', amountOutMin: '999979' }),
+      ),
+    ).toThrow('amountOutMin exceeds requested slippage')
   })
 })

--- a/tests/utils/swap-slippage-validation.test.ts
+++ b/tests/utils/swap-slippage-validation.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { SwapperMode, type SwapApiQuote } from '~/entities/swap'
+import {
+  applySlippageToInput,
+  applySlippageToOutput,
+  validateSwapQuoteSlippageData,
+} from '~/composables/useEulerOperations/swaps/verify'
+
+const makeQuote = (overrides: Partial<SwapApiQuote>): SwapApiQuote => ({
+  amountIn: '1000',
+  amountInMax: '1000',
+  amountOut: '950',
+  amountOutMin: '945',
+  route: [{ providerName: 'test-provider' }],
+  ...overrides,
+}) as SwapApiQuote
+
+describe('swap quote slippage validation', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('rounds output slippage down like the SDK', () => {
+    expect(applySlippageToOutput(950n, 0.5)).toBe(945n)
+  })
+
+  it('rounds input slippage up like the SDK', () => {
+    expect(applySlippageToInput(1000n, 0.5)).toBe(1005n)
+  })
+
+  it('rejects invalid requested slippage', () => {
+    expect(() =>
+      validateSwapQuoteSlippageData(
+        { slippage: 51, swapperMode: SwapperMode.EXACT_IN },
+        makeQuote({}),
+      ),
+    ).toThrow('Valid slippage between 0 and 50% must be provided for swap')
+  })
+
+  it('rejects amountOutMin below requested slippage', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    expect(() =>
+      validateSwapQuoteSlippageData(
+        { slippage: 0.5, swapperMode: SwapperMode.EXACT_IN },
+        makeQuote({ amountOutMin: '944' }),
+      ),
+    ).toThrow('amountOutMin exceeds requested slippage')
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[swapQuoteSlippage] Swap quote exceeds requested slippage',
+      expect.objectContaining({
+        actualSlippage: '0.6315%',
+        checkedAmount: '944',
+        expectedAmount: '945',
+        field: 'amountOutMin',
+        mode: 'output',
+        requestedSlippage: '0.5%',
+        route: 'test-provider',
+      }),
+    )
+    expect(warnSpy.mock.calls[0]?.[1]).not.toHaveProperty('quote')
+    expect(warnSpy.mock.calls[0]?.[1]).not.toHaveProperty('fullQuote')
+  })
+
+  it('rejects amountInMax above requested slippage for target debt', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    expect(() =>
+      validateSwapQuoteSlippageData(
+        { slippage: 0.5, swapperMode: SwapperMode.TARGET_DEBT },
+        makeQuote({ amountInMax: '1007' }),
+      ),
+    ).toThrow('amountInMax exceeds requested slippage')
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[swapQuoteSlippage] Swap quote exceeds requested slippage',
+      expect.objectContaining({
+        actualSlippage: '0.7000%',
+        checkedAmount: '1007',
+        expectedAmount: '1006',
+        field: 'amountInMax',
+        mode: 'input',
+        requestedSlippage: '0.5%',
+        route: 'test-provider',
+      }),
+    )
+    expect(warnSpy.mock.calls[0]?.[1]).not.toHaveProperty('quote')
+    expect(warnSpy.mock.calls[0]?.[1]).not.toHaveProperty('fullQuote')
+  })
+
+  it('allows output slippage up to the monorepo divergence allowance', () => {
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {})
+
+    expect(() =>
+      validateSwapQuoteSlippageData(
+        { slippage: 0.5, swapperMode: SwapperMode.EXACT_IN },
+        makeQuote({ amountOut: '2000000', amountOutMin: '1989999' }),
+      ),
+    ).not.toThrow()
+
+    expect(infoSpy).toHaveBeenCalledWith(
+      '[swapQuoteSlippage] Swap quote slippage validation',
+      expect.objectContaining({
+        actualSlippage: '0.5000%',
+        checkedAmount: '1989999',
+        expectedAmount: '1989999',
+        field: 'amountOutMin',
+        requestedSlippage: '0.5%',
+        route: 'test-provider',
+        status: 'passed',
+      }),
+    )
+    expect(infoSpy.mock.calls[0]?.[1]).not.toHaveProperty('quote')
+    expect(infoSpy.mock.calls[0]?.[1]).not.toHaveProperty('fullQuote')
+  })
+
+  it('allows input slippage up to the monorepo divergence allowance', () => {
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {})
+
+    expect(() =>
+      validateSwapQuoteSlippageData(
+        { slippage: 0.5, swapperMode: SwapperMode.TARGET_DEBT },
+        makeQuote({ amountIn: '2000000', amountInMax: '2010001' }),
+      ),
+    ).not.toThrow()
+
+    expect(infoSpy).toHaveBeenCalledWith(
+      '[swapQuoteSlippage] Swap quote slippage validation',
+      expect.objectContaining({
+        actualSlippage: '0.5000%',
+        checkedAmount: '2010001',
+        expectedAmount: '2010001',
+        field: 'amountInMax',
+        requestedSlippage: '0.5%',
+        route: 'test-provider',
+        status: 'passed',
+      }),
+    )
+    expect(infoSpy.mock.calls[0]?.[1]).not.toHaveProperty('quote')
+    expect(infoSpy.mock.calls[0]?.[1]).not.toHaveProperty('fullQuote')
+  })
+})

--- a/utils/swapQuotes.ts
+++ b/utils/swapQuotes.ts
@@ -1,4 +1,4 @@
-import type { SwapApiQuote } from '~/entities/swap'
+import { type SwapApiQuote, SwapperMode } from '~/entities/swap'
 import { BPS_BASE } from '~/entities/tuning-constants'
 
 export type SwapQuoteAmountField = 'amountIn' | 'amountOut'
@@ -79,5 +79,44 @@ export const getQuoteDiffPct = (
     return null
   }
   const diffBps = (diff * BPS_BASE) / bestAmount
+  return Number(diffBps) / 100
+}
+
+const parseRequiredBigInt = (value?: string | number | bigint | null) => {
+  if (value === null || value === undefined) {
+    return null
+  }
+  try {
+    return BigInt(value)
+  }
+  catch {
+    return null
+  }
+}
+
+export const computeQuoteSlippage = (
+  quote: SwapApiQuote | null | undefined,
+  swapperMode = SwapperMode.EXACT_IN,
+) => {
+  if (!quote) {
+    return null
+  }
+
+  if (swapperMode === SwapperMode.TARGET_DEBT) {
+    const amountIn = getQuoteAmount(quote, 'amountIn')
+    const amountInMax = parseRequiredBigInt(quote.amountInMax)
+    if (amountIn <= 0n || amountInMax === null || amountInMax < amountIn) {
+      return null
+    }
+    const diffBps = ((amountInMax - amountIn) * BPS_BASE) / amountIn
+    return Number(diffBps) / 100
+  }
+
+  const amountOut = getQuoteAmount(quote, 'amountOut')
+  const amountOutMin = parseRequiredBigInt(quote.amountOutMin)
+  if (amountOut <= 0n || amountOutMin === null || amountOutMin > amountOut) {
+    return null
+  }
+  const diffBps = ((amountOut - amountOutMin) * BPS_BASE) / amountOut
   return Number(diffBps) / 100
 }


### PR DESCRIPTION
## Summary
- Validate swap quote slippage against the user-selected tolerance before building verifier calldata.
- Surface quote-applied slippage in swap summaries when it differs from the selected tolerance.
- Keep Multiply transaction review focused on the actual swap delta rather than projected total position sizes.

## Changes
- Thread requested slippage through swap plan builders so verifier data is rebuilt and checked from the current quote and tolerance.
- Add shared exact-in and target-debt slippage validation helpers aligned with the swap verifier paths.
- Pass computed quote slippage into swap detail summaries across affected supply, withdraw, repay, borrow, collateral swap, debt refinance, and multiply flows.
- Add regression coverage for quote slippage display and verifier validation edge cases.

## Test plan
- [x] `npm run test:run`
- [x] `npm run test:run -- tests/utils/swap-slippage-validation.test.ts tests/utils/swap-quotes.test.ts`
- [x] `npx eslint 'pages/position/[number]/multiply.vue'`
- [x] `git diff --check`
- [x] Manually smoke tested supply with swap, withdraw with swap, collateral swap, debt refinance, and multiply at `0.05%` and `1%` slippage.
- [x] Checked `npm run typecheck`; it still fails on pre-existing unrelated `composables/useMarketGroups.ts` typing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Swap UIs display quote-derived slippage alongside your configured slippage and show a warning when they differ.
  * Transaction builders now forward the chosen slippage into swap plans so displayed and executed slippage align.
  * Centralized slippage validation added to reject inconsistent or out-of-range quotes.

* **Chores**
  * Minimum allowed slippage raised slightly.

* **Tests**
  * Added comprehensive tests for slippage computation, application, rounding, and validation (including warning logs).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->