### PR TITLE
Normalize npm dependency policy

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
+save-exact=true
 min-release-age=7

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Euler Lite provides all the core functionality of Euler Finance in a customizabl
 ```bash
 git clone <repository-url>
 cd euler-lite
-npm install
+npm ci
 ```
 
 ### 2. Environment Configuration
@@ -327,7 +327,7 @@ Before deploying:
 ### Build Errors
 
 - Ensure Node.js version is 24+ (24.14.1 recommended)
-- Clear and reinstall: `rm -rf node_modules && npm install`
+- Clear and reinstall: `rm -rf node_modules && npm ci`
 
 ### Wallet Connection Issues
 

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -5,12 +5,12 @@ This guide covers the concrete steps and scripts needed to work on this reposito
 ## Prerequisites
 
 - Node.js 24+
-- npm (or yarn/pnpm if you prefer)
+- npm
 
 ## Install and run
 
 ```bash
-npm install
+npm ci
 npm run dev
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -39,7 +39,7 @@ Welcome to the Euler Lite project! This guide will help you get up and running w
 ### Prerequisites
 
 - Node.js 24+
-- npm or yarn package manager
+- npm package manager
 - Git
 - Basic knowledge of Vue.js and TypeScript
 
@@ -55,9 +55,7 @@ Welcome to the Euler Lite project! This guide will help you get up and running w
 2. **Install dependencies**
 
    ```bash
-   npm install
-   # or
-   yarn install
+   npm ci
    ```
 
 3. **Set up environment variables**
@@ -71,8 +69,6 @@ Welcome to the Euler Lite project! This guide will help you get up and running w
 
    ```bash
    npm run dev
-   # or
-   yarn dev
    ```
 
 5. **Open your browser**

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "nuxt-app",
   "private": true,
   "type": "module",
+  "packageManager": "npm@11.10.0",
   "scripts": {
     "build": "nuxt build",
     "dev": "nuxt dev",


### PR DESCRIPTION
## Summary
- Normalize the repository around npm's lockfile-backed install flow.
- Make future dependency saves exact so the manifest stays aligned with the existing pinned dependency policy.

## Changes
- Pin the npm package manager version in `package.json`.
- Add `save-exact=true` alongside the existing npm release-age gate.
- Update contributor docs to use `npm ci` and remove mixed package-manager guidance.

## Test plan
- [x] `npm ci`
- [x] `npm run test:run`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation and development instructions to use `npm ci` for consistent dependency resolution across environments.

* **Chores**
  * Standardized project to use npm as the primary package manager.
  * Pinned npm version to 11.10.0.
  * Updated npm configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->