### PR TITLE
fix(oracle-adapters): use logger.warn after server logWarn shim removal

### DIFF
--- a/server/api/oracle-adapters.get.ts
+++ b/server/api/oracle-adapters.get.ts
@@ -2,7 +2,7 @@ import { createError, getQuery } from 'h3'
 import { createRateLimiter } from '~/server/utils/rate-limit'
 import { createTtlCache } from '~/server/utils/cache'
 import { fetchWithTimeout } from '~/server/utils/fetchWithTimeout'
-import { logWarn } from '~/server/utils/log'
+import { logger } from '~/server/utils/logger'
 
 const CACHE_TTL_MS = 300_000
 
@@ -54,7 +54,7 @@ export default defineEventHandler(async (event) => {
     return data
   }
   catch (err) {
-    logWarn('oracle-adapters', `Failed to fetch all.json for chain ${chainId}:`, err instanceof Error ? err.message : err)
+    logger.warn({ ctx: 'oracle-adapters', chainId, err }, 'fetch all.json failed')
 
     const stale = cache.getStale(key)
     if (stale !== undefined) return stale


### PR DESCRIPTION
## Summary
- `server/api/oracle-adapters.get.ts` was importing `logWarn` from `~/server/utils/log`, but commit e39f64de removed that shim from `server/utils/log.ts` (only `reportStatus` remains there). Result: nitro fails to start with `RollupError: "logWarn" is not exported by "server/utils/log.ts"`.
- The two PRs were independent: #321 / #322 cross-merged through development, but the matrix branch's merge of development happened **before** e39f64de landed, so neither CI run exercised the broken combination.
- Fix: switch to `logger.warn({ ctx, chainId, err }, 'fetch all.json failed')` directly, matching the pattern used elsewhere in `server/` (e.g. `server/utils/verified-vaults.ts`, `server/middleware/cors.ts`).

## Test plan
- [ ] `npm run dev` boots without the rollup error
- [ ] Hit `/api/oracle-adapters?chainId=1` and confirm a normal response
- [ ] Force a failure (e.g. invalid `NUXT_PUBLIC_CONFIG_ORACLE_CHECKS_BASE_URL`) and confirm a single structured warn line is emitted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal logging structure to use structured metadata for better error tracking and debugging capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->