### PR TITLE
Remove quote slippage form warning

### DIFF
--- a/components/entities/swap/SwapDetailsSummary.vue
+++ b/components/entities/swap/SwapDetailsSummary.vue
@@ -2,12 +2,11 @@
 import { isPriceImpactWarning, isSlippageWarning } from '~/utils/priceImpact'
 import { formatNumber } from '~/utils/string-utils'
 
-const props = defineProps<{
+defineProps<{
   inputDisplay: string | null
   outputDisplay: string | null
   priceImpact: number | null
   slippage: number
-  quoteSlippage?: number | null
   routedVia: string | null
   multipliedPriceImpact?: number | null
 }>()
@@ -15,20 +14,6 @@ const props = defineProps<{
 const emit = defineEmits<{
   (e: 'openSlippageSettings'): void
 }>()
-
-const SLIPPAGE_DIFF_TOLERANCE = 0.005
-
-const slippageDiffers = computed(() =>
-  props.quoteSlippage !== null
-  && props.quoteSlippage !== undefined
-  && Math.abs(props.quoteSlippage - props.slippage) >= SLIPPAGE_DIFF_TOLERANCE,
-)
-
-const quoteSlippageLabel = computed(() =>
-  props.quoteSlippage !== null && props.quoteSlippage !== undefined
-    ? formatNumber(props.quoteSlippage, 2, 0)
-    : '',
-)
 </script>
 
 <template>
@@ -83,12 +68,6 @@ const quoteSlippageLabel = computed(() =>
           class="!w-16 !h-16 text-accent-600"
         />
       </button>
-      <span
-        v-if="slippageDiffers"
-        class="text-p4 text-warning-500 text-right"
-      >
-        Quote applies {{ quoteSlippageLabel }}% slippage
-      </span>
     </div>
   </SummaryRow>
   <SummaryRow

--- a/composables/borrow/useBorrowForm.ts
+++ b/composables/borrow/useBorrowForm.ts
@@ -29,7 +29,6 @@ import { useSwapPriceImpact } from '~/composables/useSwapPriceImpact'
 import { buildSwapRouteItems } from '~/utils/swapRouteItems'
 import { formatSmartAmount, trimTrailingZeros } from '~/utils/string-utils'
 import { nanoToValue } from '~/utils/crypto-utils'
-import { computeQuoteSlippage } from '~/utils/swapQuotes'
 import { isOperationBlocked } from '~/utils/operationGuardRegistry'
 import type { TxPlan } from '~/entities/txPlan'
 import { getPlanHookDisabledWarning, getUtilisationWarning, getBorrowCapWarning, getSupplyCapWarning } from '~/composables/useVaultWarnings'
@@ -126,8 +125,6 @@ export const useBorrowForm = (options: UseBorrowFormOptions) => {
     requestQuotes: requestBorrowSwapQuotes,
     selectProvider: selectBorrowSwapQuote,
   } = useSwapQuotesParallel({ amountField: 'amountOut', compare: 'max' })
-  const borrowSwapQuoteSlippage = computed(() => computeQuoteSlippage(borrowSwapEffectiveQuote.value))
-
   // --- Form state ---
   const ltv = ref(0)
   const borrowAmount = ref('')
@@ -951,7 +948,6 @@ export const useBorrowForm = (options: UseBorrowFormOptions) => {
     borrowSwapInputDisplay,
     borrowSwapOutputDisplay,
     borrowSwapRoutedVia,
-    borrowSwapQuoteSlippage,
     borrowSwapPriceImpact,
     borrowSwapRouteItems,
 

--- a/composables/borrow/useMultiplyForm.ts
+++ b/composables/borrow/useMultiplyForm.ts
@@ -27,7 +27,6 @@ import { buildSwapRouteItems } from '~/utils/swapRouteItems'
 import { formatSmartAmount, trimTrailingZeros } from '~/utils/string-utils'
 import { nanoToValue } from '~/utils/crypto-utils'
 import { computeMultipliedPriceImpact } from '~/utils/priceImpact'
-import { computeQuoteSlippage } from '~/utils/swapQuotes'
 import { calculateRoe, computeNextHealth, computeLiquidationPrice } from '~/utils/repayUtils'
 import { computeMaxMultiplier, computeMinMultiplier, computeWeightedSupplyApy, computeLeverageDebt } from '~/utils/multiply-math'
 import type { TxPlan } from '~/entities/txPlan'
@@ -121,8 +120,6 @@ export const useMultiplyForm = (options: UseMultiplyFormOptions) => {
     requestQuotes: requestMultiplyQuotes,
     selectProvider: selectMultiplyQuote,
   } = useSwapQuotesParallel({ amountField: 'amountOut', compare: 'max' })
-  const multiplyQuoteSlippage = computed(() => computeQuoteSlippage(multiplyEffectiveQuote.value))
-
   // --- Form state ---
   const multiplyInputAmount = ref('')
   const multiplier = ref(1)
@@ -985,7 +982,6 @@ export const useMultiplyForm = (options: UseMultiplyFormOptions) => {
     isMultiplyQuoteLoading,
     multiplyQuoteError,
     multiplyQuotesStatusLabel,
-    multiplyQuoteSlippage,
     selectMultiplyQuote,
 
     // USD values

--- a/composables/position/useCollateralForm.ts
+++ b/composables/position/useCollateralForm.ts
@@ -34,7 +34,6 @@ import { useSwapPriceImpact } from '~/composables/useSwapPriceImpact'
 import { usePriceImpactGate } from '~/composables/usePriceImpactGate'
 import { formatSmartAmount } from '~/utils/string-utils'
 import { nanoToValue } from '~/utils/crypto-utils'
-import { computeQuoteSlippage } from '~/utils/swapQuotes'
 import { normalizeAddressOrEmpty } from '~/utils/accountPositionHelpers'
 import { isOpDisabled, OP_DEPOSIT, OP_WITHDRAW } from '~/utils/vault-hooks'
 import { getHookDisabledWarning } from '~/composables/useVaultWarnings'
@@ -162,8 +161,6 @@ export const useCollateralForm = (options: UseCollateralFormOptions) => {
     requestQuotes: requestSwapQuotes,
     selectProvider: selectSwapQuote,
   } = useSwapQuotesParallel({ amountField: 'amountOut', compare: 'max' })
-  const swapQuoteSlippage = computed(() => computeQuoteSlippage(swapEffectiveQuote.value))
-
   // --- Position/vault computeds ---
   const position = computed(() => getPositionBySubAccountIndex(+positionIndex))
   const isPositionLoaded = computed(() => !!position.value)
@@ -768,7 +765,6 @@ export const useCollateralForm = (options: UseCollateralFormOptions) => {
     swapSelectedProvider,
     swapSelectedQuote,
     swapEffectiveQuote,
-    swapQuoteSlippage,
     swapProvidersCount,
     isSwapQuoteLoading,
     swapQuoteError,

--- a/composables/repay/useCollateralSwapRepay.ts
+++ b/composables/repay/useCollateralSwapRepay.ts
@@ -20,7 +20,6 @@ import { getSwapInputAmount } from '~/composables/useEulerOperations/swaps/verif
 import { nanoToValue, valueToNano } from '~/utils/crypto-utils'
 import { normalizeAddressOrEmpty } from '~/utils/accountPositionHelpers'
 import { createRaceGuard } from '~/utils/race-guard'
-import { computeQuoteSlippage } from '~/utils/swapQuotes'
 import { findBlockingDisabledOp, OP_REPAY, OP_REPAY_WITH_SHARES, OP_SKIM, OP_TRANSFER, OP_WITHDRAW, type PlannedOp } from '~/utils/vault-hooks'
 import { getPlanHookDisabledWarning, getUtilisationWarning, type VaultWarning } from '~/composables/useVaultWarnings'
 
@@ -129,8 +128,6 @@ export const useCollateralSwapRepay = (options: UseCollateralSwapRepayOptions) =
     borrowVault,
     direction: core.direction,
   })
-  const quoteSlippage = computed(() => computeQuoteSlippage(core.quotes.effectiveQuote.value, core.direction.value))
-
   // --- APYs ---
   const collateralSupplyApy = computed(() => {
     if (!sourceVault.value) return null
@@ -512,7 +509,6 @@ export const useCollateralSwapRepay = (options: UseCollateralSwapRepayOptions) =
     // Swap details
     currentPrice: details.currentPrice,
     summary: details.summary,
-    quoteSlippage,
     priceImpact: details.priceImpact,
     leveragedPriceImpact: details.leveragedPriceImpact,
     routedVia: details.routedVia,

--- a/composables/repay/useSavingsRepay.ts
+++ b/composables/repay/useSavingsRepay.ts
@@ -18,7 +18,6 @@ import { useRepayHealthMetrics } from '~/composables/repay/useRepayHealthMetrics
 import { getSwapInputAmount } from '~/composables/useEulerOperations/swaps/verify'
 import { nanoToValue, valueToNano } from '~/utils/crypto-utils'
 import { createRaceGuard } from '~/utils/race-guard'
-import { computeQuoteSlippage } from '~/utils/swapQuotes'
 import { findBlockingDisabledOp, OP_REPAY_WITH_SHARES, OP_SKIM, OP_TRANSFER, OP_WITHDRAW, type PlannedOp } from '~/utils/vault-hooks'
 import { getPlanHookDisabledWarning, getUtilisationWarning, type VaultWarning } from '~/composables/useVaultWarnings'
 
@@ -108,8 +107,6 @@ export const useSavingsRepay = (options: UseSavingsRepayOptions) => {
     borrowVault,
     direction: core.direction,
   })
-  const quoteSlippage = computed(() => computeQuoteSlippage(core.quotes.effectiveQuote.value, core.direction.value))
-
   // --- Savings-specific computeds ---
   const collateralAmountAfter = computed(() => {
     if (!collateralVault.value || !position.value) return null
@@ -442,7 +439,6 @@ export const useSavingsRepay = (options: UseSavingsRepayOptions) => {
     // Swap details
     currentPrice: details.currentPrice,
     summary: details.summary,
-    quoteSlippage,
     priceImpact: details.priceImpact,
     leveragedPriceImpact: details.leveragedPriceImpact,
     routedVia: details.routedVia,

--- a/composables/repay/useWalletSwapRepay.ts
+++ b/composables/repay/useWalletSwapRepay.ts
@@ -18,7 +18,6 @@ import { amountToPercent, percentToAmountNano } from '~/utils/repayUtils'
 import { SwapperMode } from '~/entities/swap'
 import { createRaceGuard } from '~/utils/race-guard'
 import { buildSwapRouteItems } from '~/utils/swapRouteItems'
-import { computeQuoteSlippage } from '~/utils/swapQuotes'
 import { useSwapPriceImpact } from '~/composables/useSwapPriceImpact'
 import { useSwapRepayQuotes } from '~/composables/repay/useSwapRepayQuotes'
 import { getSwapInputAmount } from '~/composables/useEulerOperations/swaps/verify'
@@ -85,8 +84,6 @@ export const useWalletSwapRepay = (options: UseWalletSwapRepayOptions) => {
 
   // --- Swap quotes (dual-direction) ---
   const quotes = useSwapRepayQuotes({ direction })
-  const quoteSlippage = computed(() => computeQuoteSlippage(quotes.effectiveQuote.value, direction.value))
-
   // --- Derived ---
   const needsSwap = computed(() => {
     if (!selectedAsset.value || !borrowVault.value) return false
@@ -808,7 +805,6 @@ export const useWalletSwapRepay = (options: UseWalletSwapRepayOptions) => {
     swapInputDisplay,
     swapOutputDisplay,
     swapRoutedVia,
-    quoteSlippage,
     swapPriceImpact,
     swapRouteItems,
     isFullRepay,

--- a/composables/useEulerOperations/swaps/verify.ts
+++ b/composables/useEulerOperations/swaps/verify.ts
@@ -6,9 +6,8 @@ import { type SwapApiQuote, SwapperMode, SwapVerificationType } from '~/entities
 import { logWarn } from '~/utils/errorHandling'
 
 // Absolute extra slippage (in percentage points) the validator forgives to absorb
-// BigInt rounding between the swap API and the SDK. Must stay strictly below
-// SLIPPAGE_DIFF_TOLERANCE in SwapDetailsSummary so the user-facing warning never
-// fires on a quote the validator has accepted.
+// BigInt rounding between the swap API and the SDK. Keep this intentionally tiny
+// so accepted verifier bounds cannot drift materially beyond the selected tolerance.
 const VALIDATION_DIVERGENCE_TOLERANCE_PP = 0.001
 
 type SwapQuoteSlippageValidationContext = {

--- a/composables/useSwapPageLogic.ts
+++ b/composables/useSwapPageLogic.ts
@@ -9,11 +9,10 @@ import { getAssetUsdValue } from '~/services/pricing/priceProvider'
 import { useEulerProductOfVault } from '~/composables/useEulerLabels'
 import { isAnyVaultBlockedByCountry, getVaultTags } from '~/composables/useGeoBlock'
 import { useSwapQuotesParallel } from '~/composables/useSwapQuotesParallel'
-import { computeQuoteSlippage, getQuoteAmount, type SwapQuoteAmountField, type SwapQuoteCompare } from '~/utils/swapQuotes'
+import { getQuoteAmount, type SwapQuoteAmountField, type SwapQuoteCompare } from '~/utils/swapQuotes'
 import { buildSwapRouteItems } from '~/utils/swapRouteItems'
 import type { SwapApiRequestInput } from '~/composables/useSwapApi'
 import type { TxPlan } from '~/entities/txPlan'
-import { SwapperMode } from '~/entities/swap'
 import { useModal } from '~/components/ui/composables/useModal'
 import { useToast } from '~/components/ui/composables/useToast'
 import { isSameUnderlyingAsset, isSameVault as isSameVaultCheck } from '~/utils/vault-utils'
@@ -119,11 +118,6 @@ export const useSwapPageLogic = (options: UseSwapPageLogicOptions) => {
     requestQuotes,
     selectProvider,
   } = useSwapQuotesParallel({ amountField, compare })
-  const quoteSlippage = computed(() => computeQuoteSlippage(
-    effectiveQuote.value,
-    amountField === 'amountIn' ? SwapperMode.TARGET_DEBT : SwapperMode.EXACT_IN,
-  ))
-
   // ── Vault products & price invert ──────────────────────────────────────
   const fromProduct = useEulerProductOfVault(computed(() => fromVault.value?.address || ''))
   const toProduct = useEulerProductOfVault(computed(() => toVault.value?.address || ''))
@@ -524,7 +518,6 @@ export const useSwapPageLogic = (options: UseSwapPageLogicOptions) => {
     isQuoteLoading,
     quoteError,
     quotesStatusLabel,
-    quoteSlippage,
     selectProvider,
 
     // Vault identity

--- a/pages/borrow/[collateral]/[borrow]/index.vue
+++ b/pages/borrow/[collateral]/[borrow]/index.vue
@@ -548,7 +548,6 @@ watch(formTab, () => {
                       :output-display="borrow.borrowSwapOutputDisplay.value"
                       :price-impact="borrow.borrowSwapPriceImpact.value"
                       :slippage="borrow.borrowSwapSlippage.value"
-                      :quote-slippage="borrow.borrowSwapQuoteSlippage.value"
                       :routed-via="borrow.borrowSwapRoutedVia.value"
                       @open-slippage-settings="openSlippageSettings"
                     />
@@ -853,7 +852,6 @@ watch(formTab, () => {
                         :output-display="multiply.multiplySwapSummary.value?.to ?? null"
                         :price-impact="multiply.multiplyPriceImpact.value"
                         :slippage="multiply.multiplySlippage.value"
-                        :quote-slippage="multiply.multiplyQuoteSlippage.value"
                         :routed-via="multiply.multiplyRoutedVia.value"
                         :multiplied-price-impact="multiply.multipliedPriceImpact.value"
                         @open-slippage-settings="openSlippageSettings"

--- a/pages/lend/[vault]/[subAccount]/swap.vue
+++ b/pages/lend/[vault]/[subAccount]/swap.vue
@@ -139,7 +139,7 @@ const {
   isGeoBlocked, reviewSwapDisabled, reviewSwapLabel, simulationError,
   isQuoteLoading, quoteError, quotesStatusLabel, selectedProvider, selectedQuote,
   fromProduct, toProduct, currentPrice, swapSummary, priceImpact, routedVia,
-  quoteSlippage, swapRouteItems, swapRouteEmptyMessage,
+  swapRouteItems, swapRouteEmptyMessage,
   selectProvider, onFromInput, onToVaultChange, onRefreshQuotes, submit, openSlippageSettings,
 } = swap
 
@@ -323,7 +323,6 @@ watch([() => route.params.vault, () => route.query.to], () => {
                 :output-display="swapSummary?.to ?? null"
                 :price-impact="priceImpact"
                 :slippage="slippage"
-                :quote-slippage="quoteSlippage"
                 :routed-via="routedVia"
                 @open-slippage-settings="openSlippageSettings"
               />

--- a/pages/lend/[vault]/[subAccount]/withdraw.vue
+++ b/pages/lend/[vault]/[subAccount]/withdraw.vue
@@ -21,7 +21,6 @@ import type { TxPlan } from '~/entities/txPlan'
 import { useSwapQuotesParallel } from '~/composables/useSwapQuotesParallel'
 import { SwapperMode } from '~/entities/swap'
 import { buildSwapRouteItems } from '~/utils/swapRouteItems'
-import { computeQuoteSlippage } from '~/utils/swapQuotes'
 import { formatNumber, formatSmartAmount, formatExactAmount } from '~/utils/string-utils'
 import { useSwapPriceImpact } from '~/composables/useSwapPriceImpact'
 import { usePriceImpactGate } from '~/composables/usePriceImpactGate'
@@ -108,8 +107,6 @@ const {
   requestQuotes: requestSwapQuotes,
   selectProvider: selectSwapQuote,
 } = useSwapQuotesParallel({ amountField: 'amountOut', compare: 'max' })
-const swapQuoteSlippage = computed(() => computeQuoteSlippage(swapEffectiveQuote.value))
-
 const rewardApy = computed(() => getSupplyRewardApy(vault.value?.address || ''))
 const amountFixed = computed(() => {
   return FixedPoint.fromValue(
@@ -624,7 +621,6 @@ watch(swapSelectedQuote, () => {
                   :output-display="swapOutputDisplay"
                   :price-impact="swapPriceImpact"
                   :slippage="swapSlippage"
-                  :quote-slippage="swapQuoteSlippage"
                   :routed-via="swapRoutedVia"
                   @open-slippage-settings="openSlippageSettings"
                 />

--- a/pages/lend/[vault]/index.vue
+++ b/pages/lend/[vault]/index.vue
@@ -18,7 +18,6 @@ import { useVaultRegistry } from '~/composables/useVaultRegistry'
 import { useSwapQuotesParallel } from '~/composables/useSwapQuotesParallel'
 import { type SwapApiQuote, SwapperMode } from '~/entities/swap'
 import { buildSwapRouteItems } from '~/utils/swapRouteItems'
-import { computeQuoteSlippage } from '~/utils/swapQuotes'
 import VaultFormInfoBlock from '~/components/entities/vault/form/VaultFormInfoBlock.vue'
 import VaultFormSubmit from '~/components/entities/vault/form/VaultFormSubmit.vue'
 import SecuritizeVaultOverview from '~/components/entities/vault/overview/SecuritizeVaultOverview.vue'
@@ -130,8 +129,6 @@ const {
   requestQuotes: requestSwapQuotes,
   selectProvider: selectSwapQuote,
 } = useSwapQuotesParallel({ amountField: 'amountOut', compare: 'max' })
-const swapQuoteSlippage = computed(() => computeQuoteSlippage(swapEffectiveQuote.value))
-
 // Vault data - only one will be populated based on type
 const evkVault: Ref<Vault | undefined> = ref(undefined)
 const securitizeVault: Ref<SecuritizeVault | undefined> = ref(undefined)
@@ -900,7 +897,6 @@ watch(address, () => {
                   :output-display="swapOutputDisplay"
                   :price-impact="swapPriceImpact"
                   :slippage="swapSlippage"
-                  :quote-slippage="swapQuoteSlippage"
                   :routed-via="swapRoutedVia"
                   @open-slippage-settings="openSlippageSettings"
                 />

--- a/pages/position/[number]/borrow/swap.vue
+++ b/pages/position/[number]/borrow/swap.vue
@@ -252,7 +252,7 @@ const {
   isGeoBlocked, reviewSwapDisabled, reviewSwapLabel, simulationError,
   isQuoteLoading, quoteError, quotesStatusLabel, selectedProvider, selectedQuote,
   fromProduct, toProduct, swapPriceInvert, currentPrice, swapSummary, priceImpact, routedVia,
-  quoteSlippage, swapRouteItems, swapRouteEmptyMessage,
+  swapRouteItems, swapRouteEmptyMessage,
   selectProvider, onFromInput: _onFromInput, onRefreshQuotes, submit, openSlippageSettings,
   normalizeAddress, clearSimulationError, requestQuote,
 } = swap
@@ -552,7 +552,6 @@ const onToVaultChange = (selectedIndex: number) => {
               :output-display="swapSummary?.to ?? null"
               :price-impact="priceImpact"
               :slippage="slippage"
-              :quote-slippage="quoteSlippage"
               :routed-via="routedVia"
               @open-slippage-settings="openSlippageSettings"
             />

--- a/pages/position/[number]/collateral/swap.vue
+++ b/pages/position/[number]/collateral/swap.vue
@@ -185,7 +185,7 @@ const {
   isGeoBlocked, reviewSwapDisabled, reviewSwapLabel, simulationError,
   isQuoteLoading, quoteError, quotesStatusLabel, selectedProvider, selectedQuote,
   fromProduct, toProduct, swapPriceInvert, currentPrice, swapSummary, priceImpact, routedVia,
-  quoteSlippage, swapRouteItems, swapRouteEmptyMessage,
+  swapRouteItems, swapRouteEmptyMessage,
   selectProvider, onFromInput, onRefreshQuotes, submit, openSlippageSettings,
   normalizeAddress, clearSimulationError, resetQuoteState,
 } = swap
@@ -664,7 +664,6 @@ const nextLiquidationPrice = computed(() => {
               :output-display="swapSummary?.to ?? null"
               :price-impact="priceImpact"
               :slippage="slippage"
-              :quote-slippage="quoteSlippage"
               :routed-via="routedVia"
               @open-slippage-settings="openSlippageSettings"
             />

--- a/pages/position/[number]/multiply.vue
+++ b/pages/position/[number]/multiply.vue
@@ -9,7 +9,6 @@ import type { AccountBorrowPosition } from '~/entities/account'
 import type { Vault, VaultAsset } from '~/entities/vault'
 import { getAssetUsdValue, getAssetOraclePrice, getCollateralOraclePrice, conservativePriceRatioNumber } from '~/services/pricing/priceProvider'
 import { computeMultipliedPriceImpact } from '~/utils/priceImpact'
-import { computeQuoteSlippage } from '~/utils/swapQuotes'
 import { usePriceImpactGate } from '~/composables/usePriceImpactGate'
 import { useEulerProductOfVault } from '~/composables/useEulerLabels'
 import { isAnyVaultBlockedByCountry, isVaultRestrictedByCountry } from '~/composables/useGeoBlock'
@@ -99,8 +98,6 @@ const {
   requestQuotes: requestMultiplyQuotes,
   selectProvider: selectMultiplyQuote,
 } = useSwapQuotesParallel({ amountField: 'amountOut', compare: 'max' })
-const multiplyQuoteSlippage = computed(() => computeQuoteSlippage(multiplyEffectiveQuote.value))
-
 const multiplyLongVault = computed(() => position.value?.collateral)
 const multiplyShortVault = computed(() => position.value?.borrow)
 const multiplySubAccount = computed(() => position.value?.subAccount || null)
@@ -959,7 +956,6 @@ watch([multiplyMinMultiplier, multiplyMaxMultiplier], ([min, max]) => {
               :output-display="multiplySwapSummary?.to ?? null"
               :price-impact="multiplyPriceImpact"
               :slippage="multiplySlippage"
-              :quote-slippage="multiplyQuoteSlippage"
               :routed-via="multiplyRoutedVia"
               :multiplied-price-impact="multipliedPriceImpact"
               @open-slippage-settings="openSlippageSettings"

--- a/pages/position/[number]/repay.vue
+++ b/pages/position/[number]/repay.vue
@@ -609,7 +609,6 @@ watch(formTab, () => {
                 :output-display="walletSwap.swapOutputDisplay.value"
                 :price-impact="walletSwap.swapPriceImpact.value"
                 :slippage="slippage"
-                :quote-slippage="walletSwap.quoteSlippage.value"
                 :routed-via="walletSwap.swapRoutedVia.value"
                 @open-slippage-settings="openSlippageSettings"
               />
@@ -793,7 +792,6 @@ watch(formTab, () => {
                 :output-display="collateral.summary.value?.to ?? null"
                 :price-impact="collateral.priceImpact.value"
                 :slippage="slippage"
-                :quote-slippage="collateral.quoteSlippage.value"
                 :routed-via="collateral.routedVia.value"
                 @open-slippage-settings="openSlippageSettings"
               />
@@ -969,7 +967,6 @@ watch(formTab, () => {
                 :output-display="savings.summary.value?.to ?? null"
                 :price-impact="savings.priceImpact.value"
                 :slippage="slippage"
-                :quote-slippage="savings.quoteSlippage.value"
                 :routed-via="savings.routedVia.value"
                 @open-slippage-settings="openSlippageSettings"
               />

--- a/pages/position/[number]/supply.vue
+++ b/pages/position/[number]/supply.vue
@@ -320,7 +320,6 @@ watch(selectedAsset, async () => {
                   :output-display="form.swapOutputDisplay.value"
                   :price-impact="form.swapPriceImpact.value"
                   :slippage="form.swapSlippage.value"
-                  :quote-slippage="form.swapQuoteSlippage.value"
                   :routed-via="form.swapRoutedVia.value"
                   @open-slippage-settings="form.openSlippageSettings"
                 />

--- a/pages/position/[number]/withdraw.vue
+++ b/pages/position/[number]/withdraw.vue
@@ -264,7 +264,6 @@ watch(selectedOutputAsset, () => {
                   :output-display="form.swapOutputDisplay.value"
                   :price-impact="form.swapPriceImpact.value"
                   :slippage="form.swapSlippage.value"
-                  :quote-slippage="form.swapQuoteSlippage.value"
                   :routed-via="form.swapRoutedVia.value"
                   @open-slippage-settings="form.openSlippageSettings"
                 />

--- a/tests/utils/swap-quotes.test.ts
+++ b/tests/utils/swap-quotes.test.ts
@@ -4,18 +4,11 @@ import {
   sortQuoteCards,
   pickBestQuote,
   getQuoteDiffPct,
-  computeQuoteSlippage,
 } from '~/utils/swapQuotes'
-import { type SwapApiQuote, SwapperMode } from '~/entities/swap'
+import type { SwapApiQuote } from '~/entities/swap'
 
 const makeQuote = (amountIn: string, amountOut: string): SwapApiQuote =>
   ({ amountIn, amountOut }) as SwapApiQuote
-
-const makeSlippageQuote = (amountOut: string, amountOutMin: string): SwapApiQuote =>
-  ({ amountOut, amountOutMin }) as SwapApiQuote
-
-const makeTargetDebtSlippageQuote = (amountIn: string, amountInMax: string): SwapApiQuote =>
-  ({ amountIn, amountInMax }) as SwapApiQuote
 
 describe('getQuoteAmount', () => {
   it('returns 0n for null quote', () => {
@@ -139,71 +132,5 @@ describe('getQuoteDiffPct', () => {
   it('returns null when quote is better than best in max mode', () => {
     // quoteAmount=200 > bestAmount=100 => diff = 100-200 = -100 <= 0 => null
     expect(getQuoteDiffPct(200n, 100n, 'max')).toBeNull()
-  })
-})
-
-describe('computeQuoteSlippage', () => {
-  it('returns null for null quote', () => {
-    expect(computeQuoteSlippage(null)).toBeNull()
-  })
-
-  it('returns null when amountOut is zero', () => {
-    expect(computeQuoteSlippage(makeSlippageQuote('0', '95'))).toBeNull()
-  })
-
-  it('returns null when amountOutMin is missing', () => {
-    expect(computeQuoteSlippage({ amountOut: '100' } as SwapApiQuote)).toBeNull()
-  })
-
-  it('returns null when amountOutMin is invalid', () => {
-    expect(computeQuoteSlippage(makeSlippageQuote('100', 'invalid'))).toBeNull()
-  })
-
-  it('returns 100 when amountOutMin is zero', () => {
-    expect(computeQuoteSlippage(makeSlippageQuote('100', '0'))).toBe(100)
-  })
-
-  it('returns 0 when amountOutMin matches amountOut', () => {
-    expect(computeQuoteSlippage(makeSlippageQuote('100', '100'))).toBe(0)
-  })
-
-  it('returns null when amountOutMin is greater than amountOut', () => {
-    expect(computeQuoteSlippage(makeSlippageQuote('100', '101'))).toBeNull()
-  })
-
-  it('derives the quote slippage percentage from amountOut and amountOutMin', () => {
-    expect(computeQuoteSlippage(makeSlippageQuote('1000', '995'))).toBe(0.5)
-  })
-
-  it('rounds down to basis-point precision', () => {
-    expect(computeQuoteSlippage(makeSlippageQuote('3333', '3300'))).toBe(0.99)
-  })
-
-  it('derives target debt quote slippage from amountIn and amountInMax', () => {
-    expect(computeQuoteSlippage(
-      makeTargetDebtSlippageQuote('1000', '1005'),
-      SwapperMode.TARGET_DEBT,
-    )).toBe(0.5)
-  })
-
-  it('returns 0 when target debt amountInMax matches amountIn', () => {
-    expect(computeQuoteSlippage(
-      makeTargetDebtSlippageQuote('1000', '1000'),
-      SwapperMode.TARGET_DEBT,
-    )).toBe(0)
-  })
-
-  it('returns null when target debt amountInMax is below amountIn', () => {
-    expect(computeQuoteSlippage(
-      makeTargetDebtSlippageQuote('1000', '999'),
-      SwapperMode.TARGET_DEBT,
-    )).toBeNull()
-  })
-
-  it('returns null when target debt amountInMax is missing', () => {
-    expect(computeQuoteSlippage(
-      { amountIn: '1000' } as SwapApiQuote,
-      SwapperMode.TARGET_DEBT,
-    )).toBeNull()
   })
 })

--- a/tests/utils/swap-slippage-validation.test.ts
+++ b/tests/utils/swap-slippage-validation.test.ts
@@ -18,8 +18,14 @@ const makeQuote = (overrides: Partial<SwapApiQuote>): SwapApiQuote => ({
 const captureStdout = () => {
   const captured: string[] = []
   const originalWrite = process.stdout.write.bind(process.stdout)
-  process.stdout.write = ((chunk: unknown) => {
-    captured.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk as Uint8Array).toString())
+  process.stdout.write = ((
+    chunk: string | Uint8Array,
+    encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void),
+    callback?: (error?: Error | null) => void,
+  ) => {
+    captured.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString())
+    const writeCallback = typeof encodingOrCallback === 'function' ? encodingOrCallback : callback
+    writeCallback?.()
     return true
   }) as typeof process.stdout.write
 

--- a/tests/utils/swap-slippage-validation.test.ts
+++ b/tests/utils/swap-slippage-validation.test.ts
@@ -45,6 +45,16 @@ const captureStdout = () => {
 const validationLogLines = (capture: ReturnType<typeof captureStdout>) =>
   capture.lines().filter(line => line.ctx === 'swapQuoteSlippage')
 
+const withCapturedStdout = <T>(callback: (stdout: ReturnType<typeof captureStdout>) => T): T => {
+  const stdout = captureStdout()
+  try {
+    return callback(stdout)
+  }
+  finally {
+    stdout.restore()
+  }
+}
+
 describe('swap quote slippage validation', () => {
   it('rounds output slippage down like the SDK', () => {
     expect(applySlippageToOutput(950n, 0.5)).toBe(945n)
@@ -63,10 +73,8 @@ describe('swap quote slippage validation', () => {
     ).toThrow('Valid slippage between 0 and 50% must be provided for swap')
   })
 
-  it('rejects amountOutMin below requested slippage', () => {
-    const stdout = captureStdout()
-
-    try {
+  it('rejects amountOutMin below requested slippage', () =>
+    withCapturedStdout((stdout) => {
       expect(() =>
         validateSwapQuoteSlippageData(
           { slippage: 0.5, swapperMode: SwapperMode.EXACT_IN },
@@ -92,16 +100,10 @@ describe('swap quote slippage validation', () => {
       })
       expect(line.data).not.toHaveProperty('quote')
       expect(line.data).not.toHaveProperty('fullQuote')
-    }
-    finally {
-      stdout.restore()
-    }
-  })
+    }))
 
-  it('rejects amountInMax above requested slippage for target debt', () => {
-    const stdout = captureStdout()
-
-    try {
+  it('rejects amountInMax above requested slippage for target debt', () =>
+    withCapturedStdout((stdout) => {
       expect(() =>
         validateSwapQuoteSlippageData(
           { slippage: 0.5, swapperMode: SwapperMode.TARGET_DEBT },
@@ -127,16 +129,10 @@ describe('swap quote slippage validation', () => {
       })
       expect(line.data).not.toHaveProperty('quote')
       expect(line.data).not.toHaveProperty('fullQuote')
-    }
-    finally {
-      stdout.restore()
-    }
-  })
+    }))
 
-  it('allows output slippage up to the validator divergence tolerance', () => {
-    const stdout = captureStdout()
-
-    try {
+  it('allows output slippage up to the validator divergence tolerance', () =>
+    withCapturedStdout((stdout) => {
       // At slippage 0.5%, validator forgives up to +0.001pp absolute, so a quote
       // with amountOutMin = floor(2_000_000 * (1 - 0.00501)) = 1989980 must pass.
       expect(() =>
@@ -163,16 +159,10 @@ describe('swap quote slippage validation', () => {
           status: 'failed',
         }),
       })
-    }
-    finally {
-      stdout.restore()
-    }
-  })
+    }))
 
-  it('allows input slippage up to the validator divergence tolerance', () => {
-    const stdout = captureStdout()
-
-    try {
+  it('allows input slippage up to the validator divergence tolerance', () =>
+    withCapturedStdout((stdout) => {
       // At slippage 0.5%, validator forgives up to +0.001pp absolute, so a quote
       // with amountInMax = floor(2_000_000 * (1 + 0.00501)) = 2010020 must pass.
       expect(() =>
@@ -199,18 +189,12 @@ describe('swap quote slippage validation', () => {
           status: 'failed',
         }),
       })
-    }
-    finally {
-      stdout.restore()
-    }
-  })
+    }))
 
-  it('keeps validator divergence tolerance tiny at MAX_SLIPPAGE', () => {
-    const stdout = captureStdout()
-
-    // At MAX_SLIPPAGE = 50%, the validator forgives 0.001pp for rounding:
-    // boundary amountOutMin = floor(2_000_000 * (1 - 0.50001)) = 999_980.
-    try {
+  it('keeps validator divergence tolerance tiny at MAX_SLIPPAGE', () =>
+    withCapturedStdout((stdout) => {
+      // At MAX_SLIPPAGE = 50%, the validator forgives 0.001pp for rounding:
+      // boundary amountOutMin = floor(2_000_000 * (1 - 0.50001)) = 999_980.
       expect(() =>
         validateSwapQuoteSlippageData(
           { slippage: 50, swapperMode: SwapperMode.EXACT_IN },
@@ -234,9 +218,5 @@ describe('swap quote slippage validation', () => {
           status: 'failed',
         }),
       })
-    }
-    finally {
-      stdout.restore()
-    }
-  })
+    }))
 })

--- a/tests/utils/swap-slippage-validation.test.ts
+++ b/tests/utils/swap-slippage-validation.test.ts
@@ -74,7 +74,9 @@ describe('swap quote slippage validation', () => {
         ),
       ).toThrow('amountOutMin exceeds requested slippage')
 
-      const line = validationLogLines(stdout)[0]
+      const lines = validationLogLines(stdout)
+      expect(lines).toHaveLength(1)
+      const line = lines[0]
       expect(line).toMatchObject({
         ctx: 'swapQuoteSlippage',
         msg: 'Swap quote exceeds requested slippage',
@@ -107,7 +109,9 @@ describe('swap quote slippage validation', () => {
         ),
       ).toThrow('amountInMax exceeds requested slippage')
 
-      const line = validationLogLines(stdout)[0]
+      const lines = validationLogLines(stdout)
+      expect(lines).toHaveLength(1)
+      const line = lines[0]
       expect(line).toMatchObject({
         ctx: 'swapQuoteSlippage',
         msg: 'Swap quote exceeds requested slippage',

--- a/tests/utils/swap-slippage-validation.test.ts
+++ b/tests/utils/swap-slippage-validation.test.ts
@@ -27,7 +27,18 @@ const captureStdout = () => {
     restore: () => {
       process.stdout.write = originalWrite
     },
-    lines: () => captured.join('').split('\n').filter(Boolean).map(line => JSON.parse(line) as Record<string, unknown>),
+    lines: () => captured.join('')
+      .split('\n')
+      .map(line => line.trim())
+      .filter(Boolean)
+      .flatMap((line) => {
+        try {
+          return [JSON.parse(line) as Record<string, unknown>]
+        }
+        catch {
+          return []
+        }
+      }),
   }
 }
 
@@ -193,6 +204,8 @@ describe('swap quote slippage validation', () => {
           makeQuote({ amountOut: '2000000', amountOutMin: '999979' }),
         ),
       ).toThrow('amountOutMin exceeds requested slippage')
+
+      expect(validationLogLines(stdout)).toHaveLength(1)
     }
     finally {
       stdout.restore()

--- a/tests/utils/swap-slippage-validation.test.ts
+++ b/tests/utils/swap-slippage-validation.test.ts
@@ -154,7 +154,15 @@ describe('swap quote slippage validation', () => {
         ),
       ).toThrow('amountOutMin exceeds requested slippage')
 
-      expect(validationLogLines(stdout)).toHaveLength(1)
+      const lines = validationLogLines(stdout)
+      expect(lines).toHaveLength(1)
+      expect(lines[0]).toMatchObject({
+        data: expect.objectContaining({
+          checkedAmount: '1989979',
+          field: 'amountOutMin',
+          status: 'failed',
+        }),
+      })
     }
     finally {
       stdout.restore()
@@ -182,7 +190,15 @@ describe('swap quote slippage validation', () => {
         ),
       ).toThrow('amountInMax exceeds requested slippage')
 
-      expect(validationLogLines(stdout)).toHaveLength(1)
+      const lines = validationLogLines(stdout)
+      expect(lines).toHaveLength(1)
+      expect(lines[0]).toMatchObject({
+        data: expect.objectContaining({
+          checkedAmount: '2010021',
+          field: 'amountInMax',
+          status: 'failed',
+        }),
+      })
     }
     finally {
       stdout.restore()
@@ -209,7 +225,15 @@ describe('swap quote slippage validation', () => {
         ),
       ).toThrow('amountOutMin exceeds requested slippage')
 
-      expect(validationLogLines(stdout)).toHaveLength(1)
+      const lines = validationLogLines(stdout)
+      expect(lines).toHaveLength(1)
+      expect(lines[0]).toMatchObject({
+        data: expect.objectContaining({
+          checkedAmount: '999979',
+          field: 'amountOutMin',
+          status: 'failed',
+        }),
+      })
     }
     finally {
       stdout.restore()

--- a/tests/utils/swap-slippage-validation.test.ts
+++ b/tests/utils/swap-slippage-validation.test.ts
@@ -17,7 +17,7 @@ const makeQuote = (overrides: Partial<SwapApiQuote>): SwapApiQuote => ({
 
 const captureStdout = () => {
   const captured: string[] = []
-  const originalWrite = process.stdout.write.bind(process.stdout)
+  const originalWrite = process.stdout.write
   process.stdout.write = ((
     chunk: string | Uint8Array,
     encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void),

--- a/tests/utils/swap-slippage-validation.test.ts
+++ b/tests/utils/swap-slippage-validation.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { SwapperMode, type SwapApiQuote } from '~/entities/swap'
 import {
   applySlippageToInput,
@@ -15,11 +15,26 @@ const makeQuote = (overrides: Partial<SwapApiQuote>): SwapApiQuote => ({
   ...overrides,
 }) as SwapApiQuote
 
-describe('swap quote slippage validation', () => {
-  afterEach(() => {
-    vi.restoreAllMocks()
-  })
+const captureStdout = () => {
+  const captured: string[] = []
+  const originalWrite = process.stdout.write.bind(process.stdout)
+  process.stdout.write = ((chunk: unknown) => {
+    captured.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk as Uint8Array).toString())
+    return true
+  }) as typeof process.stdout.write
 
+  return {
+    restore: () => {
+      process.stdout.write = originalWrite
+    },
+    lines: () => captured.join('').split('\n').filter(Boolean).map(line => JSON.parse(line) as Record<string, unknown>),
+  }
+}
+
+const validationLogLines = (capture: ReturnType<typeof captureStdout>) =>
+  capture.lines().filter(line => line.ctx === 'swapQuoteSlippage')
+
+describe('swap quote slippage validation', () => {
   it('rounds output slippage down like the SDK', () => {
     expect(applySlippageToOutput(950n, 0.5)).toBe(945n)
   })
@@ -38,122 +53,149 @@ describe('swap quote slippage validation', () => {
   })
 
   it('rejects amountOutMin below requested slippage', () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const stdout = captureStdout()
 
-    expect(() =>
-      validateSwapQuoteSlippageData(
-        { slippage: 0.5, swapperMode: SwapperMode.EXACT_IN },
-        makeQuote({ amountOutMin: '944' }),
-      ),
-    ).toThrow('amountOutMin exceeds requested slippage')
+    try {
+      expect(() =>
+        validateSwapQuoteSlippageData(
+          { slippage: 0.5, swapperMode: SwapperMode.EXACT_IN },
+          makeQuote({ amountOutMin: '944' }),
+        ),
+      ).toThrow('amountOutMin exceeds requested slippage')
 
-    expect(warnSpy).toHaveBeenCalledWith(
-      '[swapQuoteSlippage]',
-      'Swap quote exceeds requested slippage',
-      expect.objectContaining({
-        actualSlippage: '0.6315%',
-        checkedAmount: '944',
-        expectedAmount: '945',
-        field: 'amountOutMin',
-        mode: 'output',
-        requestedSlippage: '0.5%',
-        route: 'test-provider',
-      }),
-    )
-    expect(warnSpy.mock.calls[0]?.[2]).not.toHaveProperty('quote')
-    expect(warnSpy.mock.calls[0]?.[2]).not.toHaveProperty('fullQuote')
+      const line = validationLogLines(stdout)[0]
+      expect(line).toMatchObject({
+        ctx: 'swapQuoteSlippage',
+        msg: 'Swap quote exceeds requested slippage',
+        data: expect.objectContaining({
+          actualSlippage: '0.6315%',
+          checkedAmount: '944',
+          expectedAmount: '945',
+          field: 'amountOutMin',
+          mode: 'output',
+          requestedSlippage: '0.5%',
+          route: 'test-provider',
+        }),
+      })
+      expect(line.data).not.toHaveProperty('quote')
+      expect(line.data).not.toHaveProperty('fullQuote')
+    }
+    finally {
+      stdout.restore()
+    }
   })
 
   it('rejects amountInMax above requested slippage for target debt', () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const stdout = captureStdout()
 
-    expect(() =>
-      validateSwapQuoteSlippageData(
-        { slippage: 0.5, swapperMode: SwapperMode.TARGET_DEBT },
-        makeQuote({ amountInMax: '1007' }),
-      ),
-    ).toThrow('amountInMax exceeds requested slippage')
+    try {
+      expect(() =>
+        validateSwapQuoteSlippageData(
+          { slippage: 0.5, swapperMode: SwapperMode.TARGET_DEBT },
+          makeQuote({ amountInMax: '1007' }),
+        ),
+      ).toThrow('amountInMax exceeds requested slippage')
 
-    expect(warnSpy).toHaveBeenCalledWith(
-      '[swapQuoteSlippage]',
-      'Swap quote exceeds requested slippage',
-      expect.objectContaining({
-        actualSlippage: '0.7000%',
-        checkedAmount: '1007',
-        expectedAmount: '1006',
-        field: 'amountInMax',
-        mode: 'input',
-        requestedSlippage: '0.5%',
-        route: 'test-provider',
-      }),
-    )
-    expect(warnSpy.mock.calls[0]?.[2]).not.toHaveProperty('quote')
-    expect(warnSpy.mock.calls[0]?.[2]).not.toHaveProperty('fullQuote')
+      const line = validationLogLines(stdout)[0]
+      expect(line).toMatchObject({
+        ctx: 'swapQuoteSlippage',
+        msg: 'Swap quote exceeds requested slippage',
+        data: expect.objectContaining({
+          actualSlippage: '0.7000%',
+          checkedAmount: '1007',
+          expectedAmount: '1006',
+          field: 'amountInMax',
+          mode: 'input',
+          requestedSlippage: '0.5%',
+          route: 'test-provider',
+        }),
+      })
+      expect(line.data).not.toHaveProperty('quote')
+      expect(line.data).not.toHaveProperty('fullQuote')
+    }
+    finally {
+      stdout.restore()
+    }
   })
 
   it('allows output slippage up to the validator divergence tolerance', () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const stdout = captureStdout()
 
-    // At slippage 0.5%, validator forgives up to +0.001pp absolute, so a quote
-    // with amountOutMin = floor(2_000_000 * (1 - 0.00501)) = 1989980 must pass.
-    expect(() =>
-      validateSwapQuoteSlippageData(
-        { slippage: 0.5, swapperMode: SwapperMode.EXACT_IN },
-        makeQuote({ amountOut: '2000000', amountOutMin: '1989980' }),
-      ),
-    ).not.toThrow()
+    try {
+      // At slippage 0.5%, validator forgives up to +0.001pp absolute, so a quote
+      // with amountOutMin = floor(2_000_000 * (1 - 0.00501)) = 1989980 must pass.
+      expect(() =>
+        validateSwapQuoteSlippageData(
+          { slippage: 0.5, swapperMode: SwapperMode.EXACT_IN },
+          makeQuote({ amountOut: '2000000', amountOutMin: '1989980' }),
+        ),
+      ).not.toThrow()
 
-    // One wei below the boundary must fail.
-    expect(() =>
-      validateSwapQuoteSlippageData(
-        { slippage: 0.5, swapperMode: SwapperMode.EXACT_IN },
-        makeQuote({ amountOut: '2000000', amountOutMin: '1989979' }),
-      ),
-    ).toThrow('amountOutMin exceeds requested slippage')
+      // One wei below the boundary must fail.
+      expect(() =>
+        validateSwapQuoteSlippageData(
+          { slippage: 0.5, swapperMode: SwapperMode.EXACT_IN },
+          makeQuote({ amountOut: '2000000', amountOutMin: '1989979' }),
+        ),
+      ).toThrow('amountOutMin exceeds requested slippage')
 
-    expect(warnSpy).toHaveBeenCalledTimes(1)
+      expect(validationLogLines(stdout)).toHaveLength(1)
+    }
+    finally {
+      stdout.restore()
+    }
   })
 
   it('allows input slippage up to the validator divergence tolerance', () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const stdout = captureStdout()
 
-    // At slippage 0.5%, validator forgives up to +0.001pp absolute, so a quote
-    // with amountInMax = floor(2_000_000 * (1 + 0.00501)) = 2010020 must pass.
-    expect(() =>
-      validateSwapQuoteSlippageData(
-        { slippage: 0.5, swapperMode: SwapperMode.TARGET_DEBT },
-        makeQuote({ amountIn: '2000000', amountInMax: '2010020' }),
-      ),
-    ).not.toThrow()
+    try {
+      // At slippage 0.5%, validator forgives up to +0.001pp absolute, so a quote
+      // with amountInMax = floor(2_000_000 * (1 + 0.00501)) = 2010020 must pass.
+      expect(() =>
+        validateSwapQuoteSlippageData(
+          { slippage: 0.5, swapperMode: SwapperMode.TARGET_DEBT },
+          makeQuote({ amountIn: '2000000', amountInMax: '2010020' }),
+        ),
+      ).not.toThrow()
 
-    // One wei above the boundary must fail.
-    expect(() =>
-      validateSwapQuoteSlippageData(
-        { slippage: 0.5, swapperMode: SwapperMode.TARGET_DEBT },
-        makeQuote({ amountIn: '2000000', amountInMax: '2010021' }),
-      ),
-    ).toThrow('amountInMax exceeds requested slippage')
+      // One wei above the boundary must fail.
+      expect(() =>
+        validateSwapQuoteSlippageData(
+          { slippage: 0.5, swapperMode: SwapperMode.TARGET_DEBT },
+          makeQuote({ amountIn: '2000000', amountInMax: '2010021' }),
+        ),
+      ).toThrow('amountInMax exceeds requested slippage')
 
-    expect(warnSpy).toHaveBeenCalledTimes(1)
+      expect(validationLogLines(stdout)).toHaveLength(1)
+    }
+    finally {
+      stdout.restore()
+    }
   })
 
-  it('keeps validator tolerance below SwapDetailsSummary warning threshold at MAX_SLIPPAGE', () => {
-    // SLIPPAGE_DIFF_TOLERANCE in SwapDetailsSummary is 0.005pp. The validator
-    // must allow strictly less so a quote it accepts never trips the user-facing
-    // warning. At MAX_SLIPPAGE = 50%, the validator forgives 0.001pp → boundary
-    // amountOutMin = floor(2_000_000 * (1 - 0.50001)) = 999_980.
-    expect(() =>
-      validateSwapQuoteSlippageData(
-        { slippage: 50, swapperMode: SwapperMode.EXACT_IN },
-        makeQuote({ amountOut: '2000000', amountOutMin: '999980' }),
-      ),
-    ).not.toThrow()
+  it('keeps validator divergence tolerance tiny at MAX_SLIPPAGE', () => {
+    const stdout = captureStdout()
 
-    expect(() =>
-      validateSwapQuoteSlippageData(
-        { slippage: 50, swapperMode: SwapperMode.EXACT_IN },
-        makeQuote({ amountOut: '2000000', amountOutMin: '999979' }),
-      ),
-    ).toThrow('amountOutMin exceeds requested slippage')
+    // At MAX_SLIPPAGE = 50%, the validator forgives 0.001pp for rounding:
+    // boundary amountOutMin = floor(2_000_000 * (1 - 0.50001)) = 999_980.
+    try {
+      expect(() =>
+        validateSwapQuoteSlippageData(
+          { slippage: 50, swapperMode: SwapperMode.EXACT_IN },
+          makeQuote({ amountOut: '2000000', amountOutMin: '999980' }),
+        ),
+      ).not.toThrow()
+
+      expect(() =>
+        validateSwapQuoteSlippageData(
+          { slippage: 50, swapperMode: SwapperMode.EXACT_IN },
+          makeQuote({ amountOut: '2000000', amountOutMin: '999979' }),
+        ),
+      ).toThrow('amountOutMin exceeds requested slippage')
+    }
+    finally {
+      stdout.restore()
+    }
   })
 })

--- a/utils/swapQuotes.ts
+++ b/utils/swapQuotes.ts
@@ -1,4 +1,4 @@
-import { type SwapApiQuote, SwapperMode } from '~/entities/swap'
+import type { SwapApiQuote } from '~/entities/swap'
 import { BPS_BASE } from '~/entities/tuning-constants'
 
 export type SwapQuoteAmountField = 'amountIn' | 'amountOut'
@@ -79,44 +79,5 @@ export const getQuoteDiffPct = (
     return null
   }
   const diffBps = (diff * BPS_BASE) / bestAmount
-  return Number(diffBps) / 100
-}
-
-const parseRequiredBigInt = (value?: string | number | bigint | null) => {
-  if (value === null || value === undefined) {
-    return null
-  }
-  try {
-    return BigInt(value)
-  }
-  catch {
-    return null
-  }
-}
-
-export const computeQuoteSlippage = (
-  quote: SwapApiQuote | null | undefined,
-  swapperMode = SwapperMode.EXACT_IN,
-) => {
-  if (!quote) {
-    return null
-  }
-
-  if (swapperMode === SwapperMode.TARGET_DEBT) {
-    const amountIn = getQuoteAmount(quote, 'amountIn')
-    const amountInMax = parseRequiredBigInt(quote.amountInMax)
-    if (amountIn <= 0n || amountInMax === null || amountInMax < amountIn) {
-      return null
-    }
-    const diffBps = ((amountInMax - amountIn) * BPS_BASE) / amountIn
-    return Number(diffBps) / 100
-  }
-
-  const amountOut = getQuoteAmount(quote, 'amountOut')
-  const amountOutMin = parseRequiredBigInt(quote.amountOutMin)
-  if (amountOut <= 0n || amountOutMin === null || amountOutMin > amountOut) {
-    return null
-  }
-  const diffBps = ((amountOut - amountOutMin) * BPS_BASE) / amountOut
   return Number(diffBps) / 100
 }


### PR DESCRIPTION
## Summary
- Remove the quote-derived slippage warning from swap form summaries so the slippage row only shows the selected tolerance.
- Keep quote slippage validation in the verifier path so calldata construction still checks quote bounds against the selected tolerance.

## Changes
- Drop the quote slippage prop and warning text from SwapDetailsSummary and remove callers across swap forms.
- Remove display-only quote slippage computed values and the unused helper/tests that fed the renderer.
- Update slippage validation tests to assert the current structured logger output.

## Test plan
- [x] npm run test:run
- [x] npm run test:run -- tests/utils/swap-slippage-validation.test.ts tests/utils/swap-quotes.test.ts
- [x] npx eslint on touched files
- [x] git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed quote-derived slippage from swap details UI across the app. Swap summary rows now show only the user-configured slippage and the edit button; the conditional “Quote applies …% slippage” message and any quote-derived slippage indicator are removed, so slippage display reflects only the configured tolerance.

* **Tests**
  * Updated tests to align with removal of quote-derived slippage behavior and related logging assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->