### PR TITLE
Add Stargate dropdown link

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,6 +59,7 @@ RPC_URL_HTTP_1=
 
 # CONFIG_ vars (override via NUXT_PUBLIC_CONFIG_* in Doppler)
 NUXT_PUBLIC_CONFIG_DOCS_URL="https://docs.euler.finance/"
+NUXT_PUBLIC_CONFIG_STARGATE_URL=https://stargate.finance/
 NUXT_PUBLIC_CONFIG_TOS_URL="https://app.euler.finance/terms"
 NUXT_PUBLIC_CONFIG_PRIVACY_POLICY_URL="https://www.euler.finance/privacy-policy"
 NUXT_PUBLIC_CONFIG_RISK_DISCLOSURES_URL="https://www.euler.finance/risk-disclosures"

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ These use Nuxt's `runtimeConfig` and are set via `NUXT_PUBLIC_CONFIG_*` env vars
 | `NUXT_PUBLIC_CONFIG_ORACLE_CHECKS_BASE_URL` | —                                          | S3/CDN base URL for oracle checks (overrides repo)    |
 | `NUXT_PUBLIC_CONFIG_EULER_CHAINS_URL`       | —                                          | URL for EulerChains.json (overrides default upstream) |
 | `NUXT_PUBLIC_CONFIG_DOCS_URL`               | —                                          | Documentation link                                    |
+| `NUXT_PUBLIC_CONFIG_STARGATE_URL`           | —                                          | Stargate link                                         |
 | `NUXT_PUBLIC_CONFIG_TOS_URL`                | —                                          | Terms of Service link                                 |
 | `NUXT_PUBLIC_CONFIG_TOS_MD_URL`             | —                                          | TOS markdown URL (enables TOS signing when set)       |
 | `NUXT_PUBLIC_CONFIG_PRIVACY_POLICY_URL`     | `https://www.euler.finance/privacy-policy` | Privacy policy link                                   |

--- a/components/layout/TheHeader.vue
+++ b/components/layout/TheHeader.vue
@@ -21,6 +21,7 @@ const modal = useModal()
 const route = useRoute()
 const {
   docsUrl,
+  stargateUrl,
   tosUrl,
   privacyPolicyUrl,
   riskDisclosuresUrl,
@@ -47,6 +48,7 @@ const links = computed(
   () =>
     [
       docsUrl ? { title: 'Docs', url: docsUrl } : null,
+      stargateUrl ? { title: 'Stargate', url: stargateUrl } : null,
       tosUrl ? { title: 'Terms of Use', url: tosUrl } : null,
       privacyPolicyUrl ? { title: 'Privacy Policy', url: privacyPolicyUrl } : null,
       riskDisclosuresUrl ? { title: 'Risk Disclosures', url: riskDisclosuresUrl } : null,

--- a/composables/useDeployConfig.ts
+++ b/composables/useDeployConfig.ts
@@ -11,6 +11,7 @@ export const useDeployConfig = () => {
   return {
     // URLs (empty string = not configured, hide UI element)
     docsUrl: rc.configDocsUrl,
+    stargateUrl: rc.configStargateUrl,
     tosUrl: rc.configTosUrl || 'https://www.euler.finance/terms',
     tosMdUrl: rc.configTosMdUrl,
     privacyPolicyUrl: rc.configPrivacyPolicyUrl || 'https://www.euler.finance/privacy-policy',

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -100,6 +100,7 @@ export default defineNuxtConfig({
     public: {
       // CONFIG_ vars (Doppler: NUXT_PUBLIC_CONFIG_*)
       configDocsUrl: '',
+      configStargateUrl: '',
       configTosUrl: '',
       configTosMdUrl: '',
       configPrivacyPolicyUrl: '',


### PR DESCRIPTION
## Summary
- Adds a configurable Stargate resource link to the top-left header dropdown.
- Documents NUXT_PUBLIC_CONFIG_STARGATE_URL for environment-based configuration.

## Changes
- Exposes configStargateUrl through Nuxt public runtime config and useDeployConfig.
- Renders "Stargate" only when configured, matching the existing optional resource link behavior.

## Test plan
- [x] git diff --check
- [x] Manual: set NUXT_PUBLIC_CONFIG_STARGATE_URL and verify the header dropdown shows "Stargate" and opens http://stargate.finance/.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Stargate link to the application header for quick access to the Stargate service.
  * Header link is shown when a Stargate URL is configured.

* **Documentation**
  * Documented the new public runtime configuration entry for the Stargate URL in the Branding & Feature Flags table.

* **Chores**
  * Added an example environment variable to illustrate the default Stargate URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->