### PR TITLE
fix: do not block repay when projected LTV is still above liquidation LTV

### DIFF
--- a/composables/repay/useWalletRepay.ts
+++ b/composables/repay/useWalletRepay.ts
@@ -258,10 +258,6 @@ export const useWalletRepay = (options: UseWalletRepayOptions) => {
       _estimateUserLTV.value = userLtvFixed.toScaledBigint(18)
       _estimateHealth.value = healthFixed ? healthFixed.toScaledBigint(18) : 10n ** 36n
       hasEstimate.value = true
-
-      if (userLtvFixed.gte(FixedPoint.fromValue(position.value!.liquidationLTV, 2))) {
-        throw new Error('Not enough liquidity for the vault, LTV is too large')
-      }
     }
     catch (e: unknown) {
       logWarn('walletRepay/syncEstimates', e)

--- a/composables/repay/useWalletSwapRepay.ts
+++ b/composables/repay/useWalletSwapRepay.ts
@@ -441,10 +441,6 @@ export const useWalletSwapRepay = (options: UseWalletSwapRepayOptions) => {
       _estimateUserLTV.value = userLtvFixed.toScaledBigint(18)
       _estimateHealth.value = healthFixed ? healthFixed.toScaledBigint(18) : 10n ** 36n
       hasEstimate.value = true
-
-      if (userLtvFixed.gte(FixedPoint.fromValue(position.value!.liquidationLTV, 2))) {
-        throw new Error('Not enough liquidity for the vault, LTV is too large')
-      }
     }
     catch (e: unknown) {
       logWarn('walletSwapRepay/syncEstimates', e)


### PR DESCRIPTION
## Summary
- Repaying debt can only weakly improve a position's LTV — never worsen it. The wallet repay and swap repay flows were throwing `Not enough liquidity for the vault, LTV is too large` whenever the projected post-repay LTV was still at or above the liquidation LTV, which prevented users from making partial repayments on already-underwater positions (the exact moment they most want to reduce debt).
- Removed the LTV gate from `composables/repay/useWalletRepay.ts` and `composables/repay/useWalletSwapRepay.ts`. The other validations (wallet balance, repay ≤ outstanding debt, swap quote / input availability) are unchanged.
- The same check is intentionally **kept** in `pages/position/[number]/withdraw.vue` because withdrawing collateral can genuinely push LTV over the liquidation threshold.

## Test plan
- [ ] Open a position whose current LTV is at or above its liquidation LTV.
- [ ] Repay (from wallet) a partial amount that does not bring LTV back below the threshold — confirm the form no longer shows the error and the repay tx can be submitted.
- [ ] Repay the full debt — still works.
- [ ] Repay > outstanding debt — still blocked with "You repaying more than required".
- [ ] Repay with insufficient wallet balance — still blocked with "Not enough balance".
- [ ] Swap-repay flow on the same underwater position — partial repay no longer blocked; missing quote / insufficient input still blocked.
- [ ] Withdraw collateral on a healthy position to a level that would push LTV over liquidation LTV — still blocked (regression check).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed validation constraints in wallet repay estimation logic, allowing calculations to proceed in scenarios that were previously blocked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->