### PR TITLE
fix: avoid BlockNotFoundError in APY block fetch

### DIFF
--- a/entities/vault/apy.ts
+++ b/entities/vault/apy.ts
@@ -113,7 +113,7 @@ const SAMPLE_DISTANCE = 10_000
 export const fetchBlockDataForAPY = async (rpcUrl: string, chainId: number): Promise<BlockDataCache | null> => {
   try {
     const client = getPublicClient(rpcUrl)
-    const currentBlock = Number(await client.getBlockNumber())
+    const currentBlock = Math.max(0, Number(await client.getBlockNumber()) - 1)
     const sampleDistance = Math.min(SAMPLE_DISTANCE, currentBlock)
 
     if (sampleDistance === 0) {


### PR DESCRIPTION
## Summary
- Step back one block from the chain head in `fetchBlockDataForAPY` (`entities/vault/apy.ts`) before requesting block data.

## Why
Production logs show recurring `BlockNotFoundError: Block at number "…" could not be found` from `apy/fetchBlockData`. The function calls `getBlockNumber()` and then `getBlock({ blockNumber: head })` against the same RPC URL. On load-balanced RPC clusters the two requests can land on different backends — one node returns a fresh head, the next is still a block behind, so the follow-up `getBlock` throws.

The error is already caught and the caller treats `null` as "skip this APY refresh tick", so impact is limited to spurious log noise and occasional missed APY updates. Sampling `head - 1` gives the cluster a beat to converge and is functionally identical for APY purposes (sample distance is 10k blocks).

## Test plan
- [ ] Watch Fargate stderr for `apy/fetchBlockData BlockNotFoundError` after deploy — expect frequency to drop to ~zero.
- [ ] Sanity check: APY still renders on Lend dashboard for both EVK and Earn vaults across chains.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved APY calculation accuracy by adjusting how the reference block is selected for baseline timing, reducing sampling variance in hourly rate estimates.
  * No changes to public interfaces; users should see more stable and reliable APY figures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->