### PR TITLE
Fix wallet reconnect startup ordering

### DIFF
--- a/plugins/00.wagmi.ts
+++ b/plugins/00.wagmi.ts
@@ -67,8 +67,6 @@ export default defineNuxtPlugin((nuxtApp) => {
     transports,
   })
 
-  nuxtApp.vueApp.use(WagmiPlugin, { config: wagmiAdapter.wagmiConfig })
-
   let appKitInstance: ReturnType<typeof createAppKit> | null = null
   const ensureAppKit = () => {
     if (appKitInstance) return appKitInstance
@@ -90,13 +88,12 @@ export default defineNuxtPlugin((nuxtApp) => {
     kit.open()
   }
 
-  // Always eagerly initialize AppKit so chunk loads and initialization
-  // side-effects (connector discovery, remote feature fetches) complete
-  // during page load rather than on first "Connect Wallet" click.
-  // Previously this was deferred for first-time visitors to avoid Phantom's
-  // unsolicited connection prompt, but that auto-connect is a pre-existing
-  // wagmi-level behavior unrelated to AppKit initialization.
+  // Initialize AppKit before wagmi mounts and runs its automatic reconnect.
+  // Otherwise wagmi can briefly hydrate a persisted connector shell before
+  // AppKit has registered the real connector methods (for example getChainId).
   ensureAppKit()
+
+  nuxtApp.vueApp.use(WagmiPlugin, { config: wagmiAdapter.wagmiConfig })
 
   return {
     provide: {


### PR DESCRIPTION
## Summary
- Fix a wallet startup race where wagmi can auto-reconnect from persisted state before AppKit has registered the real connector methods.
- Preserve wagmi normal automatic reconnect behavior instead of clearing persisted wallet state or disabling reconnect on mount.
- Avoid the transaction-modal failure mode where a hydrated connector shell can later surface `connector.getChainId is not a function`.

## Changes
- Move AppKit initialization before installing the wagmi Vue plugin.
- Keep `reconnectOnMount` at wagmi default behavior so wallets that support cold-start reconnect can still reconnect automatically.
- Keep the fix wallet-agnostic: this does not add special handling for MetaMask, OKX, Rabby, or any specific injected wallet.
- Important limitation: this only fixes app-side initialization ordering. It does not guarantee silent reconnect for wallets that start locked, return no accounts from `eth_accounts`, or require unlock/sign-in before exposing accounts.
- Observed wallet behavior differs:
  - OKX Wallet can reconnect after a full Chrome restart.
  - Rabby logs out and requires unlock/sign-in after Chrome restart, while normal page refresh still reconnects.
  - This appears to be wallet-specific locked/startup behavior rather than the original connector-method crash.

## Test plan
- [x] `npm run typecheck`
- [x] `npx eslint plugins/00.wagmi.ts`
- [x] Connect OKX Wallet, fully restart Chrome, navigate directly back to the app, and confirm the wallet auto-reconnects.
- [x] With OKX Wallet reconnected after Chrome restart, initialize a transaction and confirm the transaction modal does not show `r.connector.getChainId is not a function`.
- [x] Connect Rabby, perform a normal page refresh while Rabby is unlocked, and confirm the wallet reconnects.
- [x] Connect Rabby, fully restart Chrome, and observe Rabby-specific behavior: Rabby may show logged out or require Rabby unlock/sign-in after Chrome restart.
- [ ] Reproduce the original `r.connector.getChainId is not a function` error on an affected browser/wallet profile, then verify this branch prevents it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved wallet initialization sequence to ensure reliable connection during app startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->