### PR TITLE
Align static asset upload workflows

### DIFF
--- a/.github/workflows/build-push-deploy-prod.yaml
+++ b/.github/workflows/build-push-deploy-prod.yaml
@@ -69,20 +69,67 @@ jobs:
         if: github.event_name == 'push'
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
-      - name: Build, tag, and push docker image to Amazon ECR
+      - name: Build docker image
         if: github.event_name == 'push'
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           platforms: linux/amd64
-          push: true
-          tags: |
-            ${{ steps.login-ecr.outputs.registry }}/${{ secrets.ECR_REPOSITORY }}:${{ steps.generate-tag.outputs.image_tag }}
-            ${{ steps.login-ecr.outputs.registry }}/${{ secrets.ECR_REPOSITORY }}:latest
+          load: true
+          tags: euler-lite
           build-args: |
             SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Extract static assets from image
+        if: github.event_name == 'push'
+        run: |
+          docker create --name temp-euler euler-lite
+          docker cp temp-euler:/usr/src/app/.output/public ./static-output
+          docker rm temp-euler
+
+      - name: Configure AWS credentials for S3
+        if: github.event_name == 'push'
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Upload static assets to S3
+        if: github.event_name == 'push'
+        run: |
+          aws s3 sync ./static-output/_nuxt \
+            s3://${{ secrets.S3_STATIC_ASSETS_BUCKET }}/_nuxt \
+            --exclude "builds/**" \
+            --cache-control "public,max-age=31536000,immutable"
+
+          if [ -d ./static-output/_nuxt/builds ]; then
+            aws s3 sync ./static-output/_nuxt/builds \
+              s3://${{ secrets.S3_STATIC_ASSETS_BUCKET }}/_nuxt/builds \
+              --exclude "meta/**" \
+              --cache-control "no-cache"
+          fi
+
+          if [ -d ./static-output/_nuxt/builds/meta ]; then
+            aws s3 sync ./static-output/_nuxt/builds/meta \
+              s3://${{ secrets.S3_STATIC_ASSETS_BUCKET }}/_nuxt/builds/meta \
+              --cache-control "public,max-age=31536000,immutable"
+          fi
+
+      - name: Tag and push docker image to Amazon ECR
+        if: github.event_name == 'push'
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          IMAGE_TAG: ${{ steps.generate-tag.outputs.image_tag }}
+          ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
+        run: |
+          FULL_IMAGE="$REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+          LATEST_IMAGE="$REGISTRY/$ECR_REPOSITORY:latest"
+          docker tag euler-lite "$FULL_IMAGE"
+          docker tag euler-lite "$LATEST_IMAGE"
+          docker push "$FULL_IMAGE"
+          docker push "$LATEST_IMAGE"
 
       # ── Deploy ──
       - name: Verify dispatch is from master

--- a/.github/workflows/build-push-deploy-prod.yaml
+++ b/.github/workflows/build-push-deploy-prod.yaml
@@ -120,7 +120,7 @@ jobs:
       - name: Tag and push docker image to Amazon ECR
         if: github.event_name == 'push'
         env:
-          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          REGISTRY: ${{ secrets.ECR_REGISTRY }}
           IMAGE_TAG: ${{ steps.generate-tag.outputs.image_tag }}
           ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
         run: |

--- a/.github/workflows/build-push-deploy-stage.yaml
+++ b/.github/workflows/build-push-deploy-stage.yaml
@@ -110,7 +110,7 @@ jobs:
       - name: Tag and push docker image to Amazon ECR
         id: build
         env:
-          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          REGISTRY: ${{ secrets.ECR_REGISTRY }}
           IMAGE_TAG: ${{ steps.generate-tag.outputs.image_tag }}
           ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
         run: |

--- a/.github/workflows/build-push-deploy-stage.yaml
+++ b/.github/workflows/build-push-deploy-stage.yaml
@@ -91,7 +91,21 @@ jobs:
         run: |
           aws s3 sync ./static-output/_nuxt \
             s3://${{ secrets.S3_STATIC_ASSETS_BUCKET_STAGE }}/_nuxt \
+            --exclude "builds/**" \
             --cache-control "public,max-age=31536000,immutable"
+
+          if [ -d ./static-output/_nuxt/builds ]; then
+            aws s3 sync ./static-output/_nuxt/builds \
+              s3://${{ secrets.S3_STATIC_ASSETS_BUCKET_STAGE }}/_nuxt/builds \
+              --exclude "meta/**" \
+              --cache-control "no-cache"
+          fi
+
+          if [ -d ./static-output/_nuxt/builds/meta ]; then
+            aws s3 sync ./static-output/_nuxt/builds/meta \
+              s3://${{ secrets.S3_STATIC_ASSETS_BUCKET_STAGE }}/_nuxt/builds/meta \
+              --cache-control "public,max-age=31536000,immutable"
+          fi
 
       - name: Tag and push docker image to Amazon ECR
         id: build


### PR DESCRIPTION
## Summary
- Bring the static asset upload workflow that was merged to master onto development.
- Keep current development tag and dispatch guards while adding prod S3 upload support and safer Nuxt cache handling.

## Changes
- Builds the prod Docker image locally, extracts .output/public, uploads _nuxt assets to S3 with cache policies split by path, then tags and pushes the image to ECR.
- Applies the same _nuxt/builds cache split to stage so mutable Nuxt build manifests are not uploaded as immutable.

## Test plan
- [x] ruby YAML parse for prod and stage workflows
- [x] git diff --check
- [ ] GitHub Actions workflow run on the PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Revised deployment pipeline to build images locally, extract and upload static assets to storage with explicit cache-control, then tag and push images to the container registry.
  * Adjusted staging asset upload to separate build artifacts and apply differentiated cache policies for long-lived and no-cache assets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->