### PR TITLE
set max-old-space-size in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ COPY package.json package-lock.json ./
 RUN npm ci
 COPY . .
 
+ENV NODE_OPTIONS=--max-old-space-size=4096
+
 # Sentry source-map upload (build-time only; token never reaches production stage)
 ARG SENTRY_AUTH_TOKEN
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased Node.js heap memory allocation in the Docker build environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->