### PR TITLE
Align prod ECR registry secret

### DIFF
--- a/.github/workflows/build-push-deploy-prod.yaml
+++ b/.github/workflows/build-push-deploy-prod.yaml
@@ -120,7 +120,7 @@ jobs:
       - name: Tag and push docker image to Amazon ECR
         if: github.event_name == 'push'
         env:
-          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          REGISTRY: ${{ secrets.ECR_REGISTRY }}
           IMAGE_TAG: ${{ steps.generate-tag.outputs.image_tag }}
           ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
         run: |


### PR DESCRIPTION
## Summary
- Align the production deploy workflow with the development workflow registry configuration.
- Use the explicit ECR registry secret when tagging and pushing the production image.
- Removes the conflicting prod workflow hunk from the development-to-master release PR.

## Changes
- Updates the prod workflow `Tag and push docker image to Amazon ECR` step to read `REGISTRY` from `secrets.ECR_REGISTRY`.
- Leaves the existing static asset extraction and S3 upload flow unchanged.

## Test plan
- [ ] Let GitHub Actions validate the workflow syntax.
- [ ] Confirm the development-to-master release PR no longer reports a conflict after this merges.