### PR TITLE
Fix CoW order review edge cases

### DIFF
--- a/components/entities/operation/CowSwapReviewModal.vue
+++ b/components/entities/operation/CowSwapReviewModal.vue
@@ -17,7 +17,8 @@ const props = defineProps<{
 }>()
 
 const emit = defineEmits<{
-  close: []
+  'close': []
+  'prevent-close': [value: boolean]
 }>()
 
 const isExecuting = computed(() => {
@@ -78,6 +79,19 @@ const orderStatusVariant = computed<ToastVariant>(() => {
 })
 
 const internalSubmitting = ref(false)
+const hasUnresolvedSubmittedOrder = computed(() => isSubmitted.value && !props.orderStatus?.terminal)
+const canClose = computed(() => !internalSubmitting.value && !hasUnresolvedSubmittedOrder.value)
+
+watch(
+  canClose,
+  value => emit('prevent-close', !value),
+  { immediate: true },
+)
+
+const handleClose = () => {
+  if (!canClose.value) return
+  emit('close')
+}
 
 const handleConfirm = async () => {
   if (internalSubmitting.value) return
@@ -105,7 +119,8 @@ const handleCancel = async () => {
 <template>
   <BaseModalWrapper
     title="Transaction review"
-    @close="!internalSubmitting && emit('close')"
+    :close="canClose"
+    @close="handleClose"
   >
     <div class="flex flex-col gap-24">
       <!-- Review steps (hidden after submission) -->

--- a/components/entities/operation/CowSwapReviewModal.vue
+++ b/components/entities/operation/CowSwapReviewModal.vue
@@ -42,8 +42,11 @@ const executionLabel = computed(() => {
 
 const orderStatusLabel = computed(() => {
   if (isCancelPending.value) return 'Cancelling order'
-  if (props.locallyCancelled) return 'Order cancelled'
-  if (!props.orderStatus) return 'Waiting for solver...'
+  if (!props.orderStatus) {
+    return props.locallyCancelled
+      ? 'Cancellation submitted — checking order status...'
+      : 'Waiting for solver...'
+  }
   switch (props.orderStatus.type) {
     case 'open': return 'Order open — waiting for solver...'
     case 'active': return 'Solver found — executing...'
@@ -61,7 +64,7 @@ const orderStatusDescription = computed(() => {
   if (isCancelPending.value) {
     return 'We are cancelling the swap order.'
   }
-  if (props.locallyCancelled) {
+  if (props.locallyCancelled && !props.orderStatus?.terminal) {
     return 'The cancellation request was submitted. CoW order status may take a moment to update.'
   }
   return undefined

--- a/components/entities/operation/CowSwapReviewModal.vue
+++ b/components/entities/operation/CowSwapReviewModal.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { ToastVariant } from '~/components/ui/toast.types'
 import type { DisplayStep } from '~/utils/stepDecoding'
 import type { CowSwapExecutionStatus, CowSwapOrderStatus } from '~/entities/cowswap'
 
@@ -70,6 +71,12 @@ const orderStatusDescription = computed(() => {
   return undefined
 })
 
+const orderStatusVariant = computed<ToastVariant>(() => {
+  if (isCancelPending.value) return 'info'
+  if (props.orderStatus?.type === 'expired') return 'warning'
+  return 'info'
+})
+
 const internalSubmitting = ref(false)
 
 const handleConfirm = async () => {
@@ -138,7 +145,7 @@ const handleCancel = async () => {
         <UiToast
           :title="orderStatusLabel"
           :description="orderStatusDescription"
-          variant="info"
+          :variant="orderStatusVariant"
           size="compact"
           persistent
         />

--- a/components/entities/operation/OperationStepsList.vue
+++ b/components/entities/operation/OperationStepsList.vue
@@ -5,6 +5,12 @@ import { formatNumber } from '~/utils/string-utils'
 defineProps<{
   steps: DisplayStep[]
 }>()
+
+const getFullAmountText = (assetInfo?: DisplayStep['assetInfo']) => {
+  const amount = assetInfo?.amount
+  if (!assetInfo || amount === undefined || amount === 'max' || amount === 'remaining') return undefined
+  return `${String(amount)} ${assetInfo.symbol}`
+}
 </script>
 
 <template>
@@ -28,11 +34,16 @@ defineProps<{
           class="text-p3"
         >
           <template v-if="step.assetInfo.amount === 'max' || step.assetInfo.amount === 'remaining'">
-            {{ step.assetInfo.amount }}&nbsp;
+            {{ step.assetInfo.amount }}&nbsp;{{ step.assetInfo.symbol }}
           </template>
-          <template v-else-if="step.assetInfo.amount !== undefined">
-            {{ formatNumber(step.assetInfo.amount, 8, 0) }}&nbsp;
-          </template>{{ step.assetInfo.symbol }}
+          <template v-else-if="getFullAmountText(step.assetInfo)">
+            <UiExactAmount :exact="getFullAmountText(step.assetInfo)!">
+              {{ formatNumber(step.assetInfo.amount, 8, 0) }}&nbsp;{{ step.assetInfo.symbol }}
+            </UiExactAmount>
+          </template>
+          <template v-else>
+            {{ step.assetInfo.symbol }}
+          </template>
         </p>
       </template>
       <p
@@ -56,9 +67,14 @@ defineProps<{
           v-if="!step.iconOnly"
           class="text-p3"
         >
-          <template v-if="step.toAssetInfo.amount !== undefined">
-            {{ formatNumber(step.toAssetInfo.amount, 8, 0) }}&nbsp;
-          </template>{{ step.toAssetInfo.symbol }}
+          <template v-if="getFullAmountText(step.toAssetInfo)">
+            <UiExactAmount :exact="getFullAmountText(step.toAssetInfo)!">
+              {{ formatNumber(step.toAssetInfo.amount, 8, 0) }}&nbsp;{{ step.toAssetInfo.symbol }}
+            </UiExactAmount>
+          </template>
+          <template v-else>
+            {{ step.toAssetInfo.symbol }}
+          </template>
         </p>
       </template>
     </div>

--- a/composables/cowswap/openCowSwapReviewModal.ts
+++ b/composables/cowswap/openCowSwapReviewModal.ts
@@ -72,6 +72,7 @@ export const openCowSwapReviewModal = (
   },
 ) => {
   modal.open(CowSwapReviewModal, {
+    isNotClosable: true,
     props: {
       signSteps: options.signSteps,
       wrapperSteps: options.wrapperSteps,

--- a/composables/cowswap/useCowSwapExecutionCore.ts
+++ b/composables/cowswap/useCowSwapExecutionCore.ts
@@ -1,5 +1,5 @@
 import { ref, computed } from 'vue'
-import type { Address, Hex } from 'viem'
+import { erc20Abi, type Address, type Hex } from 'viem'
 import { useSignTypedData, useWriteContract } from '@wagmi/vue'
 import { EVC_ABI } from '~/abis/evc'
 import { logWarn } from '~/utils/errorHandling'
@@ -86,6 +86,17 @@ export const useCowSwapExecutionCore = () => {
         args: step.args as unknown[],
       })
       await client.waitForTransactionReceipt({ hash: tx })
+    }
+
+    const approvedAmount = await client.readContract({
+      address: token,
+      abi: erc20Abi,
+      functionName: 'allowance',
+      args: [userAddress, spender],
+    }) as bigint
+
+    if (approvedAmount < amount) {
+      throw new Error('Approved amount is lower than required for this order. Increase the approval and try again.')
     }
   }
 

--- a/entities/cowswap/inbox.ts
+++ b/entities/cowswap/inbox.ts
@@ -22,18 +22,18 @@ const BALANCE_ERC20 = keccak256(toHex('erc20'))
  * 12 fields × 32 bytes = 384 bytes.
  */
 const ORDER_ENCODE_DATA_ABI = [
-  { type: 'address' },  // sellToken
-  { type: 'address' },  // buyToken
-  { type: 'address' },  // receiver
-  { type: 'uint256' },  // sellAmount
-  { type: 'uint256' },  // buyAmount
-  { type: 'uint32' },   // validTo
-  { type: 'bytes32' },  // appData
-  { type: 'uint256' },  // feeAmount
-  { type: 'bytes32' },  // kind (keccak256-hashed)
-  { type: 'bool' },     // partiallyFillable
-  { type: 'bytes32' },  // sellTokenBalance (keccak256-hashed)
-  { type: 'bytes32' },  // buyTokenBalance (keccak256-hashed)
+  { type: 'address' }, // sellToken
+  { type: 'address' }, // buyToken
+  { type: 'address' }, // receiver
+  { type: 'uint256' }, // sellAmount
+  { type: 'uint256' }, // buyAmount
+  { type: 'uint32' }, // validTo
+  { type: 'bytes32' }, // appData
+  { type: 'uint256' }, // feeAmount
+  { type: 'bytes32' }, // kind (keccak256-hashed)
+  { type: 'bool' }, // partiallyFillable
+  { type: 'bytes32' }, // sellTokenBalance (keccak256-hashed)
+  { type: 'bytes32' }, // buyTokenBalance (keccak256-hashed)
 ] as const
 
 /**

--- a/entities/cowswap/order-status.ts
+++ b/entities/cowswap/order-status.ts
@@ -38,10 +38,10 @@ export const resolveCowSwapOrderStatusType = (params: {
   orderType?: CowSwapLifecycleOrderStatusType
 }): CowSwapOrderStatusType => {
   // Terminal statuses from either source take priority
+  if (params.competitionType === 'traded') return 'traded'
   if (params.orderType === 'fulfilled') return 'fulfilled'
   if (params.orderType === 'cancelled') return 'cancelled'
   if (params.orderType === 'expired') return 'expired'
-  if (params.competitionType === 'traded') return 'traded'
   if (params.competitionType === 'cancelled') return 'cancelled'
   // Non-terminal competition statuses (active, solved, executing) are transient —
   // solvers reconsider orders every auction round, so 'active' doesn't mean

--- a/entities/cowswap/order-submit.ts
+++ b/entities/cowswap/order-submit.ts
@@ -1,6 +1,8 @@
 import type { Address, Hex } from 'viem'
 import type { CowSwapOrderPayload, CowSwapOrderUid } from './types'
 
+const MAX_CANCEL_ERROR_MESSAGE_LENGTH = 180
+
 const coerceOrderUid = (data: unknown): CowSwapOrderUid => {
   if (typeof data === 'string') return data
   if (data && typeof data === 'object' && 'uid' in data) {
@@ -8,6 +10,29 @@ const coerceOrderUid = (data: unknown): CowSwapOrderUid => {
     if (typeof uid === 'string') return uid
   }
   throw new Error('Unexpected CoW order response format')
+}
+
+const truncateErrorMessage = (message: string): string => {
+  if (message.length <= MAX_CANCEL_ERROR_MESSAGE_LENGTH) return message
+  return `${message.slice(0, MAX_CANCEL_ERROR_MESSAGE_LENGTH).trimEnd()}...`
+}
+
+const extractCowSwapErrorMessage = (text: string): string => {
+  try {
+    const parsed = JSON.parse(text) as unknown
+    if (parsed && typeof parsed === 'object') {
+      const record = parsed as Record<string, unknown>
+      const type = typeof record.errorType === 'string' ? record.errorType : undefined
+      const detail = [record.description, record.message, record.error]
+        .find(value => typeof value === 'string') as string | undefined
+      return [type, detail].filter(Boolean).join(': ') || text
+    }
+  }
+  catch {
+    // Fall back to the raw response body below.
+  }
+
+  return text
 }
 
 export const submitCowSwapOrder = async (
@@ -81,6 +106,6 @@ export const cancelCowSwapOrder = async (params: CancelCowSwapOrderParams): Prom
 
   if (!res.ok) {
     const text = await res.text()
-    throw new Error(`CoW cancel API ${res.status}: ${text.slice(0, 500)}`)
+    throw new Error(`CoW cancel API ${res.status}: ${truncateErrorMessage(extractCowSwapErrorMessage(text))}`)
   }
 }

--- a/tests/entities/cowswap/order-status.test.ts
+++ b/tests/entities/cowswap/order-status.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { resolveCowSwapOrderStatusType } from '~/entities/cowswap/order-status'
+
+describe('resolveCowSwapOrderStatusType', () => {
+  it('prefers a traded competition status over a cancelled lifecycle status', () => {
+    expect(resolveCowSwapOrderStatusType({
+      competitionType: 'traded',
+      orderType: 'cancelled',
+    })).toBe('traded')
+  })
+
+  it('uses fulfilled when the lifecycle order status is fulfilled', () => {
+    expect(resolveCowSwapOrderStatusType({
+      competitionType: 'cancelled',
+      orderType: 'fulfilled',
+    })).toBe('fulfilled')
+  })
+})

--- a/tests/entities/cowswap/order-submit.test.ts
+++ b/tests/entities/cowswap/order-submit.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { Hex } from 'viem'
+import { cancelCowSwapOrder } from '~/entities/cowswap/order-submit'
+
+const cancelParams = {
+  orderUid: '0xorderuid',
+  orderbookUrl: 'https://api.cow.fi/mainnet',
+  settlementContract: '0x9008D19f58AAbD9eD0D60971565AA8510560ab41',
+  chainId: 1,
+  signTypedData: vi.fn(async () => '0xsignature' as Hex),
+} as const
+
+describe('cancelCowSwapOrder', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    cancelParams.signTypedData.mockClear()
+  })
+
+  it('throws a concise cancel API error from a structured response body', async () => {
+    const longDescription = 'This order cannot be cancelled because '.repeat(20)
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: false,
+      status: 400,
+      text: async () => JSON.stringify({
+        errorType: 'OrderNotCancellable',
+        description: longDescription,
+      }),
+    })))
+
+    await expect(cancelCowSwapOrder(cancelParams)).rejects.toThrow(
+      /^CoW cancel API 400: OrderNotCancellable: This order cannot be cancelled because /,
+    )
+
+    const err = await cancelCowSwapOrder(cancelParams).catch(error => error)
+    expect(err).toBeInstanceOf(Error)
+    expect((err as Error).message.length).toBeLessThan(230)
+  })
+})


### PR DESCRIPTION
## Summary
- Tighten CoW order submission, cancellation, and status edge cases before the integration PR lands.
- Make CoW review step amounts inspectable through the reusable exact-amount tooltip.
- Keep submitted CoW order modals open until the order reaches a terminal state.
- Use the warning/yellow toast treatment for expired CoW orders.

## Changes
- Re-read ERC-20 allowance after approval transactions before signing/submitting CoW orders.
- Prefer filled/traded CoW status over stale cancelled lifecycle status.
- Parse and truncate CoW cancel API failures for clearer modal errors.
- Use `UiExactAmount` in operation steps for styled exact amount hover/copy behavior.
- Show expired CoW orders with the shared warning toast variant.
- Prevent backdrop/back/close dismissal while a submitted CoW order is unresolved, then allow close again after terminal status.

## Test plan
- [x] `npm run test:run -- tests/entities/cowswap` passed: 4 files, 6 tests.
- [x] `npm run lint -- components/entities/operation/CowSwapReviewModal.vue composables/cowswap/openCowSwapReviewModal.ts` passed with existing `any` warnings only.
- [x] `npm run lint -- components/entities/operation/CowSwapReviewModal.vue` passed with existing CoW helper warnings only.
- [x] `git diff --check` passed.
- [x] CoW quote renders on Multiply.
- [x] Multiply CoW review modal renders expected approval/sign/wrapper steps.
- [x] Approval path works and continues to signing.
- [x] Wallet receiver mismatch verified as expected Euler sub-account behavior (`...b6` owner to `...b7` receiver / sub-account index 1).
- [x] Submitted CoW order can be cancelled.
- [x] Filled CoW order resolves to filled state and position/balances update.
- [x] CoW quote renders on position collateral swap route.
- [x] Position collateral swap CoW review modal / approval / signing flow works.
- [x] CoW quote renders on collateral-swap repay / close-position route.
- [x] Collateral-swap repay / close-position CoW review modal / approval / signing flow works.
- [x] Exact amount hover tooltips work in the CoW review modal.
- [x] Expired CoW order shows yellow/warning toast.
- [x] Submitted CoW modal close guard works: after submission, close/backdrop/back dismissal is blocked until terminal status.
- [x] Non-CoW quote regression was considered optional and not required for this branch because the changed execution paths are CoW-specific.
- [ ] `npm run typecheck` was attempted but is blocked by unrelated existing errors in `pages/lend/[vault]/[subAccount]/withdraw.vue` missing `requestedSlippage` and missing `pino` type resolution.
