### PR TITLE
Surface Multiply on the Borrow nav and page header

### DIFF
--- a/components/layout/TheHeader.vue
+++ b/components/layout/TheHeader.vue
@@ -207,7 +207,7 @@ onClickOutside(wrapperRef, () => {
           v-for="item in menuItems"
           :key="item.name"
           :to="'/' + item.name"
-          class="flex gap-8 text-[13px] font-medium no-underline py-10 px-16 rounded-8 text-content-secondary items-center justify-center hover:text-content-primary hover:bg-surface-secondary transition-all"
+          class="flex gap-8 text-[13px] font-medium no-underline py-6 px-16 rounded-8 text-content-secondary items-center justify-center hover:text-content-primary hover:bg-surface-secondary transition-all"
           :class="[
             getIsMenuItemActive(item)
               ? 'bg-surface-secondary text-content-primary'
@@ -223,7 +223,14 @@ onClickOutside(wrapperRef, () => {
             ]"
             :name="item.icon"
           />
-          <span>{{ item.label }}</span>
+          <span
+            v-if="item.sublabel"
+            class="flex flex-col items-start leading-[1.15]"
+          >
+            <span>{{ item.label }}</span>
+            <span class="text-[10px] font-normal text-content-tertiary">{{ item.sublabel }}</span>
+          </span>
+          <span v-else>{{ item.label }}</span>
         </NuxtLink>
       </div>
     </div>

--- a/components/layout/TheMenu.vue
+++ b/components/layout/TheMenu.vue
@@ -20,7 +20,7 @@ const isActive = (item: MenuItem) => {
     class="fixed bottom-0 left-0 right-0 z-[100] laptop:!hidden bg-header backdrop-blur-[20px] border-t border-line-default p-16 justify-center"
   >
     <div
-      class="flex w-full h-50 max-w-container"
+      class="flex w-full min-h-50 max-w-container items-start"
     >
       <NuxtLink
         v-for="link in menuItems"
@@ -30,11 +30,15 @@ const isActive = (item: MenuItem) => {
         :class="isActive(link) ? 'text-content-primary' : 'text-content-secondary'"
       >
         <UiIcon
-          class="!w-20 !h-20 mb-10"
+          class="!w-20 !h-20 mb-4"
           :class="isActive(link) ? 'text-accent-600' : 'text-content-muted'"
           :name="getMenuIcon(link)"
         />
-        <span>{{ link.label }}</span>
+        <span class="leading-tight">{{ link.label }}</span>
+        <span
+          v-if="link.sublabel"
+          class="leading-tight text-[9px] text-content-tertiary"
+        >{{ link.sublabel }}</span>
       </NuxtLink>
     </div>
   </div>

--- a/entities/menu.ts
+++ b/entities/menu.ts
@@ -1,6 +1,7 @@
 export interface MenuItem {
   name: string
   label: string
+  sublabel?: string
   icon: string
   activeIcon: string
 }
@@ -33,6 +34,7 @@ const allMenuItems: MenuItem[] = [
   {
     name: 'borrow',
     label: 'Borrow',
+    sublabel: 'Multiply',
     icon: 'borrow-outline',
     activeIcon: 'borrow-filled',
   },

--- a/pages/borrow/index.vue
+++ b/pages/borrow/index.vue
@@ -390,7 +390,7 @@ const sortedBorrowList = computed(() => {
 <template>
   <section class="flex flex-col min-h-[calc(100dvh-178px)]">
     <BasePageHeader
-      title="Borrow"
+      title="Borrow/Multiply"
       description="Borrow against your assets in isolated lending markets."
       class="mb-16"
     />


### PR DESCRIPTION
## Summary
- Users on the Borrow page often miss that Multiply (leveraged-loop) lives on the same surface, behind a tab on a vault-pair detail page.
- Surface "Multiply" alongside "Borrow" in the navigation and page title so the dual-purpose nature is visible at a glance, with no routing or page-structure changes.

## Changes
- `entities/menu.ts`: add an optional `sublabel` to `MenuItem`. The Borrow item now sets `label: 'Borrow'` + `sublabel: 'Multiply'`.
- `components/layout/TheHeader.vue` (desktop center nav): when a menu item has a `sublabel`, render it as a vertical stack — primary 13px label on top, 10px tertiary sublabel below. Reduced item `py-10` → `py-6` so the stacked label doesn't push the header taller. Items without a sublabel keep the original single-line render.
- `components/layout/TheMenu.vue` (mobile bottom nav): same treatment under the icon — 12px primary + 9px tertiary sublabel. Switched the row from fixed `h-50` to `min-h-50 items-start` and tightened the icon margin so the taller item doesn't clip and the others stay aligned.
- `pages/borrow/index.vue`: page header title `"Borrow"` → `"Borrow/Multiply"`. Description left unchanged (still accurately frames borrowing as the primary action).
- Form tabs on the vault-pair detail page (Borrow | Multiply), position-page "Borrow more" modal, and "Borrow APY" / "Borrow cap" metric labels are intentionally untouched — those remain explicit picks or financial-metric labels, not section names.

## Test plan
- [x] Open `/borrow` on a wide desktop viewport: nav reads "Borrow" with smaller "Multiply" subtitle; nav item visually balanced against Portfolio / Explore / Earn / Lend.
- [x] Active state styling on the Borrow nav item still triggers when visiting `/borrow` and any nested route under it.
- [x] Borrow index page header reads "Borrow/Multiply"; description still legible.
- [x] Mobile viewport (≤900px): bottom nav shows "Borrow" + small "Multiply" centred under the icon; row height accommodates the taller item without clipping; other items stay top-aligned.
- [x] Vault-pair detail page (`/borrow/<collateral>/<borrow>`): tabs still read `Borrow` and `Multiply` separately.
- [ ] Position page (`/position/<n>/borrow`): modal title still reads "Borrow more".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Menu items now support optional sublabels for additional context (displayed as a smaller second line)

* **Style**
  * Reduced header/menu item vertical padding and icon spacing
  * Tighter label typography and top-aligned menu layout
  * Updated Borrow page branding to "Borrow/Multiply"
<!-- end of auto-generated comment: release notes by coderabbit.ai -->