### PR TITLE
fix: silence missing-collateral noise in market groups

### DIFF
--- a/components/entities/vault/discovery/DiscoveryMarketCard.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketCard.vue
@@ -6,6 +6,7 @@ import { getAssetLogoUrl } from '~/composables/useTokenList'
 import {
   getMarketEntities,
   getDeprecatedVaultCount,
+  getUnknownCollateralCount,
   getMiniDiagram,
   getBorrowableVaults,
   findVault,
@@ -184,6 +185,13 @@ const onMaxRoeInfoIconClick = (event: MouseEvent, result: BestMaxRoeResult) => {
             class="text-warning-500 text-p5 mt-4"
           >
             {{ getDeprecatedVaultCount(market) }} deprecated
+          </span>
+          <span
+            v-if="getUnknownCollateralCount(market) > 0"
+            class="text-error-500 text-p5 mt-4"
+            title="Collateral vaults whose risk manager isn't part of any declared product entity (or whose vault isn't loaded into the registry)."
+          >
+            {{ getUnknownCollateralCount(market) }} unknown
           </span>
         </div>
       </template>

--- a/components/entities/vault/discovery/DiscoveryMarketGraph.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketGraph.vue
@@ -173,10 +173,10 @@ const isNodeCyclicalNote = (address: string): boolean => {
         <g
           v-for="node in enlarged.nodes"
           :key="node.address"
-          class="cursor-pointer"
+          :class="node.hasVaultData === false ? 'cursor-default' : 'cursor-pointer'"
           :opacity="isGraphNodeHighlighted(node.address) ? 1 : 0.25"
           style="transition: opacity 0.2s"
-          @click.stop="$emit('selectNode', node.address)"
+          @click.stop="node.hasVaultData !== false && $emit('selectNode', node.address)"
         >
           <clipPath :id="`graph-clip-${market.id}-${node.address}`">
             <circle

--- a/components/entities/vault/discovery/DiscoveryMarketGraph.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketGraph.vue
@@ -212,8 +212,27 @@ const isNodeCyclicalNote = (address: string): boolean => {
           >
             {{ node.assetSymbol.slice(0, 2) }}
           </text>
+          <!-- Unknown collateral badge: governor not in any declared product entity, or vault truly missing -->
+          <g v-if="node.isUnknown">
+            <circle
+              :cx="node.x + 9"
+              :cy="node.y - 9"
+              r="6"
+              style="fill: var(--error-500)"
+            />
+            <text
+              :x="node.x + 9"
+              :y="node.y - 5.5"
+              text-anchor="middle"
+              fill="white"
+              font-size="9"
+              font-weight="700"
+            >
+              !
+            </text>
+          </g>
           <!-- Deprecated badge -->
-          <g v-if="isVaultDeprecated(node.address)">
+          <g v-else-if="isVaultDeprecated(node.address)">
             <circle
               :cx="node.x + 9"
               :cy="node.y - 9"

--- a/composables/useMarketGroups.ts
+++ b/composables/useMarketGroups.ts
@@ -1,4 +1,4 @@
-import { fetchVaults, getVaultUtilization, isLiveCollateralEdge, type Vault } from '~/entities/vault'
+import { fetchVaults, getVaultUtilization, isLiveCollateralEdge, type SecuritizeVault, type Vault } from '~/entities/vault'
 import { logWarn } from '~/utils/errorHandling'
 import type { EulerLabelEntity, EulerLabelProduct } from '~/entities/euler/labels'
 import type { MarketGroup, MarketGroupMetrics, CuratorGroup } from '~/entities/lend-discovery'
@@ -11,6 +11,9 @@ import { buildFetchContext } from '~/composables/useFetchContext'
 
 const isVaultType = (vault: AnyVault): vault is Vault =>
   !('type' in vault) || (vault as { type?: string }).type === undefined
+
+const hasGovernorAdmin = (vault: AnyVault): vault is Vault | SecuritizeVault =>
+  'governorAdmin' in vault
 
 const isBorrowableVault = (vault: AnyVault): boolean => {
   if (!isVaultType(vault)) return false
@@ -106,7 +109,7 @@ const buildProductGroups = (
 const augmentWithCollateralGraph = (
   groups: MarketGroup[],
   allVaults: AnyVault[],
-  isVaultGovernorVerified: (vault: Vault) => boolean,
+  isVaultGovernorVerified: (vault: Vault | SecuritizeVault) => boolean,
 ): MarketGroup[] => {
   const vaultMap = new Map<string, AnyVault>()
   for (const vault of allVaults) {
@@ -138,7 +141,7 @@ const augmentWithCollateralGraph = (
           // of any declared product entity is the curator wiring in a vault
           // they don't actually run — surface it in the market graph too so
           // the gap is visible from discovery, not just inside one pair card.
-          if (isVaultType(externalVault) && !isVaultGovernorVerified(externalVault) && !seenUnknown.has(normalized)) {
+          if (hasGovernorAdmin(externalVault) && !isVaultGovernorVerified(externalVault) && !seenUnknown.has(normalized)) {
             seenUnknown.add(normalized)
             unknownCollateral.push(normalized)
           }

--- a/composables/useMarketGroups.ts
+++ b/composables/useMarketGroups.ts
@@ -103,10 +103,6 @@ const buildProductGroups = (
 
 // -- Step 2: Augment with Collateral Graph --
 
-// Module-scope dedupe so we warn at most once per (vault → missing-collateral)
-// pair across recomputes.
-const warnedMissingCollateral = new Set<string>()
-
 const augmentWithCollateralGraph = (
   groups: MarketGroup[],
   allVaults: AnyVault[],
@@ -129,7 +125,6 @@ const augmentWithCollateralGraph = (
     const seenUnknown = new Set<string>()
 
     for (const vault of group.vaults) {
-      const vaultAddr = getVaultAddress(vault)
       const collateralAddrs = getCollateralAddresses(vault)
       for (const colAddr of collateralAddrs) {
         const normalized = colAddr.toLowerCase()
@@ -162,14 +157,6 @@ const augmentWithCollateralGraph = (
           if (!seenUnknown.has(normalized)) {
             seenUnknown.add(normalized)
             unknownCollateral.push(normalized)
-          }
-          const key = `${vaultAddr.toLowerCase()}:${normalized}`
-          if (!warnedMissingCollateral.has(key)) {
-            warnedMissingCollateral.add(key)
-            logWarn(
-              'useMarketGroups/missing-collateral',
-              `Group "${group.name}": vault ${vaultAddr} references unresolved collateral ${colAddr}`,
-            )
           }
         }
       }

--- a/composables/useMarketGroups.ts
+++ b/composables/useMarketGroups.ts
@@ -1,9 +1,8 @@
-import { fetchVaults, type Vault } from '~/entities/vault'
+import { fetchVaults, getVaultUtilization, isLiveCollateralEdge, type Vault } from '~/entities/vault'
 import { logWarn } from '~/utils/errorHandling'
 import type { EulerLabelEntity, EulerLabelProduct } from '~/entities/euler/labels'
 import type { MarketGroup, MarketGroupMetrics, CuratorGroup } from '~/entities/lend-discovery'
 import type { AnyVault } from '~/composables/useVaultRegistry'
-import { getVaultUtilization } from '~/entities/vault'
 import { getAssetUsdValueOrZero } from '~/services/pricing/priceProvider'
 import { isVaultNotExplorable, isVaultFeatured, isVaultDeprecated, getProductKeyByVault } from '~/utils/eulerLabelsUtils'
 import { buildFetchContext } from '~/composables/useFetchContext'
@@ -21,10 +20,11 @@ const isBorrowableVault = (vault: AnyVault): boolean => {
 
 const getCollateralAddresses = (vault: AnyVault): string[] => {
   if (!isVaultType(vault)) return []
-  // Skip inactive collateral entries — EVK retains zero-LTV rows for retired
-  // or never-activated collaterals which aren't part of any usable market.
+  // Skip inactive collateral entries - EVK retains zero-LTV rows for retired
+  // or never-activated collaterals, but keep liquidation ramp-down edges
+  // visible until their current liquidation LTV reaches zero.
   return vault.collateralLTVs
-    .filter(ltv => ltv.liquidationLTV > 0n || ltv.borrowLTV > 0n)
+    .filter(ltv => isLiveCollateralEdge(ltv))
     .map(ltv => ltv.collateral)
 }
 

--- a/composables/useMarketGroups.ts
+++ b/composables/useMarketGroups.ts
@@ -21,7 +21,11 @@ const isBorrowableVault = (vault: AnyVault): boolean => {
 
 const getCollateralAddresses = (vault: AnyVault): string[] => {
   if (!isVaultType(vault)) return []
-  return vault.collateralLTVs.map(ltv => ltv.collateral)
+  // Skip inactive collateral entries — EVK retains zero-LTV rows for retired
+  // or never-activated collaterals which aren't part of any usable market.
+  return vault.collateralLTVs
+    .filter(ltv => ltv.liquidationLTV > 0n || ltv.borrowLTV > 0n)
+    .map(ltv => ltv.collateral)
 }
 
 const getVaultAddress = (vault: AnyVault): string =>
@@ -340,14 +344,15 @@ export const useMarketGroups = () => {
   const { getAll } = useVaultRegistry()
   const { products, entities } = useEulerLabels()
 
+  /** Every loaded vault, including non-explorable ones (used for collateral lookups) */
+  const registryVaults = computed((): AnyVault[] => getAll().map(entry => entry.vault))
+
   /** All vaults available for grouping */
   const allVaults = computed((): AnyVault[] => {
-    return getAll()
-      .map(entry => entry.vault)
-      .filter((vault) => {
-        const address = getVaultAddress(vault)
-        return address ? !isVaultNotExplorable(address) : true
-      })
+    return registryVaults.value.filter((vault) => {
+      const address = getVaultAddress(vault)
+      return address ? !isVaultNotExplorable(address) : true
+    })
   })
 
   /** Synchronous market groups (metrics without TVL) */
@@ -358,12 +363,15 @@ export const useMarketGroups = () => {
     // Step 1: Product-label groups
     const { groups: productGroups, assignedAddresses } = buildProductGroups(vaults, products, entities)
 
-    // Step 2: Augment with collateral graph
-    const augmented = augmentWithCollateralGraph(productGroups, vaults)
+    // Step 2: Augment with collateral graph — pass the full registry so active
+    // LTVs targeting non-explorable vaults still resolve as externalCollateral
+    // instead of triggering a missing-collateral warning.
+    const lookupVaults = registryVaults.value
+    const augmented = augmentWithCollateralGraph(productGroups, lookupVaults)
 
     // Step 3: Orphan clustering
     const orphanGroups = clusterOrphans(vaults, assignedAddresses)
-    const augmentedOrphans = augmentWithCollateralGraph(orphanGroups, vaults)
+    const augmentedOrphans = augmentWithCollateralGraph(orphanGroups, lookupVaults)
 
     return [...augmented, ...augmentedOrphans]
   })
@@ -485,8 +493,7 @@ export const useMarketGroups = () => {
     }
 
     // Augment with collateral graph using registry vaults + fetched vaults
-    const registryVaults = getAll().map(entry => entry.vault)
-    const [augmented] = augmentWithCollateralGraph([group], [...registryVaults, ...memberVaults])
+    const [augmented] = augmentWithCollateralGraph([group], [...registryVaults.value, ...memberVaults])
 
     try {
       return await resolveGroupTVL(augmented)

--- a/composables/useMarketGroups.ts
+++ b/composables/useMarketGroups.ts
@@ -5,7 +5,7 @@ import type { MarketGroup, MarketGroupMetrics, CuratorGroup } from '~/entities/l
 import type { AnyVault } from '~/composables/useVaultRegistry'
 import { getVaultUtilization } from '~/entities/vault'
 import { getAssetUsdValueOrZero } from '~/services/pricing/priceProvider'
-import { isVaultNotExplorable, isVaultFeatured } from '~/utils/eulerLabelsUtils'
+import { isVaultNotExplorable, isVaultFeatured, isVaultDeprecated, getProductKeyByVault } from '~/utils/eulerLabelsUtils'
 import { buildFetchContext } from '~/composables/useFetchContext'
 
 // -- Helpers --
@@ -149,8 +149,16 @@ const augmentWithCollateralGraph = (
           }
         }
         else {
-          // Curator referenced a collateral vault that isn't loaded into the
-          // registry at all. Track it the same way and warn once per pair.
+          // The registry hasn't loaded this collateral yet. Labels are loaded
+          // upfront and survive lazy registry hydration, so a vault tagged
+          // deprecated or assigned to any product is *known* — just not yet
+          // fetched (it'll arrive when something like the per-vault page
+          // triggers a lazy fetch). Only flag as unknown when no label
+          // recognises the address either; otherwise silently drop it so the
+          // graph doesn't churn between "unknown placeholder" and "deprecated
+          // external" as the registry fills in.
+          const knownByLabels = isVaultDeprecated(colAddr) || getProductKeyByVault(colAddr) !== undefined
+          if (knownByLabels) continue
           if (!seenUnknown.has(normalized)) {
             seenUnknown.add(normalized)
             unknownCollateral.push(normalized)

--- a/composables/useMarketGroups.ts
+++ b/composables/useMarketGroups.ts
@@ -93,6 +93,7 @@ const buildProductGroups = (
       curatorKey,
       vaults: memberVaults,
       externalCollateral: [],
+      unknownCollateral: [],
       metrics: computeMetricsSync(memberVaults),
     })
   }
@@ -109,6 +110,7 @@ const warnedMissingCollateral = new Set<string>()
 const augmentWithCollateralGraph = (
   groups: MarketGroup[],
   allVaults: AnyVault[],
+  isVaultGovernorVerified: (vault: Vault) => boolean,
 ): MarketGroup[] => {
   const vaultMap = new Map<string, AnyVault>()
   for (const vault of allVaults) {
@@ -123,6 +125,8 @@ const augmentWithCollateralGraph = (
 
     const externalCollateral: AnyVault[] = []
     const seenExternal = new Set<string>()
+    const unknownCollateral: string[] = []
+    const seenUnknown = new Set<string>()
 
     for (const vault of group.vaults) {
       const vaultAddr = getVaultAddress(vault)
@@ -134,11 +138,23 @@ const augmentWithCollateralGraph = (
         if (externalVault) {
           externalCollateral.push(externalVault)
           seenExternal.add(normalized)
+          // Mirror the per-pair "Unknown" risk-manager pill (see
+          // VaultBorrowItem). An external collateral whose governor isn't part
+          // of any declared product entity is the curator wiring in a vault
+          // they don't actually run — surface it in the market graph too so
+          // the gap is visible from discovery, not just inside one pair card.
+          if (isVaultType(externalVault) && !isVaultGovernorVerified(externalVault) && !seenUnknown.has(normalized)) {
+            seenUnknown.add(normalized)
+            unknownCollateral.push(normalized)
+          }
         }
         else {
           // Curator referenced a collateral vault that isn't loaded into the
-          // registry — silently dropping it would hide the relationship from
-          // every discovery view. Warn once per pair so the gap is visible.
+          // registry at all. Track it the same way and warn once per pair.
+          if (!seenUnknown.has(normalized)) {
+            seenUnknown.add(normalized)
+            unknownCollateral.push(normalized)
+          }
           const key = `${vaultAddr.toLowerCase()}:${normalized}`
           if (!warnedMissingCollateral.has(key)) {
             warnedMissingCollateral.add(key)
@@ -154,6 +170,7 @@ const augmentWithCollateralGraph = (
     return {
       ...group,
       externalCollateral,
+      unknownCollateral,
     }
   })
 }
@@ -235,6 +252,7 @@ const clusterOrphans = (
     curatorKey: undefined,
     vaults,
     externalCollateral: [],
+    unknownCollateral: [],
     metrics: computeMetricsSync(vaults),
   }))
 }
@@ -343,6 +361,7 @@ const resolveGroupTVL = async (group: MarketGroup): Promise<MarketGroup> => {
 export const useMarketGroups = () => {
   const { getAll } = useVaultRegistry()
   const { products, entities } = useEulerLabels()
+  const { isVaultGovernorVerified } = useVaults()
 
   /** Every loaded vault, including non-explorable ones (used for collateral lookups) */
   const registryVaults = computed((): AnyVault[] => getAll().map(entry => entry.vault))
@@ -367,11 +386,11 @@ export const useMarketGroups = () => {
     // LTVs targeting non-explorable vaults still resolve as externalCollateral
     // instead of triggering a missing-collateral warning.
     const lookupVaults = registryVaults.value
-    const augmented = augmentWithCollateralGraph(productGroups, lookupVaults)
+    const augmented = augmentWithCollateralGraph(productGroups, lookupVaults, isVaultGovernorVerified)
 
     // Step 3: Orphan clustering
     const orphanGroups = clusterOrphans(vaults, assignedAddresses)
-    const augmentedOrphans = augmentWithCollateralGraph(orphanGroups, lookupVaults)
+    const augmentedOrphans = augmentWithCollateralGraph(orphanGroups, lookupVaults, isVaultGovernorVerified)
 
     return [...augmented, ...augmentedOrphans]
   })
@@ -489,11 +508,12 @@ export const useMarketGroups = () => {
       curatorKey,
       vaults: memberVaults,
       externalCollateral: [],
+      unknownCollateral: [],
       metrics: computeMetricsSync(memberVaults),
     }
 
     // Augment with collateral graph using registry vaults + fetched vaults
-    const [augmented] = augmentWithCollateralGraph([group], [...registryVaults.value, ...memberVaults])
+    const [augmented] = augmentWithCollateralGraph([group], [...registryVaults.value, ...memberVaults], isVaultGovernorVerified)
 
     try {
       return await resolveGroupTVL(augmented)

--- a/composables/useVaults.ts
+++ b/composables/useVaults.ts
@@ -881,11 +881,11 @@ const getBorrowVaultPair = async (
 
 export const useVaults = () => {
   // Check if vault's on-chain governorAdmin matches any of the product's declared entities
-  const isVaultGovernorVerified = (vault: Vault): boolean => {
+  const isVaultGovernorVerified = (vault: Vault | SecuritizeVault): boolean => {
     const { entities } = useEulerLabels()
 
     // Escrow vaults don't have a risk manager - show "-" not "Unknown"
-    if (vault.vaultCategory === 'escrow') {
+    if ('vaultCategory' in vault && vault.vaultCategory === 'escrow') {
       return true
     }
 
@@ -917,7 +917,7 @@ export const useVaults = () => {
     }
 
     // Also verify oracle router governor if the oracle is an EulerRouter
-    const routerGovernor = getEulerRouterGovernor(vault.oracleDetailedInfo)
+    const routerGovernor = 'oracleDetailedInfo' in vault ? getEulerRouterGovernor(vault.oracleDetailedInfo) : undefined
     if (routerGovernor && routerGovernor !== zeroAddress) {
       const routerGovernorVerified = declaredEntityKeys.some((entityKey) => {
         const entity = entities[entityKey]

--- a/entities/lend-discovery.ts
+++ b/entities/lend-discovery.ts
@@ -82,6 +82,8 @@ export interface MiniNode {
   assetSymbol: string
   x: number
   y: number
+  /** False for address-only placeholder nodes that have no loaded vault data. */
+  hasVaultData?: boolean
   /**
    * True when the node should render the red "unknown" badge. Applies to
    * external collaterals with an unverified governor (resolved vault, badge

--- a/entities/lend-discovery.ts
+++ b/entities/lend-discovery.ts
@@ -18,6 +18,17 @@ export interface MarketGroup {
   vaults: AnyVault[]
   /** Vaults referenced as collateral but not in this group */
   externalCollateral: AnyVault[]
+  /**
+   * Lowercased addresses of external collateral references the discovery view
+   * should flag with a red indicator. Two cases qualify:
+   *  1. The vault is in the registry but its governor isn't part of any
+   *     declared product entity — same signal as the per-pair "Unknown"
+   *     risk-manager pill (see `useVaults.isVaultGovernorVerified`).
+   *  2. The vault isn't loaded into the registry at all (truly missing).
+   * Group-member vaults are never included — the curator's product label
+   * is an explicit attestation that those are theirs.
+   */
+  unknownCollateral: string[]
   metrics: MarketGroupMetrics
 }
 
@@ -71,6 +82,14 @@ export interface MiniNode {
   assetSymbol: string
   x: number
   y: number
+  /**
+   * True when the node should render the red "unknown" badge. Applies to
+   * external collaterals with an unverified governor (resolved vault, badge
+   * sits beside the asset logo) and to placeholder nodes for truly missing
+   * vaults (no vault data — they fall back to the standard logo-less node
+   * with the truncated vault address as their label).
+   */
+  isUnknown?: boolean
 }
 
 export interface MiniEdge {

--- a/utils/discoveryCalculations.ts
+++ b/utils/discoveryCalculations.ts
@@ -311,6 +311,7 @@ export const getMiniDiagram = (market: MarketGroup): MiniDiagramData => {
       assetSymbol,
       x: cx + rx * Math.cos(angle),
       y: cy + ry * Math.sin(angle),
+      hasVaultData: Boolean(vault),
       isUnknown,
     }
   })

--- a/utils/discoveryCalculations.ts
+++ b/utils/discoveryCalculations.ts
@@ -13,7 +13,7 @@ import {
 import { getEulerLabelEntityLogo } from '~/entities/euler/labels'
 import { getEntitiesByVault, isVaultDeprecated } from '~/utils/eulerLabelsUtils'
 import { nanoToValue } from '~/utils/crypto-utils'
-import { formatNumber, compactNumber } from '~/utils/string-utils'
+import { formatNumber, compactNumber, truncate } from '~/utils/string-utils'
 import { decodeHookedOps, formatHookedOpsSummary, isVaultEffectivelyPaused } from '~/utils/vault-hooks'
 import { INTEREST_RATE_MODEL_TYPE, CFG_DONT_SOCIALIZE_DEBT } from '~/entities/constants'
 
@@ -128,11 +128,23 @@ export const getVaultAssetAddress = (vault: AnyVault): string => {
 // Market Data Helpers
 // ============================================================
 
-export const getDeprecatedVaultCount = (market: MarketGroup): number =>
-  market.vaults.filter((v) => {
-    const addr = getVaultAddress(v)
-    return addr ? isVaultDeprecated(addr) : false
-  }).length
+// Count members and externals so the headline matches the per-node badge in
+// the graph (which paints any deprecated address regardless of role). Dedupe
+// in case the same address appears in both lists.
+export const getDeprecatedVaultCount = (market: MarketGroup): number => {
+  const seen = new Set<string>()
+  let count = 0
+  for (const v of [...market.vaults, ...market.externalCollateral]) {
+    const addr = getVaultAddress(v).toLowerCase()
+    if (!addr || seen.has(addr)) continue
+    seen.add(addr)
+    if (isVaultDeprecated(addr)) count++
+  }
+  return count
+}
+
+export const getUnknownCollateralCount = (market: MarketGroup): number =>
+  market.unknownCollateral.length
 
 export const getMarketEntities = (market: MarketGroup): { name: string, logos: string[] } => {
   const seen = new Set<string>()
@@ -210,28 +222,35 @@ export const getMiniDiagram = (market: MarketGroup): MiniDiagramData => {
     const addr = getVaultAddress(v).toLowerCase()
     if (addr) vaultByAddr.set(addr, v)
   }
+  const unknownSet = new Set(market.unknownCollateral.map(a => a.toLowerCase()))
 
   const directedEdges = new Set<string>()
   const displayEdges = new Set<string>()
   const connectedAddresses = new Set<string>()
+  const connectedUnknownAddresses = new Set<string>()
 
   for (const vault of market.vaults) {
     if (!isVaultType(vault)) continue
     for (const ltv of vault.collateralLTVs) {
       const colAddr = ltv.collateral.toLowerCase()
-      if (!vaultByAddr.has(colAddr)) continue
+      const isKnown = vaultByAddr.has(colAddr)
+      const isUnknownPlaceholder = !isKnown && unknownSet.has(colAddr)
+      if (!isKnown && !isUnknownPlaceholder) continue
       const liabAddr = vault.address.toLowerCase()
       // directedEdges drives the borrowable-pair count rendered next to the
-      // graph — only currently borrowable edges count. displayEdges drives
+      // graph — only currently borrowable edges count, and only against known
+      // collateral so the headline isn't inflated by truly missing references
+      // (those get their own "X unknown" indicator). displayEdges drives
       // graph rendering and includes mid-ramp edges so a winding-down
       // collateral remains visually connected.
-      if (ltv.borrowLTV > 0n) {
+      if (isKnown && ltv.borrowLTV > 0n) {
         directedEdges.add(`${colAddr}:${liabAddr}`)
       }
       if (isLiveCollateralEdge(ltv)) {
         displayEdges.add(`${colAddr}:${liabAddr}`)
-        connectedAddresses.add(colAddr)
         connectedAddresses.add(liabAddr)
+        if (isKnown) connectedAddresses.add(colAddr)
+        else connectedUnknownAddresses.add(colAddr)
       }
     }
   }
@@ -244,15 +263,26 @@ export const getMiniDiagram = (market: MarketGroup): MiniDiagramData => {
     }
   }
 
-  if (connectedAddresses.size === 0 && disconnectedVaults.length === 0) {
+  if (connectedAddresses.size === 0 && connectedUnknownAddresses.size === 0 && disconnectedVaults.length === 0) {
     const assetSymbols = new Set<string>()
     for (const v of market.vaults) assetSymbols.add(getVaultAssetSymbol(v))
     return { nodes: [], edges: [], pairCount: 0, assetCount: assetSymbols.size, viewWidth: 0 }
   }
 
   const allNodeEntries = [
-    ...[...connectedAddresses].map(addr => ({ address: addr, vault: vaultByAddr.get(addr)! })),
-    ...disconnectedVaults,
+    ...[...connectedAddresses].map(addr => ({
+      address: addr,
+      vault: vaultByAddr.get(addr)!,
+      // A node can be "known" (resolved vault, full identity) yet still flagged
+      // as unknown when its governor isn't part of any declared product entity
+      // — same signal as the per-pair "Unknown" risk-manager pill. Keep the
+      // logo/symbol but render the red badge in either case.
+      isUnknown: unknownSet.has(addr),
+    })),
+    ...[...connectedUnknownAddresses].map(addr => ({ address: addr, vault: undefined, isUnknown: true })),
+    // Disconnected nodes are always group members; group members are never
+    // tracked in unknownCollateral (the curator's label is an attestation).
+    ...disconnectedVaults.map(d => ({ ...d, isUnknown: false })),
   ]
   const count = allNodeEntries.length
   const baseR = Math.min(24, 10 + count * 2)
@@ -263,12 +293,26 @@ export const getMiniDiagram = (market: MarketGroup): MiniDiagramData => {
   const cy = 30
   const assetSymbols = new Set<string>()
 
-  const nodes: MiniNode[] = allNodeEntries.map(({ address, vault }, i) => {
+  const nodes: MiniNode[] = allNodeEntries.map(({ address, vault, isUnknown }, i) => {
     const angle = (Math.PI * 2 * i) / Math.max(count, 1) - Math.PI / 2
-    const assetSymbol = vault ? getVaultAssetSymbol(vault) : '?'
+    // Placeholder nodes have no asset metadata. Use the truncated vault
+    // address as the label so the curator can identify the missing entry,
+    // and let the standard logo-less fallback (stringToColor + 2-char head)
+    // handle the visual — the red badge alone signals the unknown state.
+    const assetSymbol = vault ? getVaultAssetSymbol(vault) : truncate(address)
     const assetAddress = vault ? getVaultAssetAddress(vault) : ''
-    assetSymbols.add(assetSymbol)
-    return { address, assetAddress, assetSymbol, x: cx + rx * Math.cos(angle), y: cy + ry * Math.sin(angle) }
+    // Resolvable nodes still contribute to "X assets" even when flagged as
+    // unknown (USDC stays USDC; only the badge is added). The asset count is
+    // suppressed only for placeholder nodes that have no resolved vault data.
+    if (vault) assetSymbols.add(assetSymbol)
+    return {
+      address,
+      assetAddress,
+      assetSymbol,
+      x: cx + rx * Math.cos(angle),
+      y: cy + ry * Math.sin(angle),
+      isUnknown,
+    }
   })
   const nodeMap = new Map(nodes.map(n => [n.address, n]))
 


### PR DESCRIPTION
## Summary

Two changes to how the market discovery view surfaces collateral relationships.

### 1. Silence the missing-collateral noise (original PR scope)

The console was flooded by `[useMarketGroups/missing-collateral]` warnings such as:

> Group "Frontier Falcon": vault 0xbFdc... references unresolved collateral 0xE415...

The warning conflated two distinct conditions, both of which were false positives for what the message implied (a real data gap):

1. **Inactive LTV rows.** `getCollateralAddresses` returned every entry in `vault.collateralLTVs`, including rows where both `borrowLTV` and `liquidationLTV` are `0n`. EVK keeps these around for retired or never-activated collaterals; they aren't part of any usable market. They are now filtered out.
2. **Active LTV → non-explorable vault.** `augmentWithCollateralGraph` was looked up against `allVaults`, which strips vaults filtered by `isVaultNotExplorable`. Active LTVs targeting those vaults appeared "unresolved" purely because the lookup pool excluded them. The lookup now uses the full registry, so they resolve as `externalCollateral` as intended.

After both fixes, the only remaining warnings represent genuine governance gaps.

### 2. Flag those genuine gaps in the UI

Logging warnings doesn't reach curators — they're not running our console. Mirror the existing per-pair "⚠ Unknown" risk-manager pill (driven by `isVaultGovernorVerified`) into the market discovery view so the signal is visible from the headline, not just inside individual pair cards.

A market node is flagged with a red `!` badge when:
- it's an external collateral whose `governorAdmin` isn't part of any declared product entity, OR
- the vault isn't loaded into the registry **and** no label recognises the address either.

The market card headline grows a third line — `{N} unknown` in red, alongside the existing `{N} deprecated` — with a tooltip describing both cases.

Resolved-but-unverified nodes (the common case) keep their token logo and just gain the badge — USDC stays USDC. Placeholder nodes for truly missing vaults use the standard logo-less fallback (`stringToColor` + 2-char head) with the truncated vault address as the label so the curator can identify the missing entry.

#### Lazy-hydration handling

The vault registry hydrates lazily — a collateral referenced by a member vault may not arrive until a user opens that vault's page. When labels already recognise the address (deprecated, or assigned to any product), we *do* know about it; flagging it as unknown produced false positives that flipped to a real deprecated external once the registry filled in. The unknown classification now defers judgement on registry-missing addresses that any label still recognises, and only fires immediately when neither registry nor labels know the vault — equivalent to the strict "no product attribution" case `isVaultGovernorVerified` already flags.

### Drive-by consistency fix

`getDeprecatedVaultCount` was member-only, but the graph badge (`v-else-if="isVaultDeprecated(node.address)"`) painted any deprecated address regardless of role. The headline could read `0 deprecated` while the graph showed orange badges. Updated the count to sweep both `market.vaults` and `market.externalCollateral` (deduped) so the headline matches what's drawn.

## Changes

- `composables/useMarketGroups.ts`
  - `getCollateralAddresses` filters by `liquidationLTV > 0n || borrowLTV > 0n`.
  - `registryVaults` (full registry) feeds `augmentWithCollateralGraph` for lookup, alongside the explorable-only `allVaults` used for grouping.
  - `augmentWithCollateralGraph` accepts `isVaultGovernorVerified` and tracks unverified external collaterals plus truly-unrecognised addresses on `MarketGroup.unknownCollateral`. Registry-missing collaterals that are still recognised by labels are deferred until hydration completes.
- `entities/lend-discovery.ts` — new `MarketGroup.unknownCollateral: string[]` and `MiniNode.isUnknown?: boolean`.
- `utils/discoveryCalculations.ts`
  - New `getUnknownCollateralCount(market)` helper.
  - `getDeprecatedVaultCount` now counts members + externals (deduped).
  - `getMiniDiagram` flags resolved nodes when their address is in `unknownSet` (logo preserved) and synthesizes placeholder nodes with truncated-address labels for truly missing vaults.
- `components/entities/vault/discovery/DiscoveryMarketGraph.vue` — red `!` badge added (precedes deprecated/ramping/keyring/cyclical badges).
- `components/entities/vault/discovery/DiscoveryMarketCard.vue` — `{N} unknown` headline line and matching mini-graph badge.

## Test plan

- [x] Open the lend/markets discovery view — confirm the `[useMarketGroups/missing-collateral]` spam is gone for non-explorable-but-loaded collaterals.
- [x] Inspect a previously-warning group (e.g. Frontier Falcon) — collateral relationships still appear in `externalCollateral` where active LTVs target non-explorable vaults.
- [x] Open a market with a known unverified-governor external collateral (e.g. AlphaGrowth's "Origin stETH ARM / WETH" with USDC/WBTC externals) — confirm the headline shows `{N} unknown` in red and the graph nodes show the red `!` badge while keeping their token logos.
- [ ] Spot-check a market with both deprecated members AND unknown externals — both lines render in the headline.
- [x] Confirm a market containing a deprecated external collateral has the `{N} deprecated` count match the orange badges in its graph.
- [ ] Open a market whose member vault references a label-known but registry-unhydrated collateral (e.g. 9Summits Cluster on Avalanche) — confirm it does **not** render a red unknown placeholder pre-hydration, and reappears as a normal external (with deprecated badge if applicable) once a per-vault page lazy-loads it.
- [ ] Direct-URL access to a non-explorable product (`fetchMarketGroupOnDemand`) still resolves correctly and carries the unknown indicator if applicable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Market discovery now tracks and surfaces "unknown" collateral (unverified or missing) and shows counts on market cards with tooltips.
  * Graphs render red "unknown" badges and add placeholder nodes for missing/unverified collateral; nodes without vault data are not clickable.

* **Bug Fixes / Improvements**
  * Collateral counting and diagram logic improved: deprecated/unknown counts deduped and edge/node counting updated for accurate displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->