### PR TITLE
feat: surface swap mode in operation review steps

### DIFF
--- a/components/entities/operation/OperationReviewModal.vue
+++ b/components/entities/operation/OperationReviewModal.vue
@@ -22,7 +22,7 @@ interface REULUnlockInfo {
   daysUntilMaturity: number
 }
 
-const { type, asset, assetIconUrl, campaignInfo: _campaignInfo, reulUnlockInfo, amount, onConfirm, plan, swapToAsset, swapToAmount, swapMode, supplyingAssetForBorrow, supplyingAmount, transferAmounts, submittingLabel } = defineProps<{
+const { type, asset, assetIconUrl, campaignInfo: _campaignInfo, reulUnlockInfo, amount, onConfirm, plan, swapToAsset, swapToAmount, swapMode, swapEstimatedSide, supplyingAssetForBorrow, supplyingAmount, transferAmounts, submittingLabel } = defineProps<{
   type?: 'supply' | 'withdraw' | 'borrow' | 'repay' | 'swap' | 'transfer' | 'reward' | 'brevis-reward' | 'fuul-reward' | 'reul-unlock' | 'disableCollateral' | 'swap-supply' | 'swap-withdraw' | 'swap-borrow'
   asset: VaultAsset
   assetIconUrl?: string
@@ -33,8 +33,10 @@ const { type, asset, assetIconUrl, campaignInfo: _campaignInfo, reulUnlockInfo, 
   swapToAsset?: VaultAsset
   swapToAmount?: number | string
   /** Swap mode behind this operation, when one is involved. Drives the
-   *  "Swap to repay" relabel and which leg is shown as estimated. */
+   *  "Swap to repay" relabel and default estimated leg. */
   swapMode?: SwapperMode
+  /** Display-side override for which swap amount should receive "~". */
+  swapEstimatedSide?: 'input' | 'output'
   campaignInfo?: Campaign
   reulUnlockInfo?: REULUnlockInfo
   onConfirm: () => void | Promise<void>
@@ -142,7 +144,7 @@ const displaySteps = computed((): DisplayStep[] => {
   const ctx: StepDecodingContext = {
     type, asset, assetIconUrl, amount,
     supplyingAssetForBorrow, supplyingAmount,
-    swapToAsset, swapToAmount, swapMode, transferAmounts,
+    swapToAsset, swapToAmount, swapMode, swapEstimatedSide, transferAmounts,
   }
 
   return buildDisplaySteps(plan, ctx, getVault, getAssetLogoUrl, hasPermit2Approval.value)

--- a/components/entities/operation/OperationReviewModal.vue
+++ b/components/entities/operation/OperationReviewModal.vue
@@ -4,6 +4,7 @@ import type { Address, Hex } from 'viem'
 import type { Campaign } from '~/entities/brevis'
 import type { VaultAsset } from '~/entities/vault'
 import type { TxPlan } from '~/entities/txPlan'
+import type { SwapperMode } from '~/entities/swap'
 import type { EVCCall } from '~/utils/evc-converter'
 import { applyOperationGuards } from '~/utils/operationGuardRegistry'
 import { buildDisplaySteps, type DisplayStep, type StepDecodingContext } from '~/utils/stepDecoding'
@@ -21,7 +22,7 @@ interface REULUnlockInfo {
   daysUntilMaturity: number
 }
 
-const { type, asset, assetIconUrl, campaignInfo: _campaignInfo, reulUnlockInfo, amount, onConfirm, plan, swapToAsset, swapToAmount, supplyingAssetForBorrow, supplyingAmount, transferAmounts, submittingLabel } = defineProps<{
+const { type, asset, assetIconUrl, campaignInfo: _campaignInfo, reulUnlockInfo, amount, onConfirm, plan, swapToAsset, swapToAmount, swapMode, supplyingAssetForBorrow, supplyingAmount, transferAmounts, submittingLabel } = defineProps<{
   type?: 'supply' | 'withdraw' | 'borrow' | 'repay' | 'swap' | 'transfer' | 'reward' | 'brevis-reward' | 'fuul-reward' | 'reul-unlock' | 'disableCollateral' | 'swap-supply' | 'swap-withdraw' | 'swap-borrow'
   asset: VaultAsset
   assetIconUrl?: string
@@ -31,6 +32,9 @@ const { type, asset, assetIconUrl, campaignInfo: _campaignInfo, reulUnlockInfo, 
   supplyingAmount?: number | string
   swapToAsset?: VaultAsset
   swapToAmount?: number | string
+  /** Swap mode behind this operation, when one is involved. Drives the
+   *  "Swap to repay" relabel and which leg is shown as estimated. */
+  swapMode?: SwapperMode
   campaignInfo?: Campaign
   reulUnlockInfo?: REULUnlockInfo
   onConfirm: () => void | Promise<void>
@@ -138,7 +142,7 @@ const displaySteps = computed((): DisplayStep[] => {
   const ctx: StepDecodingContext = {
     type, asset, assetIconUrl, amount,
     supplyingAssetForBorrow, supplyingAmount,
-    swapToAsset, swapToAmount, transferAmounts,
+    swapToAsset, swapToAmount, swapMode, transferAmounts,
   }
 
   return buildDisplaySteps(plan, ctx, getVault, getAssetLogoUrl, hasPermit2Approval.value)

--- a/components/entities/operation/OperationStepsList.vue
+++ b/components/entities/operation/OperationStepsList.vue
@@ -31,7 +31,7 @@ defineProps<{
             {{ step.assetInfo.amount }}&nbsp;
           </template>
           <template v-else-if="step.assetInfo.amount !== undefined">
-            {{ formatNumber(step.assetInfo.amount, 8, 0) }}&nbsp;
+            {{ step.assetInfo.estimated ? '~' : '' }}{{ formatNumber(step.assetInfo.amount, 8, 0) }}&nbsp;
           </template>{{ step.assetInfo.symbol }}
         </p>
       </template>
@@ -57,7 +57,7 @@ defineProps<{
           class="text-p3"
         >
           <template v-if="step.toAssetInfo.amount !== undefined">
-            {{ formatNumber(step.toAssetInfo.amount, 8, 0) }}&nbsp;
+            {{ step.toAssetInfo.estimated ? '~' : '' }}{{ formatNumber(step.toAssetInfo.amount, 8, 0) }}&nbsp;
           </template>{{ step.toAssetInfo.symbol }}
         </p>
       </template>

--- a/composables/borrow/useBorrowForm.ts
+++ b/composables/borrow/useBorrowForm.ts
@@ -657,6 +657,7 @@ export const useBorrowForm = (options: UseBorrowFormOptions) => {
             plan: plan.value || undefined,
             swapToAsset: collateralVault.value.asset,
             swapToAmount: borrowSwapEstimatedCollateral.value,
+            swapMode: SwapperMode.EXACT_IN,
             onConfirm: async () => {
               await send()
             },

--- a/composables/borrow/useMultiplyForm.ts
+++ b/composables/borrow/useMultiplyForm.ts
@@ -815,6 +815,7 @@ export const useMultiplyForm = (options: UseMultiplyFormOptions) => {
           supplyingAmount: multiplyInputAmount.value,
           swapToAsset: quote ? multiplyLongVault.value.asset : undefined,
           swapToAmount: quote ? multiplyLongAmount.value : undefined,
+          swapMode: quote ? SwapperMode.EXACT_IN : undefined,
           subAccount,
           onConfirm: () => {
             setTimeout(() => {

--- a/composables/position/useCollateralForm.ts
+++ b/composables/position/useCollateralForm.ts
@@ -26,7 +26,7 @@ import { isAnyVaultBlockedByCountry, isVaultRestrictedByCountry, isAssetBlockedB
 import { isOperationBlocked } from '~/utils/operationGuardRegistry'
 import { useVaultRegistry } from '~/composables/useVaultRegistry'
 import { useSwapQuotesParallel } from '~/composables/useSwapQuotesParallel'
-import type { SwapApiQuote } from '~/entities/swap'
+import { SwapperMode, type SwapApiQuote } from '~/entities/swap'
 import type { SwapTokenSelectMeta } from '~/components/entities/asset/SwapTokenSelector.vue'
 import type { SwapApiRequestInput } from '~/composables/useSwapApi'
 import { buildSwapRouteItems } from '~/utils/swapRouteItems'
@@ -659,6 +659,7 @@ export const useCollateralForm = (options: UseCollateralFormOptions) => {
             hasBorrows: (position.value?.borrowed || 0n) > 0n,
             swapToAsset: options.needsSwap.value ? options.getSwapToAsset() : undefined,
             swapToAmount: options.needsSwap.value ? swapEstimatedOutput.value : undefined,
+            swapMode: options.needsSwap.value ? SwapperMode.EXACT_IN : undefined,
             onConfirm: async () => {
               await send()
             },

--- a/composables/repay/useCollateralSwapRepay.ts
+++ b/composables/repay/useCollateralSwapRepay.ts
@@ -426,6 +426,7 @@ export const useCollateralSwapRepay = (options: UseCollateralSwapRepayOptions) =
           plan: plan.value || undefined,
           swapToAsset: !core.isSameAsset.value ? borrowVault.value.asset : undefined,
           swapToAmount: !core.isSameAsset.value ? core.debtAmount.value : undefined,
+          swapMode: !core.isSameAsset.value ? core.direction.value : undefined,
           subAccount: position.value?.subAccount,
           hasBorrows: (position.value?.borrowed || 0n) > 0n,
           onConfirm: async () => {

--- a/composables/repay/useSavingsRepay.ts
+++ b/composables/repay/useSavingsRepay.ts
@@ -353,6 +353,7 @@ export const useSavingsRepay = (options: UseSavingsRepayOptions) => {
           amount: core.amount.value,
           swapToAsset: !core.isSameAsset.value ? borrowVault.value.asset : undefined,
           swapToAmount: !core.isSameAsset.value ? core.debtAmount.value : undefined,
+          swapMode: !core.isSameAsset.value ? core.direction.value : undefined,
           plan: plan.value || undefined,
           subAccount: position.value?.subAccount,
           hasBorrows: (position.value?.borrowed || 0n) > 0n,

--- a/composables/repay/useWalletSwapRepay.ts
+++ b/composables/repay/useWalletSwapRepay.ts
@@ -734,7 +734,7 @@ export const useWalletSwapRepay = (options: UseWalletSwapRepayOptions) => {
           asset: reviewAsset,
           amount: inputDisplay,
           swapToAsset: borrowVault.value.asset,
-          swapToAmount: swapEstimatedOutput.value,
+          swapToAmount: direction.value === SwapperMode.TARGET_DEBT ? debtAmount.value : swapEstimatedOutput.value,
           swapMode: direction.value,
           plan: plan.value || undefined,
           subAccount: position.value?.subAccount,

--- a/composables/repay/useWalletSwapRepay.ts
+++ b/composables/repay/useWalletSwapRepay.ts
@@ -735,6 +735,7 @@ export const useWalletSwapRepay = (options: UseWalletSwapRepayOptions) => {
           amount: inputDisplay,
           swapToAsset: borrowVault.value.asset,
           swapToAmount: swapEstimatedOutput.value,
+          swapMode: direction.value,
           plan: plan.value || undefined,
           subAccount: position.value?.subAccount,
           hasBorrows: (position.value?.borrowed || 0n) > 0n,

--- a/composables/useSwapPageLogic.ts
+++ b/composables/useSwapPageLogic.ts
@@ -4,7 +4,7 @@ import { logWarn } from '~/utils/errorHandling'
 import { OperationReviewModal, SlippageSettingsModal } from '#components'
 import { usePriceImpactGate } from '~/composables/usePriceImpactGate'
 import type { Vault, SecuritizeVault } from '~/entities/vault'
-import type { SwapApiQuote } from '~/entities/swap'
+import type { SwapApiQuote, SwapperMode } from '~/entities/swap'
 import { getAssetUsdValue } from '~/services/pricing/priceProvider'
 import { useEulerProductOfVault } from '~/composables/useEulerLabels'
 import { isAnyVaultBlockedByCountry, getVaultTags } from '~/composables/useGeoBlock'
@@ -58,6 +58,9 @@ export interface UseSwapPageLogicOptions {
   computePriceImpact?: (quote: SwapApiQuote) => Promise<number | null>
   /** Modal type when from/to share the same underlying asset. Default 'transfer'; borrow uses 'swap'. */
   sameAssetModalType?: 'transfer' | 'swap'
+  /** Mode the page quotes its swap in. Drives the review-modal "Swap to repay" relabel
+   *  and which leg is rendered as estimated. */
+  swapperMode: SwapperMode
 }
 
 export const useSwapPageLogic = (options: UseSwapPageLogicOptions) => {
@@ -79,6 +82,7 @@ export const useSwapPageLogic = (options: UseSwapPageLogicOptions) => {
     additionalErrors = [],
     computePriceImpact,
     sameAssetModalType = 'transfer',
+    swapperMode,
   } = options
 
   const otherAmountField: SwapQuoteAmountField = displayAmountField === 'amountIn' ? 'amountOut' : 'amountIn'
@@ -463,6 +467,7 @@ export const useSwapPageLogic = (options: UseSwapPageLogicOptions) => {
             amount: fromAmount.value,
             swapToAsset: showSwapAmounts ? toVault.value?.asset : undefined,
             swapToAmount: showSwapAmounts ? toAmount.value : undefined,
+            swapMode: showSwapAmounts ? swapperMode : undefined,
             plan: plan.value || undefined,
             onConfirm: async () => {
               await send()

--- a/composables/useSwapPageLogic.ts
+++ b/composables/useSwapPageLogic.ts
@@ -61,6 +61,8 @@ export interface UseSwapPageLogicOptions {
   /** Mode the page quotes its swap in. Drives the review-modal "Swap to repay" relabel
    *  and which leg is rendered as estimated. */
   swapperMode: SwapperMode
+  /** Override the displayed side marked as estimated in the review modal. */
+  reviewSwapEstimatedSide?: 'input' | 'output'
 }
 
 export const useSwapPageLogic = (options: UseSwapPageLogicOptions) => {
@@ -83,6 +85,7 @@ export const useSwapPageLogic = (options: UseSwapPageLogicOptions) => {
     computePriceImpact,
     sameAssetModalType = 'transfer',
     swapperMode,
+    reviewSwapEstimatedSide,
   } = options
 
   const otherAmountField: SwapQuoteAmountField = displayAmountField === 'amountIn' ? 'amountOut' : 'amountIn'
@@ -468,6 +471,7 @@ export const useSwapPageLogic = (options: UseSwapPageLogicOptions) => {
             swapToAsset: showSwapAmounts ? toVault.value?.asset : undefined,
             swapToAmount: showSwapAmounts ? toAmount.value : undefined,
             swapMode: showSwapAmounts ? swapperMode : undefined,
+            swapEstimatedSide: showSwapAmounts ? reviewSwapEstimatedSide : undefined,
             plan: plan.value || undefined,
             onConfirm: async () => {
               await send()

--- a/pages/lend/[vault]/[subAccount]/swap.vue
+++ b/pages/lend/[vault]/[subAccount]/swap.vue
@@ -84,6 +84,7 @@ const swap = useSwapPageLogic({
   displayAmountField: 'amountOut',
   quoteDiffPrefix: '-',
   redirectPath: '/portfolio/saving',
+  swapperMode: SwapperMode.EXACT_IN,
 
   buildQuoteRequest(amount) {
     if (!fromVault.value || !toVault.value) return null

--- a/pages/lend/[vault]/[subAccount]/withdraw.vue
+++ b/pages/lend/[vault]/[subAccount]/withdraw.vue
@@ -389,6 +389,7 @@ const submit = async () => {
           plan: plan.value || undefined,
           swapToAsset: needsSwap.value ? selectedOutputAsset.value : undefined,
           swapToAmount: needsSwap.value ? swapEstimatedOutput.value : undefined,
+          swapMode: needsSwap.value ? SwapperMode.EXACT_IN : undefined,
           submittingLabel: 'Submitting...',
           onConfirm: async () => {
             await send()

--- a/pages/lend/[vault]/index.vue
+++ b/pages/lend/[vault]/index.vue
@@ -460,6 +460,7 @@ const submit = async () => {
           plan: plan.value || undefined,
           swapToAsset: needsSwap.value ? asset.value : undefined,
           swapToAmount: needsSwap.value ? swapEstimatedOutput.value : undefined,
+          swapMode: needsSwap.value ? SwapperMode.EXACT_IN : undefined,
           submittingLabel: 'Submitting...',
           onConfirm: async () => {
             await send()

--- a/pages/position/[number]/borrow/swap.vue
+++ b/pages/position/[number]/borrow/swap.vue
@@ -183,6 +183,7 @@ const swap = useSwapPageLogic({
   targetVaultAddress,
   additionalErrors: [healthError],
   sameAssetModalType: 'swap',
+  swapperMode: SwapperMode.TARGET_DEBT,
 
   buildQuoteRequest(amount) {
     if (!fromVault.value || !toVault.value || !position.value) return null

--- a/pages/position/[number]/borrow/swap.vue
+++ b/pages/position/[number]/borrow/swap.vue
@@ -184,6 +184,7 @@ const swap = useSwapPageLogic({
   additionalErrors: [healthError],
   sameAssetModalType: 'swap',
   swapperMode: SwapperMode.TARGET_DEBT,
+  reviewSwapEstimatedSide: 'output',
 
   buildQuoteRequest(amount) {
     if (!fromVault.value || !toVault.value || !position.value) return null

--- a/pages/position/[number]/collateral/swap.vue
+++ b/pages/position/[number]/collateral/swap.vue
@@ -107,6 +107,7 @@ const swap = useSwapPageLogic({
   quoteDiffPrefix: '-',
   redirectPath: '/portfolio',
   targetVaultAddress,
+  swapperMode: SwapperMode.EXACT_IN,
 
   buildQuoteRequest(amount) {
     if (!fromVault.value || !toVault.value || !position.value) return null

--- a/pages/position/[number]/multiply.vue
+++ b/pages/position/[number]/multiply.vue
@@ -638,6 +638,7 @@ const submitMultiply = async () => {
           plan: plan.value || undefined,
           swapToAsset: quote ? multiplyLongVault.value.asset : undefined,
           swapToAmount: reviewSwapToAmount,
+          swapMode: quote ? SwapperMode.EXACT_IN : undefined,
           subAccount,
           submittingLabel: 'Submitting...',
           onConfirm: async () => {

--- a/utils/stepDecoding.ts
+++ b/utils/stepDecoding.ts
@@ -58,6 +58,8 @@ export interface StepDecodingContext {
 // Constants (internal)
 // ---------------------------------------------------------------------------
 
+type SwapEstimatedSide = 'input' | 'output'
+
 const SELECTOR_LABELS: Record<string, string> = {
   [toFunctionSelector('function deposit(uint256,address)')]: 'Supply',
   [toFunctionSelector('function borrow(uint256,address)')]: 'Borrow',
@@ -83,6 +85,20 @@ const SELECTOR_LABELS: Record<string, string> = {
 }
 
 const MAX_UINT256 = 2n ** 256n - 1n
+
+const getDefaultSwapEstimatedSide = (swapMode: SwapperMode): SwapEstimatedSide => {
+  switch (swapMode) {
+    case SwapperMode.EXACT_IN:
+      return 'output'
+    case SwapperMode.EXACT_OUT:
+    case SwapperMode.TARGET_DEBT:
+      return 'input'
+    default: {
+      const exhaustive: never = swapMode
+      return exhaustive
+    }
+  }
+}
 
 // Selectors where the first uint256 param is shares, not assets.
 // Decoding these as assets would show a wrong amount in the UI.
@@ -402,7 +418,7 @@ export function buildDisplaySteps(
           }
           if (label === 'Swap' && (ctx.swapMode !== undefined || ctx.swapEstimatedSide)) {
             const estimatedSide = ctx.swapEstimatedSide
-              ?? (ctx.swapMode === SwapperMode.EXACT_IN ? 'output' : 'input')
+              ?? (ctx.swapMode !== undefined ? getDefaultSwapEstimatedSide(ctx.swapMode) : undefined)
             if (estimatedSide === 'output' && toAssetInfo) {
               toAssetInfo = { ...toAssetInfo, estimated: true }
             }

--- a/utils/stepDecoding.ts
+++ b/utils/stepDecoding.ts
@@ -43,12 +43,14 @@ export interface StepDecodingContext {
   swapToAmount?: number | string
   /**
    * Mode of the swap behind this operation, when one is involved. Drives the
-   * "Swap to repay" relabel and which leg is shown as estimated:
+   * "Swap to repay" relabel and the default estimated leg:
    *   EXACT_IN     → output amount is an estimate
    *   EXACT_OUT    → input amount is an estimate
    *   TARGET_DEBT  → input amount is an estimate, label becomes "Swap to repay"
    */
   swapMode?: SwapperMode
+  /** Display-side override for flows whose review order differs from swap input/output. */
+  swapEstimatedSide?: 'input' | 'output'
   transferAmounts?: Record<string, string>
 }
 
@@ -398,18 +400,13 @@ export function buildDisplaySteps(
           else if (label === 'Update price feeds' && stepAssetInfo && secondAsset && secondAsset.symbol !== ctx.asset.symbol) {
             toAssetInfo = { symbol: secondAsset.symbol, address: secondAsset.address }
           }
-          // For swap steps, the leg that the user did NOT pin is an estimate.
-          // EXACT_IN pins input (output is estimated); EXACT_OUT and TARGET_DEBT
-          // pin output / target debt (input is estimated). TARGET_DEBT additionally
-          // relabels the step to "Swap to repay".
-          if (label === 'Swap' && ctx.swapMode !== undefined) {
-            if (ctx.swapMode === SwapperMode.EXACT_IN && toAssetInfo) {
+          if (label === 'Swap' && (ctx.swapMode !== undefined || ctx.swapEstimatedSide)) {
+            const estimatedSide = ctx.swapEstimatedSide
+              ?? (ctx.swapMode === SwapperMode.EXACT_IN ? 'output' : 'input')
+            if (estimatedSide === 'output' && toAssetInfo) {
               toAssetInfo = { ...toAssetInfo, estimated: true }
             }
-            else if (
-              (ctx.swapMode === SwapperMode.EXACT_OUT || ctx.swapMode === SwapperMode.TARGET_DEBT)
-              && stepAssetInfo
-            ) {
+            else if (estimatedSide === 'input' && stepAssetInfo) {
               stepAssetInfo = { ...stepAssetInfo, estimated: true }
             }
           }

--- a/utils/stepDecoding.ts
+++ b/utils/stepDecoding.ts
@@ -1,6 +1,7 @@
 import { formatUnits, getAddress, toFunctionSelector, zeroAddress } from 'viem'
 import type { TxPlan } from '~/entities/txPlan'
 import type { EVCCall } from '~/utils/evc-converter'
+import { SwapperMode } from '~/entities/swap'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -11,6 +12,8 @@ export interface StepAssetInfo {
   address?: string
   amount?: number | string
   iconUrl?: string
+  /** When true, the displayed amount is an estimate (rendered with a "~" prefix). */
+  estimated?: boolean
 }
 
 export interface DisplayStep {
@@ -38,6 +41,14 @@ export interface StepDecodingContext {
   supplyingAmount?: number | string
   swapToAsset?: { symbol: string, address: string, decimals: bigint }
   swapToAmount?: number | string
+  /**
+   * Mode of the swap behind this operation, when one is involved. Drives the
+   * "Swap to repay" relabel and which leg is shown as estimated:
+   *   EXACT_IN     → output amount is an estimate
+   *   EXACT_OUT    → input amount is an estimate
+   *   TARGET_DEBT  → input amount is an estimate, label becomes "Swap to repay"
+   */
+  swapMode?: SwapperMode
   transferAmounts?: Record<string, string>
 }
 
@@ -372,7 +383,7 @@ export function buildDisplaySteps(
         for (const item of batchItems) {
           index++
           const label = decodeBatchItemLabel(item.data)
-          const stepAssetInfo = getAssetInfoForStep(label, item.data, item.targetContract, item, ctx, getVault, usedSupply, usedBorrow, usedSwapTo, lastWithdrawAmount)
+          let stepAssetInfo = getAssetInfoForStep(label, item.data, item.targetContract, item, ctx, getVault, usedSupply, usedBorrow, usedSwapTo, lastWithdrawAmount)
           const secondAsset = ctx.supplyingAssetForBorrow || ctx.swapToAsset
           let toAssetInfo: StepAssetInfo | undefined
           if (label === 'Wrap native currency') {
@@ -387,11 +398,28 @@ export function buildDisplaySteps(
           else if (label === 'Update price feeds' && stepAssetInfo && secondAsset && secondAsset.symbol !== ctx.asset.symbol) {
             toAssetInfo = { symbol: secondAsset.symbol, address: secondAsset.address }
           }
+          // For swap steps, the leg that the user did NOT pin is an estimate.
+          // EXACT_IN pins input (output is estimated); EXACT_OUT and TARGET_DEBT
+          // pin output / target debt (input is estimated). TARGET_DEBT additionally
+          // relabels the step to "Swap to repay".
+          if (label === 'Swap' && ctx.swapMode !== undefined) {
+            if (ctx.swapMode === SwapperMode.EXACT_IN && toAssetInfo) {
+              toAssetInfo = { ...toAssetInfo, estimated: true }
+            }
+            else if (
+              (ctx.swapMode === SwapperMode.EXACT_OUT || ctx.swapMode === SwapperMode.TARGET_DEBT)
+              && stepAssetInfo
+            ) {
+              stepAssetInfo = { ...stepAssetInfo, estimated: true }
+            }
+          }
           const displayLabel = label === 'Transfer to account'
             ? 'Transfer'
             : label === 'Wrap native currency'
               ? 'Wrap'
-              : label
+              : label === 'Swap' && ctx.swapMode === SwapperMode.TARGET_DEBT
+                ? 'Swap to repay'
+                : label
           const isWrapTransfer = label === 'Transfer' && prevLabel === 'Wrap native currency'
           const batchLabelSuffix = label === 'Transfer to account'
             ? 'to savings'


### PR DESCRIPTION
## Summary

The operation review modal — the per-step list shown before a user confirms a transaction — now reflects the actual swap mode behind the operation:

1. **TARGET_DEBT swaps relabel as "Swap to repay".** When a user repays debt by swapping a collateral or wallet asset into the borrow asset, the step is labeled `Swap to repay` instead of just `Swap`. Plain swaps (deposit-side conversion, multiply, collateral→collateral) keep `Swap`.

2. **The unpinned leg of every swap is prefixed with `~`** to make clear which side is exact and which is an estimate that can move within slippage:

   | Mode | Pinned (exact) | Estimated (`~`) |
   |---|---|---|
   | `EXACT_IN` | input | output |
   | `EXACT_OUT` | output | input |
   | `TARGET_DEBT` | target debt amount | input |

## Implementation

- `utils/stepDecoding.ts` — adds `swapMode?: SwapperMode` to `StepDecodingContext` and `estimated?: boolean` to `StepAssetInfo`. `buildDisplaySteps` derives the relabel and the per-leg estimated flag from `ctx.swapMode` only when the step label is `Swap`.
- `OperationReviewModal.vue` — accepts an optional `swapMode` prop and forwards it into the decoding context.
- `OperationStepsList.vue` — renders the `~` prefix on each leg whose `estimated` is true.
- **No calldata decoding.** The form composables already pass `swapperMode` into their swap-quote builders, so this PR just plumbs that same value one prop further into the modal at every call site that already passes `swapToAsset`/`swapToAmount`.
- `useSwapPageLogic` gets a new required `swapperMode` config option so the three swap-page entry points can pass their static mode through.

## Test plan

- [ ] Lend → swap (`/lend/[vault]/[subAccount]/swap`): `Swap` label, output side prefixed with `~`.
- [ ] Position → collateral swap (`/position/[number]/collateral/swap`): `Swap` label, output side prefixed with `~`.
- [ ] Position → borrow swap (`/position/[number]/borrow/swap`): `Swap to repay` label, input side prefixed with `~`, target-debt output amount exact.
- [ ] Lend deposit with input-asset swap-in (`/lend/[vault]` choosing a non-asset input): `Swap` label, output (target asset) prefixed with `~`.
- [ ] Lend withdraw with output-asset swap-out (`/lend/[vault]/[subAccount]/withdraw` choosing a non-asset output): `Swap` label, output prefixed with `~`.
- [ ] Multiply (`/position/[number]/multiply`): `Swap` label, output (long asset) prefixed with `~`.
- [ ] Borrow with collateral-side swap (`useBorrowForm` swap-borrow path): `Swap` label, output (collateral) prefixed with `~`.
- [ ] Repay flows that swap (collateral repay, savings repay, wallet swap repay) with both `EXACT_IN` and `TARGET_DEBT` directions: relabel and `~` move correctly when toggling direction.
- [ ] Same-asset repay/transfer/swap (no actual swap step): no relabel, no `~`.
- [ ] Operations without any swap (plain supply/borrow/withdraw/repay): no `~` anywhere.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Operation review now accepts and shows swap mode and an estimated-side override for clearer swap reviews.
  * Swap steps can relabel (e.g., "Swap to repay") when in target-debt mode.

* **Bug Fixes**
  * Estimated amounts are now prefixed with "~" to distinguish them from exact values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->