### PR TITLE
Standardize RPC URL env names

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,17 +45,17 @@ TENDERLY_ACCOUNT_SLUG=
 TENDERLY_PROJECT_SLUG=
 
 # Chain configuration
-# Enabled chains are derived from RPC_URL_HTTP_<chainId> env vars.
+# Enabled chains are derived from RPC_URL_<chainId> env vars.
 # Each RPC URL also needs a matching NUXT_PUBLIC_SUBGRAPH_URI_<chainId>.
 # Any chain ID supported by @reown/appkit/networks works — no code changes needed.
 #
 # Deprecated chains (comma-separated chain IDs, e.g. "1,56,236")
 # These chains are shown in a collapsed section in the chain selector.
-# Only chains that also have a RPC_URL_HTTP_<chainId> will appear.
+# Only chains that also have a RPC_URL_<chainId> will appear.
 DEPRECATED_CHAINS=
 #
 # RPC URLs (server-side only, never exposed to client bundle)
-RPC_URL_HTTP_1=
+RPC_URL_1=
 
 # CONFIG_ vars (override via NUXT_PUBLIC_CONFIG_* in Doppler)
 NUXT_PUBLIC_CONFIG_DOCS_URL="https://docs.euler.finance/"

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ cp .env.example .env
 | ------------------------------------ | ----------------------------------------------------------- |
 | `APPKIT_PROJECT_ID`                  | Reown (WalletConnect) project ID                            |
 | `NUXT_PUBLIC_APP_URL`                | Your app's public URL                                       |
-| `RPC_URL_HTTP_<chainId>`             | RPC endpoint per chain (e.g. `RPC_URL_HTTP_1` for Ethereum) |
+| `RPC_URL_<chainId>`                  | RPC endpoint per chain (e.g. `RPC_URL_1` for Ethereum)      |
 | `NUXT_PUBLIC_SUBGRAPH_URI_<chainId>` | Subgraph URI per chain                                      |
 
 #### API URLs
@@ -99,15 +99,15 @@ Chains are configured dynamically at runtime. Each chain requires two env vars:
 
 ```bash
 # Ethereum Mainnet
-RPC_URL_HTTP_1=https://your-rpc-endpoint.com
+RPC_URL_1=https://your-rpc-endpoint.com
 NUXT_PUBLIC_SUBGRAPH_URI_1=https://api.goldsky.com/.../euler-simple-mainnet/latest/gn
 
 # Arbitrum
-RPC_URL_HTTP_42161=https://your-arbitrum-rpc.com
+RPC_URL_42161=https://your-arbitrum-rpc.com
 NUXT_PUBLIC_SUBGRAPH_URI_42161=https://api.goldsky.com/.../euler-simple-arbitrum/latest/gn
 ```
 
-The app scans for `RPC_URL_HTTP_<chainId>` env vars at server startup and automatically enables those chains. No code changes needed to add or remove chains.
+The app scans for `RPC_URL_<chainId>` env vars at server startup and automatically enables those chains. No code changes needed to add or remove chains.
 
 ### 3. Customize Your Instance
 
@@ -253,7 +253,7 @@ docker run -p 3000:3000 \
   -e SWAP_API_URL=https://swap.euler.finance \
   -e PRICE_API_URL=https://indexer.euler.finance \
   -e APPKIT_PROJECT_ID=your-project-id \
-  -e RPC_URL_HTTP_1=https://your-rpc.com \
+  -e RPC_URL_1=https://your-rpc.com \
   -e NUXT_PUBLIC_SUBGRAPH_URI_1=https://your-subgraph.com \
   euler-lite node .output/server/index.mjs
 ```
@@ -312,7 +312,7 @@ Before deploying:
 - [ ] Copied `.env.example` to `.env` and filled in values
 - [ ] Set `APPKIT_PROJECT_ID` and `NUXT_PUBLIC_APP_URL`
 - [ ] Set `EULER_API_URL`, `SWAP_API_URL`, `PRICE_API_URL`
-- [ ] Added at least one `RPC_URL_HTTP_<chainId>` with matching `NUXT_PUBLIC_SUBGRAPH_URI_<chainId>`
+- [ ] Added at least one `RPC_URL_<chainId>` with matching `NUXT_PUBLIC_SUBGRAPH_URI_<chainId>`
 - [ ] Configured branding via `NUXT_PUBLIC_CONFIG_*` env vars (title, description, logo, social links, social share image)
 - [ ] Customized theme colors in `assets/styles/variables.scss` (THEME CONFIGURATION section)
 - [ ] Replaced favicon files in `public/favicons/`
@@ -338,7 +338,7 @@ Before deploying:
 
 ### No Chains Available
 
-- Ensure at least one `RPC_URL_HTTP_<chainId>` env var is set
+- Ensure at least one `RPC_URL_<chainId>` env var is set
 - Each chain needs a matching `NUXT_PUBLIC_SUBGRAPH_URI_<chainId>`
 
 ## Additional Resources

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -58,7 +58,7 @@ Configuration is split into two mechanisms:
 
 2. **Nuxt `runtimeConfig`** (`useDeployConfig()`) — branding, social links, feature flags. Set via `NUXT_PUBLIC_CONFIG_*` env vars. Includes `NUXT_PUBLIC_CONFIG_LABELS_BASE_URL`, `NUXT_PUBLIC_CONFIG_ORACLE_CHECKS_BASE_URL`, and `NUXT_PUBLIC_CONFIG_EULER_CHAINS_URL` for configuring upstream data sources (GitHub or S3/CDN). All three are fetched through server-side proxy endpoints with 5-minute caching — see [Server-Side Data Proxies](#server-side-data-proxies) below.
 
-3. **Chain config** (`useChainConfig()`) — derived dynamically from `RPC_URL_HTTP_<chainId>` env vars at server startup, injected via `window.__CHAIN_CONFIG__`.
+3. **Chain config** (`useChainConfig()`) — derived dynamically from `RPC_URL_<chainId>` env vars at server startup, injected via `window.__CHAIN_CONFIG__`.
 
 See the [README](../README.md) for the full env var reference.
 
@@ -121,7 +121,7 @@ The `/api/pyth/updates` endpoint proxies Pyth Hermes price update requests throu
 ## Troubleshooting
 
 - If the app fails to start, ensure Node 24+ and reinstall deps.
-- If blockchain calls fail, verify `RPC_URL_HTTP_<chainId>` env vars and check that matching `NUXT_PUBLIC_SUBGRAPH_URI_<chainId>` is set.
+- If blockchain calls fail, verify `RPC_URL_<chainId>` env vars and check that matching `NUXT_PUBLIC_SUBGRAPH_URI_<chainId>` is set.
 - If token logos don't load, verify `EULER_API_URL` (or `NUXT_PUBLIC_EULER_API_URL`) is set. Token data is fetched server-side via `/api/token-list` which aggregates Euler API, Uniswap, and DefiLlama sources with fallback.
 
 ---

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -99,7 +99,7 @@ SWAP_API_URL=https://swap.euler.finance
 PRICE_API_URL=https://indexer.euler.finance
 
 # Chain RPC endpoints (one per chain you want to enable)
-RPC_URL_HTTP_1=https://your-ethereum-rpc.com
+RPC_URL_1=https://your-ethereum-rpc.com
 NUXT_PUBLIC_SUBGRAPH_URI_1=https://your-subgraph.com
 ```
 
@@ -145,7 +145,7 @@ NUXT_PUBLIC_SUBGRAPH_URI_1=https://your-subgraph.com
 
 ### Blockchain Connection Issues
 
-- Verify `RPC_URL_HTTP_<chainId>` env vars are set correctly
+- Verify `RPC_URL_<chainId>` env vars are set correctly
 - Ensure matching `NUXT_PUBLIC_SUBGRAPH_URI_<chainId>` exists for each chain
 - Ensure RPC endpoints are accessible
 

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -104,4 +104,4 @@ const map = await res.json()
 - Handler: `server/api/public/is-known.get.ts`
 - Verified-set builder + cache: `server/utils/verified-vaults.ts`
 - CORS bypass for the `/api/public/` prefix lives in `server/middleware/cors.ts`.
-- Escrow vaults are read via an `eth_call` to `escrowedCollateralPerspective.verifiedArray()`. The perspective address is looked up from `EulerChains.json` (served by `/api/euler-chains`), and the RPC endpoint is taken from `RPC_URL_HTTP_<chainId>`. Products and earn-vault label files are fetched via internal self-calls to `/api/labels/<file>` to reuse the labels endpoint's own cache and validation.
+- Escrow vaults are read via an `eth_call` to `escrowedCollateralPerspective.verifiedArray()`. The perspective address is looked up from `EulerChains.json` (served by `/api/euler-chains`), and the RPC endpoint is taken from `RPC_URL_<chainId>`. Products and earn-vault label files are fetched via internal self-calls to `/api/labels/<file>` to reuse the labels endpoint's own cache and validation.

--- a/plugins/00.wagmi.ts
+++ b/plugins/00.wagmi.ts
@@ -21,7 +21,7 @@ export default defineNuxtPlugin((nuxtApp) => {
 
   if (!enabledChainIds.length) {
     throw new Error(
-      '[wagmi] No enabled chains. Set at least one RPC_URL_HTTP_<chainId> env var.',
+      '[wagmi] No enabled chains. Set at least one RPC_URL_<chainId> env var.',
     )
   }
 

--- a/server/plugins/csp.ts
+++ b/server/plugins/csp.ts
@@ -64,9 +64,9 @@ function scanDynamicEnvUrls(): string[] {
   const urls: string[] = []
   for (const [key, value] of Object.entries(process.env)) {
     if (!value) continue
-    // RPC_URL_HTTP_<chainId> — wagmi uses these directly on the client
+    // RPC_URL_<chainId> — wagmi uses these directly on the client
     // NUXT_PUBLIC_SUBGRAPH_URI_<chainId> — client-side GraphQL queries
-    if (/^RPC_URL_HTTP_\d+$/.test(key) || /^NUXT_PUBLIC_SUBGRAPH_URI_\d+$/.test(key)) {
+    if (/^RPC_URL_\d+$/.test(key) || /^NUXT_PUBLIC_SUBGRAPH_URI_\d+$/.test(key)) {
       urls.push(value)
     }
   }
@@ -82,7 +82,7 @@ function scanDynamicEnvUrls(): string[] {
 function parseChainPublicRpcOrigins(): string[] {
   const origins = new Set<string>()
   for (const [key, value] of Object.entries(process.env)) {
-    const match = key.match(/^RPC_URL_HTTP_(\d+)$/)
+    const match = key.match(/^RPC_URL_(\d+)$/)
     // Require a non-empty value so empty placeholder env vars don't widen
     // connect-src for chains that chain-config.ts correctly treats as disabled.
     if (!match || !value) continue

--- a/server/utils/rpc.ts
+++ b/server/utils/rpc.ts
@@ -1,4 +1,4 @@
 export const resolveRpcUrl = (chainId: number): string | undefined => {
-  const key = `RPC_URL_HTTP_${chainId}`
+  const key = `RPC_URL_${chainId}`
   return process.env[key]
 }

--- a/server/utils/vault-categories-store.ts
+++ b/server/utils/vault-categories-store.ts
@@ -183,7 +183,7 @@ const fetchEscrowVerifiedArray = async (
   perspectiveAddress: string | undefined,
 ): Promise<Set<string>> => {
   if (!perspectiveAddress) return new Set()
-  const rpcUrl = process.env[`RPC_URL_HTTP_${chainId}`]
+  const rpcUrl = process.env[`RPC_URL_${chainId}`]
   if (!rpcUrl) {
     reportStatus('vault-categories', `no-rpc:${chainId}`, 'missing-rpc-url',
       `no RPC URL for chain=${chainId}, skipping escrow categorization`)

--- a/server/utils/vaults-cache.ts
+++ b/server/utils/vaults-cache.ts
@@ -139,7 +139,7 @@ export const refreshChainVaults = (chainId: number): Promise<SerialisedSnapshot>
     // Errors bubble up to callers (warm-cache plugin or /api/vaults handler),
     // both of which log with their own context. A middle-layer catch here
     // would double-log every failure.
-    const rpcUrl = process.env[`RPC_URL_HTTP_${chainId}`]
+    const rpcUrl = process.env[`RPC_URL_${chainId}`]
     if (!rpcUrl) throw new Error(`No RPC URL configured for chain ${chainId}`)
 
     const cfg = await getChainConfig(chainId)

--- a/utils/chain-env.ts
+++ b/utils/chain-env.ts
@@ -5,14 +5,14 @@
  * (plugins, API handlers) and client-side code executed during SSR
  * (e.g. `useChainConfig` on the server branch) import from a single
  * source of truth. The convention is:
- *   - `RPC_URL_HTTP_<chainId>` — enables a chain (presence, not value, matters)
+ *   - `RPC_URL_<chainId>` — enables a chain (presence, not value, matters)
  *   - `NUXT_PUBLIC_SUBGRAPH_URI_<chainId>` — subgraph URL for that chain
  */
 
 export function getEnabledChainIds(env: NodeJS.ProcessEnv = process.env): number[] {
   const ids: number[] = []
   for (const [key, value] of Object.entries(env)) {
-    const match = key.match(/^RPC_URL_HTTP_(\d+)$/)
+    const match = key.match(/^RPC_URL_(\d+)$/)
     if (match && value) {
       ids.push(Number(match[1]))
     }


### PR DESCRIPTION
## Summary
- Rename chain RPC environment variables from `RPC_URL_HTTP_<chainId>` to `RPC_URL_<chainId>`.
- Keep docs, examples, chain discovery, RPC resolution, and CSP origin scanning aligned on the new convention.

## Changes
- Update server-side RPC lookups and enabled-chain discovery to use `RPC_URL_<chainId>`.
- Update `.env.example`, README, and docs references to the standardized env name.

## Test plan
- [x] `rg "RPC_URL_HTTP" .`
- [x] `git diff --check`
- [x] `npm run typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Standardized chain RPC environment variable naming from `RPC_URL_HTTP_<chainId>` to `RPC_URL_<chainId>`. Update your configuration accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->