### PR TITLE
fix full repay pre-existing deposits

### DIFF
--- a/composables/useEulerOperations/preExistingDeposit.ts
+++ b/composables/useEulerOperations/preExistingDeposit.ts
@@ -1,0 +1,26 @@
+import type { Address } from 'viem'
+import type { OperationsContext } from './types'
+import { erc20BalanceOfAbi } from '~/abis/erc20'
+import { logWarn } from '~/utils/errorHandling'
+
+export const hasPreExistingVaultDeposit = async (
+  ctx: OperationsContext,
+  vaultAddress: Address,
+  account: Address,
+  logScope: string,
+): Promise<boolean> => {
+  try {
+    const shares = await ctx.rpcProvider.readContract({
+      address: vaultAddress,
+      abi: erc20BalanceOfAbi,
+      functionName: 'balanceOf',
+      args: [account],
+    }) as bigint
+
+    return shares > 0n
+  }
+  catch (err) {
+    logWarn(logScope, err)
+    return false
+  }
+}

--- a/composables/useEulerOperations/repay.ts
+++ b/composables/useEulerOperations/repay.ts
@@ -1,13 +1,12 @@
 import type { Address, Hash } from 'viem'
 import { maxUint256 } from 'viem'
 import { adjustForInterest } from './helpers'
+import { hasPreExistingVaultDeposit } from './preExistingDeposit'
 import type { OperationsContext, OperationHelpers } from './types'
 import { evcDisableCollateralAbi, evcDisableControllerAbi } from '~/abis/evc'
-import { vaultRepayAbi, vaultRepayWithSharesAbi, vaultRedeemAbi, vaultSkimAbi, vaultTransferFromMaxAbi, vaultWithdrawAbi, vaultConvertToAssetsAbi } from '~/abis/vault'
-import { erc20BalanceOfAbi } from '~/abis/erc20'
+import { vaultRepayAbi, vaultRepayWithSharesAbi, vaultRedeemAbi, vaultSkimAbi, vaultTransferFromMaxAbi, vaultWithdrawAbi } from '~/abis/vault'
 import { SaHooksBuilder } from '~/entities/saHooksSDK'
 import { convertSaHooksToEVCCalls, type EVCCall } from '~/utils/evc-converter'
-import { logWarn } from '~/utils/errorHandling'
 import type { TxPlan } from '~/entities/txPlan'
 
 export const createRepayBuilders = (
@@ -314,28 +313,12 @@ export const createRepayBuilders = (
     const savingsSubAccountAddr = savingsSubAccount as Address
     const borrowSubAccountAddr = borrowSubAccount as Address
 
-    // Pre-flight: read pre-existing deposit in borrow vault
-    let preExistingBorrowDeposit = 0n
-    try {
-      const balanceOfResult = await ctx.rpcProvider.readContract({
-        address: borrowVaultAddr,
-        abi: erc20BalanceOfAbi,
-        functionName: 'balanceOf',
-        args: [borrowSubAccountAddr],
-      }) as bigint
-      if (balanceOfResult > 0n) {
-        const assetsResult = await ctx.rpcProvider.readContract({
-          address: borrowVaultAddr,
-          abi: vaultConvertToAssetsAbi,
-          functionName: 'convertToAssets',
-          args: [balanceOfResult],
-        }) as bigint
-        preExistingBorrowDeposit = assetsResult
-      }
-    }
-    catch (err) {
-      logWarn('buildSavingsFullRepayPlan', err)
-    }
+    const hasPreExistingBorrowDeposit = await hasPreExistingVaultDeposit(
+      ctx,
+      borrowVaultAddr,
+      borrowSubAccountAddr,
+      'buildSavingsFullRepayPlan',
+    )
 
     const sameVault = savingsVaultAddr.toLowerCase() === borrowVaultAddr.toLowerCase()
     const collateralAddresses = enabledCollaterals || []
@@ -387,18 +370,22 @@ export const createRepayBuilders = (
         value: 0n,
         data: hooks.getDataForCall(borrowVaultAddr, 'repayWithShares', [maxUint256, borrowSubAccountAddr]) as Hash,
       })
-      evcCalls.push({
-        targetContract: borrowVaultAddr,
-        onBehalfOfAccount: borrowSubAccountAddr,
-        value: 0n,
-        data: hooks.getDataForCall(borrowVaultAddr, 'redeem', [maxUint256, savingsVaultAddr, borrowSubAccountAddr]) as Hash,
-      })
-      evcCalls.push({
-        targetContract: savingsVaultAddr,
-        onBehalfOfAccount: savingsSubAccountAddr,
-        value: 0n,
-        data: hooks.getDataForCall(savingsVaultAddr, 'skim', [preExistingBorrowDeposit, savingsSubAccountAddr]) as Hash,
-      })
+      // Only sweep the repay cushion when the borrow vault did not already hold shares.
+      // Otherwise redeem(max) would also migrate the user's pre-existing borrow-vault deposit.
+      if (!hasPreExistingBorrowDeposit) {
+        evcCalls.push({
+          targetContract: borrowVaultAddr,
+          onBehalfOfAccount: borrowSubAccountAddr,
+          value: 0n,
+          data: hooks.getDataForCall(borrowVaultAddr, 'redeem', [maxUint256, savingsVaultAddr, borrowSubAccountAddr]) as Hash,
+        })
+        evcCalls.push({
+          targetContract: savingsVaultAddr,
+          onBehalfOfAccount: savingsSubAccountAddr,
+          value: 0n,
+          data: hooks.getDataForCall(savingsVaultAddr, 'skim', [maxUint256, savingsSubAccountAddr]) as Hash,
+        })
+      }
     }
 
     // Disable controller (no more debt)

--- a/composables/useEulerOperations/swaps/same-asset.ts
+++ b/composables/useEulerOperations/swaps/same-asset.ts
@@ -1,13 +1,12 @@
 import type { Address, Hash } from 'viem'
 import { maxUint256 } from 'viem'
 import { adjustForInterest } from '../helpers'
+import { hasPreExistingVaultDeposit } from '../preExistingDeposit'
 import type { OperationsContext, OperationHelpers } from '../types'
 import { evcDisableCollateralAbi, evcDisableControllerAbi, evcEnableCollateralAbi, evcEnableControllerAbi } from '~/abis/evc'
-import { erc20BalanceOfAbi } from '~/abis/erc20'
-import { vaultBorrowAbi, vaultConvertToAssetsAbi, vaultRedeemAbi, vaultRepayWithSharesAbi, vaultSkimAbi, vaultTransferFromMaxAbi, vaultWithdrawAbi } from '~/abis/vault'
+import { vaultBorrowAbi, vaultRedeemAbi, vaultRepayWithSharesAbi, vaultSkimAbi, vaultTransferFromMaxAbi, vaultWithdrawAbi } from '~/abis/vault'
 import { SaHooksBuilder } from '~/entities/saHooksSDK'
 import type { EVCCall } from '~/utils/evc-converter'
-import { logWarn } from '~/utils/errorHandling'
 import type { TxPlan } from '~/entities/txPlan'
 
 export const createSameAssetSwapBuilders = (
@@ -225,28 +224,12 @@ export const createSameAssetSwapBuilders = (
     const evcAddress = ctx.eulerCoreAddresses.value.evc as Address
     const subAccountAddr = subAccount as Address
 
-    // Pre-flight: read pre-existing deposit in borrow vault
-    let preExistingBorrowDeposit = 0n
-    try {
-      const balanceOfResult = await ctx.rpcProvider.readContract({
-        address: borrowVaultAddr,
-        abi: erc20BalanceOfAbi,
-        functionName: 'balanceOf',
-        args: [subAccountAddr],
-      }) as bigint
-      if (balanceOfResult > 0n) {
-        const assetsResult = await ctx.rpcProvider.readContract({
-          address: borrowVaultAddr,
-          abi: vaultConvertToAssetsAbi,
-          functionName: 'convertToAssets',
-          args: [balanceOfResult],
-        }) as bigint
-        preExistingBorrowDeposit = assetsResult
-      }
-    }
-    catch (err) {
-      logWarn('buildSameAssetFullRepayPlan', err)
-    }
+    const hasPreExistingBorrowDeposit = await hasPreExistingVaultDeposit(
+      ctx,
+      borrowVaultAddr,
+      subAccountAddr,
+      'buildSameAssetFullRepayPlan',
+    )
 
     const hooks = new SaHooksBuilder()
     hooks.addContractInterface(collateralVaultAddr, [...vaultWithdrawAbi, ...vaultSkimAbi, ...vaultTransferFromMaxAbi])
@@ -301,23 +284,25 @@ export const createSameAssetSwapBuilders = (
       })
     }
 
-    // 6. Redeem ALL remaining shares from borrow vault
-    evcCalls.push({
-      targetContract: borrowVaultAddr,
-      onBehalfOfAccount: subAccountAddr,
-      value: 0n,
-      data: hooks.getDataForCall(borrowVaultAddr, 'redeem', [maxUint256, collateralVaultAddr, subAccountAddr]) as Hash,
-    })
+    // Only sweep the repay cushion when the borrow vault did not already hold shares.
+    // Otherwise redeem(max) would also migrate the user's pre-existing borrow-vault deposit.
+    if (!hasPreExistingBorrowDeposit) {
+      evcCalls.push({
+        targetContract: borrowVaultAddr,
+        onBehalfOfAccount: subAccountAddr,
+        value: 0n,
+        data: hooks.getDataForCall(borrowVaultAddr, 'redeem', [maxUint256, collateralVaultAddr, subAccountAddr]) as Hash,
+      })
 
-    // 7. Skim on collateral vault
-    evcCalls.push({
-      targetContract: collateralVaultAddr,
-      onBehalfOfAccount: subAccountAddr,
-      value: 0n,
-      data: hooks.getDataForCall(collateralVaultAddr, 'skim', [preExistingBorrowDeposit, subAccountAddr]) as Hash,
-    })
+      evcCalls.push({
+        targetContract: collateralVaultAddr,
+        onBehalfOfAccount: subAccountAddr,
+        value: 0n,
+        data: hooks.getDataForCall(collateralVaultAddr, 'skim', [maxUint256, subAccountAddr]) as Hash,
+      })
+    }
 
-    // 8. Transfer remaining collateral back to main account
+    // Transfer remaining collateral back to main account.
     const isMainAccount = subAccountAddr.toLowerCase() === userAddr.toLowerCase()
     if (!isMainAccount) {
       evcCalls.push({
@@ -357,28 +342,12 @@ export const createSameAssetSwapBuilders = (
     const evcAddress = ctx.eulerCoreAddresses.value.evc as Address
     const subAccountAddr = subAccount as Address
 
-    // Pre-flight: read pre-existing deposit in OLD vault
-    let preExistingOldVaultDeposit = 0n
-    try {
-      const balanceOfResult = await ctx.rpcProvider.readContract({
-        address: oldVaultAddr,
-        abi: erc20BalanceOfAbi,
-        functionName: 'balanceOf',
-        args: [subAccountAddr],
-      }) as bigint
-      if (balanceOfResult > 0n) {
-        const assetsResult = await ctx.rpcProvider.readContract({
-          address: oldVaultAddr,
-          abi: vaultConvertToAssetsAbi,
-          functionName: 'convertToAssets',
-          args: [balanceOfResult],
-        }) as bigint
-        preExistingOldVaultDeposit = assetsResult
-      }
-    }
-    catch (err) {
-      logWarn('buildSameAssetDebtSwapPlan', err)
-    }
+    const hasPreExistingOldVaultDeposit = await hasPreExistingVaultDeposit(
+      ctx,
+      oldVaultAddr,
+      subAccountAddr,
+      'buildSameAssetDebtSwapPlan',
+    )
 
     const hooks = new SaHooksBuilder()
     hooks.addContractInterface(newVaultAddr, [...vaultBorrowAbi, ...vaultSkimAbi, ...vaultTransferFromMaxAbi])
@@ -436,23 +405,25 @@ export const createSameAssetSwapBuilders = (
       data: hooks.getDataForCall(oldVaultAddr, 'disableController', []) as Hash,
     })
 
-    // 6. Redeem ALL remaining shares from old vault
-    evcCalls.push({
-      targetContract: oldVaultAddr,
-      onBehalfOfAccount: subAccountAddr,
-      value: 0n,
-      data: hooks.getDataForCall(oldVaultAddr, 'redeem', [maxUint256, newVaultAddr, subAccountAddr]) as Hash,
-    })
+    // Only sweep the migration cushion when the old vault did not already hold shares.
+    // Otherwise redeem(max) would also migrate the user's pre-existing old-vault deposit.
+    if (!hasPreExistingOldVaultDeposit) {
+      evcCalls.push({
+        targetContract: oldVaultAddr,
+        onBehalfOfAccount: subAccountAddr,
+        value: 0n,
+        data: hooks.getDataForCall(oldVaultAddr, 'redeem', [maxUint256, newVaultAddr, subAccountAddr]) as Hash,
+      })
 
-    // 7. Skim on new vault
-    evcCalls.push({
-      targetContract: newVaultAddr,
-      onBehalfOfAccount: subAccountAddr,
-      value: 0n,
-      data: hooks.getDataForCall(newVaultAddr, 'skim', [preExistingOldVaultDeposit, subAccountAddr]) as Hash,
-    })
+      evcCalls.push({
+        targetContract: newVaultAddr,
+        onBehalfOfAccount: subAccountAddr,
+        value: 0n,
+        data: hooks.getDataForCall(newVaultAddr, 'skim', [maxUint256, subAccountAddr]) as Hash,
+      })
+    }
 
-    // 8. Transfer all new vault shares from sub-account to main account
+    // Transfer all new vault shares from sub-account to main account.
     const isMainAccount = subAccountAddr.toLowerCase() === userAddr.toLowerCase()
     if (!isMainAccount) {
       evcCalls.push({

--- a/tests/composables/useEulerOperations-pre-existing-deposit.test.ts
+++ b/tests/composables/useEulerOperations-pre-existing-deposit.test.ts
@@ -1,0 +1,160 @@
+import type { Abi, Address } from 'viem'
+import { decodeFunctionData, maxUint256 } from 'viem'
+import { computed, ref } from 'vue'
+import { describe, expect, it, vi } from 'vitest'
+import { evcDisableCollateralAbi, evcDisableControllerAbi, evcEnableControllerAbi } from '~/abis/evc'
+import { vaultBorrowAbi, vaultRedeemAbi, vaultRepayWithSharesAbi, vaultSkimAbi, vaultTransferFromMaxAbi, vaultWithdrawAbi } from '~/abis/vault'
+import type { TxPlan } from '~/entities/txPlan'
+import { createRepayBuilders } from '~/composables/useEulerOperations/repay'
+import { createSameAssetSwapBuilders } from '~/composables/useEulerOperations/swaps/same-asset'
+import type { OperationHelpers, OperationsContext } from '~/composables/useEulerOperations/types'
+import type { EVCCall } from '~/utils/evc-converter'
+
+const USER = '0x0000000000000000000000000000000000000001' as Address
+const SUB_ACCOUNT = '0x0000000000000000000000000000000000000002' as Address
+const SAVINGS_ACCOUNT = '0x0000000000000000000000000000000000000003' as Address
+const EVC = '0x0000000000000000000000000000000000000004' as Address
+const COLLATERAL_VAULT = '0x0000000000000000000000000000000000000011' as Address
+const BORROW_VAULT = '0x0000000000000000000000000000000000000012' as Address
+const SAVINGS_VAULT = '0x0000000000000000000000000000000000000013' as Address
+const NEW_VAULT = '0x0000000000000000000000000000000000000014' as Address
+
+const decodeAbi = [
+  ...vaultBorrowAbi,
+  ...vaultWithdrawAbi,
+  ...vaultSkimAbi,
+  ...vaultRepayWithSharesAbi,
+  ...vaultRedeemAbi,
+  ...vaultTransferFromMaxAbi,
+  ...evcDisableControllerAbi,
+  ...evcDisableCollateralAbi,
+  ...evcEnableControllerAbi,
+] as const satisfies Abi
+
+const createContext = (existingShares: bigint): OperationsContext => ({
+  address: ref(USER),
+  chainId: ref(1),
+  writeContractAsync: vi.fn(),
+  signTypedDataAsync: vi.fn(),
+  config: {} as OperationsContext['config'],
+  eulerCoreAddresses: computed(() => ({ evc: EVC })),
+  eulerPeripheryAddresses: computed(() => ({})),
+  eulerLensAddresses: computed(() => ({})),
+  rpcUrl: '',
+  PYTH_HERMES_URL: '',
+  SUBGRAPH_URL: '',
+  registryGet: vi.fn(),
+  registryGetVault: vi.fn(),
+  permit2Enabled: ref(false),
+  rpcProvider: {
+    readContract: vi.fn(async () => existingShares),
+  } as unknown as OperationsContext['rpcProvider'],
+})
+
+const helpers: OperationHelpers = {
+  prepareTokenApproval: vi.fn(),
+  injectPythHealthCheckUpdates: vi.fn(async () => undefined),
+  buildEvcBatchStep: ({ evcCalls, label }) => ({
+    type: 'evc-batch',
+    label,
+    to: EVC,
+    abi: [],
+    functionName: 'batch',
+    args: [evcCalls],
+  }),
+  buildNativeWrapCalls: vi.fn(),
+  resolveEffectiveCollaterals: vi.fn(),
+  adjustForInterest: (amount: bigint) => (amount * 10_001n) / 10_000n,
+  preparePythUpdates: vi.fn(),
+  preparePythUpdatesForHealthCheck: vi.fn(),
+}
+
+const planCalls = (plan: TxPlan): EVCCall[] => plan.steps[0]?.args[0] as EVCCall[]
+
+const decodedCalls = (plan: TxPlan) => planCalls(plan).map(call => ({
+  target: call.targetContract,
+  ...decodeFunctionData({ abi: decodeAbi, data: call.data }),
+}))
+
+describe('full repay pre-existing liability deposit cleanup', () => {
+  it('keeps same-asset full repay borrow-vault shares when they pre-exist', async () => {
+    const builders = createSameAssetSwapBuilders(createContext(1n), helpers)
+
+    const plan = await builders.buildSameAssetFullRepayPlan({
+      collateralVaultAddress: COLLATERAL_VAULT,
+      borrowVaultAddress: BORROW_VAULT,
+      amount: 100n,
+      subAccount: SUB_ACCOUNT,
+    })
+
+    const calls = decodedCalls(plan)
+
+    expect(calls.map(call => call.functionName)).not.toContain('redeem')
+    expect(calls.some(call => call.target === COLLATERAL_VAULT && call.functionName === 'skim')).toBe(false)
+  })
+
+  it('sweeps same-asset full repay cushion when there is no pre-existing borrow-vault deposit', async () => {
+    const builders = createSameAssetSwapBuilders(createContext(0n), helpers)
+
+    const plan = await builders.buildSameAssetFullRepayPlan({
+      collateralVaultAddress: COLLATERAL_VAULT,
+      borrowVaultAddress: BORROW_VAULT,
+      amount: 100n,
+      subAccount: SUB_ACCOUNT,
+    })
+
+    const calls = decodedCalls(plan)
+
+    expect(calls).toContainEqual(expect.objectContaining({
+      target: BORROW_VAULT,
+      functionName: 'redeem',
+      args: [maxUint256, COLLATERAL_VAULT, SUB_ACCOUNT],
+    }))
+    expect(calls).toContainEqual(expect.objectContaining({
+      target: COLLATERAL_VAULT,
+      functionName: 'skim',
+      args: [maxUint256, SUB_ACCOUNT],
+    }))
+  })
+
+  it('keeps savings full repay borrow-vault shares when they pre-exist', async () => {
+    const builders = createRepayBuilders(createContext(1n), helpers)
+
+    const plan = await builders.buildSavingsFullRepayPlan({
+      savingsVaultAddress: SAVINGS_VAULT,
+      borrowVaultAddress: BORROW_VAULT,
+      amount: 100n,
+      savingsSubAccount: SAVINGS_ACCOUNT,
+      borrowSubAccount: SUB_ACCOUNT,
+    })
+
+    const calls = decodedCalls(plan)
+
+    expect(calls.map(call => call.functionName)).not.toContain('redeem')
+    expect(calls.some(call => call.target === SAVINGS_VAULT && call.functionName === 'skim')).toBe(false)
+  })
+
+  it('sweeps debt migration cushion only when the old vault has no pre-existing deposit', async () => {
+    const builders = createSameAssetSwapBuilders(createContext(0n), helpers)
+
+    const plan = await builders.buildSameAssetDebtSwapPlan({
+      oldVaultAddress: BORROW_VAULT,
+      newVaultAddress: NEW_VAULT,
+      amount: 100n,
+      subAccount: SUB_ACCOUNT,
+    })
+
+    const calls = decodedCalls(plan)
+
+    expect(calls).toContainEqual(expect.objectContaining({
+      target: BORROW_VAULT,
+      functionName: 'redeem',
+      args: [maxUint256, NEW_VAULT, SUB_ACCOUNT],
+    }))
+    expect(calls).toContainEqual(expect.objectContaining({
+      target: NEW_VAULT,
+      functionName: 'skim',
+      args: [maxUint256, SUB_ACCOUNT],
+    }))
+  })
+})


### PR DESCRIPTION
In repay from the same asset, different vault, there is a logic which snapshots pre-existing deposit in the vault. I'm assuming this is to make sure the clean up doesn't pull this deposit to the source vault of the repay, but this exactly what's happening - the pre-existing deposit amount is used to skim into the source vault and I think leaving the extra dust (extra cushion for accruing debt) unskimmed. 

The correct behavior should be to skim the pre-exising deposit back to liability vault, or, and this is implemented in the PR, just don't skim the asset back to the source vault. Assumption being - if there's already deposit, extra dust will not confuse the user.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pre-existing deposit detection in repay and debt swap operations to prevent unnecessary vault operations and accidental deposit migrations, enhancing transaction efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->