### PR TITLE
refactor: dedupe post-tx refresh and redirect flow

### DIFF
--- a/composables/borrow/useBorrowForm.ts
+++ b/composables/borrow/useBorrowForm.ts
@@ -87,14 +87,13 @@ export const useBorrowForm = (options: UseBorrowFormOptions) => {
     borrowAddress: _borrowAddress,
   } = options
 
-  const router = useRouter()
   const modal = useModal()
   const { error } = useToast()
   const { buildBorrowPlan, buildBorrowBySavingPlan, buildSwapAndBorrowPlan, executeTxPlan } = useEulerOperations()
   const { address, isConnected } = useAccount()
-  const { refreshAllPositions } = useEulerAccount()
-  const { eulerLensAddresses, chainId } = useEulerAddresses()
+  const { chainId } = useEulerAddresses()
   const { fetchSingleBalance } = useWallets()
+  const { finalizeTxAndRedirect } = useTxFinalization()
 
   const {
     runSimulation: runBorrowSimulation,
@@ -794,12 +793,7 @@ export const useBorrowForm = (options: UseBorrowFormOptions) => {
             )
       }
       await executeTxPlan(txPlan)
-
-      modal.close()
-      refreshAllPositions(eulerLensAddresses.value, address.value || '')
-      setTimeout(() => {
-        router.replace('/portfolio')
-      }, 400)
+      await finalizeTxAndRedirect()
     }
     catch (e) {
       logWarn('borrow/send', e)

--- a/composables/borrow/useMultiplyForm.ts
+++ b/composables/borrow/useMultiplyForm.ts
@@ -81,14 +81,13 @@ export const useMultiplyForm = (options: UseMultiplyFormOptions) => {
     isMultiplyRestricted,
   } = options
 
-  const router = useRouter()
   const modal = useModal()
   const { error } = useToast()
   const { buildMultiplyPlan, executeTxPlan } = useEulerOperations()
-  const { address, isConnected } = useAccount()
-  const { refreshAllPositions, depositPositions } = useEulerAccount()
-  const { eulerLensAddresses } = useEulerAddresses()
+  const { isConnected } = useAccount()
+  const { depositPositions } = useEulerAccount()
   const { fetchSingleBalance } = useWallets()
+  const { finalizeTxAndRedirect } = useTxFinalization()
   const { getSupplyRewardApy, getBorrowRewardApy } = useRewardsApy()
   const { withIntrinsicBorrowApy, withIntrinsicSupplyApy } = useIntrinsicApy()
   const {
@@ -839,11 +838,7 @@ export const useMultiplyForm = (options: UseMultiplyFormOptions) => {
       })
       multiplyPlan.value = plan
       await executeTxPlan(plan)
-      modal.close()
-      refreshAllPositions(eulerLensAddresses.value, address.value || '')
-      setTimeout(() => {
-        router.replace('/portfolio')
-      }, 400)
+      await finalizeTxAndRedirect()
     }
     catch (e) {
       logWarn('multiply/send', e)

--- a/composables/position/useCollateralForm.ts
+++ b/composables/position/useCollateralForm.ts
@@ -109,7 +109,6 @@ export interface UseCollateralFormOptions {
 }
 
 export const useCollateralForm = (options: UseCollateralFormOptions) => {
-  const router = useRouter()
   const route = useRoute()
   const modal = useModal()
   const { error } = useToast()
@@ -117,6 +116,7 @@ export const useCollateralForm = (options: UseCollateralFormOptions) => {
   const { executeTxPlan } = useEulerOperations()
   const { isConnected, address } = useAccount()
   const { isSpyMode } = useSpyMode()
+  const { finalizeTxAndRedirect } = useTxFinalization()
   const positionIndex = usePositionIndex()
   const { isPositionsLoaded, getPositionBySubAccountIndex } = useEulerAccount()
   const { getSupplyRewardApy, getBorrowRewardApy } = useRewardsApy()
@@ -698,12 +698,7 @@ export const useCollateralForm = (options: UseCollateralFormOptions) => {
         })
       }
       await executeTxPlan(txPlan)
-
-      modal.close()
-      await options.onAfterSend?.()
-      setTimeout(() => {
-        router.replace('/portfolio')
-      }, 400)
+      await finalizeTxAndRedirect({ onAfterClose: options.onAfterSend })
     }
     catch (e) {
       logWarn('collateral/send', e)

--- a/composables/repay/useCollateralSwapRepay.ts
+++ b/composables/repay/useCollateralSwapRepay.ts
@@ -54,13 +54,12 @@ export const useCollateralSwapRepay = (options: UseCollateralSwapRepayOptions) =
     isEligibleForLiquidation,
   } = options
 
-  const router = useRouter()
   const modal = useModal()
   const { error } = useToast()
   const { isConnected, address } = useAccount()
   const { buildSwapPlan, buildSameAssetRepayPlan, buildSameAssetFullRepayPlan, buildSwapFullRepayPlan, executeTxPlan } = useEulerOperations()
-  const { refreshAllPositions } = useEulerAccount()
   const { eulerLensAddresses, isReady: isEulerAddressesReady, loadEulerConfig } = useEulerAddresses()
+  const { finalizeTxAndRedirect } = useTxFinalization()
   const { client: rpcClient } = useRpcClient()
   const { withIntrinsicSupplyApy, withIntrinsicBorrowApy } = useIntrinsicApy()
   const { getSupplyRewardApy, getBorrowRewardApy } = useRewardsApy()
@@ -447,12 +446,7 @@ export const useCollateralSwapRepay = (options: UseCollateralSwapRepayOptions) =
       isSubmitting.value = true
       const txPlan = await buildRepayPlan()
       await executeTxPlan(txPlan)
-
-      modal.close()
-      refreshAllPositions(eulerLensAddresses.value, address.value as string)
-      setTimeout(() => {
-        router.replace('/portfolio')
-      }, 400)
+      await finalizeTxAndRedirect()
     }
     catch (e) {
       error('Transaction failed')

--- a/composables/repay/useSavingsRepay.ts
+++ b/composables/repay/useSavingsRepay.ts
@@ -56,14 +56,12 @@ export const useSavingsRepay = (options: UseSavingsRepayOptions) => {
     borrowApy,
   } = options
 
-  const router = useRouter()
   const modal = useModal()
   const { error } = useToast()
   const { isConnected, address } = useAccount()
   const { buildSwapPlan, buildSavingsRepayPlan, buildSavingsFullRepayPlan, buildSwapFullRepayPlan, executeTxPlan } = useEulerOperations()
-  const { refreshAllPositions } = useEulerAccount()
-  const { eulerLensAddresses } = useEulerAddresses()
   const { getVault: registryGetVault } = useVaultRegistry()
+  const { finalizeTxAndRedirect } = useTxFinalization()
 
   // --- Savings options ---
   const { savingsPositions, savingsVaults, savingsOptions, getSavingsPosition } = useRepaySavingsOptions()
@@ -376,12 +374,7 @@ export const useSavingsRepay = (options: UseSavingsRepayOptions) => {
       isSubmitting.value = true
       const txPlan = await buildRepayPlan()
       await executeTxPlan(txPlan)
-
-      modal.close()
-      refreshAllPositions(eulerLensAddresses.value, address.value as string)
-      setTimeout(() => {
-        router.replace('/portfolio')
-      }, 400)
+      await finalizeTxAndRedirect()
     }
     catch (e) {
       error('Transaction failed')

--- a/composables/repay/useWalletRepay.ts
+++ b/composables/repay/useWalletRepay.ts
@@ -58,13 +58,11 @@ export const useWalletRepay = (options: UseWalletRepayOptions) => {
     oraclePriceRatio,
   } = options
 
-  const router = useRouter()
   const modal = useModal()
   const { error } = useToast()
   const { buildRepayPlan, buildFullRepayPlan, executeTxPlan } = useEulerOperations()
-  const { refreshAllPositions } = useEulerAccount()
-  const { eulerLensAddresses } = useEulerAddresses()
-  const { isConnected, address } = useAccount()
+  const { isConnected } = useAccount()
+  const { finalizeTxAndRedirect } = useTxFinalization()
 
   const amount = ref('')
   const walletRepayPercent = ref(0)
@@ -211,12 +209,7 @@ export const useWalletRepay = (options: UseWalletRepayOptions) => {
             { includePermit2Call: true },
           )
       await executeTxPlan(txPlan)
-
-      modal.close()
-      refreshAllPositions(eulerLensAddresses.value, address.value as string)
-      setTimeout(() => {
-        router.replace('/portfolio')
-      }, 400)
+      await finalizeTxAndRedirect()
     }
     catch (e) {
       error('Transaction failed')

--- a/composables/repay/useWalletSwapRepay.ts
+++ b/composables/repay/useWalletSwapRepay.ts
@@ -63,14 +63,13 @@ export const useWalletSwapRepay = (options: UseWalletSwapRepayOptions) => {
     oraclePriceRatio,
   } = options
 
-  const router = useRouter()
   const modal = useModal()
   const { error } = useToast()
   const { buildSwapAndRepayPlan, executeTxPlan } = useEulerOperations()
-  const { refreshAllPositions } = useEulerAccount()
-  const { eulerLensAddresses, chainId } = useEulerAddresses()
+  const { chainId } = useEulerAddresses()
   const { isConnected, address } = useAccount()
   const { fetchSingleBalance } = useWallets()
+  const { finalizeTxAndRedirect } = useTxFinalization()
   const { getVault: registryGetVault } = useVaultRegistry()
 
   // --- State ---
@@ -757,12 +756,7 @@ export const useWalletSwapRepay = (options: UseWalletSwapRepayOptions) => {
 
       const txPlan = await buildRepayPlan(true)
       await executeTxPlan(txPlan)
-
-      modal.close()
-      refreshAllPositions(eulerLensAddresses.value, address.value as string)
-      setTimeout(() => {
-        router.replace('/portfolio')
-      }, 400)
+      await finalizeTxAndRedirect()
     }
     catch (e) {
       error('Transaction failed')

--- a/composables/useEulerAccount.ts
+++ b/composables/useEulerAccount.ts
@@ -51,7 +51,8 @@ export const useEulerAccount = () => {
 
   const updatePositions = async () => {
     const targetAddress = portfolioAddress.value
-    if (!refreshCoordinator.begin(targetAddress)) return
+    const refreshToken = refreshCoordinator.begin(targetAddress)
+    if (!refreshToken) return
     try {
       beginRefreshCycle()
       const gen = positionGuard.current()
@@ -88,7 +89,7 @@ export const useEulerAccount = () => {
       isDepositsLoaded.value = true
     }
     finally {
-      await refreshCoordinator.finish(targetAddress, updatePositions)
+      await refreshCoordinator.finish(refreshToken, updatePositions)
     }
   }
 
@@ -167,7 +168,8 @@ export const useEulerAccount = () => {
     lensAddresses: EulerLensAddresses,
     walletAddress: string,
   ) => {
-    if (!refreshCoordinator.begin(walletAddress)) return
+    const refreshToken = refreshCoordinator.begin(walletAddress)
+    if (!refreshToken) return
     try {
       beginRefreshCycle()
       const gen = positionGuard.current()
@@ -190,7 +192,7 @@ export const useEulerAccount = () => {
       isDepositsLoaded.value = true
     }
     finally {
-      await refreshCoordinator.finish(walletAddress, () => refreshAllPositions(lensAddresses, walletAddress))
+      await refreshCoordinator.finish(refreshToken, () => refreshAllPositions(lensAddresses, walletAddress))
     }
   }
 

--- a/composables/useEulerAccount.ts
+++ b/composables/useEulerAccount.ts
@@ -32,7 +32,11 @@ const {
   finalizeRefreshCycle,
 } = useAccountPositions()
 
-let fetchInProgress = false
+// Tracks the address whose fetch is currently in flight. Same-address calls
+// dedupe; different-address calls preempt. Combined with positionGuard
+// generations and the address watcher's reset, this protects against
+// stale results bleeding across address switches.
+let inFlightAddress: string | null = null
 
 const {
   totalSuppliedValue,
@@ -49,12 +53,12 @@ export const useEulerAccount = () => {
   const portfolioAddress = computed(() => normalizeAddressOrEmpty(spyAddress.value) || normalizeAddressOrEmpty(address.value))
 
   const updatePositions = async () => {
-    if (fetchInProgress) return
-    fetchInProgress = true
+    const targetAddress = portfolioAddress.value
+    if (inFlightAddress === targetAddress) return
+    inFlightAddress = targetAddress
     try {
       beginRefreshCycle()
       const gen = positionGuard.current()
-      const targetAddress = portfolioAddress.value
       const { SUBGRAPH_URL } = useEulerConfig()
 
       // Fetch both borrow and deposit entries in a single subgraph query
@@ -88,7 +92,7 @@ export const useEulerAccount = () => {
       isDepositsLoaded.value = true
     }
     finally {
-      fetchInProgress = false
+      inFlightAddress = null
     }
   }
 
@@ -107,7 +111,7 @@ export const useEulerAccount = () => {
     if (newAddress !== oldAddress) {
       // Invalidate in-flight fetches so they discard stale results
       positionGuard.next()
-      fetchInProgress = false
+      inFlightAddress = null
 
       // Clear stale data and reset loading state so UI shows loader
       clearPositions()
@@ -166,8 +170,8 @@ export const useEulerAccount = () => {
     lensAddresses: EulerLensAddresses,
     walletAddress: string,
   ) => {
-    if (fetchInProgress) return
-    fetchInProgress = true
+    if (inFlightAddress === walletAddress) return
+    inFlightAddress = walletAddress
     try {
       beginRefreshCycle()
       const gen = positionGuard.current()
@@ -190,7 +194,7 @@ export const useEulerAccount = () => {
       isDepositsLoaded.value = true
     }
     finally {
-      fetchInProgress = false
+      inFlightAddress = null
     }
   }
 

--- a/composables/useEulerAccount.ts
+++ b/composables/useEulerAccount.ts
@@ -8,6 +8,7 @@ import { useAccountPortfolioMetrics } from './useAccountPortfolioMetrics'
 import type { EulerLensAddresses } from '~/composables/useEulerAddresses'
 import type { AccountBorrowPosition } from '~/entities/account'
 import { normalizeAddressOrEmpty } from '~/utils/accountPositionHelpers'
+import { createAddressRefreshCoordinator } from '~/utils/address-refresh-coordinator'
 import { fetchAccountPositions, type SubgraphPositionEntry } from '~/utils/subgraph'
 import { logWarn } from '~/utils/errorHandling'
 
@@ -32,11 +33,7 @@ const {
   finalizeRefreshCycle,
 } = useAccountPositions()
 
-// Tracks the address whose fetch is currently in flight. Same-address calls
-// dedupe; different-address calls preempt. Combined with positionGuard
-// generations and the address watcher's reset, this protects against
-// stale results bleeding across address switches.
-let inFlightAddress: string | null = null
+const refreshCoordinator = createAddressRefreshCoordinator(() => positionGuard.next())
 
 const {
   totalSuppliedValue,
@@ -54,8 +51,7 @@ export const useEulerAccount = () => {
 
   const updatePositions = async () => {
     const targetAddress = portfolioAddress.value
-    if (inFlightAddress === targetAddress) return
-    inFlightAddress = targetAddress
+    if (!refreshCoordinator.begin(targetAddress)) return
     try {
       beginRefreshCycle()
       const gen = positionGuard.current()
@@ -92,7 +88,7 @@ export const useEulerAccount = () => {
       isDepositsLoaded.value = true
     }
     finally {
-      inFlightAddress = null
+      await refreshCoordinator.finish(targetAddress, updatePositions)
     }
   }
 
@@ -111,7 +107,7 @@ export const useEulerAccount = () => {
     if (newAddress !== oldAddress) {
       // Invalidate in-flight fetches so they discard stale results
       positionGuard.next()
-      inFlightAddress = null
+      refreshCoordinator.reset()
 
       // Clear stale data and reset loading state so UI shows loader
       clearPositions()
@@ -132,6 +128,7 @@ export const useEulerAccount = () => {
   // Clear stale positions and invalidate in-flight fetches on chain change
   watch(chainId, () => {
     positionGuard.next()
+    refreshCoordinator.reset()
     clearPositions()
     isPositionsLoaded.value = false
     isPositionsLoading.value = true
@@ -170,8 +167,7 @@ export const useEulerAccount = () => {
     lensAddresses: EulerLensAddresses,
     walletAddress: string,
   ) => {
-    if (inFlightAddress === walletAddress) return
-    inFlightAddress = walletAddress
+    if (!refreshCoordinator.begin(walletAddress)) return
     try {
       beginRefreshCycle()
       const gen = positionGuard.current()
@@ -194,7 +190,7 @@ export const useEulerAccount = () => {
       isDepositsLoaded.value = true
     }
     finally {
-      inFlightAddress = null
+      await refreshCoordinator.finish(walletAddress, () => refreshAllPositions(lensAddresses, walletAddress))
     }
   }
 

--- a/composables/useEulerOperations/execution.ts
+++ b/composables/useEulerOperations/execution.ts
@@ -1,10 +1,11 @@
-import type { Address, Hash, Hex, StateOverride } from 'viem'
+import type { Address, Hash, Hex, StateOverride, TransactionReceipt } from 'viem'
 import { getAccount, simulateContract } from '@wagmi/vue/actions'
 import type { OperationsContext, AllowanceHelpers } from './types'
 import type { TxPlan } from '~/entities/txPlan'
-import { catchToFallback } from '~/utils/errorHandling'
+import { catchToFallback, logWarn } from '~/utils/errorHandling'
 import { isNonBlockingSimulationError } from '~/utils/tx-errors'
 import { applyOperationGuards } from '~/utils/operationGuardRegistry'
+import { waitForSubgraphBlock } from '~/utils/subgraph'
 
 const OKX_POST_APPROVE_DELAY_MS = 3000
 
@@ -33,15 +34,16 @@ const isOkxWallet = async (connector?: { id?: string, name?: string, getProvider
 export const createExecutionHelpers = (ctx: OperationsContext, allowanceHelpers: AllowanceHelpers) => {
   const { triggerPortfolioRefresh } = usePortfolioRefresh()
 
-  const waitForTxReceipt = async (txHash?: Hash) => {
+  const waitForTxReceipt = async (txHash?: Hash): Promise<TransactionReceipt | undefined> => {
     if (!txHash) {
-      return
+      return undefined
     }
 
     const receipt = await ctx.rpcProvider.waitForTransactionReceipt({ hash: txHash })
     if (receipt.status === 'reverted') {
       throw new Error('Transaction reverted')
     }
+    return receipt
   }
 
   const executeTxPlan = async (plan: TxPlan) => {
@@ -56,6 +58,7 @@ export const createExecutionHelpers = (ctx: OperationsContext, allowanceHelpers:
 
     const guardedPlan = applyOperationGuards(plan)
     let lastHash: Hex | undefined
+    let lastReceipt: TransactionReceipt | undefined
 
     for (const step of guardedPlan.steps) {
       /* eslint-disable @typescript-eslint/no-explicit-any -- wagmi writeContractAsync requires ABI-specific generics */
@@ -69,7 +72,7 @@ export const createExecutionHelpers = (ctx: OperationsContext, allowanceHelpers:
       /* eslint-enable @typescript-eslint/no-explicit-any */
 
       lastHash = txHash
-      await waitForTxReceipt(txHash)
+      lastReceipt = await waitForTxReceipt(txHash)
 
       // OKX wallet's simulation backend lags behind on-chain state after approvals.
       // Without a delay, the next step's preview shows "unable to decode asset changes".
@@ -79,8 +82,17 @@ export const createExecutionHelpers = (ctx: OperationsContext, allowanceHelpers:
       }
     }
 
+    // Immediate trigger covers wallet balances and best-effort positions; the
+    // delayed trigger fires once the subgraph has indexed the tx's block so
+    // the user lands on /portfolio with positions reflecting the new state.
     triggerPortfolioRefresh()
-    setTimeout(triggerPortfolioRefresh, 5000)
+    if (lastReceipt && ctx.SUBGRAPH_URL) {
+      void waitForSubgraphBlock(ctx.SUBGRAPH_URL, lastReceipt.blockNumber)
+        .then((caughtUp) => {
+          if (caughtUp) triggerPortfolioRefresh()
+        })
+        .catch(err => logWarn('execution/subgraphPoll', err))
+    }
     return lastHash
   }
 

--- a/composables/useTxFinalization.ts
+++ b/composables/useTxFinalization.ts
@@ -1,0 +1,19 @@
+import { useModal } from '~/components/ui/composables/useModal'
+import { MODAL_CLOSE_REDIRECT_DELAY_MS } from '~/entities/tuning-constants'
+
+interface FinalizeOptions {
+  onAfterClose?: () => void | Promise<void>
+}
+
+export const useTxFinalization = () => {
+  const router = useRouter()
+  const modal = useModal()
+
+  const finalizeTxAndRedirect = async (options: FinalizeOptions = {}) => {
+    modal.close()
+    if (options.onAfterClose) await options.onAfterClose()
+    setTimeout(() => router.replace('/portfolio'), MODAL_CLOSE_REDIRECT_DELAY_MS)
+  }
+
+  return { finalizeTxAndRedirect }
+}

--- a/entities/tuning-constants.ts
+++ b/entities/tuning-constants.ts
@@ -37,6 +37,19 @@ export const LIST_ROW_HEIGHT_PX = 88
  * within this window reuses the cached Map rather than re-fetching. */
 export const FULL_BALANCES_TTL_MS = 60_000
 
+// ── UI/Interaction Timings ────────────────────────────────
+/** Delay after modal close before redirecting to /portfolio so the close
+ * animation can play before the route change unmounts the form. */
+export const MODAL_CLOSE_REDIRECT_DELAY_MS = 400
+
+// ── Subgraph indexing catch-up ────────────────────────────
+/** Poll interval while waiting for the subgraph to index the tx's block. */
+export const SUBGRAPH_BLOCK_POLL_INTERVAL_MS = 1_000
+/** Hard cap on the catch-up wait. If subgraph is this far behind, we fall
+ * back on the immediate triggerPortfolioRefresh + the 60s portfolio page
+ * poll to eventually reconcile state. */
+export const SUBGRAPH_BLOCK_CATCHUP_TIMEOUT_MS = 30_000
+
 // ── Basis Points ──────────────────────────────────────────
 export const BPS_BASE = 10_000n
 /** BPS_BASE + 1: pads amounts by 0.01% to cover interest accrual */

--- a/tests/utils/address-refresh-coordinator.test.ts
+++ b/tests/utils/address-refresh-coordinator.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createAddressRefreshCoordinator } from '~/utils/address-refresh-coordinator'
+
+describe('createAddressRefreshCoordinator', () => {
+  it('queues one same-address rerun while a refresh is in flight', async () => {
+    const coordinator = createAddressRefreshCoordinator()
+    const rerun = vi.fn(async () => {})
+
+    expect(coordinator.begin('0xabc')).toBe(true)
+    expect(coordinator.begin('0xabc')).toBe(false)
+    expect(coordinator.begin('0xabc')).toBe(false)
+
+    await coordinator.finish('0xabc', rerun)
+
+    expect(rerun).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not clear a newer different-address refresh when the old one finishes', async () => {
+    const onPreempt = vi.fn()
+    const coordinator = createAddressRefreshCoordinator(onPreempt)
+    const oldRerun = vi.fn(async () => {})
+    const currentRerun = vi.fn(async () => {})
+
+    expect(coordinator.begin('0xabc')).toBe(true)
+    expect(coordinator.begin('0xdef')).toBe(true)
+    expect(onPreempt).toHaveBeenCalledTimes(1)
+
+    await coordinator.finish('0xabc', oldRerun)
+    expect(oldRerun).not.toHaveBeenCalled()
+
+    expect(coordinator.begin('0xdef')).toBe(false)
+    await coordinator.finish('0xdef', currentRerun)
+    expect(currentRerun).toHaveBeenCalledTimes(1)
+  })
+
+  it('drops queued work on reset', async () => {
+    const coordinator = createAddressRefreshCoordinator()
+    const rerun = vi.fn(async () => {})
+
+    expect(coordinator.begin('0xabc')).toBe(true)
+    expect(coordinator.begin('0xabc')).toBe(false)
+    coordinator.reset()
+
+    await coordinator.finish('0xabc', rerun)
+
+    expect(rerun).not.toHaveBeenCalled()
+    expect(coordinator.begin('0xabc')).toBe(true)
+  })
+})

--- a/tests/utils/address-refresh-coordinator.test.ts
+++ b/tests/utils/address-refresh-coordinator.test.ts
@@ -1,16 +1,21 @@
 import { describe, expect, it, vi } from 'vitest'
 import { createAddressRefreshCoordinator } from '~/utils/address-refresh-coordinator'
 
+function expectToken(token: false | symbol): asserts token is symbol {
+  expect(token).toBeTypeOf('symbol')
+}
+
 describe('createAddressRefreshCoordinator', () => {
   it('queues one same-address rerun while a refresh is in flight', async () => {
     const coordinator = createAddressRefreshCoordinator()
     const rerun = vi.fn(async () => {})
 
-    expect(coordinator.begin('0xabc')).toBe(true)
+    const token = coordinator.begin('0xabc')
+    expectToken(token)
     expect(coordinator.begin('0xabc')).toBe(false)
     expect(coordinator.begin('0xabc')).toBe(false)
 
-    await coordinator.finish('0xabc', rerun)
+    await coordinator.finish(token, rerun)
 
     expect(rerun).toHaveBeenCalledTimes(1)
   })
@@ -21,29 +26,54 @@ describe('createAddressRefreshCoordinator', () => {
     const oldRerun = vi.fn(async () => {})
     const currentRerun = vi.fn(async () => {})
 
-    expect(coordinator.begin('0xabc')).toBe(true)
-    expect(coordinator.begin('0xdef')).toBe(true)
+    const oldToken = coordinator.begin('0xabc')
+    expectToken(oldToken)
+    const currentToken = coordinator.begin('0xdef')
+    expectToken(currentToken)
     expect(onPreempt).toHaveBeenCalledTimes(1)
 
-    await coordinator.finish('0xabc', oldRerun)
+    await coordinator.finish(oldToken, oldRerun)
     expect(oldRerun).not.toHaveBeenCalled()
 
     expect(coordinator.begin('0xdef')).toBe(false)
-    await coordinator.finish('0xdef', currentRerun)
+    await coordinator.finish(currentToken, currentRerun)
     expect(currentRerun).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not let an old same-address refresh evict a newer owner after an address switch', async () => {
+    const onPreempt = vi.fn()
+    const coordinator = createAddressRefreshCoordinator(onPreempt)
+    const oldRerun = vi.fn(async () => {})
+    const newRerun = vi.fn(async () => {})
+
+    const oldToken = coordinator.begin('0xabc')
+    expectToken(oldToken)
+    const middleToken = coordinator.begin('0xdef')
+    expectToken(middleToken)
+    const newToken = coordinator.begin('0xabc')
+    expectToken(newToken)
+    expect(onPreempt).toHaveBeenCalledTimes(2)
+
+    expect(coordinator.begin('0xabc')).toBe(false)
+    await coordinator.finish(oldToken, oldRerun)
+    expect(oldRerun).not.toHaveBeenCalled()
+
+    await coordinator.finish(newToken, newRerun)
+    expect(newRerun).toHaveBeenCalledTimes(1)
   })
 
   it('drops queued work on reset', async () => {
     const coordinator = createAddressRefreshCoordinator()
     const rerun = vi.fn(async () => {})
 
-    expect(coordinator.begin('0xabc')).toBe(true)
+    const token = coordinator.begin('0xabc')
+    expectToken(token)
     expect(coordinator.begin('0xabc')).toBe(false)
     coordinator.reset()
 
-    await coordinator.finish('0xabc', rerun)
+    await coordinator.finish(token, rerun)
 
     expect(rerun).not.toHaveBeenCalled()
-    expect(coordinator.begin('0xabc')).toBe(true)
+    expect(coordinator.begin('0xabc')).toBeTypeOf('symbol')
   })
 })

--- a/utils/address-refresh-coordinator.ts
+++ b/utils/address-refresh-coordinator.ts
@@ -1,5 +1,6 @@
 export function createAddressRefreshCoordinator(onPreempt?: () => void) {
   let inFlightAddress: string | null = null
+  let inFlightToken: symbol | null = null
   let queuedRefreshAddress: string | null = null
 
   const begin = (targetAddress: string) => {
@@ -12,13 +13,17 @@ export function createAddressRefreshCoordinator(onPreempt?: () => void) {
       queuedRefreshAddress = null
     }
     inFlightAddress = targetAddress
-    return true
+    inFlightToken = Symbol()
+    return inFlightToken
   }
 
-  const finish = async (targetAddress: string, rerun: () => Promise<void>) => {
-    const ownsInFlight = inFlightAddress === targetAddress
-    const shouldRerun = ownsInFlight && queuedRefreshAddress === targetAddress
-    if (ownsInFlight) inFlightAddress = null
+  const finish = async (token: symbol, rerun: () => Promise<void>) => {
+    const ownsInFlight = inFlightToken === token
+    const shouldRerun = ownsInFlight && queuedRefreshAddress === inFlightAddress
+    if (ownsInFlight) {
+      inFlightAddress = null
+      inFlightToken = null
+    }
     if (shouldRerun) {
       queuedRefreshAddress = null
       await rerun()
@@ -27,6 +32,7 @@ export function createAddressRefreshCoordinator(onPreempt?: () => void) {
 
   const reset = () => {
     inFlightAddress = null
+    inFlightToken = null
     queuedRefreshAddress = null
   }
 

--- a/utils/address-refresh-coordinator.ts
+++ b/utils/address-refresh-coordinator.ts
@@ -1,0 +1,38 @@
+export function createAddressRefreshCoordinator(onPreempt?: () => void) {
+  let inFlightAddress: string | null = null
+  let queuedRefreshAddress: string | null = null
+
+  const begin = (targetAddress: string) => {
+    if (inFlightAddress === targetAddress) {
+      queuedRefreshAddress = targetAddress
+      return false
+    }
+    if (inFlightAddress !== null) {
+      onPreempt?.()
+      queuedRefreshAddress = null
+    }
+    inFlightAddress = targetAddress
+    return true
+  }
+
+  const finish = async (targetAddress: string, rerun: () => Promise<void>) => {
+    const ownsInFlight = inFlightAddress === targetAddress
+    const shouldRerun = ownsInFlight && queuedRefreshAddress === targetAddress
+    if (ownsInFlight) inFlightAddress = null
+    if (shouldRerun) {
+      queuedRefreshAddress = null
+      await rerun()
+    }
+  }
+
+  const reset = () => {
+    inFlightAddress = null
+    queuedRefreshAddress = null
+  }
+
+  return {
+    begin,
+    finish,
+    reset,
+  }
+}

--- a/utils/subgraph.ts
+++ b/utils/subgraph.ts
@@ -1,7 +1,11 @@
 import { getAddress } from 'viem'
 import axios from 'axios'
 import { logger } from '~/utils/logger'
-import { SUBGRAPH_TIMEOUT_MS } from '~/entities/tuning-constants'
+import {
+  SUBGRAPH_TIMEOUT_MS,
+  SUBGRAPH_BLOCK_POLL_INTERVAL_MS,
+  SUBGRAPH_BLOCK_CATCHUP_TIMEOUT_MS,
+} from '~/entities/tuning-constants'
 
 export interface SubgraphPositionEntry {
   subAccount: string
@@ -50,4 +54,34 @@ export async function fetchAccountPositions(subgraphUrl: string, walletAddress: 
     )
     return { borrows: [], deposits: [] }
   }
+}
+
+export async function waitForSubgraphBlock(
+  subgraphUrl: string,
+  targetBlock: bigint,
+  opts: { intervalMs?: number, timeoutMs?: number } = {},
+): Promise<boolean> {
+  const intervalMs = opts.intervalMs ?? SUBGRAPH_BLOCK_POLL_INTERVAL_MS
+  const timeoutMs = opts.timeoutMs ?? SUBGRAPH_BLOCK_CATCHUP_TIMEOUT_MS
+  const deadline = Date.now() + timeoutMs
+
+  while (Date.now() < deadline) {
+    try {
+      const { data } = await axios.post(
+        subgraphUrl,
+        { query: '{ _meta { block { number } } }' },
+        { timeout: SUBGRAPH_TIMEOUT_MS },
+      )
+      const indexed = BigInt(data?.data?._meta?.block?.number ?? 0)
+      if (indexed >= targetBlock) return true
+    }
+    catch (error) {
+      logger.warn(
+        { ctx: 'subgraph/waitForBlock', target: targetBlock.toString(), err: error },
+        'failed to poll subgraph block height',
+      )
+    }
+    await new Promise(resolve => setTimeout(resolve, intervalMs))
+  }
+  return false
 }


### PR DESCRIPTION
## Summary

Cleans up the post-transaction refresh-and-redirect path that was duplicated across 7 form composables (`useBorrowForm`, `useMultiplyForm`, `useCollateralForm`, `useWalletRepay`, `useCollateralSwapRepay`, `useWalletSwapRepay`, `useSavingsRepay`).

- **Single epilogue**: extract `modal.close → setTimeout(router.replace('/portfolio'), 400)` into `useTxFinalization().finalizeTxAndRedirect()` so a future change lands in one place.
- **Dedupe refresh**: drop the per-form `refreshAllPositions(...)` calls. `executeTxPlan` already triggers the global refresh counter, whose watchers run the same fetch — and the `useEulerAccount` single-flight guard collapses overlapping calls.
- **Subgraph-aware refresh timing**: replace `setTimeout(triggerPortfolioRefresh, 5000)` (a guess at indexing lag) with `waitForSubgraphBlock` — polls `{ _meta { block { number } } }` at 1s cadence until the indexed block catches up to the tx receipt's `blockNumber`, bounded by a 30s timeout. The 60s portfolio interval remains the long-tail safety net.
- **Per-address dedup**: `fetchInProgress: boolean` → `inFlightAddress: string | null`. Same-address back-to-back calls dedupe (existing behavior); different-address calls preempt instead of being silently dropped, complementing the existing `positionGuard` generation token.
- **No magic numbers**: 400ms, 1s poll, 30s catch-up timeout all moved into `entities/tuning-constants.ts`.

## Notes

`updateBalances` already has its own `isFetching` + `fetchPromise` dedup in `useWallets.ts` — no changes needed there.

Two page-level redirect sites are intentionally out of scope: `pages/position/[number]/multiply.vue` (preserves `?network=` query so it'd need a `redirectTo` option on the helper) and `pages/position/[number]/withdraw.vue` (passes `refreshAllPositions` as `onAfterSend` — now redundant but harmless). Easy follow-up cleanup.

## Test plan

- [ ] `npx vue-tsc --noEmit` passes
- [ ] `npm run lint` clean for touched files
- [ ] `npx vitest run` — all 591 tests passing
- [ ] Manual smoke on each of the 7 flows: borrow, multiply, collateral (deposit/withdraw), wallet repay, collateral-swap repay, wallet-swap repay, savings repay. Confirm: tx submits → modal closes → ~400ms later route changes to /portfolio → `_meta` polling visible in network tab → second `trackingActiveAccount` query fires once subgraph catches up → positions reflect the new state
- [ ] Address-switch race: submit tx, switch wallets within ~1s, verify no stale positions render
- [ ] Subgraph timeout fallback: with subgraph unreachable, tx still finalizes and `/portfolio` 60s interval reconciles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized transaction finalization/redirect flow and configurable timing constants.
  * Subgraph block-waiting utility to better coordinate refreshes with indexing.

* **Bug Fixes**
  * More reliable portfolio refresh timing after transactions.
  * Address-scoped refresh coordinator to avoid duplicate or overridden refreshes when switching addresses.

* **Tests**
  * Added tests covering the address refresh coordinator behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->