### PR TITLE
Keep app running with invalid RPC chain env

### DIFF
--- a/composables/useChainConfig.ts
+++ b/composables/useChainConfig.ts
@@ -8,45 +8,75 @@
  * This avoids runtimeConfig (which is frozen in production) and works
  * with runtime-injected env vars (e.g. Doppler on Railway).
  */
-import { getConfiguredChainIds, getEnabledChainIds, getSubgraphUris } from '~/utils/chain-env'
+import { getChainEnvIssues, getConfiguredChainIds, getEnabledChainIds, getSubgraphUris, type ChainEnvIssues } from '~/utils/chain-env'
 import { getUnknownChainIds } from '~/entities/chainRegistry'
+import { logger } from '~/utils/logger'
 
 interface ChainConfig {
   enabledChainIds: number[]
   deprecatedChainIds: number[]
   subgraphUris: Record<string, string>
+  unsupportedChainIds?: number[]
+  chainEnvIssues?: ChainEnvIssues
 }
 
 let cached: ChainConfig | null = null
 
-function warnUnknownChainIds(chainIds: readonly number[]) {
+function logUnknownChainIds(chainIds: readonly number[]) {
   if (chainIds.length) {
-    console.warn(
-      `[chainConfig] Ignoring unsupported chain IDs from RPC_URL_<chainId> env vars: ${chainIds.join(', ')}. Add only chains exported by @reown/appkit/networks.`,
+    logger.error(
+      { ctx: 'chain-config', chainIds },
+      'ignoring unsupported chain IDs from RPC_URL_<chainId> env vars; add only chains exported by @reown/appkit/networks',
+    )
+  }
+}
+
+function logChainEnvIssues(issues: ChainEnvIssues) {
+  if (issues.emptyRpcUrlChainIds.length) {
+    logger.error(
+      { ctx: 'chain-config', chainIds: issues.emptyRpcUrlChainIds },
+      'ignoring empty RPC_URL_<chainId> env vars; set a valid HTTP(S) RPC URL or remove the env var',
+    )
+  }
+  if (issues.malformedRpcUrlChainIds.length) {
+    logger.error(
+      { ctx: 'chain-config', chainIds: issues.malformedRpcUrlChainIds },
+      'ignoring malformed RPC_URL_<chainId> env vars; set a valid HTTP(S) RPC URL',
     )
   }
 }
 
 function normalizeChainConfig(config: ChainConfig): ChainConfig {
-  const unknownChainIds = getUnknownChainIds(config.enabledChainIds)
-  warnUnknownChainIds(unknownChainIds)
+  const unknownChainIds = [...new Set([
+    ...(config.unsupportedChainIds ?? []),
+    ...getUnknownChainIds(config.enabledChainIds),
+  ])]
+  const chainEnvIssues = config.chainEnvIssues ?? {
+    emptyRpcUrlChainIds: [],
+    malformedRpcUrlChainIds: [],
+  }
+  logUnknownChainIds(unknownChainIds)
+  logChainEnvIssues(chainEnvIssues)
 
   const enabledChainIds = config.enabledChainIds.filter(id => !unknownChainIds.includes(id))
   const enabledSet = new Set(enabledChainIds)
   const deprecatedChainIds = config.deprecatedChainIds.filter(id => enabledSet.has(id))
 
-  return { ...config, enabledChainIds, deprecatedChainIds }
+  return { ...config, enabledChainIds, deprecatedChainIds, unsupportedChainIds: unknownChainIds, chainEnvIssues }
 }
 
 function scanEnv(): ChainConfig {
-  warnUnknownChainIds(getUnknownChainIds(getConfiguredChainIds()))
+  const chainEnvIssues = getChainEnvIssues()
+  const unsupportedChainIds = getUnknownChainIds(getConfiguredChainIds())
+  logUnknownChainIds(unsupportedChainIds)
+  logChainEnvIssues(chainEnvIssues)
 
   const enabledChainIds = getEnabledChainIds()
   const subgraphUris = getSubgraphUris()
   const enabledSet = new Set(enabledChainIds)
   const deprecatedChainIds = parseDeprecatedChains(process.env.DEPRECATED_CHAINS, enabledSet)
 
-  return { enabledChainIds, deprecatedChainIds, subgraphUris }
+  return { enabledChainIds, deprecatedChainIds, subgraphUris, unsupportedChainIds, chainEnvIssues }
 }
 
 export const useChainConfig = (): ChainConfig => {

--- a/composables/useChainConfig.ts
+++ b/composables/useChainConfig.ts
@@ -8,7 +8,8 @@
  * This avoids runtimeConfig (which is frozen in production) and works
  * with runtime-injected env vars (e.g. Doppler on Railway).
  */
-import { getEnabledChainIds, getSubgraphUris } from '~/utils/chain-env'
+import { getConfiguredChainIds, getEnabledChainIds, getSubgraphUris } from '~/utils/chain-env'
+import { getUnknownChainIds } from '~/entities/chainRegistry'
 
 interface ChainConfig {
   enabledChainIds: number[]
@@ -18,7 +19,28 @@ interface ChainConfig {
 
 let cached: ChainConfig | null = null
 
+function warnUnknownChainIds(chainIds: readonly number[]) {
+  if (chainIds.length) {
+    console.warn(
+      `[chainConfig] Ignoring unsupported chain IDs from RPC_URL_<chainId> env vars: ${chainIds.join(', ')}. Add only chains exported by @reown/appkit/networks.`,
+    )
+  }
+}
+
+function normalizeChainConfig(config: ChainConfig): ChainConfig {
+  const unknownChainIds = getUnknownChainIds(config.enabledChainIds)
+  warnUnknownChainIds(unknownChainIds)
+
+  const enabledChainIds = config.enabledChainIds.filter(id => !unknownChainIds.includes(id))
+  const enabledSet = new Set(enabledChainIds)
+  const deprecatedChainIds = config.deprecatedChainIds.filter(id => enabledSet.has(id))
+
+  return { ...config, enabledChainIds, deprecatedChainIds }
+}
+
 function scanEnv(): ChainConfig {
+  warnUnknownChainIds(getUnknownChainIds(getConfiguredChainIds()))
+
   const enabledChainIds = getEnabledChainIds()
   const subgraphUris = getSubgraphUris()
   const enabledSet = new Set(enabledChainIds)
@@ -31,11 +53,11 @@ export const useChainConfig = (): ChainConfig => {
   if (cached) return cached
 
   if (import.meta.server) {
-    cached = scanEnv()
+    cached = normalizeChainConfig(scanEnv())
   }
   /* eslint-disable @typescript-eslint/no-explicit-any -- server-injected window global */
   else if (typeof window !== 'undefined' && (window as any).__CHAIN_CONFIG__) {
-    cached = (window as any).__CHAIN_CONFIG__
+    cached = normalizeChainConfig((window as any).__CHAIN_CONFIG__)
   /* eslint-enable @typescript-eslint/no-explicit-any */
   }
   else {

--- a/entities/chainRegistry.ts
+++ b/entities/chainRegistry.ts
@@ -70,6 +70,15 @@ export const getNetworksByChainIds = (ids: readonly number[]): AppKitNetwork[] =
 export const getChainById = (chainId: number): AppKitNetwork | undefined =>
   chainMap.get(chainId)
 
+export const isKnownChainId = (chainId: number): boolean =>
+  chainMap.has(chainId)
+
+export const getKnownChainIds = (ids: readonly number[]): number[] =>
+  ids.filter(isKnownChainId)
+
+export const getUnknownChainIds = (ids: readonly number[]): number[] =>
+  ids.filter(id => !isKnownChainId(id))
+
 const DEFI_LLAMA_NAMES: ReadonlyMap<number, string> = new Map([
   [1, 'Ethereum'],
   [56, 'BSC'],

--- a/server/plugins/chain-config.ts
+++ b/server/plugins/chain-config.ts
@@ -7,15 +7,30 @@
  * accessible to the client synchronously via window.__CHAIN_CONFIG__.
  */
 import { parseDeprecatedChains } from '../../utils/parseDeprecatedChains'
-import { getConfiguredChainIds, getEnabledChainIds, getSubgraphUris } from '~/utils/chain-env'
+import { getChainEnvIssues, getConfiguredChainIds, getEnabledChainIds, getSubgraphUris } from '~/utils/chain-env'
 import { getUnknownChainIds } from '~/entities/chainRegistry'
+import { logger } from '~/server/utils/logger'
 
 export default defineNitroPlugin((nitroApp) => {
   const configuredChainIds = getConfiguredChainIds()
   const unknownChainIds = getUnknownChainIds(configuredChainIds)
+  const chainEnvIssues = getChainEnvIssues()
   if (unknownChainIds.length) {
-    console.warn(
-      `[chainConfig] Ignoring unsupported chain IDs from RPC_URL_<chainId> env vars: ${unknownChainIds.join(', ')}. Add only chains exported by @reown/appkit/networks.`,
+    logger.error(
+      { ctx: 'chain-config', chainIds: unknownChainIds },
+      'ignoring unsupported chain IDs from RPC_URL_<chainId> env vars; add only chains exported by @reown/appkit/networks',
+    )
+  }
+  if (chainEnvIssues.emptyRpcUrlChainIds.length) {
+    logger.error(
+      { ctx: 'chain-config', chainIds: chainEnvIssues.emptyRpcUrlChainIds },
+      'ignoring empty RPC_URL_<chainId> env vars; set a valid HTTP(S) RPC URL or remove the env var',
+    )
+  }
+  if (chainEnvIssues.malformedRpcUrlChainIds.length) {
+    logger.error(
+      { ctx: 'chain-config', chainIds: chainEnvIssues.malformedRpcUrlChainIds },
+      'ignoring malformed RPC_URL_<chainId> env vars; set a valid HTTP(S) RPC URL',
     )
   }
 
@@ -25,7 +40,7 @@ export default defineNitroPlugin((nitroApp) => {
   const enabledSet = new Set(enabledChainIds)
   const deprecatedChainIds = parseDeprecatedChains(process.env.DEPRECATED_CHAINS, enabledSet)
 
-  const scriptTag = `<script>window.__CHAIN_CONFIG__=${JSON.stringify({ enabledChainIds, deprecatedChainIds, subgraphUris })}</script>`
+  const scriptTag = `<script>window.__CHAIN_CONFIG__=${JSON.stringify({ enabledChainIds, deprecatedChainIds, subgraphUris, unsupportedChainIds: unknownChainIds, chainEnvIssues })}</script>`
 
   nitroApp.hooks.hook('render:html', (html) => {
     html.head.push(scriptTag)

--- a/server/plugins/chain-config.ts
+++ b/server/plugins/chain-config.ts
@@ -7,9 +7,18 @@
  * accessible to the client synchronously via window.__CHAIN_CONFIG__.
  */
 import { parseDeprecatedChains } from '../../utils/parseDeprecatedChains'
-import { getEnabledChainIds, getSubgraphUris } from '~/utils/chain-env'
+import { getConfiguredChainIds, getEnabledChainIds, getSubgraphUris } from '~/utils/chain-env'
+import { getUnknownChainIds } from '~/entities/chainRegistry'
 
 export default defineNitroPlugin((nitroApp) => {
+  const configuredChainIds = getConfiguredChainIds()
+  const unknownChainIds = getUnknownChainIds(configuredChainIds)
+  if (unknownChainIds.length) {
+    console.warn(
+      `[chainConfig] Ignoring unsupported chain IDs from RPC_URL_<chainId> env vars: ${unknownChainIds.join(', ')}. Add only chains exported by @reown/appkit/networks.`,
+    )
+  }
+
   const enabledChainIds = getEnabledChainIds()
   const subgraphUris = getSubgraphUris()
 

--- a/tests/entities/chain-registry.test.ts
+++ b/tests/entities/chain-registry.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getKnownChainIds,
+  getNetworksByChainIds,
+  getUnknownChainIds,
+  isKnownChainId,
+} from '~/entities/chainRegistry'
+
+describe('chainRegistry', () => {
+  it('identifies supported chain IDs', () => {
+    expect(isKnownChainId(1)).toBe(true)
+    expect(isKnownChainId(923)).toBe(false)
+  })
+
+  it('partitions known and unknown chain IDs', () => {
+    const chainIds = [1, 923, 42161]
+
+    expect(getKnownChainIds(chainIds)).toEqual([1, 42161])
+    expect(getUnknownChainIds(chainIds)).toEqual([923])
+  })
+
+  it('keeps strict network lookup errors for unsupported chains', () => {
+    expect(() => getNetworksByChainIds([923])).toThrow(
+      '[chainRegistry] Unknown chain ID 923. Not found in @reown/appkit/networks.',
+    )
+  })
+})

--- a/tests/utils/chain-env.test.ts
+++ b/tests/utils/chain-env.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import { getConfiguredChainIds, getEnabledChainIds } from '~/utils/chain-env'
+
+describe('chain-env', () => {
+  it('keeps configured chain IDs separate from AppKit-supported enabled chain IDs', () => {
+    const env = {
+      RPC_URL_1: 'https://example.com/mainnet',
+      RPC_URL_923: 'https://example.com/unknown',
+      RPC_URL_42161: 'https://example.com/arbitrum',
+    }
+
+    expect(getConfiguredChainIds(env)).toEqual([1, 923, 42161])
+    expect(getEnabledChainIds(env)).toEqual([1, 42161])
+  })
+})

--- a/tests/utils/chain-env.test.ts
+++ b/tests/utils/chain-env.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { getConfiguredChainIds, getEnabledChainIds } from '~/utils/chain-env'
+import { getChainEnvIssues, getConfiguredChainIds, getEnabledChainIds } from '~/utils/chain-env'
 
 describe('chain-env', () => {
-  it('keeps configured chain IDs separate from AppKit-supported enabled chain IDs', () => {
+  it('keeps valid configured chain IDs separate from AppKit-supported enabled chain IDs', () => {
     const env = {
       RPC_URL_1: 'https://example.com/mainnet',
       RPC_URL_923: 'https://example.com/unknown',
@@ -11,5 +11,20 @@ describe('chain-env', () => {
 
     expect(getConfiguredChainIds(env)).toEqual([1, 923, 42161])
     expect(getEnabledChainIds(env)).toEqual([1, 42161])
+  })
+
+  it('does not enable empty or malformed RPC URL env vars', () => {
+    const env = {
+      RPC_URL_1: '',
+      RPC_URL_56: 'not-a-url',
+      RPC_URL_42161: 'https://example.com/arbitrum',
+    }
+
+    expect(getConfiguredChainIds(env)).toEqual([42161])
+    expect(getEnabledChainIds(env)).toEqual([42161])
+    expect(getChainEnvIssues(env)).toMatchObject({
+      emptyRpcUrlChainIds: [1],
+      malformedRpcUrlChainIds: [56],
+    })
   })
 })

--- a/utils/chain-env.ts
+++ b/utils/chain-env.ts
@@ -8,8 +8,9 @@
  *   - `RPC_URL_<chainId>` — enables a chain (presence, not value, matters)
  *   - `NUXT_PUBLIC_SUBGRAPH_URI_<chainId>` — subgraph URL for that chain
  */
+import { getKnownChainIds } from '~/entities/chainRegistry'
 
-export function getEnabledChainIds(env: NodeJS.ProcessEnv = process.env): number[] {
+export function getConfiguredChainIds(env: NodeJS.ProcessEnv = process.env): number[] {
   const ids: number[] = []
   for (const [key, value] of Object.entries(env)) {
     const match = key.match(/^RPC_URL_(\d+)$/)
@@ -18,6 +19,10 @@ export function getEnabledChainIds(env: NodeJS.ProcessEnv = process.env): number
     }
   }
   return ids.sort((a, b) => a - b)
+}
+
+export function getEnabledChainIds(env: NodeJS.ProcessEnv = process.env): number[] {
+  return getKnownChainIds(getConfiguredChainIds(env))
 }
 
 export function getSubgraphUris(env: NodeJS.ProcessEnv = process.env): Record<string, string> {

--- a/utils/chain-env.ts
+++ b/utils/chain-env.ts
@@ -10,25 +10,75 @@
  */
 import { getKnownChainIds } from '~/entities/chainRegistry'
 
+const RPC_URL_KEY = /^RPC_URL_(\d+)$/
+const SUBGRAPH_URI_KEY = /^NUXT_PUBLIC_SUBGRAPH_URI_(\d+)$/
+
+export interface ChainEnvIssues {
+  emptyRpcUrlChainIds: number[]
+  malformedRpcUrlChainIds: number[]
+}
+
+function parseHttpUrl(value: string): URL | null {
+  try {
+    const url = new URL(value.trim())
+    return url.protocol === 'http:' || url.protocol === 'https:' ? url : null
+  }
+  catch {
+    return null
+  }
+}
+
+function uniqueSorted(ids: number[]): number[] {
+  return [...new Set(ids)].sort((a, b) => a - b)
+}
+
+function isValidRpcUrl(value: string | undefined): boolean {
+  if (!value?.trim()) return false
+  return parseHttpUrl(value) != null
+}
+
 export function getConfiguredChainIds(env: NodeJS.ProcessEnv = process.env): number[] {
   const ids: number[] = []
   for (const [key, value] of Object.entries(env)) {
-    const match = key.match(/^RPC_URL_(\d+)$/)
-    if (match && value) {
+    const match = key.match(RPC_URL_KEY)
+    if (match && isValidRpcUrl(value)) {
       ids.push(Number(match[1]))
     }
   }
-  return ids.sort((a, b) => a - b)
+  return uniqueSorted(ids)
 }
 
 export function getEnabledChainIds(env: NodeJS.ProcessEnv = process.env): number[] {
   return getKnownChainIds(getConfiguredChainIds(env))
 }
 
+export function getChainEnvIssues(env: NodeJS.ProcessEnv = process.env): ChainEnvIssues {
+  const emptyRpcUrlChainIds: number[] = []
+  const malformedRpcUrlChainIds: number[] = []
+
+  for (const [key, value] of Object.entries(env)) {
+    const rpcMatch = key.match(RPC_URL_KEY)
+    if (rpcMatch) {
+      const chainId = Number(rpcMatch[1])
+      if (!value?.trim()) {
+        emptyRpcUrlChainIds.push(chainId)
+      }
+      else if (parseHttpUrl(value) == null) {
+        malformedRpcUrlChainIds.push(chainId)
+      }
+    }
+  }
+
+  return {
+    emptyRpcUrlChainIds: uniqueSorted(emptyRpcUrlChainIds),
+    malformedRpcUrlChainIds: uniqueSorted(malformedRpcUrlChainIds),
+  }
+}
+
 export function getSubgraphUris(env: NodeJS.ProcessEnv = process.env): Record<string, string> {
   const uris: Record<string, string> = {}
   for (const [key, value] of Object.entries(env)) {
-    const match = key.match(/^NUXT_PUBLIC_SUBGRAPH_URI_(\d+)$/)
+    const match = key.match(SUBGRAPH_URI_KEY)
     if (match && value) {
       uris[match[1]] = value
     }


### PR DESCRIPTION
## Summary
- Keep app initialization resilient when `RPC_URL_<chainId>` env vars are unsupported, empty, or malformed.
- Emit structured error-level logs for broken RPC chain config so deployment monitoring catches it without logging RPC URL values.

## Changes
- Validate RPC env vars as non-empty HTTP(S) URLs before treating a chain as configured/enabled.
- Continue filtering unsupported AppKit chain IDs out of enabled chain config instead of letting wagmi/AppKit initialization fail.
- Carry rejected chain config metadata into `window.__CHAIN_CONFIG__` so the client-safe logger surfaces the same errors in the browser path.
- Keep RPC env vars as the source of truth for enabled chains; subgraph-only config remains inert and does not create its own error.
- Add regression coverage for unsupported, empty, and malformed RPC chain env config.

## Test plan
- [x] `npm run test:run -- tests/entities/chain-registry.test.ts tests/utils/chain-env.test.ts tests/utils/logger.test.ts tests/utils/logger-bundle.test.ts`
- [x] `npm run lint -- utils/chain-env.ts server/plugins/chain-config.ts composables/useChainConfig.ts tests/utils/chain-env.test.ts`
- [x] Loaded `http://localhost:3000/lend?network=56` and confirmed malformed RPC env config logs through `[chain-config]` at error level.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configuration now validates chain IDs, logs unsupported IDs, and excludes them from active configuration.
  * Environment RPC URL issues (empty or malformed URLs) are detected and reported; chain enablement is stricter and normalized.

* **Tests**
  * Added tests covering chain registry validation and chain environment/RPC URL handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
