### PR TITLE
Use vault cash for liquidity-limited outflows

### DIFF
--- a/composables/borrow/useMultiplyForm.ts
+++ b/composables/borrow/useMultiplyForm.ts
@@ -539,7 +539,7 @@ export const useMultiplyForm = (options: UseMultiplyFormOptions) => {
     if (multiplyBalance.value < valueToNano(multiplyInputAmount.value, multiplySupplyVault.value.asset.decimals)) {
       return 'Not enough balance'
     }
-    if (multiplyDebtAmountNano.value > 0n && (multiplyShortVault.value.supply || 0n) < multiplyDebtAmountNano.value) {
+    if (multiplyDebtAmountNano.value > 0n && (multiplyShortVault.value.totalCash || 0n) < multiplyDebtAmountNano.value) {
       return 'Not enough liquidity in the vault'
     }
     return null

--- a/composables/repay/useCollateralSwapRepay.ts
+++ b/composables/repay/useCollateralSwapRepay.ts
@@ -71,7 +71,7 @@ export const useCollateralSwapRepay = (options: UseCollateralSwapRepayOptions) =
   const sourceAssets = ref(0n)
   const sourceBalance = computed(() => getCashLimitedWithdrawAmount(
     sourceAssets.value,
-    sourceVault.value?.totalCash,
+    sourceVault.value,
   ))
   const debtBalance = computed(() => position.value?.borrowed || 0n)
 

--- a/composables/repay/useCollateralSwapRepay.ts
+++ b/composables/repay/useCollateralSwapRepay.ts
@@ -5,7 +5,7 @@ import { logWarn } from '~/utils/errorHandling'
 import { useModal } from '~/components/ui/composables/useModal'
 import { OperationReviewModal } from '#components'
 import { useToast } from '~/components/ui/composables/useToast'
-import { isEVKVault, type Vault } from '~/entities/vault'
+import { getCashLimitedWithdrawAmount, isEVKVault, type Vault } from '~/entities/vault'
 import { getAssetUsdValue, getAssetOraclePrice, conservativePriceRatioNumber } from '~/services/pricing/priceProvider'
 import type { AccountBorrowPosition } from '~/entities/account'
 import type { TxPlan } from '~/entities/txPlan'
@@ -16,6 +16,7 @@ import { useEulerProductOfVault } from '~/composables/useEulerLabels'
 import { useRepaySwapCore } from '~/composables/repay/useRepaySwapCore'
 import { useRepaySwapDetails } from '~/composables/repay/useRepaySwapDetails'
 import { useRepayHealthMetrics } from '~/composables/repay/useRepayHealthMetrics'
+import { adjustForInterest } from '~/composables/useEulerOperations/helpers'
 import { getSwapInputAmount } from '~/composables/useEulerOperations/swaps/verify'
 import { nanoToValue, valueToNano } from '~/utils/crypto-utils'
 import { normalizeAddressOrEmpty } from '~/utils/accountPositionHelpers'
@@ -68,7 +69,10 @@ export const useCollateralSwapRepay = (options: UseCollateralSwapRepayOptions) =
   // --- Source vault state ---
   const sourceVault: Ref<Vault | undefined> = ref()
   const sourceAssets = ref(0n)
-  const sourceBalance = computed(() => sourceAssets.value)
+  const sourceBalance = computed(() => getCashLimitedWithdrawAmount(
+    sourceAssets.value,
+    sourceVault.value?.totalCash,
+  ))
   const debtBalance = computed(() => position.value?.borrowed || 0n)
 
   const priceInvert = usePriceInvert(
@@ -246,12 +250,15 @@ export const useCollateralSwapRepay = (options: UseCollateralSwapRepayOptions) =
   // Uses amountInMax (slippage-padded) when available so the user sees an
   // insufficient-balance error before hitting an on-chain revert.
   const requiredInput = computed(() => {
-    if (core.isSameAsset.value) return core.spent.value ?? 0n
+    if (core.isSameAsset.value) {
+      const spent = core.spent.value ?? 0n
+      return isEffectivelyFullRepay.value ? adjustForInterest(spent) : spent
+    }
     const q = core.quotes.selectedQuote.value
     if (!q) return 0n
     return getSwapInputAmount(q, core.direction.value)
   })
-  const isInsufficientSource = computed(() => requiredInput.value > 0n && requiredInput.value > sourceBalance.value)
+  const isInsufficientSource = computed(() => requiredInput.value > 0n && requiredInput.value > sourceAssets.value)
   const isInsufficientVaultLiquidity = computed(() =>
     requiredInput.value > 0n && requiredInput.value > (sourceVault.value?.totalCash || 0n),
   )

--- a/composables/repay/useSavingsRepay.ts
+++ b/composables/repay/useSavingsRepay.ts
@@ -78,9 +78,11 @@ export const useSavingsRepay = (options: UseSavingsRepayOptions) => {
     && !!borrowVault.value
     && normalizeAddressOrEmpty(sourceVault.value.address) === normalizeAddressOrEmpty(borrowVault.value.address),
   )
+  // Same-vault repay never withdraws (uses repayWithShares directly), so cash
+  // capacity is irrelevant — only sourceAssets bounds the operation.
   const sourceBalance = computed(() => getCashLimitedWithdrawAmount(
     sourceAssets.value,
-    isSameVaultRepay.value ? undefined : sourceVault.value?.totalCash,
+    isSameVaultRepay.value ? undefined : sourceVault.value,
   ))
   const debtBalance = computed(() => position.value?.borrowed || 0n)
 

--- a/composables/repay/useSavingsRepay.ts
+++ b/composables/repay/useSavingsRepay.ts
@@ -5,7 +5,7 @@ import { logWarn } from '~/utils/errorHandling'
 import { useModal } from '~/components/ui/composables/useModal'
 import { OperationReviewModal } from '#components'
 import { useToast } from '~/components/ui/composables/useToast'
-import { isEVKVault, type Vault, type SecuritizeVault } from '~/entities/vault'
+import { getCashLimitedWithdrawAmount, isEVKVault, type Vault, type SecuritizeVault } from '~/entities/vault'
 import { getAssetUsdValue } from '~/services/pricing/priceProvider'
 import type { AccountBorrowPosition } from '~/entities/account'
 import type { TxPlan } from '~/entities/txPlan'
@@ -15,8 +15,10 @@ import { useEulerProductOfVault } from '~/composables/useEulerLabels'
 import { useRepaySwapCore } from '~/composables/repay/useRepaySwapCore'
 import { useRepaySwapDetails } from '~/composables/repay/useRepaySwapDetails'
 import { useRepayHealthMetrics } from '~/composables/repay/useRepayHealthMetrics'
+import { adjustForInterest } from '~/composables/useEulerOperations/helpers'
 import { getSwapInputAmount } from '~/composables/useEulerOperations/swaps/verify'
 import { nanoToValue, valueToNano } from '~/utils/crypto-utils'
+import { normalizeAddressOrEmpty } from '~/utils/accountPositionHelpers'
 import { createRaceGuard } from '~/utils/race-guard'
 import { findBlockingDisabledOp, OP_REPAY_WITH_SHARES, OP_SKIM, OP_TRANSFER, OP_WITHDRAW, type PlannedOp } from '~/utils/vault-hooks'
 import { getPlanHookDisabledWarning, getUtilisationWarning, type VaultWarning } from '~/composables/useVaultWarnings'
@@ -71,7 +73,15 @@ export const useSavingsRepay = (options: UseSavingsRepayOptions) => {
   // --- Source vault state ---
   const sourceVault: Ref<Vault | undefined> = ref()
   const sourceAssets = ref(0n)
-  const sourceBalance = computed(() => sourceAssets.value)
+  const isSameVaultRepay = computed(() =>
+    !!sourceVault.value
+    && !!borrowVault.value
+    && normalizeAddressOrEmpty(sourceVault.value.address) === normalizeAddressOrEmpty(borrowVault.value.address),
+  )
+  const sourceBalance = computed(() => getCashLimitedWithdrawAmount(
+    sourceAssets.value,
+    isSameVaultRepay.value ? undefined : sourceVault.value?.totalCash,
+  ))
   const debtBalance = computed(() => position.value?.borrowed || 0n)
 
   const priceInvert = usePriceInvert(
@@ -166,9 +176,11 @@ export const useSavingsRepay = (options: UseSavingsRepayOptions) => {
 
   const savingsRepayPlannedOps = computed<PlannedOp[]>(() => {
     const steps: PlannedOp[] = []
-    if (sourceVault.value) steps.push({ vault: sourceVault.value as Vault, op: OP_WITHDRAW })
+    if (sourceVault.value && !isSameVaultRepay.value) steps.push({ vault: sourceVault.value as Vault, op: OP_WITHDRAW })
     if (borrowVault.value) {
-      steps.push({ vault: borrowVault.value as Vault, op: OP_SKIM })
+      if (!isSameVaultRepay.value) {
+        steps.push({ vault: borrowVault.value as Vault, op: OP_SKIM })
+      }
       steps.push({ vault: borrowVault.value as Vault, op: OP_REPAY_WITH_SHARES })
     }
     if (isEffectivelyFullRepay.value) {
@@ -190,14 +202,19 @@ export const useSavingsRepay = (options: UseSavingsRepayOptions) => {
   // Uses amountInMax (slippage-padded) when available so the user sees an
   // insufficient-balance error before hitting an on-chain revert.
   const requiredInput = computed(() => {
-    if (core.isSameAsset.value) return core.spent.value ?? 0n
+    if (core.isSameAsset.value) {
+      const spent = core.spent.value ?? 0n
+      return isEffectivelyFullRepay.value
+        ? adjustForInterest(spent)
+        : spent
+    }
     const q = core.quotes.selectedQuote.value
     if (!q) return 0n
     return getSwapInputAmount(q, core.direction.value)
   })
-  const isInsufficientSource = computed(() => requiredInput.value > 0n && requiredInput.value > sourceBalance.value)
+  const isInsufficientSource = computed(() => requiredInput.value > 0n && requiredInput.value > sourceAssets.value)
   const isInsufficientVaultLiquidity = computed(() =>
-    requiredInput.value > 0n && requiredInput.value > (sourceVault.value?.totalCash || 0n),
+    !isSameVaultRepay.value && requiredInput.value > 0n && requiredInput.value > (sourceVault.value?.totalCash || 0n),
   )
   const liquidityWarning = computed<VaultWarning | null>(() => {
     if (!sourceVault.value) return null

--- a/entities/vault/index.ts
+++ b/entities/vault/index.ts
@@ -92,6 +92,7 @@ export {
   convertAssetsToShares,
   previewWithdraw,
   getMaxWithdraw,
+  getCashLimitedWithdrawAmount,
   getUtilization,
   getVaultUtilization,
   getSupplyCapPercentage,

--- a/entities/vault/utils.ts
+++ b/entities/vault/utils.ts
@@ -122,8 +122,7 @@ export const getCashLimitedWithdrawAmount = (
     return userWithdrawableAssets
   }
 
-  const availableCash = vaultCash < 0n ? 0n : vaultCash
-  return userWithdrawableAssets < availableCash ? userWithdrawableAssets : availableCash
+  return userWithdrawableAssets < vaultCash ? userWithdrawableAssets : vaultCash
 }
 
 export const getUtilization = (totalAssets: bigint, totalBorrow: bigint): number => {

--- a/entities/vault/utils.ts
+++ b/entities/vault/utils.ts
@@ -1,5 +1,5 @@
 import { maxUint256, type Address } from 'viem'
-import type { Vault, SecuritizeVault, BorrowVaultPair } from './types'
+import type { Vault, SecuritizeVault, EarnVault, BorrowVaultPair } from './types'
 import {
   vaultConvertToAssetsAbi,
   vaultConvertToSharesAbi,
@@ -114,15 +114,23 @@ export const getMaxWithdraw = (vaultAddress: string, account: string): Promise<b
   }) as Promise<bigint>
 }
 
+// What the vault can actually pay out right now in its underlying asset:
+// - EVK Vault: only cash on hand (the rest is lent out to borrowers).
+// - SecuritizeVault: the whole supply (no borrowing).
+// - EarnVault: liquidity reachable across allocated strategies.
+const getVaultWithdrawCapacity = (vault: Vault | SecuritizeVault | EarnVault): bigint => {
+  if ('type' in vault && vault.type === 'securitize') return vault.totalAssets
+  if ('type' in vault && vault.type === 'earn') return vault.availableAssets
+  return vault.totalCash
+}
+
 export const getCashLimitedWithdrawAmount = (
   userWithdrawableAssets: bigint,
-  vaultCash?: bigint,
+  vault: Vault | SecuritizeVault | EarnVault | undefined,
 ): bigint => {
-  if (vaultCash === undefined) {
-    return userWithdrawableAssets
-  }
-
-  return userWithdrawableAssets < vaultCash ? userWithdrawableAssets : vaultCash
+  if (!vault) return userWithdrawableAssets
+  const capacity = getVaultWithdrawCapacity(vault)
+  return userWithdrawableAssets < capacity ? userWithdrawableAssets : capacity
 }
 
 export const getUtilization = (totalAssets: bigint, totalBorrow: bigint): number => {

--- a/entities/vault/utils.ts
+++ b/entities/vault/utils.ts
@@ -114,6 +114,18 @@ export const getMaxWithdraw = (vaultAddress: string, account: string): Promise<b
   }) as Promise<bigint>
 }
 
+export const getCashLimitedWithdrawAmount = (
+  userWithdrawableAssets: bigint,
+  vaultCash?: bigint,
+): bigint => {
+  if (vaultCash === undefined) {
+    return userWithdrawableAssets
+  }
+
+  const availableCash = vaultCash < 0n ? 0n : vaultCash
+  return userWithdrawableAssets < availableCash ? userWithdrawableAssets : availableCash
+}
+
 export const getUtilization = (totalAssets: bigint, totalBorrow: bigint): number => {
   if (!totalAssets || totalAssets <= 0n || !totalBorrow || totalBorrow <= 0n) {
     return 0

--- a/pages/earn/[vault]/[subAccount]/withdraw.vue
+++ b/pages/earn/[vault]/[subAccount]/withdraw.vue
@@ -6,6 +6,7 @@ import { OperationReviewModal } from '#components'
 import { useToast } from '~/components/ui/composables/useToast'
 import {
   convertSharesToAssets,
+  getCashLimitedWithdrawAmount,
   type EarnVault,
   type VaultAsset,
 } from '~/entities/vault'
@@ -54,6 +55,7 @@ const estimatesError = ref('')
 
 // Reactive USD prices for display
 const assetsBalanceUsd = ref(0)
+const withdrawableAssetsUsd = ref(0)
 const deltaUsd = ref(0)
 
 const rewardApy = computed(() => getSupplyRewardApy(vault.value?.address || ''))
@@ -63,9 +65,13 @@ const amountFixed = computed(() => {
     Number(asset.value?.decimals || 0),
   )
 })
+const withdrawableAssets = computed(() => getCashLimitedWithdrawAmount(
+  assetsBalance.value,
+  vault.value?.availableAssets,
+))
 const isSubmitDisabled = computed(() => {
   if (!isConnected.value) return false
-  return assetsBalance.value < amountFixed.value.value
+  return withdrawableAssets.value < amountFixed.value.value
     || isLoading.value
     || amountFixed.value.isZero() || amountFixed.value.isNegative()
     || !!(estimatesError.value)
@@ -74,6 +80,7 @@ const reviewWithdrawDisabled = isSubmitDisabled
 const disabledReasonInfo = computed((): DisabledReasonInfo | undefined => {
   if (estimatesError.value) return { message: estimatesError.value, variant: 'error' }
   if (!amountFixed.value.isZero() && assetsBalance.value < amountFixed.value.value) return { message: 'Insufficient balance', variant: 'error' }
+  if (!amountFixed.value.isZero() && withdrawableAssets.value < amountFixed.value.value) return { message: 'Not enough liquidity in vault', variant: 'error' }
   return undefined
 })
 const supplyAPYDisplay = computed(() => {
@@ -206,6 +213,9 @@ const updateEstimates = () => {
     if (assetsBalance.value < amountFixed.value.value) {
       throw new Error('Not enough balance')
     }
+    if (withdrawableAssets.value < amountFixed.value.value) {
+      throw new Error('Not enough liquidity in vault')
+    }
     delta.value = assetsBalance.value - amountFixed.value.value
     estimateSupplyAPY.value = nanoToValue(vault.value.interestRateInfo.supplyAPY, 25)
   }
@@ -224,10 +234,12 @@ load()
 watchEffect(async () => {
   if (!vault.value) {
     assetsBalanceUsd.value = 0
+    withdrawableAssetsUsd.value = 0
     deltaUsd.value = 0
     return
   }
   assetsBalanceUsd.value = await getAssetUsdValueOrZero(assetsBalance.value, vault.value, 'off-chain')
+  withdrawableAssetsUsd.value = await getAssetUsdValueOrZero(withdrawableAssets.value, vault.value, 'off-chain')
   deltaUsd.value = await getAssetUsdValueOrZero(delta.value, vault.value, 'off-chain')
 })
 
@@ -272,7 +284,7 @@ watch(amount, () => {
               label="Withdraw amount"
               :asset="asset"
               :vault="vault"
-              :balance="assetsBalance"
+              :balance="withdrawableAssets"
               maxable
             />
 
@@ -315,11 +327,11 @@ watch(amount, () => {
                 v-if="asset"
                 class="text-p2 flex items-center gap-4"
               >
-                <UiExactAmount :exact="formatExactAmount(assetsBalance, asset.decimals, asset.symbol)">
-                  {{ formatSmartAmount(nanoToValue(assetsBalance, asset.decimals)) }}
+                <UiExactAmount :exact="formatExactAmount(withdrawableAssets, asset.decimals, asset.symbol)">
+                  {{ formatSmartAmount(nanoToValue(withdrawableAssets, asset.decimals)) }}
                   <span class="text-p3 text-content-tertiary">{{ asset.symbol }}</span>
                 </UiExactAmount>
-                <span class="text-p3 text-content-tertiary">&asymp; ${{ formatNumber(assetsBalanceUsd) }}</span>
+                <span class="text-p3 text-content-tertiary">&asymp; ${{ formatNumber(withdrawableAssetsUsd) }}</span>
               </p>
             </SummaryRow>
           </VaultFormInfoBlock>

--- a/pages/earn/[vault]/[subAccount]/withdraw.vue
+++ b/pages/earn/[vault]/[subAccount]/withdraw.vue
@@ -67,7 +67,7 @@ const amountFixed = computed(() => {
 })
 const withdrawableAssets = computed(() => getCashLimitedWithdrawAmount(
   assetsBalance.value,
-  vault.value?.availableAssets,
+  vault.value,
 ))
 const isSubmitDisabled = computed(() => {
   if (!isConnected.value) return false

--- a/pages/lend/[vault]/[subAccount]/swap.vue
+++ b/pages/lend/[vault]/[subAccount]/swap.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useAccount } from '@wagmi/vue'
 import { isAddress, getAddress, zeroAddress, type Address } from 'viem'
-import { getCashLimitedWithdrawAmount, isEVKVault, type Vault, type SecuritizeVault, fetchSecuritizeVault } from '~/entities/vault'
+import { getCashLimitedWithdrawAmount, type Vault, type SecuritizeVault, fetchSecuritizeVault } from '~/entities/vault'
 import { isSecuritizeVault } from '~/entities/vault/factory'
 import { getSubAccountAddress } from '~/entities/account'
 import { useSwapCollateralOptions } from '~/composables/useSwapCollateralOptions'
@@ -62,7 +62,7 @@ const savingPosition = computed(() => {
 const assetsBalance = computed(() => savingPosition.value?.assets || 0n)
 const balance = computed(() => getCashLimitedWithdrawAmount(
   assetsBalance.value,
-  fromVault.value && isEVKVault(fromVault.value) ? fromVault.value.totalCash : undefined,
+  fromVault.value,
 ))
 
 // ── Supply APY ───────────────────────────────────────────────────────────

--- a/pages/lend/[vault]/[subAccount]/swap.vue
+++ b/pages/lend/[vault]/[subAccount]/swap.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useAccount } from '@wagmi/vue'
 import { isAddress, getAddress, zeroAddress, type Address } from 'viem'
-import { type Vault, type SecuritizeVault, fetchSecuritizeVault } from '~/entities/vault'
+import { getCashLimitedWithdrawAmount, isEVKVault, type Vault, type SecuritizeVault, fetchSecuritizeVault } from '~/entities/vault'
 import { isSecuritizeVault } from '~/entities/vault/factory'
 import { getSubAccountAddress } from '~/entities/account'
 import { useSwapCollateralOptions } from '~/composables/useSwapCollateralOptions'
@@ -59,7 +59,11 @@ const savingPosition = computed(() => {
   ) || null
 })
 
-const balance = computed(() => savingPosition.value?.assets || 0n)
+const assetsBalance = computed(() => savingPosition.value?.assets || 0n)
+const balance = computed(() => getCashLimitedWithdrawAmount(
+  assetsBalance.value,
+  fromVault.value && isEVKVault(fromVault.value) ? fromVault.value.totalCash : undefined,
+))
 
 // ── Supply APY ───────────────────────────────────────────────────────────
 const fromSupplyApy = computed(() => {
@@ -109,7 +113,7 @@ const swap = useSwapPageLogic({
     if (isSameAsset.value) {
       if (!fromVault.value || !toVault.value) throw new Error('Vaults not loaded')
       const amount = valueToNano(fromAmount.value, fromVault.value.asset.decimals)
-      const isMax = balance.value > 0n && amount >= balance.value
+      const isMax = assetsBalance.value > 0n && amount >= assetsBalance.value
       return buildSameAssetSwapPlan({
         fromVaultAddress: fromVault.value.address,
         toVaultAddress: toVault.value.address,
@@ -129,7 +133,11 @@ const swap = useSwapPageLogic({
     })
   },
 
-  getBalanceError: amountNano => balance.value < amountNano ? 'Not enough balance' : null,
+  getBalanceError: (amountNano) => {
+    if (assetsBalance.value < amountNano) return 'Not enough balance'
+    if (balance.value < amountNano) return 'Not enough liquidity in vault'
+    return null
+  },
   getGeoBlockedAddresses: () => [getVaultAddress()],
 })
 

--- a/pages/lend/[vault]/[subAccount]/withdraw.vue
+++ b/pages/lend/[vault]/[subAccount]/withdraw.vue
@@ -11,6 +11,7 @@ import {
   type Vault,
   type SecuritizeVault,
   type VaultAsset,
+  getCashLimitedWithdrawAmount,
   getProjectedRates,
 } from '~/entities/vault'
 import { isSecuritizeVault } from '~/entities/vault/factory'
@@ -115,6 +116,12 @@ const amountFixed = computed(() => {
     Number(asset.value?.decimals || 0),
   )
 })
+const withdrawableAssets = computed(() => getCashLimitedWithdrawAmount(
+  assetsBalance.value,
+  vault.value && !isSecuritizeVaultType.value
+    ? (vault.value as Vault).interestRateInfo.cash
+    : undefined,
+))
 const effectiveWithdrawOp = computed(() => {
   const isMax = FixedPoint.fromValue(assetsBalance.value, asset.value?.decimals).lte(amountFixed.value)
   return isMax ? OP_REDEEM : OP_WITHDRAW
@@ -129,7 +136,7 @@ const isSubmitDisabled = computed(() => {
   if (!isConnected.value) return false
   if (vault.value && !isSecuritizeVaultType.value && isOpDisabled(vault.value as Vault, effectiveWithdrawOp.value)) return true
   if (isOutputAssetBlocked.value || isOutputAssetRestricted.value) return true
-  if (assetsBalance.value < amountFixed.value.value) return true
+  if (withdrawableAssets.value < amountFixed.value.value) return true
   if (isLoading.value || amountFixed.value.isZero() || amountFixed.value.isNegative()) return true
   if (estimatesError.value) return true
   if (needsSwap.value && !swapSelectedQuote.value && !isSwapQuoteLoading.value) return true
@@ -141,6 +148,7 @@ const disabledReasonInfo = computed((): DisabledReasonInfo | undefined => {
   if (isOutputAssetBlocked.value || isOutputAssetRestricted.value) return { message: 'Receiving this asset is not available in your region', variant: 'warning' }
   if (estimatesError.value) return { message: estimatesError.value, variant: 'error' }
   if (!amountFixed.value.isZero() && assetsBalance.value < amountFixed.value.value) return { message: 'Insufficient balance', variant: 'error' }
+  if (!amountFixed.value.isZero() && withdrawableAssets.value < amountFixed.value.value) return { message: 'Not enough liquidity in vault', variant: 'error' }
   if (needsSwap.value && isSwapQuoteLoading.value && !amountFixed.value.isZero()) return { message: 'Fetching swap quotes...', variant: 'warning' }
   if (needsSwap.value && !swapSelectedQuote.value && !amountFixed.value.isZero()) return { message: 'Select a swap quote to continue', variant: 'warning' }
   return undefined
@@ -157,16 +165,19 @@ const estimateSupplyAPYDisplay = computed(() => {
 
 // Reactive USD prices for display
 const assetsBalanceUsd = ref(0)
+const withdrawableAssetsUsd = ref(0)
 const deltaUsd = ref(0)
 
 // Update USD prices when vault or amounts change
 watchEffect(async () => {
   if (!vault.value || isSecuritizeVaultType.value) {
     assetsBalanceUsd.value = 0
+    withdrawableAssetsUsd.value = 0
     deltaUsd.value = 0
     return
   }
   assetsBalanceUsd.value = await getAssetUsdValueOrZero(assetsBalance.value, vault.value as Vault, 'off-chain')
+  withdrawableAssetsUsd.value = await getAssetUsdValueOrZero(withdrawableAssets.value, vault.value as Vault, 'off-chain')
   deltaUsd.value = await getAssetUsdValueOrZero(delta.value, vault.value as Vault, 'off-chain')
 })
 
@@ -461,10 +472,7 @@ const updateSyncEstimates = () => {
       throw new Error('Not enough balance')
     }
 
-    // Check liquidity (securitize: borrow is always 0)
-    const liquidity = vault.value.supply - vault.value.borrow
-
-    if (liquidity < amountFixed.value.value) {
+    if (withdrawableAssets.value < amountFixed.value.value) {
       throw new Error('Not enough liquidity in vault')
     }
 
@@ -584,7 +592,7 @@ watch(swapSelectedQuote, () => {
               label="Withdraw amount"
               :asset="asset"
               :vault="(vault as Vault)"
-              :balance="assetsBalance"
+              :balance="withdrawableAssets"
               maxable
             />
 
@@ -703,14 +711,14 @@ watch(swapSelectedQuote, () => {
                 v-if="asset"
                 class="text-p2 flex items-center gap-4"
               >
-                <UiExactAmount :exact="formatExactAmount(assetsBalance, asset.decimals, asset.symbol)">
-                  {{ formatSmartAmount(nanoToValue(assetsBalance, asset.decimals)) }}
+                <UiExactAmount :exact="formatExactAmount(withdrawableAssets, asset.decimals, asset.symbol)">
+                  {{ formatSmartAmount(nanoToValue(withdrawableAssets, asset.decimals)) }}
                   <span class="text-p3 text-content-tertiary">{{ asset.symbol }}</span>
                 </UiExactAmount>
                 <span
                   v-if="!isSecuritizeVaultType"
                   class="text-p3 text-content-tertiary"
-                >≈ ${{ formatNumber(assetsBalanceUsd) }}</span>
+                >≈ ${{ formatNumber(withdrawableAssetsUsd) }}</span>
               </p>
             </SummaryRow>
           </VaultFormInfoBlock>

--- a/pages/lend/[vault]/[subAccount]/withdraw.vue
+++ b/pages/lend/[vault]/[subAccount]/withdraw.vue
@@ -118,9 +118,7 @@ const amountFixed = computed(() => {
 })
 const withdrawableAssets = computed(() => getCashLimitedWithdrawAmount(
   assetsBalance.value,
-  vault.value && !isSecuritizeVaultType.value
-    ? (vault.value as Vault).totalCash
-    : undefined,
+  vault.value,
 ))
 const effectiveWithdrawOp = computed(() => {
   const isMax = FixedPoint.fromValue(assetsBalance.value, asset.value?.decimals).lte(amountFixed.value)

--- a/pages/lend/[vault]/[subAccount]/withdraw.vue
+++ b/pages/lend/[vault]/[subAccount]/withdraw.vue
@@ -119,7 +119,7 @@ const amountFixed = computed(() => {
 const withdrawableAssets = computed(() => getCashLimitedWithdrawAmount(
   assetsBalance.value,
   vault.value && !isSecuritizeVaultType.value
-    ? (vault.value as Vault).interestRateInfo.cash
+    ? (vault.value as Vault).totalCash
     : undefined,
 ))
 const effectiveWithdrawOp = computed(() => {

--- a/pages/position/[number]/multiply.vue
+++ b/pages/position/[number]/multiply.vue
@@ -453,7 +453,7 @@ const multiplyErrorText = computed(() => {
   if (!multiplyShortVault.value) {
     return null
   }
-  if (multiplyDebtAmountNano.value > 0n && (multiplyShortVault.value.supply || 0n) < multiplyDebtAmountNano.value) {
+  if (multiplyDebtAmountNano.value > 0n && (multiplyShortVault.value.totalCash || 0n) < multiplyDebtAmountNano.value) {
     return 'Not enough liquidity in the vault'
   }
   return null

--- a/pages/position/[number]/withdraw.vue
+++ b/pages/position/[number]/withdraw.vue
@@ -2,7 +2,7 @@
 import { useAccount } from '@wagmi/vue'
 import { getAddress, type Address, zeroAddress } from 'viem'
 import { FixedPoint } from '~/utils/fixed-point'
-import { getCashLimitedWithdrawAmount, isEVKVault, type Vault, type VaultAsset } from '~/entities/vault'
+import { getCashLimitedWithdrawAmount, type Vault, type VaultAsset } from '~/entities/vault'
 import type { SwapTokenSelectMeta } from '~/components/entities/asset/SwapTokenSelector.vue'
 import { getUtilisationWarning } from '~/composables/useVaultWarnings'
 import {
@@ -40,19 +40,13 @@ const needsSwap = computed(() => {
   }
 })
 
-function getCashLimitedCollateralAssets() {
-  return getCashLimitedWithdrawAmount(
-    form.collateralAssets.value,
-    form.collateralVault.value && isEVKVault(form.collateralVault.value)
-      ? form.collateralVault.value.totalCash
-      : undefined,
-  )
-}
+const cashLimitedCollateralAssets = () =>
+  getCashLimitedWithdrawAmount(form.collateralAssets.value, form.collateralVault.value)
 
 const form = useCollateralForm({
   mode: 'withdraw',
   needsSwap,
-  effectiveBalance: computed(() => getCashLimitedCollateralAssets()),
+  effectiveBalance: computed(() => cashLimitedCollateralAssets()),
   effectiveAsset: computed(() => form.asset.value),
 
   computePriceFixed: (_pos, borrowVault, collateralVault) => {
@@ -81,7 +75,7 @@ const form = useCollateralForm({
     if (userLtvFixed.gte(FixedPoint.fromValue(form.position.value.liquidationLTV, 2))) {
       throw new Error('Not enough liquidity for the vault, LTV is too large')
     }
-    if (getCashLimitedCollateralAssets() < amountFixed.value) {
+    if (cashLimitedCollateralAssets() < amountFixed.value) {
       throw new Error('Not enough liquidity in vault')
     }
   },
@@ -148,7 +142,7 @@ const form = useCollateralForm({
   },
 })
 useOperationGuard(computed(() => [form.collateralVault.value?.address, form.borrowVault.value?.address].filter(Boolean)))
-const withdrawableCollateralAssets = computed(() => getCashLimitedCollateralAssets())
+const withdrawableCollateralAssets = computed(() => cashLimitedCollateralAssets())
 
 const disabledReasonInfo = computed((): DisabledReasonInfo | undefined => {
   if (form.isGeoBlocked.value) return { message: 'This operation is not available in your region', variant: 'warning' }

--- a/pages/position/[number]/withdraw.vue
+++ b/pages/position/[number]/withdraw.vue
@@ -2,7 +2,7 @@
 import { useAccount } from '@wagmi/vue'
 import { getAddress, type Address, zeroAddress } from 'viem'
 import { FixedPoint } from '~/utils/fixed-point'
-import type { Vault, VaultAsset } from '~/entities/vault'
+import { getCashLimitedWithdrawAmount, type Vault, type VaultAsset } from '~/entities/vault'
 import type { SwapTokenSelectMeta } from '~/components/entities/asset/SwapTokenSelector.vue'
 import { getUtilisationWarning } from '~/composables/useVaultWarnings'
 import {
@@ -43,7 +43,10 @@ const needsSwap = computed(() => {
 const form = useCollateralForm({
   mode: 'withdraw',
   needsSwap,
-  effectiveBalance: computed(() => form.collateralAssets.value),
+  effectiveBalance: computed(() => getCashLimitedWithdrawAmount(
+    form.collateralAssets.value,
+    form.collateralVault.value?.interestRateInfo.cash,
+  )),
   effectiveAsset: computed(() => form.asset.value),
 
   computePriceFixed: (_pos, borrowVault, collateralVault) => {
@@ -71,6 +74,12 @@ const form = useCollateralForm({
     if (!form.position.value) return
     if (userLtvFixed.gte(FixedPoint.fromValue(form.position.value.liquidationLTV, 2))) {
       throw new Error('Not enough liquidity for the vault, LTV is too large')
+    }
+    if (getCashLimitedWithdrawAmount(
+      form.collateralAssets.value,
+      form.collateralVault.value?.interestRateInfo.cash,
+    ) < amountFixed.value) {
+      throw new Error('Not enough liquidity in vault')
     }
   },
 
@@ -136,6 +145,10 @@ const form = useCollateralForm({
   },
 })
 useOperationGuard(computed(() => [form.collateralVault.value?.address, form.borrowVault.value?.address].filter(Boolean)))
+const withdrawableCollateralAssets = computed(() => getCashLimitedWithdrawAmount(
+  form.collateralAssets.value,
+  form.collateralVault.value?.interestRateInfo.cash,
+))
 
 const disabledReasonInfo = computed((): DisabledReasonInfo | undefined => {
   if (form.isGeoBlocked.value) return { message: 'This operation is not available in your region', variant: 'warning' }
@@ -219,7 +232,7 @@ watch(selectedOutputAsset, () => {
               label="Withdraw amount"
               :asset="form.asset.value"
               :vault="(form.collateralVault.value as Vault)"
-              :balance="form.collateralAssets.value"
+              :balance="withdrawableCollateralAssets"
               maxable
             />
 

--- a/pages/position/[number]/withdraw.vue
+++ b/pages/position/[number]/withdraw.vue
@@ -2,7 +2,7 @@
 import { useAccount } from '@wagmi/vue'
 import { getAddress, type Address, zeroAddress } from 'viem'
 import { FixedPoint } from '~/utils/fixed-point'
-import { getCashLimitedWithdrawAmount, type Vault, type VaultAsset } from '~/entities/vault'
+import { getCashLimitedWithdrawAmount, isEVKVault, type Vault, type VaultAsset } from '~/entities/vault'
 import type { SwapTokenSelectMeta } from '~/components/entities/asset/SwapTokenSelector.vue'
 import { getUtilisationWarning } from '~/composables/useVaultWarnings'
 import {
@@ -40,13 +40,19 @@ const needsSwap = computed(() => {
   }
 })
 
+function getCashLimitedCollateralAssets() {
+  return getCashLimitedWithdrawAmount(
+    form.collateralAssets.value,
+    form.collateralVault.value && isEVKVault(form.collateralVault.value)
+      ? form.collateralVault.value.totalCash
+      : undefined,
+  )
+}
+
 const form = useCollateralForm({
   mode: 'withdraw',
   needsSwap,
-  effectiveBalance: computed(() => getCashLimitedWithdrawAmount(
-    form.collateralAssets.value,
-    form.collateralVault.value?.interestRateInfo.cash,
-  )),
+  effectiveBalance: computed(() => getCashLimitedCollateralAssets()),
   effectiveAsset: computed(() => form.asset.value),
 
   computePriceFixed: (_pos, borrowVault, collateralVault) => {
@@ -75,10 +81,7 @@ const form = useCollateralForm({
     if (userLtvFixed.gte(FixedPoint.fromValue(form.position.value.liquidationLTV, 2))) {
       throw new Error('Not enough liquidity for the vault, LTV is too large')
     }
-    if (getCashLimitedWithdrawAmount(
-      form.collateralAssets.value,
-      form.collateralVault.value?.interestRateInfo.cash,
-    ) < amountFixed.value) {
+    if (getCashLimitedCollateralAssets() < amountFixed.value) {
       throw new Error('Not enough liquidity in vault')
     }
   },
@@ -145,10 +148,7 @@ const form = useCollateralForm({
   },
 })
 useOperationGuard(computed(() => [form.collateralVault.value?.address, form.borrowVault.value?.address].filter(Boolean)))
-const withdrawableCollateralAssets = computed(() => getCashLimitedWithdrawAmount(
-  form.collateralAssets.value,
-  form.collateralVault.value?.interestRateInfo.cash,
-))
+const withdrawableCollateralAssets = computed(() => getCashLimitedCollateralAssets())
 
 const disabledReasonInfo = computed((): DisabledReasonInfo | undefined => {
   if (form.isGeoBlocked.value) return { message: 'This operation is not available in your region', variant: 'warning' }

--- a/tests/composables/useSavingsRepay.test.ts
+++ b/tests/composables/useSavingsRepay.test.ts
@@ -1,5 +1,5 @@
 import { computed, ref, watch, watchEffect } from 'vue'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Vault } from '~/entities/vault'
 import type { AccountBorrowPosition, AccountDepositPosition } from '~/entities/account'
 import { useSavingsRepay } from '~/composables/repay/useSavingsRepay'
@@ -147,6 +147,11 @@ describe('useSavingsRepay', () => {
       getSwapProviders: vi.fn(async () => []),
       getSwapQuotes: vi.fn(async () => []),
     }))
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
   })
 
   it('skips the cash cap for same-vault savings repay max amount', () => {

--- a/tests/composables/useSavingsRepay.test.ts
+++ b/tests/composables/useSavingsRepay.test.ts
@@ -1,0 +1,181 @@
+import { computed, ref, watch, watchEffect } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Vault } from '~/entities/vault'
+import type { AccountBorrowPosition, AccountDepositPosition } from '~/entities/account'
+import { useSavingsRepay } from '~/composables/repay/useSavingsRepay'
+
+const USER = '0x0000000000000000000000000000000000000001'
+const VAULT = '0x0000000000000000000000000000000000000002'
+const ASSET = '0x0000000000000000000000000000000000000003'
+
+const mocks = vi.hoisted(() => ({
+  getSavingsPosition: vi.fn(),
+  runSimulation: vi.fn(),
+}))
+
+vi.mock('@wagmi/vue', () => ({
+  useAccount: () => ({
+    isConnected: ref(true),
+    address: ref(USER),
+  }),
+}))
+
+vi.mock('#components', () => ({
+  OperationReviewModal: {},
+}))
+
+vi.mock('~/components/ui/composables/useModal', () => ({
+  useModal: () => ({
+    open: vi.fn(),
+    close: vi.fn(),
+  }),
+}))
+
+vi.mock('~/components/ui/composables/useToast', () => ({
+  useToast: () => ({
+    error: vi.fn(),
+  }),
+}))
+
+vi.mock('~/services/pricing/priceProvider', () => ({
+  getAssetUsdValue: vi.fn(async () => null),
+}))
+
+vi.mock('~/composables/repay/useRepaySwapDetails', () => ({
+  useRepaySwapDetails: () => ({
+    currentPrice: ref(null),
+    summary: ref([]),
+    priceImpact: ref(null),
+    leveragedPriceImpact: ref(null),
+    routedVia: ref(null),
+    routeEmptyMessage: ref(null),
+    routeItems: ref([]),
+  }),
+}))
+
+vi.mock('~/composables/repay/useRepayHealthMetrics', () => ({
+  useRepayHealthMetrics: () => ({
+    roeBefore: ref(null),
+    roeAfter: ref(null),
+    currentHealth: ref(null),
+    currentLtv: ref(null),
+    nextLtv: ref(null),
+    nextHealth: ref(null),
+    currentLiquidationPrice: ref(null),
+    nextLiquidationPrice: ref(null),
+  }),
+}))
+
+vi.mock('~/composables/useEulerLabels', () => ({
+  useEulerProductOfVault: () => computed(() => 'Euler Yield'),
+}))
+
+vi.mock('~/composables/useRepaySavingsOptions', () => ({
+  useRepaySavingsOptions: () => {
+    const savingsVaults = ref([sameVault])
+    const savingsPosition = {
+      vault: sameVault,
+      subAccount: USER,
+      assets: 1_000n,
+      shares: 1_000n,
+    } as AccountDepositPosition
+
+    mocks.getSavingsPosition.mockImplementation((vaultAddress: string) =>
+      vaultAddress.toLowerCase() === VAULT.toLowerCase() ? savingsPosition : undefined,
+    )
+
+    return {
+      savingsPositions: ref([savingsPosition]),
+      savingsVaults,
+      savingsOptions: ref([]),
+      getSavingsPosition: mocks.getSavingsPosition,
+    }
+  },
+}))
+
+const sameVault = {
+  address: VAULT,
+  totalCash: 100n,
+  decimals: 0n,
+  asset: {
+    address: ASSET,
+    symbol: 'USDe',
+    decimals: 0n,
+  },
+  collateralLTVs: [],
+} as unknown as Vault
+
+const position = {
+  borrow: sameVault,
+  collateral: sameVault,
+  subAccount: USER,
+  borrowed: 2_000n,
+  supplied: 0n,
+  collaterals: [],
+  health: 0n,
+  userLTV: 0n,
+  price: 0n,
+  borrowLTV: 0n,
+  liquidationLTV: 0n,
+  liabilityValueBorrowing: 0n,
+  liabilityValueLiquidation: 0n,
+  timeToLiquidation: 0n,
+  collateralValueLiquidation: 0n,
+} as AccountBorrowPosition
+
+describe('useSavingsRepay', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubGlobal('ref', ref)
+    vi.stubGlobal('computed', computed)
+    vi.stubGlobal('watch', watch)
+    vi.stubGlobal('watchEffect', watchEffect)
+    vi.stubGlobal('useDebounceFn', (fn: unknown) => fn)
+    vi.stubGlobal('useRouter', () => ({ replace: vi.fn() }))
+    vi.stubGlobal('usePriceInvert', () => ({ autoInvert: vi.fn() }))
+    vi.stubGlobal('useEulerOperations', () => ({
+      buildSwapPlan: vi.fn(),
+      buildSavingsRepayPlan: vi.fn(),
+      buildSavingsFullRepayPlan: vi.fn(),
+      buildSwapFullRepayPlan: vi.fn(),
+      executeTxPlan: vi.fn(),
+    }))
+    vi.stubGlobal('useEulerAccount', () => ({ refreshAllPositions: vi.fn() }))
+    vi.stubGlobal('useEulerAddresses', () => ({ eulerLensAddresses: ref({}) }))
+    vi.stubGlobal('useVaultRegistry', () => ({ getVault: vi.fn() }))
+    vi.stubGlobal('useSwapApi', () => ({
+      getSwapProviders: vi.fn(async () => []),
+      getSwapQuotes: vi.fn(async () => []),
+    }))
+  })
+
+  it('skips the cash cap for same-vault savings repay max amount', () => {
+    const repay = useSavingsRepay({
+      position: ref(position),
+      borrowVault: computed(() => sameVault),
+      collateralVault: computed(() => sameVault),
+      formTab: ref('savings'),
+      plan: ref(null),
+      isSubmitting: ref(false),
+      isPreparing: ref(false),
+      slippage: ref(0.5),
+      oraclePriceRatio: computed(() => 1),
+      clearSimulationError: vi.fn(),
+      runSimulation: mocks.runSimulation,
+      getCurrentDebt: () => position.borrowed,
+      collateralSupplyApy: computed(() => 0),
+      borrowApy: computed(() => 0),
+    })
+
+    repay.initVault()
+
+    expect(repay.sourceVault.value?.address).toBe(VAULT)
+    expect(repay.sourceBalance.value).toBe(1_000n)
+
+    repay.onSourceMax()
+
+    expect(repay.amount.value).toBe('1000')
+    expect(repay.isSubmitDisabled.value).toBe(false)
+    expect(repay.disabledReason.value).toBeUndefined()
+  })
+})

--- a/tests/composables/useSavingsRepay.test.ts
+++ b/tests/composables/useSavingsRepay.test.ts
@@ -4,14 +4,32 @@ import type { Vault } from '~/entities/vault'
 import type { AccountBorrowPosition, AccountDepositPosition } from '~/entities/account'
 import { useSavingsRepay } from '~/composables/repay/useSavingsRepay'
 
-const USER = '0x0000000000000000000000000000000000000001'
-const VAULT = '0x0000000000000000000000000000000000000002'
-const ASSET = '0x0000000000000000000000000000000000000003'
+const { USER, VAULT, sameVault, mocks } = vi.hoisted(() => {
+  const USER = '0x0000000000000000000000000000000000000001'
+  const VAULT = '0x0000000000000000000000000000000000000002'
+  const ASSET = '0x0000000000000000000000000000000000000003'
+  const sameVault = {
+    address: VAULT,
+    totalCash: 100n,
+    decimals: 0n,
+    asset: {
+      address: ASSET,
+      symbol: 'USDe',
+      decimals: 0n,
+    },
+    collateralLTVs: [],
+  } as unknown as Vault
 
-const mocks = vi.hoisted(() => ({
-  getSavingsPosition: vi.fn(),
-  runSimulation: vi.fn(),
-}))
+  return {
+    USER,
+    VAULT,
+    sameVault,
+    mocks: {
+      getSavingsPosition: vi.fn(),
+      runSimulation: vi.fn(),
+    },
+  }
+})
 
 vi.mock('@wagmi/vue', () => ({
   useAccount: () => ({
@@ -92,18 +110,6 @@ vi.mock('~/composables/useRepaySavingsOptions', () => ({
     }
   },
 }))
-
-const sameVault = {
-  address: VAULT,
-  totalCash: 100n,
-  decimals: 0n,
-  asset: {
-    address: ASSET,
-    symbol: 'USDe',
-    decimals: 0n,
-  },
-  collateralLTVs: [],
-} as unknown as Vault
 
 const position = {
   borrow: sameVault,

--- a/tests/entities/vault/utils.test.ts
+++ b/tests/entities/vault/utils.test.ts
@@ -7,7 +7,7 @@ import {
   getBorrowVaultsByMap,
   isCyclicalNoteVault,
 } from '~/entities/vault/utils'
-import type { Vault, SecuritizeVault } from '~/entities/vault/types'
+import type { Vault, SecuritizeVault, EarnVault } from '~/entities/vault/types'
 
 describe('getUtilization', () => {
   it('returns 0 when totalAssets is zero', () => {
@@ -64,23 +64,39 @@ describe('getVaultUtilization', () => {
 })
 
 describe('getCashLimitedWithdrawAmount', () => {
-  it('returns the user withdrawable amount when cash is higher', () => {
-    expect(getCashLimitedWithdrawAmount(1_000n, 2_000n)).toBe(1_000n)
+  const evkVault = (totalCash: bigint) => ({ totalCash } as Vault)
+  const securitizeVault = (totalAssets: bigint) =>
+    ({ type: 'securitize', totalAssets } as unknown as SecuritizeVault)
+  const earnVault = (availableAssets: bigint) =>
+    ({ type: 'earn', availableAssets } as unknown as EarnVault)
+
+  it('returns the user withdrawable amount when EVK cash is higher', () => {
+    expect(getCashLimitedWithdrawAmount(1_000n, evkVault(2_000n))).toBe(1_000n)
   })
 
-  it('caps the amount to vault cash when cash is lower', () => {
-    expect(getCashLimitedWithdrawAmount(2_000n, 1_000n)).toBe(1_000n)
+  it('caps the amount to EVK totalCash when cash is lower', () => {
+    expect(getCashLimitedWithdrawAmount(2_000n, evkVault(1_000n))).toBe(1_000n)
   })
 
-  it('keeps existing behavior when vault cash is unavailable', () => {
-    expect(getCashLimitedWithdrawAmount(2_000n)).toBe(2_000n)
+  it('returns the user amount when the vault is undefined', () => {
+    expect(getCashLimitedWithdrawAmount(2_000n, undefined)).toBe(2_000n)
+  })
+
+  it('caps SecuritizeVault by totalAssets (no borrowing on these vaults)', () => {
+    expect(getCashLimitedWithdrawAmount(2_000n, securitizeVault(1_000n))).toBe(1_000n)
+    expect(getCashLimitedWithdrawAmount(500n, securitizeVault(1_000n))).toBe(500n)
+  })
+
+  it('caps EarnVault by availableAssets (strategies may have allocated cash out)', () => {
+    expect(getCashLimitedWithdrawAmount(2_000n, earnVault(1_000n))).toBe(1_000n)
+    expect(getCashLimitedWithdrawAmount(500n, earnVault(1_000n))).toBe(500n)
   })
 
   it('models the withdraw form cap when vault cash is lower than user balance', () => {
     const assetsBalance = 1_000n
-    const vaultCash = 300n
+    const vault = evkVault(300n)
     const amount = 301n
-    const withdrawableAssets = getCashLimitedWithdrawAmount(assetsBalance, vaultCash)
+    const withdrawableAssets = getCashLimitedWithdrawAmount(assetsBalance, vault)
 
     expect(withdrawableAssets).toBe(300n)
     expect(assetsBalance < amount).toBe(false)
@@ -89,9 +105,9 @@ describe('getCashLimitedWithdrawAmount', () => {
 
   it('models the withdraw form allowing the cash-capped max amount', () => {
     const assetsBalance = 1_000n
-    const vaultCash = 300n
+    const vault = evkVault(300n)
     const amount = 300n
-    const withdrawableAssets = getCashLimitedWithdrawAmount(assetsBalance, vaultCash)
+    const withdrawableAssets = getCashLimitedWithdrawAmount(assetsBalance, vault)
 
     expect(withdrawableAssets).toBe(amount)
     expect(withdrawableAssets < amount).toBe(false)

--- a/tests/entities/vault/utils.test.ts
+++ b/tests/entities/vault/utils.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from 'vitest'
 import { INTEREST_RATE_MODEL_TYPE } from '~/entities/constants'
-import { getUtilization, getVaultUtilization, getBorrowVaultsByMap, isCyclicalNoteVault } from '~/entities/vault/utils'
+import {
+  getCashLimitedWithdrawAmount,
+  getUtilization,
+  getVaultUtilization,
+  getBorrowVaultsByMap,
+  isCyclicalNoteVault,
+} from '~/entities/vault/utils'
 import type { Vault, SecuritizeVault } from '~/entities/vault/types'
 
 describe('getUtilization', () => {
@@ -54,6 +60,45 @@ describe('getVaultUtilization', () => {
   it('returns 0 for vault with no borrows', () => {
     const vault = { totalAssets: 1000n, borrow: 0n } as Vault
     expect(getVaultUtilization(vault)).toBe(0)
+  })
+})
+
+describe('getCashLimitedWithdrawAmount', () => {
+  it('returns the user withdrawable amount when cash is higher', () => {
+    expect(getCashLimitedWithdrawAmount(1_000n, 2_000n)).toBe(1_000n)
+  })
+
+  it('caps the amount to vault cash when cash is lower', () => {
+    expect(getCashLimitedWithdrawAmount(2_000n, 1_000n)).toBe(1_000n)
+  })
+
+  it('keeps existing behavior when vault cash is unavailable', () => {
+    expect(getCashLimitedWithdrawAmount(2_000n)).toBe(2_000n)
+  })
+
+  it('treats negative cash as zero', () => {
+    expect(getCashLimitedWithdrawAmount(2_000n, -1n)).toBe(0n)
+  })
+
+  it('models the withdraw form cap when vault cash is lower than user balance', () => {
+    const assetsBalance = 1_000n
+    const vaultCash = 300n
+    const amount = 301n
+    const withdrawableAssets = getCashLimitedWithdrawAmount(assetsBalance, vaultCash)
+
+    expect(withdrawableAssets).toBe(300n)
+    expect(assetsBalance < amount).toBe(false)
+    expect(withdrawableAssets < amount).toBe(true)
+  })
+
+  it('models the withdraw form allowing the cash-capped max amount', () => {
+    const assetsBalance = 1_000n
+    const vaultCash = 300n
+    const amount = 300n
+    const withdrawableAssets = getCashLimitedWithdrawAmount(assetsBalance, vaultCash)
+
+    expect(withdrawableAssets).toBe(amount)
+    expect(withdrawableAssets < amount).toBe(false)
   })
 })
 

--- a/tests/entities/vault/utils.test.ts
+++ b/tests/entities/vault/utils.test.ts
@@ -76,10 +76,6 @@ describe('getCashLimitedWithdrawAmount', () => {
     expect(getCashLimitedWithdrawAmount(2_000n)).toBe(2_000n)
   })
 
-  it('treats negative cash as zero', () => {
-    expect(getCashLimitedWithdrawAmount(2_000n, -1n)).toBe(0n)
-  })
-
   it('models the withdraw form cap when vault cash is lower than user balance', () => {
     const assetsBalance = 1_000n
     const vaultCash = 300n


### PR DESCRIPTION
## Summary
- Keep user-facing max and available amounts aligned with actual vault cash for flows that withdraw from a vault.
- Prevent users from selecting an amount their balance covers but the vault cannot currently pay out.
- Extend the same cash-liquidity check to related repay, savings swap, earn withdraw, and multiply/deleverage paths.

## Changes
- Added `getCashLimitedWithdrawAmount` and use it where withdrawable assets need to be capped by vault liquidity.
- Use `totalCash` for EVK vault cash checks and `availableAssets` for Earn vault withdraw availability.
- Preserve distinct validation messages for user balance insufficiency versus vault liquidity insufficiency.
- Cap repay source maxes for collateral and savings repay while keeping same-vault savings repay out of the cash-withdraw path.
- Keep full repay source checks interest-adjusted so close flows do not pass with only the current debt snapshot.
- Check multiply/deleverage borrow liquidity against `totalCash` instead of total supply.

## Test plan
- [x] `npm run test:run`
- [x] `npm run test:run -- tests/entities/vault/utils.test.ts`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `git diff --check`
- [x] Deep review with subagents against the final local diff and review notes

### Automated / local smoke
- [x] Local built-server smoke with spy-mode account `0x000001ac4e512d670c34fedf6c71ce2f49fb160b`
  - [x] Portfolio loaded pseudo-connected state with borrow positions, savings, and rewards
  - [x] Position repay route rendered wallet/collateral/savings repay tabs
  - [x] Position multiply route rendered and used the updated borrow-liquidity surface
  - [x] Position withdraw route rendered; clicking Max filled `0.01` and surfaced `Not enough liquidity in your position`
  - [x] Lend savings withdraw route rendered cash-capped Max and Available for withdraw
  - [x] Lend savings swap route rendered cash-capped source balance
  - [x] Portfolio savings route rendered direct lending position and withdraw/asset-swap links
  - [x] Repay from savings tab rendered savings source Max and debt Max
  - [x] Earn index and Earn withdraw route rendered with Available for withdraw/Max surfaces

### Manual smoke: limited-liquidity EVK vault
- Preview: `https://production-master-branch-euler-lite-pr-354.up.railway.app`
- Development baseline: `https://euler-development-production.up.railway.app`
- Vault: `0xd001f0a15d272542687b2677ba627f48a4333b5d`
- Spy account: `0xdd82875f0840aad58a455a70b88eed9f59cec7c7`
- User supplied balance verified onchain / Etherscan as about `29,235,016.345947628017078978 eUSD0-4`, converting to about `30.45M USD0`

#### Lend withdraw
- [x] PR route: `/lend/0xd001f0a15d272542687b2677ba627f48a4333b5d/0/withdraw?network=1&spy=0xdd82875f0840aad58a455a70b88eed9f59cec7c7`
- [x] PR preview Max / Available capped to about `12,048,535.628423387546922428 USD0`
- [x] PR preview input `13000000` showed `Not enough liquidity in vault`
- [x] PR preview input `12000000` was allowed
- [x] Development baseline Max showed old uncapped balance `30,453,338.771240963848806123 USD0`
- [x] Development baseline input `13000000` showed `Not enough liquidity in vault`
- [x] Development baseline input `12000000` was allowed

#### Lend savings swap
- [x] PR route: `/lend/0xd001f0a15d272542687b2677ba627f48a4333b5d/0/swap?network=1&spy=0xdd82875f0840aad58a455a70b88eed9f59cec7c7`
- [x] PR preview Max showed `12048535.628423387546922428`
- [x] PR preview input `13000000` showed `Not enough liquidity in vault`
- [x] PR preview input `30000000` showed `Not enough liquidity in vault`
- [x] Development baseline did not show a liquidity failure for `13000000` or `30000000`, confirming the old uncapped swap behavior

### Manual smoke: Earn withdraw
- Earn vault: `0x3cd3718f8f047aA32F775E2cb4245A164E1C99fB`
- Spy account: `0x514272d916419eb3048d8eadebbdff1b116273cd`
- Route: `/earn/0x3cd3718f8f047aA32F775E2cb4245A164E1C99fB/0/withdraw?network=1&spy=0x514272d916419eb3048d8eadebbdff1b116273cd`
- [x] Max showed `1360.53299`
- [x] Input `2000` showed `Not enough liquidity in vault`
- [x] Input `1000` was allowed
- Note: an earlier attempted Earn URL with EVK vault `0xd001...b5d` correctly failed to load because the Earn lens reverts for non-Earn vaults; that route was discarded as an invalid fixture.

### Manual smoke: position flows
- Position account: `0x000001ac4e512d670c34fedf6c71ce2f49fb160b`
- [x] Position withdraw route `/position/1/withdraw?network=1&spy=0x000001ac4e512d670c34fedf6c71ce2f49fb160b`
  - Max/input `0.01` surfaced `Not enough liquidity in your position`
- [x] Position multiply route `/position/1/multiply?network=1&spy=0x000001ac4e512d670c34fedf6c71ce2f49fb160b`
  - Rendered `Additional collateral` and `Debt`
  - Quotes fetched successfully
  - No visible error state
- [x] Position repay route `/position/1/repay?network=1&spy=0x000001ac4e512d670c34fedf6c71ce2f49fb160b`
  - From wallet / From collateral / From savings tabs rendered
  - Repay from savings/collateral could not validate the liquidity-cap path because this fixture returned `No quotes found` / `Unable to fetch swap quote. Swapping is not available for this asset.`
  - Treated as inconclusive for liquidity-cap behavior, not a PR failure

## Follow-up
- Created Linear TODO [EUL4-196](https://linear.app/euler-labs/issue/EUL4-196/skip-swap-quotes-when-balance-validation-fails) to avoid unnecessary swap quote calls when balance/liquidity validation already fails.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Withdrawal, repayment, swap and multiply flows now respect vault cash/liquidity limits, capping available amounts shown to users.
  * Input max/balance fields and USD displays reflect the cash-limited available amount.
  * Validation and submit gating updated to show “Not enough liquidity in vault” when vault liquidity is insufficient.

* **Tests**
  * Added tests covering liquidity-capping behavior and related validation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->