### PR TITLE
Fix rewards placeholder typography

### DIFF
--- a/pages/portfolio/rewards.vue
+++ b/pages/portfolio/rewards.vue
@@ -174,17 +174,19 @@ const sortedBrevisRewards = computed(() => {
         </div>
         <div
           v-else-if="locks.length === 0"
-          class="flex flex-col flex-1 min-h-[100px] justify-center items-center py-32 text-neutral-500 gap-8"
+          class="flex flex-1 min-h-[100px] justify-center items-center"
         >
-          <div class="flex w-48 h-48 justify-center items-center rounded-12 bg-neutral-100">
-            <SvgIcon name="search" />
+          <div class="flex flex-col gap-8 items-center text-neutral-500 py-32">
+            <div class="flex w-48 h-48 justify-center items-center rounded-12 bg-neutral-100">
+              <SvgIcon name="search" />
+            </div>
+            <template v-if="isConnected || isSpyMode">
+              You don't have locks yet
+            </template>
+            <template v-else>
+              Connect your wallet to see your locks
+            </template>
           </div>
-          <template v-if="isConnected || isSpyMode">
-            You don't have locks yet
-          </template>
-          <template v-else>
-            Connect your wallet to see your locks
-          </template>
         </div>
         <div
           v-else

--- a/pages/portfolio/rewards.vue
+++ b/pages/portfolio/rewards.vue
@@ -50,9 +50,9 @@ const sortedBrevisRewards = computed(() => {
           </div>
           <div
             v-else-if="rewards.length === 0"
-            class="flex flex-1 min-h-[100px] justify-center items-center py-32"
+            class="flex flex-1 min-h-[100px] justify-center items-center"
           >
-            <div class="flex flex-col gap-8 items-center text-neutral-500 text-p2">
+            <div class="flex flex-col gap-8 items-center text-neutral-500 py-32">
               <div class="flex w-48 h-48 justify-center items-center rounded-12 bg-neutral-100">
                 <SvgIcon name="search" />
               </div>
@@ -91,9 +91,9 @@ const sortedBrevisRewards = computed(() => {
           </div>
           <div
             v-else-if="brevisRewards.length === 0"
-            class="flex flex-1 min-h-[100px] justify-center items-center py-32"
+            class="flex flex-1 min-h-[100px] justify-center items-center"
           >
-            <div class="flex flex-col gap-8 items-center text-neutral-500 text-p2">
+            <div class="flex flex-col gap-8 items-center text-neutral-500 py-32">
               <div class="flex w-48 h-48 justify-center items-center rounded-12 bg-neutral-100">
                 <SvgIcon name="search" />
               </div>
@@ -132,9 +132,9 @@ const sortedBrevisRewards = computed(() => {
           </div>
           <div
             v-else-if="!hasUnclaimedFuul"
-            class="flex flex-1 min-h-[100px] justify-center items-center py-32"
+            class="flex flex-1 min-h-[100px] justify-center items-center"
           >
-            <div class="flex flex-col gap-8 items-center text-neutral-500 text-p2">
+            <div class="flex flex-col gap-8 items-center text-neutral-500 py-32">
               <div class="flex w-48 h-48 justify-center items-center rounded-12 bg-neutral-100">
                 <SvgIcon name="search" />
               </div>
@@ -174,7 +174,7 @@ const sortedBrevisRewards = computed(() => {
         </div>
         <div
           v-else-if="locks.length === 0"
-          class="flex flex-col flex-1 min-h-[100px] justify-center items-center py-32 text-neutral-500 gap-8 text-p2"
+          class="flex flex-col flex-1 min-h-[100px] justify-center items-center py-32 text-neutral-500 gap-8"
         >
           <div class="flex w-48 h-48 justify-center items-center rounded-12 bg-neutral-100">
             <SvgIcon name="search" />


### PR DESCRIPTION
## Summary
- Align Rewards portfolio empty-state text with the placeholder typography used by Positions and Savings.
- Preserve the existing card spacing while removing the extra smaller text style from Rewards placeholders.

## Changes
- Removed `text-p2` from Merkl, Incentra, Fuul, and rEUL empty states on the Rewards tab.
- Kept vertical padding on the inner empty-state content so the placeholder remains centered consistently.

## Test plan
- [x] `git diff --check`
- [x] Pre-commit hook ran `eslint --fix` through lint-staged
- [x] Smoke test the Portfolio Positions, Savings, and Rewards empty states in the browser


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated empty-state UI for reward sections (Merkl, Incentra, Fuul, EUL): refined vertical spacing and typography for clearer, more consistent presentation and improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->