### PR TITLE
Refine modal entrance animation

### DIFF
--- a/assets/styles/transitions.scss
+++ b/assets/styles/transitions.scss
@@ -46,25 +46,58 @@
   transition: color 0.2s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-// Modal - slide up with spring easing
-.modal-enter-active {
-  transition: transform 0.4s cubic-bezier(0.34, 1.56, 0.64, 1),
-              opacity 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+// Modal layer - calm backdrop fade
+.modal-layer-enter-active {
+  transition: opacity 0.18s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-.modal-leave-active {
-  transition: transform 0.25s cubic-bezier(0.4, 0, 1, 1),
-              opacity 0.2s cubic-bezier(0.4, 0, 1, 1);
+.modal-layer-leave-active {
+  transition: opacity 0.14s cubic-bezier(0.4, 0, 1, 1);
 }
 
-.modal-enter-from {
-  transform: translateY(100%);
-  opacity: 0.5;
-}
-
-.modal-leave-to {
-  transform: translateY(100%);
+.modal-layer-enter-from,
+.modal-layer-leave-to {
   opacity: 0;
+}
+
+// Modal panel - straight bottom-up entrance without overshoot
+.modal-panel-enter-active,
+.modal-panel-leave-active {
+  transition: opacity 0.18s cubic-bezier(0.4, 0, 0.2, 1);
+
+  .ui-modal__panel-motion {
+    transition: transform 0.32s cubic-bezier(0.16, 1, 0.3, 1),
+                opacity 0.22s cubic-bezier(0.4, 0, 0.2, 1);
+  }
+}
+
+.modal-panel-leave-active {
+  transition-duration: 0.14s;
+
+  .ui-modal__panel-motion {
+    transition-duration: 0.16s, 0.14s;
+    transition-timing-function: cubic-bezier(0.4, 0, 1, 1),
+                                cubic-bezier(0.4, 0, 1, 1);
+  }
+}
+
+.modal-panel-enter-from,
+.modal-panel-leave-to {
+  opacity: 0;
+
+  .ui-modal__panel-motion {
+    transform: translateY(88px);
+    opacity: 0;
+  }
+}
+
+@media (max-width: 900px) {
+  .modal-panel-enter-from,
+  .modal-panel-leave-to {
+    .ui-modal__panel-motion {
+      transform: translateY(100%);
+    }
+  }
 }
 
 // Layout transitions

--- a/components/ui/UiModal.vue
+++ b/components/ui/UiModal.vue
@@ -63,7 +63,7 @@ onBeforeUnmount(() => {
     :style="styles"
   >
     <Transition
-      name="modal"
+      name="modal-panel"
       mode="out-in"
       appear
       @after-leave="beforeComponentLeave"
@@ -73,13 +73,18 @@ onBeforeUnmount(() => {
         class="ui-modal__wrapper"
         @click.self="onClickWrapper"
       >
-        <component
-          :is="component"
-          v-bind="data.props"
-          :modal-id="id"
-          @prevent-close="handlePreventClose"
-          @close="close"
-        />
+        <div
+          class="ui-modal__panel-motion"
+          @click.self="onClickWrapper"
+        >
+          <component
+            :is="component"
+            v-bind="data.props"
+            :modal-id="id"
+            @prevent-close="handlePreventClose"
+            @close="close"
+          />
+        </div>
       </div>
     </Transition>
   </div>
@@ -103,6 +108,12 @@ onBeforeUnmount(() => {
     height: 100%;
     position: relative;
     margin: 0 auto;
+  }
+
+  &__panel-motion {
+    position: relative;
+    width: 100%;
+    height: 100%;
   }
 }
 </style>

--- a/components/ui/UiModals.vue
+++ b/components/ui/UiModals.vue
@@ -9,7 +9,7 @@ const { list } = useModal()
     v-if="list.length"
     class="ui-modals"
   >
-    <transition-group name="modal">
+    <transition-group name="modal-layer">
       <UiModal
         v-for="modal in list"
         v-show="modal"


### PR DESCRIPTION
## Summary
- Replace the springy modal popup with a calmer bottom-up entrance that feels more deliberate.
- Separate the backdrop fade from the panel motion so the overlay no longer slides with the modal content.

## Changes
- Rename the outer modal transition to `modal-layer` for a simple backdrop opacity fade.
- Rename the inner transition to `modal-panel` and add a dedicated motion wrapper so the modal's own centering transform is preserved.
- Use a straight vertical slide from below on desktop, with the existing full bottom-sheet rise retained on mobile.
- Keep outside-click dismissal working through the new motion wrapper.

## Test plan
- [x] Run `npm run lint`
- [x] Run `git diff --check`
- [x] Manually open a modal on desktop and confirm it slides up from the bottom without corner drift or overshoot
- [x] Manually open a modal on mobile width and confirm the bottom-sheet entrance still feels correct


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Modal animations have been refined with separate, more targeted transition effects for the backdrop and modal panel, delivering smoother visual feedback
  * Optimized animation responsiveness across devices, with viewport-specific adjustments for smaller screens

<!-- end of auto-generated comment: release notes by coderabbit.ai -->