### PR TITLE
Show collateral supply APY on borrow pairs

### DIFF
--- a/components/entities/vault/VaultBorrowItem.vue
+++ b/components/entities/vault/VaultBorrowItem.vue
@@ -11,7 +11,7 @@ import { isVaultFeatured, isVaultKeyring, getEntitiesByVault } from '~/utils/eul
 import { getEulerLabelEntityLogo } from '~/entities/euler/labels'
 import { isAnyVaultBlockedByCountry, isVaultRestrictedByCountry } from '~/composables/useGeoBlock'
 import { useModal } from '~/components/ui/composables/useModal'
-import { VaultBorrowApyModal, VaultMaxRoeModal, VaultNetApyPairModal } from '#components'
+import { VaultBorrowApyModal, VaultMaxRoeModal, VaultNetApyPairModal, VaultSupplyApyModal } from '#components'
 
 const { pair } = defineProps<{ pair: AnyBorrowVaultPair }>()
 const { enableEntityBranding } = useDeployConfig()
@@ -186,6 +186,22 @@ const onBorrowInfoIconClick = (event: MouseEvent) => {
   })
 }
 
+const onSupplyInfoIconClick = (event: MouseEvent) => {
+  event.preventDefault()
+  event.stopPropagation()
+  const baseSupply = 'interestRateInfo' in pair.collateral
+    ? nanoToValue(pair.collateral.interestRateInfo.supplyAPY, 25)
+    : 0
+  modal.open(VaultSupplyApyModal, {
+    props: {
+      lendingAPY: baseSupply,
+      intrinsicAPY: getIntrinsicApy(pair.collateral.asset.address),
+      intrinsicApyInfo: getIntrinsicApyInfo(pair.collateral.asset.address),
+      campaigns: getSupplyRewardCampaigns(pair.collateral.address),
+    },
+  })
+}
+
 const onNetApyInfoIconClick = (event: MouseEvent) => {
   event.preventDefault()
   event.stopPropagation()
@@ -238,15 +254,15 @@ const linkPath = computed(() => ({
     :to="linkPath"
     class="grid gap-x-16 mobile:block no-underline text-content-primary bg-surface rounded-12 border border-line-default shadow-card hover:shadow-card-hover hover:border-line-emphasis transition-all"
     :class="[
-      enableEntityBranding ? '' : 'grid-cols-5',
+      enableEntityBranding ? '' : 'grid-cols-6',
       (isGeoBlocked || isPairEffectivelyBlocked) ? 'opacity-50' : '',
     ]"
-    :style="enableEntityBranding ? { gridTemplateColumns: 'repeat(6, 1fr)' } : undefined"
+    :style="enableEntityBranding ? { gridTemplateColumns: 'repeat(7, 1fr)' } : undefined"
   >
     <!-- Header: contents on desktop (children become grid items), flex on mobile -->
     <div class="contents mobile:!flex mobile:py-16 mobile:px-16 mobile:pb-12 mobile:border-b mobile:border-line-subtle">
       <div
-        :class="enableEntityBranding ? 'col-span-4' : 'col-span-3'"
+        :class="enableEntityBranding ? 'col-span-5' : 'col-span-4'"
         class="flex pl-16 py-16 pb-12 mobile:!p-0 mobile:flex-1 mobile:min-w-0 mobile:items-center"
       >
         <AssetAvatar
@@ -410,6 +426,25 @@ const linkPath = computed(() => ({
           {{ liquidityDisplay }}
         </div>
       </div>
+      <div class="py-12 pb-12 text-center mobile:!hidden">
+        <div class="text-content-tertiary text-p3 mb-4 flex items-center justify-center gap-4">
+          Supply APY
+          <SvgIcon
+            class="!w-16 !h-16 shrink-0 text-content-muted hover:text-content-secondary transition-colors cursor-pointer"
+            name="info-circle"
+            @click="onSupplyInfoIconClick"
+          />
+        </div>
+        <div class="text-p2 text-content-primary flex items-center justify-center">
+          <SvgIcon
+            v-if="hasSupplyRewards(pair.collateral.address)"
+            class="!w-20 !h-20 text-accent-500 mr-4 cursor-pointer"
+            name="sparks"
+            @click="onSupplyInfoIconClick"
+          />
+          {{ formatNumber(supplyApyWithRewards, 2, 2) }}%
+        </div>
+      </div>
       <div class="py-12 pb-12 text-center mobile:!p-0">
         <div class="text-content-tertiary text-p3 mb-4 flex items-center justify-center gap-4">
           Net APY
@@ -503,6 +538,29 @@ const linkPath = computed(() => ({
         <div class="flex gap-8 justify-end items-center text-right flex-1">
           <div class="text-p2 text-content-primary">
             {{ compactNumber(maxLTV, 2, 2) }}%
+          </div>
+        </div>
+      </div>
+      <div class="flex w-full justify-between">
+        <div class="flex-1">
+          <div class="text-content-tertiary text-p3 flex items-center gap-4">
+            Supply APY
+            <SvgIcon
+              class="!w-16 !h-16 shrink-0 text-content-muted hover:text-content-secondary transition-colors cursor-pointer"
+              name="info-circle"
+              @click="onSupplyInfoIconClick"
+            />
+          </div>
+        </div>
+        <div class="flex gap-8 justify-end items-center text-right flex-1">
+          <SvgIcon
+            v-if="hasSupplyRewards(pair.collateral.address)"
+            class="!w-20 !h-20 text-accent-500 cursor-pointer"
+            name="sparks"
+            @click="onSupplyInfoIconClick"
+          />
+          <div class="text-p2 text-content-primary">
+            {{ formatNumber(supplyApyWithRewards, 2, 2) }}%
           </div>
         </div>
       </div>

--- a/components/entities/vault/overview/VaultOverviewPairBlockGeneral.vue
+++ b/components/entities/vault/overview/VaultOverviewPairBlockGeneral.vue
@@ -9,7 +9,7 @@ import { getMaxMultiplier, getMaxRoe } from '~/utils/leverage'
 import type { AccountBorrowPosition } from '~/entities/account'
 import type { LTVRampConfig } from '~/entities/vault/ltv'
 import { useModal } from '~/components/ui/composables/useModal'
-import { VaultNetApyPairModal, VaultMaxRoeModal, VaultRampDownModal } from '#components'
+import { VaultNetApyPairModal, VaultMaxRoeModal, VaultRampDownModal, VaultSupplyApyModal, VaultBorrowApyModal } from '#components'
 
 const { pair } = defineProps<{ pair: AnyBorrowVaultPair | AccountBorrowPosition }>()
 
@@ -22,7 +22,7 @@ const isRamping = computed(() =>
 )
 
 const modal = useModal()
-const { withIntrinsicBorrowApy, withIntrinsicSupplyApy, getIntrinsicApy } = useIntrinsicApy()
+const { withIntrinsicBorrowApy, withIntrinsicSupplyApy, getIntrinsicApy, getIntrinsicApyInfo } = useIntrinsicApy()
 const { getSupplyRewardApy, getBorrowRewardApy, getLoopingRewardApy, getSupplyRewardCampaigns, getBorrowRewardCampaigns, getLoopingRewardCampaigns, hasSupplyRewards, hasBorrowRewards, hasLoopingRewards } = useRewardsApy()
 const { borrowList } = useVaults()
 
@@ -77,6 +77,28 @@ const price = computed(() => {
 
   return nanoToValue(collateralPrice.amountOutMid, 18) / nanoToValue(borrowPrice.amountOutMid, 18)
 })
+
+const onSupplyInfoIconClick = () => {
+  modal.open(VaultSupplyApyModal, {
+    props: {
+      lendingAPY: baseSupplyApy.value,
+      intrinsicAPY: intrinsicSupplyApy.value,
+      intrinsicApyInfo: getIntrinsicApyInfo(pair.collateral.asset.address),
+      campaigns: supplyCampaignsForModal.value,
+    },
+  })
+}
+
+const onBorrowInfoIconClick = () => {
+  modal.open(VaultBorrowApyModal, {
+    props: {
+      borrowingAPY: baseBorrowApy.value,
+      intrinsicAPY: intrinsicBorrowApy.value,
+      intrinsicApyInfo: getIntrinsicApyInfo(pair.borrow.asset.address),
+      campaigns: borrowCampaignsForModal.value,
+    },
+  })
+}
 
 const onNetApyInfoIconClick = () => {
   modal.open(VaultNetApyPairModal, {
@@ -182,6 +204,48 @@ const onRampDownInfoIconClick = (event: MouseEvent, pair: LTVRampConfig) => {
           label="Max multiplier"
           :value="`${formatNumber(maxMultiplier, 2, 2)}x`"
         />
+        <VaultOverviewLabelValue>
+          <template #label>
+            <span class="flex items-center gap-4">
+              Supply APY
+              <SvgIcon
+                class="!w-20 !h-20 text-content-muted cursor-pointer hover:text-content-secondary"
+                name="info-circle"
+                @click="onSupplyInfoIconClick"
+              />
+            </span>
+          </template>
+          <span class="flex items-center gap-4">
+            <SvgIcon
+              v-if="hasSupplyRewards(pair.collateral.address)"
+              class="!w-20 !h-20 text-accent-500 cursor-pointer"
+              name="sparks"
+              @click="onSupplyInfoIconClick"
+            />
+            {{ formatNumber(supplyApyWithRewards) }}%
+          </span>
+        </VaultOverviewLabelValue>
+        <VaultOverviewLabelValue>
+          <template #label>
+            <span class="flex items-center gap-4">
+              Borrow APY
+              <SvgIcon
+                class="!w-20 !h-20 text-content-muted cursor-pointer hover:text-content-secondary"
+                name="info-circle"
+                @click="onBorrowInfoIconClick"
+              />
+            </span>
+          </template>
+          <span class="flex items-center gap-4">
+            <SvgIcon
+              v-if="hasBorrowRewards(pair.borrow.address, pair.collateral.address)"
+              class="!w-20 !h-20 text-accent-500 cursor-pointer"
+              name="sparks"
+              @click="onBorrowInfoIconClick"
+            />
+            {{ formatNumber(borrowApyWithRewards) }}%
+          </span>
+        </VaultOverviewLabelValue>
         <VaultOverviewLabelValue>
           <template #label>
             <span class="flex items-center gap-4">

--- a/pages/borrow/index.vue
+++ b/pages/borrow/index.vue
@@ -171,6 +171,15 @@ const getPairBorrowApy = (pair: AnyBorrowVaultPair): number => {
   return borrowApy - borrowRewards
 }
 
+const getPairSupplyApy = (pair: AnyBorrowVaultPair): number => {
+  const baseSupplyApy = 'interestRateInfo' in pair.collateral
+    ? nanoToValue(pair.collateral.interestRateInfo.supplyAPY, 25)
+    : 0
+  const supplyApy = withIntrinsicSupplyApy(baseSupplyApy, pair.collateral.asset.address)
+  const supplyRewards = getSupplyRewardApy(pair.collateral.address)
+  return supplyApy + supplyRewards
+}
+
 const getPairMaxLtv = (pair: AnyBorrowVaultPair): number => {
   return nanoToValue(pair.borrowLTV, 2)
 }
@@ -190,6 +199,7 @@ const {
   [
     { key: 'liquidity', label: 'Available liquidity', shortLabel: 'Avail. liquidity', unit: 'usd' },
     { key: 'totalBorrowed', label: 'Total borrowed', shortLabel: 'Total borrowed', unit: 'usd' },
+    { key: 'supplyApy', label: 'Supply APY', shortLabel: 'Supply APY', unit: 'percent' },
     { key: 'borrowApy', label: 'Borrow APY', shortLabel: 'Borrow APY', unit: 'percent' },
     { key: 'netApy', label: 'Net APY', shortLabel: 'Net APY', unit: 'percent' },
     { key: 'maxRoe', label: 'Max ROE', shortLabel: 'Max ROE', unit: 'percent' },
@@ -202,6 +212,7 @@ const {
     switch (metric) {
       case 'liquidity': return pairLiquidityUsd.value.get(key) ?? 0
       case 'totalBorrowed': return pairBorrowedUsd.value.get(key) ?? 0
+      case 'supplyApy': return getPairSupplyApy(pair)
       case 'borrowApy': return getPairBorrowApy(pair)
       case 'netApy': return 'borrowLTV' in pair ? getNetApy(pair as BorrowVaultPair) : 0
       case 'maxRoe': return 'borrowLTV' in pair ? getSortMaxRoe(pair as BorrowVaultPair) : 0
@@ -357,6 +368,11 @@ const sortedBorrowList = computed(() => {
         return Number(a.borrow.interestRateInfo.borrowAPY) - Number(b.borrow.interestRateInfo.borrowAPY)
       }))
       break
+    case 'Supply APY':
+      sorted = applyFeaturedPairSort([...filteredBorrowList.value].sort((a: AnyBorrowVaultPair, b: AnyBorrowVaultPair) => {
+        return getPairSupplyApy(b) - getPairSupplyApy(a)
+      }))
+      break
     case 'Utilization':
       sorted = applyFeaturedPairSort([...filteredBorrowList.value].sort((a: AnyBorrowVaultPair, b: AnyBorrowVaultPair) => {
         return getVaultUtilization(b.borrow) - getVaultUtilization(a.borrow)
@@ -414,6 +430,7 @@ const sortedBorrowList = computed(() => {
             { label: 'Liquidity', icon: 'wallet' },
             { label: 'Total Borrowed', icon: 'borrow-outline' },
             { label: 'Utilization', icon: 'pulse' },
+            { label: 'Supply APY', icon: 'percent' },
             { label: 'Borrow APY', icon: 'percent' },
             { label: 'Net APY', icon: 'percent' },
             { label: 'Max ROE', icon: 'percent' },


### PR DESCRIPTION
## Summary
- Make borrow pair rows show the collateral Supply APY so users can compare collateral yield alongside borrow terms.
- Add Supply APY as a sortable/filterable borrow table metric.
- Balance the pair details overview by showing Supply APY and Borrow APY alongside the existing risk metrics.

## Changes
- Computes collateral Supply APY from base supply APY, intrinsic APY, and supply rewards.
- Reuses the existing Supply APY and Borrow APY modals from row and overview info icons.
- Expands desktop borrow row metric columns while keeping mobile values in expanded details.

## Test plan
- [x] npm run lint
- [x] npm run typecheck
- [x] npm run build
- [x] Production-build smoke: /borrow?network=1 returned 200 and hydrated with Supply APY, Borrow APY, and Net APY visible.
- [x] Production-build smoke: borrow pair detail route loaded and surfaced Supply APY in the Pair details overview tab.
- [x] Targeted browser smoke: Supply APY sorting state rendered the borrow table with Supply APY selected.
- [x] Targeted browser smoke: Supply APY custom filter could be added and applied, showing the expected empty state for an extreme threshold.
- [x] Targeted browser smoke: 390px mobile viewport had no horizontal overflow and still surfaced Supply APY.
- [x] Manual check: mobile sorting was exercised and looked OK.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Display Supply APY metrics on vault pages with detailed breakdown information modals
* Supply APY now available as a sortable and filterable metric on the Borrow/Multiply page
* Enhanced UI to highlight supply reward information across key metrics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->