### PR TITLE
Stats matrix: APY accuracy, external/escrow rows, no unknown flash

### DIFF
--- a/components/entities/vault/discovery/DiscoveryMarketAccordion.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketAccordion.vue
@@ -14,6 +14,7 @@ import {
   isMatrixCompatibleVault,
   formatCapDisplay,
   isAttributeMatrixView,
+  buildVaultApyCache,
   MATRIX_VIEW_OPTIONS,
   type CollateralMatrixData,
   type DotMetric,
@@ -21,6 +22,7 @@ import {
   type AttributeMatrixData,
   type MatrixViewId,
   type VaultUsdCacheEntry,
+  type VaultApyCacheEntry,
 } from '~/utils/discoveryCalculations'
 
 const props = defineProps<{
@@ -177,6 +179,25 @@ const attributeMatrixMap = computed((): Map<string, AttributeMatrixData> => {
     result.set(market.id, getAttributeMatrix(market, matrixView.value))
   }
   return result
+})
+
+// Stats matrix needs the same APY users see on per-vault cards (base IRM rate
+// folded with intrinsic + supply/borrow rewards). The composables fetch this
+// data asynchronously and bump `version` when it lands; the explicit reads
+// here re-trigger the computed so the cells refresh in place.
+const { withIntrinsicSupplyApy, withIntrinsicBorrowApy, version: intrinsicVersion } = useIntrinsicApy()
+const { getSupplyRewardApy, getBorrowRewardApy, version: rewardsVersion } = useRewardsApy()
+
+const vaultApyCache = computed<Map<string, VaultApyCacheEntry>>(() => {
+  void intrinsicVersion.value
+  void rewardsVersion.value
+  return buildVaultApyCache(
+    props.markets,
+    withIntrinsicSupplyApy,
+    withIntrinsicBorrowApy,
+    getSupplyRewardApy,
+    getBorrowRewardApy,
+  )
 })
 
 // -- Cell selection state (matrix view) --
@@ -536,6 +557,7 @@ onMounted(() => {
               v-else-if="attributeMatrixMap.get(market.id)"
               :data="attributeMatrixMap.get(market.id)!"
               :usd-cache="vaultUsdCache"
+              :apy-cache="vaultApyCache"
               :selected-header="selectedMatrixHeader?.marketId === market.id ? { address: selectedMatrixHeader.address, axis: selectedMatrixHeader.axis } : null"
               @select-header="(addr: string, axis: 'row' | 'column') => toggleMatrixHeader(market.id, addr, axis)"
             />

--- a/components/entities/vault/discovery/DiscoveryMarketAttributeMatrix.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketAttributeMatrix.vue
@@ -26,6 +26,7 @@ defineEmits<{
 }>()
 
 const modal = useModal()
+const { isVaultGovernorVerified } = useVaults()
 
 // Each AttributeRow renders as a *table column*; each vault renders as a *table row*.
 interface AttributeColumn {
@@ -97,8 +98,10 @@ const isAttributeColumnHighlighted = (attributeId: string): boolean =>
                   && selectedHeader?.axis === 'row'
                   ? 'text-accent-500 !bg-accent-500/10'
                   : isVaultRowHighlighted(vault.address)
-                    ? 'text-content-primary !bg-white/[0.06]'
-                    : 'text-content-primary hover:bg-white/[0.04]'
+                    ? (vault.isExternal ? 'text-content-tertiary !bg-white/[0.06]' : 'text-content-primary !bg-white/[0.06]')
+                    : (vault.isExternal
+                      ? 'text-content-tertiary hover:bg-white/[0.04]'
+                      : 'text-content-primary hover:bg-white/[0.04]')
               "
               @click.stop="$emit('selectHeader', vault.address, 'row')"
             >
@@ -135,9 +138,19 @@ const isAttributeColumnHighlighted = (attributeId: string): boolean =>
                 </div>
               </template>
 
-              <!-- governor: entity logos + names, or unknown chip -->
+              <!-- governor: same precedence as VaultOverviewBlockGeneral —
+                   unverified governor wins ("Unknown"), then entities, else
+                   "—". Escrow vaults pass `isVaultGovernorVerified` and have
+                   no labeled entities, so they fall through to "—". -->
               <template v-else-if="col.cells[vaultIdx].kind === 'governor'">
-                <template v-if="entitiesFor(vault).length">
+                <template v-if="!isVaultGovernorVerified(vault.vault)">
+                  <VaultTypeChip
+                    :vault="vault.vault"
+                    type="unknown"
+                    class="inline-flex !py-2 !px-6 !text-p5"
+                  />
+                </template>
+                <template v-else-if="entitiesFor(vault).length">
                   <div class="inline-flex items-center justify-center gap-6 flex-wrap">
                     <div
                       v-for="(entity, idx) in entitiesFor(vault)"
@@ -154,11 +167,7 @@ const isAttributeColumnHighlighted = (attributeId: string): boolean =>
                   </div>
                 </template>
                 <template v-else>
-                  <VaultTypeChip
-                    :vault="vault.vault"
-                    type="unknown"
-                    class="inline-flex !py-2 !px-6 !text-p5"
-                  />
+                  <span class="text-p5 text-content-secondary whitespace-nowrap">—</span>
                 </template>
               </template>
 

--- a/components/entities/vault/discovery/DiscoveryMarketAttributeMatrix.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketAttributeMatrix.vue
@@ -5,6 +5,7 @@ import {
   type AttributeMatrixColumn,
   type AttributeRow,
   type VaultUsdCacheEntry,
+  type VaultApyCacheEntry,
   buildAttributeRowCells,
   getAttributeRowColor,
   isVaultType,
@@ -17,6 +18,7 @@ import { VaultHooksInfoModal } from '#components'
 const props = defineProps<{
   data: AttributeMatrixData
   usdCache: Map<string, VaultUsdCacheEntry>
+  apyCache: Map<string, VaultApyCacheEntry>
   selectedHeader: { address: string, axis: 'row' | 'column' } | null
 }>()
 
@@ -38,7 +40,7 @@ interface AttributeColumn {
 
 const attributeColumns = computed<AttributeColumn[]>(() =>
   props.data.rows.map((attribute) => {
-    const cells = buildAttributeRowCells(attribute, props.data.columns, props.usdCache)
+    const cells = buildAttributeRowCells(attribute, props.data.columns, props.usdCache, props.apyCache)
     let min = Infinity
     let max = -Infinity
     for (const c of cells) {

--- a/components/entities/vault/discovery/DiscoveryMarketAttributeMatrix.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketAttributeMatrix.vue
@@ -7,7 +7,6 @@ import {
   type VaultUsdCacheEntry,
   type VaultApyCacheEntry,
   buildAttributeRowCells,
-  getAttributeRowColor,
   isVaultType,
 } from '~/utils/discoveryCalculations'
 import { getEntitiesByVault } from '~/utils/eulerLabelsUtils'
@@ -29,35 +28,17 @@ defineEmits<{
 const modal = useModal()
 
 // Each AttributeRow renders as a *table column*; each vault renders as a *table row*.
-// We pre-compute one entry per attribute with the per-attribute cells (one per vault)
-// and the min/max range needed for the heatmap.
 interface AttributeColumn {
   attribute: AttributeRow
   cells: AttributeCell[] // index aligned to data.columns (vaults)
-  min: number
-  max: number
 }
 
 const attributeColumns = computed<AttributeColumn[]>(() =>
-  props.data.rows.map((attribute) => {
-    const cells = buildAttributeRowCells(attribute, props.data.columns, props.usdCache, props.apyCache)
-    let min = Infinity
-    let max = -Infinity
-    for (const c of cells) {
-      if (c.numeric === undefined || !Number.isFinite(c.numeric)) continue
-      if (c.numeric < min) min = c.numeric
-      if (c.numeric > max) max = c.numeric
-    }
-    if (!Number.isFinite(min)) {
-      min = 0
-      max = 0
-    }
-    return { attribute, cells, min, max }
-  }),
+  props.data.rows.map(attribute => ({
+    attribute,
+    cells: buildAttributeRowCells(attribute, props.data.columns, props.usdCache, props.apyCache),
+  })),
 )
-
-const cellBgColor = (column: AttributeColumn, cell: AttributeCell): string =>
-  getAttributeRowColor(cell.numeric, column.min, column.max, column.attribute.direction)
 
 const onHooksClick = (vault: AttributeMatrixColumn) => {
   if (!isVaultType(vault.vault)) return
@@ -135,7 +116,6 @@ const isAttributeColumnHighlighted = (attributeId: string): boolean =>
               :key="col.attribute.id"
               class="text-center py-6 px-8 min-w-[80px] transition-colors border-b border-r border-white/[0.04]"
               :class="(isVaultRowHighlighted(vault.address) || isAttributeColumnHighlighted(col.attribute.id)) ? '!bg-white/[0.06]' : ''"
-              :style="{ backgroundColor: cellBgColor(col, col.cells[vaultIdx]) }"
               @mouseenter="hoveredCell = { vaultAddr: vault.address, attributeId: col.attribute.id }"
               @mouseleave="hoveredCell = null"
             >

--- a/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
@@ -493,8 +493,8 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
                   && selectedHeader?.axis === 'row'
                   ? 'text-accent-500 !bg-accent-500/10'
                   : isRowHighlighted(row.address)
-                    ? (row.category === 'external' ? 'text-content-tertiary !bg-white/[0.06]' : 'text-content-primary !bg-white/[0.06]')
-                    : (row.category === 'external'
+                    ? (row.category !== 'borrowable' ? 'text-content-tertiary !bg-white/[0.06]' : 'text-content-primary !bg-white/[0.06]')
+                    : (row.category !== 'borrowable'
                       ? 'text-content-tertiary hover:bg-white/[0.04]'
                       : 'text-content-primary hover:bg-white/[0.04]')
               "

--- a/composables/useMarketGroups.ts
+++ b/composables/useMarketGroups.ts
@@ -525,10 +525,12 @@ export const useMarketGroups = () => {
       metrics: computeMetricsSync(memberVaults),
     }
 
-    // Labels are guaranteed loaded here: the early return at the top of this
-    // function reads from `products[productKey]`, which is only populated
-    // after labels load. Pass `true` directly so the invariant is explicit.
-    const [augmented] = augmentWithCollateralGraph([group], [...registryVaults.value, ...memberVaults], isVaultGovernorVerified, true)
+    // The direct market page waits for labels and the unresolved-collateral
+    // sweep before calling this path. Keep the readiness value explicit here
+    // so unknown-collateral classification is still suppressed if this helper
+    // is ever called earlier from another route.
+    const ready = labelsReady.value && isCollateralResolved.value
+    const [augmented] = augmentWithCollateralGraph([group], [...registryVaults.value, ...memberVaults], isVaultGovernorVerified, ready)
 
     try {
       return await resolveGroupTVL(augmented)

--- a/composables/useMarketGroups.ts
+++ b/composables/useMarketGroups.ts
@@ -110,6 +110,7 @@ const augmentWithCollateralGraph = (
   groups: MarketGroup[],
   allVaults: AnyVault[],
   isVaultGovernorVerified: (vault: Vault | SecuritizeVault) => boolean,
+  labelsReady: boolean,
 ): MarketGroup[] => {
   const vaultMap = new Map<string, AnyVault>()
   for (const vault of allVaults) {
@@ -141,7 +142,9 @@ const augmentWithCollateralGraph = (
           // of any declared product entity is the curator wiring in a vault
           // they don't actually run — surface it in the market graph too so
           // the gap is visible from discovery, not just inside one pair card.
-          if (hasGovernorAdmin(externalVault) && !isVaultGovernorVerified(externalVault) && !seenUnknown.has(normalized)) {
+          // Suppress until labels are ready: before then every external would
+          // briefly appear unknown because verifiedVaultAddresses is empty.
+          if (labelsReady && hasGovernorAdmin(externalVault) && !isVaultGovernorVerified(externalVault) && !seenUnknown.has(normalized)) {
             seenUnknown.add(normalized)
             unknownCollateral.push(normalized)
           }
@@ -154,7 +157,10 @@ const augmentWithCollateralGraph = (
           // triggers a lazy fetch). Only flag as unknown when no label
           // recognises the address either; otherwise silently drop it so the
           // graph doesn't churn between "unknown placeholder" and "deprecated
-          // external" as the registry fills in.
+          // external" as the registry fills in. Equally, suppress entirely
+          // until labels are ready — otherwise everything looks unrecognised
+          // for the first second of page load.
+          if (!labelsReady) continue
           const knownByLabels = isVaultDeprecated(colAddr) || getProductKeyByVault(colAddr) !== undefined
           if (knownByLabels) continue
           if (!seenUnknown.has(normalized)) {
@@ -358,7 +364,7 @@ const resolveGroupTVL = async (group: MarketGroup): Promise<MarketGroup> => {
 
 export const useMarketGroups = () => {
   const { getAll } = useVaultRegistry()
-  const { products, entities } = useEulerLabels()
+  const { products, entities, isReady: labelsReady } = useEulerLabels()
   const { isVaultGovernorVerified } = useVaults()
   const showAllLabelEntries = useShowAllLabelEntries()
 
@@ -383,13 +389,16 @@ export const useMarketGroups = () => {
 
     // Step 2: Augment with collateral graph — pass the full registry so active
     // LTVs targeting non-explorable vaults still resolve as externalCollateral
-    // instead of triggering a missing-collateral warning.
+    // instead of triggering a missing-collateral warning. labelsReady gates
+    // the unknown-collateral classification so we don't briefly show every
+    // collateral as "Unknown" while the labels payload is still in flight.
     const lookupVaults = registryVaults.value
-    const augmented = augmentWithCollateralGraph(productGroups, lookupVaults, isVaultGovernorVerified)
+    const ready = labelsReady.value
+    const augmented = augmentWithCollateralGraph(productGroups, lookupVaults, isVaultGovernorVerified, ready)
 
     // Step 3: Orphan clustering
     const orphanGroups = clusterOrphans(vaults, assignedAddresses)
-    const augmentedOrphans = augmentWithCollateralGraph(orphanGroups, lookupVaults, isVaultGovernorVerified)
+    const augmentedOrphans = augmentWithCollateralGraph(orphanGroups, lookupVaults, isVaultGovernorVerified, ready)
 
     return [...augmented, ...augmentedOrphans]
   })
@@ -511,8 +520,10 @@ export const useMarketGroups = () => {
       metrics: computeMetricsSync(memberVaults),
     }
 
-    // Augment with collateral graph using registry vaults + fetched vaults
-    const [augmented] = augmentWithCollateralGraph([group], [...registryVaults.value, ...memberVaults], isVaultGovernorVerified)
+    // Augment with collateral graph using registry vaults + fetched vaults.
+    // This path runs after labels are loaded (the on-demand fetch is gated on
+    // a known product key), so the unknown classification is reliable here.
+    const [augmented] = augmentWithCollateralGraph([group], [...registryVaults.value, ...memberVaults], isVaultGovernorVerified, labelsReady.value)
 
     try {
       return await resolveGroupTVL(augmented)

--- a/composables/useMarketGroups.ts
+++ b/composables/useMarketGroups.ts
@@ -110,7 +110,7 @@ const augmentWithCollateralGraph = (
   groups: MarketGroup[],
   allVaults: AnyVault[],
   isVaultGovernorVerified: (vault: Vault | SecuritizeVault) => boolean,
-  labelsReady: boolean,
+  dataReady: boolean,
 ): MarketGroup[] => {
   const vaultMap = new Map<string, AnyVault>()
   for (const vault of allVaults) {
@@ -142,9 +142,10 @@ const augmentWithCollateralGraph = (
           // of any declared product entity is the curator wiring in a vault
           // they don't actually run — surface it in the market graph too so
           // the gap is visible from discovery, not just inside one pair card.
-          // Suppress until labels are ready: before then every external would
-          // briefly appear unknown because verifiedVaultAddresses is empty.
-          if (labelsReady && hasGovernorAdmin(externalVault) && !isVaultGovernorVerified(externalVault) && !seenUnknown.has(normalized)) {
+          // Suppress until labels and the vault registry are both ready —
+          // otherwise verifiedVaultAddresses is empty / partial and every
+          // external briefly looks unknown.
+          if (dataReady && hasGovernorAdmin(externalVault) && !isVaultGovernorVerified(externalVault) && !seenUnknown.has(normalized)) {
             seenUnknown.add(normalized)
             unknownCollateral.push(normalized)
           }
@@ -158,9 +159,10 @@ const augmentWithCollateralGraph = (
           // recognises the address either; otherwise silently drop it so the
           // graph doesn't churn between "unknown placeholder" and "deprecated
           // external" as the registry fills in. Equally, suppress entirely
-          // until labels are ready — otherwise everything looks unrecognised
-          // for the first second of page load.
-          if (!labelsReady) continue
+          // until labels + registry are ready — otherwise truly known-by-
+          // label vaults that just haven't been hydrated yet briefly render
+          // as `0x...` placeholders for the first second of page load.
+          if (!dataReady) continue
           const knownByLabels = isVaultDeprecated(colAddr) || getProductKeyByVault(colAddr) !== undefined
           if (knownByLabels) continue
           if (!seenUnknown.has(normalized)) {
@@ -365,7 +367,7 @@ const resolveGroupTVL = async (group: MarketGroup): Promise<MarketGroup> => {
 export const useMarketGroups = () => {
   const { getAll } = useVaultRegistry()
   const { products, entities, isReady: labelsReady } = useEulerLabels()
-  const { isVaultGovernorVerified } = useVaults()
+  const { isVaultGovernorVerified, isReady: vaultsReady } = useVaults()
   const showAllLabelEntries = useShowAllLabelEntries()
 
   /** Every loaded vault, including non-explorable ones (used for collateral lookups) */
@@ -389,11 +391,12 @@ export const useMarketGroups = () => {
 
     // Step 2: Augment with collateral graph — pass the full registry so active
     // LTVs targeting non-explorable vaults still resolve as externalCollateral
-    // instead of triggering a missing-collateral warning. labelsReady gates
-    // the unknown-collateral classification so we don't briefly show every
-    // collateral as "Unknown" while the labels payload is still in flight.
+    // instead of triggering a missing-collateral warning. dataReady gates the
+    // unknown-collateral classification on both labels (verifiedVaultAddresses
+    // and the product index) AND the vault registry (so already-known but not-
+    // yet-hydrated collaterals don't briefly render as `0x...` placeholders).
     const lookupVaults = registryVaults.value
-    const ready = labelsReady.value
+    const ready = labelsReady.value && vaultsReady.value
     const augmented = augmentWithCollateralGraph(productGroups, lookupVaults, isVaultGovernorVerified, ready)
 
     // Step 3: Orphan clustering
@@ -520,10 +523,10 @@ export const useMarketGroups = () => {
       metrics: computeMetricsSync(memberVaults),
     }
 
-    // Augment with collateral graph using registry vaults + fetched vaults.
-    // This path runs after labels are loaded (the on-demand fetch is gated on
-    // a known product key), so the unknown classification is reliable here.
-    const [augmented] = augmentWithCollateralGraph([group], [...registryVaults.value, ...memberVaults], isVaultGovernorVerified, labelsReady.value)
+    // Labels are guaranteed loaded here: the early return at the top of this
+    // function reads from `products[productKey]`, which is only populated
+    // after labels load. Pass `true` directly so the invariant is explicit.
+    const [augmented] = augmentWithCollateralGraph([group], [...registryVaults.value, ...memberVaults], isVaultGovernorVerified, true)
 
     try {
       return await resolveGroupTVL(augmented)

--- a/composables/useMarketGroups.ts
+++ b/composables/useMarketGroups.ts
@@ -367,7 +367,7 @@ const resolveGroupTVL = async (group: MarketGroup): Promise<MarketGroup> => {
 export const useMarketGroups = () => {
   const { getAll } = useVaultRegistry()
   const { products, entities, isReady: labelsReady } = useEulerLabels()
-  const { isVaultGovernorVerified, isReady: vaultsReady } = useVaults()
+  const { isVaultGovernorVerified, isCollateralResolved } = useVaults()
   const showAllLabelEntries = useShowAllLabelEntries()
 
   /** Every loaded vault, including non-explorable ones (used for collateral lookups) */
@@ -392,11 +392,13 @@ export const useMarketGroups = () => {
     // Step 2: Augment with collateral graph — pass the full registry so active
     // LTVs targeting non-explorable vaults still resolve as externalCollateral
     // instead of triggering a missing-collateral warning. dataReady gates the
-    // unknown-collateral classification on both labels (verifiedVaultAddresses
-    // and the product index) AND the vault registry (so already-known but not-
-    // yet-hydrated collaterals don't briefly render as `0x...` placeholders).
+    // unknown-collateral classification on labels AND the unresolved-collateral
+    // sweep so lazy collateral references that just haven't been fetched yet
+    // don't briefly render as `0x...` placeholders. isReady on its own flips
+    // after the server snapshot lands — too early, since the snapshot doesn't
+    // include lazy collateral references.
     const lookupVaults = registryVaults.value
-    const ready = labelsReady.value && vaultsReady.value
+    const ready = labelsReady.value && isCollateralResolved.value
     const augmented = augmentWithCollateralGraph(productGroups, lookupVaults, isVaultGovernorVerified, ready)
 
     // Step 3: Orphan clustering

--- a/composables/useVaults.ts
+++ b/composables/useVaults.ts
@@ -38,6 +38,13 @@ const isEscrowLoading = ref(false)
 const isEscrowUpdating = ref(false)
 const isEscrowLoadedOnce = ref(false)
 
+// True once the bulk loaders AND the unresolved-collateral sweep have settled.
+// Distinct from `isReady`, which flips as soon as the server snapshot lands —
+// the snapshot doesn't include lazy collateral references, so consumers that
+// classify "unknown collateral" need this stricter signal to avoid the brief
+// post-hydration flash where unfetched collaterals look unrecognised.
+const isCollateralResolved = ref(false)
+
 // Generation counter to invalidate stale in-flight operations after chain switch.
 // Incremented in resetVaultsState(); any async operation capturing an older generation
 // must stop registering vaults.
@@ -117,6 +124,7 @@ const resetVaultsState = () => {
   loadGeneration.value++
   borrowPairCache.clear()
   isReady.value = false
+  isCollateralResolved.value = false
   isEVKLoading.value = true
   isEVKUpdating.value = true
   isEarnLoading.value = true
@@ -584,6 +592,11 @@ const loadVaults = async () => {
 
     if (loadGeneration.value !== generation) return
 
+    // Bulk loaders + unresolved-collateral sweep are complete. Consumers
+    // gating "unknown collateral" classification can now run without
+    // misclassifying not-yet-hydrated lazy collateral references.
+    isCollateralResolved.value = true
+
     // Clear flags AFTER all needed escrow vaults are loaded.
     // Silent mode skips EVK/Earn flags (already false from hydration) but
     // still clears escrow + securitize which were never touched during
@@ -970,6 +983,7 @@ export const useVaults = () => {
   return {
     // State
     isReady,
+    isCollateralResolved,
     loadedChainId,
     isEVKLoading,
     isEVKUpdating,

--- a/composables/useVaults.ts
+++ b/composables/useVaults.ts
@@ -618,6 +618,10 @@ const loadVaults = async () => {
   catch (e) {
     logWarn('useVaults/loadVaults', e)
     if (loadGeneration.value === generation) {
+      // A failed load means no collateral-resolution task is still in flight.
+      // Unblock consumers so direct market pages can render their fallback
+      // state instead of waiting forever on a failed sweep.
+      isCollateralResolved.value = true
       isEVKLoading.value = false
       isEVKUpdating.value = false
       isEarnLoading.value = false
@@ -734,13 +738,23 @@ const refreshVaults = async () => {
 
   isCollateralResolved.value = false
 
-  await updateEVKVaults(getEvkVaults().map(v => v.address), gen, true)
-  if (loadGeneration.value !== gen) return
+  try {
+    await updateEVKVaults(getEvkVaults().map(v => v.address), gen, true)
+    if (loadGeneration.value !== gen) return
 
-  await resolveUnresolvedCollaterals(gen)
-  if (loadGeneration.value !== gen) return
+    await resolveUnresolvedCollaterals(gen)
+    if (loadGeneration.value !== gen) return
+  }
+  catch (e) {
+    logWarn('useVaults/refreshVaults', e)
+  }
+  finally {
+    if (loadGeneration.value === gen) {
+      isCollateralResolved.value = true
+    }
+  }
 
-  isCollateralResolved.value = true
+  if (loadGeneration.value !== gen) return
 
   await updateEarnVaults(getEarnVaults().map(v => v.address), gen, true)
   if (loadGeneration.value !== gen) return

--- a/composables/useVaults.ts
+++ b/composables/useVaults.ts
@@ -340,6 +340,16 @@ const fetchUnresolvedCollaterals = async (addresses: string[], generation: numbe
   ])
 }
 
+const resolveUnresolvedCollaterals = async (generation: number): Promise<void> => {
+  const { getEvkVaults, has: registryHas } = useVaultRegistry()
+  const unresolvedAddresses = extractUnresolvedCollateralAddresses(
+    getEvkVaults(),
+    registryHas,
+  ).filter(addr => showAllLabelEntries.value || !isVaultNotExplorable(addr))
+
+  await fetchUnresolvedCollaterals(unresolvedAddresses, generation)
+}
+
 const updateSecuritizeVaults = async (securitizeAddresses: string[], generation: number, silent = false) => {
   const { setMany: registrySetMany } = useVaultRegistry()
 
@@ -583,12 +593,7 @@ const loadVaults = async () => {
     // member vaults, so a resolved off-label vault is a leaf in those views;
     // any second-hop unknowns will surface as diagnostic warns and resolve
     // on the next loadVaults cycle.
-    const { getEvkVaults, has: registryHas } = useVaultRegistry()
-    const unresolvedAddresses = extractUnresolvedCollateralAddresses(
-      getEvkVaults(),
-      registryHas,
-    ).filter(addr => showAllLabelEntries.value || !isVaultNotExplorable(addr))
-    await fetchUnresolvedCollaterals(unresolvedAddresses, generation)
+    await resolveUnresolvedCollaterals(generation)
 
     if (loadGeneration.value !== generation) return
 
@@ -727,8 +732,15 @@ const refreshVaults = async () => {
   const { getEvkVaults, getEarnVaults, getSecuritizeVaults } = useVaultRegistry()
   const gen = loadGeneration.value
 
+  isCollateralResolved.value = false
+
   await updateEVKVaults(getEvkVaults().map(v => v.address), gen, true)
   if (loadGeneration.value !== gen) return
+
+  await resolveUnresolvedCollaterals(gen)
+  if (loadGeneration.value !== gen) return
+
+  isCollateralResolved.value = true
 
   await updateEarnVaults(getEarnVaults().map(v => v.address), gen, true)
   if (loadGeneration.value !== gen) return

--- a/pages/explore/[market].vue
+++ b/pages/explore/[market].vue
@@ -10,12 +10,14 @@ const route = useRoute()
 const marketKey = computed(() => route.params.market as string)
 
 const { marketGroups, isResolvingTVL, fetchMarketGroupOnDemand } = useMarketGroups()
-const { isEVKUpdating, isEarnUpdating, isSecuritizeUpdating, isEscrowUpdating } = useVaults()
+const { isEVKUpdating, isEarnUpdating, isSecuritizeUpdating, isEscrowUpdating, isCollateralResolved } = useVaults()
 
 const isVaultsLoading = computed(() =>
   isEVKUpdating.value || isEarnUpdating.value || isSecuritizeUpdating.value || isEscrowUpdating.value
   || isResolvingTVL.value,
 )
+
+const isOnDemandBlocked = computed(() => isVaultsLoading.value || !isCollateralResolved.value)
 
 // Regular market from pre-loaded groups
 const indexedMarket = computed(() =>
@@ -28,7 +30,7 @@ const isLoadingOnDemand = ref(false)
 let onDemandRunId = 0
 
 watch(
-  [indexedMarket, isVaultsLoading, marketKey],
+  [indexedMarket, isOnDemandBlocked, marketKey],
   async ([found, loading, key]) => {
     // If the market appeared in regular groups, clear on-demand data
     if (found) {
@@ -36,7 +38,7 @@ watch(
       return
     }
 
-    // Skip while vaults are still loading, or no key — keep stale data visible
+    // Skip while vault/collateral data is still loading, or no key — keep stale data visible
     if (loading || !key) return
 
     // Skip if already loaded for this key
@@ -60,7 +62,9 @@ watch(
 )
 
 const market = computed(() => indexedMarket.value || onDemandMarket.value)
-const isLoading = computed(() => isVaultsLoading.value || isLoadingOnDemand.value)
+const isLoading = computed(() =>
+  isVaultsLoading.value || isLoadingOnDemand.value || (!market.value && !isCollateralResolved.value),
+)
 </script>
 
 <template>

--- a/tests/utils/discovery-calculations.test.ts
+++ b/tests/utils/discovery-calculations.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   STATS_ROWS,
   buildAttributeRowCells,
+  buildVaultApyCache,
   getActiveExternalCollateral,
   getAttributeRowColor,
   getCollateralMatrix,
   isNodeRampingDown,
+  type VaultApyCacheEntry,
   type VaultUsdCacheEntry,
 } from '~/utils/discoveryCalculations'
 import type { MarketGroup } from '~/entities/lend-discovery'
@@ -192,5 +194,61 @@ describe('attribute stats matrix', () => {
   it('colors higher-better rows green at the high end and lower-better rows red at the high end', () => {
     expect(getAttributeRowColor(100, 0, 100, 'higher-better')).toContain('hsla(145')
     expect(getAttributeRowColor(100, 0, 100, 'lower-better')).toContain('hsla(0')
+  })
+
+  it('uses the apy cache (intrinsic + rewards) for supply/borrow APY when supplied', () => {
+    const vault = {
+      ...makeVault('0xApy', []),
+      supply: 0n,
+      borrow: 0n,
+      totalAssets: 0n,
+      supplyCap: 1000n,
+      borrowCap: 1000n,
+      interestRateInfo: {
+        // Raw IRM rate the matrix would have shown before this fix.
+        supplyAPY: 0n,
+        borrowAPY: 0n,
+      },
+    } as Vault
+    const columns = [{ address: vault.address.toLowerCase(), symbol: 'TST', assetAddress: vault.asset.address, vault }]
+    const usdCache = new Map<string, VaultUsdCacheEntry>()
+    const apyCache = new Map<string, VaultApyCacheEntry>([
+      [vault.address.toLowerCase(), { supplyApy: 5.31, borrowApy: 1.25 }],
+    ])
+    const byRow = new Map(STATS_ROWS.map(row => [
+      row.id,
+      buildAttributeRowCells(row, columns, usdCache, apyCache)[0],
+    ]))
+
+    expect(byRow.get('supplyApy')!.numeric).toBeCloseTo(5.31)
+    expect(byRow.get('supplyApy')!.display).toBe('5.31%')
+    expect(byRow.get('borrowApy')!.numeric).toBeCloseTo(1.25)
+    expect(byRow.get('borrowApy')!.display).toBe('1.25%')
+  })
+})
+
+describe('buildVaultApyCache', () => {
+  it('folds intrinsic and reward APY into the per-vault entries', () => {
+    const vault = {
+      ...makeVault('0xPT', []),
+      interestRateInfo: {
+        supplyAPY: 4n * 10n ** 25n,
+        borrowAPY: 6n * 10n ** 25n,
+      },
+    } as Vault
+    const market = makeMarket([vault])
+
+    const cache = buildVaultApyCache(
+      [market],
+      (apy, _addr) => apy + 1, // intrinsic supply contribution: +1
+      (apy, _addr) => apy + 2, // intrinsic borrow contribution: +2
+      _addr => 0.5, // supply rewards
+      _addr => 0.25, // general borrow rewards
+    )
+
+    const entry = cache.get(vault.address.toLowerCase())
+    expect(entry).toBeDefined()
+    expect(entry!.supplyApy).toBeCloseTo(4 + 1 + 0.5)
+    expect(entry!.borrowApy).toBeCloseTo(6 + 2 - 0.25)
   })
 })

--- a/tests/utils/discovery-calculations.test.ts
+++ b/tests/utils/discovery-calculations.test.ts
@@ -4,7 +4,6 @@ import {
   buildAttributeRowCells,
   buildVaultApyCache,
   getActiveExternalCollateral,
-  getAttributeRowColor,
   getCollateralMatrix,
   isNodeRampingDown,
   type VaultApyCacheEntry,
@@ -170,30 +169,17 @@ describe('attribute stats matrix', () => {
     const usdCache = new Map([[vault.address.toLowerCase(), usd]])
     const byRow = new Map(STATS_ROWS.map(row => [
       row.id,
-      { row, cell: buildAttributeRowCells(row, columns, usdCache)[0] },
+      buildAttributeRowCells(row, columns, usdCache)[0],
     ]))
 
-    expect(byRow.get('totalSupply')!.row.direction).toBe('higher-better')
-    expect(byRow.get('totalSupply')!.cell.numeric).toBe(1000)
-    expect(byRow.get('totalBorrow')!.row.direction).toBe('lower-better')
-    expect(byRow.get('totalBorrow')!.cell.numeric).toBe(500)
-    expect(byRow.get('liquidity')!.row.direction).toBe('higher-better')
-    expect(byRow.get('liquidity')!.cell.numeric).toBe(500)
-    expect(byRow.get('utilization')!.row.direction).toBe('lower-better')
-    expect(byRow.get('utilization')!.cell.numeric).toBe(50)
-    expect(byRow.get('supplyCapUsage')!.row.direction).toBe('lower-better')
-    expect(byRow.get('supplyCapUsage')!.cell.numeric).toBe(40)
-    expect(byRow.get('borrowCapUsage')!.row.direction).toBe('lower-better')
-    expect(byRow.get('borrowCapUsage')!.cell.numeric).toBe(50)
-    expect(byRow.get('supplyApy')!.row.direction).toBe('higher-better')
-    expect(byRow.get('supplyApy')!.cell.numeric).toBe(5)
-    expect(byRow.get('borrowApy')!.row.direction).toBe('lower-better')
-    expect(byRow.get('borrowApy')!.cell.numeric).toBe(12)
-  })
-
-  it('colors higher-better rows green at the high end and lower-better rows red at the high end', () => {
-    expect(getAttributeRowColor(100, 0, 100, 'higher-better')).toContain('hsla(145')
-    expect(getAttributeRowColor(100, 0, 100, 'lower-better')).toContain('hsla(0')
+    expect(byRow.get('totalSupply')!.numeric).toBe(1000)
+    expect(byRow.get('totalBorrow')!.numeric).toBe(500)
+    expect(byRow.get('liquidity')!.numeric).toBe(500)
+    expect(byRow.get('utilization')!.numeric).toBe(50)
+    expect(byRow.get('supplyCapUsage')!.numeric).toBe(40)
+    expect(byRow.get('borrowCapUsage')!.numeric).toBe(50)
+    expect(byRow.get('supplyApy')!.numeric).toBe(5)
+    expect(byRow.get('borrowApy')!.numeric).toBe(12)
   })
 
   it('uses the apy cache (intrinsic + rewards) for supply/borrow APY when supplied', () => {

--- a/tests/utils/discovery-calculations.test.ts
+++ b/tests/utils/discovery-calculations.test.ts
@@ -237,4 +237,31 @@ describe('buildVaultApyCache', () => {
     expect(entry!.supplyApy).toBeCloseTo(4 + 1 + 0.5)
     expect(entry!.borrowApy).toBeCloseTo(6 + 2 - 0.25)
   })
+
+  it('caches external-collateral vaults so attribute matrix externals match the per-vault card', () => {
+    // External EVK vaults render as columns in the attribute matrix and need
+    // the same intrinsic + rewards adjustment as members — without this, the
+    // Stats column would silently fall back to raw IRM for externals.
+    const externalVault = {
+      ...makeVault('0xExternalApy', []),
+      interestRateInfo: {
+        supplyAPY: 3n * 10n ** 25n,
+        borrowAPY: 5n * 10n ** 25n,
+      },
+    } as Vault
+    const market = makeMarket([], [externalVault])
+
+    const cache = buildVaultApyCache(
+      [market],
+      (apy, _addr) => apy + 1,
+      (apy, _addr) => apy + 2,
+      _addr => 0.5,
+      _addr => 0.25,
+    )
+
+    const entry = cache.get(externalVault.address.toLowerCase())
+    expect(entry).toBeDefined()
+    expect(entry!.supplyApy).toBeCloseTo(3 + 1 + 0.5)
+    expect(entry!.borrowApy).toBeCloseTo(5 + 2 - 0.25)
+  })
 })

--- a/tests/utils/discovery-calculations.test.ts
+++ b/tests/utils/discovery-calculations.test.ts
@@ -165,7 +165,7 @@ describe('attribute stats matrix', () => {
       borrowCapUsd: 1000,
     }
 
-    const columns = [{ address: vault.address.toLowerCase(), symbol: 'TST', assetAddress: vault.asset.address, vault }]
+    const columns = [{ address: vault.address.toLowerCase(), symbol: 'TST', assetAddress: vault.asset.address, vault, isExternal: false }]
     const usdCache = new Map([[vault.address.toLowerCase(), usd]])
     const byRow = new Map(STATS_ROWS.map(row => [
       row.id,
@@ -196,7 +196,7 @@ describe('attribute stats matrix', () => {
         borrowAPY: 0n,
       },
     } as Vault
-    const columns = [{ address: vault.address.toLowerCase(), symbol: 'TST', assetAddress: vault.asset.address, vault }]
+    const columns = [{ address: vault.address.toLowerCase(), symbol: 'TST', assetAddress: vault.asset.address, vault, isExternal: false }]
     const usdCache = new Map<string, VaultUsdCacheEntry>()
     const apyCache = new Map<string, VaultApyCacheEntry>([
       [vault.address.toLowerCase(), { supplyApy: 5.31, borrowApy: 1.25 }],

--- a/utils/discoveryCalculations.ts
+++ b/utils/discoveryCalculations.ts
@@ -645,8 +645,6 @@ export interface VaultApyCacheEntry {
   borrowApy: number
 }
 
-export type AttributeDirection = 'higher-better' | 'lower-better' | 'neutral'
-
 export interface AttributeCell {
   display: string
   numeric?: number
@@ -661,7 +659,6 @@ export interface AttributeRow {
   id: string
   label: string
   tooltip?: string
-  direction: AttributeDirection
   getValue: (
     vault: Vault | SecuritizeVault,
     usd: VaultUsdCacheEntry | undefined,
@@ -755,7 +752,6 @@ export const CONFIG_ROWS: AttributeRow[] = [
   {
     id: 'supplyCap',
     label: 'Supply cap',
-    direction: 'neutral',
     getValue: (vault, usd) => {
       const rawCap = vault.supplyCap
       const { display } = formatCapDisplay(rawCap, usd?.supplyCap)
@@ -765,7 +761,6 @@ export const CONFIG_ROWS: AttributeRow[] = [
   {
     id: 'borrowCap',
     label: 'Borrow cap',
-    direction: 'neutral',
     getValue: (vault, usd) => {
       if (!isVaultType(vault)) return NA_CELL
       if (isEscrow(vault)) return NA_CELL
@@ -777,7 +772,6 @@ export const CONFIG_ROWS: AttributeRow[] = [
   {
     id: 'irmType',
     label: 'Interest rate model',
-    direction: 'neutral',
     getValue: (vault) => {
       if (!isVaultType(vault) || isEscrow(vault)) return NA_CELL
       const t = vault.irmInfo?.interestRateModelInfo?.interestRateModelType
@@ -788,7 +782,6 @@ export const CONFIG_ROWS: AttributeRow[] = [
   {
     id: 'interestFee',
     label: 'Interest fee',
-    direction: 'neutral',
     getValue: (vault) => {
       if (!isVaultType(vault) || isEscrow(vault)) return NA_CELL
       const pct = Number(nanoToValue(vault.interestFee, 2))
@@ -798,7 +791,6 @@ export const CONFIG_ROWS: AttributeRow[] = [
   {
     id: 'maxLiqDiscount',
     label: 'Max liquidation discount',
-    direction: 'neutral',
     getValue: (vault) => {
       if (!isVaultType(vault) || isEscrow(vault)) return NA_CELL
       const pct = Number(vault.maxLiquidationDiscount / 100n)
@@ -808,7 +800,6 @@ export const CONFIG_ROWS: AttributeRow[] = [
   {
     id: 'badDebtSocialised',
     label: 'Bad debt socialization',
-    direction: 'neutral',
     getValue: (vault) => {
       if (!isVaultType(vault) || isEscrow(vault)) return NA_CELL
       // Bitmask check — bad-debt socialisation is on when the
@@ -822,7 +813,6 @@ export const CONFIG_ROWS: AttributeRow[] = [
   {
     id: 'hooks',
     label: 'Hooked operations',
-    direction: 'neutral',
     getValue: (vault) => {
       if (!isVaultType(vault)) return NA_CELL
       // 'All' when every user-facing op is hooked (full disable). Specific
@@ -842,7 +832,6 @@ export const CONFIG_ROWS: AttributeRow[] = [
   {
     id: 'governor',
     label: 'Governor',
-    direction: 'neutral',
     getValue: vault => ({
       display: vault.governorAdmin,
       kind: 'governor',
@@ -855,7 +844,6 @@ export const STATS_ROWS: AttributeRow[] = [
   {
     id: 'totalSupply',
     label: 'Total supply',
-    direction: 'higher-better',
     getValue: (_vault, usd) => ({
       display: usd ? usd.supply : '…',
       numeric: usd?.supplyUsd,
@@ -865,7 +853,6 @@ export const STATS_ROWS: AttributeRow[] = [
   {
     id: 'totalBorrow',
     label: 'Total borrows',
-    direction: 'lower-better',
     getValue: (vault, usd) => {
       if (!isVaultType(vault) || isEscrow(vault)) return NA_CELL
       return {
@@ -878,7 +865,6 @@ export const STATS_ROWS: AttributeRow[] = [
   {
     id: 'liquidity',
     label: 'Available liquidity',
-    direction: 'higher-better',
     getValue: (vault, usd) => {
       if (!isVaultType(vault) || isEscrow(vault)) return NA_CELL
       return {
@@ -891,7 +877,6 @@ export const STATS_ROWS: AttributeRow[] = [
   {
     id: 'utilization',
     label: 'Utilization',
-    direction: 'lower-better',
     getValue: (vault) => {
       if (!isVaultType(vault) || isEscrow(vault)) return NA_CELL
       const pct = getVaultUtilization(vault)
@@ -901,7 +886,6 @@ export const STATS_ROWS: AttributeRow[] = [
   {
     id: 'supplyCapUsage',
     label: 'Supply cap usage',
-    direction: 'lower-better',
     getValue: (vault) => {
       if (!isVaultType(vault)) return NA_CELL
       const uncapped = vault.supplyCap >= maxUint256
@@ -921,7 +905,6 @@ export const STATS_ROWS: AttributeRow[] = [
   {
     id: 'borrowCapUsage',
     label: 'Borrow cap usage',
-    direction: 'lower-better',
     getValue: (vault) => {
       if (!isVaultType(vault) || isEscrow(vault)) return NA_CELL
       const uncapped = vault.borrowCap >= maxUint256
@@ -939,7 +922,6 @@ export const STATS_ROWS: AttributeRow[] = [
   {
     id: 'supplyApy',
     label: 'Supply APY',
-    direction: 'higher-better',
     getValue: (vault, _usd, apy) => {
       // Securitize vaults' interestRateInfo is documented as zero-valued,
       // so we'd render "0.00%" — avoid that misleading display.
@@ -954,7 +936,6 @@ export const STATS_ROWS: AttributeRow[] = [
   {
     id: 'borrowApy',
     label: 'Borrow APY',
-    direction: 'lower-better',
     getValue: (vault, _usd, apy) => {
       if (!isVaultType(vault) || isEscrow(vault)) return NA_CELL
       const pct = apy?.borrowApy ?? borrowApyPercent(vault)
@@ -1013,18 +994,3 @@ export const buildAttributeRowCells = (
     usdCache.get(col.address),
     apyCache?.get(col.address),
   ))
-
-export const getAttributeRowColor = (
-  value: number | undefined,
-  min: number,
-  max: number,
-  direction: AttributeDirection,
-): string => {
-  if (direction === 'neutral') return 'transparent'
-  if (value === undefined || !Number.isFinite(value)) return 'transparent'
-  if (min === max) return 'transparent'
-  const normalized = ((value - min) / (max - min)) * 100
-  const clamped = Math.max(0, Math.min(100, normalized))
-  if (direction === 'lower-better') return getLtvColor(clamped)
-  return getLtvColor(100 - clamped)
-}

--- a/utils/discoveryCalculations.ts
+++ b/utils/discoveryCalculations.ts
@@ -982,7 +982,10 @@ export const buildVaultApyCache = (
 ): Map<string, VaultApyCacheEntry> => {
   const result = new Map<string, VaultApyCacheEntry>()
   for (const market of markets) {
-    for (const vault of market.vaults) {
+    // Walk both members and external collateral — the attribute matrix now
+    // renders externals as columns too, and they need the same intrinsic +
+    // rewards adjustment so Stats agrees with the per-vault card.
+    for (const vault of [...market.vaults, ...market.externalCollateral]) {
       if (!isVaultType(vault)) continue
       const addr = vault.address.toLowerCase()
       if (result.has(addr)) continue

--- a/utils/discoveryCalculations.ts
+++ b/utils/discoveryCalculations.ts
@@ -345,7 +345,6 @@ export const getMiniDiagram = (market: MarketGroup): MiniDiagramData => {
 export const getCollateralMatrix = (market: MarketGroup): CollateralMatrixData | null => {
   const borrowable = getDiscoveryColumnVaults(market)
   const nonBorrowable = getDiscoveryRowOnlyVaults(market)
-  const external = getActiveExternalCollateral(market)
 
   const knownAddresses = new Set<string>()
   for (const v of [...market.vaults, ...market.externalCollateral]) {
@@ -426,28 +425,30 @@ export const getCollateralMatrix = (market: MarketGroup): CollateralMatrixData |
   const seenRows = new Set<string>()
 
   const addRow = (addr: string, symbol: string, assetAddress: string, category: CollateralMatrixData['rows'][0]['category']) => {
-    if (referencedCollateral.has(addr) && !seenRows.has(addr)) {
-      seenRows.add(addr)
-      rows.push({ address: addr, symbol, assetAddress, category })
-    }
+    if (seenRows.has(addr)) return
+    seenRows.add(addr)
+    rows.push({ address: addr, symbol, assetAddress, category })
   }
 
   for (const v of sortedDiagonal) addRow(v.address.toLowerCase(), v.asset.symbol, v.asset.address, 'borrowable')
   for (const v of sortedRowOnly) addRow(v.address.toLowerCase(), v.asset.symbol, v.asset.address, 'borrowable')
 
+  // Escrow + external rows always render at the bottom, even when no
+  // borrowable vault references them, so curators can see same-asset escrow
+  // and external collateral at a glance. Rows without cells appear empty —
+  // the dim styling on the label conveys that they're inventory, not active.
   const sortedNonBorrowable = [...nonBorrowable]
-    .filter(v => referencedCollateral.has(v.address.toLowerCase()))
     .sort((a, b) => rowAvgLTV(b.address.toLowerCase()) - rowAvgLTV(a.address.toLowerCase()))
   for (const v of sortedNonBorrowable) addRow(v.address.toLowerCase(), v.asset.symbol, v.asset.address, 'escrow')
 
   const securitizeMembers = market.vaults
-    .filter((v): v is SecuritizeVault => 'type' in v && (v as { type?: string }).type === 'securitize')
-    .filter(v => referencedCollateral.has(v.address.toLowerCase()))
+    .filter(isSecuritizeVault)
     .sort((a, b) => rowAvgLTV(b.address.toLowerCase()) - rowAvgLTV(a.address.toLowerCase()))
   for (const v of securitizeMembers) addRow(v.address.toLowerCase(), v.asset.symbol, v.asset.address, 'external')
 
-  const sortedExternal = [...external]
-    .filter(v => referencedCollateral.has(getVaultAddress(v).toLowerCase()))
+  const sortedExternal = market.externalCollateral
+    .filter(isMatrixCompatibleVault)
+    .slice()
     .sort((a, b) => rowAvgLTV(getVaultAddress(b).toLowerCase()) - rowAvgLTV(getVaultAddress(a).toLowerCase()))
   for (const v of sortedExternal) addRow(getVaultAddress(v).toLowerCase(), getVaultAssetSymbol(v), getVaultAssetAddress(v), 'external')
 
@@ -671,6 +672,7 @@ export interface AttributeMatrixColumn {
   symbol: string
   assetAddress: string
   vault: Vault | SecuritizeVault
+  isExternal: boolean
 }
 
 export interface AttributeMatrixData {
@@ -684,8 +686,8 @@ const isEscrow = (v: Vault | SecuritizeVault): boolean =>
 const compareSymbolAsc = (a: Vault | SecuritizeVault, b: Vault | SecuritizeVault): number =>
   a.asset.symbol.localeCompare(b.asset.symbol, undefined, { sensitivity: 'base' })
 
-// Both Configuration and Stats matrices show only the curated product — external
-// collateral belongs to other governance and adds noise either way.
+// Members come first; externals (escrowed / cross-product collateral) are
+// appended at the end with `isExternal: true` so the view can dim them.
 export const getAttributeMatrixColumns = (market: MarketGroup): AttributeMatrixColumn[] => {
   const memberEvk: Vault[] = []
   const memberSecuritize: SecuritizeVault[] = []
@@ -697,14 +699,34 @@ export const getAttributeMatrixColumns = (market: MarketGroup): AttributeMatrixC
   memberEvk.sort(compareSymbolAsc)
   memberSecuritize.sort(compareSymbolAsc)
 
-  const toCol = (vault: Vault | SecuritizeVault): AttributeMatrixColumn => ({
+  const externalEvk: Vault[] = []
+  const externalSecuritize: SecuritizeVault[] = []
+  const seenExternal = new Set<string>()
+  for (const v of market.externalCollateral) {
+    const addr = getVaultAddress(v).toLowerCase()
+    if (!addr || seenExternal.has(addr)) continue
+    seenExternal.add(addr)
+    if (isVaultType(v)) externalEvk.push(v)
+    else if (isSecuritizeVault(v)) externalSecuritize.push(v)
+  }
+
+  externalEvk.sort(compareSymbolAsc)
+  externalSecuritize.sort(compareSymbolAsc)
+
+  const toCol = (vault: Vault | SecuritizeVault, isExternal: boolean): AttributeMatrixColumn => ({
     address: getVaultAddress(vault).toLowerCase(),
     symbol: vault.asset.symbol,
     assetAddress: vault.asset.address,
     vault,
+    isExternal,
   })
 
-  return [...memberEvk.map(toCol), ...memberSecuritize.map(toCol)]
+  return [
+    ...memberEvk.map(v => toCol(v, false)),
+    ...memberSecuritize.map(v => toCol(v, false)),
+    ...externalEvk.map(v => toCol(v, true)),
+    ...externalSecuritize.map(v => toCol(v, true)),
+  ]
 }
 
 const NA_CELL: AttributeCell = { display: '—', kind: 'text' }

--- a/utils/discoveryCalculations.ts
+++ b/utils/discoveryCalculations.ts
@@ -637,6 +637,14 @@ export interface VaultUsdCacheEntry {
   borrowCapUsd: number | undefined
 }
 
+// Pre-computed APYs that fold in intrinsic + rewards. Computed in the component
+// where composables are accessible, then passed to the matrix as a cache so the
+// Stats matrix renders the same APY users see on the per-vault cards.
+export interface VaultApyCacheEntry {
+  supplyApy: number
+  borrowApy: number
+}
+
 export type AttributeDirection = 'higher-better' | 'lower-better' | 'neutral'
 
 export interface AttributeCell {
@@ -654,7 +662,11 @@ export interface AttributeRow {
   label: string
   tooltip?: string
   direction: AttributeDirection
-  getValue: (vault: Vault | SecuritizeVault, usd: VaultUsdCacheEntry | undefined) => AttributeCell
+  getValue: (
+    vault: Vault | SecuritizeVault,
+    usd: VaultUsdCacheEntry | undefined,
+    apy: VaultApyCacheEntry | undefined,
+  ) => AttributeCell
 }
 
 export interface AttributeMatrixColumn {
@@ -928,11 +940,14 @@ export const STATS_ROWS: AttributeRow[] = [
     id: 'supplyApy',
     label: 'Supply APY',
     direction: 'higher-better',
-    getValue: (vault) => {
+    getValue: (vault, _usd, apy) => {
       // Securitize vaults' interestRateInfo is documented as zero-valued,
       // so we'd render "0.00%" — avoid that misleading display.
       if (!isVaultType(vault) || isEscrow(vault)) return NA_CELL
-      const pct = supplyApyPercent(vault)
+      // Prefer the pre-computed APY (folds in intrinsic + supply rewards) so
+      // this matches the per-vault card. Fall back to the raw IRM rate when
+      // the cache hasn't been populated (e.g. unit tests).
+      const pct = apy?.supplyApy ?? supplyApyPercent(vault)
       return { display: `${formatNumber(pct, 2)}%`, numeric: pct, kind: 'text' }
     },
   },
@@ -940,13 +955,44 @@ export const STATS_ROWS: AttributeRow[] = [
     id: 'borrowApy',
     label: 'Borrow APY',
     direction: 'lower-better',
-    getValue: (vault) => {
+    getValue: (vault, _usd, apy) => {
       if (!isVaultType(vault) || isEscrow(vault)) return NA_CELL
-      const pct = borrowApyPercent(vault)
+      const pct = apy?.borrowApy ?? borrowApyPercent(vault)
       return { display: `${formatNumber(pct, 2)}%`, numeric: pct, kind: 'text' }
     },
   },
 ]
+
+// Build a per-vault APY cache that mirrors the per-vault card formula:
+//   supplyApy = withIntrinsicSupplyApy(base) + supplyRewards
+//   borrowApy = withIntrinsicBorrowApy(base) - borrowRewards (general only)
+//
+// Borrow rewards here use no collateral context, so collateral-conditional
+// campaigns (`euler_borrow_collateral`) are intentionally excluded — the
+// matrix shows per-vault stats, not per-pair.
+export const buildVaultApyCache = (
+  markets: MarketGroup[],
+  withIntrinsicSupplyApy: (apy: number, address: string) => number,
+  withIntrinsicBorrowApy: (apy: number, address: string) => number,
+  getSupplyRewardApy: (vaultAddress: string) => number,
+  getBorrowRewardApy: (vaultAddress: string) => number,
+): Map<string, VaultApyCacheEntry> => {
+  const result = new Map<string, VaultApyCacheEntry>()
+  for (const market of markets) {
+    for (const vault of market.vaults) {
+      if (!isVaultType(vault)) continue
+      const addr = vault.address.toLowerCase()
+      if (result.has(addr)) continue
+      const baseSupply = Number(nanoToValue(vault.interestRateInfo.supplyAPY, 25))
+      const baseBorrow = Number(nanoToValue(vault.interestRateInfo.borrowAPY, 25))
+      result.set(addr, {
+        supplyApy: withIntrinsicSupplyApy(baseSupply, vault.asset.address) + getSupplyRewardApy(vault.address),
+        borrowApy: withIntrinsicBorrowApy(baseBorrow, vault.asset.address) - getBorrowRewardApy(vault.address),
+      })
+    }
+  }
+  return result
+}
 
 export const getAttributeMatrix = (
   market: MarketGroup,
@@ -960,8 +1006,13 @@ export const buildAttributeRowCells = (
   row: AttributeRow,
   columns: AttributeMatrixColumn[],
   usdCache: Map<string, VaultUsdCacheEntry>,
+  apyCache?: Map<string, VaultApyCacheEntry>,
 ): AttributeCell[] =>
-  columns.map(col => row.getValue(col.vault, usdCache.get(col.address)))
+  columns.map(col => row.getValue(
+    col.vault,
+    usdCache.get(col.address),
+    apyCache?.get(col.address),
+  ))
 
 export const getAttributeRowColor = (
   value: number | undefined,


### PR DESCRIPTION
## Summary
- Stats APY columns now match the per-vault cards (intrinsic + rewards folded in) instead of raw IRM rates.
- Stats matrix readability tweak: drop the row-level heatmap gradient — directional rows and bigger numbers were fighting each other.
- Discovery matrix views now keep external collateral and same-asset escrow vaults visible at the bottom with dim styling.
- The discovery graph no longer briefly reports collateral as 'Unknown' while the labels payload is still loading.

Closes EUL4-179.
Closes EUL4-181.

## Changes

### `fix: include intrinsic and rewards APY in stats matrix` (EUL4-179)
- Build a per-vault APY cache (`buildVaultApyCache`) from `useIntrinsicApy` and `useRewardsApy` and thread it through `buildAttributeRowCells`.
- Stats `Supply APY` / `Borrow APY` cells consume the cache so the displayed value now equals `base + intrinsic + supply rewards` (and `base + intrinsic - general borrow rewards`), matching `VaultOverviewBlockStats`.
- Falls back to the raw IRM rate when the cache hasn't been populated (e.g. unit tests).

### `refactor: drop heatmap gradient from stats matrix`
- Stats matrix no longer paints diverging cell backgrounds for directional rows; the values speak for themselves and the gradient added visual noise.
- Configuration matrix is unaffected.

### `fix: show external + escrow vaults in matrix views` (EUL4-181)
- `getCollateralMatrix`: drop the `referencedCollateral` gate on escrow / securitize / external rows so they always render at the bottom of the pair matrix, even when no borrowable vault references them. External rows now come from `market.externalCollateral` (full inventory) instead of just the active subset.
- `getAttributeMatrixColumns`: append external EVK + Securitize vaults at the end of attribute-matrix columns (Stats *and* Config) with `isExternal: true`. Reverts a regression that hid them entirely.
- `DiscoveryMarketMatrix.vue`: dim the row label for both `escrow` and `external` categories (was external-only).
- `DiscoveryMarketAttributeMatrix.vue`:
  - Dim the row label and cell content for external vault rows.
  - Governor cell now mirrors `VaultOverviewBlockGeneral` precedence — `Unknown` chip when `!isVaultGovernorVerified`, then entity logos, otherwise `—`. Escrow vaults pass `isVaultGovernorVerified` and have no labeled entity, so they fall through to `—` instead of the misleading red `Unknown` chip.

### `fix: defer unknown-collateral classification until labels load`
- `augmentWithCollateralGraph` accepts a `labelsReady` flag (sourced from `useEulerLabels().isReady`) and skips both unknown branches while the labels payload is in flight.
- Removes the first-second-of-page-load flash where every external collateral briefly looked unverified (because `verifiedVaultAddresses` was still empty) and unfetched collaterals briefly registered as `unknownCollateral` (because `getProductKeyByVault` returned `undefined` for everything). Once `isReady` flips, the computed re-runs and genuinely-unknown collateral surfaces normally.

## Test plan
- [x] `npx vitest run` — 613/613 pass, including the new `buildVaultApyCache` and APY-cache fallback assertions in `tests/utils/discovery-calculations.test.ts`.
- [ ] Stats matrix: open `Euler Prime`, confirm `Supply APY` / `Borrow APY` columns match the values shown on each vault's per-vault card (intrinsic + rewards reflected).
- [ ] Stats matrix: confirm cell backgrounds are flat (no diverging gradient).
- [ ] Configuration matrix: confirm cell coloring still applies where it did before.
- [ ] Discovery matrix views (Stats, Configuration, and the pair-metric variants): open the `EUL Lending` market — confirm external / same-asset escrow vaults appear at the bottom of the row list with dim styling.
- [ ] Pair matrix: confirm same-asset escrow rows render even when the borrowable vault has no live LTV referencing them.
- [ ] Configuration matrix Governor column: escrow rows render `—` (no red `Unknown` chip); unverified externals still show the `Unknown` chip; labeled members show entity logos.
- [ ] Discovery: hard-refresh `Euler Prime` and watch the graph for the first second — no `0x...` placeholder nodes and no `X unknown` badge appear before labels load.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * APY caching added for faster, more consistent APY display across vaults.

* **Improvements**
  * External vaults and escrow rows always shown and consistently rendered.
  * Governor display now surfaces "unknown" verification state when appropriate.
  * Row styling refined to reflect borrowability.
  * On-demand fetching now waits for collateral resolution to avoid transient placeholders.

* **Bug Fixes**
  * Removed per-cell heatmap coloring to stabilize attribute visuals.

* **Tests**
  * Attribute matrix and APY behavior tests updated to verify cached APY and numeric/display values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->