### PR TITLE
Fix dark mode startup flash

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -33,6 +33,7 @@ const { theme } = useTheme()
 watch(theme, (newTheme) => {
   if (import.meta.client) {
     document.documentElement.setAttribute('data-theme', newTheme)
+    document.documentElement.style.colorScheme = newTheme
   }
 }, { immediate: true })
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,5 +1,7 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 
+const themeBootstrapScript = '(function(){var theme="dark";try{theme=localStorage.getItem("theme")==="light"?"light":"dark"}catch(e){}document.documentElement.setAttribute("data-theme",theme);document.documentElement.style.colorScheme=theme})()'
+
 export default defineNuxtConfig({
   modules: ['@nuxtjs/tailwindcss', '@nuxt/eslint', '@gvade/nuxt3-svg-sprite', '@vueuse/nuxt', '@sentry/nuxt/module'],
   ssr: false,
@@ -29,8 +31,17 @@ export default defineNuxtConfig({
     head: {
       title: 'Euler Lite',
       htmlAttrs: {
-        lang: 'en',
+        'lang': 'en',
+        'data-theme': 'dark',
       },
+      script: [
+        {
+          id: 'theme-bootstrap',
+          innerHTML: themeBootstrapScript,
+          tagPosition: 'head',
+          tagPriority: 'critical',
+        },
+      ],
       meta: [
         {
           name: 'description',


### PR DESCRIPTION
## Summary
- Prevent the initial white flash before Vue hydrates dark mode.
- Apply the saved or default theme before the main stylesheet can paint the page.

## Changes
- Add a small head bootstrap script that sets `data-theme` and `color-scheme` from `localStorage`, defaulting to dark.
- Render the HTML shell with `data-theme="dark"` so dark variables are available immediately.
- Keep `color-scheme` synced when the runtime theme watcher updates.

## Test plan
- [x] npm run lint
- [x] npm run typecheck
- [x] npm run build
- [x] Verified built HTML includes `data-theme="dark"` and the theme bootstrap before the stylesheet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added persistent theme storage that automatically restores your preference on page load.

* **Improvements**
  * Enhanced theme consistency by synchronizing colorScheme with your selected theme.
  * Default theme set to dark mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->