### PR TITLE
Fix savings repay unit test setup

### DIFF
--- a/tests/composables/useSavingsRepay.test.ts
+++ b/tests/composables/useSavingsRepay.test.ts
@@ -149,6 +149,7 @@ describe('useSavingsRepay', () => {
     vi.stubGlobal('useEulerAccount', () => ({ refreshAllPositions: vi.fn() }))
     vi.stubGlobal('useEulerAddresses', () => ({ eulerLensAddresses: ref({}) }))
     vi.stubGlobal('useVaultRegistry', () => ({ getVault: vi.fn() }))
+    vi.stubGlobal('useTxFinalization', () => ({ finalizeTxAndRedirect: vi.fn() }))
     vi.stubGlobal('useSwapApi', () => ({
       getSwapProviders: vi.fn(async () => []),
       getSwapQuotes: vi.fn(async () => []),


### PR DESCRIPTION
## Summary
- Stub the new tx finalization composable in the savings repay unit test so direct composable imports have the same Nuxt auto-import dependency available as runtime.
- Unblocks the full Vitest suite for the rc release preflight.

## Changes
- Add a useTxFinalization global stub returning a finalizeTxAndRedirect spy in useSavingsRepay.test.ts.

## Test plan
- [x] npm run test:run -- tests/composables/useSavingsRepay.test.ts
- [x] npm run test:run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test setup infrastructure to support composable testing with improved mock dependencies.

**Note:** This release contains internal testing improvements with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->