### PR TITLE
Fix repay review safety checks

### DIFF
--- a/composables/repay/reviewAmount.ts
+++ b/composables/repay/reviewAmount.ts
@@ -1,0 +1,26 @@
+import { formatUnits } from 'viem'
+import type { SwapApiQuote } from '~/entities/swap'
+import { SwapperMode } from '~/entities/swap'
+import { getSwapInputAmount } from '~/composables/useEulerOperations/swaps/verify'
+import { trimTrailingZeros } from '~/utils/string-utils'
+
+export const getRepaySwapReviewInputAmount = ({
+  amount,
+  quote,
+  sourceDecimals,
+  swapperMode,
+}: {
+  amount: string
+  quote?: SwapApiQuote | null
+  sourceDecimals: bigint | number
+  swapperMode: SwapperMode
+}): string => {
+  if (swapperMode === SwapperMode.TARGET_DEBT && quote) {
+    const inputAmount = getSwapInputAmount(quote, swapperMode)
+    if (inputAmount > 0n) {
+      return trimTrailingZeros(formatUnits(inputAmount, Number(sourceDecimals)))
+    }
+  }
+
+  return amount || '0'
+}

--- a/composables/repay/useCollateralSwapRepay.ts
+++ b/composables/repay/useCollateralSwapRepay.ts
@@ -16,6 +16,7 @@ import { useEulerProductOfVault } from '~/composables/useEulerLabels'
 import { useRepaySwapCore } from '~/composables/repay/useRepaySwapCore'
 import { useRepaySwapDetails } from '~/composables/repay/useRepaySwapDetails'
 import { useRepayHealthMetrics } from '~/composables/repay/useRepayHealthMetrics'
+import { getRepaySwapReviewInputAmount } from '~/composables/repay/reviewAmount'
 import { adjustForInterest } from '~/composables/useEulerOperations/helpers'
 import { getSwapInputAmount } from '~/composables/useEulerOperations/swaps/verify'
 import { nanoToValue, valueToNano } from '~/utils/crypto-utils'
@@ -424,11 +425,18 @@ export const useCollateralSwapRepay = (options: UseCollateralSwapRepayOptions) =
         if (!ok) return
       }
 
+      const inputDisplay = getRepaySwapReviewInputAmount({
+        amount: core.amount.value,
+        quote: core.quotes.selectedQuote.value,
+        sourceDecimals: sourceVault.value.asset.decimals,
+        swapperMode: core.direction.value,
+      })
+
       modal.open(OperationReviewModal, {
         props: {
           type: 'repay',
           asset: sourceVault.value.asset,
-          amount: core.amount.value,
+          amount: inputDisplay,
           plan: plan.value || undefined,
           swapToAsset: !core.isSameAsset.value ? borrowVault.value.asset : undefined,
           swapToAmount: !core.isSameAsset.value ? core.debtAmount.value : undefined,

--- a/composables/repay/useSavingsRepay.ts
+++ b/composables/repay/useSavingsRepay.ts
@@ -15,6 +15,7 @@ import { useEulerProductOfVault } from '~/composables/useEulerLabels'
 import { useRepaySwapCore } from '~/composables/repay/useRepaySwapCore'
 import { useRepaySwapDetails } from '~/composables/repay/useRepaySwapDetails'
 import { useRepayHealthMetrics } from '~/composables/repay/useRepayHealthMetrics'
+import { getRepaySwapReviewInputAmount } from '~/composables/repay/reviewAmount'
 import { adjustForInterest } from '~/composables/useEulerOperations/helpers'
 import { getSwapInputAmount } from '~/composables/useEulerOperations/swaps/verify'
 import { nanoToValue, valueToNano } from '~/utils/crypto-utils'
@@ -363,11 +364,18 @@ export const useSavingsRepay = (options: UseSavingsRepayOptions) => {
         transferAmounts[addr] = nanoToValue(position.value.supplied, collateralVault.value.decimals).toString()
       }
 
+      const inputDisplay = getRepaySwapReviewInputAmount({
+        amount: core.amount.value,
+        quote: core.quotes.selectedQuote.value,
+        sourceDecimals: sourceVault.value.asset.decimals,
+        swapperMode: core.direction.value,
+      })
+
       modal.open(OperationReviewModal, {
         props: {
           type: 'repay',
           asset: sourceVault.value.asset,
-          amount: core.amount.value,
+          amount: inputDisplay,
           swapToAsset: !core.isSameAsset.value ? borrowVault.value.asset : undefined,
           swapToAmount: !core.isSameAsset.value ? core.debtAmount.value : undefined,
           swapMode: !core.isSameAsset.value ? core.direction.value : undefined,

--- a/composables/repay/useWalletSwapRepay.ts
+++ b/composables/repay/useWalletSwapRepay.ts
@@ -20,6 +20,7 @@ import { createRaceGuard } from '~/utils/race-guard'
 import { buildSwapRouteItems } from '~/utils/swapRouteItems'
 import { useSwapPriceImpact } from '~/composables/useSwapPriceImpact'
 import { useSwapRepayQuotes } from '~/composables/repay/useSwapRepayQuotes'
+import { getRepaySwapReviewInputAmount } from '~/composables/repay/reviewAmount'
 import { getSwapInputAmount } from '~/composables/useEulerOperations/swaps/verify'
 import { findBlockingDisabledOp, OP_REPAY, OP_TRANSFER, type PlannedOp } from '~/utils/vault-hooks'
 import { getPlanHookDisabledWarning } from '~/composables/useVaultWarnings'
@@ -715,9 +716,12 @@ export const useWalletSwapRepay = (options: UseWalletSwapRepayOptions) => {
       if (!ok) return
 
       // For review modal: show input token as primary asset, borrow asset as swap target
-      const inputDisplay = direction.value === SwapperMode.TARGET_DEBT && amount.value
-        ? amount.value
-        : (amount.value || '0')
+      const inputDisplay = getRepaySwapReviewInputAmount({
+        amount: amount.value,
+        quote: quotes.selectedQuote.value,
+        sourceDecimals: selectedAsset.value.decimals,
+        swapperMode: direction.value,
+      })
 
       const isNativeRepay = isNativeCurrencyAddress(selectedAsset.value.address)
       const reviewAsset = isNativeRepay

--- a/composables/useEulerOperations/preExistingDeposit.ts
+++ b/composables/useEulerOperations/preExistingDeposit.ts
@@ -21,6 +21,6 @@ export const hasPreExistingVaultDeposit = async (
   }
   catch (err) {
     logWarn(logScope, err)
-    return false
+    return true
   }
 }

--- a/tests/composables/repay-review-amount.test.ts
+++ b/tests/composables/repay-review-amount.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import type { SwapApiQuote } from '~/entities/swap'
+import { SwapperMode } from '~/entities/swap'
+import { getRepaySwapReviewInputAmount } from '~/composables/repay/reviewAmount'
+
+const makeQuote = (overrides: Partial<SwapApiQuote> = {}): SwapApiQuote => ({
+  amountIn: '1234567',
+  amountInMax: '1240000',
+  amountOut: '5000000',
+  amountOutMin: '4990000',
+  ...overrides,
+}) as SwapApiQuote
+
+describe('getRepaySwapReviewInputAmount', () => {
+  it('uses quote-derived source input limit for target-debt swaps', () => {
+    expect(getRepaySwapReviewInputAmount({
+      amount: '',
+      quote: makeQuote(),
+      sourceDecimals: 6n,
+      swapperMode: SwapperMode.TARGET_DEBT,
+    })).toBe('1.24')
+  })
+
+  it('keeps the user-entered source amount for exact-in swaps', () => {
+    expect(getRepaySwapReviewInputAmount({
+      amount: '3.5',
+      quote: makeQuote(),
+      sourceDecimals: 6n,
+      swapperMode: SwapperMode.EXACT_IN,
+    })).toBe('3.5')
+  })
+})

--- a/tests/composables/useEulerOperations-pre-existing-deposit.test.ts
+++ b/tests/composables/useEulerOperations-pre-existing-deposit.test.ts
@@ -51,6 +51,15 @@ const createContext = (existingShares: bigint): OperationsContext => ({
   } as unknown as OperationsContext['rpcProvider'],
 })
 
+const createFailingContext = (): OperationsContext => ({
+  ...createContext(0n),
+  rpcProvider: {
+    readContract: vi.fn(async () => {
+      throw new Error('balance read failed')
+    }),
+  } as unknown as OperationsContext['rpcProvider'],
+})
+
 const helpers: OperationHelpers = {
   prepareTokenApproval: vi.fn(),
   injectPythHealthCheckUpdates: vi.fn(async () => undefined),
@@ -115,6 +124,22 @@ describe('full repay pre-existing liability deposit cleanup', () => {
       functionName: 'skim',
       args: [maxUint256, SUB_ACCOUNT],
     }))
+  })
+
+  it('skips same-asset full repay cushion cleanup when the pre-existing deposit read fails', async () => {
+    const builders = createSameAssetSwapBuilders(createFailingContext(), helpers)
+
+    const plan = await builders.buildSameAssetFullRepayPlan({
+      collateralVaultAddress: COLLATERAL_VAULT,
+      borrowVaultAddress: BORROW_VAULT,
+      amount: 100n,
+      subAccount: SUB_ACCOUNT,
+    })
+
+    const calls = decodedCalls(plan)
+
+    expect(calls.map(call => call.functionName)).not.toContain('redeem')
+    expect(calls.some(call => call.target === COLLATERAL_VAULT && call.functionName === 'skim')).toBe(false)
   })
 
   it('keeps savings full repay borrow-vault shares when they pre-exist', async () => {


### PR DESCRIPTION
## Summary
- Fail closed when pre-existing vault deposit checks cannot be read so repay cleanup steps do not assume unknown deposits are safe to sweep.
- Show the quote-derived source spend in target-debt swap repay reviews so the review modal reflects what leaves the wallet, collateral, or savings source.

## Changes
- Add a shared repay review amount helper that uses the selected quote input limit for target-debt swaps and preserves entered source amounts for exact-in swaps.
- Wire the helper through wallet, collateral, and savings swap-repay review modal paths.
- Add regression tests for quote-derived target-debt review amounts and read-failure same-asset repay cleanup behavior.

## Test plan
- [x] npm run test:run -- tests/composables/repay-review-amount.test.ts tests/composables/useEulerOperations-pre-existing-deposit.test.ts
- [x] npm run lint
- [x] npm run typecheck
- [x] npm run test:run
- [x] npm run build
- [x] SPY smoke: portfolio and repay page loaded for a real mainnet account; wallet repay review opened with confirm disabled as `Spy mode (read-only)`
- [ ] Browser-smoke collateral target-debt quote review against an environment where the swap provider API is not blocked by localhost CORS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced amount display calculations in repay review modals for improved accuracy during swap operations.

* **Bug Fixes**
  * Improved error resilience when checking for pre-existing deposits.

* **Tests**
  * Added comprehensive test coverage for review amount calculations and error handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->