### PR TITLE
Fix discovery refresh follow-ups

### DIFF
--- a/composables/useVaults.ts
+++ b/composables/useVaults.ts
@@ -736,8 +736,6 @@ const refreshVaults = async () => {
   const { getEvkVaults, getEarnVaults, getSecuritizeVaults } = useVaultRegistry()
   const gen = loadGeneration.value
 
-  isCollateralResolved.value = false
-
   try {
     await updateEVKVaults(getEvkVaults().map(v => v.address), gen, true)
     if (loadGeneration.value !== gen) return

--- a/pages/explore/[market].vue
+++ b/pages/explore/[market].vue
@@ -48,7 +48,7 @@ watch(
     isLoadingOnDemand.value = true
     try {
       const result = await fetchMarketGroupOnDemand(key)
-      if (runId === onDemandRunId) {
+      if (runId === onDemandRunId && marketKey.value === key) {
         onDemandMarket.value = result
       }
     }


### PR DESCRIPTION
## Summary
- Keep unknown-collateral discovery state stable during silent vault refreshes so badges do not disappear while polling updates registry data.
- Prevent direct hidden market routes from applying an on-demand result after the user has already navigated to a different market key.

## Changes
- Leave `isCollateralResolved` unchanged at the start of `refreshVaults()`; initial loads and chain resets still clear it through the existing load/reset paths.
- Add a current-route key check before assigning `onDemandMarket` after an async fetch resolves.

## Test plan
- [x] npm run lint
- [x] npm run typecheck
- [x] npm run test:run


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed stale market data overwriting the current market during rapid navigation between markets.
  * Improved collateral resolution state handling during vault refresh operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->