### PR TITLE
Show collateral supply cap warnings

### DIFF
--- a/components/entities/vault/VaultBorrowItem.vue
+++ b/components/entities/vault/VaultBorrowItem.vue
@@ -3,7 +3,7 @@ import { getAddress } from 'viem'
 import { formatNumber, compactNumber, formatCompactUsdValue } from '~/utils/string-utils'
 import { nanoToValue } from '~/utils/crypto-utils'
 import { type AnyBorrowVaultPair, type Vault, getVaultUtilization, isCyclicalNoteVault } from '~/entities/vault'
-import { getUtilisationWarning, getBorrowCapWarning } from '~/composables/useVaultWarnings'
+import { getUtilisationWarning, getBorrowCapWarning, getCollateralSupplyCapWarning } from '~/composables/useVaultWarnings'
 import { formatAssetValue } from '~/services/pricing/priceProvider'
 import { getMaxMultiplier, getMaxRoe } from '~/utils/leverage'
 import { useEulerProductOfVault } from '~/composables/useEulerLabels'
@@ -164,6 +164,7 @@ const maxLTV = computed(() => formatNumber(nanoToValue(pair.borrowLTV, 2), 2))
 const utilization = computed(() => getVaultUtilization(pair.borrow))
 const utilisationWarning = computed(() => getUtilisationWarning(pair.borrow, 'borrow'))
 const borrowCapInfo = computed(() => getBorrowCapWarning(pair.borrow))
+const supplyCapInfo = computed(() => getCollateralSupplyCapWarning(pair.collateral))
 
 const liquidityDisplay = ref('-')
 
@@ -258,6 +259,10 @@ const linkPath = computed(() => ({
             <VaultDisplayName
               :name="pairName"
               :is-unverified="isAnyUnverified"
+            />
+            <VaultWarningIcon
+              :warning="supplyCapInfo"
+              tooltip-placement="top-start"
             />
             <span
               v-if="isFeatured"

--- a/components/entities/vault/VaultBorrowItem.vue
+++ b/components/entities/vault/VaultBorrowItem.vue
@@ -276,10 +276,6 @@ const linkPath = computed(() => ({
               :name="pairName"
               :is-unverified="isAnyUnverified"
             />
-            <VaultWarningIcon
-              :warning="supplyCapInfo"
-              tooltip-placement="top-start"
-            />
             <span
               v-if="isFeatured"
               class="inline-flex items-center gap-4 rounded-8 px-8 py-2 bg-accent-100 text-accent-600 text-p5"
@@ -423,7 +419,7 @@ const linkPath = computed(() => ({
         <div class="text-content-tertiary text-p3 mb-4 flex items-center gap-4">
           Available liquidity
           <VaultWarningIcon
-            :warning="borrowCapInfo"
+            :warning="[borrowCapInfo, supplyCapInfo]"
             tooltip-placement="top-start"
           />
         </div>

--- a/components/entities/vault/VaultWarningIcon.vue
+++ b/components/entities/vault/VaultWarningIcon.vue
@@ -1,24 +1,40 @@
 <script setup lang="ts">
 import type { AlignedPlacement } from '@floating-ui/vue'
-import type { VaultWarning } from '~/composables/useVaultWarnings'
+import type { VaultWarning, WarningLevel } from '~/composables/useVaultWarnings'
 
 const { warning, tooltipPlacement = 'top-end' } = defineProps<{
-  warning: VaultWarning | null
+  warning: VaultWarning | (VaultWarning | null)[] | null
   tooltipPlacement?: AlignedPlacement
 }>()
+
+const warnings = computed<VaultWarning[]>(() => {
+  if (!warning) return []
+  return (Array.isArray(warning) ? warning : [warning]).filter((w): w is VaultWarning => w !== null)
+})
+
+const LEVEL_RANK: Record<WarningLevel, number> = { info: 0, high: 1, critical: 2 }
+
+const highestLevel = computed<WarningLevel | null>(() => {
+  if (warnings.value.length === 0) return null
+  return warnings.value.reduce<WarningLevel>(
+    (acc, w) => (LEVEL_RANK[w.level] > LEVEL_RANK[acc] ? w.level : acc),
+    'info',
+  )
+})
+
+const sections = computed(() =>
+  warnings.value.map(w => ({ title: w.title, text: w.message })),
+)
 </script>
 
 <template>
   <UiFootnote
-    v-if="warning"
-    :icon="warning.level === 'info' ? 'info-circle' : 'warning'"
-    :title="warning.title"
-    :text="warning.message"
+    v-if="highestLevel"
+    :icon="highestLevel === 'info' ? 'info-circle' : 'warning'"
+    :sections="sections"
     :tooltip-placement="tooltipPlacement"
-    :class="warning.level === 'critical'
+    :class="highestLevel === 'critical'
       ? '[--ui-footnote-icon-color:var(--error-500)]'
-      : warning.level === 'info'
-        ? '[--ui-footnote-icon-color:var(--warning-500)]'
-        : '[--ui-footnote-icon-color:var(--warning-500)]'"
+      : '[--ui-footnote-icon-color:var(--warning-500)]'"
   />
 </template>

--- a/components/ui/UiFootnote.vue
+++ b/components/ui/UiFootnote.vue
@@ -4,13 +4,20 @@ import { flip, offset, shift, useFloating, type AlignedPlacement } from '@floati
 import { useModal } from '~/components/ui/composables/useModal'
 import { UiFootnoteModal } from '#components'
 
-const { title, text, tooltipPlacement = 'top-start', customModal, icon = 'info-circle' } = defineProps<{
-  title: string
-  text: string
+const { title, text, sections, tooltipPlacement = 'top-start', customModal, icon = 'info-circle' } = defineProps<{
+  title?: string
+  text?: string
+  sections?: { title: string, text: string }[]
   tooltipPlacement?: AlignedPlacement
   customModal?: Component
   icon?: string
 }>()
+
+const resolvedSections = computed<{ title: string, text: string }[]>(() => {
+  if (sections && sections.length > 0) return sections
+  if (title !== undefined && text !== undefined) return [{ title, text }]
+  return []
+})
 
 const reference = ref(null)
 const floating = ref(null)
@@ -30,10 +37,13 @@ const canHover = typeof window !== 'undefined' && window.matchMedia('(hover: hov
 
 const onClick = () => {
   if (!canHover) {
+    const first = resolvedSections.value[0]
+    if (!first) return
     modal.open(customModal || UiFootnoteModal, {
       props: {
-        modalTitle: title,
-        text,
+        modalTitle: first.title,
+        text: first.text,
+        sections: resolvedSections.value.length > 1 ? resolvedSections.value : undefined,
       },
     })
   }
@@ -82,12 +92,21 @@ onClickOutside(reference, () => {
         @click.stop
       >
         <div class="ui-footnote__floating-content">
-          <div class="ui-footnote__floating-title">
-            {{ title }}
-          </div>
-          <div class="ui-footnote__floating-text">
-            {{ text }}
-          </div>
+          <template
+            v-for="(section, idx) in resolvedSections"
+            :key="idx"
+          >
+            <div
+              v-if="idx > 0"
+              class="ui-footnote__floating-divider"
+            />
+            <div class="ui-footnote__floating-title">
+              {{ section.title }}
+            </div>
+            <div class="ui-footnote__floating-text">
+              {{ section.text }}
+            </div>
+          </template>
         </div>
       </div>
     </Transition>
@@ -142,6 +161,12 @@ onClickOutside(reference, () => {
     word-wrap: break-word;
     overflow-wrap: break-word;
     hyphens: auto;
+  }
+
+  &__floating-divider {
+    height: 1px;
+    background-color: var(--line-subtle);
+    margin: 8px 0;
   }
 
 }

--- a/components/ui/UiFootnote.vue
+++ b/components/ui/UiFootnote.vue
@@ -4,16 +4,19 @@ import { flip, offset, shift, useFloating, type AlignedPlacement } from '@floati
 import { useModal } from '~/components/ui/composables/useModal'
 import { UiFootnoteModal } from '#components'
 
-const { title, text, sections, tooltipPlacement = 'top-start', customModal, icon = 'info-circle' } = defineProps<{
-  title?: string
-  text?: string
-  sections?: { title: string, text: string }[]
+type Section = { title: string, text: string }
+type FootnoteCommonProps = {
   tooltipPlacement?: AlignedPlacement
   customModal?: Component
   icon?: string
-}>()
+}
+type FootnoteProps
+  = | (FootnoteCommonProps & { title: string, text: string, sections?: never })
+    | (FootnoteCommonProps & { sections: Section[], title?: never, text?: never })
 
-const resolvedSections = computed<{ title: string, text: string }[]>(() => {
+const { title, text, sections, tooltipPlacement = 'top-start', customModal, icon = 'info-circle' } = defineProps<FootnoteProps>()
+
+const resolvedSections = computed<Section[]>(() => {
   if (sections && sections.length > 0) return sections
   if (title !== undefined && text !== undefined) return [{ title, text }]
   return []
@@ -36,17 +39,14 @@ const { floatingStyles, update } = useFloating(reference, floating, {
 const canHover = typeof window !== 'undefined' && window.matchMedia('(hover: hover)').matches
 
 const onClick = () => {
-  if (!canHover) {
-    const first = resolvedSections.value[0]
-    if (!first) return
-    modal.open(customModal || UiFootnoteModal, {
-      props: {
-        modalTitle: first.title,
-        text: first.text,
-        sections: resolvedSections.value.length > 1 ? resolvedSections.value : undefined,
-      },
-    })
-  }
+  if (canHover) return
+  const all = resolvedSections.value
+  if (all.length === 0) return
+  modal.open(customModal || UiFootnoteModal, {
+    props: all.length > 1
+      ? { sections: all }
+      : { modalTitle: all[0].title, text: all[0].text },
+  })
 }
 
 const onMouseEnter = () => {
@@ -151,7 +151,8 @@ onClickOutside(reference, () => {
     font-weight: 600;
     font-size: 14px;
     line-height: 20px;
-    white-space: nowrap;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
   }
 
   &__floating-text {

--- a/components/ui/modals/UiFootnoteModal.vue
+++ b/components/ui/modals/UiFootnoteModal.vue
@@ -1,18 +1,18 @@
 <script setup lang="ts">
 defineEmits(['close'])
-const { modalTitle, text, sections } = defineProps<{
-  modalTitle: string
-  text: string
-  sections?: { title: string, text: string }[]
-}>()
+type Section = { title: string, text: string }
+type UiFootnoteModalProps
+  = | { modalTitle: string, text: string, sections?: never }
+    | { sections: Section[], modalTitle?: never, text?: never }
+const { modalTitle, text, sections } = defineProps<UiFootnoteModalProps>()
 </script>
 
 <template>
   <BaseModalWrapper
-    :title="sections && sections.length > 1 ? 'Details' : modalTitle"
+    :title="sections ? 'Details' : modalTitle"
     @close="$emit('close')"
   >
-    <template v-if="sections && sections.length > 1">
+    <template v-if="sections">
       <div class="flex flex-col gap-12">
         <div
           v-for="(section, idx) in sections"

--- a/components/ui/modals/UiFootnoteModal.vue
+++ b/components/ui/modals/UiFootnoteModal.vue
@@ -1,17 +1,37 @@
 <script setup lang="ts">
 defineEmits(['close'])
-const { modalTitle, text } = defineProps<{
+const { modalTitle, text, sections } = defineProps<{
   modalTitle: string
   text: string
+  sections?: { title: string, text: string }[]
 }>()
 </script>
 
 <template>
   <BaseModalWrapper
-    :title="modalTitle"
+    :title="sections && sections.length > 1 ? 'Details' : modalTitle"
     @close="$emit('close')"
   >
-    <div class="text-p2 text-content-primary">
+    <template v-if="sections && sections.length > 1">
+      <div class="flex flex-col gap-12">
+        <div
+          v-for="(section, idx) in sections"
+          :key="idx"
+          class="flex flex-col gap-4"
+        >
+          <div class="text-p2 font-semibold text-content-primary">
+            {{ section.title }}
+          </div>
+          <div class="text-p2 text-content-primary">
+            {{ section.text }}
+          </div>
+        </div>
+      </div>
+    </template>
+    <div
+      v-else
+      class="text-p2 text-content-primary"
+    >
       {{ text }}
     </div>
   </BaseModalWrapper>

--- a/composables/useVaultWarnings.ts
+++ b/composables/useVaultWarnings.ts
@@ -103,40 +103,35 @@ export const getUtilisationWarning = (
   return { level, title, message }
 }
 
-export const getSupplyCapWarning = (vault: Vault): VaultWarning | null => {
-  const percentage = getSupplyCapPercentage(vault)
+// Cap level only determines the message text, not the visual severity.
+// Reaching a cap means the vault is popular, not that something is wrong.
+const buildSupplyCapWarning = (noun: string, percentage: number): VaultWarning | null => {
   const level = getCapLevel(percentage)
   if (!level) return null
 
+  const Noun = noun[0].toUpperCase() + noun.slice(1)
   const title = percentage >= 100
-    ? 'Supply cap reached'
+    ? `${Noun} reached`
     : percentage >= CAP_CRITICAL
-      ? 'Supply cap nearly reached'
-      : 'Supply cap approaching limit'
+      ? `${Noun} nearly reached`
+      : `${Noun} approaching limit`
   const message = percentage >= 100
-    ? 'The supply cap has been reached. New deposits will fail.'
+    ? `The ${noun} has been reached. New deposits will fail.`
     : percentage >= CAP_CRITICAL
-      ? 'The supply cap is nearly reached. New deposits may be limited or fail.'
-      : 'The supply cap is approaching its limit. Available capacity for new deposits is limited.'
+      ? `The ${noun} is nearly reached. New deposits may be limited or fail.`
+      : `The ${noun} is approaching its limit. Available capacity for new deposits is limited.`
 
-  // Cap level only determines the message text, not the visual severity.
-  // Reaching a cap means the vault is popular, not that something is wrong.
   return { level: 'info', title, message }
 }
+
+export const getSupplyCapWarning = (vault: Vault): VaultWarning | null =>
+  buildSupplyCapWarning('supply cap', getSupplyCapPercentage(vault))
 
 export const getCollateralSupplyCapWarning = (
   vault: Vault | SecuritizeVault,
 ): VaultWarning | null => {
   if (!isEVKVault(vault)) return null
-
-  const warning = getSupplyCapWarning(vault)
-  if (!warning) return null
-
-  return {
-    ...warning,
-    title: warning.title.replace('Supply cap', 'Collateral supply cap'),
-    message: warning.message.replace('The supply cap', 'The collateral supply cap'),
-  }
+  return buildSupplyCapWarning('collateral supply cap', getSupplyCapPercentage(vault))
 }
 
 export const getIsSupplyCapReached = (vault: Vault): boolean => {

--- a/composables/useVaultWarnings.ts
+++ b/composables/useVaultWarnings.ts
@@ -1,4 +1,4 @@
-import { getVaultUtilization, getSupplyCapPercentage, getBorrowCapPercentage, type Vault } from '~/entities/vault'
+import { getVaultUtilization, getSupplyCapPercentage, getBorrowCapPercentage, isEVKVault, type SecuritizeVault, type Vault } from '~/entities/vault'
 import {
   findBlockingDisabledOp,
   getOpMeta,
@@ -122,6 +122,21 @@ export const getSupplyCapWarning = (vault: Vault): VaultWarning | null => {
   // Cap level only determines the message text, not the visual severity.
   // Reaching a cap means the vault is popular, not that something is wrong.
   return { level: 'info', title, message }
+}
+
+export const getCollateralSupplyCapWarning = (
+  vault: Vault | SecuritizeVault,
+): VaultWarning | null => {
+  if (!isEVKVault(vault)) return null
+
+  const warning = getSupplyCapWarning(vault)
+  if (!warning) return null
+
+  return {
+    ...warning,
+    title: warning.title.replace('Supply cap', 'Collateral supply cap'),
+    message: warning.message.replace('The supply cap', 'The collateral supply cap'),
+  }
 }
 
 export const getIsSupplyCapReached = (vault: Vault): boolean => {

--- a/tests/composables/useVaultWarnings.test.ts
+++ b/tests/composables/useVaultWarnings.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { getCollateralSupplyCapWarning } from '~/composables/useVaultWarnings'
+import type { SecuritizeVault, Vault } from '~/entities/vault'
+
+const makeVault = (supply: bigint, supplyCap: bigint): Vault =>
+  ({
+    supply,
+    supplyCap,
+  }) as Vault
+
+describe('getCollateralSupplyCapWarning', () => {
+  it('returns collateral-specific copy when an EVK collateral supply cap is near its limit', () => {
+    const warning = getCollateralSupplyCapWarning(makeVault(95n, 100n))
+
+    expect(warning).toEqual({
+      level: 'info',
+      title: 'Collateral supply cap approaching limit',
+      message: 'The collateral supply cap is approaching its limit. Available capacity for new deposits is limited.',
+    })
+  })
+
+  it('returns collateral-specific copy when an EVK collateral supply cap is reached', () => {
+    const warning = getCollateralSupplyCapWarning(makeVault(100n, 100n))
+
+    expect(warning).toEqual({
+      level: 'info',
+      title: 'Collateral supply cap reached',
+      message: 'The collateral supply cap has been reached. New deposits will fail.',
+    })
+  })
+
+  it('does not warn for EVK collateral below the shared cap threshold', () => {
+    expect(getCollateralSupplyCapWarning(makeVault(94n, 100n))).toBeNull()
+  })
+
+  it('does not warn for Securitize collateral', () => {
+    const securitizeVault = {
+      type: 'securitize',
+      supply: 100n,
+      supplyCap: 100n,
+    } as SecuritizeVault
+
+    expect(getCollateralSupplyCapWarning(securitizeVault)).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
- Surface collateral supply cap warnings directly on borrow listing rows so users can spot collateral capacity constraints before opening a pair.
- Keep Securitize collateral rows quiet because those collateral types do not use the EVK supply cap warning model.

## Changes
- Add a collateral-specific warning wrapper that reuses the existing supply cap thresholds while making tooltip copy explicit about the collateral side.
- Render the warning icon beside the borrow pair name so the row-level collateral warning is visible across desktop and mobile layouts.
- Cover capped, below-threshold, and Securitize collateral cases with focused warning tests.

## Test plan
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test:run -- tests/composables/useVaultWarnings.test.ts`
- [x] `npm run build`
- [x] Smoke tested rebuilt preview at `/borrow?network=1` with `DEV_GEO_COUNTRY=GB`; page hydrated to 193 rows and collateral supply cap tooltip titles were present.

<img width="1440" height="1200" alt="image" src="https://github.com/user-attachments/assets/807a92d1-6d45-4423-8ff0-dd9fc6ad28cd" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Collateral supply cap warnings added and shown alongside borrow cap warnings in vault headers.

* **UI**
  * Warning icon consolidates multiple warnings and shows aggregated severity.
  * Footnote/tooltips and details modal support multiple titled sections for clearer guidance.
  * Tooltip text wrapping improved for better readability.

* **Tests**
  * Added tests covering collateral supply cap warning scenarios and vault types.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/euler-xyz/euler-lite/pull/371)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->