### PR TITLE
fix: avoid negatively caching transport errors in pricing resolver

### DIFF
--- a/entities/vault/pricing.ts
+++ b/entities/vault/pricing.ts
@@ -153,7 +153,9 @@ export const resolveUnitOfAccountPriceInfo = async (
   }
 
   const priceInfo = await resolveAssetPriceInfo(rpcUrl, utilsLensAddress, unitOfAccount)
-  unitOfAccountPriceCache.set(normalized, priceInfo || null)
+  if (priceInfo || assetPriceCache.has(normalized)) {
+    unitOfAccountPriceCache.set(normalized, priceInfo || null)
+  }
   return priceInfo
 }
 

--- a/entities/vault/pricing.ts
+++ b/entities/vault/pricing.ts
@@ -152,8 +152,9 @@ export const resolveUnitOfAccountPriceInfo = async (
     return undefined
   }
 
+  const gen = cacheGeneration
   const priceInfo = await resolveAssetPriceInfo(rpcUrl, utilsLensAddress, unitOfAccount)
-  if (priceInfo || assetPriceCache.has(normalized)) {
+  if (cacheGeneration === gen && (priceInfo || assetPriceCache.has(normalized))) {
     unitOfAccountPriceCache.set(normalized, priceInfo || null)
   }
   return priceInfo

--- a/entities/vault/pricing.ts
+++ b/entities/vault/pricing.ts
@@ -3,6 +3,7 @@ import { USD_ADDRESS } from '~/entities/constants'
 import { eulerUtilsLensABI } from '~/entities/euler/abis'
 import { logger } from '~/utils/logger'
 import { getPublicClient } from '~/utils/public-client'
+import { summarizeViemError } from '~/utils/viem-errors'
 
 export interface FullAssetPriceInfo {
   amountIn: bigint
@@ -86,7 +87,11 @@ const resolveAndCacheAssetPrice = (
         { ctx: 'pricing/resolveAssetPrice', asset: assetAddress, err: e },
         `error fetching price for asset ${assetAddress}`,
       )
-      if (cacheGeneration === gen) {
+      // Negatively cache only contract-level failures. Transport errors
+      // (RPC down, rate limit, timeout) are transient — caching null here
+      // would poison this asset's price for the rest of the process lifetime,
+      // since clearPriceCaches() only fires on chain switch.
+      if (cacheGeneration === gen && !summarizeViemError(e).isTransport) {
         assetPriceCache.set(key, null)
       }
       return undefined

--- a/tests/entities/vault/pricing.test.ts
+++ b/tests/entities/vault/pricing.test.ts
@@ -148,4 +148,51 @@ describe('resolveAssetPriceInfo cache behaviour', () => {
     expect(c).toBeUndefined()
     expect(readContractMock).toHaveBeenCalledTimes(1)
   })
+
+  it('does NOT cache a unit-of-account miss caused by a transport error', async () => {
+    const transport = new HttpRequestError({
+      url: 'https://rpc.example/tac',
+      status: 503,
+      body: { jsonrpc: '2.0', id: 1, method: 'eth_call', params: [] },
+      details: 'Service Unavailable',
+    })
+    readContractMock.mockRejectedValueOnce(transport)
+    readContractMock.mockResolvedValueOnce({
+      queryFailure: false,
+      amountIn: 10n ** 18n,
+      amountOutAsk: 300n,
+      amountOutBid: 299n,
+      amountOutMid: 300n,
+      timestamp: 1n,
+      oracle: '0x0000000000000000000000000000000000000001',
+    })
+
+    const { resolveUnitOfAccountPriceInfo } = await import('~/entities/vault/pricing')
+    const first = await resolveUnitOfAccountPriceInfo(RPC_URL, LENS, ASSET)
+    const second = await resolveUnitOfAccountPriceInfo(RPC_URL, LENS, ASSET)
+
+    expect(first).toBeUndefined()
+    expect(second?.amountOutMid).toBe(300n)
+    expect(readContractMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('caches unit-of-account queryFailure: true so the call is not retried', async () => {
+    readContractMock.mockResolvedValue({
+      queryFailure: true,
+      amountIn: 10n ** 18n,
+      amountOutAsk: 0n,
+      amountOutBid: 0n,
+      amountOutMid: 0n,
+      timestamp: 0n,
+      oracle: '0x0000000000000000000000000000000000000001',
+    })
+
+    const { resolveUnitOfAccountPriceInfo } = await import('~/entities/vault/pricing')
+    const first = await resolveUnitOfAccountPriceInfo(RPC_URL, LENS, ASSET)
+    const second = await resolveUnitOfAccountPriceInfo(RPC_URL, LENS, ASSET)
+
+    expect(first).toBeUndefined()
+    expect(second).toBeUndefined()
+    expect(readContractMock).toHaveBeenCalledTimes(1)
+  })
 })

--- a/tests/entities/vault/pricing.test.ts
+++ b/tests/entities/vault/pricing.test.ts
@@ -195,4 +195,42 @@ describe('resolveAssetPriceInfo cache behaviour', () => {
     expect(second).toBeUndefined()
     expect(readContractMock).toHaveBeenCalledTimes(1)
   })
+
+  it('does NOT cache a unit-of-account price resolved after caches are cleared', async () => {
+    let resolveFirst!: (value: Record<string, unknown>) => void
+    const firstRead = new Promise<Record<string, unknown>>((resolve) => {
+      resolveFirst = resolve
+    })
+    readContractMock.mockReturnValueOnce(firstRead)
+
+    const { clearPriceCaches, resolveUnitOfAccountPriceInfo } = await import('~/entities/vault/pricing')
+    const firstPromise = resolveUnitOfAccountPriceInfo(RPC_URL, LENS, ASSET)
+    clearPriceCaches()
+
+    resolveFirst({
+      queryFailure: false,
+      amountIn: 10n ** 18n,
+      amountOutAsk: 400n,
+      amountOutBid: 399n,
+      amountOutMid: 400n,
+      timestamp: 1n,
+      oracle: '0x0000000000000000000000000000000000000001',
+    })
+    readContractMock.mockResolvedValueOnce({
+      queryFailure: false,
+      amountIn: 10n ** 18n,
+      amountOutAsk: 500n,
+      amountOutBid: 499n,
+      amountOutMid: 500n,
+      timestamp: 2n,
+      oracle: '0x0000000000000000000000000000000000000001',
+    })
+
+    const first = await firstPromise
+    const second = await resolveUnitOfAccountPriceInfo(RPC_URL, LENS, ASSET)
+
+    expect(first?.amountOutMid).toBe(400n)
+    expect(second?.amountOutMid).toBe(500n)
+    expect(readContractMock).toHaveBeenCalledTimes(2)
+  })
 })

--- a/tests/entities/vault/pricing.test.ts
+++ b/tests/entities/vault/pricing.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { BaseError, HttpRequestError, TimeoutError } from 'viem'
+
+const readContractMock = vi.fn()
+
+vi.mock('~/utils/public-client', () => ({
+  getPublicClient: () => ({ readContract: readContractMock }),
+}))
+
+const RPC_URL = 'https://example.test/rpc'
+const LENS = '0x000000000000000000000000000000000000DEAD'
+const ASSET = '0x000000000000000000000000000000000000BEEF'
+
+describe('resolveAssetPriceInfo cache behaviour', () => {
+  beforeEach(async () => {
+    const { clearPriceCaches } = await import('~/entities/vault/pricing')
+    clearPriceCaches()
+    readContractMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('caches a successful price and avoids a second RPC call', async () => {
+    readContractMock.mockResolvedValue({
+      queryFailure: false,
+      amountIn: 10n ** 18n,
+      amountOutAsk: 100n,
+      amountOutBid: 99n,
+      amountOutMid: 100n,
+      timestamp: 1n,
+      oracle: '0x0000000000000000000000000000000000000001',
+    })
+
+    const { resolveAssetPriceInfo } = await import('~/entities/vault/pricing')
+    const first = await resolveAssetPriceInfo(RPC_URL, LENS, ASSET)
+    const second = await resolveAssetPriceInfo(RPC_URL, LENS, ASSET)
+
+    expect(first?.amountOutMid).toBe(100n)
+    expect(second?.amountOutMid).toBe(100n)
+    expect(readContractMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('caches queryFailure: true (contract-level no-price) so the call is not retried', async () => {
+    readContractMock.mockResolvedValue({
+      queryFailure: true,
+      amountIn: 10n ** 18n,
+      amountOutAsk: 0n,
+      amountOutBid: 0n,
+      amountOutMid: 0n,
+      timestamp: 0n,
+      oracle: '0x0000000000000000000000000000000000000001',
+    })
+
+    const { resolveAssetPriceInfo } = await import('~/entities/vault/pricing')
+    const first = await resolveAssetPriceInfo(RPC_URL, LENS, ASSET)
+    const second = await resolveAssetPriceInfo(RPC_URL, LENS, ASSET)
+
+    expect(first).toBeUndefined()
+    expect(second).toBeUndefined()
+    expect(readContractMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('does NOT cache when the failure is a transport error (HTTP 5xx)', async () => {
+    const transport = new HttpRequestError({
+      url: 'https://rpc.ankr.com/tac',
+      status: 503,
+      body: { jsonrpc: '2.0', id: 1, method: 'eth_call', params: [] },
+      details: 'Service Unavailable',
+    })
+    readContractMock.mockRejectedValueOnce(transport)
+    readContractMock.mockResolvedValueOnce({
+      queryFailure: false,
+      amountIn: 10n ** 18n,
+      amountOutAsk: 200n,
+      amountOutBid: 199n,
+      amountOutMid: 200n,
+      timestamp: 1n,
+      oracle: '0x0000000000000000000000000000000000000001',
+    })
+
+    const { resolveAssetPriceInfo } = await import('~/entities/vault/pricing')
+    const first = await resolveAssetPriceInfo(RPC_URL, LENS, ASSET)
+    const second = await resolveAssetPriceInfo(RPC_URL, LENS, ASSET)
+
+    expect(first).toBeUndefined()
+    expect(second?.amountOutMid).toBe(200n)
+    expect(readContractMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('does NOT cache when the failure is a timeout', async () => {
+    const timeout = new TimeoutError({
+      body: { jsonrpc: '2.0', id: 1, method: 'eth_call', params: [] },
+      url: 'https://rpc.example/tac',
+    })
+    readContractMock.mockRejectedValueOnce(timeout)
+    readContractMock.mockResolvedValueOnce({
+      queryFailure: false,
+      amountIn: 10n ** 18n,
+      amountOutAsk: 50n,
+      amountOutBid: 49n,
+      amountOutMid: 50n,
+      timestamp: 1n,
+      oracle: '0x0000000000000000000000000000000000000001',
+    })
+
+    const { resolveAssetPriceInfo } = await import('~/entities/vault/pricing')
+    const first = await resolveAssetPriceInfo(RPC_URL, LENS, ASSET)
+    const second = await resolveAssetPriceInfo(RPC_URL, LENS, ASSET)
+
+    expect(first).toBeUndefined()
+    expect(second?.amountOutMid).toBe(50n)
+    expect(readContractMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('caches non-transport errors (e.g. unexpected revert) so we do not hammer the RPC', async () => {
+    const revert = new BaseError('unexpected revert', { name: 'ContractFunctionRevertedError' })
+    readContractMock.mockRejectedValue(revert)
+
+    const { resolveAssetPriceInfo } = await import('~/entities/vault/pricing')
+    const first = await resolveAssetPriceInfo(RPC_URL, LENS, ASSET)
+    const second = await resolveAssetPriceInfo(RPC_URL, LENS, ASSET)
+
+    expect(first).toBeUndefined()
+    expect(second).toBeUndefined()
+    expect(readContractMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('concurrent calls during a transport failure share one in-flight request', async () => {
+    const transport = new HttpRequestError({
+      url: 'https://rpc.example/tac',
+      status: 503,
+      body: { jsonrpc: '2.0', id: 1, method: 'eth_call', params: [] },
+      details: 'Service Unavailable',
+    })
+    readContractMock.mockRejectedValueOnce(transport)
+
+    const { resolveAssetPriceInfo } = await import('~/entities/vault/pricing')
+    const [a, b, c] = await Promise.all([
+      resolveAssetPriceInfo(RPC_URL, LENS, ASSET),
+      resolveAssetPriceInfo(RPC_URL, LENS, ASSET),
+      resolveAssetPriceInfo(RPC_URL, LENS, ASSET),
+    ])
+
+    expect(a).toBeUndefined()
+    expect(b).toBeUndefined()
+    expect(c).toBeUndefined()
+    expect(readContractMock).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Summary

Single transport-level RPC failures (timeout, HTTP 5xx, rate limit) were poisoning the asset price cache in `entities/vault/pricing.ts`: the `.catch` handler stored `null` for the asset, and since `clearPriceCaches()` only fires on chain switch, the next caller saw a permanent miss for the rest of the process lifetime — even after the RPC fully recovered. On the warm-cache server process this means a single Ankr blip can blank a vault's USD value until the next deploy.

The fix walks the cause chain via `summarizeViemError` and only writes to the negative cache when the failure is *not* a transport error. Genuine "no oracle for this pair" signals (the lens returning `queryFailure: true`, plus contract reverts) still cache as before — the in-flight dedup map prevents thundering-herd retries during a sustained outage.

Real-world trigger that surfaced this: wstETH on TAC (chain 239) hit a transient `code: -32062` from `rpc.ankr.com/tac`. The same call works now in 450ms, but the cached `null` would have kept that asset unpriced until the Fargate task restarted.

## Test plan

- [x] New unit tests in `tests/entities/vault/pricing.test.ts` covering: success cache, `queryFailure: true` cache, transport-error skip-cache (HTTP 5xx + timeout), non-transport-error cache, and concurrent in-flight dedup during a transport failure.
- [x] Full vitest suite: 627 passing, 1 skipped (no regressions).
- [ ] Manual: monitor BetterStack for `ctx: pricing/resolveAssetPrice` warnings after deploy — single-asset bursts should now self-recover instead of going silent at one warning per process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved price-resolution caching: transient transport/RPC errors are no longer permanently cached, allowing retries; contract/query failures remain cached to avoid redundant lookups. Unit-of-account cache updates now occur only when a valid price is available or an existing asset entry exists, preventing unnecessary null writes.

* **Tests**
  * Expanded coverage for caching and error-handling: transient failures, timeouts, query failures, cache invalidation, and concurrent requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->