### PR TITLE
fix: allow confirming/transacting modals to close

### DIFF
--- a/components/base/BaseModalWrapper.vue
+++ b/components/base/BaseModalWrapper.vue
@@ -141,14 +141,26 @@ const dragStyle = computed(() => ({
           />
           {{ title }}
         </p>
-        <UiButton
+        <button
           v-if="close"
-          variant="primary-stroke"
-          icon="close"
+          type="button"
+          class="ui-button ui-button--medium ui-button--primary-stroke is-icon-only"
           name="cross"
-          icon-only
-          @click="$emit('close')"
-        />
+          aria-label="Close modal"
+          @click="emit('close')"
+        >
+          <div class="ui-button__wrap">
+            <div
+              class="ui-button__icon"
+              aria-hidden="true"
+            >
+              <SvgIcon
+                class="ui-button__icon-svg"
+                name="close"
+              />
+            </div>
+          </div>
+        </button>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- Replace the modal header close control with a native button while preserving existing UI button classes.
- Keep the close click independent from the loading/confirming state used by operation review modals.

## Test Plan
- npm run lint
- npm run typecheck
- Smoke tested confirming operation modal: header X closes while pending, backdrop close still works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the modal close button implementation with improved accessibility and styling consistency. No changes to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->