### PR TITLE
Deep link Merkl reward sources

### DIFF
--- a/composables/useMerkl.ts
+++ b/composables/useMerkl.ts
@@ -61,6 +61,21 @@ interface MerklProxyResponse {
   }
 }
 
+const MERKL_EULER_SOURCE_URL = 'https://app.merkl.xyz/?protocol=euler'
+
+const merklOpportunityUrl = (
+  opportunity: Opportunity,
+  type: 'EULER' | 'ERC20LOGPROCESSOR' | 'MULTILENDBORROW',
+): string => {
+  if (!opportunity.identifier) return MERKL_EULER_SOURCE_URL
+
+  const chain = (opportunity.chain?.name || String(opportunity.chainId)).trim()
+  if (!chain) return MERKL_EULER_SOURCE_URL
+
+  const chainSlug = chain.toLowerCase().replace(/\s+/g, '-')
+  return `https://app.merkl.xyz/opportunities/${encodeURIComponent(chainSlug)}/${type}/${encodeURIComponent(opportunity.identifier)}`
+}
+
 // Public campaign data flows through `/api/rewards/merkl`, which warms the
 // three Merkl opportunity types server-side and returns one CDN-cacheable
 // GET. User-specific /users/{addr}/rewards stays direct (per-wallet data
@@ -127,7 +142,7 @@ const processOpportunitiesToCampaigns = (
         provider: 'merkl',
         endTimestamp: campaign.endTimestamp,
         rewardToken: { symbol: campaign.rewardToken.symbol, icon: campaign.rewardToken.icon },
-        sourceUrl: 'https://app.merkl.xyz/?protocol=euler',
+        sourceUrl: merklOpportunityUrl(opportunity, opType),
       }
 
       const existing = campaignMap.get(vaultAddress)
@@ -190,7 +205,7 @@ const processMultiLendBorrowOpportunities = (
           provider: 'merkl',
           endTimestamp: campaign.endTimestamp,
           rewardToken: { symbol: campaign.rewardToken.symbol, icon: campaign.rewardToken.icon },
-          sourceUrl: `https://app.merkl.xyz/opportunities/${(opportunity.chain?.name || String(opportunity.chainId)).toLowerCase()}/MULTILENDBORROW/${opportunity.identifier}`,
+          sourceUrl: merklOpportunityUrl(opportunity, 'MULTILENDBORROW'),
         }
 
         const existing = campaignMap.get(vaultAddress)

--- a/composables/useMerkl.ts
+++ b/composables/useMerkl.ts
@@ -69,7 +69,7 @@ const merklOpportunityUrl = (
 ): string => {
   if (!opportunity.identifier) return MERKL_EULER_SOURCE_URL
 
-  const chain = (opportunity.chain?.name || String(opportunity.chainId)).trim()
+  const chain = (opportunity.chain?.name || opportunity.chainId?.toString())?.trim()
   if (!chain) return MERKL_EULER_SOURCE_URL
 
   const chainSlug = chain.toLowerCase().replace(/\s+/g, '-')


### PR DESCRIPTION
## Summary
- Link Merkl reward rows to exact opportunity pages so APY breakdown users land on the relevant Merkl context instead of the generic Euler listing.
- Reuse one URL builder across EULER, ERC20LOGPROCESSOR, and MULTILENDBORROW rewards while preserving the generic fallback when a route cannot be built.

## Changes
- Build Merkl source URLs from the opportunity payload using `opportunities/{chainSlug}/{type}/{identifier}`.
- Slugify chain names before encoding so multi-word chain routes keep matching Merkl app URLs.
- Route the existing MULTILENDBORROW source link through the shared helper.

## Test plan
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test:run`
- [x] Open the local EULER reward row from `localhost:3000/lend/0x502e4a0B61dEBA3015Eb9E51116B832003B22c2C?network=143` and verify the Merkl source link points to `https://app.merkl.xyz/opportunities/monad/EULER/0x502e4a0B61dEBA3015Eb9E51116B832003B22c2C`.
- [x] Open the local ERC20LOGPROCESSOR reward row from `localhost:3000/earn/0xA981f053C118FE4dB0e1aEBA192AAD20Ec7F7801?network=143` and verify the Merkl source link points to `https://app.merkl.xyz/opportunities/monad/ERC20LOGPROCESSOR/0xA981f053C118FE4dB0e1aEBA192AAD20Ec7F7801`.
- [x] Confirm the MULTILENDBORROW Merkl opportunity URL returns HTTP 200: `https://app.merkl.xyz/opportunities/arbitrum/MULTILENDBORROW/0x795dfbde983ef7f2f2340c30c9c1c89d0c56377e`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved Merkl opportunity links so each listing now has a tailored deep link built from its chain and identifier, with sensible fallbacks to a protocol page when data is missing—resulting in more accurate and reliable source links for opportunities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->