### PR TITLE
Hide static share token exchange rates

### DIFF
--- a/components/entities/vault/overview/VaultOverviewBlockRiskParameters.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockRiskParameters.vue
@@ -32,6 +32,7 @@ const isBorrowable = computed(() => borrowCount.value > 0)
 
 const supplyCapPercentageDisplay = computed(() => getSupplyCapPercentage(vault))
 const borrowCapPercentageDisplay = computed(() => getBorrowCapPercentage(vault))
+const showShareTokenExchangeRate = computed(() => vault.vaultCategory !== 'escrow' && vault.borrowCap !== 0n)
 
 const supplyCapDisplay = ref('-')
 const borrowCapDisplay = ref('-')
@@ -63,6 +64,8 @@ watchEffect(async () => {
 })
 
 const load = async () => {
+  if (!showShareTokenExchangeRate.value) return
+
   const client = rpcClient.value!
   shareTokenExchangeRate.value = await client.readContract({
     address: vault.address as Address,
@@ -151,6 +154,7 @@ const openHooksModal = () => {
         </div>
       </VaultOverviewLabelValue>
       <VaultOverviewLabelValue
+        v-if="showShareTokenExchangeRate"
         label="Share token exchange rate"
         orientation="horizontal"
       >

--- a/components/entities/vault/overview/VaultOverviewBlockRiskParameters.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockRiskParameters.vue
@@ -32,7 +32,7 @@ const isBorrowable = computed(() => borrowCount.value > 0)
 
 const supplyCapPercentageDisplay = computed(() => getSupplyCapPercentage(vault))
 const borrowCapPercentageDisplay = computed(() => getBorrowCapPercentage(vault))
-const showShareTokenExchangeRate = computed(() => vault.vaultCategory !== 'escrow' && vault.borrowCap !== 0n)
+const showShareTokenExchangeRate = computed(() => vault.vaultCategory !== 'escrow' && (vault.borrowCap !== 0n || vault.borrow > 0n))
 
 const supplyCapDisplay = ref('-')
 const borrowCapDisplay = ref('-')


### PR DESCRIPTION
## Summary
- Hide the share token exchange rate row when an EVK vault cannot accrue depositor interest, keeping the risk parameters block focused on useful values.
- Avoid the `convertToAssets` read for those static-rate vaults instead of fetching the value and hiding it later.

## Changes
- Adds a computed display predicate for escrow vaults and collateral-only EVK vaults.
- Reuses that predicate to gate both the row rendering and the contract read.
- Leaves Securitize vault overview behavior unchanged.

## Test plan
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] Checked a standard borrowable vault keeps showing the share token exchange rate row.
- [x] Checked a collateral-only EVK vault hides the row.
- [x] Checked an escrow vault hides the row.
- [x] Checked the escrow page RPC payloads did not include the `convertToAssets` selector.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Share token exchange rate now only appears on vault overview when applicable, preventing misleading or irrelevant information.
* **Performance**
  * Reduced background data requests for vaults where the exchange rate is not applicable, improving responsiveness and efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->