### PR TITLE
Stabilize multiply tab loading state

### DIFF
--- a/pages/borrow/[collateral]/[borrow]/index.vue
+++ b/pages/borrow/[collateral]/[borrow]/index.vue
@@ -868,6 +868,15 @@ watch(formTab, () => {
                   </div>
                 </div>
               </template>
+
+              <template v-else-if="formTab === 'multiply'">
+                <div
+                  class="flex min-h-[624px] items-center justify-center rounded-16 bg-surface-secondary shadow-card"
+                  aria-busy="true"
+                >
+                  <UiLoader class="text-content-muted" />
+                </div>
+              </template>
             </template>
 
             <template #buttons>


### PR DESCRIPTION
## Summary
- Prevent the Multiply tab from rendering an empty form body while its vault state is still initializing.
- Keep the submit/TOS area from appearing visually orphaned during tab switches.

## Changes
- Render a centered loader placeholder when the Multiply tab is active but the multiply form vault refs are not ready yet.
- Leave the existing ready-state form rendering and submit/TOS behavior unchanged.

## Test plan
- [x] npm run lint
- [x] npm run typecheck
- [x] Manually forced a delayed multiply supply vault initialization and verified the loader fills the transient state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added loading state display when multiply mode is accessed before vault data is fully prepared.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->