### PR TITLE
Fix iPad header nav overlap

### DIFF
--- a/components/layout/TheHeader.vue
+++ b/components/layout/TheHeader.vue
@@ -106,7 +106,7 @@ onClickOutside(wrapperRef, () => {
 
 <template>
   <header
-    class="relative sticky top-0 right-0 left-0 z-[101] min-h-[72px] border-b border-line-default py-16 px-24 mobile:min-h-[56px] mobile:border-b-0 mobile:p-16 flex items-center justify-between bg-header backdrop-blur-[20px]"
+    class="relative sticky top-0 right-0 left-0 z-[101] min-h-[72px] border-b border-line-default py-16 px-24 mobile:min-h-[56px] mobile:border-b-0 mobile:p-16 flex items-center gap-16 bg-header backdrop-blur-[20px]"
   >
     <!-- Left: Logo -->
     <div
@@ -202,14 +202,14 @@ onClickOutside(wrapperRef, () => {
       </Transition>
     </div>
 
-    <!-- Center: Navigation -->
-    <div class="absolute left-1/2 -translate-x-1/2 pointer-events-none mobile:!hidden">
-      <div class="flex pointer-events-auto">
+    <!-- Navigation -->
+    <div class="hidden laptop:block min-w-0 tablet:absolute tablet:left-1/2 tablet:-translate-x-1/2">
+      <div class="flex gap-4 tablet:gap-0">
         <NuxtLink
           v-for="item in menuItems"
           :key="item.name"
           :to="'/' + item.name"
-          class="flex gap-8 text-[13px] font-medium no-underline py-6 px-16 rounded-8 text-content-secondary items-center justify-center hover:text-content-primary hover:bg-surface-secondary transition-all"
+          class="flex gap-8 text-[13px] font-medium no-underline py-6 px-12 tablet:px-16 rounded-8 text-content-secondary items-center justify-center hover:text-content-primary hover:bg-surface-secondary transition-all"
           :class="[
             getIsMenuItemActive(item)
               ? 'bg-surface-secondary text-content-primary'
@@ -238,7 +238,7 @@ onClickOutside(wrapperRef, () => {
     </div>
 
     <!-- Right: Wallet -->
-    <div class="flex flex-nowrap gap-8 min-w-0">
+    <div class="ml-auto flex flex-nowrap gap-8 min-w-0">
       <UiButton
         v-if="canSwitchChains"
         class="py-6 px-12"


### PR DESCRIPTION
## Summary
- Left align the header nav in iPad widths so it does not collide with chain and wallet controls.
- Keep centered nav positioning at the tablet/desktop breakpoint.

## Changes
- Replace the always-centered nav with responsive positioning: left-aligned on laptop widths, centered again on tablet and wider.
- Tighten nav item padding below the tablet breakpoint and add a small gap between nav buttons for iPad readability.

## Test plan
- [x] npm run lint
- [x] Manually verify the header at iPad width with multiple chains enabled
- [x] Manually verify desktop nav remains centered

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reorganized header layout structure with improved alignment and centered navigation positioning for larger displays.
  * Enhanced responsive design with refined visibility controls and spacing adjustments across all screen sizes.
  * Adjusted positioning of navigation and user account elements to improve header presentation on mobile, tablet, and desktop.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->