### PR TITLE
fix: redirect legacy market links

### DIFF
--- a/middleware/01.network.global.ts
+++ b/middleware/01.network.global.ts
@@ -1,24 +1,9 @@
 import { parseChainId } from '~/entities/chainRegistry'
+import { omitQueryKeys, rewriteLegacyPath } from '~/utils/legacy-route-rewrites'
 
 const rawNetworkParam = (value: unknown): string | null => {
   const normalized = Array.isArray(value) ? value[0] : value
   return typeof normalized === 'string' ? normalized : null
-}
-
-// Legacy path rewrites from the pre-lite app. Preserves any trailing segments
-// (e.g. vault/collateral addresses) after the renamed prefix.
-const LEGACY_PATH_REWRITES: ReadonlyArray<{ from: RegExp, to: string }> = [
-  { from: /^\/vault(\/.*)?$/, to: '/lend' },
-  { from: /^\/positions(\/.*)?$/, to: '/borrow' },
-  { from: /^\/account(\/.*)?$/, to: '/position' },
-]
-
-const rewriteLegacyPath = (path: string): string | null => {
-  for (const { from, to } of LEGACY_PATH_REWRITES) {
-    const match = path.match(from)
-    if (match) return to + (match[1] ?? '')
-  }
-  return null
 }
 
 export default defineNuxtRouteMiddleware((to) => {
@@ -36,7 +21,7 @@ export default defineNuxtRouteMiddleware((to) => {
   const rawNetwork = rawNetworkParam(rawChainParam)
   const needsNormalization = queryChainId != null && rawNetwork !== String(queryChainId)
   const hasLegacyChainIdParam = to.query.chainId != null
-  const rewrittenPath = rewriteLegacyPath(to.path)
+  const legacyPathRewrite = rewriteLegacyPath(to.path)
 
   // Sync state chainId to the URL's chainId before downstream middleware
   // (e.g. ensure-vault) runs chain-scoped lookups. Without this, a legacy URL
@@ -51,12 +36,13 @@ export default defineNuxtRouteMiddleware((to) => {
     localStorage.setItem('chainId', String(fallbackChainId))
   }
 
-  if (rewrittenPath || !queryChainId || queryChainId !== fallbackChainId || needsNormalization || hasLegacyChainIdParam) {
+  if (legacyPathRewrite || !queryChainId || queryChainId !== fallbackChainId || needsNormalization || hasLegacyChainIdParam) {
     const { chainId: _legacyChainId, ...restQuery } = to.query
+    const sanitizedQuery = omitQueryKeys(restQuery, legacyPathRewrite?.dropQueryKeys ?? [])
     return navigateTo({
-      path: rewrittenPath ?? to.path,
+      path: legacyPathRewrite?.path ?? to.path,
       query: {
-        ...restQuery,
+        ...sanitizedQuery,
         network: fallbackChainId,
       },
       hash: to.hash,

--- a/tests/utils/legacy-route-rewrites.test.ts
+++ b/tests/utils/legacy-route-rewrites.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { omitQueryKeys, rewriteLegacyPath } from '~/utils/legacy-route-rewrites'
+
+describe('legacy route rewrites', () => {
+  it('rewrites legacy market links to explore market links', () => {
+    expect(rewriteLegacyPath('/market/sentora-ondo')).toEqual({
+      path: '/explore/sentora-ondo',
+      dropQueryKeys: ['tab'],
+    })
+  })
+
+  it('removes legacy market tab query params without dropping unrelated params', () => {
+    expect(omitQueryKeys({
+      network: '1',
+      tab: 'positions',
+      spy: '0x123',
+    }, ['tab'])).toEqual({
+      network: '1',
+      spy: '0x123',
+    })
+  })
+
+  it('keeps existing legacy vault rewrites intact', () => {
+    expect(rewriteLegacyPath('/vault/0xVault')).toEqual({
+      path: '/lend/0xVault',
+      dropQueryKeys: undefined,
+    })
+    expect(rewriteLegacyPath('/positions/12')).toEqual({
+      path: '/borrow/12',
+      dropQueryKeys: undefined,
+    })
+    expect(rewriteLegacyPath('/account/3')).toEqual({
+      path: '/position/3',
+      dropQueryKeys: undefined,
+    })
+  })
+
+  it('does not rewrite current routes', () => {
+    expect(rewriteLegacyPath('/explore/sentora-ondo')).toBeNull()
+  })
+})

--- a/utils/legacy-route-rewrites.ts
+++ b/utils/legacy-route-rewrites.ts
@@ -1,0 +1,39 @@
+export type LegacyPathRewrite = {
+  path: string
+  dropQueryKeys?: readonly string[]
+}
+
+type LegacyPathRewriteRule = {
+  from: RegExp
+  to: string
+  dropQueryKeys?: readonly string[]
+}
+
+// Legacy path rewrites from the pre-lite app. Preserves any trailing segments
+// (e.g. vault/collateral addresses) after the renamed prefix.
+const LEGACY_PATH_REWRITES: readonly LegacyPathRewriteRule[] = [
+  { from: /^\/vault(\/.*)?$/, to: '/lend' },
+  { from: /^\/positions(\/.*)?$/, to: '/borrow' },
+  { from: /^\/account(\/.*)?$/, to: '/position' },
+  { from: /^\/market(\/.*)?$/, to: '/explore', dropQueryKeys: ['tab'] },
+]
+
+export const rewriteLegacyPath = (path: string): LegacyPathRewrite | null => {
+  for (const { from, to, dropQueryKeys } of LEGACY_PATH_REWRITES) {
+    const match = path.match(from)
+    if (match) return { path: to + (match[1] ?? ''), dropQueryKeys }
+  }
+  return null
+}
+
+export const omitQueryKeys = <T extends Record<string, unknown>>(
+  query: T,
+  keys: readonly string[],
+): Partial<T> => {
+  if (!keys.length) return { ...query }
+
+  const keysToOmit = new Set(keys)
+  return Object.fromEntries(
+    Object.entries(query).filter(([key]) => !keysToOmit.has(key)),
+  ) as Partial<T>
+}


### PR DESCRIPTION
## Summary
- Redirect legacy `/market/:market` links to `/explore/:market`.
- Drop the old `tab` query param for market links while preserving `network`, `spy`, and hash/query normalization.
- Move legacy rewrite rules into a small tested helper so existing `/vault`, `/positions`, and `/account` rewrites stay covered.

## Linear
- EUL4-197

## Tests
- `npm run test:run -- tests/utils/legacy-route-rewrites.test.ts`
- `npm run typecheck`
- `npx eslint utils/legacy-route-rewrites.ts middleware/01.network.global.ts tests/utils/legacy-route-rewrites.test.ts`

## Manual checks
- `http://localhost:3000/market/sentora-ondo?network=1&tab=positions` redirects to `/explore/sentora-ondo?network=1`.
- `http://localhost:3000/market/sentora-ondo?network=1` redirects to `/explore/sentora-ondo?network=1`.
- `http://localhost:3000/market/sentora-ondo?chainId=1&tab=positions` redirects to `/explore/sentora-ondo?network=1`.
- `http://localhost:3000/market/sentora-ondo?network=1&tab=positions&spy=0x0000000000000000000000000000000000000000` preserves `spy` and drops `tab`.
- `http://localhost:3000/vault/0xD8b27CF359b7D15710a5BE299AF6e7Bf904984C2?network=1` redirects to `/lend/0xD8b27CF359b7D15710a5BE299AF6e7Bf904984C2?network=1`.
- `http://localhost:3000/positions/0xD8b27CF359b7D15710a5BE299AF6e7Bf904984C2/0xbC4B4AC47582c3E38Ce5940B80Da65401F4628f1?network=1` redirects to `/borrow/0xD8b27CF359b7D15710a5BE299AF6e7Bf904984C2/0xbC4B4AC47582c3E38Ce5940B80Da65401F4628f1?network=1`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved legacy route handling with better path rewriting and query parameter cleanup for backward compatibility.

* **Tests**
  * Added comprehensive test coverage for legacy route rewrite functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->