### PR TITLE
feat: add Accountable intrinsic-APY adapter

### DIFF
--- a/entities/custom.ts
+++ b/entities/custom.ts
@@ -18,6 +18,7 @@ export type IntrinsicApySourceConfig
     | { provider: 'benqi', address: string, chainId: number }
     | { provider: 'avant', address: string, chainId: number }
     | { provider: 'infinifi', address: string, chainId: number, infinifiVariant: 'locked' | 'staked', infinifiLockedKey?: string }
+    | { provider: 'accountable', address: string, chainId: number, loanAddress: string }
 
 export const intrinsicApySources: readonly IntrinsicApySourceConfig[] = [
   // DefiLlama pools — Ethereum (1)
@@ -85,6 +86,9 @@ export const intrinsicApySources: readonly IntrinsicApySourceConfig[] = [
   // DefiLlama pools — Monad (143)
   { provider: 'defillama', chainId: 143, address: '0x10Aeaf63194db8d453d4D85a06E5eFE1dd0b5417', poolId: '747c1d2a-c668-4682-b9f9-296708a3dd90' },
   { provider: 'defillama', chainId: 143, address: '0x1b68626dca36c7fe922fd2d55e4f631d962de19c', poolId: 'ee40513c-9356-4c53-9f26-446b484a8ae2' },
+
+  // Accountable loans — Monad (143)
+  { provider: 'accountable', chainId: 143, address: '0x8d3F9f9Eb2f5E8B48EFBB4074440D1E2A34Bc365', loanAddress: '0x8dCE15fc6a98484C995Fc702cBfBdA14A30454af' },
 
   // DefiLlama pools — Sonic (146)
   { provider: 'defillama', chainId: 146, address: '0x16af6b1315471Dc306D47e9CcEfEd6e5996285B6', poolId: '24b3096a-488d-4a61-afa6-e5e9be2ce4bf' },

--- a/server/utils/intrinsic-apy.ts
+++ b/server/utils/intrinsic-apy.ts
@@ -317,7 +317,12 @@ async function extractInfinifi(sources: InfinifiSource[]): Promise<Array<[string
 }
 
 type AccountableSource = Extract<IntrinsicApySourceConfig, { provider: 'accountable' }>
-type AccountableLoanResponse = { loan_computed?: { net_apy?: number } }
+type AccountableLoanResponse = {
+  loan_computed?: {
+    net_apy?: number
+    rewards_apy_boost?: { total_apy_boost_percent?: number }
+  }
+}
 
 const ACCOUNTABLE_CONCURRENCY = 10
 
@@ -334,8 +339,10 @@ async function extractAccountable(sources: AccountableSource[]): Promise<Array<[
   for (const r of settled) {
     if (r.status !== 'fulfilled') continue
     const { source, data } = r.value
-    const apy = Number(data?.loan_computed?.net_apy)
-    if (!Number.isFinite(apy)) continue
+    const netApy = Number(data?.loan_computed?.net_apy)
+    if (!Number.isFinite(netApy)) continue
+    const rewardsBoost = Number(data?.loan_computed?.rewards_apy_boost?.total_apy_boost_percent ?? 0)
+    const apy = Math.max(0, netApy - (Number.isFinite(rewardsBoost) ? rewardsBoost : 0))
     out.push([normalize(source.address), {
       apy,
       provider: 'Accountable',

--- a/server/utils/intrinsic-apy.ts
+++ b/server/utils/intrinsic-apy.ts
@@ -320,7 +320,6 @@ type AccountableSource = Extract<IntrinsicApySourceConfig, { provider: 'accounta
 type AccountableLoanResponse = {
   loan_computed?: {
     net_apy?: number
-    rewards_apy_boost?: { total_apy_boost_percent?: number }
   }
 }
 
@@ -339,10 +338,8 @@ async function extractAccountable(sources: AccountableSource[]): Promise<Array<[
   for (const r of settled) {
     if (r.status !== 'fulfilled') continue
     const { source, data } = r.value
-    const netApy = Number(data?.loan_computed?.net_apy)
-    if (!Number.isFinite(netApy)) continue
-    const rewardsBoost = Number(data?.loan_computed?.rewards_apy_boost?.total_apy_boost_percent ?? 0)
-    const apy = Math.max(0, netApy - (Number.isFinite(rewardsBoost) ? rewardsBoost : 0))
+    const apy = Number(data?.loan_computed?.net_apy)
+    if (!Number.isFinite(apy)) continue
     out.push([normalize(source.address), {
       apy,
       provider: 'Accountable',

--- a/server/utils/intrinsic-apy.ts
+++ b/server/utils/intrinsic-apy.ts
@@ -38,6 +38,7 @@ const UPSTREAM_URLS = {
   securitize: 'https://public-feed.securitize.io/asset-stats',
   stablewatch: 'https://api.stablewatch.io/api/pools',
   infinifi: 'https://eth-api.infinifi.xyz/api/protocol/data',
+  accountable: 'https://yield.accountable.capital/api/loan/address',
 } as const
 
 const PENDLE_API_BASE = 'https://api-v2.pendle.finance/core/v2'
@@ -315,6 +316,35 @@ async function extractInfinifi(sources: InfinifiSource[]): Promise<Array<[string
   })
 }
 
+type AccountableSource = Extract<IntrinsicApySourceConfig, { provider: 'accountable' }>
+type AccountableLoanResponse = { loan_computed?: { net_apy?: number } }
+
+const ACCOUNTABLE_CONCURRENCY = 10
+
+async function extractAccountable(sources: AccountableSource[]): Promise<Array<[string, IntrinsicApyInfo]>> {
+  const settled = await mapWithConcurrency(sources, ACCOUNTABLE_CONCURRENCY, async (s) => {
+    const loan = s.loanAddress.toLowerCase()
+    const key = `accountable:${loan}`
+    const url = `${UPSTREAM_URLS.accountable}/${s.loanAddress}`
+    const data = await fetchUpstream<AccountableLoanResponse>(key, url)
+    return { source: s, data }
+  })
+
+  const out: Array<[string, IntrinsicApyInfo]> = []
+  for (const r of settled) {
+    if (r.status !== 'fulfilled') continue
+    const { source, data } = r.value
+    const apy = Number(data?.loan_computed?.net_apy)
+    if (!Number.isFinite(apy)) continue
+    out.push([normalize(source.address), {
+      apy,
+      provider: 'Accountable',
+      source: 'https://accountable.capital',
+    }])
+  }
+  return out
+}
+
 type YoSource = Extract<IntrinsicApySourceConfig, { provider: 'yo' }>
 
 async function extractYo(sources: YoSource[]): Promise<Array<[string, IntrinsicApyInfo]>> {
@@ -369,7 +399,7 @@ async function extractSimple<S extends IntrinsicApySourceConfig, T>(
 }
 
 // Providers with dedicated extractors in the switch below.
-type ExplicitProvider = 'defillama' | 'pendle' | 'securitize' | 'stablewatch' | 'renzo' | 'midas' | 'yo' | 'infinifi'
+type ExplicitProvider = 'defillama' | 'pendle' | 'securitize' | 'stablewatch' | 'renzo' | 'midas' | 'yo' | 'infinifi' | 'accountable'
 // Every remaining provider must have an entry in SIMPLE_SPECS — enforced at the type level.
 type SimpleProvider = Exclude<IntrinsicApySourceConfig['provider'], ExplicitProvider>
 
@@ -435,6 +465,7 @@ async function extractForProvider(
     case 'midas': return extractMidas(sources as MidasSource[])
     case 'yo': return extractYo(sources as YoSource[])
     case 'infinifi': return extractInfinifi(sources as InfinifiSource[])
+    case 'accountable': return extractAccountable(sources as AccountableSource[])
     default: {
       const simpleProvider: SimpleProvider = provider
       const spec = SIMPLE_SPECS[simpleProvider]


### PR DESCRIPTION
## Summary

- Adds a new `accountable` intrinsic-APY provider that fetches yield from Accountable Capital's per-loan API (`https://yield.accountable.capital/api/loan/address/{loanAddress}`).
- Wires the first source: Valos loan on Monad (chainId 143), crediting the share token `0x8d3F9f9Eb2f5E8B48EFBB4074440D1E2A34Bc365` with `loan_computed.net_apy` from loan `0x8dCE15fc6a98484C995Fc702cBfBdA14A30454af`.
- Mirrors the per-source-URL pattern of `extractPendle`: bounded-concurrency fan-out via `mapWithConcurrency` + `fetchUpstream` keyed by `accountable:{loanAddress}` (5-min TTL, in-flight dedup, stale fallback).
- `net_apy` is consumed verbatim — already a percentage and already includes MERKL rewards boost; ACC point boosts are intentionally excluded.

## Files

- `entities/custom.ts` — new `provider: 'accountable'` variant in `IntrinsicApySourceConfig` and the Valos source row.
- `server/utils/intrinsic-apy.ts` — `UPSTREAM_URLS.accountable` entry, `extractAccountable`, `'accountable'` added to the `ExplicitProvider` union, switch case in `extractForProvider`.

No client code changes — the existing `/api/intrinsic-apy?chainId=…` flow picks up the new provider automatically. Warm-cache and SWR semantics are inherited from the existing orchestrator.

## Test plan

- [ ] `npm run typecheck` passes (no new errors in touched files).
- [ ] `npm run lint` passes.
- [ ] `curl 'http://localhost:3000/api/intrinsic-apy?chainId=143' | jq '."0x8d3f9f9eb2f5e8b48efbb4074440d1e2a34bc365"'` returns `{ apy: ~9.x, provider: "Accountable", source: "https://accountable.capital" }`.
- [ ] Server log shows `upstream:accountable:0x8dce15fc6a98484c995fc702cbfbda14a30454af ok` and `provider:accountable:chain=143 ok` on first hit; subsequent hits within 5 min are merged-cache hits.
- [ ] Confirm DefiLlama Monad entries continue to resolve (extractor isolation — one provider failing must not affect others).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Accountable as an intrinsic APY data provider for the Monad chain, expanding available yield information sources for loans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->