### PR TITLE
Soften vault type copy

### DIFF
--- a/components/entities/vault/VaultTypeChip.vue
+++ b/components/entities/vault/VaultTypeChip.vue
@@ -47,25 +47,7 @@ const icon = computed(() => {
 })
 
 const label = computed(() => {
-  if (!isVerified.value) {
-    return 'Unknown'
-  }
-  switch (type) {
-    case 'governed':
-      return 'Governed'
-    case 'managed':
-      return 'Managed'
-    case 'escrow':
-      return 'Escrowed collateral'
-    case 'securitize':
-      return 'Securitize Digital Security'
-    case 'ungoverned':
-      return 'Ungoverned'
-    case 'unknown':
-      return 'Unknown'
-  }
-
-  return 'Unknown'
+  return getVaultTypeLabel(type, isVerified.value)
 })
 
 const effectiveType = computed(() => isVerified.value ? type : 'unknown')

--- a/docs/portfolio-logic.md
+++ b/docs/portfolio-logic.md
@@ -11,7 +11,7 @@ Every on-chain deposit a user holds falls into one of three categories:
 | **Borrow Position** | A deposit used as collateral backing a loan | Subgraph `borrows` + AccountLens |
 | **Savings (Deposit/Earn)** | A standalone deposit not used as collateral (includes both EVK and EulerEarn vaults) | Subgraph `deposits` + AccountLens |
 
-Savings positions are stored in a single `depositPositions` array. The UI splits them into "Managed lending" (earn vaults) and "Direct lending" (EVK/securitize vaults) using `isEarnVault()` from the vault registry.
+Savings positions are stored in a single `depositPositions` array. The UI splits them into "Curated lending" (earn vaults) and "Direct lending" (EVK/securitize vaults) using `isEarnVault()` from the vault registry.
 
 Portfolio cards can display operational **portfolio notices** from the labels system (e.g. migration announcements, temporary pauses). Notices are resolved via `getVaultNotice()` which checks earn vault notices, vault overrides, and product-level `portfolioNotice` in priority order. On borrow cards, collateral and borrow notices are shown separately with deduplication when both vaults share the same product-level notice.
 
@@ -93,7 +93,7 @@ deposit entry
 ```
 
 The UI then filters the unified `depositPositions` array:
-- **Managed lending (earn)**: `depositPositions.filter(p => isEarnVault(p.vault.address))`
+- **Curated lending (earn)**: `depositPositions.filter(p => isEarnVault(p.vault.address))`
 - **Direct lending (EVK/securitize)**: `depositPositions.filter(p => !isEarnVault(p.vault.address))`
 
 ### Position Types

--- a/entities/vault/descriptions.ts
+++ b/entities/vault/descriptions.ts
@@ -3,7 +3,7 @@ export const vaultTypeDescriptions: Record<string, string> = {
   escrow: 'Escrow vaults hold deposits that do not earn interest because the vault does not allow borrowing. They are typically used as collateral for taking out loans from other vaults. They are ungoverned and have no active risk management.',
   managed: 'Curated vaults hold supplied assets that may be allocated across multiple strategies according to parameters set by the curator. Review the curator, fees, caps, strategy composition, and risks before supplying.',
   ungoverned: 'Ungoverned vaults have no active governor managing their risk parameters. Their configuration is immutable. Depositors should assess risk independently.',
-  governanceLimited: 'Governance-limited vaults have a governor who may have authority to adjust certain parameters, but there is no active risk manager monitoring and managing them on an ongoing basis. Depositors should assess risk independently.',
+  governanceLimited: 'Vaults with limited governance have a governor who may have authority to adjust certain parameters, but there is no active risk manager monitoring and managing them on an ongoing basis. Depositors should assess risk independently.',
   securitize: 'Securitize vaults hold tokenized real-world assets that may be used as collateral for taking out loans from other vaults. They are powered by the DS Protocol — a blockchain-based framework by Securitize for the regulated issuance, management, and trading of digital securities and tokenized assets, integrating ERC-20 compatible security tokens with onchain services for identity, regulation, and compliance.',
   unknown: 'This vault\'s governor has not been verified. Interacting with unknown and unverified vaults may pose security risks, as such vaults could potentially be used for phishing attempts. Ensure you trust the source before continuing.',
 }
@@ -14,7 +14,7 @@ export const vaultTypeLabels: Record<string, string> = {
   escrow: 'Escrowed collateral',
   securitize: 'Securitize Digital Security',
   ungoverned: 'Ungoverned',
-  governanceLimited: 'Governed - limited',
+  governanceLimited: 'Limited',
   unknown: 'Unknown',
 }
 

--- a/entities/vault/descriptions.ts
+++ b/entities/vault/descriptions.ts
@@ -1,7 +1,7 @@
 export const vaultTypeDescriptions: Record<string, string> = {
-  governed: 'Governed vaults are actively managed by a DAO, risk manager, or an individual who controls risk parameters such as interest rates, collateral requirements, and loan-to-value ratios. They are suited for passive lenders who trust the governor\'s management.',
+  governed: 'Governed vaults have a DAO, risk manager, or other governor that may control parameters such as interest rates, collateral settings, and loan-to-value ratios. Users should review the governor, market configuration, and risks before supplying or borrowing.',
   escrow: 'Escrow vaults hold deposits that do not earn interest because the vault does not allow borrowing. They are typically used as collateral for taking out loans from other vaults. They are ungoverned and have no active risk management.',
-  managed: 'Managed vaults hold deposits that are allocated across multiple strategies to optimize yield. Trusted curators actively manage risk and strategy allocation while maintaining security.',
+  managed: 'Curated vaults hold supplied assets that may be allocated across multiple strategies according to parameters set by the curator. Review the curator, fees, caps, strategy composition, and risks before supplying.',
   ungoverned: 'Ungoverned vaults have no active governor managing their risk parameters. Their configuration is immutable. Depositors should assess risk independently.',
   governanceLimited: 'Governance-limited vaults have a governor who may have authority to adjust certain parameters, but there is no active risk manager monitoring and managing them on an ongoing basis. Depositors should assess risk independently.',
   securitize: 'Securitize vaults hold tokenized real-world assets that may be used as collateral for taking out loans from other vaults. They are powered by the DS Protocol — a blockchain-based framework by Securitize for the regulated issuance, management, and trading of digital securities and tokenized assets, integrating ERC-20 compatible security tokens with onchain services for identity, regulation, and compliance.',
@@ -10,7 +10,7 @@ export const vaultTypeDescriptions: Record<string, string> = {
 
 export const vaultTypeLabels: Record<string, string> = {
   governed: 'Governed',
-  managed: 'Managed',
+  managed: 'Curated',
   escrow: 'Escrowed collateral',
   securitize: 'Securitize Digital Security',
   ungoverned: 'Ungoverned',

--- a/pages/portfolio/saving.vue
+++ b/pages/portfolio/saving.vue
@@ -39,11 +39,11 @@ watchEffect(async () => {
   <div class="mx-16">
     <div class="flex justify-between items-center mb-8">
       <h3 class="text-h3 font-normal text-neutral-800">
-        Managed lending
+        Curated lending
       </h3>
     </div>
     <p class="text-p2 text-neutral-500 mb-16">
-      Passive yield earned across professionally curated strategies.
+      Supplied assets in curated vault strategies.
     </p>
     <div class="flex flex-1 p-8 rounded-12 mb-16 border border-line-default bg-card">
       <div


### PR DESCRIPTION
## Summary
- update vault type descriptions to use more neutral wording
- rename managed vault labels to curated in shared labels and portfolio copy
- reuse the shared vault type label helper for chip text

## Test plan
- npm run typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Vault type chips now display the canonical vault label (aligned with the shared label generator) for consistent UI text.
* **Documentation**
  * Updated terminology from "Managed lending" to "Curated lending" across portfolio docs and vault descriptions; refreshed curated vault strategy copy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->