### PR TITLE
fix: scale UoA prices by unitOfAccountDecimals, not 1e18

### DIFF
--- a/composables/useAccountPositions.ts
+++ b/composables/useAccountPositions.ts
@@ -535,10 +535,14 @@ const updateBorrowPositions = async (
 
     if (liabilityValueBorrowing === 0n && p.res.vaultAccountInfo.borrowed > 0n) {
       logWarn('updateBorrowPositions', 'liabilityValueBorrowing is 0 but borrowed amount exists, calculating manually')
-      const borrowedInUnitOfAccount = FixedPoint.fromValue(p.res.vaultAccountInfo.borrowed, p.borrowVault.decimals)
-        .mul(FixedPoint.fromValue(p.borrowVault.liabilityPriceInfo.amountOutMid, 18))
-        .div(FixedPoint.fromValue(p.borrowVault.liabilityPriceInfo.amountIn, 0))
-      liabilityValueBorrowing = borrowedInUnitOfAccount.value
+      // liabilityPriceInfo prices are scaled in the UoA token's native decimals,
+      // not 18. The lens normalizes UoA values to 18 decimals — match that target
+      // by computing in UoA-decimal space then rescaling.
+      const uoaDecimals = Number(p.borrowVault.unitOfAccountDecimals ?? 18n)
+      const borrowedInUoA = FixedPoint.fromValue(p.res.vaultAccountInfo.borrowed, p.borrowVault.decimals)
+        .mul(FixedPoint.fromValue(p.borrowVault.liabilityPriceInfo.amountOutMid, uoaDecimals))
+        .div(FixedPoint.fromValue(p.borrowVault.liabilityPriceInfo.amountIn, p.borrowVault.decimals))
+      liabilityValueBorrowing = borrowedInUoA.toScaledBigint(18)
     }
 
     const healthFixed = liabilityValueBorrowing === 0n

--- a/docs/portfolio-logic.md
+++ b/docs/portfolio-logic.md
@@ -146,8 +146,8 @@ Lens contracts are read-only helpers deployed on every Euler chain. They aggrega
 Returns the complete state of an EVK vault in a single call:
 
 - **Basic info**: name, symbol, decimals, totalAssets, totalShares, supply/borrow caps
-- **`liabilityPriceInfo`**: The vault asset's price in the vault's unit of account (UoA). Contains `amountOutMid`, `amountOutAsk`, `amountOutBid` (18-decimal fixed-point).
-- **`collateralPrices[]`**: Price of each accepted collateral in the vault's UoA. These are **share prices** (price per vault share, not per underlying asset).
+- **`liabilityPriceInfo`**: The vault asset's price in the vault's unit of account (UoA). Contains `amountOutMid`, `amountOutAsk`, `amountOutBid` scaled in the **UoA token's native decimals** (`unitOfAccountDecimals`) — not always 18. The USD-magic UoA address (`0x…0348`) is treated as 18 decimals on-chain, which is why USD-denominated vaults look like 18-decimal fixed-point. Conversion to USD must divide by `10^unitOfAccountDecimals`, not by `1e18`.
+- **`collateralPrices[]`**: Price of each accepted collateral in the vault's UoA, same scaling rules as `liabilityPriceInfo`. These are **share prices** (price per vault share, not per underlying asset).
 - **`collateralLTVs[]`**: Borrow LTV, liquidation LTV, and ramp parameters for each collateral.
 - **`oracleDetailedInfo`**: Recursive oracle configuration tree (see Oracle section below).
 - **`interestRateInfo`**: Current borrow/supply APY, cash, borrows.

--- a/docs/pricing-system.md
+++ b/docs/pricing-system.md
@@ -196,11 +196,15 @@ getAssetUsdPrice(vault, source, backend):
      - If available, return backend price
 
   2. Oracle calculation (fallback or primary if source='on-chain'):
-     a. oraclePrice = vault.liabilityPriceInfo.amountOutMid  // Always on-chain
+     a. oraclePrice = vault.liabilityPriceInfo.amountOutMid
+        // On-chain. Scaled in vault.unitOfAccountDecimals (UoA's native decimals)
      b. uoaRate = await getUnitOfAccountUsdRate(vault)
         - Always tries backend first, falls back to on-chain
         - Returns 1e18 if vault.unitOfAccount === USD_ADDRESS
-     c. return (oraclePrice × uoaRate) / 1e18
+        - Always 18-decimal fixed-point (USD per 1 whole UoA token)
+     c. return (oraclePrice × uoaRate) / 10^unitOfAccountDecimals
+        // Result is 18-decimal USD. The divisor is the UoA's native decimals,
+        // NOT 1e18 — for USD UoA those happen to coincide.
 ```
 
 **Note on UoA Rate**: The UoA rate always tries the backend first, regardless of the caller's `source` parameter. Since UoA is a common denominator (both collateral and borrow prices use the same UoA), using an off-chain UoA rate doesn't affect health factor/LTV ratios - only the USD display values.
@@ -224,7 +228,8 @@ getCollateralUsdPrice(liabilityVault, collateralVault, source, backend):
         // ERC-4626 standard defines 1:1 ratio, so use sharePrice directly
      c. uoaRate = await getUnitOfAccountUsdRate(liabilityVault)
         // Use LIABILITY's UoA - always tries backend first
-     d. return (assetPrice × uoaRate) / 1e18
+     d. return (assetPrice × uoaRate) / 10^liabilityVault.unitOfAccountDecimals
+        // Same scaling rule as getAssetUsdPrice — divisor is UoA's native decimals.
 ```
 
 ## EulerRouter Oracle Configuration

--- a/services/pricing/priceProvider.ts
+++ b/services/pricing/priceProvider.ts
@@ -278,6 +278,17 @@ const backendPriceToPriceResult = (data: BackendPriceData): PriceResult | undefi
 }
 
 /**
+ * Scale factor for the vault's unit of account. The on-chain VaultLens
+ * returns liability/collateral prices in the UoA token's native decimals;
+ * dividing by this scale (rather than ONE_18) yields a USD price in
+ * 18-decimal fixed-point regardless of UoA decimals.
+ */
+const getUoaScale = (vault: Vault | null | undefined): bigint => {
+  const decimals = vault?.unitOfAccountDecimals
+  return decimals !== undefined ? 10n ** BigInt(decimals) : ONE_18
+}
+
+/**
  * Get asset price in USD using on-chain oracle + UoA conversion.
  * UoA rate can still come from backend if source is 'off-chain'.
  */
@@ -305,10 +316,12 @@ const getAssetUsdPriceFromOracle = async (
   const uoaRate = await getUnitOfAccountUsdRate(vault as Vault)
   if (!uoaRate) return undefined
 
+  const uoaScale = getUoaScale(vault as Vault)
+
   return {
-    amountOutMid: (oraclePrice.amountOutMid * uoaRate) / ONE_18,
-    amountOutAsk: (oraclePrice.amountOutAsk * uoaRate) / ONE_18,
-    amountOutBid: (oraclePrice.amountOutBid * uoaRate) / ONE_18,
+    amountOutMid: (oraclePrice.amountOutMid * uoaRate) / uoaScale,
+    amountOutAsk: (oraclePrice.amountOutAsk * uoaRate) / uoaScale,
+    amountOutBid: (oraclePrice.amountOutBid * uoaRate) / uoaScale,
   }
 }
 
@@ -332,10 +345,12 @@ const getCollateralUsdPriceFromOracle = async (
   const uoaRate = await getUnitOfAccountUsdRate(liabilityVault)
   if (!uoaRate) return undefined
 
+  const uoaScale = getUoaScale(liabilityVault)
+
   return {
-    amountOutMid: (oraclePrice.amountOutMid * uoaRate) / ONE_18,
-    amountOutAsk: (oraclePrice.amountOutAsk * uoaRate) / ONE_18,
-    amountOutBid: (oraclePrice.amountOutBid * uoaRate) / ONE_18,
+    amountOutMid: (oraclePrice.amountOutMid * uoaRate) / uoaScale,
+    amountOutAsk: (oraclePrice.amountOutAsk * uoaRate) / uoaScale,
+    amountOutBid: (oraclePrice.amountOutBid * uoaRate) / uoaScale,
   }
 }
 


### PR DESCRIPTION
## Summary

USD price conversion in `services/pricing/priceProvider.ts` divided `oraclePrice × uoaRate` by `1e18`, which silently assumes the unit-of-account token has 18 decimals. VaultLens actually returns `liabilityPriceInfo` / `collateralPrices[]` in the **UoA token's native decimals**. The bug stayed hidden because the magic USD address (`0x…0348`) is treated as 18-decimal on-chain. The first real ERC-20 UoA (AUSD on Monad, 6 decimals) exposed it: the Overview rendered `<\$0.01` instead of `~\$1` — off by exactly `10^(18 − 6) = 10^12`.

## Fix

- Divide by `10^unitOfAccountDecimals` (defaults to `1e18` when missing) in `getAssetUsdPriceFromOracle` and `getCollateralUsdPriceFromOracle`. For USD UoA the divisor is still `1e18`, so behavior is unchanged on existing chains.
- Repair the manual `liabilityValueBorrowing` fallback in `composables/useAccountPositions.ts` that wrapped `liabilityPriceInfo.amountOutMid` as `FixedPoint(_, 18)`. That code was a silent no-op for *every* UoA — for USD it returned `1n` instead of `1e18`, for AUSD it underflowed to `0n` so the existing zero-guard zeroed health. Now it uses the actual UoA decimals and rescales to the lens's 18-decimal convention via `toScaledBigint(18)`.
- Correct the assertion in `docs/pricing-system.md` and `docs/portfolio-logic.md` that `liabilityPriceInfo` is "18-decimal fixed-point" — it isn't.

## Why so many display values were quietly wrong

Every Layer 2/3 caller (`getAssetUsdPrice`, `getCollateralUsdPrice`, `getAssetUsdValue`, `getCollateralUsdValue`, `formatAssetValue`) flowed through the broken path. Across the app that's 60+ call sites: vault overviews, asset input USD subtitles, position page unit/oracle/liquidation prices, portfolio totals, TVL/liquidity displays, monthly earnings, etc. All transitively correct now.

Health factor / LTV / max-borrow / max-withdraw on-chain math was unaffected — those compare lens-supplied 18-decimal UoA values, not raw `liabilityPriceInfo`, so the scale bug never reached liquidation-sensitive paths.

## Test plan

- [x] \`npm run typecheck\`
- [x] \`npm run test:run\` (625 tests pass)
- [ ] Smoke-test on Monad: visit Valos vUSD/AUSD market, confirm Overview Price ≈ \$1.00 and pair-page USD displays look sane
- [ ] Smoke-test on a USD-UoA chain (e.g. mainnet): confirm Overview Price unchanged from before
- [ ] Spot-check a position page (collateral USD value, liquidation price) on both a USD-UoA market and the AUSD market

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed health factor and liquidation risk calculations for borrowed positions in certain scenarios.
  * Corrected USD price conversion logic to properly account for unit-of-account token decimals across all vault types.

* **Documentation**
  * Updated pricing and portfolio documentation to clarify unit-of-account decimal scaling behavior and USD price calculation formulas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->