### PR TITLE
Fix Vault type badge rendering for unverified vaults

### DIFF
--- a/components/entities/vault/VaultTypeBadges.vue
+++ b/components/entities/vault/VaultTypeBadges.vue
@@ -1,34 +1,31 @@
 <script setup lang="ts">
 import { zeroAddress } from 'viem'
-import type { Vault, EarnVault } from '~/entities/vault'
+import type { AnyVault } from '~/composables/useVaultRegistry'
+import type { Vault, EarnVault, SecuritizeVault } from '~/entities/vault'
 import { isCyclicalNoteVault } from '~/entities/vault'
 import { isVaultKeyring, getEntitiesByVault, getEntitiesByEarnVault } from '~/utils/eulerLabelsUtils'
 import { useEulerProductOfVault } from '~/composables/useEulerLabels'
 
-const { vaultAddress } = defineProps<{
-  vaultAddress: string
+const { vault } = defineProps<{
+  vault: AnyVault
 }>()
 
 const { isVaultGovernorVerified, isEarnVaultOwnerVerified } = useVaults()
-const { getVault, isEarnVault, isSecuritizeVault } = useVaultRegistry()
 
-const addressRef = computed(() => vaultAddress)
+const addressRef = computed(() => vault.address)
 const product = useEulerProductOfVault(addressRef)
-const vault = computed(() => getVault(vaultAddress))
 
-const isEarn = computed(() => isEarnVault(vaultAddress))
-const isSecuritize = computed(() => isSecuritizeVault(vaultAddress))
+const isEarn = computed(() => 'type' in vault && vault.type === 'earn')
+const isSecuritize = computed(() => 'type' in vault && vault.type === 'securitize')
 
 const entities = computed(() => {
-  if (!vault.value) return []
-  if (isEarn.value) return getEntitiesByEarnVault(vault.value as EarnVault)
-  return getEntitiesByVault(vault.value as Vault)
+  if (isEarn.value) return getEntitiesByEarnVault(vault as EarnVault)
+  return getEntitiesByVault(vault as Vault | SecuritizeVault)
 })
 
 const isVerified = computed(() => {
-  if (!vault.value) return false
-  if (isEarn.value) return isEarnVaultOwnerVerified(vault.value as EarnVault)
-  return isVaultGovernorVerified(vault.value as Vault)
+  if (isEarn.value) return isEarnVaultOwnerVerified(vault as EarnVault)
+  return isVaultGovernorVerified(vault as Vault)
 })
 
 const isGovernanceLimited = computed(() =>
@@ -36,14 +33,12 @@ const isGovernanceLimited = computed(() =>
 )
 
 const governanceType = computed(() => {
-  if (!vault.value) return 'unknown'
-
   if (isEarn.value) {
     return entities.value.length ? 'managed' : 'unknown'
   }
 
-  const v = vault.value as Vault
-  if (v.vaultCategory === 'escrow') return 'escrow'
+  const v = vault as Vault | SecuritizeVault
+  if ('vaultCategory' in v && v.vaultCategory === 'escrow') return 'escrow'
   if (!v.governorAdmin) return 'unknown'
   if (v.governorAdmin === zeroAddress) return 'ungoverned'
   if (entities.value.length) {
@@ -57,19 +52,16 @@ const extraType = computed(() => {
   return undefined
 })
 
-const isKeyring = computed(() => isVaultKeyring(vaultAddress))
+const isKeyring = computed(() => isVaultKeyring(vault.address))
 
 const isCyclicalNote = computed(() => {
-  if (!vault.value || isEarn.value) return false
-  return isCyclicalNoteVault(vault.value as Vault)
+  if (isEarn.value || isSecuritize.value) return false
+  return isCyclicalNoteVault(vault as Vault)
 })
 </script>
 
 <template>
-  <div
-    v-if="vault"
-    class="flex items-center gap-8 flex-wrap"
-  >
+  <div class="flex items-center gap-8 flex-wrap">
     <VaultTypeChip
       :vault="vault"
       :type="governanceType"

--- a/components/entities/vault/overview/SecuritizeVaultOverview.vue
+++ b/components/entities/vault/overview/SecuritizeVaultOverview.vue
@@ -251,7 +251,7 @@ const supplyCapPercentageDisplay = computed(() => {
           v-if="enableVaultTypeDisplay"
           label="Vault type"
         >
-          <VaultTypeBadges :vault-address="vault.address" />
+          <VaultTypeBadges :vault="vault" />
         </VaultOverviewLabelValue>
         <VaultOverviewLabelValue label="Can be borrowed">
           <div class="flex items-center gap-8">

--- a/components/entities/vault/overview/VaultOverviewBlockGeneral.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockGeneral.vue
@@ -141,7 +141,7 @@ watchEffect(async () => {
           v-if="enableVaultTypeDisplay"
           label="Vault type"
         >
-          <VaultTypeBadges :vault-address="vault.address" />
+          <VaultTypeBadges :vault="vault" />
         </VaultOverviewLabelValue>
         <VaultOverviewLabelValue label="Can be borrowed">
           <div class="flex items-center gap-8">

--- a/components/entities/vault/overview/earn/VaultOverviewEarnBlockGeneral.vue
+++ b/components/entities/vault/overview/earn/VaultOverviewEarnBlockGeneral.vue
@@ -126,7 +126,7 @@ const feeDisplay = computed(() => {
           v-if="enableVaultTypeDisplay"
           label="Vault type"
         >
-          <VaultTypeBadges :vault-address="vault.address" />
+          <VaultTypeBadges :vault="vault" />
         </VaultOverviewLabelValue>
       </div>
     </div>

--- a/composables/useVaults.ts
+++ b/composables/useVaults.ts
@@ -871,6 +871,7 @@ const getBorrowVaultPair = async (
   if (!borrowVault) {
     throw '[getBorrowVaultPair]: Borrow vault not found'
   }
+  registrySet(borrowAddr, borrowVault, 'evk')
 
   const collateralLTV = borrowVault.collateralLTVs.find(c => c.collateral === collateralAddr)
   if (!collateralLTV) {
@@ -890,11 +891,13 @@ const getBorrowVaultPair = async (
   else {
     try {
       collateralVault = await fetchVault(collateralAddr, ctx)
+      registrySet(collateralAddr, collateralVault, 'evk')
     }
     catch {
       // Try escrow vault first
       try {
         collateralVault = await fetchEscrowVault(collateralAddr, ctx)
+        registrySet(collateralAddr, collateralVault, 'evk')
       }
       catch {
         // Check if it's a securitize vault


### PR DESCRIPTION
## Summary
- The 'Vault type' cell in the vault overview rendered empty for unknown / unverified vaults instead of showing an 'Unknown' chip, even though the rest of the page (header warning, Risk manager) correctly flagged the vault.
- Root cause was twofold: `VaultTypeBadges` looked the vault up via the vault registry by address and skipped its entire render block when the registry didn't have it; and `getBorrowVaultPair` fell back to `fetchVault` for unknown borrow/collateral vaults without inserting them into the registry.

## Changes
- `VaultTypeBadges` now takes the vault as a prop instead of doing a registry lookup, and drops the wrapping `v-if`. `isEarn` / `isSecuritize` are derived from the vault's `type` discriminator. The 'Unknown' chip now shows whenever no governance/category info applies, matching the Risk manager fallback right above it.
- All three callers (`VaultOverviewBlockGeneral`, `SecuritizeVaultOverview`, `earn/VaultOverviewEarnBlockGeneral`) updated to pass `:vault` instead of `:vault-address`.
- `getBorrowVaultPair` now calls `registrySet(addr, vault, 'evk')` after the borrow-vault `fetchVault` and after each EVK / escrow collateral fallback, so registry consumers see the vault when a pair is loaded directly via deep link to an unverified pair.

## Test plan
- [ ] Open a borrow pair page for an unverified vault (one that triggers the red 'Unknown' header). Confirm the 'Vault type' cell now shows an 'Unknown' chip instead of being blank.
- [ ] Open a verified EVK borrow pair and confirm the existing badges (governed/managed/escrow/securitize, Keyring, governance-limited, cyclical-note) still render.
- [ ] Open an Earn vault overview and a Securitize vault overview — confirm the badge area renders unchanged.
- [ ] Run `npm run typecheck` and `npx eslint .` — both should pass.