### PR TITLE
fix: treat labels CDN 403 the same as 404 for absent files

### DIFF
--- a/server/api/labels/[file].get.ts
+++ b/server/api/labels/[file].get.ts
@@ -140,11 +140,12 @@ function getUpstreamUrl(scope: LabelScope, file: string): string {
  * the in-flight map.
  *
  * `persist=true` writes the empty shape into the cache so subsequent
- * requests skip upstream entirely. Reserved for the 404 case, where the
- * file is legitimately absent for this scope. For other failures
- * (transient 5xx, network errors, JSON parse, validation) return empty
- * but DON'T persist — otherwise a single upstream blip pins the empty
- * allowlist for 5 minutes, making every verified vault appear unverified.
+ * requests skip upstream entirely. Reserved for the absent-file cases
+ * (404 and 403 — see below), where the file is legitimately not published
+ * for this scope. For other failures (transient 5xx, network errors,
+ * JSON parse, validation) return empty but DON'T persist — otherwise a
+ * single upstream blip pins the empty allowlist for 5 minutes, making
+ * every verified vault appear unverified.
  */
 export function refreshLabelFile(scope: LabelScope, file: LabelFile): Promise<unknown> {
   const key = `${scope}:${file}`
@@ -162,17 +163,20 @@ export function refreshLabelFile(scope: LabelScope, file: LabelFile): Promise<un
     try {
       const resp = await fetchWithTimeout(getUpstreamUrl(scope, file))
       if (!resp.ok) {
-        // 404 is the expected signal for "file not published at this scope"
-        // — treat it as a steady-state "absent" and don't spam the logs
-        // each warm cycle. Other non-2xx statuses (403/5xx) are reported
-        // as transitions so the first occurrence surfaces but repeats do not.
-        if (resp.status !== 404) {
-          reportStatus('labels', statusKey, `http-${resp.status}`,
-            `${file} upstream returned ${resp.status} for scope ${scope}; treating as absent`)
-          return fallback(false)
+        // 404 and 403 are both expected signals for "file not published
+        // at this scope". The labels CDN (S3+CloudFront origin without
+        // ListBucket grant) returns 403 AccessDenied for missing keys
+        // rather than 404, so we treat them identically: persist the
+        // empty fallback and stay quiet on subsequent warm cycles.
+        // Other non-2xx statuses (5xx etc.) are reported as transitions
+        // so the first occurrence surfaces but repeats do not.
+        if (resp.status === 404 || resp.status === 403) {
+          reportStatus('labels', statusKey, `absent-${resp.status}`)
+          return fallback(true)
         }
-        reportStatus('labels', statusKey, 'absent-404')
-        return fallback(true)
+        reportStatus('labels', statusKey, `http-${resp.status}`,
+          `${file} upstream returned ${resp.status} for scope ${scope}; treating as absent`)
+        return fallback(false)
       }
 
       const data: unknown = await resp.json()


### PR DESCRIPTION
## Summary

The labels.euler.finance CDN serves files from S3+CloudFront. The bucket isn't granted anonymous `ListBucket`, so S3 returns **403 AccessDenied** for missing keys instead of 404. Our handler only persisted an empty fallback for 404 and treated 403 as a transient/transition error — so every 5-minute warm cycle re-fetched the same missing files and re-emitted a warning, drowning logs in stable, non-actionable noise.

This change groups 403 with 404 as an "absent" signal: cache the empty fallback once and stay quiet on subsequent cycles. Other 4xx/5xx remain transient (no persist) so a real upstream blip doesn't pin an empty allowlist for 5 minutes.

### Verified
```
$ curl -i https://labels.euler.finance/master/1/assets.json
HTTP/2 403
<Code>AccessDenied</Code><Message>Access Denied</Message>

$ curl -i https://labels.euler.finance/master/1/products.json
HTTP/2 200
```
Most chains genuinely don't ship `assets.json` / `earn-vaults.json`; the GitHub raw fallback also returns 404 for them, so the empty payload is correct.

## Test plan
- [ ] Server logs no longer show repeated `http-403` lines for the same `file:scope` after warm cycles
- [ ] First fetch of an absent file emits a single `absent-403` (or `absent-404`) info-level transition
- [ ] Files that *do* exist continue to populate normally (e.g. `products.json` / `entities.json` for chain 1)
- [ ] A simulated 5xx on an upstream still does **not** persist the empty fallback (verified by reading the unchanged 5xx branch)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved label file retrieval when files are missing or inaccessible, preventing errors during these expected scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->