### PR TITLE
fix: warm caches one chain at a time to avoid cold-start abort wave

### DIFF
--- a/server/plugins/warm-cache.ts
+++ b/server/plugins/warm-cache.ts
@@ -12,12 +12,22 @@
  * warm pipeline always find a cached entry (refresh completes just as the
  * previous entry would otherwise expire).
  *
- * Warm-up structure (per cycle): all tasks run in parallel.
+ * Warm-up structure (per cycle):
  *
- *   • Global:    /api/euler-chains
- *   • Per-chain: labels, token-list, intrinsic-apy, vault-categories,
- *                Merkl opportunities × 3, Brevis campaigns, Fuul × 2,
- *                refreshChainVaults(chainId)
+ *   • Global (parallel with the chain loop): /api/euler-chains and
+ *     cross-chain `all/assets.json`.
+ *   • Per-chain (serialized one chain at a time): labels, token-list,
+ *     intrinsic-apy, vault-categories, Merkl opportunities × 3,
+ *     Brevis campaigns, Fuul × 2, refreshChainVaults(chainId). Tasks
+ *     within a single chain still run in parallel.
+ *
+ * Serializing chains avoids a cold-start thundering herd (~250
+ * simultaneous HTTPS requests across all chains × all providers) that
+ * overshot the 10 s upstream timeout for slow first-hit DNS/TLS
+ * handshakes. Cross-chain upstreams (defillama, stablewatch, etherfi,
+ * etc.) dedupe via the in-flight cache, so chains 2..N hit warm cache
+ * for those rather than refetching — sequential mode is therefore much
+ * cheaper than N× the first chain's wall time.
  *
  * Per-chain warms skip chains listed in `DEPRECATED_CHAINS`. Their data
  * is still served — the first visitor to a deprecated chain pays a
@@ -158,12 +168,18 @@ export default defineNitroPlugin(() => {
   const chainIds = enabledChainIds.filter(id => !deprecatedChainIds.has(id))
   if (chainIds.length === 0) return
 
+  const warmChainsSequentially = async () => {
+    for (const chainId of chainIds) {
+      await Promise.allSettled(warmChainTasks(chainId))
+    }
+  }
+
   const warmAll = async () => {
     try {
       await Promise.allSettled([
         warmEulerChains(),
         warmGlobalAssets(),
-        ...chainIds.flatMap(warmChainTasks),
+        warmChainsSequentially(),
       ])
     }
     catch (err) {


### PR DESCRIPTION
## Summary

The boot warm-up was firing ~250 simultaneous HTTPS requests in a single tick — every chain × every provider in parallel. On a cold node, DNS/TLS plus slow-to-respond upstreams overshot the 10 s `UPSTREAM_FETCH_TIMEOUT_MS` for a large fraction of calls, producing a wave of `AbortError` log lines (etherfi, stablewatch, brevis, fuul, merkl, etc.) at server start.

This serializes the chain loop while keeping:
- intra-chain tasks parallel (labels × 5, token-list, intrinsic-apy, vault-categories, rewards × 6, vaults — all still concurrent within a single chain), and
- the global warms (`euler-chains` and cross-chain `all/assets.json`) running alongside the chain loop.

## Why this works without slowing things down meaningfully

Cross-chain upstreams (defillama, stablewatch, etherfi, treehouse, benqi, avant, plus the `all/assets.json` label scope) already dedupe via the in-flight + TTL caches in `server/utils/intrinsic-apy.ts` and `labels/[file].get.ts`. So:

- Chain 1 pays the real cost of every upstream (worst case: ~10 s if anything's cold).
- Chains 2..N hit warm cache for those shared providers and only do their own per-chain work (subgraph, vaults, label files, Merkl/Brevis/Fuul).

So sequential warm is materially quieter than the parallel version when the network or any single upstream is cold, while only a small constant slower on a healthy network.

## Test plan
- [ ] On a fresh server start, no wave of `{"ctx":"warm-cache",...,"This operation was aborted"}` log lines
- [ ] First-cycle warm completes in under ~30 s end-to-end (vs ~10–15 s today, but cleaner)
- [ ] Subsequent 5-min cycles complete with `status: ok` for healthy upstreams
- [ ] /api/labels, /api/intrinsic-apy, /api/token-list still serve cached data correctly during and after warm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modified cache warming scheduler to process per-chain warm-up tasks sequentially rather than in parallel, while maintaining concurrent execution of global warm-up tasks. Updated documentation to reflect the new execution model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->