### PR TITLE
fix: render vault-overview borrow-side data for unverified pairs

### DIFF
--- a/components/entities/vault/overview/SecuritizeVaultOverview.vue
+++ b/components/entities/vault/overview/SecuritizeVaultOverview.vue
@@ -22,7 +22,7 @@ const { enableEntityBranding: enableEntityBrandingDisplay, enableVaultType: enab
 
 const { client: rpcClient } = useRpcClient()
 const { chainId } = useEulerAddresses()
-const { borrowList: _borrowList, isVaultGovernorVerified } = useVaults()
+const { isVaultGovernorVerified } = useVaults()
 const { getEvkVaults } = useVaultRegistry()
 const { getIntrinsicApy, getIntrinsicApyInfo } = useIntrinsicApy()
 const modal = useModal()

--- a/components/entities/vault/overview/VaultOverviewBlockAddresses.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockAddresses.vue
@@ -5,14 +5,15 @@ import { getSpecialAddressLabel } from '~/utils/special-addresses'
 
 const { vault } = defineProps<{ vault: Vault }>()
 
-const { borrowList } = useVaults()
 const { chainId } = useEulerAddresses()
 
-const borrowCount = computed(() => {
-  return borrowList.value.filter(pair => pair.borrow.address === vault.address).length
-})
-
-const isBorrowable = computed(() => borrowCount.value > 0)
+// "Borrowable" = the vault has at least one collateral configured to allow
+// borrowing. Read from the vault's own LTV table rather than `borrowList`
+// membership so unverified (off-label) borrow vaults still surface their
+// debt-token / fee-receiver / oracle addresses.
+const isBorrowable = computed(() =>
+  vault.collateralLTVs.some(ltv => ltv.borrowLTV > 0n),
+)
 
 const vaultAddresesInfo = computed(() => {
   const baseAddresses = [

--- a/components/entities/vault/overview/VaultOverviewBlockGeneral.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockGeneral.vue
@@ -12,7 +12,8 @@ const { vault } = defineProps<{ vault: Vault }>()
 const route = useRoute()
 const { enableEntityBranding: enableEntityBrandingDisplay, enableVaultType: enableVaultTypeDisplay } = useDeployConfig()
 
-const { borrowList, isVaultGovernorVerified } = useVaults()
+const { isVaultGovernorVerified } = useVaults()
+const { getEvkVaults } = useVaultRegistry()
 
 const vaultAddress = computed(() => getAddress(vault.address))
 const product = useEulerProductOfVault(vaultAddress)
@@ -30,9 +31,16 @@ const isRestricted = computed(() => isVaultBlockedByCountry(vault.address))
 const isGovernorVerified = computed(() => isVaultGovernorVerified(vault))
 const isGovernanceLimited = computed(() => product.isGovernanceLimited && isGovernorVerified.value)
 
-// Count how many borrow pairs have this vault as collateral
+// Count how many EVK vaults reference this vault as a borrowable collateral.
+// Sources from the registry directly (not `borrowList`) so deep-linked
+// unverified pairs still report "Yes in N markets" — `borrowList` is filtered
+// to verified vaults for discovery views and would otherwise hide the
+// relationship even though we're literally rendering it. Mirrors the pattern
+// in SecuritizeVaultOverview.vue.
 const collateralCount = computed(() => {
-  return borrowList.value.filter(pair => pair.collateral.address === vault.address).length
+  return getEvkVaults().filter(v => v.collateralLTVs.some(
+    ltv => ltv.collateral === vault.address && ltv.borrowLTV > 0n,
+  )).length
 })
 
 // Count how many borrow pairs have this vault as the liability (borrow) side

--- a/components/entities/vault/overview/VaultOverviewBlockRiskParameters.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockRiskParameters.vue
@@ -20,15 +20,16 @@ const { vault } = defineProps<{ vault: Vault }>()
 const modal = useModal()
 
 const { client: rpcClient } = useRpcClient()
-const { borrowList } = useVaults()
 
 const shareTokenExchangeRate: Ref<bigint | undefined> = ref()
 
-const borrowCount = computed(() => {
-  return borrowList.value.filter(pair => pair.borrow.address === vault.address).length
-})
-
-const isBorrowable = computed(() => borrowCount.value > 0)
+// "Borrowable" = the vault has at least one collateral configured to allow
+// borrowing. Read from the vault's own LTV table rather than `borrowList`
+// membership so unverified (off-label) borrow vaults still expose their
+// borrow-side risk parameters.
+const isBorrowable = computed(() =>
+  vault.collateralLTVs.some(ltv => ltv.borrowLTV > 0n),
+)
 
 const supplyCapPercentageDisplay = computed(() => getSupplyCapPercentage(vault))
 const borrowCapPercentageDisplay = computed(() => getBorrowCapPercentage(vault))

--- a/components/entities/vault/overview/VaultOverviewPairBlockGeneral.vue
+++ b/components/entities/vault/overview/VaultOverviewPairBlockGeneral.vue
@@ -24,13 +24,13 @@ const isRamping = computed(() =>
 const modal = useModal()
 const { withIntrinsicBorrowApy, withIntrinsicSupplyApy, getIntrinsicApy, getIntrinsicApyInfo } = useIntrinsicApy()
 const { getSupplyRewardApy, getBorrowRewardApy, getLoopingRewardApy, getSupplyRewardCampaigns, getBorrowRewardCampaigns, getLoopingRewardCampaigns, hasSupplyRewards, hasBorrowRewards, hasLoopingRewards } = useRewardsApy()
-const { borrowList } = useVaults()
 
-const borrowCount = computed(() => {
-  return borrowList.value.filter(p => p.borrow.address === pair.borrow.address).length
-})
-
-const isBorrowable = computed(() => borrowCount.value > 0)
+// On a borrow pair detail page the pair only exists because the on-chain
+// collateralLTV has a non-zero borrowLTV — gate on that directly so deep links
+// to unverified (off-label) pairs render the borrow-side metrics. Sourcing this
+// from `useVaults().borrowList` would skip pairs whose borrow vault isn't in
+// the labels repo.
+const isBorrowable = computed(() => pair.borrowLTV > 0n)
 const isRestricted = computed(() => isAnyVaultBlockedByCountry(pair.collateral.address, pair.borrow.address))
 const isDeprecated = computed(() => isVaultDeprecated(pair.collateral.address) || isVaultDeprecated(pair.borrow.address))
 

--- a/composables/useVaults.ts
+++ b/composables/useVaults.ts
@@ -871,6 +871,7 @@ const getBorrowVaultPair = async (
   if (!borrowVault) {
     throw '[getBorrowVaultPair]: Borrow vault not found'
   }
+  registrySet(borrowAddr, borrowVault, 'evk')
 
   const collateralLTV = borrowVault.collateralLTVs.find(c => c.collateral === collateralAddr)
   if (!collateralLTV) {
@@ -890,11 +891,13 @@ const getBorrowVaultPair = async (
   else {
     try {
       collateralVault = await fetchVault(collateralAddr, ctx)
+      registrySet(collateralAddr, collateralVault, 'evk')
     }
     catch {
       // Try escrow vault first
       try {
         collateralVault = await fetchEscrowVault(collateralAddr, ctx)
+        registrySet(collateralAddr, collateralVault, 'evk')
       }
       catch {
         // Check if it's a securitize vault
@@ -910,6 +913,14 @@ const getBorrowVaultPair = async (
       }
     }
   }
+
+  // Fire the off-label sweep so the freshly registered borrow / collateral
+  // vault's own collateralLTVs[] get resolved into the registry — without
+  // this, deep-linked unverified pairs render with empty Collateral exposure
+  // blocks because referenced vaults were never loaded by the bulk pipeline.
+  // Fire-and-forget: the pair render shouldn't wait on additional lens reads,
+  // and resolveUnresolvedCollaterals updates the reactive registry as it goes.
+  void resolveUnresolvedCollaterals(loadGeneration.value)
 
   return {
     borrow: borrowVault,


### PR DESCRIPTION
## Summary

Direct navigation to an unverified borrow pair (e.g. a vault not in the
`euler-labels` repo on a chain like Monad) silently hid most of the
borrow-side overview content. Pair-detail Max ROE / Max multiplier
disappeared; the per-asset tabs reported `Can be used as collateral: No`
even on the pair page that demonstrated otherwise; risk-parameter and
address blocks dropped Liquidation bonus, Borrow cap, Interest fee,
debt-token / fee-receiver / oracle-router rows; and the Collateral
exposure block stayed empty.

Root cause is two intersecting filters that assume "if you can see this
pair, it's verified":

1. Several overview blocks gated borrow-side fields on `borrowList`
   membership. `borrowList` is built from `getVerifiedEvkVaults()` (set
   in #215b6382 to keep unknown collaterals out of discovery tables).
   For unverified borrow vaults the count is `0` so the gate evaluates
   to `false` and the fields render as `No` / disappear.
2. The lazy off-label collateral sweep (#05bb3372) walks
   `getEvkVaults()` only during `loadVaults` / `refreshVaults`. Deep
   links to unverified pairs go through `getBorrowVaultPair`'s fallback
   path, which fetched both vaults via `fetchVault` without registering
   them — so the sweep had no member vaults to walk and the registry
   never learned about the pair's collateral references.

## Changes

- **`VaultOverviewPairBlockGeneral.vue`** — `isBorrowable` now derives
  from `pair.borrowLTV > 0n`. The pair only renders because the
  on-chain LTV is borrowable, so this is sufficient and label-coverage
  independent.
- **`VaultOverviewBlockGeneral.vue`** — `collateralCount` iterates
  `useVaultRegistry().getEvkVaults()` and counts vaults whose
  `collateralLTVs[]` reference this vault with `borrowLTV > 0`, instead
  of filtering `borrowList`. Mirrors the pattern already used in
  `SecuritizeVaultOverview.vue`.
- **`VaultOverviewBlockRiskParameters.vue`**,
  **`VaultOverviewBlockAddresses.vue`** — `isBorrowable` now reads from
  `vault.collateralLTVs.some(ltv => ltv.borrowLTV > 0n)` instead of
  `borrowList` membership, so borrow-side risk parameters and addresses
  surface for any vault that's actually borrowable.
- **`SecuritizeVaultOverview.vue`** — drops a now-unused `_borrowList`
  import.
- **`composables/useVaults.ts` `getBorrowVaultPair`** — registers
  fetched borrow / EVK / escrow collateral vaults via `registrySet`,
  then fires `void resolveUnresolvedCollaterals(loadGeneration.value)`
  so the freshly-registered vaults' own `collateralLTVs[]` get resolved
  into the registry. Fire-and-forget keeps the pair-page render
  unblocked; the reactive registry causes consumers to re-render as
  references resolve.

`borrowList` itself is unchanged. It still backs the `pages/borrow`,
`pages/lend`, and `useSwapCollateralOptions` discovery surfaces, where
verified-only is the right semantics.

Overlaps with #390 on the `registrySet` calls in `getBorrowVaultPair`;
either lands fine on its own. Trivial conflict on those three lines if
both go in.

## Test plan

- [ ] Navigate directly to `/borrow/<unverified-collateral>/<unverified-borrow>?network=<chain>`
- [ ] Pair details tab shows Max LTV, Liquidation LTV, Max multiplier, Max ROE, Borrow APY, Net APY (previously hidden)
- [ ] Borrow-vault tab shows `Can be used as collateral: Yes in N markets` reflecting the current pair, and the borrow-side risk parameters / debt-token & oracle addresses
- [ ] Collateral-vault tab's Collateral exposure block resolves and renders the cross-collateral entry
- [ ] Verified borrow pair pages still render identically (no regression in `borrowList`-fed discovery tables)
- [ ] `npm run typecheck` and `npx eslint .` pass