### PR TITLE
fix: clamp viem JSON-RPC batch size on Ankr public endpoints

### DIFF
--- a/tests/utils/public-client.test.ts
+++ b/tests/utils/public-client.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { isPublicAnkrRpcUrl } from '~/utils/public-client'
+
+describe('isPublicAnkrRpcUrl', () => {
+  it('matches the free public-tier shape (single chain segment)', () => {
+    expect(isPublicAnkrRpcUrl('https://rpc.ankr.com/tac')).toBe(true)
+    expect(isPublicAnkrRpcUrl('https://rpc.ankr.com/swell')).toBe(true)
+    expect(isPublicAnkrRpcUrl('https://rpc.ankr.com/eth/')).toBe(true)
+  })
+
+  it('rejects premium URLs that carry an API key in the path', () => {
+    expect(isPublicAnkrRpcUrl('https://rpc.ankr.com/eth/abc123def456')).toBe(false)
+    expect(isPublicAnkrRpcUrl('https://rpc.ankr.com/premium-http/eth/abc123def456')).toBe(false)
+  })
+
+  it('rejects unrelated hosts', () => {
+    expect(isPublicAnkrRpcUrl('https://rpc.soniclabs.com/')).toBe(false)
+    expect(isPublicAnkrRpcUrl('https://chaotic-blissful-moon.quiknode.pro/abc/')).toBe(false)
+    expect(isPublicAnkrRpcUrl('https://example.com/ankr.com/eth')).toBe(false)
+  })
+
+  it('does not match a host that merely ends with ankr.com', () => {
+    // Defends against future host changes — guard is exact-match on host.
+    expect(isPublicAnkrRpcUrl('https://attacker-rpc.ankr.com.evil.tld/eth')).toBe(false)
+  })
+
+  it('returns false for malformed input', () => {
+    expect(isPublicAnkrRpcUrl('not-a-url')).toBe(false)
+    expect(isPublicAnkrRpcUrl('')).toBe(false)
+  })
+})

--- a/utils/public-client.ts
+++ b/utils/public-client.ts
@@ -2,6 +2,25 @@ import { createPublicClient, http, type PublicClient } from 'viem'
 
 const clientCache = new Map<string, PublicClient>()
 
+const DEFAULT_BATCH_SIZE = 100
+// Ankr's free public endpoints (`https://rpc.ankr.com/<chain>` with no API
+// key in the path) reject JSON-RPC arrays of 11+ with `code: -32062`,
+// `message: "Batch size too large"`, which collapses every concurrent
+// readContract in the burst at once. Premium URLs carry an API key as an
+// extra path segment and are unaffected, so clamp only on the free shape.
+const ANKR_PUBLIC_BATCH_SIZE = 10
+
+export const isPublicAnkrRpcUrl = (rpcUrl: string): boolean => {
+  try {
+    const u = new URL(rpcUrl)
+    if (u.host !== 'rpc.ankr.com') return false
+    return u.pathname.split('/').filter(Boolean).length === 1
+  }
+  catch {
+    return false
+  }
+}
+
 export const getPublicClient = (rpcUrl: string): PublicClient => {
   const cached = clientCache.get(rpcUrl)
   if (cached) {
@@ -14,7 +33,7 @@ export const getPublicClient = (rpcUrl: string): PublicClient => {
       // retries here amplify Cloudflare rate-limit bursts (1 failure → 4 requests).
       retryCount: 0,
       batch: {
-        batchSize: 100,
+        batchSize: isPublicAnkrRpcUrl(rpcUrl) ? ANKR_PUBLIC_BATCH_SIZE : DEFAULT_BATCH_SIZE,
         wait: 100,
       },
     }),


### PR DESCRIPTION
## Summary

Production logs on chain 239 (TAC) showed every `pricing/resolveAssetPrice` call in a warmup burst failing simultaneously with `kind: rpc-unreachable`, `code: -32062`. The cluster of 12 failed price reads always landed within the same 4 ms window — a single transport error fanning out, not 12 independent failures.

## Root cause

Ankr's free public endpoints (host `rpc.ankr.com`, no API key in the path) cap JSON-RPC array bodies at **10 entries**. Verified directly:

| Batch of N calls in one POST | Result |
|---|---|
| 2, 5, 8, 10 | OK |
| 11, 12, 15, 20 | `code: -32062, "Batch size too large"` |

`getPublicClient` configures `http(rpcUrl, { batch: { batchSize: 100, wait: 100 } })`, so when `loadChainSnapshot(239)` finishes Phase 2 and the per-vault price `Promise.all` fans out over the 12 unique TAC assets, viem packs all 12 into one HTTP POST and Ankr rejects every entry. Same dynamic on Swell (chain 1923, also Ankr public).

## Fix

Detect the free-tier URL shape (host exactly `rpc.ankr.com` with a single path segment) and clamp `batchSize` to 10 only there. Everywhere else stays at 100.

- **Premium Ankr** (`/<chain>/<API_KEY>` or `/premium-http/<chain>/<API_KEY>`) — stays at 100, unaffected.
- **Every non-Ankr provider** (QuikNode, Sonic, BOB, Goldsky…) — stays at 100, no extra HTTP requests.
- **Free Ankr** (TAC, Swell) — capped at 10; bursts of 11+ split into multiple parallel POSTs.

The blast radius for non-Ankr chains is zero. The two free-Ankr chains pay one extra HTTP request whenever a price burst exceeds 10 unique assets, which is the exact case that's currently failing.

## Verified

- Direct curl probe of `rpc.ankr.com/tac` confirms the 10-entry cap and `code -32062` on 11+
- `Promise.allSettled` over the 12 assets from the production log via the actual `getPublicClient`: **0/12 ok before → 12/12 ok after**
- 5 unit tests in `tests/utils/public-client.test.ts` lock in the URL shape heuristic, including a guard against suffix-confusion hosts (`attacker-rpc.ankr.com.evil.tld`)
- Full vitest suite: 635/635 pass
- `vue-tsc --noEmit`: clean

## Test plan
- [ ] After deploy, no more `pricing/resolveAssetPrice` clusters with `code: -32062` against `rpc.ankr.com` for chains 239 / 1923
- [ ] Other chains' warmup HTTP request counts unchanged (QuikNode billing/rate-limit telemetry steady)
- [ ] Vault snapshot endpoints (`/api/vaults?chainId=239`, `?chainId=1923`) return the full price-populated payload on cold start

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced support for Ankr free public RPC endpoints with optimized batch sizing to improve reliability and prevent request rejections.

* **Tests**
  * Added test coverage for RPC endpoint validation, including detection of free tier vs. premium Ankr URLs and edge case handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->