### PR TITLE
Neutralize discovery labels

### DIFF
--- a/components/entities/vault/VaultMaxRoeModal.vue
+++ b/components/entities/vault/VaultMaxRoeModal.vue
@@ -87,13 +87,13 @@ const handleClose = () => {
 
 <template>
   <BaseModalWrapper
-    :title="isBestInMarket ? 'Best Max ROE' : 'Max ROE'"
+    title="Max ROE"
     @close="handleClose"
   >
     <p class="text-content-primary text-p3 mb-16">
       ROE (Return on Equity) estimates the annualized return on your own capital in a multiplied position. A positive ROE means the supply yield exceeds borrowing costs at the given multiplier. A negative ROE means the position is gradually losing value to interest costs.
       <template v-if="isBestInMarket">
-        The value shown is the best max ROE out of all possible collateral/borrow pairs in this market.
+        The value shown is the max modelled ROE across possible collateral/borrow pairs in this market. Not guaranteed. Borrowing and multiplied positions involve changing rates, liquidity constraints, and liquidation risk.
       </template>
     </p>
     <div class="mb-24">

--- a/components/entities/vault/VaultSortButton.vue
+++ b/components/entities/vault/VaultSortButton.vue
@@ -4,14 +4,19 @@ import { VaultSortTypeModal } from '#components'
 
 const model = defineModel<string>({ required: true })
 const dir = defineModel<'desc' | 'asc'>('dir', { default: 'desc' })
+
+type SortOption = { label: string, value?: string, icon?: string }
+
 const props = defineProps<{
-  options: { label: string, icon?: string }[]
+  options: SortOption[]
   placeholder?: string
   title?: string
   disableDir?: boolean
 }>()
 
 const modal = useModal()
+const optionValue = (option: SortOption) => option.value ?? option.label
+const selectedOption = computed(() => props.options.find(option => optionValue(option) === model.value))
 
 const open = () => {
   modal.open(VaultSortTypeModal, {
@@ -47,7 +52,7 @@ const toggleDir = (e: Event) => {
     <span
       v-if="model"
       class="inline-flex justify-center items-center text-accent-700 text-[14px] font-medium py-2 px-8 bg-accent-300/30 rounded-[100px]"
-    >{{ model }}</span>
+    >{{ selectedOption?.label ?? model }}</span>
     <button
       class="flex items-center justify-center w-20 h-20 rounded-full transition-all"
       :class="disableDir ? 'opacity-40 cursor-not-allowed' : 'cursor-pointer hover:bg-surface-tertiary'"

--- a/components/entities/vault/VaultSortButton.vue
+++ b/components/entities/vault/VaultSortButton.vue
@@ -5,7 +5,7 @@ import { VaultSortTypeModal } from '#components'
 const model = defineModel<string>({ required: true })
 const dir = defineModel<'desc' | 'asc'>('dir', { default: 'desc' })
 
-type SortOption = { label: string, value?: string, icon?: string }
+type SortOption = { label: string, icon?: string }
 
 const props = defineProps<{
   options: SortOption[]
@@ -15,8 +15,6 @@ const props = defineProps<{
 }>()
 
 const modal = useModal()
-const optionValue = (option: SortOption) => option.value ?? option.label
-const selectedOption = computed(() => props.options.find(option => optionValue(option) === model.value))
 
 const open = () => {
   modal.open(VaultSortTypeModal, {
@@ -52,7 +50,7 @@ const toggleDir = (e: Event) => {
     <span
       v-if="model"
       class="inline-flex justify-center items-center text-accent-700 text-[14px] font-medium py-2 px-8 bg-accent-300/30 rounded-[100px]"
-    >{{ selectedOption?.label ?? model }}</span>
+    >{{ model }}</span>
     <button
       class="flex items-center justify-center w-20 h-20 rounded-full transition-all"
       :class="disableDir ? 'opacity-40 cursor-not-allowed' : 'cursor-pointer hover:bg-surface-tertiary'"

--- a/components/entities/vault/VaultSortTypeModal.vue
+++ b/components/entities/vault/VaultSortTypeModal.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 const emits = defineEmits(['close'])
 
-type SortOption = { label: string, value?: string, icon?: string }
+type SortOption = { label: string, icon?: string }
 
 const { options, selected, onSave } = defineProps<{
   options: SortOption[]
@@ -10,8 +10,7 @@ const { options, selected, onSave } = defineProps<{
   onSave: (selected: string) => void
 }>()
 
-const optionValue = (option: SortOption) => option.value ?? option.label
-const selectedIdx = ref(options.findIndex(option => optionValue(option) === selected))
+const selectedIdx = ref(options.findIndex(option => option.label === selected))
 
 const handleClose = () => {
   emits('close')
@@ -28,7 +27,7 @@ const handleClose = () => {
       :key="`options-${idx}`"
       class="flex items-center gap-12 py-12 px-16 cursor-pointer rounded-16"
       :class="[selectedIdx === idx ? 'bg-card-hover' : '']"
-      @click="onSave(optionValue(option))"
+      @click="onSave(option.label)"
     >
       <UiIcon
         v-if="option.icon"

--- a/components/entities/vault/VaultSortTypeModal.vue
+++ b/components/entities/vault/VaultSortTypeModal.vue
@@ -1,13 +1,17 @@
 <script setup lang="ts">
 const emits = defineEmits(['close'])
+
+type SortOption = { label: string, value?: string, icon?: string }
+
 const { options, selected, onSave } = defineProps<{
-  options: { label: string, icon?: string }[]
+  options: SortOption[]
   selected?: string
   title?: string
   onSave: (selected: string) => void
 }>()
 
-const selectedIdx = ref(options.findIndex(option => option.label === selected))
+const optionValue = (option: SortOption) => option.value ?? option.label
+const selectedIdx = ref(options.findIndex(option => optionValue(option) === selected))
 
 const handleClose = () => {
   emits('close')
@@ -24,7 +28,7 @@ const handleClose = () => {
       :key="`options-${idx}`"
       class="flex items-center gap-12 py-12 px-16 cursor-pointer rounded-16"
       :class="[selectedIdx === idx ? 'bg-card-hover' : '']"
-      @click="onSave(option.label)"
+      @click="onSave(optionValue(option))"
     >
       <UiIcon
         v-if="option.icon"

--- a/components/entities/vault/discovery/DiscoveryMarketCard.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketCard.vue
@@ -230,7 +230,7 @@ const onMaxRoeInfoIconClick = (event: MouseEvent, result: BestMaxRoeResult) => {
           <div class="flex-1 min-w-0">
             <template v-if="bestRoe.value > 0">
               <div class="text-content-tertiary text-p3 mb-4 flex items-center gap-4">
-                Best max ROE
+                Max ROE
                 <SvgIcon
                   class="!w-16 !h-16 shrink-0 text-content-muted hover:text-content-secondary transition-colors cursor-pointer"
                   name="info-circle"
@@ -364,7 +364,7 @@ const onMaxRoeInfoIconClick = (event: MouseEvent, result: BestMaxRoeResult) => {
           class="flex w-full justify-between"
         >
           <div class="text-content-tertiary text-p3 flex items-center gap-4 whitespace-nowrap">
-            Best max ROE
+            Max ROE
             <SvgIcon
               class="!w-16 !h-16 shrink-0 text-content-muted hover:text-content-secondary transition-colors cursor-pointer"
               name="info-circle"

--- a/pages/borrow/index.vue
+++ b/pages/borrow/index.vue
@@ -427,7 +427,7 @@ const sortedBorrowList = computed(() => {
           v-model:dir="sortDir"
           class="shrink-0 mobile:flex-1 mobile:basis-[calc(50%-4px)]"
           :options="[
-            { label: 'Recommended', icon: 'sparks' },
+            { label: 'Active', value: 'Recommended', icon: 'sparks' },
             { label: 'Liquidity', icon: 'wallet' },
             { label: 'Total Borrowed', icon: 'borrow-outline' },
             { label: 'Utilization', icon: 'pulse' },

--- a/pages/borrow/index.vue
+++ b/pages/borrow/index.vue
@@ -85,12 +85,12 @@ const selectedCollateral = ref<string[]>([])
 const selectedDebt = ref<string[]>([])
 const selectedMarkets = ref<string[]>([])
 const selectedRiskManagers = ref<string[]>([])
-const sortBy = ref<string>('Recommended')
+const sortBy = ref<string>('Active')
 const sortDir = ref<'desc' | 'asc'>('desc')
 
 useUrlQuerySync([
   { ref: searchQuery, default: '', queryKey: 'search' },
-  { ref: sortBy, default: 'Recommended', queryKey: 'sort' },
+  { ref: sortBy, default: 'Active', queryKey: 'sort' },
   { ref: sortDir, default: 'desc', queryKey: 'dir' },
   { ref: selectedCollateral, default: [], queryKey: 'collateral' },
   { ref: selectedDebt, default: [], queryKey: 'debt' },
@@ -99,7 +99,7 @@ useUrlQuerySync([
 ])
 
 watch(sortBy, (newSortBy) => {
-  if (newSortBy === 'Recommended') {
+  if (newSortBy === 'Active') {
     sortDir.value = 'desc'
   }
 })
@@ -329,7 +329,7 @@ const applyDeprecatedPairSort = (sorted: AnyBorrowVaultPair[]): AnyBorrowVaultPa
 const sortedBorrowList = computed(() => {
   let sorted: AnyBorrowVaultPair[]
   switch (sortBy.value) {
-    case 'Recommended': {
+    case 'Active': {
       const list = [...filteredBorrowList.value]
 
       const scores = list.map((pair) => {
@@ -354,7 +354,7 @@ const sortedBorrowList = computed(() => {
         return b.compositeScore - a.compositeScore
       })
 
-      // Recommended sort ignores direction toggle
+      // Active sort ignores direction toggle
       return applyDeprecatedPairSort(applyFeaturedPairSort(scored.map(s => s.pair)))
     }
     case 'Liquidity':
@@ -427,7 +427,7 @@ const sortedBorrowList = computed(() => {
           v-model:dir="sortDir"
           class="shrink-0 mobile:flex-1 mobile:basis-[calc(50%-4px)]"
           :options="[
-            { label: 'Active', value: 'Recommended', icon: 'sparks' },
+            { label: 'Active', icon: 'sparks' },
             { label: 'Liquidity', icon: 'wallet' },
             { label: 'Total Borrowed', icon: 'borrow-outline' },
             { label: 'Utilization', icon: 'pulse' },
@@ -436,7 +436,7 @@ const sortedBorrowList = computed(() => {
             { label: 'Net APY', icon: 'percent' },
             { label: 'Max ROE', icon: 'percent' },
           ]"
-          :disable-dir="sortBy === 'Recommended'"
+          :disable-dir="sortBy === 'Active'"
           title="Sorting type"
         />
         <UiSelect

--- a/pages/explore/index.vue
+++ b/pages/explore/index.vue
@@ -43,12 +43,12 @@ const { searchQuery, matchesSearch, clearSearch } = useVaultSearch<MarketGroup>(
 const selectedMarkets = ref<string[]>([])
 const selectedAssets = ref<string[]>([])
 const selectedRiskManagers = ref<string[]>([])
-const sortBy = ref<string>('Recommended')
+const sortBy = ref<string>('Active')
 const sortDir = ref<'desc' | 'asc'>('desc')
 
 useUrlQuerySync([
   { ref: searchQuery, default: '', queryKey: 'search' },
-  { ref: sortBy, default: 'Recommended', queryKey: 'sort' },
+  { ref: sortBy, default: 'Active', queryKey: 'sort' },
   { ref: sortDir, default: 'desc', queryKey: 'dir' },
   { ref: selectedMarkets, default: [], queryKey: 'market' },
   { ref: selectedAssets, default: [], queryKey: 'asset' },
@@ -76,7 +76,7 @@ const {
 )
 
 watch(sortBy, (newSortBy) => {
-  if (newSortBy === 'Recommended') {
+  if (newSortBy === 'Active') {
     sortDir.value = 'desc'
   }
 })
@@ -206,7 +206,7 @@ const applyDeprecatedGroupSort = (sorted: MarketGroup[]): MarketGroup[] => {
 const sortedMarkets = computed(() => {
   let sorted: MarketGroup[]
   switch (sortBy.value) {
-    case 'Recommended': {
+    case 'Active': {
       const list = [...filteredMarkets.value]
 
       const maxTVL = Math.max(...list.map(g => g.metrics.totalTVL), 0)
@@ -234,7 +234,7 @@ const sortedMarkets = computed(() => {
       scored.sort((a, b) => b.compositeScore - a.compositeScore)
       return applyDeprecatedGroupSort(applyFeaturedSort(scored.map(s => s.group)))
     }
-    case 'Best Max ROE':
+    case 'Max ROE':
       sorted = applyFeaturedSort([...filteredMarkets.value].sort((a, b) =>
         getBestMaxROE(b.id).value - getBestMaxROE(a.id).value,
       ))
@@ -291,13 +291,13 @@ const { isSlow } = useSlowLoading(isLoading)
           v-model="sortBy"
           v-model:dir="sortDir"
           :options="[
-            { label: 'Active', value: 'Recommended', icon: 'sparks' },
-            { label: 'Max ROE', value: 'Best Max ROE', icon: 'percent' },
+            { label: 'Active', icon: 'sparks' },
+            { label: 'Max ROE', icon: 'percent' },
             { label: 'Total Supply', icon: 'lend-outline' },
             { label: 'Total Borrowed', icon: 'borrow-outline' },
             { label: 'Available Liquidity', icon: 'wallet' },
           ]"
-          :disable-dir="sortBy === 'Recommended'"
+          :disable-dir="sortBy === 'Active'"
           title="Sorting type"
         />
         <UiSelect

--- a/pages/explore/index.vue
+++ b/pages/explore/index.vue
@@ -63,7 +63,7 @@ const {
   matchesCustomFilters,
 } = useCustomFilters<MarketGroup>(
   [
-    { key: 'bestMaxROE', label: 'Best max ROE', shortLabel: 'Best max ROE', unit: 'percent' },
+    { key: 'bestMaxROE', label: 'Max ROE', shortLabel: 'Max ROE', unit: 'percent' },
     { key: 'totalTVL', label: 'Total supply', shortLabel: 'Total supply', unit: 'usd' },
     { key: 'totalBorrowed', label: 'Total borrowed', shortLabel: 'Total borrowed', unit: 'usd' },
     { key: 'totalAvailableLiquidity', label: 'Available liquidity', shortLabel: 'Avail. liquidity', unit: 'usd' },
@@ -291,8 +291,8 @@ const { isSlow } = useSlowLoading(isLoading)
           v-model="sortBy"
           v-model:dir="sortDir"
           :options="[
-            { label: 'Recommended', icon: 'sparks' },
-            { label: 'Best Max ROE', icon: 'percent' },
+            { label: 'Active', value: 'Recommended', icon: 'sparks' },
+            { label: 'Max ROE', value: 'Best Max ROE', icon: 'percent' },
             { label: 'Total Supply', icon: 'lend-outline' },
             { label: 'Total Borrowed', icon: 'borrow-outline' },
             { label: 'Available Liquidity', icon: 'wallet' },


### PR DESCRIPTION
## Summary

- Show “Active” instead of “Recommended” in Explore and Borrow sort controls
- Show “Max ROE” instead of “Best Max ROE” while preserving the existing sort behavior
- Update Max ROE discovery copy to avoid “best” wording and add risk context

## Test plan

- `npm run typecheck`
- `npm run lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced sorting options to display custom labels while maintaining flexible value mapping.

* **Bug Fixes**
  * Improved clarity of Max ROE labels across market discovery and vault interfaces.
  * Refined sort option display labels ("Active" instead of "Recommended") for better UX consistency.

* **Documentation**
  * Added risk and liquidity disclaimers to Max ROE modal for better transparency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->