### PR TITLE
Refresh estimate and product copy

### DIFF
--- a/components/entities/operation/OperationReviewModal.vue
+++ b/components/entities/operation/OperationReviewModal.vue
@@ -227,7 +227,7 @@ const hasTenderlyFailedSimulation = computed(() => {
   return !!(tenderlyUrl.value && tenderlyError.value)
 })
 
-const permit2DisclaimerText = 'You are granting the permit2 contract unlimited access to your tokens. This is a safe, one-time setup — permit2 (by Uniswap) is a widely trusted and audited contract that replaces repeated approval transactions with gasless signatures. Each future transaction still requires your explicit signature, limited in both amount and duration.'
+const permit2DisclaimerText = 'You are granting the Permit2 contract approval to spend this token. Permit2 is a Uniswap contract used to authorize future transfers with signatures. Each future transaction still requires your explicit signature and can be limited by amount and duration.'
 </script>
 
 <template>

--- a/components/entities/operation/OperationReviewModal.vue
+++ b/components/entities/operation/OperationReviewModal.vue
@@ -227,7 +227,7 @@ const hasTenderlyFailedSimulation = computed(() => {
   return !!(tenderlyUrl.value && tenderlyError.value)
 })
 
-const permit2DisclaimerText = 'You are granting the Permit2 contract approval to spend this token. Permit2 is a Uniswap contract used to authorize future transfers with signatures. Each future transaction still requires your explicit signature and can be limited by amount and duration.'
+const permit2DisclaimerText = 'You are granting the Permit2 contract an unlimited token allowance. Permit2 is a Uniswap contract used to authorize future transfers with signatures. Each future transfer still requires your explicit signature and can be limited by amount and duration.'
 </script>
 
 <template>

--- a/components/entities/portfolio/PortfolioEarnItem.vue
+++ b/components/entities/portfolio/PortfolioEarnItem.vue
@@ -197,7 +197,7 @@ const onClick = () => {
           class="flex justify-between"
         >
           <div class="text-content-tertiary text-p3">
-            Projected earnings per month
+            Estimated monthly yield
           </div>
           <div class="flex justify-between gap-8 text-right">
             <div class="text-content-primary text-p3">

--- a/components/entities/portfolio/PortfolioSavingItem.vue
+++ b/components/entities/portfolio/PortfolioSavingItem.vue
@@ -325,7 +325,7 @@ const onClick = () => {
           class="flex justify-between"
         >
           <div class="text-content-tertiary text-p3">
-            Projected earnings per month
+            Estimated monthly yield
           </div>
           <div class="flex justify-between gap-8 text-right">
             <div class="text-content-primary text-p3">

--- a/components/entities/vault/CyclicalNoteInfoModal.vue
+++ b/components/entities/vault/CyclicalNoteInfoModal.vue
@@ -22,7 +22,7 @@ defineEmits<{ close: [] }>()
           Fixed rates with recurring cycles
         </p>
         <p class="text-p3 text-content-secondary text-center">
-          Cyclical Notes offer borrowers a fixed interest rate for most of the cycle, followed by a short repayment window with a sharply higher rate to incentivise repayment. Lenders earn an elevated, predictable yield in exchange for reduced withdrawal flexibility.
+          Lender returns depend on the configured cycle rate, available liquidity, and market conditions. Withdrawals may be limited during the cycle.
         </p>
       </div>
 

--- a/pages/earn/[vault]/index.vue
+++ b/pages/earn/[vault]/index.vue
@@ -340,7 +340,7 @@ watch(address, () => {
               variant="card"
             >
               <SummaryRow
-                label="Projected earnings per month"
+                label="Estimated monthly yield"
                 align-top
               >
                 <p class="text-content-tertiary">

--- a/pages/lend/[vault]/index.vue
+++ b/pages/lend/[vault]/index.vue
@@ -969,7 +969,7 @@ watch(address, () => {
               variant="card"
             >
               <SummaryRow
-                label="Projected earnings per month"
+                label="Estimated monthly yield"
                 align-top
               >
                 <p class="text-content-tertiary">


### PR DESCRIPTION
## Summary

- Rename monthly earnings labels to “Estimated monthly yield”
- Update Permit2 helper copy to clarify the unlimited token allowance and signature-limited future transfers
- Refresh Cyclical Notes modal copy to better describe cycle-dependent returns and withdrawals

## Test plan

- `npm run typecheck`
- `npm run lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved clarity on Permit2 functionality, explaining unlimited token allowance and signature requirements for each transaction
  * Unified earnings display labels across the platform to "Estimated monthly yield"
  * Enhanced cyclical notes explanation regarding how lender returns depend on market conditions and cycle rates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->