### PR TITLE
Relabel portfolio savings tab to yield

### DIFF
--- a/docs/portfolio-logic.md
+++ b/docs/portfolio-logic.md
@@ -9,15 +9,15 @@ Every on-chain deposit a user holds falls into one of three categories:
 | Category | Description | Data Source |
 |----------|-------------|-------------|
 | **Borrow Position** | A deposit used as collateral backing a loan | Subgraph `borrows` + AccountLens |
-| **Savings (Deposit/Earn)** | A standalone deposit not used as collateral (includes both EVK and EulerEarn vaults) | Subgraph `deposits` + AccountLens |
+| **Yield Position (Deposit/Earn)** | A standalone deposit not used as collateral (includes both EVK and EulerEarn vaults) | Subgraph `deposits` + AccountLens |
 
-Savings positions are stored in a single `depositPositions` array. The UI splits them into "Curated lending" (earn vaults) and "Direct lending" (EVK/securitize vaults) using `isEarnVault()` from the vault registry.
+Yield positions are stored in a single `depositPositions` array. The UI splits them into "Curated lending" (earn vaults) and "Direct lending" (EVK/securitize vaults) using `isEarnVault()` from the vault registry.
 
 Portfolio cards can display operational **portfolio notices** from the labels system (e.g. migration announcements, temporary pauses). Notices are resolved via `getVaultNotice()` which checks earn vault notices, vault overrides, and product-level `portfolioNotice` in priority order. On borrow cards, collateral and borrow notices are shown separately with deduplication when both vaults share the same product-level notice.
 
 ### How Categorization Works
 
-Categorization depends on a strict loading order: **borrows first, then savings**.
+Categorization depends on a strict loading order: **borrows first, then standalone deposits**.
 
 #### Step 1: Load Borrow Positions
 
@@ -58,9 +58,9 @@ borrow entry (from subgraph)
   +-- Include as borrow position
 ```
 
-After processing all entries, a `collateralUsageSet` is built containing every `"subAccount:collateralVaultAddress"` pair. This is the key data structure that enables the savings/position split — deposits that appear in this set are shown under their borrow position rather than as standalone savings.
+After processing all entries, a `collateralUsageSet` is built containing every `"subAccount:collateralVaultAddress"` pair. This is the key data structure that enables the yield/position split — deposits that appear in this set are shown under their borrow position rather than as standalone yield positions.
 
-#### Step 2: Load Savings Positions
+#### Step 2: Load Yield Positions
 
 `updateSavingsPositions()` makes a **single** subgraph query for deposits and processes all vault types (EVK, securitize, and earn) in one pass:
 
@@ -89,7 +89,7 @@ deposit entry
   |-- Does accountLens return shares > 0?
   |     NO  -> skip
   |
-  +-- Include as savings position (in depositPositions array)
+  +-- Include as yield position (in depositPositions array)
 ```
 
 The UI then filters the unified `depositPositions` array:
@@ -117,7 +117,7 @@ interface AccountBorrowPosition {
 }
 
 interface AccountDepositPosition {
-  vault: Vault | SecuritizeVault | EarnVault  // Any savings vault type
+  vault: Vault | SecuritizeVault | EarnVault  // Any standalone yield vault type
   subAccount: string           // EVC sub-account address
   shares: bigint               // Vault share balance
   assets: bigint               // Equivalent asset amount

--- a/docs/portfolio-logic.md
+++ b/docs/portfolio-logic.md
@@ -9,9 +9,9 @@ Every on-chain deposit a user holds falls into one of three categories:
 | Category | Description | Data Source |
 |----------|-------------|-------------|
 | **Borrow Position** | A deposit used as collateral backing a loan | Subgraph `borrows` + AccountLens |
-| **Yield Position (Deposit/Earn)** | A standalone deposit not used as collateral (includes both EVK and EulerEarn vaults) | Subgraph `deposits` + AccountLens |
+| **Deposit Position (Deposit/Earn)** | A standalone deposit not used as collateral (includes both EVK and EulerEarn vaults) | Subgraph `deposits` + AccountLens |
 
-Yield positions are stored in a single `depositPositions` array. The UI splits them into "Curated lending" (earn vaults) and "Direct lending" (EVK/securitize vaults) using `isEarnVault()` from the vault registry.
+Deposit positions are stored in a single `depositPositions` array. The UI splits them into "Curated lending" (earn vaults) and "Direct lending" (EVK/securitize vaults) using `isEarnVault()` from the vault registry.
 
 Portfolio cards can display operational **portfolio notices** from the labels system (e.g. migration announcements, temporary pauses). Notices are resolved via `getVaultNotice()` which checks earn vault notices, vault overrides, and product-level `portfolioNotice` in priority order. On borrow cards, collateral and borrow notices are shown separately with deduplication when both vaults share the same product-level notice.
 
@@ -58,9 +58,9 @@ borrow entry (from subgraph)
   +-- Include as borrow position
 ```
 
-After processing all entries, a `collateralUsageSet` is built containing every `"subAccount:collateralVaultAddress"` pair. This is the key data structure that enables the yield/position split — deposits that appear in this set are shown under their borrow position rather than as standalone yield positions.
+After processing all entries, a `collateralUsageSet` is built containing every `"subAccount:collateralVaultAddress"` pair. This is the key data structure that enables the deposit/position split — deposits that appear in this set are shown under their borrow position rather than as standalone deposit positions.
 
-#### Step 2: Load Yield Positions
+#### Step 2: Load Deposit Positions
 
 `updateSavingsPositions()` makes a **single** subgraph query for deposits and processes all vault types (EVK, securitize, and earn) in one pass:
 
@@ -89,7 +89,7 @@ deposit entry
   |-- Does accountLens return shares > 0?
   |     NO  -> skip
   |
-  +-- Include as yield position (in depositPositions array)
+  +-- Include as deposit position (in depositPositions array)
 ```
 
 The UI then filters the unified `depositPositions` array:
@@ -117,7 +117,7 @@ interface AccountBorrowPosition {
 }
 
 interface AccountDepositPosition {
-  vault: Vault | SecuritizeVault | EarnVault  // Any standalone yield vault type
+  vault: Vault | SecuritizeVault | EarnVault  // Any standalone deposit vault type
   subAccount: string           // EVC sub-account address
   shares: bigint               // Vault share balance
   assets: bigint               // Equivalent asset amount

--- a/pages/portfolio.vue
+++ b/pages/portfolio.vue
@@ -53,7 +53,7 @@ const tabs = computed(() => [
     badge: borrowPositions.value.length || null,
   },
   {
-    label: 'Savings',
+    label: 'Yield',
     value: 'portfolio-saving',
     badge: depositPositions.value.length || null,
   },

--- a/pages/portfolio.vue
+++ b/pages/portfolio.vue
@@ -53,7 +53,7 @@ const tabs = computed(() => [
     badge: borrowPositions.value.length || null,
   },
   {
-    label: 'Yield',
+    label: 'Deposits',
     value: 'portfolio-saving',
     badge: depositPositions.value.length || null,
   },

--- a/pages/portfolio/saving.vue
+++ b/pages/portfolio/saving.vue
@@ -61,10 +61,10 @@ watchEffect(async () => {
             <SvgIcon name="search" />
           </div>
           <template v-if="isConnected">
-            You don't have yield positions yet
+            You don't have deposit positions yet
           </template>
           <template v-else>
-            Connect your wallet to see your yield positions
+            Connect your wallet to see your deposit positions
           </template>
         </div>
       </div>
@@ -91,7 +91,7 @@ watchEffect(async () => {
       </h3>
     </div>
     <p class="text-p2 text-neutral-500 mb-16">
-      Yield from assets supplied to Euler vaults.
+      Assets supplied to Euler vaults.
     </p>
     <div class="flex flex-1 p-8 rounded-12 border border-line-default bg-card">
       <div
@@ -109,10 +109,10 @@ watchEffect(async () => {
             <SvgIcon name="search" />
           </div>
           <template v-if="isConnected">
-            You don't have yield positions yet
+            You don't have deposit positions yet
           </template>
           <template v-else>
-            Connect your wallet to see your yield positions
+            Connect your wallet to see your deposit positions
           </template>
         </div>
       </div>

--- a/pages/portfolio/saving.vue
+++ b/pages/portfolio/saving.vue
@@ -61,10 +61,10 @@ watchEffect(async () => {
             <SvgIcon name="search" />
           </div>
           <template v-if="isConnected">
-            You don't have savings yet
+            You don't have yield positions yet
           </template>
           <template v-else>
-            Connect your wallet to see your savings
+            Connect your wallet to see your yield positions
           </template>
         </div>
       </div>
@@ -91,7 +91,7 @@ watchEffect(async () => {
       </h3>
     </div>
     <p class="text-p2 text-neutral-500 mb-16">
-      Yield earned by lending assets directly to borrowers.
+      Yield from assets supplied to Euler vaults.
     </p>
     <div class="flex flex-1 p-8 rounded-12 border border-line-default bg-card">
       <div
@@ -109,10 +109,10 @@ watchEffect(async () => {
             <SvgIcon name="search" />
           </div>
           <template v-if="isConnected">
-            You don't have savings yet
+            You don't have yield positions yet
           </template>
           <template v-else>
-            Connect your wallet to see your savings
+            Connect your wallet to see your yield positions
           </template>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- Rename the Portfolio “Savings” tab to “Yield” while preserving the existing route
- Update empty states to refer to yield positions
- Refresh portfolio yield section copy and matching internal docs terminology

## Test plan

- `npm run typecheck`
- `npm run lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified portfolio position categorization and loading order; renamed standalone "Savings" terminology to a yield-oriented "Yield Position (Deposit/Earn)" and updated explanatory flow and diagrams.

* **Style**
  * Updated UI labels and empty-state copy to use "Deposits", "deposit positions" or "yield positions" and refined lending subtitles (e.g., "Assets supplied to vaults").
<!-- end of auto-generated comment: release notes by coderabbit.ai -->