### PR TITLE
Refresh Earn page copy

### DIFF
--- a/components/entities/vault/VaultEarnItem.vue
+++ b/components/entities/vault/VaultEarnItem.vue
@@ -164,7 +164,7 @@ const onSupplyInfoIconClick = (event: MouseEvent) => {
         v-if="enableEntityBranding"
         class="flex-1 mobile:!hidden"
       >
-        <div class="text-content-tertiary text-p3 mb-4">Capital allocator</div>
+        <div class="text-content-tertiary text-p3 mb-4">Curator</div>
         <div
           v-if="!isOwnerVerified"
           class="flex gap-8 items-center py-4 px-8 rounded-8 bg-error-100 text-error-500 text-p2 w-fit"
@@ -236,7 +236,7 @@ const onSupplyInfoIconClick = (event: MouseEvent) => {
         class="flex w-full justify-between"
       >
         <div class="flex-1">
-          <div class="text-content-tertiary text-p3">Capital allocator</div>
+          <div class="text-content-tertiary text-p3">Curator</div>
         </div>
         <div class="flex gap-8 justify-end items-center text-right flex-1">
           <div

--- a/components/entities/vault/overview/earn/VaultOverviewEarnBlockGeneral.vue
+++ b/components/entities/vault/overview/earn/VaultOverviewEarnBlockGeneral.vue
@@ -87,7 +87,7 @@ const feeDisplay = computed(() => {
         />
         <VaultOverviewLabelValue
           v-if="enableEntityBrandingDisplay"
-          label="Capital allocator"
+          label="Curator"
         >
           <div
             v-if="entities.length && isOwnerVerified"

--- a/pages/earn/index.vue
+++ b/pages/earn/index.vue
@@ -51,7 +51,7 @@ useUrlQuerySync([
   { ref: sortBy, default: 'Total Supply', queryKey: 'sort' },
   { ref: sortDir, default: 'desc', queryKey: 'dir' },
   { ref: selectedCollateral, default: [], queryKey: 'vault' },
-  { ref: selectedCurators, default: [], queryKey: 'allocator' },
+  { ref: selectedCurators, default: [], queryKey: 'curator' },
 ])
 
 // Cache for USD values used in sorting (keyed by vault address)

--- a/pages/earn/index.vue
+++ b/pages/earn/index.vue
@@ -210,7 +210,7 @@ const sortedList = computed(() => {
   <section class="flex flex-col min-h-[calc(100dvh-178px)]">
     <BasePageHeader
       title="Earn"
-      description="One deposit, diversified yield. Curators allocate your capital across multiple lending strategies."
+      description="Explore curator-configured vaults that allocate supplied assets across multiple lending strategies."
       class="mb-16"
       arrow-right
     />
@@ -240,9 +240,9 @@ const sortedList = computed(() => {
           :key="`curators-${chainId}`"
           v-model="selectedCurators"
           :options="curatorOptions"
-          placeholder="Capital allocator"
-          title="Capital allocator"
-          modal-input-placeholder="Search allocator"
+          placeholder="Curator"
+          title="Curator"
+          modal-input-placeholder="Search curator"
           icon="search-user"
         />
         <UiSelect


### PR DESCRIPTION
## Summary

- Rename visible Earn “Capital allocator” labels to “Curator”
- Update Earn page header copy to describe curator-configured vaults
- Preserve existing query keys and filtering behavior

## Test plan

- `npm run typecheck`
- `npm run lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Refactor**
* Updated all occurrences of "Capital allocator" terminology to "Curator" across earning pages and vault components for consistency
* Refreshed curator filter labels, descriptions, and modal input placeholders throughout the platform
* Synchronized URL query parameters with updated curator naming conventions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->