### PR TITLE
Harden Sentry tunnel validation

### DIFF
--- a/server/api/sentry-tunnel.post.ts
+++ b/server/api/sentry-tunnel.post.ts
@@ -8,10 +8,138 @@ const rateLimiter = createRateLimiter({
   label: 'sentry-tunnel',
 })
 
+interface SentryEnvelopeHeader {
+  dsn?: string
+}
+
+interface SentryEnvelopeItemHeader {
+  type?: string
+  length?: number
+}
+
 function buildIngestUrl(dsn: string): string {
   const url = new URL(dsn)
   const projectId = url.pathname.slice(1)
   return `https://${url.hostname}/api/${projectId}/envelope/`
+}
+
+function normalizeDsn(dsn: string): string {
+  return dsn.trim().replace(/\/$/, '')
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function readJsonLine<T>(body: Buffer, offset: number): { value: T, nextOffset: number } {
+  if (offset >= body.length) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid envelope' })
+  }
+
+  const newline = body.indexOf(10, offset)
+  const lineEnd = newline === -1 ? body.length : newline
+
+  try {
+    return {
+      value: JSON.parse(body.slice(offset, lineEnd).toString()) as T,
+      nextOffset: newline === -1 ? body.length : newline + 1,
+    }
+  }
+  catch {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid envelope' })
+  }
+}
+
+function readItemPayload(body: Buffer, itemHeader: SentryEnvelopeItemHeader, offset: number): { payload: Buffer, nextOffset: number } {
+  if (typeof itemHeader.length === 'number') {
+    if (!Number.isInteger(itemHeader.length) || itemHeader.length < 0) {
+      throw createError({ statusCode: 400, statusMessage: 'Invalid envelope' })
+    }
+
+    const payloadEnd = offset + itemHeader.length
+    if (payloadEnd > body.length) {
+      throw createError({ statusCode: 400, statusMessage: 'Invalid envelope' })
+    }
+
+    return {
+      payload: body.slice(offset, payloadEnd),
+      nextOffset: body[payloadEnd] === 10 ? payloadEnd + 1 : payloadEnd,
+    }
+  }
+
+  const newline = body.indexOf(10, offset)
+  const payloadEnd = newline === -1 ? body.length : newline
+  return {
+    payload: body.slice(offset, payloadEnd),
+    nextOffset: newline === -1 ? body.length : newline + 1,
+  }
+}
+
+function validateBrowserEventPayload(itemType: string | undefined, payload: Buffer): void {
+  if (itemType !== 'event' && itemType !== 'transaction' && itemType !== 'replay_event') {
+    return
+  }
+
+  let eventPayload: unknown
+  try {
+    eventPayload = JSON.parse(payload.toString())
+  }
+  catch {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid envelope' })
+  }
+
+  if (!isRecord(eventPayload)) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid envelope' })
+  }
+
+  // The tunnel is only used by the browser SDK. Browser events should never
+  // contain server-side identity fields; reject forged server events before
+  // they can create alert noise in the Sentry project.
+  if (typeof eventPayload.server_name === 'string' && eventPayload.server_name.trim()) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid Sentry event' })
+  }
+
+  if (typeof eventPayload.platform === 'string' && eventPayload.platform !== 'javascript') {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid Sentry event' })
+  }
+
+  const sdk = eventPayload.sdk
+  if (isRecord(sdk) && typeof sdk.name === 'string' && !sdk.name.startsWith('sentry.javascript.')) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid Sentry event' })
+  }
+}
+
+export function parseAndValidateSentryEnvelope(body: Buffer, sentryDsn: string): SentryEnvelopeHeader {
+  const { value: envelopeHeader, nextOffset } = readJsonLine<unknown>(body, 0)
+  const envelopeDsn = isRecord(envelopeHeader) && typeof envelopeHeader.dsn === 'string'
+    ? envelopeHeader.dsn
+    : ''
+
+  if (normalizeDsn(envelopeDsn) !== normalizeDsn(sentryDsn)) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid DSN' })
+  }
+
+  let offset = nextOffset
+  while (offset < body.length) {
+    const { value: itemHeader, nextOffset: payloadOffset } = readJsonLine<unknown>(body, offset)
+    if (!isRecord(itemHeader)) {
+      throw createError({ statusCode: 400, statusMessage: 'Invalid envelope' })
+    }
+
+    if ('length' in itemHeader && typeof itemHeader.length !== 'number') {
+      throw createError({ statusCode: 400, statusMessage: 'Invalid envelope' })
+    }
+
+    const normalizedItemHeader: SentryEnvelopeItemHeader = {
+      type: typeof itemHeader.type === 'string' ? itemHeader.type : undefined,
+      length: typeof itemHeader.length === 'number' ? itemHeader.length : undefined,
+    }
+    const { payload, nextOffset: nextItemOffset } = readItemPayload(body, normalizedItemHeader, payloadOffset)
+    validateBrowserEventPayload(normalizedItemHeader.type, payload)
+    offset = nextItemOffset
+  }
+
+  return { dsn: envelopeDsn }
 }
 
 export default defineEventHandler(async (event) => {
@@ -30,18 +158,9 @@ export default defineEventHandler(async (event) => {
 
   // Parse envelope header (first line) and validate the DSN to prevent
   // this endpoint from being used to relay events to arbitrary Sentry projects.
-  let envelopeHeader: { dsn?: string }
-  try {
-    envelopeHeader = JSON.parse(body.slice(0, body.indexOf(10)).toString())
-  }
-  catch {
-    throw createError({ statusCode: 400, statusMessage: 'Invalid envelope' })
-  }
-
-  const normalize = (dsn: string) => dsn.trim().replace(/\/$/, '')
-  if (normalize(envelopeHeader.dsn ?? '') !== normalize(sentryDsn)) {
-    throw createError({ statusCode: 400, statusMessage: 'Invalid DSN' })
-  }
+  // Also reject server-flavoured event payloads; this tunnel is only for the
+  // browser SDK and must not be a shortcut for forged Node/server events.
+  parseAndValidateSentryEnvelope(body, sentryDsn)
 
   const contentType = getHeader(event, 'content-type') ?? 'application/x-sentry-envelope'
 

--- a/tests/server/sentry-tunnel.test.ts
+++ b/tests/server/sentry-tunnel.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+import { parseAndValidateSentryEnvelope } from '~/server/api/sentry-tunnel.post'
+
+const DSN = 'https://public@example.ingest.sentry.io/123'
+
+function envelope(items: Array<{ header: Record<string, unknown>, payload: unknown }>, dsn = DSN): Buffer {
+  return Buffer.from([
+    JSON.stringify({ dsn, sent_at: '2026-05-11T00:00:00.000Z' }),
+    ...items.flatMap(item => [
+      JSON.stringify(item.header),
+      typeof item.payload === 'string' ? item.payload : JSON.stringify(item.payload),
+    ]),
+  ].join('\n'))
+}
+
+describe('parseAndValidateSentryEnvelope', () => {
+  it('accepts browser SDK event envelopes for the configured DSN', () => {
+    const body = envelope([
+      {
+        header: { type: 'event' },
+        payload: {
+          event_id: '0'.repeat(32),
+          platform: 'javascript',
+          sdk: { name: 'sentry.javascript.nuxt', version: '10.50.0' },
+          message: 'real browser error',
+        },
+      },
+    ])
+
+    expect(parseAndValidateSentryEnvelope(body, DSN)).toMatchObject({ dsn: DSN })
+  })
+
+  it('rejects envelopes for another Sentry project', () => {
+    const body = envelope([
+      {
+        header: { type: 'event' },
+        payload: {
+          platform: 'javascript',
+          sdk: { name: 'sentry.javascript.nuxt', version: '10.50.0' },
+          message: 'wrong project',
+        },
+      },
+    ], 'https://public@example.ingest.sentry.io/999')
+
+    expect(() => parseAndValidateSentryEnvelope(body, DSN)).toThrow(expect.objectContaining({ statusCode: 400 }))
+  })
+
+  it('rejects forged server-name event payloads', () => {
+    const body = envelope([
+      {
+        header: { type: 'event' },
+        payload: {
+          platform: 'javascript',
+          sdk: { name: 'sentry.javascript.nuxt', version: '10.50.0' },
+          server_name: 'external-host',
+          message: 'server-side event',
+        },
+      },
+    ])
+
+    expect(() => parseAndValidateSentryEnvelope(body, DSN)).toThrow(expect.objectContaining({
+      statusCode: 400,
+      statusMessage: 'Invalid Sentry event',
+    }))
+  })
+
+  it('rejects non-browser SDK event payloads', () => {
+    const body = envelope([
+      {
+        header: { type: 'event' },
+        payload: {
+          platform: 'node',
+          sdk: { name: 'sentry.javascript.node', version: '10.50.0' },
+          message: 'server event',
+        },
+      },
+    ])
+
+    expect(() => parseAndValidateSentryEnvelope(body, DSN)).toThrow(expect.objectContaining({ statusCode: 400 }))
+  })
+})


### PR DESCRIPTION
## Summary
- Tighten the Sentry tunnel so forwarded event payloads must match browser SDK expectations.
- Keep configured-project DSN validation while adding item-level envelope parsing for event payloads.

## Changes
- Parse Sentry envelope item headers and payloads while preserving binary/replay forwarding support.
- Reject server-side identity fields, non-javascript platforms, and non-browser SDK names in event items.
- Add focused server tests for accepted browser envelopes and rejected non-browser/foreign-project envelopes.

## Test plan
- [x] npm run test:run -- tests/server/sentry-tunnel.test.ts
- [x] npm run lint -- server/api/sentry-tunnel.post.ts tests/server/sentry-tunnel.test.ts
- [x] npm run typecheck
- [x] npm run test:run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error tracking endpoint security by validating event sources and rejecting unauthorized submissions, non-browser platforms, and events from misconfigured projects.

* **Tests**
  * Added comprehensive test coverage for error tracking validation logic, including DSN verification, platform filtering, and malformed event rejection.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/euler-xyz/euler-lite/pull/408)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->