### PR TITLE
Add USPC Coinshift intrinsic APY

### DIFF
--- a/entities/custom.ts
+++ b/entities/custom.ts
@@ -19,9 +19,11 @@ export type IntrinsicApySourceConfig
     | { provider: 'avant', address: string, chainId: number }
     | { provider: 'infinifi', address: string, chainId: number, infinifiVariant: 'locked' | 'staked', infinifiLockedKey?: string }
     | { provider: 'accountable', address: string, chainId: number, loanAddress: string }
+    | { provider: 'coinshift', address: string, chainId: number, period: '7d' | '30d' | '90d' }
 
 export const intrinsicApySources: readonly IntrinsicApySourceConfig[] = [
   // DefiLlama pools — Ethereum (1)
+  { provider: 'coinshift', chainId: 1, address: '0xbF4e3fbE8B60062A00C7a6B1D97d0d49c2971A19', period: '7d' },
   { provider: 'defillama', chainId: 1, address: '0x0655977FEb2f289A4aB78af67BAB0d17aAb84367', poolId: '5fd328af-4203-471b-bd16-1705c726d926' },
   { provider: 'defillama', chainId: 1, address: '0x09db87A538BD693E9d08544577d5cCfAA6373A48', poolId: '44dd4153-aa9f-4616-9a88-e6803c86b995' },
   { provider: 'defillama', chainId: 1, address: '0x0d86883FAf4FfD7aEb116390af37746F45b6f378', poolId: '9c4e675e-7615-4d60-90ef-03d58c66b476' },

--- a/server/utils/intrinsic-apy.ts
+++ b/server/utils/intrinsic-apy.ts
@@ -39,6 +39,7 @@ const UPSTREAM_URLS = {
   stablewatch: 'https://api.stablewatch.io/api/pools',
   infinifi: 'https://eth-api.infinifi.xyz/api/protocol/data',
   accountable: 'https://yield.accountable.capital/api/loan/address',
+  coinshift: 'https://uspc-nav.coinshift.xyz/api/nav/returns',
 } as const
 
 const PENDLE_API_BASE = 'https://api-v2.pendle.finance/core/v2'
@@ -349,6 +350,28 @@ async function extractAccountable(sources: AccountableSource[]): Promise<Array<[
   return out
 }
 
+type CoinshiftSource = Extract<IntrinsicApySourceConfig, { provider: 'coinshift' }>
+type CoinshiftReturnsResponse = {
+  data?: {
+    returns?: Partial<Record<CoinshiftSource['period'], { apy?: number | null } | null>>
+  }
+}
+
+async function extractCoinshift(sources: CoinshiftSource[]): Promise<Array<[string, IntrinsicApyInfo]>> {
+  const data = await fetchUpstream<CoinshiftReturnsResponse>('coinshift', UPSTREAM_URLS.coinshift)
+  const out: Array<[string, IntrinsicApyInfo]> = []
+  for (const s of sources) {
+    const apy = Number(data?.data?.returns?.[s.period]?.apy)
+    if (!Number.isFinite(apy)) continue
+    out.push([normalize(s.address), {
+      apy,
+      provider: 'Coinshift',
+      source: UPSTREAM_URLS.coinshift,
+    }])
+  }
+  return out
+}
+
 type YoSource = Extract<IntrinsicApySourceConfig, { provider: 'yo' }>
 
 async function extractYo(sources: YoSource[]): Promise<Array<[string, IntrinsicApyInfo]>> {
@@ -403,7 +426,7 @@ async function extractSimple<S extends IntrinsicApySourceConfig, T>(
 }
 
 // Providers with dedicated extractors in the switch below.
-type ExplicitProvider = 'defillama' | 'pendle' | 'securitize' | 'stablewatch' | 'renzo' | 'midas' | 'yo' | 'infinifi' | 'accountable'
+type ExplicitProvider = 'defillama' | 'pendle' | 'securitize' | 'stablewatch' | 'renzo' | 'midas' | 'yo' | 'infinifi' | 'accountable' | 'coinshift'
 // Every remaining provider must have an entry in SIMPLE_SPECS — enforced at the type level.
 type SimpleProvider = Exclude<IntrinsicApySourceConfig['provider'], ExplicitProvider>
 
@@ -470,6 +493,7 @@ async function extractForProvider(
     case 'yo': return extractYo(sources as YoSource[])
     case 'infinifi': return extractInfinifi(sources as InfinifiSource[])
     case 'accountable': return extractAccountable(sources as AccountableSource[])
+    case 'coinshift': return extractCoinshift(sources as CoinshiftSource[])
     default: {
       const simpleProvider: SimpleProvider = provider
       const spec = SIMPLE_SPECS[simpleProvider]


### PR DESCRIPTION
## Summary
- Add a Coinshift intrinsic APY provider for USPC in Lite.
- Use the Coinshift NAV returns endpoint instead of hardcoding a fixed APY value.

## Changes
- Adds a coinshift intrinsic APY source type with an explicit return period.
- Adds USPC on Ethereum using the 7d APY from https://uspc-nav.coinshift.xyz/api/nav/returns.
- Wires Coinshift into the server-side intrinsic APY extractor path so the client continues to consume the existing /api/intrinsic-apy response shape.

## Test plan
- [x] npm run typecheck
- [x] npx eslint entities/custom.ts server/utils/intrinsic-apy.ts
- [x] curl https://uspc-nav.coinshift.xyz/api/nav/returns