### PR TITLE
Remove projected monthly earnings estimates

### DIFF
--- a/components/entities/portfolio/PortfolioEarnItem.vue
+++ b/components/entities/portfolio/PortfolioEarnItem.vue
@@ -7,7 +7,7 @@ import { type AccountDepositPosition, getSubAccountIndex } from '~/entities/acco
 import type { EarnVault } from '~/entities/vault'
 import { VaultOverviewModal, VaultSupplyApyModal } from '#components'
 import { useModal } from '~/components/ui/composables/useModal'
-import { formatNumber, formatCompactUsdValue, compactNumber, formatExactAmount } from '~/utils/string-utils'
+import { formatNumber, formatCompactUsdValue, formatExactAmount } from '~/utils/string-utils'
 import { nanoToValue, roundAndCompactTokens } from '~/utils/crypto-utils'
 
 const { position } = defineProps<{ position: AccountDepositPosition }>()
@@ -56,22 +56,6 @@ const updateHasPrice = async () => {
 
 watchEffect(() => {
   updateHasPrice()
-})
-
-const projectedEarningsPerMonth = ref('—')
-
-const updateProjectedEarningsPerMonth = async () => {
-  const price = await getAssetUsdValue(position.assets, vault.value, 'off-chain')
-  if (price === undefined || price === 0) {
-    projectedEarningsPerMonth.value = '—'
-    return
-  }
-  // Monthly earnings = (value * APY%) / 12
-  projectedEarningsPerMonth.value = compactNumber((price * supplyApyWithRewards.value) / 12 / 100)
-}
-
-watchEffect(() => {
-  updateProjectedEarningsPerMonth()
 })
 
 const onSupplyInfoIconClick = (event: MouseEvent) => {
@@ -190,19 +174,6 @@ const onClick = () => {
             >
               ~ {{ roundAndCompactTokens(position.assets, vault.asset.decimals) }} {{ vault.asset.symbol }}
             </UiExactAmount>
-          </div>
-        </div>
-        <div
-          v-if="hasPrice"
-          class="flex justify-between"
-        >
-          <div class="text-content-tertiary text-p3">
-            Projected earnings per month
-          </div>
-          <div class="flex justify-between gap-8 text-right">
-            <div class="text-content-primary text-p3">
-              ${{ projectedEarningsPerMonth }}
-            </div>
           </div>
         </div>
         <div

--- a/components/entities/portfolio/PortfolioSavingItem.vue
+++ b/components/entities/portfolio/PortfolioSavingItem.vue
@@ -5,7 +5,7 @@ import { getUtilisationWarning } from '~/composables/useVaultWarnings'
 import { getAssetUsdValue, formatAssetValue } from '~/services/pricing/priceProvider'
 import { isVaultBlockedByCountry } from '~/composables/useGeoBlock'
 import { isVaultDeprecated, getVaultNotice } from '~/utils/eulerLabelsUtils'
-import { formatNumber, compactNumber, formatCompactUsdValue, formatSmartAmount, formatExactAmount } from '~/utils/string-utils'
+import { formatNumber, formatCompactUsdValue, formatSmartAmount, formatExactAmount } from '~/utils/string-utils'
 import { nanoToValue, roundAndCompactTokens } from '~/utils/crypto-utils'
 import { type AccountDepositPosition, getSubAccountIndex } from '~/entities/account'
 import { VaultOverviewModal, VaultSupplyApyModal } from '#components'
@@ -74,22 +74,6 @@ const updateHasPrice = async () => {
 
 watchEffect(() => {
   updateHasPrice()
-})
-
-const projectedEarningsPerMonth = ref('—')
-
-const updateProjectedEarningsPerMonth = async () => {
-  const price = await getAssetUsdValue(position.assets, vault.value, 'off-chain')
-  if (price === undefined || price === 0) {
-    projectedEarningsPerMonth.value = '—'
-    return
-  }
-  // Monthly earnings = (value * APY%) / 12
-  projectedEarningsPerMonth.value = compactNumber((price * supplyApyWithRewards.value) / 12 / 100)
-}
-
-watchEffect(() => {
-  updateProjectedEarningsPerMonth()
 })
 
 // Securitize-specific computed properties
@@ -318,19 +302,6 @@ const onClick = () => {
               ~ {{ roundAndCompactTokens(position.assets, vault.decimals) }}
               {{ vault.asset.symbol }}
             </UiExactAmount>
-          </div>
-        </div>
-        <div
-          v-if="hasPrice"
-          class="flex justify-between"
-        >
-          <div class="text-content-tertiary text-p3">
-            Projected earnings per month
-          </div>
-          <div class="flex justify-between gap-8 text-right">
-            <div class="text-content-primary text-p3">
-              ${{ projectedEarningsPerMonth }}
-            </div>
           </div>
         </div>
         <div

--- a/pages/earn/[vault]/index.vue
+++ b/pages/earn/[vault]/index.vue
@@ -4,13 +4,12 @@ import { useModal } from '~/components/ui/composables/useModal'
 import { OperationReviewModal, VaultSupplyApyModal, VaultUnverifiedDisclaimerModal } from '#components'
 import { useToast } from '~/components/ui/composables/useToast'
 import type { EarnVault, VaultAsset } from '~/entities/vault'
-import { getAssetUsdValueOrZero } from '~/services/pricing/priceProvider'
 import type { TxPlan } from '~/entities/txPlan'
 import { useEulerProductOfVault } from '~/composables/useEulerLabels'
 import { isVaultBlockedByCountry } from '~/composables/useGeoBlock'
 import VaultFormInfoBlock from '~/components/entities/vault/form/VaultFormInfoBlock.vue'
 import VaultFormSubmit from '~/components/entities/vault/form/VaultFormSubmit.vue'
-import { formatNumber, compactNumber } from '~/utils/string-utils'
+import { formatNumber } from '~/utils/string-utils'
 import { isOperationBlocked } from '~/utils/operationGuardRegistry'
 import type { DisabledReasonInfo } from '~/components/entities/vault/form/types'
 
@@ -39,8 +38,6 @@ const plan = ref<TxPlan | null>(null)
 const vault: Ref<EarnVault | undefined> = ref(undefined)
 const asset: Ref<VaultAsset | undefined> = ref(undefined)
 const estimateSupplyAPY = ref(0)
-const monthlyEarnings = ref(0)
-const monthlyEarningsUsd = ref(0)
 const balance = ref(0n)
 
 const fetchBalance = async () => {
@@ -187,9 +184,6 @@ const updateEstimates = async () => {
     await updateEarnVault(vault.value.address)
     if (!asset.value?.address) return
     estimateSupplyAPY.value = nanoToValue(vault.value.interestRateInfo.supplyAPY, 25) + totalRewardsAPY.value
-    monthlyEarnings.value = !amount.value
-      ? 0
-      : +(amount.value || 0) * (estimateSupplyAPY.value / 12 / 100)
   }
   catch (e) {
     logWarn('earn-supply/estimates', e)
@@ -212,15 +206,6 @@ const onSupplyInfoIconClick = () => {
 
 // Initialize estimateSupplyAPY after vault is loaded
 estimateSupplyAPY.value = nanoToValue(vault.value?.interestRateInfo.supplyAPY ?? 0n, 25) + totalRewardsAPY.value
-
-// Update USD value when monthlyEarnings or vault changes
-watchEffect(async () => {
-  if (!vault.value || !monthlyEarnings.value) {
-    monthlyEarningsUsd.value = 0
-    return
-  }
-  monthlyEarningsUsd.value = await getAssetUsdValueOrZero(monthlyEarnings.value, vault.value, 'off-chain')
-})
 
 watch(amount, () => {
   clearSimulationError()
@@ -339,18 +324,6 @@ watch(address, () => {
               :loading="isEstimatesLoading"
               variant="card"
             >
-              <SummaryRow
-                label="Projected earnings per month"
-                align-top
-              >
-                <p class="text-content-tertiary">
-                  <span class="text-content-primary text-p2">{{ compactNumber(monthlyEarnings, 4) }}</span> {{
-                    asset.symbol
-                  }}
-                  ≈ ${{ compactNumber(monthlyEarningsUsd) }}
-                </p>
-              </SummaryRow>
-
               <SummaryRow label="Supply APY">
                 <SummaryValue
                   :after="estimateSupplyAPYDisplay"

--- a/pages/lend/[vault]/index.vue
+++ b/pages/lend/[vault]/index.vue
@@ -9,7 +9,6 @@ import { getProjectedRates, getCurrentLiquidationLTV, type SecuritizeVault, type
 import { isSecuritizeVault } from '~/entities/vault/factory'
 import { getHookDisabledWarning, getUtilisationWarning, getSupplyCapWarning } from '~/composables/useVaultWarnings'
 import { collectPythFeedIds } from '~/entities/oracle'
-import { getAssetUsdValueOrZero } from '~/services/pricing/priceProvider'
 import { fetchBackendPrice } from '~/services/pricing/backendClient'
 import type { TxPlan } from '~/entities/txPlan'
 import { useEulerProductOfVault } from '~/composables/useEulerLabels'
@@ -21,7 +20,7 @@ import { buildSwapRouteItems } from '~/utils/swapRouteItems'
 import VaultFormInfoBlock from '~/components/entities/vault/form/VaultFormInfoBlock.vue'
 import VaultFormSubmit from '~/components/entities/vault/form/VaultFormSubmit.vue'
 import SecuritizeVaultOverview from '~/components/entities/vault/overview/SecuritizeVaultOverview.vue'
-import { formatNumber, compactNumber, formatSmartAmount } from '~/utils/string-utils'
+import { formatNumber, formatSmartAmount } from '~/utils/string-utils'
 import { useSwapPriceImpact } from '~/composables/useSwapPriceImpact'
 import { usePriceImpactGate } from '~/composables/usePriceImpactGate'
 import { isOperationBlocked } from '~/utils/operationGuardRegistry'
@@ -89,8 +88,6 @@ const isEstimatesLoading = ref(false)
 const amount = ref('')
 const plan = ref<TxPlan | null>(null)
 const estimateSupplyAPY = ref(0n)
-const monthlyEarnings = ref(0)
-const monthlyEarningsUsd = ref(0)
 
 // Swap & deposit state
 const selectedAsset = ref<VaultAsset | undefined>()
@@ -543,20 +540,9 @@ const updateEstimates = useDebounceFn(async () => {
         const rawAPY = projected?.supplyAPY ?? evkVault.value.interestRateInfo.supplyAPY
         estimateSupplyAPY.value = rawAPY + valueToNano(totalRewardsAPY.value + intrinsicApy.value, 25)
       }
-
-      const supplyAmount = needsSwap.value
-        ? nanoToValue(BigInt(swapEffectiveQuote.value?.amountOut || 0), Number(evkVault.value.decimals))
-        : +(amount.value || 0)
-      monthlyEarnings.value = supplyAmount <= 0
-        ? 0
-        : supplyAmount * (nanoToValue(estimateSupplyAPY.value, 27) / 12)
     }
     else {
       estimateSupplyAPY.value = valueToNano(totalRewardsAPY.value + intrinsicApy.value, 25)
-      const supplyAmount = +(amount.value || 0)
-      monthlyEarnings.value = supplyAmount <= 0
-        ? 0
-        : supplyAmount * (nanoToValue(estimateSupplyAPY.value, 27) / 12)
     }
   }
   catch (e) {
@@ -745,15 +731,6 @@ watch(swapEffectiveQuote, () => {
     isEstimatesLoading.value = true
     updateEstimates()
   }
-})
-
-// Update USD value when monthlyEarnings or vault changes
-watchEffect(async () => {
-  if (!vault.value || !monthlyEarnings.value) {
-    monthlyEarningsUsd.value = 0
-    return
-  }
-  monthlyEarningsUsd.value = await getAssetUsdValueOrZero(monthlyEarnings.value, vault.value, 'off-chain')
 })
 
 watch(amount, async () => {
@@ -968,20 +945,6 @@ watch(address, () => {
               :loading="isEstimatesLoading"
               variant="card"
             >
-              <SummaryRow
-                label="Projected earnings per month"
-                align-top
-              >
-                <p class="text-content-tertiary">
-                  <span class="text-content-primary text-p2">{{ compactNumber(monthlyEarnings, 4) }}</span> {{
-                    asset.symbol
-                  }}
-                  <template v-if="features.hasPriceInfo && vault">
-                    ≈ ${{ compactNumber(monthlyEarningsUsd) }}
-                  </template>
-                </p>
-              </SummaryRow>
-
               <SummaryRow label="Supply APY">
                 <SummaryValue
                   :after="estimateSupplyAPYDisplay"


### PR DESCRIPTION
## Summary

Supersedes #399 (which renamed the same labels).

Removes the "Projected earnings per month" row across the app. The figure was a naive `value * APY / 12` projection — it ignored compounding, reward decay, fees, and APY drift, so the headline number was decorative at best and misleading at worst.

Affected surfaces:
- `components/entities/portfolio/PortfolioEarnItem.vue`
- `components/entities/portfolio/PortfolioSavingItem.vue`
- `pages/earn/[vault]/index.vue`
- `pages/lend/[vault]/index.vue`

Removes the template row, the underlying `monthlyEarnings` / `projectedEarningsPerMonth` state and compute, the USD watchers, and now-unused imports (`compactNumber`, `getAssetUsdValueOrZero` where they were the sole consumer).

Out of scope: `getProjectedRates` in `entities/vault/apy.ts` is rate-projection (post-action APY), a different concept — kept as-is.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint` (clean on touched files; pre-existing failures in untracked `scripts/*.mjs` only)
- [ ] Smoke: Portfolio page — earn and saving rows no longer show the monthly row, no layout gap
- [ ] Smoke: `/earn/<vault>` — supply summary renders APY only, no monthly row, no console errors when typing an amount
- [ ] Smoke: `/lend/<vault>` — same as above (both EVK and securitize variants)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed projected earnings per month display from portfolio Earn and Saving item components.
  * Removed projected monthly earnings information from Earn and Lend vault detail pages.
  * Pages now display supply APY metric information only.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/euler-xyz/euler-lite/pull/413)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->