### PR TITLE
Refresh Permit2 disclaimer copy

### DIFF
--- a/components/entities/operation/OperationReviewModal.vue
+++ b/components/entities/operation/OperationReviewModal.vue
@@ -227,7 +227,7 @@ const hasTenderlyFailedSimulation = computed(() => {
   return !!(tenderlyUrl.value && tenderlyError.value)
 })
 
-const permit2DisclaimerText = 'You are granting the permit2 contract unlimited access to your tokens. This is a safe, one-time setup — permit2 (by Uniswap) is a widely trusted and audited contract that replaces repeated approval transactions with gasless signatures. Each future transaction still requires your explicit signature, limited in both amount and duration.'
+const permit2DisclaimerText = 'You are granting the Permit2 contract an unlimited token allowance. Permit2 is a Uniswap contract used to authorize future transfers with signatures. Each future transfer still requires your explicit signature and can be limited by amount and duration.'
 </script>
 
 <template>

--- a/components/entities/vault/CyclicalNoteInfoModal.vue
+++ b/components/entities/vault/CyclicalNoteInfoModal.vue
@@ -22,7 +22,7 @@ defineEmits<{ close: [] }>()
           Fixed rates with recurring cycles
         </p>
         <p class="text-p3 text-content-secondary text-center">
-          Cyclical Notes offer borrowers a fixed interest rate for most of the cycle, followed by a short repayment window with a sharply higher rate to incentivise repayment. Lenders earn an elevated, predictable yield in exchange for reduced withdrawal flexibility.
+          Cyclical Notes offer borrowers a fixed interest rate for most of the cycle, followed by a short repayment window with a sharply higher rate to incentivise repayment. For lenders, withdrawals may be limited during the cycle.
         </p>
       </div>
 

--- a/components/entities/vault/CyclicalNoteInfoModal.vue
+++ b/components/entities/vault/CyclicalNoteInfoModal.vue
@@ -22,7 +22,7 @@ defineEmits<{ close: [] }>()
           Fixed rates with recurring cycles
         </p>
         <p class="text-p3 text-content-secondary text-center">
-          Cyclical Notes offer borrowers a fixed interest rate for most of the cycle, followed by a short repayment window with a sharply higher rate to incentivise repayment. Lenders earn an elevated, predictable yield in exchange for reduced withdrawal flexibility.
+          Lender returns depend on the configured cycle rate, available liquidity, and market conditions. Withdrawals may be limited during the cycle.
         </p>
       </div>
 

--- a/components/entities/vault/CyclicalNoteInfoModal.vue
+++ b/components/entities/vault/CyclicalNoteInfoModal.vue
@@ -22,7 +22,7 @@ defineEmits<{ close: [] }>()
           Fixed rates with recurring cycles
         </p>
         <p class="text-p3 text-content-secondary text-center">
-          Lender returns depend on the configured cycle rate, available liquidity, and market conditions. Withdrawals may be limited during the cycle.
+          Cyclical Notes offer borrowers a fixed interest rate for most of the cycle, followed by a short repayment window with a sharply higher rate to incentivise repayment. Lenders earn an elevated, predictable yield in exchange for reduced withdrawal flexibility.
         </p>
       </div>
 


### PR DESCRIPTION
## Summary

Carries over one copy change from the closed #399:

- **Permit2 disclaimer** (`OperationReviewModal.vue`) — clarifies that you grant Permit2 an unlimited token allowance, while each transfer still needs a per-transaction signature that can be amount- and duration-limited.

The Cyclical Notes copy change from #399 is dropped — the replacement description was inaccurate, so the original explanation of the cyclical interest-rate / repayment-window mechanic is kept.

The monthly-earnings rename portion of #399 is no longer needed — those rows are deleted in #413.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint` (clean on touched files)
- [ ] Smoke: trigger an operation that surfaces the Permit2 disclaimer in `OperationReviewModal`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Permit2 approval disclaimer to clarify authorization terms
  * Updated Cyclical Notes description to better explain lender limitations

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/euler-xyz/euler-lite/pull/414)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->