### PR TITLE
fix: scope v3 token list to base type

### DIFF
--- a/server/api/token-list.get.ts
+++ b/server/api/token-list.get.ts
@@ -68,8 +68,12 @@ function refreshEulerApi(chainId: number): Promise<TokenEntry[]> {
     let offset = 0
 
     for (let pageNum = 0; pageNum < MAX_PAGES; pageNum++) {
+      // type=base restores the v1-style catalog (vault underlying assets only).
+      // Without it the v3 API also returns eTokens (vault shares) and dTokens
+      // (debt tokens), which leak into the "pay with" picker and bloat the
+      // wallet-balance RPC fan-out by ~7x on mainnet.
       const resp = await fetchWithTimeout(
-        `${baseUrl}/v3/tokens?chainId=${chainId}&limit=${PAGE_LIMIT}&offset=${offset}`,
+        `${baseUrl}/v3/tokens?chainId=${chainId}&limit=${PAGE_LIMIT}&offset=${offset}&type=base`,
       )
       if (!resp.ok) throw new Error(`Euler API returned ${resp.status}`)
 


### PR DESCRIPTION
## Summary

After migrating the token list to the v3 indexer, the `/api/token-list` response now includes EVK vault shares (eTokens) and debt tokens (dTokens) alongside regular ERC20s. They leak into the "pay with" picker (`SwapTokenSelector.vue`) as selectable tokens and bloat the wallet-balance RPC batch in `useWallets.ts`.

The v1 indexer only returned vault underlying assets, and the v3 backend documents `type=base` as the v1-equivalent (`euler-data-v3/src/interface/http/routes/tokens.ts`):

```
- type=base returns v1-style minimal catalog (vault underlying assets only)
- Default (no type param) returns comprehensive catalog (all tokens)
```

This change appends `&type=base` to the v3 request in `server/api/token-list.get.ts` to restore the prior shape.

### Impact (chain 1)

| | before | after |
| --- | --- | --- |
| Euler API tokens | 2010 | 287 |
| dTokens leaked | 807 | 0 |
| Vault shares leaked | ~900 | 0 |

Reward tokens like rEUL continue to come in via the Merkl source, and popular swap assets still flow in from Uniswap and DefiLlama, so the merged list is unaffected outside of dropping the protocol-internal artifacts.

## Test plan

- [ ] Open the `/position/\<n\>/repay` page on mainnet and confirm the "Pay with" modal no longer lists `EVK Vault e…` or `Debt token of…` entries
- [ ] Confirm USDC / USDT / WETH / WBTC / DAI / EUL / rEUL / wstETH / sUSDe / USDe still appear in the picker
- [ ] Confirm wallet balances still load for held tokens

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated token retrieval to display only base tokens from the Euler v3 API, excluding additional token types.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/euler-xyz/euler-lite/pull/416)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->