### PR TITLE
Fix Earn APY conversion for tiny computed rates

### DIFF
--- a/tests/utils/crypto-utils.test.ts
+++ b/tests/utils/crypto-utils.test.ts
@@ -70,6 +70,34 @@ describe('valueToNano', () => {
   it('handles negative number input', () => {
     expect(valueToNano(-1.5, 6)).toBe(-1_500_000n)
   })
+
+  it('handles small number input stringified as scientific notation', () => {
+    expect(valueToNano(2.8478322e-7, 25)).toBe(2_847_832_200_000_000_000n)
+  })
+
+  it('preserves precision from scientific notation number strings', () => {
+    expect(valueToNano(2.5345658399999994e-7, 25)).toBe(2_534_565_839_999_999_400n)
+  })
+
+  it('handles negative scientific notation input', () => {
+    expect(valueToNano('-1.5e-3', 6)).toBe(-1_500n)
+  })
+
+  it('matches equivalent plain decimal strings for scientific notation inputs', () => {
+    expect(valueToNano(1.2530461679999999e-6, 25)).toBe(valueToNano('0.0000012530461679999999', 25))
+  })
+
+  it('truncates expanded scientific notation to the requested decimals', () => {
+    expect(valueToNano('1.23456789e-3', 6)).toBe(1_234n)
+  })
+
+  it('handles positive scientific notation exponents', () => {
+    expect(valueToNano('1.23e+3', 6)).toBe(1_230_000_000n)
+  })
+
+  it('truncates scientific notation values smaller than the target precision to zero', () => {
+    expect(valueToNano(1e-30, 25)).toBe(0n)
+  })
 })
 
 describe('formatTtl', () => {

--- a/utils/crypto-utils.ts
+++ b/utils/crypto-utils.ts
@@ -6,13 +6,31 @@ export const nanoToValue = (src: bigint | number | string, decimals: number | bi
   return +formatUnits(BigInt(src), Number(decimals))
 }
 
+const expandScientificNotation = (src: string): string => {
+  const match = src.match(/^([+-]?)(\d+)(?:\.(\d*))?[eE]([+-]?\d+)$/)
+  if (!match) return src
+
+  const [, sign, intPart, fracPart = '', exponentRaw] = match
+  const digits = `${intPart}${fracPart}`
+  const decimalIndex = intPart.length + Number(exponentRaw)
+
+  if (decimalIndex <= 0) {
+    return `${sign}0.${'0'.repeat(-decimalIndex)}${digits}`
+  }
+  if (decimalIndex >= digits.length) {
+    return `${sign}${digits}${'0'.repeat(decimalIndex - digits.length)}`
+  }
+  return `${sign}${digits.slice(0, decimalIndex)}.${digits.slice(decimalIndex)}`
+}
+
 export const valueToNano = (src: number | string, decimals: number | bigint = 9) => {
   if (!src) {
     return 0n
   }
-  const parts = String(src).split('.')
-  const value = parts[0] + '.' + (parts[1] || '').substring(0, Number(decimals))
-  return parseUnits(value, Number(decimals))
+  const decimalsNumber = Number(decimals)
+  const parts = expandScientificNotation(String(src).trim()).split('.')
+  const value = parts[0] + '.' + (parts[1] || '').substring(0, decimalsNumber)
+  return parseUnits(value, decimalsNumber)
 }
 
 export interface FormatTtlResult {


### PR DESCRIPTION
## Summary
- Fixes an Earn vault snapshot failure where tiny computed APY values could be stringified by JavaScript in scientific notation, then rejected by viem `parseUnits()`.
- The production warning surfaced on Base Earn vault loading for `Clearstar ETH Fusion` (`CSETH`), where the local APY calculation produced values such as `2.8478322e-7`.
- Keeps normal decimal conversion behavior unchanged while allowing `valueToNano()` to safely handle both number and string inputs that contain exponent notation.

## Root Cause
- Earn vault APYs are computed locally from on-chain `convertToAssets()` exchange-rate deltas over an approximately one-hour block window.
- For very small deltas, JavaScript may represent the computed APY as scientific notation when converted with `String(number)`.
- `valueToNano()` previously split the raw string on `.` and passed the result directly to viem `parseUnits()`.
- viem intentionally accepts plain decimal strings only, so a value like `2.8478322e-7` triggered `InvalidDecimalNumberError: Number \`2.8478322e-7\` is not a valid decimal number.`
- Normal EVK vault APYs are not on this failing path because they come from the vault lens as bigint rate values instead of being locally converted from a computed JavaScript number.

## Changes
- Adds a small `expandScientificNotation()` helper inside `utils/crypto-utils.ts`.
- Normalizes scientific notation into a plain decimal string before truncating to the requested precision and calling `parseUnits()`.
- Preserves the existing truncation semantics for decimal inputs with more fractional digits than the target precision.
- Covers signed values, positive exponents, negative exponents, and values smaller than the target precision.
- Leaves callers unchanged, including the Earn vault APY conversion path that stores supply APY using `valueToNano(supplyAPYNumber, 25)`.

## Validation
- Replayed the failing Base Earn vault path for `0x6370c6445073b8df18368e3E11Bfecf0cEd13b01` (`Clearstar ETH Fusion`, `CSETH`):
  - vault decimals: `18`
  - asset: `WETH`
  - failing historical example:
    - current rate: `1000000000000325095`
    - one-hour-ago rate: `1000000000000000000`
    - raw delta: `325095`
    - computed APY: `2.8478322e-7`
    - scaled APY after the fix: `2847832200000000000`
- Recreated the same vault object path against live Base RPC after the fix and confirmed the APY conversion no longer throws.
- Swept additional active Earn vaults through the same conversion check where public RPC access allowed:
  - Ethereum: `9/9` active Earn vaults validated
  - Base: `2/2` active Earn vaults validated
  - Avalanche: `2/2` active Earn vaults validated
  - Linea: `2/5` active Earn vaults validated; remaining vault checks hit public RPC provider limits
  - BSC: `2/2` active vaults were reconstructed at current state, but historical APY reads failed on public RPC because the provider did not serve the needed historical state
- For every vault that completed the APY path, `valueToNano(apy, 25)` matched an independent plain-decimal scaling check.

## Test plan
- [x] `npm run test:run -- tests/utils/crypto-utils.test.ts`
- [x] Verified exact failing scientific-notation values from the Base Earn vault logs.
- [x] Verified equivalent scientific notation and plain decimal inputs produce the same scaled bigint.
- [x] Verified existing normal decimal, integer, truncation, and negative-number conversion behavior remains covered.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * `valueToNano` now correctly handles scientific notation inputs, improving precision and edge-case handling.

* **Tests**
  * Added comprehensive unit tests for `valueToNano` covering scientific notation inputs and boundary conditions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/euler-xyz/euler-lite/pull/417)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->