### PR TITLE
Add Base app verification meta tag

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -53,6 +53,10 @@ export default defineNuxtConfig({
           content: 'width=device-width, initial-scale=1, user-scalable=no',
         },
         {
+          name: 'base:app_id',
+          content: '6a032ec8f8601f8d21fe6b80',
+        },
+        {
           property: 'og:title',
           content: 'Euler Lite',
         },


### PR DESCRIPTION
## Summary
- Add the Base.dev domain verification meta tag so Base can verify ownership of the app domain.

## Changes
- Defines `base:app_id` in Nuxt's static `app.head.meta` configuration so the tag is emitted in the document `<head>`.

## Test plan
- [x] Run `npm run typecheck`
- [x] Run `npm run lint`
- [x] Confirm the tag renders locally at `localhost:3000`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application metadata configuration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/euler-xyz/euler-lite/pull/423)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->