### PR TITLE
Bind swap verifier payloads to request context

### DIFF
--- a/composables/useEulerOperations/swaps/cross-asset.ts
+++ b/composables/useEulerOperations/swaps/cross-asset.ts
@@ -1,7 +1,7 @@
 import type { Address, Hash } from 'viem'
 import { encodeFunctionData } from 'viem'
 import type { OperationsContext, OperationHelpers } from '../types'
-import { buildSwapVerifierData, getSwapInputAmount } from './verify'
+import { buildSwapVerifierData, getSwapInputAmount, getSwapVerifierExpectedContext } from './verify'
 import { evcDisableCollateralAbi, evcDisableControllerAbi, evcEnableCollateralAbi, evcEnableControllerAbi } from '~/abis/evc'
 import { vaultBorrowAbi, vaultTransferFromMaxAbi, vaultWithdrawAbi } from '~/abis/vault'
 import { SaHooksBuilder } from '~/entities/saHooksSDK'
@@ -63,7 +63,15 @@ export const createCrossAssetSwapBuilders = (
       throw new Error('Swap amount is zero')
     }
 
-    const verifierData = buildSwapVerifierData({ quote, swapperMode, isRepay, requestedSlippage, targetDebt, currentDebt })
+    const verifierData = buildSwapVerifierData({
+      quote,
+      expectedContext: getSwapVerifierExpectedContext(quote),
+      swapperMode,
+      isRepay,
+      requestedSlippage,
+      targetDebt,
+      currentDebt,
+    })
 
     if (verifierData.toLowerCase() !== quote.verify.verifierData.toLowerCase()) {
       logWarn('swap', 'SwapVerifier data mismatch')

--- a/composables/useEulerOperations/swaps/supply-borrow.ts
+++ b/composables/useEulerOperations/swaps/supply-borrow.ts
@@ -1,7 +1,7 @@
 import type { Address, Hash } from 'viem'
 import { encodeFunctionData } from 'viem'
 import type { OperationsContext, OperationHelpers } from '../types'
-import { buildSwapVerifierData } from './verify'
+import { buildSwapVerifierData, getSwapVerifierExpectedContext } from './verify'
 import { evcDisableCollateralAbi, evcDisableControllerAbi, evcEnableCollateralAbi, evcEnableControllerAbi } from '~/abis/evc'
 import { vaultBorrowAbi, vaultRedeemAbi, vaultTransferFromMaxAbi, vaultWithdrawAbi } from '~/abis/vault'
 import { SaHooksBuilder } from '~/entities/saHooksSDK'
@@ -97,7 +97,13 @@ export const createSupplyBorrowSwapBuilders = (
       throw new Error('Swap verifier type mismatch')
     }
 
-    const verifierData = buildSwapVerifierData({ quote, swapperMode: SwapperMode.EXACT_IN, isRepay: false, requestedSlippage })
+    const verifierData = buildSwapVerifierData({
+      quote,
+      expectedContext: getSwapVerifierExpectedContext(quote),
+      swapperMode: SwapperMode.EXACT_IN,
+      isRepay: false,
+      requestedSlippage,
+    })
     if (verifierData.toLowerCase() !== quote.verify.verifierData.toLowerCase()) {
       logWarn('swap-supply', 'SwapVerifier data mismatch')
       throw new Error('SwapVerifier data mismatch')
@@ -213,7 +219,13 @@ export const createSupplyBorrowSwapBuilders = (
       throw new Error('Swap verifier type mismatch')
     }
 
-    const verifierData = buildSwapVerifierData({ quote: swapQuote, swapperMode: SwapperMode.EXACT_IN, isRepay: false, requestedSlippage })
+    const verifierData = buildSwapVerifierData({
+      quote: swapQuote,
+      expectedContext: getSwapVerifierExpectedContext(swapQuote),
+      swapperMode: SwapperMode.EXACT_IN,
+      isRepay: false,
+      requestedSlippage,
+    })
     if (verifierData.toLowerCase() !== swapQuote.verify.verifierData.toLowerCase()) {
       logWarn('swap-borrow', 'SwapVerifier data mismatch')
       throw new Error('SwapVerifier data mismatch')
@@ -337,7 +349,13 @@ export const createSupplyBorrowSwapBuilders = (
       throw new Error('Swap verifier type mismatch')
     }
 
-    const verifierData = buildSwapVerifierData({ quote, swapperMode: SwapperMode.EXACT_IN, isRepay: false, requestedSlippage })
+    const verifierData = buildSwapVerifierData({
+      quote,
+      expectedContext: getSwapVerifierExpectedContext(quote),
+      swapperMode: SwapperMode.EXACT_IN,
+      isRepay: false,
+      requestedSlippage,
+    })
     if (verifierData.toLowerCase() !== quote.verify.verifierData.toLowerCase()) {
       logWarn('swap-withdraw', 'SwapVerifier data mismatch')
       throw new Error('SwapVerifier data mismatch')
@@ -427,7 +445,13 @@ export const createSupplyBorrowSwapBuilders = (
       throw new Error('Swap verifier type mismatch')
     }
 
-    const redeemVerifierData = buildSwapVerifierData({ quote, swapperMode: SwapperMode.EXACT_IN, isRepay: false, requestedSlippage })
+    const redeemVerifierData = buildSwapVerifierData({
+      quote,
+      expectedContext: getSwapVerifierExpectedContext(quote),
+      swapperMode: SwapperMode.EXACT_IN,
+      isRepay: false,
+      requestedSlippage,
+    })
     if (redeemVerifierData.toLowerCase() !== quote.verify.verifierData.toLowerCase()) {
       logWarn('swap-redeem', 'SwapVerifier data mismatch')
       throw new Error('SwapVerifier data mismatch')
@@ -505,7 +529,15 @@ export const createSupplyBorrowSwapBuilders = (
       throw new Error('Swap verifier type mismatch')
     }
 
-    const verifierData = buildSwapVerifierData({ quote, swapperMode, isRepay: true, requestedSlippage, targetDebt, currentDebt })
+    const verifierData = buildSwapVerifierData({
+      quote,
+      expectedContext: getSwapVerifierExpectedContext(quote),
+      swapperMode,
+      isRepay: true,
+      requestedSlippage,
+      targetDebt,
+      currentDebt,
+    })
     if (verifierData.toLowerCase() !== quote.verify.verifierData.toLowerCase()) {
       logWarn('swap-repay', 'SwapVerifier data mismatch')
       throw new Error('SwapVerifier data mismatch')

--- a/composables/useEulerOperations/swaps/verify.ts
+++ b/composables/useEulerOperations/swaps/verify.ts
@@ -1,8 +1,9 @@
+import type { Address } from 'viem'
 import { encodeFunctionData } from 'viem'
 import { adjustForInterest } from '../helpers'
 import { swapVerifierAbi } from '~/entities/euler/abis'
 import { MAX_SLIPPAGE } from '~/entities/constants'
-import { type SwapApiQuote, SwapperMode, SwapVerificationType } from '~/entities/swap'
+import { type SwapApiQuote, type SwapApiQuoteRequestContext, SwapperMode, SwapVerificationType } from '~/entities/swap'
 import { logWarn } from '~/utils/errorHandling'
 
 // Absolute extra slippage (in percentage points) the validator forgives to absorb
@@ -206,8 +207,110 @@ function shouldLogFullSwapQuote() {
   return localStorage.getItem('debug-swap-quotes') === 'true'
 }
 
+export function getSwapVerifierExpectedContext(quote: SwapApiQuote): SwapApiQuoteRequestContext {
+  if (!quote.requestContext) {
+    throw new Error('Swap quote request context missing')
+  }
+
+  return quote.requestContext
+}
+
+function getQuoteTokenAddress(quote: SwapApiQuote, field: 'tokenIn' | 'tokenOut'): Address {
+  const address = quote[field].address || quote[field].addressInfo
+  if (!address) {
+    throw new Error(`Swap quote ${field} address missing`)
+  }
+
+  return address
+}
+
+function assertSameAddress(field: string, actual: Address, expected: Address) {
+  if (actual.toLowerCase() !== expected.toLowerCase()) {
+    throw new Error(`Swap quote ${field} mismatch`)
+  }
+}
+
+function assertSameDeadline(actual: number, expected: number) {
+  if (actual !== expected) {
+    throw new Error('Swap quote deadline mismatch')
+  }
+}
+
+function validateSwapQuoteRequestIntent({
+  quote,
+  expectedContext,
+  swapperMode,
+  isRepay,
+  targetDebt,
+  currentDebt,
+}: {
+  quote: SwapApiQuote
+  expectedContext: SwapApiQuoteRequestContext
+  swapperMode: SwapperMode
+  isRepay: boolean
+  targetDebt: bigint
+  currentDebt: bigint
+}) {
+  if (swapperMode !== expectedContext.swapperMode) {
+    throw new Error('Swap quote mode mismatch')
+  }
+  if (isRepay !== expectedContext.isRepay) {
+    throw new Error('Swap quote repay intent mismatch')
+  }
+  if (targetDebt !== expectedContext.targetDebt) {
+    throw new Error('Swap quote target debt mismatch')
+  }
+  if (currentDebt !== expectedContext.currentDebt) {
+    throw new Error('Swap quote current debt mismatch')
+  }
+
+  if (expectedContext.swapperMode === SwapperMode.EXACT_IN) {
+    const amountIn = BigInt(quote.amountIn || 0)
+    if (amountIn !== expectedContext.amount) {
+      throw new Error('Swap quote amountIn mismatch')
+    }
+    return
+  }
+
+  const amountOut = BigInt(quote.amountOut || 0)
+  if (amountOut !== expectedContext.amount) {
+    throw new Error('Swap quote amountOut mismatch')
+  }
+}
+
+function validateSwapVerifierContext({
+  quote,
+  expectedContext,
+  amount,
+  validateVerifierAccount,
+}: {
+  quote: SwapApiQuote
+  expectedContext: SwapApiQuoteRequestContext
+  amount: bigint
+  validateVerifierAccount: boolean
+}) {
+  assertSameAddress('tokenIn', getQuoteTokenAddress(quote, 'tokenIn'), expectedContext.tokenIn)
+  assertSameAddress('tokenOut', getQuoteTokenAddress(quote, 'tokenOut'), expectedContext.tokenOut)
+  assertSameAddress('accountIn', quote.accountIn, expectedContext.accountIn)
+  assertSameAddress('accountOut', quote.accountOut, expectedContext.accountOut)
+  assertSameAddress('vaultIn', quote.vaultIn, expectedContext.vaultIn)
+  assertSameAddress('receiver', quote.receiver, expectedContext.receiver)
+  assertSameAddress('verifier', quote.verify.verifierAddress, expectedContext.verifierAddress)
+  assertSameAddress('swapper', quote.swap.swapperAddress, expectedContext.swapperAddress)
+  assertSameAddress('verify.vault', quote.verify.vault, expectedContext.receiver)
+  if (validateVerifierAccount) {
+    assertSameAddress('verify.account', quote.verify.account, expectedContext.accountOut)
+  }
+  assertSameDeadline(quote.verify.deadline, expectedContext.deadline)
+
+  if (BigInt(quote.verify.amount || 0) !== amount) {
+    throw new Error('Swap quote verify amount mismatch')
+  }
+}
+
 export const buildSwapVerifierData = ({
   quote,
+  expectedContext,
   swapperMode,
   isRepay,
   requestedSlippage,
@@ -215,12 +318,21 @@ export const buildSwapVerifierData = ({
   currentDebt = 0n,
 }: {
   quote: SwapApiQuote
+  expectedContext: SwapApiQuoteRequestContext
   swapperMode: SwapperMode
   isRepay: boolean
   requestedSlippage: number
   targetDebt?: bigint
   currentDebt?: bigint
 }) => {
+  validateSwapQuoteRequestIntent({
+    quote,
+    expectedContext,
+    swapperMode,
+    isRepay,
+    targetDebt,
+    currentDebt,
+  })
   validateSwapQuoteSlippageData({ slippage: requestedSlippage, swapperMode }, quote)
 
   let functionName: 'verifyAmountMinAndSkim' | 'verifyAmountMinAndTransfer' | 'verifyDebtMax'
@@ -240,13 +352,18 @@ export const buildSwapVerifierData = ({
   else if (quote.verify.type === SwapVerificationType.TransferMin) {
     functionName = 'verifyAmountMinAndTransfer'
     amount = BigInt(quote.amountOutMin || 0)
+    validateSwapVerifierContext({
+      quote,
+      expectedContext,
+      amount,
+      validateVerifierAccount: false,
+    })
 
     // verifyAmountMinAndTransfer(token, receiver, amountMin, deadline)
-    // token = output token address, receiver = verify.vault (destination for the transfer)
     return encodeFunctionData({
       abi: swapVerifierAbi,
       functionName,
-      args: [quote.tokenOut.address!, quote.verify.vault, amount, BigInt(quote.verify.deadline || 0)],
+      args: [expectedContext.tokenOut, expectedContext.receiver, amount, BigInt(expectedContext.deadline || 0)],
     })
   }
   else {
@@ -254,11 +371,18 @@ export const buildSwapVerifierData = ({
     amount = BigInt(quote.amountOutMin || 0)
   }
 
+  validateSwapVerifierContext({
+    quote,
+    expectedContext,
+    amount,
+    validateVerifierAccount: true,
+  })
+
   // SkimMin: verifyAmountMinAndSkim(vault, receiver, amountMin, deadline)
   // DebtMax: verifyDebtMax(vault, account, amountMax, deadline)
   return encodeFunctionData({
     abi: swapVerifierAbi,
     functionName,
-    args: [quote.verify.vault, quote.verify.account, amount, BigInt(quote.verify.deadline || 0)],
+    args: [expectedContext.receiver, expectedContext.accountOut, amount, BigInt(expectedContext.deadline || 0)],
   })
 }

--- a/composables/useEulerOperations/vault.ts
+++ b/composables/useEulerOperations/vault.ts
@@ -1,6 +1,6 @@
 import type { Address, Hash } from 'viem'
 import { encodeFunctionData, getAddress } from 'viem'
-import { buildSwapVerifierData, getSwapInputAmount } from './swaps/verify'
+import { buildSwapVerifierData, getSwapInputAmount, getSwapVerifierExpectedContext } from './swaps/verify'
 import type { OperationsContext, OperationHelpers, Permit2Helpers, AllowanceHelpers } from './types'
 import { erc20ApproveAbi, erc20TransferAbi } from '~/abis/erc20'
 import { evcEnableCollateralAbi, evcEnableControllerAbi } from '~/abis/evc'
@@ -596,6 +596,7 @@ export const createVaultBuilders = (
 
       const verifierData = buildSwapVerifierData({
         quote,
+        expectedContext: getSwapVerifierExpectedContext(quote),
         swapperMode,
         isRepay: false,
         requestedSlippage,

--- a/composables/useSwapApi.ts
+++ b/composables/useSwapApi.ts
@@ -2,6 +2,7 @@ import axios from 'axios'
 import { zeroAddress, type Address } from 'viem'
 import { logWarn } from '~/utils/errorHandling'
 import {
+  type SwapApiQuoteRequestContext,
   type RoutingConfig,
   type SwapApiQuote,
   type SwapApiResponse,
@@ -86,9 +87,17 @@ const parseSwapProvidersResponse = (payload: { success?: boolean, data?: string[
   return []
 }
 
+const attachRequestContext = (
+  quote: SwapApiQuote,
+  context: SwapApiQuoteRequestContext,
+): SwapApiQuote => ({
+  ...quote,
+  requestContext: context,
+})
+
 export const useSwapApi = () => {
   const { SWAP_API_URL } = useEulerConfig()
-  const { chainId } = useEulerAddresses()
+  const { chainId, eulerPeripheryAddresses } = useEulerAddresses()
   const { address } = useWagmi()
 
   const baseUrl = SWAP_API_URL
@@ -103,7 +112,29 @@ export const useSwapApi = () => {
 
     const origin = params.origin || address.value || zeroAddress
     const deadline = params.deadline || (Math.floor(Date.now() / 1000) + SWAP_DEFAULT_DEADLINE_SECONDS)
+    const swapperAddress = eulerPeripheryAddresses.value?.swapper
+    const verifierAddress = eulerPeripheryAddresses.value?.swapVerifier
+    if (!swapperAddress || !verifierAddress) {
+      throw new Error('Swap periphery addresses not configured')
+    }
+
     const requestParams = buildRequestParams(chainId.value, origin, params, deadline)
+    const requestContext: SwapApiQuoteRequestContext = {
+      tokenIn: params.tokenIn,
+      tokenOut: params.tokenOut,
+      accountIn: params.accountIn,
+      accountOut: params.accountOut,
+      amount: params.amount,
+      vaultIn: params.vaultIn,
+      receiver: params.receiver,
+      swapperMode: params.swapperMode ?? SwapperMode.EXACT_IN,
+      isRepay: params.isRepay ?? false,
+      targetDebt: params.targetDebt ?? 0n,
+      currentDebt: params.currentDebt ?? 0n,
+      deadline,
+      verifierAddress: verifierAddress as Address,
+      swapperAddress: swapperAddress as Address,
+    }
 
     const response = await axios.get<SwapApiResponse>(
       `${baseUrl}/swaps`,
@@ -114,6 +145,7 @@ export const useSwapApi = () => {
     )
 
     return parseSwapApiResponse(response.data)
+      .map(quote => attachRequestContext(quote, requestContext))
   }
 
   const getSwapProviders = async (): Promise<string[]> => {

--- a/entities/swap.ts
+++ b/entities/swap.ts
@@ -45,6 +45,23 @@ export interface SwapApiVerify {
   deadline: number
 }
 
+export interface SwapApiQuoteRequestContext {
+  tokenIn: Address
+  tokenOut: Address
+  accountIn: Address
+  accountOut: Address
+  amount: bigint
+  vaultIn: Address
+  receiver: Address
+  swapperMode: SwapperMode
+  isRepay: boolean
+  targetDebt: bigint
+  currentDebt: bigint
+  deadline: number
+  verifierAddress: Address
+  swapperAddress: Address
+}
+
 export interface SwapApiRouteItem {
   providerName: string
 }
@@ -64,6 +81,7 @@ export interface SwapApiQuote {
   swap: SwapApiSwapBundle
   verify: SwapApiVerify
   route: SwapApiRouteItem[]
+  requestContext?: SwapApiQuoteRequestContext
 }
 
 export interface SwapApiResponse {

--- a/tests/utils/swap-slippage-validation.test.ts
+++ b/tests/utils/swap-slippage-validation.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { SwapperMode, type SwapApiQuote } from '~/entities/swap'
+import { encodeFunctionData, type Address } from 'viem'
+import { SwapperMode, SwapVerificationType, type SwapApiQuote, type SwapApiQuoteRequestContext } from '~/entities/swap'
+import { swapVerifierAbi } from '~/entities/euler/abis'
 import {
   applySlippageToInput,
   applySlippageToOutput,
+  buildSwapVerifierData,
   validateSwapQuoteSlippageData,
 } from '~/composables/useEulerOperations/swaps/verify'
 
@@ -14,6 +17,109 @@ const makeQuote = (overrides: Partial<SwapApiQuote>): SwapApiQuote => ({
   route: [{ providerName: 'test-provider' }],
   ...overrides,
 }) as SwapApiQuote
+
+const TEST_CONTEXT: SwapApiQuoteRequestContext = {
+  tokenIn: '0x0000000000000000000000000000000000000001',
+  tokenOut: '0x0000000000000000000000000000000000000002',
+  accountIn: '0x0000000000000000000000000000000000000003',
+  accountOut: '0x0000000000000000000000000000000000000004',
+  amount: 1000n,
+  vaultIn: '0x0000000000000000000000000000000000000005',
+  receiver: '0x0000000000000000000000000000000000000006',
+  swapperMode: SwapperMode.EXACT_IN,
+  isRepay: false,
+  targetDebt: 0n,
+  currentDebt: 0n,
+  deadline: 1_800_000_000,
+  verifierAddress: '0x0000000000000000000000000000000000000007',
+  swapperAddress: '0x0000000000000000000000000000000000000008',
+}
+
+const makeContext = (overrides: Partial<SwapApiQuoteRequestContext> = {}): SwapApiQuoteRequestContext => ({
+  ...TEST_CONTEXT,
+  ...overrides,
+})
+
+const encodeVerifierData = (
+  type: SwapVerificationType,
+  amount: bigint,
+  context: SwapApiQuoteRequestContext = TEST_CONTEXT,
+) => {
+  if (type === SwapVerificationType.TransferMin) {
+    return encodeFunctionData({
+      abi: swapVerifierAbi,
+      functionName: 'verifyAmountMinAndTransfer',
+      args: [context.tokenOut, context.receiver, amount, BigInt(context.deadline)],
+    })
+  }
+
+  return encodeFunctionData({
+    abi: swapVerifierAbi,
+    functionName: type === SwapVerificationType.DebtMax ? 'verifyDebtMax' : 'verifyAmountMinAndSkim',
+    args: [context.receiver, context.accountOut, amount, BigInt(context.deadline)],
+  })
+}
+
+const makeVerifierQuote = (
+  type: SwapVerificationType,
+  overrides: Partial<SwapApiQuote> = {},
+): SwapApiQuote => {
+  const amount = type === SwapVerificationType.DebtMax ? 500n : 945n
+  const context = overrides.requestContext ?? (type === SwapVerificationType.DebtMax
+    ? makeContext({
+        amount: 500n,
+        swapperMode: SwapperMode.TARGET_DEBT,
+        isRepay: true,
+        targetDebt: 500n,
+        currentDebt: 1000n,
+      })
+    : TEST_CONTEXT)
+
+  return {
+    amountIn: '1000',
+    amountInMax: '1000',
+    amountOut: type === SwapVerificationType.DebtMax ? '500' : '950',
+    amountOutMin: type === SwapVerificationType.DebtMax ? '500' : '945',
+    accountIn: context.accountIn,
+    accountOut: context.accountOut,
+    vaultIn: context.vaultIn,
+    receiver: context.receiver,
+    tokenIn: {
+      address: context.tokenIn,
+      chainId: 1,
+      decimals: 18,
+      logoURI: '',
+      name: 'Input',
+      symbol: 'IN',
+    },
+    tokenOut: {
+      address: context.tokenOut,
+      chainId: 1,
+      decimals: 18,
+      logoURI: '',
+      name: 'Output',
+      symbol: 'OUT',
+    },
+    slippage: 0.5,
+    swap: {
+      swapperAddress: context.swapperAddress,
+      swapperData: '0x',
+      multicallItems: [],
+    },
+    verify: {
+      verifierAddress: context.verifierAddress,
+      verifierData: encodeVerifierData(type, amount, context),
+      type,
+      vault: context.receiver,
+      account: context.accountOut,
+      amount: amount.toString(),
+      deadline: context.deadline,
+    },
+    route: [{ providerName: 'test-provider' }],
+    requestContext: context,
+    ...overrides,
+  }
+}
 
 const captureStdout = () => {
   const captured: string[] = []
@@ -231,4 +337,123 @@ describe('swap quote slippage validation', () => {
         }),
       })
     }))
+})
+
+describe('swap verifier context validation', () => {
+  it.each([
+    [SwapVerificationType.TransferMin, false, SwapperMode.EXACT_IN, 0n],
+    [SwapVerificationType.SkimMin, false, SwapperMode.EXACT_IN, 0n],
+    [SwapVerificationType.DebtMax, true, SwapperMode.TARGET_DEBT, 500n],
+  ])('builds %s verifier calldata from expected request context', (
+    type,
+    isRepay,
+    swapperMode,
+    targetDebt,
+  ) => {
+    const quote = makeVerifierQuote(type)
+
+    const verifierData = buildSwapVerifierData({
+      quote,
+      expectedContext: quote.requestContext!,
+      swapperMode,
+      isRepay,
+      requestedSlippage: 0.5,
+      currentDebt: quote.requestContext!.currentDebt,
+      targetDebt,
+    })
+
+    expect(verifierData.toLowerCase()).toBe(quote.verify.verifierData.toLowerCase())
+  })
+
+  it('rejects transfer verifier calldata redirected away from the requested receiver', () => {
+    const quote = makeVerifierQuote(SwapVerificationType.TransferMin)
+    const badReceiver = '0x0000000000000000000000000000000000000009' as Address
+    const maliciousContext = { ...TEST_CONTEXT, receiver: badReceiver }
+    quote.verify = {
+      ...quote.verify,
+      vault: badReceiver,
+      verifierData: encodeVerifierData(SwapVerificationType.TransferMin, 945n, maliciousContext),
+    }
+
+    expect(() =>
+      buildSwapVerifierData({
+        quote,
+        expectedContext: TEST_CONTEXT,
+        swapperMode: SwapperMode.EXACT_IN,
+        isRepay: false,
+        requestedSlippage: 0.5,
+      }),
+    ).toThrow('Swap quote verify.vault mismatch')
+  })
+
+  it('rejects skim verifier calldata redirected away from the requested account', () => {
+    const quote = makeVerifierQuote(SwapVerificationType.SkimMin)
+    const badAccount = '0x0000000000000000000000000000000000000009' as Address
+    const maliciousContext = { ...TEST_CONTEXT, accountOut: badAccount }
+    quote.verify = {
+      ...quote.verify,
+      account: badAccount,
+      verifierData: encodeVerifierData(SwapVerificationType.SkimMin, 945n, maliciousContext),
+    }
+
+    expect(() =>
+      buildSwapVerifierData({
+        quote,
+        expectedContext: TEST_CONTEXT,
+        swapperMode: SwapperMode.EXACT_IN,
+        isRepay: false,
+        requestedSlippage: 0.5,
+      }),
+    ).toThrow('Swap quote verify.account mismatch')
+  })
+
+  it('rejects debt verifier quotes that use an unexpected swapper', () => {
+    const quote = makeVerifierQuote(SwapVerificationType.DebtMax)
+    quote.swap = {
+      ...quote.swap,
+      swapperAddress: '0x0000000000000000000000000000000000000009',
+    }
+
+    expect(() =>
+      buildSwapVerifierData({
+        quote,
+        expectedContext: quote.requestContext!,
+        swapperMode: SwapperMode.TARGET_DEBT,
+        isRepay: true,
+        requestedSlippage: 0.5,
+        currentDebt: 1000n,
+        targetDebt: 500n,
+      }),
+    ).toThrow('Swap quote swapper mismatch')
+  })
+
+  it('rejects exact-in quotes that change the requested input amount', () => {
+    const quote = makeVerifierQuote(SwapVerificationType.SkimMin, { amountIn: '1001' })
+
+    expect(() =>
+      buildSwapVerifierData({
+        quote,
+        expectedContext: TEST_CONTEXT,
+        swapperMode: SwapperMode.EXACT_IN,
+        isRepay: false,
+        requestedSlippage: 0.5,
+      }),
+    ).toThrow('Swap quote amountIn mismatch')
+  })
+
+  it('rejects target-debt quotes that change the requested output amount', () => {
+    const quote = makeVerifierQuote(SwapVerificationType.DebtMax, { amountOut: '501' })
+
+    expect(() =>
+      buildSwapVerifierData({
+        quote,
+        expectedContext: quote.requestContext!,
+        swapperMode: SwapperMode.TARGET_DEBT,
+        isRepay: true,
+        requestedSlippage: 0.5,
+        currentDebt: 1000n,
+        targetDebt: 500n,
+      }),
+    ).toThrow('Swap quote amountOut mismatch')
+  })
 })


### PR DESCRIPTION
## Summary
- Bind swap verifier calldata validation to locally requested swap context instead of quote-controlled verifier fields.
- Reject quotes whose verifier payload context disagrees with the requested token, vault, account, receiver, deadline, verifier, or swapper.
- Keep existing slippage checks in place while adding focused coverage for transfer, skim, and debt verifier modes.

## Changes
- Attach request context to swap API quotes at fetch time so transaction builders can compare quote payloads against local intent.
- Build verifier calldata from expected request context after validating quote fields against that context.
- Thread expected context through swap-and-supply, swap-and-borrow, withdraw/redeem swap, wallet repay, cross-asset swap, and multiply flows.
- Bind requested amount, swap mode, and repay debt intent into the quote context so amount tampering and quote replay across modes are rejected.
- Add verifier-context tests for valid payloads and malicious redirects of receiver, account, swapper, input amount, and target output amount.

## Test plan
- [x] npm run test:run -- tests/utils/swap-slippage-validation.test.ts
- [x] npm run typecheck
- [x] npm run lint
- [x] npm run test:run
- [x] npm run build
- [x] Local dev server smoke test on http://127.0.0.1:3058/
- [x] Built Nitro server smoke test on http://127.0.0.1:3061/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced swap verification with explicit context validation to ensure verifier data consistency across cross-asset and supply-borrow operations.
  * Improved error handling when swap periphery addresses are not configured.

* **Tests**
  * Added comprehensive test suite validating swap verifier context and detecting inconsistencies in verifier calldata generation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/euler-xyz/euler-lite/pull/425)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->