### PR TITLE
Validate wallet swap repay quotes

### DIFF
--- a/composables/repay/useWalletSwapRepay.ts
+++ b/composables/repay/useWalletSwapRepay.ts
@@ -21,7 +21,7 @@ import { buildSwapRouteItems } from '~/utils/swapRouteItems'
 import { useSwapPriceImpact } from '~/composables/useSwapPriceImpact'
 import { useSwapRepayQuotes } from '~/composables/repay/useSwapRepayQuotes'
 import { getRepaySwapReviewInputAmount } from '~/composables/repay/reviewAmount'
-import { getSwapInputAmount } from '~/composables/useEulerOperations/swaps/verify'
+import { getSwapInputAmount, validateWalletSwapRepayQuote } from '~/composables/useEulerOperations/swaps/verify'
 import { findBlockingDisabledOp, OP_REPAY, OP_TRANSFER, type PlannedOp } from '~/utils/vault-hooks'
 import { getPlanHookDisabledWarning } from '~/composables/useVaultWarnings'
 
@@ -67,7 +67,7 @@ export const useWalletSwapRepay = (options: UseWalletSwapRepayOptions) => {
   const modal = useModal()
   const { error } = useToast()
   const { buildSwapAndRepayPlan, executeTxPlan } = useEulerOperations()
-  const { chainId } = useEulerAddresses()
+  const { chainId, eulerPeripheryAddresses } = useEulerAddresses()
   const { isConnected, address } = useAccount()
   const { fetchSingleBalance } = useWallets()
   const { finalizeTxAndRedirect } = useTxFinalization()
@@ -664,21 +664,41 @@ export const useWalletSwapRepay = (options: UseWalletSwapRepayOptions) => {
       targetDebt = debtAmountNano >= currentDebt ? 0n : currentDebt - debtAmountNano
     }
 
-    const inputAmount = getSwapInputAmount(quotes.selectedQuote.value, swapMode)
-
     const isNative = isNativeCurrencyAddress(selectedAsset.value.address)
     const wrappedAddress = isNative ? resolveWrappedNativeAddress(chainId.value!) : null
     if (isNative && !wrappedAddress) {
       throw new Error('Wrapped native token not found')
     }
+    const inputTokenAddress = (wrappedAddress || selectedAsset.value.address) as Address
+    const subAccount = (position.value.subAccount || address.value || zeroAddress) as Address
+    const quote = quotes.selectedQuote.value
+    const expectedInputAmount = swapMode === SwapperMode.EXACT_IN
+      ? valueToNano(amount.value, selectedAsset.value.decimals)
+      : undefined
+
+    validateWalletSwapRepayQuote(quote, {
+      expectedTokenIn: inputTokenAddress,
+      expectedTokenOut: borrowVault.value.asset.address as Address,
+      expectedAccountOut: subAccount,
+      expectedReceiver: borrowVault.value.address as Address,
+      expectedSwapperAddress: eulerPeripheryAddresses.value?.swapper as Address | undefined,
+      expectedVerifierAddress: eulerPeripheryAddresses.value?.swapVerifier as Address | undefined,
+      expectedInputAmount,
+      requestedSlippage: slippage.value,
+      swapperMode: swapMode,
+      targetDebt,
+      currentDebt,
+    })
+
+    const inputAmount = getSwapInputAmount(quote, swapMode)
 
     return buildSwapAndRepayPlan({
-      inputTokenAddress: (wrappedAddress || selectedAsset.value.address) as Address,
+      inputTokenAddress,
       inputAmount,
-      quote: quotes.selectedQuote.value,
+      quote,
       requestedSlippage: slippage.value,
       borrowVaultAddress: borrowVault.value.address as Address,
-      subAccount: (position.value.subAccount || address.value || zeroAddress) as Address,
+      subAccount,
       enabledCollaterals: position.value.collaterals ?? [collateralVault.value.address],
       isFullRepay: isFullRepay.value,
       swapperMode: swapMode,

--- a/composables/useEulerOperations/swaps/verify.ts
+++ b/composables/useEulerOperations/swaps/verify.ts
@@ -1,14 +1,16 @@
-import { encodeFunctionData } from 'viem'
+import { encodeFunctionData, getAddress, zeroAddress, type Address } from 'viem'
 import { adjustForInterest } from '../helpers'
 import { swapVerifierAbi } from '~/entities/euler/abis'
-import { MAX_SLIPPAGE } from '~/entities/constants'
+import { MAX_SLIPPAGE, SWAP_DEFAULT_DEADLINE_SECONDS } from '~/entities/constants'
 import { type SwapApiQuote, SwapperMode, SwapVerificationType } from '~/entities/swap'
 import { logWarn } from '~/utils/errorHandling'
+import { assertSwapperVerifierAllowed } from '~/utils/swap-validation'
 
 // Absolute extra slippage (in percentage points) the validator forgives to absorb
 // BigInt rounding between the swap API and the SDK. Keep this intentionally tiny
 // so accepted verifier bounds cannot drift materially beyond the selected tolerance.
 const VALIDATION_DIVERGENCE_TOLERANCE_PP = 0.001
+const DEADLINE_VALIDATION_TOLERANCE_SECONDS = 60
 
 type SwapQuoteSlippageValidationContext = {
   actualSlippage: string
@@ -42,6 +44,166 @@ export const getSwapInputAmount = (quote: SwapApiQuote, swapperMode: SwapperMode
   const amountInMax = BigInt(quote.amountInMax || 0)
   if (swapperMode === SwapperMode.EXACT_IN) return amountIn
   return amountInMax > 0n ? amountInMax : amountIn
+}
+
+export type WalletSwapRepayQuoteValidationContext = {
+  expectedAccountOut: Address
+  expectedReceiver: Address
+  expectedSwapperAddress: Address | undefined
+  expectedTokenIn: Address
+  expectedTokenOut: Address
+  expectedVerifierAddress: Address | undefined
+  expectedInputAmount?: bigint
+  requestedSlippage: number
+  swapperMode: SwapperMode
+  targetDebt: bigint
+  currentDebt: bigint
+  nowTimestamp?: number
+}
+
+const normalizeAddress = (value: string | undefined, field: string) => {
+  if (!value) {
+    throw new Error(`Swap quote missing ${field}`)
+  }
+  try {
+    return getAddress(value)
+  }
+  catch {
+    throw new Error(`Swap quote invalid ${field}`)
+  }
+}
+
+const assertQuoteAddress = (
+  actual: string | undefined,
+  expected: string,
+  field: string,
+) => {
+  if (normalizeAddress(actual, field) !== normalizeAddress(expected, `expected ${field}`)) {
+    throw new Error(`Swap quote ${field} mismatch`)
+  }
+}
+
+const parseQuoteBigInt = (value: string | number | bigint | undefined, field: string) => {
+  try {
+    return BigInt(value ?? '')
+  }
+  catch {
+    throw new Error(`Swap quote invalid ${field}`)
+  }
+}
+
+export const getSwapRepayVerifierAmount = ({
+  quote,
+  swapperMode,
+  targetDebt,
+  currentDebt,
+}: {
+  quote: SwapApiQuote
+  swapperMode: SwapperMode
+  targetDebt: bigint
+  currentDebt: bigint
+}) => {
+  if (swapperMode === SwapperMode.TARGET_DEBT) {
+    return targetDebt
+  }
+
+  let amount = currentDebt - BigInt(quote.amountOutMin || 0)
+  if (amount < 0n) amount = 0n
+  return adjustForInterest(amount)
+}
+
+export function validateWalletSwapRepayQuote(
+  quote: SwapApiQuote,
+  context: WalletSwapRepayQuoteValidationContext,
+): void {
+  if (!quote.tokenIn) {
+    throw new Error('Swap quote missing tokenIn')
+  }
+  if (!quote.tokenOut) {
+    throw new Error('Swap quote missing tokenOut')
+  }
+  if (!quote.swap) {
+    throw new Error('Swap quote missing swap')
+  }
+  if (!quote.verify) {
+    throw new Error('Swap quote missing verify')
+  }
+  if (!quote.verify.verifierData) {
+    throw new Error('Swap quote missing verify.verifierData')
+  }
+  if (!quote.verify.verifierAddress) {
+    throw new Error('Swap quote missing verify.verifierAddress')
+  }
+  if (!context.expectedSwapperAddress) {
+    throw new Error('Known swapper address not configured')
+  }
+  assertSwapperVerifierAllowed(quote.verify.verifierAddress, context.expectedVerifierAddress)
+
+  assertQuoteAddress(quote.tokenIn.address, context.expectedTokenIn, 'tokenIn')
+  assertQuoteAddress(quote.tokenOut.address, context.expectedTokenOut, 'tokenOut')
+  assertQuoteAddress(quote.accountIn, zeroAddress, 'accountIn')
+  assertQuoteAddress(quote.accountOut, context.expectedAccountOut, 'accountOut')
+  assertQuoteAddress(quote.vaultIn, zeroAddress, 'vaultIn')
+  assertQuoteAddress(quote.receiver, context.expectedReceiver, 'receiver')
+  assertQuoteAddress(quote.verify.vault, context.expectedReceiver, 'verify.vault')
+  assertQuoteAddress(quote.verify.account, context.expectedAccountOut, 'verify.account')
+  assertQuoteAddress(quote.swap.swapperAddress, context.expectedSwapperAddress, 'swap.swapperAddress')
+
+  if (quote.verify.type !== SwapVerificationType.DebtMax) {
+    throw new Error('Swap verifier type mismatch')
+  }
+
+  if (!Number.isSafeInteger(quote.verify.deadline) || quote.verify.deadline <= 0) {
+    throw new Error('Swap quote invalid verify.deadline')
+  }
+  const nowTimestamp = context.nowTimestamp ?? Math.floor(Date.now() / 1000)
+  if (quote.verify.deadline <= nowTimestamp) {
+    throw new Error('Swap quote verify.deadline expired')
+  }
+  if (quote.verify.deadline > nowTimestamp + SWAP_DEFAULT_DEADLINE_SECONDS + DEADLINE_VALIDATION_TOLERANCE_SECONDS) {
+    throw new Error('Swap quote verify.deadline too far in the future')
+  }
+
+  const inputAmount = getSwapInputAmount(quote, context.swapperMode)
+  if (inputAmount <= 0n) {
+    throw new Error('Swap quote input amount must be greater than zero')
+  }
+  if (context.swapperMode === SwapperMode.EXACT_IN) {
+    if (context.expectedInputAmount === undefined || context.expectedInputAmount <= 0n) {
+      throw new Error('Expected swap input amount must be greater than zero')
+    }
+    const quoteAmountIn = parseQuoteBigInt(quote.amountIn, 'amountIn')
+    if (quoteAmountIn !== context.expectedInputAmount) {
+      throw new Error('Swap quote amountIn mismatch')
+    }
+  }
+
+  const expectedVerifierAmount = getSwapRepayVerifierAmount({
+    quote,
+    swapperMode: context.swapperMode,
+    targetDebt: context.targetDebt,
+    currentDebt: context.currentDebt,
+  })
+  const verifierAmount = parseQuoteBigInt(quote.verify.amount, 'verify.amount')
+  if (expectedVerifierAmount > 0n && verifierAmount <= 0n) {
+    throw new Error('Swap quote verify.amount must be greater than zero')
+  }
+  if (verifierAmount !== expectedVerifierAmount) {
+    throw new Error('Swap quote verify.amount mismatch')
+  }
+
+  const verifierData = buildSwapVerifierData({
+    quote,
+    swapperMode: context.swapperMode,
+    isRepay: true,
+    requestedSlippage: context.requestedSlippage,
+    targetDebt: context.targetDebt,
+    currentDebt: context.currentDebt,
+  })
+  if (verifierData.toLowerCase() !== quote.verify.verifierData.toLowerCase()) {
+    logWarn('wallet-swap-repay', 'SwapVerifier data mismatch')
+    throw new Error('SwapVerifier data mismatch')
+  }
 }
 
 export function validateSwapQuoteSlippageData(
@@ -228,14 +390,7 @@ export const buildSwapVerifierData = ({
 
   if (isRepay) {
     functionName = 'verifyDebtMax'
-    if (swapperMode === SwapperMode.TARGET_DEBT) {
-      amount = targetDebt
-    }
-    else {
-      amount = currentDebt - BigInt(quote.amountOutMin || 0)
-      if (amount < 0n) amount = 0n
-      amount = adjustForInterest(amount)
-    }
+    amount = getSwapRepayVerifierAmount({ quote, swapperMode, targetDebt, currentDebt })
   }
   else if (quote.verify.type === SwapVerificationType.TransferMin) {
     functionName = 'verifyAmountMinAndTransfer'

--- a/tests/utils/wallet-swap-repay-quote-validation.test.ts
+++ b/tests/utils/wallet-swap-repay-quote-validation.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from 'vitest'
+import type { Address } from 'viem'
+import { SwapperMode, SwapVerificationType, type SwapApiQuote } from '~/entities/swap'
+import {
+  buildSwapVerifierData,
+  getSwapRepayVerifierAmount,
+  validateWalletSwapRepayQuote,
+  type WalletSwapRepayQuoteValidationContext,
+} from '~/composables/useEulerOperations/swaps/verify'
+
+const TOKEN_IN = '0x0000000000000000000000000000000000000011' as Address
+const TOKEN_OUT = '0x0000000000000000000000000000000000000022' as Address
+const BORROW_VAULT = '0x0000000000000000000000000000000000000033' as Address
+const ACCOUNT = '0x0000000000000000000000000000000000000044' as Address
+const SWAPPER = '0x0000000000000000000000000000000000000055' as Address
+const VERIFIER = '0x0000000000000000000000000000000000000066' as Address
+const ZERO = '0x0000000000000000000000000000000000000000' as Address
+
+const makeContext = (): WalletSwapRepayQuoteValidationContext => ({
+  expectedAccountOut: ACCOUNT,
+  expectedReceiver: BORROW_VAULT,
+  expectedSwapperAddress: SWAPPER,
+  expectedTokenIn: TOKEN_IN,
+  expectedTokenOut: TOKEN_OUT,
+  expectedVerifierAddress: VERIFIER,
+  expectedInputAmount: 1000n,
+  requestedSlippage: 10,
+  swapperMode: SwapperMode.EXACT_IN,
+  targetDebt: 0n,
+  currentDebt: 1000n,
+  nowTimestamp: 1_700_000_000,
+})
+
+const makeQuote = (
+  overrides: Partial<SwapApiQuote> = {},
+  context = makeContext(),
+): SwapApiQuote => {
+  const base = {
+    amountIn: '1000',
+    amountInMax: '1000',
+    amountOut: '1000',
+    amountOutMin: '900',
+    accountIn: ZERO,
+    accountOut: context.expectedAccountOut,
+    vaultIn: ZERO,
+    receiver: context.expectedReceiver,
+    tokenIn: {
+      address: context.expectedTokenIn,
+      chainId: 1,
+      decimals: 18,
+      logoURI: '',
+      name: 'Input',
+      symbol: 'IN',
+    },
+    tokenOut: {
+      address: context.expectedTokenOut,
+      chainId: 1,
+      decimals: 18,
+      logoURI: '',
+      name: 'Output',
+      symbol: 'OUT',
+    },
+    slippage: context.requestedSlippage,
+    swap: {
+      swapperAddress: context.expectedSwapperAddress!,
+      swapperData: '0x',
+      multicallItems: [],
+    },
+    verify: {
+      verifierAddress: context.expectedVerifierAddress!,
+      verifierData: '0x',
+      type: SwapVerificationType.DebtMax,
+      vault: context.expectedReceiver,
+      account: context.expectedAccountOut,
+      amount: '0',
+      deadline: 1_700_001_800,
+    },
+    route: [{ providerName: 'test-provider' }],
+    ...overrides,
+  } as SwapApiQuote
+
+  const verifierAmount = getSwapRepayVerifierAmount({
+    quote: base,
+    swapperMode: context.swapperMode,
+    targetDebt: context.targetDebt,
+    currentDebt: context.currentDebt,
+  })
+  const quote = {
+    ...base,
+    verify: {
+      ...base.verify,
+      amount: verifierAmount.toString(),
+    },
+  }
+
+  return {
+    ...quote,
+    verify: {
+      ...quote.verify,
+      verifierData: buildSwapVerifierData({
+        quote,
+        swapperMode: context.swapperMode,
+        isRepay: true,
+        requestedSlippage: context.requestedSlippage,
+        targetDebt: context.targetDebt,
+        currentDebt: context.currentDebt,
+      }),
+    },
+  }
+}
+
+describe('validateWalletSwapRepayQuote', () => {
+  it('accepts a quote bound to the expected wallet repay context', () => {
+    expect(() => validateWalletSwapRepayQuote(makeQuote(), makeContext())).not.toThrow()
+  })
+
+  it('rejects a quote whose verifier payload was tampered after signing the quote fields', () => {
+    const quote = makeQuote()
+    quote.verify.verifierData = '0x1234'
+
+    expect(() => validateWalletSwapRepayQuote(quote, makeContext())).toThrow('SwapVerifier data mismatch')
+  })
+
+  it('rejects an exact-in quote whose input amount does not match the user request', () => {
+    expect(() =>
+      validateWalletSwapRepayQuote(makeQuote({ amountIn: '1001' }), makeContext()),
+    ).toThrow('amountIn mismatch')
+  })
+
+  it('accepts a target-debt quote whose verifier amount matches the target debt', () => {
+    const context = {
+      ...makeContext(),
+      expectedInputAmount: undefined,
+      swapperMode: SwapperMode.TARGET_DEBT,
+      targetDebt: 250n,
+      currentDebt: 1000n,
+    }
+
+    expect(() => validateWalletSwapRepayQuote(makeQuote({}, context), context)).not.toThrow()
+  })
+
+  it.each([
+    ['tokenIn', { tokenIn: { ...makeQuote().tokenIn, address: TOKEN_OUT } }],
+    ['tokenOut', { tokenOut: { ...makeQuote().tokenOut, address: TOKEN_IN } }],
+    ['receiver', { receiver: TOKEN_IN }],
+    ['accountOut', { accountOut: TOKEN_IN }],
+    ['verify.vault', { verify: { ...makeQuote().verify, vault: TOKEN_IN } }],
+  ])('rejects a quote with mismatched %s', (_field, overrides) => {
+    expect(() => validateWalletSwapRepayQuote(makeQuote(overrides as Partial<SwapApiQuote>), makeContext())).toThrow('mismatch')
+  })
+
+  it('rejects a quote with a mismatched verifier address', () => {
+    expect(() =>
+      validateWalletSwapRepayQuote(
+        makeQuote({ verify: { ...makeQuote().verify, verifierAddress: TOKEN_IN } }),
+        makeContext(),
+      ),
+    ).toThrow('Unknown swap verifier address')
+  })
+
+  it('rejects a quote with a mismatched swapper', () => {
+    expect(() =>
+      validateWalletSwapRepayQuote(
+        makeQuote({ swap: { ...makeQuote().swap, swapperAddress: TOKEN_IN } }),
+        makeContext(),
+      ),
+    ).toThrow('swap.swapperAddress mismatch')
+  })
+
+  it('rejects stale or malformed verifier deadlines', () => {
+    expect(() =>
+      validateWalletSwapRepayQuote(makeQuote({ verify: { ...makeQuote().verify, deadline: 1_600_000_000 } }), makeContext()),
+    ).toThrow('verify.deadline expired')
+
+    expect(() =>
+      validateWalletSwapRepayQuote(makeQuote({ verify: { ...makeQuote().verify, deadline: 1_700_010_000 } }), makeContext()),
+    ).toThrow('verify.deadline too far in the future')
+
+    const malformedDeadlineQuote = makeQuote()
+    malformedDeadlineQuote.verify.deadline = Number.NaN
+    expect(() =>
+      validateWalletSwapRepayQuote(malformedDeadlineQuote, makeContext()),
+    ).toThrow('invalid verify.deadline')
+  })
+
+  it('rejects malformed and zero verifier amounts', () => {
+    const malformedAmountQuote = makeQuote()
+    malformedAmountQuote.verify.amount = 'not-a-number'
+    expect(() =>
+      validateWalletSwapRepayQuote(malformedAmountQuote, makeContext()),
+    ).toThrow('invalid verify.amount')
+
+    const zeroAmountQuote = makeQuote()
+    zeroAmountQuote.verify.amount = '0'
+    expect(() =>
+      validateWalletSwapRepayQuote(zeroAmountQuote, makeContext()),
+    ).toThrow('verify.amount must be greater than zero')
+  })
+})


### PR DESCRIPTION
## Summary
- Reject wallet swap repay quotes that do not match the intended repay context before building or executing a transaction.
- Bind quote token, account, vault, receiver, swapper, verifier, input amount, deadline, and verifier payload fields to the current request.
- Add regression coverage for valid quotes and tampered quote fields.

## Changes
- Added a wallet swap repay quote validator alongside existing swap verifier/slippage helpers.
- Reused verifier calldata generation so selected quote payloads must match the expected `verifyDebtMax` call.
- Keep exact-in spend amount tied to the parsed user input and cap verifier deadlines to the normal quote window.

## Test plan
- [x] npm run test:run
- [x] npm run lint
- [x] npm run typecheck
- [x] git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented comprehensive validation for swap-and-repay operations to enhance transaction safety and prevent execution of invalid or misconfigured quotes. Validation includes address verification, amount accuracy confirmation, transaction deadline checks, and payload integrity verification to ensure all swap-and-repay transactions execute correctly and securely before on-chain processing.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/euler-xyz/euler-lite/pull/426)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->