### PR TITLE
Fail closed on compliance blockers

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { POLL_INTERVAL_60S_MS } from '~/entities/tuning-constants'
 import { useModal } from '~/components/ui/composables/useModal'
+import { useComplianceBlockers } from '~/composables/guards/useComplianceBlockers'
+import { useTosGuard } from '~/composables/guards/useTosGuard'
 import { MigrationAnnouncementModal } from '#components'
 
 const route = useRoute()
@@ -17,6 +19,9 @@ const { loadCountry } = useGeoBlock()
 const { updateBalances, resetBalances } = useWallets()
 const { isConnected, address } = useWagmi()
 const showAllLabelEntries = useShowAllLabelEntries()
+
+useComplianceBlockers()
+useTosGuard()
 
 // Eagerly instantiate useEulerAccount at app root so its internal watchers
 // trigger updatePositions() as soon as balances + lens addresses are ready.

--- a/components/entities/operation/OperationReviewModal.vue
+++ b/components/entities/operation/OperationReviewModal.vue
@@ -6,7 +6,7 @@ import type { VaultAsset } from '~/entities/vault'
 import type { TxPlan } from '~/entities/txPlan'
 import type { SwapperMode } from '~/entities/swap'
 import type { EVCCall } from '~/utils/evc-converter'
-import { applyOperationGuards } from '~/utils/operationGuardRegistry'
+import { applyOperationGuards, assertOperationNotBlocked, isOperationBlocked, operationBlockReason } from '~/utils/operationGuardRegistry'
 import { buildDisplaySteps, type DisplayStep, type StepDecodingContext } from '~/utils/stepDecoding'
 import { useVaultRegistry } from '~/composables/useVaultRegistry'
 import { logWarn } from '~/utils/errorHandling'
@@ -120,6 +120,7 @@ const internalSubmitting = ref(false)
 
 const handleConfirm = async () => {
   if (internalSubmitting.value) return
+  assertOperationNotBlocked()
   const result = onConfirm()
   // If onConfirm returns a promise, keep the modal open with a loading state
   // and let the caller close it via modal.close(). Otherwise close immediately
@@ -336,13 +337,20 @@ const permit2DisclaimerText = 'You are granting the Permit2 contract an unlimite
         :description="permit2DisclaimerText"
         size="compact"
       />
+      <UiToast
+        v-if="operationBlockReason"
+        title="Action required"
+        variant="warning"
+        :description="operationBlockReason"
+        size="compact"
+      />
 
       <!-- Confirm button -->
       <UiButton
         variant="primary"
         size="xlarge"
         rounded
-        :disabled="isSpyMode || internalSubmitting"
+        :disabled="isSpyMode || internalSubmitting || isOperationBlocked"
         :loading="internalSubmitting"
         @click="handleConfirm"
       >

--- a/components/entities/vault/form/VaultFormSubmit.vue
+++ b/components/entities/vault/form/VaultFormSubmit.vue
@@ -50,6 +50,7 @@ const needToSwitchChain = computed(() => {
 })
 const hasActiveSession = computed(() => isConnected.value || isSpyMode.value)
 const _disabled = computed(() => {
+  if (!hasActiveSession.value || needToSwitchChain.value) return false
   if (isOperationBlocked.value) return true
   return props.disabled && !needToSwitchChain.value
 })
@@ -101,7 +102,7 @@ const showKeyringFlow = computed(() =>
 )
 
 const showTosFlow = computed(() =>
-  !showKeyringFlow.value && tosGuard?.isTermsRequired === true && !tosGuard?.tosLoadFailed,
+  hasActiveSession.value && !showKeyringFlow.value && tosGuard?.isTermsRequired === true && !tosGuard?.tosLoadFailed,
 )
 
 const showUnverifiedVaultFlow = computed(() =>

--- a/composables/guards/useComplianceBlockers.ts
+++ b/composables/guards/useComplianceBlockers.ts
@@ -1,0 +1,60 @@
+import { registerOperationBlocker, unregisterOperationBlocker } from '~/utils/operationGuardRegistry'
+import { SANCTIONED_COUNTRIES } from '~/entities/country-constants'
+
+const sameAddress = (a?: string | null, b?: string | null): boolean =>
+  Boolean(a && b && a.toLowerCase() === b.toLowerCase())
+
+export const useComplianceBlockers = () => {
+  if (!import.meta.client) return
+
+  const { address, isConnected } = useWagmi()
+  const { country } = useGeoBlock()
+  const { screeningStatus, screenedAddress } = useAddressScreen()
+
+  watch(
+    [isConnected, address, screeningStatus, screenedAddress],
+    () => {
+      if (!isConnected.value || !address.value) {
+        unregisterOperationBlocker('wallet-screening')
+        return
+      }
+
+      if (screeningStatus.value === 'allowed' && sameAddress(screenedAddress.value, address.value)) {
+        unregisterOperationBlocker('wallet-screening')
+        return
+      }
+
+      if (screeningStatus.value === 'blocked' && sameAddress(screenedAddress.value, address.value)) {
+        registerOperationBlocker('wallet-screening', 'Wallet screening failed')
+        return
+      }
+
+      registerOperationBlocker('wallet-screening', 'Checking wallet compliance')
+    },
+    { immediate: true },
+  )
+
+  watch(
+    country,
+    (value) => {
+      if (value === undefined) {
+        registerOperationBlocker('geo', 'Checking location restrictions')
+      }
+      else if (value === null) {
+        registerOperationBlocker('geo', 'Unable to verify location')
+      }
+      else if (SANCTIONED_COUNTRIES.includes(value.toUpperCase())) {
+        registerOperationBlocker('geo', 'Location is restricted')
+      }
+      else {
+        unregisterOperationBlocker('geo')
+      }
+    },
+    { immediate: true },
+  )
+
+  onUnmounted(() => {
+    unregisterOperationBlocker('wallet-screening')
+    unregisterOperationBlocker('geo')
+  })
+}

--- a/composables/guards/useTosGuard.ts
+++ b/composables/guards/useTosGuard.ts
@@ -13,6 +13,8 @@ export interface TosGuardState {
 }
 
 export const useTosGuard = () => {
+  if (!import.meta.client) return
+
   const { address } = useWagmi()
   const { eulerPeripheryAddresses, isReady, loadEulerConfig, chainId } = useEulerAddresses()
   const { client: rpcClient } = useRpcClient()
@@ -22,6 +24,7 @@ export const useTosGuard = () => {
   const sessionAccepted = useState<boolean>('tosGuardSessionAccepted', () => false)
   const tosLoadFailed = useState<boolean>('tosGuardLoadFailed', () => false)
   const tosData = ref<TosData | null>(null)
+  let checkGeneration = 0
 
   const isTermsRequired = computed(() =>
     enableTosSignature && hasSigned.value === false && !sessionAccepted.value && !tosLoadFailed.value,
@@ -32,26 +35,38 @@ export const useTosGuard = () => {
   )
 
   const checkHasSigned = async () => {
+    const generation = ++checkGeneration
+    const checkedAddress = address.value
+    const checkedChainId = chainId.value
+
+    const isCurrentCheck = () =>
+      generation === checkGeneration
+      && address.value === checkedAddress
+      && chainId.value === checkedChainId
+
     if (!enableTosSignature) {
       hasSigned.value = true
       return
     }
     if (hasSigned.value === true) return
-    if (!address.value) {
+    if (!checkedAddress) {
       hasSigned.value = false
       return
     }
     if (!isReady.value) {
       await loadEulerConfig()
+      if (!isCurrentCheck()) return
     }
     if (!tosSignerAddress.value) {
-      hasSigned.value = false
+      tosLoadFailed.value = true
+      hasSigned.value = null
       return
     }
 
     let data: TosData
     try {
       data = await getTosData()
+      if (!isCurrentCheck()) return
       tosData.value = data
       tosLoadFailed.value = false
     }
@@ -68,8 +83,9 @@ export const useTosGuard = () => {
         address: tosSignerAddress.value,
         abi: tosSignerReadAbi,
         functionName: 'lastTermsOfUseSignatureTimestamp',
-        args: [address.value as Address, data.tosMessageHash],
+        args: [checkedAddress as Address, data.tosMessageHash],
       })
+      if (!isCurrentCheck()) return
       hasSigned.value = (lastSignTimestamp as bigint) > 0
     }
     catch (e) {
@@ -117,6 +133,9 @@ export const useTosGuard = () => {
     if (enableTosSignature && tosLoadFailed.value) {
       registerOperationBlocker('tos', 'Unable to load Terms of Use')
     }
+    else if (enableTosSignature && hasSigned.value === null) {
+      registerOperationBlocker('tos', 'Checking Terms of Use signature')
+    }
     else if (isTermsRequired.value) {
       registerOperationBlocker('tos', 'Terms of Use acceptance required')
     }
@@ -135,6 +154,7 @@ export const useTosGuard = () => {
   })
 
   watch(address, () => {
+    checkGeneration++
     hasSigned.value = null
     sessionAccepted.value = false
     unregisterOperationGuard('tos')
@@ -144,6 +164,7 @@ export const useTosGuard = () => {
   })
 
   watch(chainId, () => {
+    checkGeneration++
     hasSigned.value = null
     sessionAccepted.value = false
     unregisterOperationGuard('tos')

--- a/composables/useAddressScreen.ts
+++ b/composables/useAddressScreen.ts
@@ -49,6 +49,7 @@ export const useAddressScreen = () => {
     if (isRestricted) {
       screeningStatus.value = 'blocked'
       await disconnect()
+      if (gen !== screeningGeneration) return false
       showBlockedModal(address)
       return true
     }

--- a/composables/useAddressScreen.ts
+++ b/composables/useAddressScreen.ts
@@ -1,10 +1,17 @@
 import { useDisconnect } from '@wagmi/vue'
 import { useModal } from '~/components/ui/composables/useModal'
 import { BlockedAddressModal } from '#components'
-import { detectVpn, resetVpnCache } from '~/services/vpn'
 import { resetCountryCache } from '~/services/country'
 import { screenAddress } from '~/services/trm'
 import { getDefaultPageRoute } from '~/entities/menu'
+
+export type AddressScreeningStatus = 'idle' | 'pending' | 'allowed' | 'blocked'
+
+const blockedAddress = ref<string | null>(null)
+const screenedAddress = ref<string | null>(null)
+const screeningStatus = ref<AddressScreeningStatus>('idle')
+const isScreening = computed(() => screeningStatus.value === 'pending')
+let screeningGeneration = 0
 
 export const useAddressScreen = () => {
   const modal = useModal()
@@ -13,9 +20,6 @@ export const useAddressScreen = () => {
 
   const { enableEarnPage, enableLendPage, enableExplorePage } = useDeployConfig()
   const defaultPageRoute = getDefaultPageRoute(enableEarnPage, enableLendPage, enableExplorePage)
-  const blockedAddress = ref<string | null>(null)
-  const isScreening = ref(false)
-  let screeningGeneration = 0
 
   const showBlockedModal = (address: string) => {
     blockedAddress.value = address
@@ -37,35 +41,33 @@ export const useAddressScreen = () => {
     }
 
     const gen = ++screeningGeneration
-    isScreening.value = true
-    try {
-      const vpnIsUsed = await detectVpn()
-      if (gen !== screeningGeneration) return false
+    screenedAddress.value = address
+    screeningStatus.value = 'pending'
+    const isRestricted = await screenAddress(address)
+    if (gen !== screeningGeneration) return false
 
-      const isRestricted = await screenAddress(address, vpnIsUsed)
-      if (gen !== screeningGeneration) return false
-
-      if (isRestricted) {
-        await disconnect()
-        showBlockedModal(address)
-        return true
-      }
-      return false
+    if (isRestricted) {
+      screeningStatus.value = 'blocked'
+      await disconnect()
+      showBlockedModal(address)
+      return true
     }
-    finally {
-      if (gen === screeningGeneration) {
-        isScreening.value = false
-      }
-    }
+    screeningStatus.value = 'allowed'
+    return false
   }
 
   const resetScreeningCache = () => {
-    resetVpnCache()
+    screeningGeneration++
+    screenedAddress.value = null
+    blockedAddress.value = null
+    screeningStatus.value = 'idle'
     resetCountryCache()
   }
 
   return {
     isScreening,
+    screeningStatus,
+    screenedAddress,
     blockedAddress,
     screenConnectedAddress,
     resetScreeningCache,

--- a/composables/useBrevis.ts
+++ b/composables/useBrevis.ts
@@ -255,6 +255,7 @@ export const useBrevis = () => {
       throw new Error('Wallet not connected')
     }
 
+    assertOperationNotBlocked()
     await ensureWalletOnCurrentChain()
 
     const request: MerkleProofRequest = {

--- a/composables/useBrevis.ts
+++ b/composables/useBrevis.ts
@@ -10,6 +10,7 @@ import { CampaignAction } from '~/entities/brevis'
 import { CACHE_TTL_1MIN_MS, POLL_INTERVAL_60S_MS } from '~/entities/tuning-constants'
 import { logWarn } from '~/utils/errorHandling'
 import { createInFlightDedup } from '~/utils/in-flight'
+import { assertOperationNotBlocked } from '~/utils/operationGuardRegistry'
 
 // Server proxy response shape for public campaigns (raw pass-through of the
 // Brevis POST response body).
@@ -274,6 +275,7 @@ export const useBrevis = () => {
     }
 
     const merkleData = rewardsBatch[0]
+    assertOperationNotBlocked()
 
     const hash = await writeContractAsync({
       address: merkleData.claimContractAddr as Address,

--- a/composables/useEulerOperations/execution.ts
+++ b/composables/useEulerOperations/execution.ts
@@ -4,7 +4,7 @@ import type { OperationsContext, AllowanceHelpers } from './types'
 import type { TxPlan } from '~/entities/txPlan'
 import { catchToFallback, logWarn } from '~/utils/errorHandling'
 import { isNonBlockingSimulationError } from '~/utils/tx-errors'
-import { applyOperationGuards } from '~/utils/operationGuardRegistry'
+import { applyOperationGuards, assertOperationNotBlocked } from '~/utils/operationGuardRegistry'
 import { waitForSubgraphBlock } from '~/utils/subgraph'
 
 const OKX_POST_APPROVE_DELAY_MS = 3000
@@ -56,11 +56,15 @@ export const createExecutionHelpers = (ctx: OperationsContext, allowanceHelpers:
       throw new Error('Wallet not connected')
     }
 
+    assertOperationNotBlocked()
+
     const guardedPlan = applyOperationGuards(plan)
     let lastHash: Hex | undefined
     let lastReceipt: TransactionReceipt | undefined
 
     for (const step of guardedPlan.steps) {
+      assertOperationNotBlocked()
+
       /* eslint-disable @typescript-eslint/no-explicit-any -- wagmi writeContractAsync requires ABI-specific generics */
       const txHash = await ctx.writeContractAsync({
         address: step.to,

--- a/composables/useEulerOperations/helpers.ts
+++ b/composables/useEulerOperations/helpers.ts
@@ -11,6 +11,7 @@ import { buildPythUpdateCalls, buildPythUpdateCallsFromFeeds, collectPythFeedsFo
 import { logWarn } from '~/utils/errorHandling'
 import { INTEREST_ADJUSTMENT_BPS, BPS_BASE } from '~/entities/tuning-constants'
 import type { Vault } from '~/entities/vault'
+import { assertOperationNotBlocked } from '~/utils/operationGuardRegistry'
 
 /** Pad amount by 0.01% to cover interest accrual between plan build and tx execution */
 export const adjustForInterest = (amount: bigint) => (amount * INTEREST_ADJUSTMENT_BPS) / BPS_BASE
@@ -100,6 +101,7 @@ export const createOperationHelpers = (ctx: OperationsContext, permit2: Permit2H
       }
 
       if (includePermit2) {
+        assertOperationNotBlocked()
         permitCall = await permit2.buildPermit2Call(assetAddr, spenderAddr, amount, userAddr, permit2Address)
       }
     }

--- a/composables/useEulerOperations/permit2.ts
+++ b/composables/useEulerOperations/permit2.ts
@@ -4,6 +4,7 @@ import type { OperationsContext, Permit2Helpers } from './types'
 import { MAX_UINT160, PERMIT2_TYPES, permit2Abi } from '~/entities/permit2'
 import { PERMIT2_SIG_WINDOW } from '~/entities/constants'
 import type { EVCCall } from '~/utils/evc-converter'
+import { assertOperationNotBlocked } from '~/utils/operationGuardRegistry'
 
 const maxUint256Hex = toHex(maxUint256, { size: 32 })
 const nowInSeconds = () => BigInt(Math.floor(Date.now() / 1000))
@@ -63,6 +64,7 @@ export const createPermit2Helpers = (ctx: OperationsContext): Permit2Helpers => 
       sigDeadline: currentTime + PERMIT2_SIG_WINDOW,
     }
 
+    assertOperationNotBlocked()
     const signature = await ctx.signTypedDataAsync({
       domain: {
         name: 'Permit2',

--- a/composables/useFuul.ts
+++ b/composables/useFuul.ts
@@ -236,6 +236,7 @@ export const useFuul = () => {
       throw new Error('Wallet not connected')
     }
 
+    assertOperationNotBlocked()
     await ensureWalletOnCurrentChain()
 
     const contractCheck = mapRewardToContractCheck(reward)

--- a/composables/useFuul.ts
+++ b/composables/useFuul.ts
@@ -10,6 +10,7 @@ import { CACHE_TTL_1MIN_MS, POLL_INTERVAL_60S_MS } from '~/entities/tuning-const
 import { logWarn } from '~/utils/errorHandling'
 import { createInFlightDedup } from '~/utils/in-flight'
 import { createRaceGuard } from '~/utils/race-guard'
+import { assertOperationNotBlocked } from '~/utils/operationGuardRegistry'
 
 const address = ref('')
 
@@ -239,6 +240,7 @@ export const useFuul = () => {
 
     const contractCheck = mapRewardToContractCheck(reward)
     const fee = await readClaimFee(reward.project_address)
+    assertOperationNotBlocked()
 
     const hash = await writeContractAsync({
       address: FUUL_MANAGER_ADDRESS as Address,

--- a/composables/useMerkl.ts
+++ b/composables/useMerkl.ts
@@ -10,6 +10,7 @@ import type { TxPlan } from '~/entities/txPlan'
 import { CACHE_TTL_1MIN_MS, POLL_INTERVAL_60S_MS } from '~/entities/tuning-constants'
 import { logWarn } from '~/utils/errorHandling'
 import { createInFlightDedup } from '~/utils/in-flight'
+import { assertOperationNotBlocked } from '~/utils/operationGuardRegistry'
 
 // The per-user /users/{addr}/rewards endpoint stays direct (it carries the
 // wallet address, which we deliberately keep off the shared server cache).
@@ -358,6 +359,7 @@ export const useMerkl = () => {
     }
 
     await ensureWalletOnCurrentChain()
+    assertOperationNotBlocked()
 
     const hash = await writeContractAsync({
       address: MERKL_ADDRESS as Address,

--- a/composables/useMerkl.ts
+++ b/composables/useMerkl.ts
@@ -358,6 +358,7 @@ export const useMerkl = () => {
       throw new Error('Wallet not connected')
     }
 
+    assertOperationNotBlocked()
     await ensureWalletOnCurrentChain()
     assertOperationNotBlocked()
 

--- a/composables/useOperationGuard.ts
+++ b/composables/useOperationGuard.ts
@@ -2,7 +2,6 @@ import { computed, isRef, watch, onUnmounted, provide, reactive, type Ref } from
 import { useAccount, useChainId } from '@wagmi/vue'
 import type { Address } from 'viem'
 import { useKeyring, KeyringFlowState } from '~/composables/useKeyring'
-import { useTosGuard } from '~/composables/guards/useTosGuard'
 import { useUnverifiedVaultGuard } from '~/composables/guards/useUnverifiedVaultGuard'
 import { registerOperationGuard, unregisterOperationGuard, registerOperationBlocker, unregisterOperationBlocker } from '~/utils/operationGuardRegistry'
 import { injectKeyringCredential } from '~/utils/keyring-injection'
@@ -16,9 +15,6 @@ export const useOperationGuard = (vaultAddresses: Ref<(string | undefined)[]> | 
     const raw = isRef(vaultAddresses) ? vaultAddresses.value : vaultAddresses
     return raw.filter((addr): addr is string => Boolean(addr))
   })
-
-  // --- TOS guard (global, not vault-specific) ---
-  useTosGuard()
 
   // --- Unverified vault guard ---
   useUnverifiedVaultGuard(addresses)

--- a/composables/useREULLocks.ts
+++ b/composables/useREULLocks.ts
@@ -5,6 +5,7 @@ import type { REULLock } from '~/entities/reul'
 import type { TxPlan } from '~/entities/txPlan'
 import { logWarn } from '~/utils/errorHandling'
 import { BATCH_SIZE_RPC_CALLS, POLL_INTERVAL_60S_MS } from '~/entities/tuning-constants'
+import { assertOperationNotBlocked } from '~/utils/operationGuardRegistry'
 
 const isLoaded = ref(false)
 const isLocksLoading = ref(true)
@@ -144,6 +145,8 @@ export const useREULLocks = () => {
     if (!reulTokenContractAddress.value) {
       throw new Error('REUL contract address not available')
     }
+
+    assertOperationNotBlocked()
 
     const hash = await writeContractAsync({
       address: reulTokenContractAddress.value as Address,

--- a/server/api/screen-address.post.ts
+++ b/server/api/screen-address.post.ts
@@ -1,4 +1,4 @@
-import { createError, readBody } from 'h3'
+import { createError, readBody, type H3Event } from 'h3'
 import { createRateLimiter } from '~/server/utils/rate-limit'
 import { UPSTREAM_FETCH_TIMEOUT_MS } from '~/server/utils/fetchWithTimeout'
 import { logger } from '~/server/utils/logger'
@@ -14,6 +14,40 @@ function isValidAddress(value: unknown): value is string {
   return typeof value === 'string' && /^0x[0-9a-fA-F]{40}$/.test(value)
 }
 
+function headerValue(value: string | string[] | undefined): string {
+  return (Array.isArray(value) ? value[0] : value ?? '').trim().toLowerCase()
+}
+
+function isTruthyHeader(value: string | string[] | undefined): boolean {
+  return ['1', 'true', 'yes'].includes(headerValue(value))
+}
+
+interface ScreeningPayload {
+  address: string
+  chain: 'all'
+  vpnIsUsed: string
+}
+
+export function getTrustedVpnIsUsed(event: H3Event): boolean {
+  const headers = event.node.req.headers
+  return isTruthyHeader(headers['x-is-vpn']) || isTruthyHeader(headers['x-is-proxy-or-vpn'])
+}
+
+export function buildScreeningPayload(address: string, event: H3Event): ScreeningPayload {
+  return {
+    address,
+    chain: 'all',
+    vpnIsUsed: String(getTrustedVpnIsUsed(event)),
+  }
+}
+
+export function isAddressSuspiciousResponse(data: unknown): boolean {
+  if (!data || typeof data !== 'object') {
+    return true
+  }
+  return (data as { addressIsSuspicious?: unknown }).addressIsSuspicious !== false
+}
+
 export default defineEventHandler(async (event) => {
   rateLimiter.consume(event)
 
@@ -24,7 +58,6 @@ export default defineEventHandler(async (event) => {
   }
 
   const address = body.address
-  const vpnIsUsed = String(body.vpnIsUsed ?? false)
 
   const screeningUri = process.env.WALLET_SCREENING_URI
 
@@ -40,7 +73,7 @@ export default defineEventHandler(async (event) => {
     const resp = await fetch(screeningUri, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ address, chain: 'all', vpnIsUsed }),
+      body: JSON.stringify(buildScreeningPayload(address, event)),
       signal: controller.signal,
     })
 
@@ -50,7 +83,7 @@ export default defineEventHandler(async (event) => {
     }
 
     const data = await resp.json()
-    const isSuspicious = Boolean(data?.addressIsSuspicious)
+    const isSuspicious = isAddressSuspiciousResponse(data)
 
     if (isSuspicious) {
       logger.warn({ ctx: 'screen-address', address }, 'flagged address')

--- a/services/trm.ts
+++ b/services/trm.ts
@@ -1,6 +1,5 @@
 export async function screenAddress(
   address: string,
-  vpnIsUsed: boolean,
 ): Promise<boolean> {
   if (!address) return false
 
@@ -8,11 +7,15 @@ export async function screenAddress(
     const resp = await fetch('/api/screen-address', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ address, vpnIsUsed }),
+      body: JSON.stringify({ address }),
     })
 
+    if (!resp.ok) {
+      return true
+    }
+
     const data = await resp.json()
-    return Boolean(data?.addressIsSuspicious)
+    return data?.addressIsSuspicious !== false
   }
   catch {
     return true

--- a/tests/server/screen-address.test.ts
+++ b/tests/server/screen-address.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import type { H3Event } from 'h3'
+import { buildScreeningPayload, getTrustedVpnIsUsed, isAddressSuspiciousResponse } from '~/server/api/screen-address.post'
+
+const eventWithHeaders = (headers: Record<string, string | string[] | undefined>): H3Event =>
+  ({ node: { req: { headers } } }) as unknown as H3Event
+
+describe('screen-address trusted VPN signal', () => {
+  const address = '0x1111111111111111111111111111111111111111'
+
+  it('does not mark VPN usage without trusted provider headers', () => {
+    const event = eventWithHeaders({})
+
+    expect(getTrustedVpnIsUsed(event)).toBe(false)
+    expect(buildScreeningPayload(address, event)).toEqual({
+      address,
+      chain: 'all',
+      vpnIsUsed: 'false',
+    })
+  })
+
+  it('derives VPN usage from provider headers', () => {
+    const event = eventWithHeaders({ 'x-is-proxy-or-vpn': 'true' })
+
+    expect(getTrustedVpnIsUsed(event)).toBe(true)
+    expect(buildScreeningPayload(address, event).vpnIsUsed).toBe('true')
+  })
+
+  it('accepts x-is-vpn as an advisory trusted signal', () => {
+    const event = eventWithHeaders({ 'x-is-vpn': '1' })
+
+    expect(getTrustedVpnIsUsed(event)).toBe(true)
+  })
+})
+
+describe('screen-address upstream response parsing', () => {
+  it('allows only an explicit false suspicious flag', () => {
+    expect(isAddressSuspiciousResponse({ addressIsSuspicious: false })).toBe(false)
+  })
+
+  it('fails closed for suspicious, missing, null, or malformed responses', () => {
+    expect(isAddressSuspiciousResponse({ addressIsSuspicious: true })).toBe(true)
+    expect(isAddressSuspiciousResponse({})).toBe(true)
+    expect(isAddressSuspiciousResponse({ addressIsSuspicious: null })).toBe(true)
+    expect(isAddressSuspiciousResponse(null)).toBe(true)
+  })
+})

--- a/tests/services/trm.test.ts
+++ b/tests/services/trm.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { screenAddress } from '~/services/trm'
+
+const originalFetch = globalThis.fetch
+
+describe('screenAddress', () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  it('allows only an explicit non-suspicious response', async () => {
+    globalThis.fetch = vi.fn(async () =>
+      new Response(JSON.stringify({ addressIsSuspicious: false }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    ) as typeof globalThis.fetch
+
+    await expect(screenAddress('0x1111111111111111111111111111111111111111')).resolves.toBe(false)
+  })
+
+  it('fails closed on non-2xx API responses', async () => {
+    globalThis.fetch = vi.fn(async () =>
+      new Response(JSON.stringify({ statusCode: 451, statusMessage: 'Unavailable For Legal Reasons' }), {
+        status: 451,
+        headers: { 'content-type': 'application/json' },
+      }),
+    ) as typeof globalThis.fetch
+
+    await expect(screenAddress('0x1111111111111111111111111111111111111111')).resolves.toBe(true)
+  })
+
+  it('fails closed when the response does not explicitly allow the address', async () => {
+    globalThis.fetch = vi.fn(async () =>
+      new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    ) as typeof globalThis.fetch
+
+    await expect(screenAddress('0x1111111111111111111111111111111111111111')).resolves.toBe(true)
+  })
+})

--- a/tests/utils/operation-guard-registry.test.ts
+++ b/tests/utils/operation-guard-registry.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  assertOperationNotBlocked,
+  isOperationBlocked,
+  operationBlockReason,
+  registerOperationBlocker,
+  unregisterOperationBlocker,
+} from '~/utils/operationGuardRegistry'
+
+describe('operation guard registry blockers', () => {
+  afterEach(() => {
+    unregisterOperationBlocker('test-compliance')
+  })
+
+  it('allows execution when no blocker is active', () => {
+    unregisterOperationBlocker('test-compliance')
+
+    expect(isOperationBlocked.value).toBe(false)
+    expect(() => assertOperationNotBlocked()).not.toThrow()
+  })
+
+  it('throws the active blocker reason for final execution gates', () => {
+    registerOperationBlocker('test-compliance', 'Checking wallet compliance')
+
+    expect(isOperationBlocked.value).toBe(true)
+    expect(operationBlockReason.value).toBe('Checking wallet compliance')
+    expect(() => assertOperationNotBlocked()).toThrow('Checking wallet compliance')
+  })
+})

--- a/utils/operationGuardRegistry.ts
+++ b/utils/operationGuardRegistry.ts
@@ -54,6 +54,13 @@ export const operationBlockReason = computed(() => {
   return first.done ? undefined : first.value
 })
 
+/** Throw when any operation blocker is active. Used by final execution paths. */
+export const assertOperationNotBlocked = (): void => {
+  if (isOperationBlocked.value) {
+    throw new Error(operationBlockReason.value ?? 'Operation blocked')
+  }
+}
+
 /** Reactive: true when a guard with the given key is registered */
 export const hasGuard = (key: string) => computed(() => guards.value.has(key))
 


### PR DESCRIPTION
## Summary
- Fail closed while compliance state is unresolved so wallet screening, location detection, and Terms of Use checks gate transaction execution instead of only form buttons.
- Remove client authority over the VPN advisory value sent to wallet screening while keeping VPN non-blocking.
- Extend final write-path enforcement to transaction plans, review modal confirmations, and direct reward/unlock writers.

## Changes
- Adds a global compliance blocker composable for wallet-screening and geo states, including sanctioned-country blocking.
- Makes wallet screening state shared across composable callers and treats only explicit screening allow responses as non-suspicious.
- Moves Terms of Use guard setup to app scope, keeps it client-only, and guards against stale async signature checks after address or chain changes.
- Adds final blocker assertions in `executeTxPlan`, `OperationReviewModal`, and reward/unlock direct write functions.
- Derives the screening `vpnIsUsed` payload server-side from advisory request headers and fails closed on malformed upstream screening responses.

## Test plan
- [x] `npm run test:run -- tests/server/screen-address.test.ts tests/services/trm.test.ts tests/utils/operation-guard-registry.test.ts`
- [x] `npm run test:run`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] Local smoke test with mock `WALLET_SCREENING_URI`, `DEV_GEO_COUNTRY=US`, and `/api/screen-address` probes confirming body-provided VPN status is ignored.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added compliance verification to protect operations based on wallet status and location restrictions.
  * Improved Terms of Service acceptance flow.

* **Bug Fixes**
  * Enhanced operation-blocking enforcement during confirmations.
  * Fixed submit button behavior for active wallet sessions.
  * Refined address screening validation logic.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/euler-xyz/euler-lite/pull/427)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->