### PR TITLE
Fix borrow review plan validation

### DIFF
--- a/components/entities/operation/OperationReviewModal.vue
+++ b/components/entities/operation/OperationReviewModal.vue
@@ -22,12 +22,13 @@ interface REULUnlockInfo {
   daysUntilMaturity: number
 }
 
-const { type, asset, assetIconUrl, campaignInfo: _campaignInfo, reulUnlockInfo, amount, onConfirm, plan, swapToAsset, swapToAmount, swapMode, swapEstimatedSide, supplyingAssetForBorrow, supplyingAmount, transferAmounts, submittingLabel } = defineProps<{
+const { type, asset, assetIconUrl, campaignInfo: _campaignInfo, reulUnlockInfo, amount, onConfirm, plan, requirePlanForConfirm, swapToAsset, swapToAmount, swapMode, swapEstimatedSide, supplyingAssetForBorrow, supplyingAmount, transferAmounts, submittingLabel } = defineProps<{
   type?: 'supply' | 'withdraw' | 'borrow' | 'repay' | 'swap' | 'transfer' | 'reward' | 'brevis-reward' | 'fuul-reward' | 'reul-unlock' | 'disableCollateral' | 'swap-supply' | 'swap-withdraw' | 'swap-borrow'
   asset: VaultAsset
   assetIconUrl?: string
   amount: number | string
   plan?: TxPlan
+  requirePlanForConfirm?: boolean
   supplyingAssetForBorrow?: VaultAsset
   supplyingAmount?: number | string
   swapToAsset?: VaultAsset
@@ -120,6 +121,7 @@ const internalSubmitting = ref(false)
 
 const handleConfirm = async () => {
   if (internalSubmitting.value) return
+  if (requirePlanForConfirm && !plan?.steps?.length) return
   const result = onConfirm()
   // If onConfirm returns a promise, keep the modal open with a loading state
   // and let the caller close it via modal.close(). Otherwise close immediately
@@ -342,7 +344,7 @@ const permit2DisclaimerText = 'You are granting the Permit2 contract an unlimite
         variant="primary"
         size="xlarge"
         rounded
-        :disabled="isSpyMode || internalSubmitting"
+        :disabled="isSpyMode || internalSubmitting || (requirePlanForConfirm && !plan?.steps?.length)"
         :loading="internalSubmitting"
         @click="handleConfirm"
       >

--- a/composables/borrow/useBorrowForm.ts
+++ b/composables/borrow/useBorrowForm.ts
@@ -589,27 +589,36 @@ export const useBorrowForm = (options: UseBorrowFormOptions) => {
   }, 500)
 
   // --- Actions: submit & send ---
-  const buildSwapBorrowPlanFromQuote = async (quote: SwapApiQuote, planOptions: { includePermit2Call?: boolean } = {}): Promise<TxPlan> => {
-    if (!borrowSelectedAsset.value || !collateralVault.value || !borrowVault.value) {
-      throw new Error('Missing vault or asset data')
-    }
-    const isNative = isNativeCurrencyAddress(borrowSelectedAsset.value.address)
-    const inputAmount = valueToNano(collateralAmount.value || '0', borrowSelectedAsset.value.decimals)
-    const wrappedAddress = isNative ? resolveWrappedNativeAddress(chainId.value!) : null
+  const buildSwapBorrowPlanFromSnapshot = async (
+    snapshot: {
+      quote: SwapApiQuote
+      selectedAsset: VaultAsset
+      collateralVault: Vault
+      borrowVault: Vault
+      collateralAmount: string
+      borrowAmount: string
+      slippage: number
+      subAccount: string
+      chainId: number
+    },
+    planOptions: { includePermit2Call?: boolean } = {},
+  ): Promise<TxPlan> => {
+    const isNative = isNativeCurrencyAddress(snapshot.selectedAsset.address)
+    const inputAmount = valueToNano(snapshot.collateralAmount || '0', snapshot.selectedAsset.decimals)
+    const wrappedAddress = isNative ? resolveWrappedNativeAddress(snapshot.chainId) : null
     if (isNative && !wrappedAddress) {
       throw new Error('Wrapped native token not found')
     }
-    const borrowAmountNano = valueToNano(borrowAmount.value || '0', borrowVault.value.decimals)
-    const subAccount = await resolvePendingSubAccount()
+    const borrowAmountNano = valueToNano(snapshot.borrowAmount || '0', snapshot.borrowVault.decimals)
     return buildSwapAndBorrowPlan({
-      inputTokenAddress: (wrappedAddress || borrowSelectedAsset.value.address) as Address,
+      inputTokenAddress: (wrappedAddress || snapshot.selectedAsset.address) as Address,
       inputAmount,
-      collateralVaultAddress: collateralVault.value.address as Address,
-      borrowVaultAddress: borrowVault.value.address as Address,
+      collateralVaultAddress: snapshot.collateralVault.address as Address,
+      borrowVaultAddress: snapshot.borrowVault.address as Address,
       borrowAmount: borrowAmountNano,
-      swapQuote: quote,
-      requestedSlippage: borrowSwapSlippage.value,
-      subAccount,
+      swapQuote: snapshot.quote,
+      requestedSlippage: snapshot.slippage,
+      subAccount: snapshot.subAccount,
       includePermit2Call: planOptions.includePermit2Call,
       wrappedNativeInfo: isNative && wrappedAddress
         ? { wrappedTokenAddress: wrappedAddress, nativeAmount: inputAmount }
@@ -633,19 +642,35 @@ export const useBorrowForm = (options: UseBorrowFormOptions) => {
 
       // Swap & borrow path
       if (borrowNeedsSwap.value && borrowSwapEffectiveQuote.value) {
+        let reviewedSwapSnapshot: Parameters<typeof buildSwapBorrowPlanFromSnapshot>[0]
         try {
-          plan.value = await buildSwapBorrowPlanFromQuote(borrowSwapEffectiveQuote.value, { includePermit2Call: false })
+          if (!borrowSelectedAsset.value || !collateralVault.value || !borrowVault.value) {
+            throw new Error('Missing vault or asset data')
+          }
+          reviewedSwapSnapshot = {
+            quote: borrowSwapEffectiveQuote.value,
+            selectedAsset: borrowSelectedAsset.value,
+            collateralVault: collateralVault.value,
+            borrowVault: borrowVault.value,
+            collateralAmount: collateralAmount.value,
+            borrowAmount: borrowAmount.value,
+            slippage: borrowSwapSlippage.value,
+            subAccount: await resolvePendingSubAccount(),
+            chainId: chainId.value!,
+          }
+          plan.value = await buildSwapBorrowPlanFromSnapshot(reviewedSwapSnapshot, { includePermit2Call: false })
         }
         catch (e) {
           logWarn('borrow/buildSwapPlan', e)
+          error('Failed to build transaction')
           plan.value = null
+          return
         }
 
-        if (plan.value) {
-          const ok = await runBorrowSimulation(plan.value)
-          if (!ok) {
-            return
-          }
+        const reviewedPlan = plan.value
+        const ok = await runBorrowSimulation(reviewedPlan)
+        if (!ok) {
+          return
         }
 
         const isNativeSwap = borrowSelectedAsset.value && isNativeCurrencyAddress(borrowSelectedAsset.value.address)
@@ -657,12 +682,13 @@ export const useBorrowForm = (options: UseBorrowFormOptions) => {
             type: 'swap-borrow' as const,
             asset: reviewAsset,
             amount: collateralAmount.value,
-            plan: plan.value || undefined,
+            plan: reviewedPlan,
+            requirePlanForConfirm: true,
             swapToAsset: collateralVault.value.asset,
             swapToAmount: borrowSwapEstimatedCollateral.value,
             swapMode: SwapperMode.EXACT_IN,
             onConfirm: async () => {
-              await send()
+              await send(reviewedPlan, () => buildSwapBorrowPlanFromSnapshot(reviewedSwapSnapshot, { includePermit2Call: true }))
             },
             submittingLabel: 'Submitting...',
           },
@@ -674,8 +700,12 @@ export const useBorrowForm = (options: UseBorrowFormOptions) => {
       const collateralAmountNano = valueToNano(collateralAmount.value || '0', collateralVault.value?.decimals)
       const borrowAmountNano = valueToNano(borrowAmount.value || '0', borrowVault.value?.decimals)
       let collateralAmountForPlan = collateralAmountNano
+      const reviewedCollateralVault = collateralVault.value
+      const reviewedBorrowVault = borrowVault.value
+      const reviewedIsSavingCollateral = isSavingCollateral.value
+      const reviewedSavingSubAccount = savingCollateral.value?.subAccount
 
-      if (isSavingCollateral.value) {
+      if (reviewedIsSavingCollateral) {
         if (savingCollateral.value?.assets === collateralAmountNano) {
           collateralAmountForPlan = savingBalance.value
         }
@@ -683,43 +713,45 @@ export const useBorrowForm = (options: UseBorrowFormOptions) => {
           collateralAmountForPlan = await convertAssetsToShares(collateralVault.value.address, collateralAmountNano)
         }
       }
+      const reviewedWrappedNativeInfo = isBorrowNativeWrap.value
+        ? { wrappedTokenAddress: resolveWrappedNativeAddress(chainId.value!)!, nativeAmount: collateralAmountForPlan }
+        : undefined
 
       try {
-        plan.value = isSavingCollateral.value
+        plan.value = reviewedIsSavingCollateral
           ? await buildBorrowBySavingPlan(
-              collateralVault.value.address,
+              reviewedCollateralVault.address,
               collateralAmountForPlan,
-              borrowVault.value.address,
+              reviewedBorrowVault.address,
               borrowAmountNano,
               undefined,
               undefined,
-              savingCollateral.value?.subAccount,
+              reviewedSavingSubAccount,
             )
           : await buildBorrowPlan(
-              collateralVault.value.address,
-              collateralVault.value.asset.address,
+              reviewedCollateralVault.address,
+              reviewedCollateralVault.asset.address,
               collateralAmountForPlan,
-              borrowVault.value.address,
+              reviewedBorrowVault.address,
               borrowAmountNano,
               undefined,
               {
                 includePermit2Call: false,
-                wrappedNativeInfo: isBorrowNativeWrap.value
-                  ? { wrappedTokenAddress: resolveWrappedNativeAddress(chainId.value!)!, nativeAmount: collateralAmountForPlan }
-                  : undefined,
+                wrappedNativeInfo: reviewedWrappedNativeInfo,
               },
             )
       }
       catch (e) {
         logWarn('borrow/buildPlan', e)
+        error('Failed to build transaction')
         plan.value = null
+        return
       }
 
-      if (plan.value) {
-        const ok = await runBorrowSimulation(plan.value)
-        if (!ok) {
-          return
-        }
+      const reviewedPlan = plan.value
+      const ok = await runBorrowSimulation(reviewedPlan)
+      if (!ok) {
+        return
       }
 
       modal.open(OperationReviewModal, {
@@ -727,11 +759,33 @@ export const useBorrowForm = (options: UseBorrowFormOptions) => {
           type: 'borrow',
           asset: borrowVault.value?.asset,
           amount: borrowAmount.value,
-          plan: plan.value || undefined,
+          plan: reviewedPlan,
+          requirePlanForConfirm: true,
           supplyingAssetForBorrow: collateralVault.value?.asset,
           supplyingAmount: collateralAmount.value,
           onConfirm: async () => {
-            await send()
+            await send(reviewedPlan, () => reviewedIsSavingCollateral
+              ? buildBorrowBySavingPlan(
+                  reviewedCollateralVault.address,
+                  collateralAmountForPlan,
+                  reviewedBorrowVault.address,
+                  borrowAmountNano,
+                  undefined,
+                  undefined,
+                  reviewedSavingSubAccount,
+                )
+              : buildBorrowPlan(
+                  reviewedCollateralVault.address,
+                  reviewedCollateralVault.asset.address,
+                  collateralAmountForPlan,
+                  reviewedBorrowVault.address,
+                  borrowAmountNano,
+                  undefined,
+                  {
+                    includePermit2Call: true,
+                    wrappedNativeInfo: reviewedWrappedNativeInfo,
+                  },
+                ))
           },
           submittingLabel: 'Submitting...',
         },
@@ -742,60 +796,17 @@ export const useBorrowForm = (options: UseBorrowFormOptions) => {
     }
   }
 
-  const send = async () => {
+  const send = async (reviewedPlan?: TxPlan | null, buildReviewedExecutionPlan?: () => Promise<TxPlan>) => {
     try {
       isSubmitting.value = true
-      if (!collateralVault.value || !borrowVault.value) {
+      if (!reviewedPlan || plan.value !== reviewedPlan || !buildReviewedExecutionPlan) {
+        error('Transaction review expired')
         return
       }
-
-      let txPlan: TxPlan
-
-      // Swap & borrow path
-      if (borrowNeedsSwap.value) {
-        const quote = borrowSwapSelectedQuote.value || borrowSwapEffectiveQuote.value
-        if (!quote) {
-          error('No swap quote available')
-          return
-        }
-        txPlan = await buildSwapBorrowPlanFromQuote(quote)
-      }
-      else {
-        // Standard borrow path
-        let collateralAmountForPlan = collateralAmountFixed.value.toFormat({ decimals: Number(collateralVault.value.decimals) }).value
-        if (isSavingCollateral.value) {
-          if (savingCollateral.value?.assets === collateralAmountForPlan) {
-            collateralAmountForPlan = savingBalance.value
-          }
-          else {
-            collateralAmountForPlan = await convertAssetsToShares(collateralVault.value.address, collateralAmountForPlan)
-          }
-        }
-        const borrowAmountNano = borrowAmountFixed.value.toFormat({ decimals: Number(borrowVault.value.decimals) }).value
-        txPlan = isSavingCollateral.value
-          ? await buildBorrowBySavingPlan(
-              collateralVault.value.address,
-              collateralAmountForPlan,
-              borrowVault.value.address,
-              borrowAmountNano,
-              undefined,
-              undefined,
-              savingCollateral.value?.subAccount,
-            )
-          : await buildBorrowPlan(
-              collateralVault.value.address,
-              collateralVault.value.asset.address,
-              collateralAmountForPlan,
-              borrowVault.value.address,
-              borrowAmountNano,
-              undefined,
-              {
-                includePermit2Call: true,
-                wrappedNativeInfo: isBorrowNativeWrap.value
-                  ? { wrappedTokenAddress: resolveWrappedNativeAddress(chainId.value!)!, nativeAmount: collateralAmountForPlan }
-                  : undefined,
-              },
-            )
+      const txPlan = await buildReviewedExecutionPlan()
+      const ok = await runBorrowSimulation(txPlan)
+      if (!ok) {
+        return
       }
       await executeTxPlan(txPlan)
       await finalizeTxAndRedirect()

--- a/tests/composables/useBorrowForm.test.ts
+++ b/tests/composables/useBorrowForm.test.ts
@@ -1,0 +1,373 @@
+import { computed, nextTick, ref, watch, watchEffect } from 'vue'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { TxPlan } from '~/entities/txPlan'
+import type { AnyBorrowVaultPair, Vault, VaultAsset } from '~/entities/vault'
+import type { SwapApiQuote } from '~/entities/swap'
+import { valueToNano } from '~/utils/crypto-utils'
+import { useBorrowForm } from '~/composables/borrow/useBorrowForm'
+
+const { USER, COLLATERAL_VAULT, BORROW_VAULT, mocks } = vi.hoisted(() => {
+  const USER = '0x0000000000000000000000000000000000000001'
+  const COLLATERAL_VAULT = '0x0000000000000000000000000000000000000002'
+  const BORROW_VAULT = '0x0000000000000000000000000000000000000003'
+  const COLLATERAL_ASSET = '0x0000000000000000000000000000000000000004'
+  const BORROW_ASSET = '0x0000000000000000000000000000000000000005'
+  const WALLET_ASSET = '0x0000000000000000000000000000000000000006'
+
+  const collateralAsset = {
+    address: COLLATERAL_ASSET,
+    name: 'USDC',
+    symbol: 'USDC',
+    decimals: 6,
+  }
+  const borrowAsset = {
+    address: BORROW_ASSET,
+    name: 'USDT',
+    symbol: 'USDT',
+    decimals: 6,
+  }
+  const walletAsset = {
+    address: WALLET_ASSET,
+    name: 'DAI',
+    symbol: 'DAI',
+    decimals: 6,
+  }
+
+  const collateralVault = {
+    address: COLLATERAL_VAULT,
+    asset: collateralAsset,
+    decimals: 6,
+    supply: 1_000_000_000n,
+    interestRateInfo: { cash: 0n, borrows: 0n, supplyAPY: 0n, borrowAPY: 0n },
+    collateralLTVs: [],
+  } as unknown as Vault
+
+  const borrowVault = {
+    address: BORROW_VAULT,
+    asset: borrowAsset,
+    decimals: 6,
+    supply: 1_000_000_000n,
+    interestRateInfo: { cash: 0n, borrows: 0n, supplyAPY: 0n, borrowAPY: 0n },
+    collateralLTVs: [],
+  } as unknown as Vault
+
+  return {
+    USER,
+    COLLATERAL_VAULT,
+    BORROW_VAULT,
+    WALLET_ASSET,
+    mocks: {
+      collateralVault,
+      borrowVault,
+      walletAsset,
+      modalOpen: vi.fn(),
+      modalClose: vi.fn(),
+      toastError: vi.fn(),
+      buildBorrowPlan: vi.fn(),
+      buildBorrowBySavingPlan: vi.fn(),
+      buildSwapAndBorrowPlan: vi.fn(),
+      executeTxPlan: vi.fn(),
+      finalizeTxAndRedirect: vi.fn(),
+      runSimulation: vi.fn(),
+      resolvePendingSubAccount: vi.fn(),
+      swapEffectiveQuote: null as SwapApiQuote | null,
+    },
+  }
+})
+
+vi.mock('@wagmi/vue', () => ({
+  useAccount: () => ({
+    address: ref(USER),
+    isConnected: ref(true),
+  }),
+}))
+
+vi.mock('#components', () => ({
+  OperationReviewModal: {},
+  SwapTokenSelector: {},
+}))
+
+vi.mock('~/components/ui/composables/useModal', () => ({
+  useModal: () => ({
+    open: mocks.modalOpen,
+    close: mocks.modalClose,
+  }),
+}))
+
+vi.mock('~/components/ui/composables/useToast', () => ({
+  useToast: () => ({
+    error: mocks.toastError,
+  }),
+}))
+
+vi.mock('~/utils/native-currency', () => ({
+  isNativeCurrencyAddress: () => false,
+  isNativeOfWrapped: () => false,
+  resolveWrappedNativeAddress: () => undefined,
+  resolveWrappedNativeAsset: () => undefined,
+}))
+
+vi.mock('~/services/pricing/priceProvider', () => ({
+  getAssetUsdValueOrZero: vi.fn(async () => 0),
+  getAssetOraclePrice: vi.fn(() => 1n),
+  getCollateralOraclePrice: vi.fn(() => 1n),
+  getCollateralUsdPrice: vi.fn(async () => null),
+  conservativePriceRatio: vi.fn(() => 1),
+}))
+
+vi.mock('~/services/pricing/backendClient', () => ({
+  fetchBackendPrice: vi.fn(async () => null),
+}))
+
+vi.mock('~/composables/useSwapPriceImpact', () => ({
+  useSwapPriceImpact: () => ({ priceImpact: ref(null) }),
+}))
+
+vi.mock('~/utils/swapRouteItems', () => ({
+  buildSwapRouteItems: vi.fn(() => []),
+}))
+
+vi.mock('~/composables/useVaultWarnings', () => ({
+  getPlanHookDisabledWarning: vi.fn(() => null),
+  getUtilisationWarning: vi.fn(() => null),
+  getBorrowCapWarning: vi.fn(() => null),
+  getSupplyCapWarning: vi.fn(() => null),
+}))
+
+vi.mock('~/composables/useGeoBlock', () => ({
+  getVaultTags: vi.fn(() => ({ tags: [], disabled: false })),
+  isVaultRestrictedByCountry: vi.fn(() => false),
+  isAssetBlockedByCountry: vi.fn(() => false),
+}))
+
+vi.mock('~/composables/useSwapQuotesParallel', async () => {
+  const vue = await vi.importActual<typeof import('vue')>('vue')
+  return {
+    useSwapQuotesParallel: () => ({
+      sortedQuoteCards: vue.ref([]),
+      selectedProvider: vue.ref(null),
+      selectedQuote: vue.ref(null),
+      effectiveQuote: vue.ref(mocks.swapEffectiveQuote),
+      isLoading: vue.ref(false),
+      quoteError: vue.ref(null),
+      statusLabel: vue.ref(''),
+      getQuoteDiffPct: vi.fn(() => 0),
+      reset: vi.fn(),
+      requestQuotes: vi.fn(),
+      selectProvider: vi.fn(),
+    }),
+  }
+})
+
+vi.mock('~/utils/operationGuardRegistry', () => ({
+  isOperationBlocked: ref(false),
+}))
+
+vi.mock('~/utils/vault-hooks', () => ({
+  findBlockingDisabledOp: vi.fn(() => null),
+  OP_BORROW: 'borrow',
+  OP_DEPOSIT: 'deposit',
+  OP_SKIM: 'skim',
+  OP_TRANSFER: 'transfer',
+}))
+
+vi.mock('~/entities/vault', async () => {
+  const actual = await vi.importActual<object>('~/entities/vault')
+  return {
+    ...actual,
+    convertAssetsToShares: vi.fn(async (amount: bigint) => amount),
+    getNetAPY: vi.fn(() => 0),
+    getProjectedRates: vi.fn(async () => null),
+  }
+})
+
+const reviewPlan = (label: string): TxPlan => ({
+  kind: 'borrow',
+  steps: [{
+    type: 'evc-batch',
+    label,
+    to: BORROW_VAULT as `0x${string}`,
+    abi: [],
+    functionName: 'batch',
+    args: [],
+    value: 0n,
+  }],
+})
+
+const quote = {
+  amountIn: '1000000',
+  amountOut: '1000000',
+  route: [],
+  swap: {
+    swapperAddress: '0x0000000000000000000000000000000000000007',
+    multicallItems: [],
+  },
+  verify: {
+    verifierAddress: '0x0000000000000000000000000000000000000008',
+    verifierData: '0x',
+    account: USER,
+  },
+} as unknown as SwapApiQuote
+
+const pair = {
+  borrowLTV: 5000n,
+  liquidationLTV: 8000n,
+} as AnyBorrowVaultPair
+
+const createBorrowForm = () => {
+  const borrow = useBorrowForm({
+    pair: ref(pair),
+    borrowVault: computed(() => mocks.borrowVault),
+    collateralVault: computed(() => mocks.collateralVault),
+    formTab: ref('borrow'),
+    savingCollateral: computed(() => undefined),
+    balance: ref(1_000_000_000n),
+    savingBalance: ref(0n),
+    savingAssets: ref(0n),
+    resolvePendingSubAccount: mocks.resolvePendingSubAccount,
+    collateralSupplyApy: computed(() => 0),
+    borrowApy: computed(() => 0),
+    collateralSupplyRewardApy: computed(() => 0),
+    borrowRewardApy: computed(() => 0),
+    collateralSupplyApyWithRewards: computed(() => 0),
+    isSecuritizeCollateral: computed(() => false),
+    isGeoBlocked: computed(() => false),
+    isBorrowRestricted: computed(() => false),
+    collateralAddress: COLLATERAL_VAULT,
+    borrowAddress: BORROW_VAULT,
+  })
+
+  borrow.collateralAmount.value = '1'
+  borrow.borrowAmount.value = '1'
+  return borrow
+}
+
+describe('useBorrowForm review flow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.swapEffectiveQuote = null
+    mocks.resolvePendingSubAccount.mockResolvedValue(USER)
+    mocks.runSimulation.mockResolvedValue(true)
+    mocks.executeTxPlan.mockResolvedValue('0xhash')
+    mocks.finalizeTxAndRedirect.mockResolvedValue(undefined)
+
+    vi.stubGlobal('ref', ref)
+    vi.stubGlobal('computed', computed)
+    vi.stubGlobal('watch', watch)
+    vi.stubGlobal('watchEffect', watchEffect)
+    vi.stubGlobal('nextTick', nextTick)
+    vi.stubGlobal('useDebounceFn', (fn: unknown) => fn)
+    vi.stubGlobal('valueToNano', valueToNano)
+    vi.stubGlobal('getIsSupplyCapReached', () => false)
+    vi.stubGlobal('getIsBorrowCapReached', () => false)
+    vi.stubGlobal('useEulerOperations', () => ({
+      buildBorrowPlan: mocks.buildBorrowPlan,
+      buildBorrowBySavingPlan: mocks.buildBorrowBySavingPlan,
+      buildSwapAndBorrowPlan: mocks.buildSwapAndBorrowPlan,
+      executeTxPlan: mocks.executeTxPlan,
+    }))
+    vi.stubGlobal('useEulerAddresses', () => ({
+      chainId: ref(1),
+    }))
+    vi.stubGlobal('useWallets', () => ({
+      fetchSingleBalance: vi.fn(async () => 0n),
+    }))
+    vi.stubGlobal('useTxFinalization', () => ({
+      finalizeTxAndRedirect: mocks.finalizeTxAndRedirect,
+    }))
+    vi.stubGlobal('useTxPlanSimulation', () => ({
+      runSimulation: mocks.runSimulation,
+      simulationError: ref(''),
+      clearSimulationError: vi.fn(),
+    }))
+    vi.stubGlobal('usePriceInvert', () => ({
+      autoInvert: vi.fn(),
+    }))
+    vi.stubGlobal('useSlippage', () => ({
+      slippage: ref(0.5),
+    }))
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('does not open review when standard borrow plan preparation fails', async () => {
+    mocks.buildBorrowPlan.mockRejectedValueOnce(new Error('prepare failed'))
+    const borrow = createBorrowForm()
+
+    await borrow.submit()
+
+    expect(mocks.modalOpen).not.toHaveBeenCalled()
+    expect(mocks.runSimulation).not.toHaveBeenCalled()
+    expect(mocks.executeTxPlan).not.toHaveBeenCalled()
+    expect(mocks.toastError).toHaveBeenCalledWith('Failed to build transaction')
+  })
+
+  it('requires a reviewed plan and simulates the final standard borrow plan before execution', async () => {
+    const preparedPlan = reviewPlan('reviewed borrow')
+    const executionPlan = reviewPlan('execution borrow')
+    mocks.buildBorrowPlan
+      .mockResolvedValueOnce(preparedPlan)
+      .mockResolvedValueOnce(executionPlan)
+    const borrow = createBorrowForm()
+
+    await borrow.submit()
+    const props = mocks.modalOpen.mock.calls[0][1].props
+    borrow.collateralAmount.value = '5'
+    borrow.borrowAmount.value = '5'
+    await props.onConfirm()
+
+    expect(props.plan).toStrictEqual(preparedPlan)
+    expect(props.requirePlanForConfirm).toBe(true)
+    expect(mocks.buildBorrowPlan).toHaveBeenNthCalledWith(
+      2,
+      COLLATERAL_VAULT,
+      mocks.collateralVault.asset.address,
+      1_000_000n,
+      BORROW_VAULT,
+      1_000_000n,
+      undefined,
+      { includePermit2Call: true, wrappedNativeInfo: undefined },
+    )
+    expect(mocks.runSimulation).toHaveBeenNthCalledWith(1, preparedPlan)
+    expect(mocks.runSimulation).toHaveBeenNthCalledWith(2, executionPlan)
+    expect(mocks.executeTxPlan).toHaveBeenCalledWith(executionPlan)
+  })
+
+  it('does not execute when confirmation is missing the reviewed plan', async () => {
+    const borrow = createBorrowForm()
+
+    await borrow.send()
+
+    expect(mocks.executeTxPlan).not.toHaveBeenCalled()
+    expect(mocks.toastError).toHaveBeenCalledWith('Transaction review expired')
+  })
+
+  it('does not execute when confirmation uses a stale reviewed plan', async () => {
+    const stalePlan = reviewPlan('stale borrow')
+    const currentPlan = reviewPlan('current borrow')
+    const borrow = createBorrowForm()
+    borrow.plan.value = currentPlan
+
+    await borrow.send(stalePlan, async () => reviewPlan('execution borrow'))
+
+    expect(mocks.executeTxPlan).not.toHaveBeenCalled()
+    expect(mocks.toastError).toHaveBeenCalledWith('Transaction review expired')
+  })
+
+  it('does not open review when swap-borrow plan preparation fails', async () => {
+    mocks.swapEffectiveQuote = quote
+    mocks.buildSwapAndBorrowPlan.mockRejectedValueOnce(new Error('prepare failed'))
+    const borrow = createBorrowForm()
+    borrow.onSelectBorrowSwapAsset(mocks.walletAsset as unknown as VaultAsset)
+
+    await borrow.submit()
+
+    expect(mocks.modalOpen).not.toHaveBeenCalled()
+    expect(mocks.runSimulation).not.toHaveBeenCalled()
+    expect(mocks.executeTxPlan).not.toHaveBeenCalled()
+    expect(mocks.toastError).toHaveBeenCalledWith('Failed to build transaction')
+  })
+})


### PR DESCRIPTION
## Summary
- Borrow review requires a prepared transaction plan before confirmation.
- Borrow execution is rebuilt from the reviewed inputs and simulated immediately before submission, keeping the signed transaction tied to the reviewed state.
- The review modal supports opt-in plan-required confirmation without changing unrelated modal flows.

## Changes
- Capture review-time borrow and swap-borrow inputs, including amounts, vaults, quote, slippage, subaccount, and native-wrap details.
- Stop opening borrow review when plan preparation fails and surface a transaction-build error.
- Add focused composable tests for failed preparation, missing/stale reviewed plans, and final execution using reviewed amounts.

## Test plan
- [x] npm run test:run -- tests/composables/useBorrowForm.test.ts
- [x] npm run lint
- [x] npm run typecheck
- [x] Local smoke test: booted Nuxt dev server, opened Explore/Borrow/borrow-pair routes, checked for browser console errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Borrow form submission now uses review snapshots to maintain transaction consistency between initial review and final confirmation execution.
  * Operation review modal now supports optional plan step validation, preventing confirmation when required plan data is absent.

* **Tests**
  * Added comprehensive test suite for borrow form review flow, covering plan preparation failures, transaction simulation validation, and confirmation behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/euler-xyz/euler-lite/pull/428)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->