### PR TITLE
Fix swap quote context validation

### DIFF
--- a/composables/useEulerOperations/swaps/supply-borrow.ts
+++ b/composables/useEulerOperations/swaps/supply-borrow.ts
@@ -1,4 +1,4 @@
-import type { Address, Hash } from 'viem'
+import { zeroAddress, type Address, type Hash } from 'viem'
 import { encodeFunctionData } from 'viem'
 import type { OperationsContext, OperationHelpers } from '../types'
 import { buildSwapVerifierData } from './verify'
@@ -12,18 +12,30 @@ import { buildCollateralCleanupCalls } from '~/utils/collateral-cleanup'
 import type { TxPlan } from '~/entities/txPlan'
 import { type SwapApiQuote, SwapperMode, SwapVerificationType } from '~/entities/swap'
 import { logWarn } from '~/utils/errorHandling'
-import { assertSwapperVerifierAllowed } from '~/utils/swap-validation'
+import { assertSwapQuoteMatchesContext } from '~/utils/swap-validation'
 
 export const createSupplyBorrowSwapBuilders = (
   ctx: OperationsContext,
   helpers: OperationHelpers,
 ) => {
+  const getVaultAssetAddress = (vaultAddress: Address): Address => {
+    const vault = ctx.registryGetVault(vaultAddress)
+    const assetAddress = vault?.asset?.address
+    if (!assetAddress) {
+      throw new Error('Vault asset not available for swap quote validation')
+    }
+    return assetAddress as Address
+  }
+
   /**
    * Swap an arbitrary token from the user's wallet and deposit the output into a vault.
    */
   const buildSwapAndSupplyPlan = async ({
     inputTokenAddress,
     inputAmount,
+    outputVaultAddress,
+    outputTokenAddress,
+    accountOut,
     quote,
     requestedSlippage,
     includePermit2Call = true,
@@ -31,6 +43,9 @@ export const createSupplyBorrowSwapBuilders = (
   }: {
     inputTokenAddress: Address
     inputAmount: bigint
+    outputVaultAddress: Address
+    outputTokenAddress: Address
+    accountOut?: Address
     quote: SwapApiQuote
     requestedSlippage: number
     includePermit2Call?: boolean
@@ -42,8 +57,31 @@ export const createSupplyBorrowSwapBuilders = (
 
     const userAddr = ctx.address.value as Address
     const swapVerifierAddress = ctx.eulerPeripheryAddresses.value.swapVerifier as Address
+    const swapperAddress = ctx.eulerPeripheryAddresses.value.swapper as Address
+    const accountOutAddr = (accountOut || userAddr) as Address
 
-    assertSwapperVerifierAllowed(quote.verify.verifierAddress, ctx.eulerPeripheryAddresses.value.swapVerifier)
+    assertSwapQuoteMatchesContext(quote, {
+      knownSwapVerifier: swapVerifierAddress,
+      knownSwapper: swapperAddress,
+      verificationType: SwapVerificationType.SkimMin,
+      swapperMode: SwapperMode.EXACT_IN,
+      isRepay: false,
+      tokenIn: inputTokenAddress,
+      tokenOut: outputTokenAddress,
+      accountIn: zeroAddress,
+      accountOut: accountOutAddr,
+      vaultIn: zeroAddress,
+      receiver: outputVaultAddress,
+      verifierVault: outputVaultAddress,
+      verifierAccount: accountOutAddr,
+      amountIn: inputAmount,
+    })
+
+    const verifierData = buildSwapVerifierData({ quote, swapperMode: SwapperMode.EXACT_IN, isRepay: false, requestedSlippage })
+    if (verifierData.toLowerCase() !== quote.verify.verifierData.toLowerCase()) {
+      logWarn('swap-supply', 'SwapVerifier data mismatch')
+      throw new Error('SwapVerifier data mismatch')
+    }
 
     const { steps, permitCall, usesPermit2 } = await helpers.prepareTokenApproval({
       assetAddr: inputTokenAddress,
@@ -55,7 +93,7 @@ export const createSupplyBorrowSwapBuilders = (
 
     const hooks = new SaHooksBuilder()
     hooks.addContractInterface(swapVerifierAddress, [...transferFromSenderAbi, ...swapVerifierAbi])
-    hooks.addContractInterface(quote.swap.swapperAddress, swapperAbi)
+    hooks.addContractInterface(swapperAddress, swapperAbi)
 
     const evcCalls: EVCCall[] = []
 
@@ -77,12 +115,12 @@ export const createSupplyBorrowSwapBuilders = (
       targetContract: swapVerifierAddress,
       onBehalfOfAccount: userAddr,
       value: 0n,
-      data: hooks.getDataForCall(swapVerifierAddress, 'transferFromSender', [inputTokenAddress, inputAmount, quote.swap.swapperAddress]) as Hash,
+      data: hooks.getDataForCall(swapVerifierAddress, 'transferFromSender', [inputTokenAddress, inputAmount, swapperAddress]) as Hash,
     })
 
     // Swapper multicall
     evcCalls.push({
-      targetContract: quote.swap.swapperAddress,
+      targetContract: swapperAddress,
       onBehalfOfAccount: userAddr,
       value: 0n,
       data: encodeFunctionData({
@@ -92,20 +130,9 @@ export const createSupplyBorrowSwapBuilders = (
       }),
     })
 
-    // Verify min output and skim into vault
-    if (quote.verify.type !== SwapVerificationType.SkimMin) {
-      throw new Error('Swap verifier type mismatch')
-    }
-
-    const verifierData = buildSwapVerifierData({ quote, swapperMode: SwapperMode.EXACT_IN, isRepay: false, requestedSlippage })
-    if (verifierData.toLowerCase() !== quote.verify.verifierData.toLowerCase()) {
-      logWarn('swap-supply', 'SwapVerifier data mismatch')
-      throw new Error('SwapVerifier data mismatch')
-    }
-
     evcCalls.push({
-      targetContract: quote.verify.verifierAddress,
-      onBehalfOfAccount: quote.verify.account,
+      targetContract: swapVerifierAddress,
+      onBehalfOfAccount: accountOutAddr,
       value: 0n,
       data: verifierData,
     })
@@ -154,10 +181,33 @@ export const createSupplyBorrowSwapBuilders = (
     const userAddr = ctx.address.value as Address
     const evcAddress = ctx.eulerCoreAddresses.value.evc as Address
     const swapVerifierAddress = ctx.eulerPeripheryAddresses.value.swapVerifier as Address
-
-    assertSwapperVerifierAllowed(swapQuote.verify.verifierAddress, ctx.eulerPeripheryAddresses.value.swapVerifier)
+    const swapperAddress = ctx.eulerPeripheryAddresses.value.swapper as Address
 
     const subAccountAddr = (subAccount || await getNewSubAccount(ctx.address.value)) as Address
+    const collateralTokenAddress = getVaultAssetAddress(collateralVaultAddress)
+
+    assertSwapQuoteMatchesContext(swapQuote, {
+      knownSwapVerifier: swapVerifierAddress,
+      knownSwapper: swapperAddress,
+      verificationType: SwapVerificationType.SkimMin,
+      swapperMode: SwapperMode.EXACT_IN,
+      isRepay: false,
+      tokenIn: inputTokenAddress,
+      tokenOut: collateralTokenAddress,
+      accountIn: zeroAddress,
+      accountOut: subAccountAddr,
+      vaultIn: zeroAddress,
+      receiver: collateralVaultAddress,
+      verifierVault: collateralVaultAddress,
+      verifierAccount: subAccountAddr,
+      amountIn: inputAmount,
+    })
+
+    const verifierData = buildSwapVerifierData({ quote: swapQuote, swapperMode: SwapperMode.EXACT_IN, isRepay: false, requestedSlippage })
+    if (verifierData.toLowerCase() !== swapQuote.verify.verifierData.toLowerCase()) {
+      logWarn('swap-borrow', 'SwapVerifier data mismatch')
+      throw new Error('SwapVerifier data mismatch')
+    }
 
     const { steps, permitCall, usesPermit2 } = await helpers.prepareTokenApproval({
       assetAddr: inputTokenAddress,
@@ -169,7 +219,7 @@ export const createSupplyBorrowSwapBuilders = (
 
     const hooks = new SaHooksBuilder()
     hooks.addContractInterface(swapVerifierAddress, [...transferFromSenderAbi, ...swapVerifierAbi])
-    hooks.addContractInterface(swapQuote.swap.swapperAddress, swapperAbi)
+    hooks.addContractInterface(swapperAddress, swapperAbi)
     hooks.addContractInterface(evcAddress, [...evcEnableControllerAbi, ...evcEnableCollateralAbi])
     hooks.addContractInterface(borrowVaultAddress, vaultBorrowAbi)
 
@@ -193,12 +243,12 @@ export const createSupplyBorrowSwapBuilders = (
       targetContract: swapVerifierAddress,
       onBehalfOfAccount: userAddr,
       value: 0n,
-      data: hooks.getDataForCall(swapVerifierAddress, 'transferFromSender', [inputTokenAddress, inputAmount, swapQuote.swap.swapperAddress]) as Hash,
+      data: hooks.getDataForCall(swapVerifierAddress, 'transferFromSender', [inputTokenAddress, inputAmount, swapperAddress]) as Hash,
     })
 
     // Swapper multicall
     evcCalls.push({
-      targetContract: swapQuote.swap.swapperAddress,
+      targetContract: swapperAddress,
       onBehalfOfAccount: userAddr,
       value: 0n,
       data: encodeFunctionData({
@@ -208,20 +258,9 @@ export const createSupplyBorrowSwapBuilders = (
       }),
     })
 
-    // Verify min output and skim into collateral vault
-    if (swapQuote.verify.type !== SwapVerificationType.SkimMin) {
-      throw new Error('Swap verifier type mismatch')
-    }
-
-    const verifierData = buildSwapVerifierData({ quote: swapQuote, swapperMode: SwapperMode.EXACT_IN, isRepay: false, requestedSlippage })
-    if (verifierData.toLowerCase() !== swapQuote.verify.verifierData.toLowerCase()) {
-      logWarn('swap-borrow', 'SwapVerifier data mismatch')
-      throw new Error('SwapVerifier data mismatch')
-    }
-
     evcCalls.push({
-      targetContract: swapQuote.verify.verifierAddress,
-      onBehalfOfAccount: swapQuote.verify.account,
+      targetContract: swapVerifierAddress,
+      onBehalfOfAccount: subAccountAddr,
       value: 0n,
       data: verifierData,
     })
@@ -283,6 +322,7 @@ export const createSupplyBorrowSwapBuilders = (
   const buildWithdrawAndSwapPlan = async ({
     vaultAddress: vaultAddr,
     assetsAmount,
+    outputTokenAddress,
     quote,
     requestedSlippage,
     subAccount,
@@ -290,6 +330,7 @@ export const createSupplyBorrowSwapBuilders = (
   }: {
     vaultAddress: Address
     assetsAmount: bigint
+    outputTokenAddress: Address
     quote: SwapApiQuote
     requestedSlippage: number
     subAccount?: string
@@ -301,9 +342,32 @@ export const createSupplyBorrowSwapBuilders = (
 
     const userAddr = ctx.address.value as Address
     const withdrawFromAddr = subAccount ? (subAccount as Address) : userAddr
-    const swapperAddress = quote.swap.swapperAddress as Address
+    const swapVerifierAddress = ctx.eulerPeripheryAddresses.value.swapVerifier as Address
+    const swapperAddress = ctx.eulerPeripheryAddresses.value.swapper as Address
+    const inputTokenAddress = getVaultAssetAddress(vaultAddr)
 
-    assertSwapperVerifierAllowed(quote.verify.verifierAddress, ctx.eulerPeripheryAddresses.value.swapVerifier)
+    assertSwapQuoteMatchesContext(quote, {
+      knownSwapVerifier: swapVerifierAddress,
+      knownSwapper: swapperAddress,
+      verificationType: SwapVerificationType.TransferMin,
+      swapperMode: SwapperMode.EXACT_IN,
+      isRepay: false,
+      tokenIn: inputTokenAddress,
+      tokenOut: outputTokenAddress,
+      accountIn: withdrawFromAddr,
+      accountOut: zeroAddress,
+      vaultIn: vaultAddr,
+      receiver: userAddr,
+      verifierVault: userAddr,
+      verifierAccount: userAddr,
+      amountIn: assetsAmount,
+    })
+
+    const verifierData = buildSwapVerifierData({ quote, swapperMode: SwapperMode.EXACT_IN, isRepay: false, requestedSlippage })
+    if (verifierData.toLowerCase() !== quote.verify.verifierData.toLowerCase()) {
+      logWarn('swap-withdraw', 'SwapVerifier data mismatch')
+      throw new Error('SwapVerifier data mismatch')
+    }
 
     const hooks = new SaHooksBuilder()
     hooks.addContractInterface(vaultAddr, vaultWithdrawAbi)
@@ -323,7 +387,7 @@ export const createSupplyBorrowSwapBuilders = (
     // Swapper multicall
     evcCalls.push({
       targetContract: swapperAddress,
-      onBehalfOfAccount: quote.accountIn as Address,
+      onBehalfOfAccount: withdrawFromAddr,
       value: 0n,
       data: encodeFunctionData({
         abi: swapperAbi,
@@ -332,19 +396,8 @@ export const createSupplyBorrowSwapBuilders = (
       }),
     })
 
-    // Verify min output
-    if (quote.verify.type !== SwapVerificationType.TransferMin) {
-      throw new Error('Swap verifier type mismatch')
-    }
-
-    const verifierData = buildSwapVerifierData({ quote, swapperMode: SwapperMode.EXACT_IN, isRepay: false, requestedSlippage })
-    if (verifierData.toLowerCase() !== quote.verify.verifierData.toLowerCase()) {
-      logWarn('swap-withdraw', 'SwapVerifier data mismatch')
-      throw new Error('SwapVerifier data mismatch')
-    }
-
     evcCalls.push({
-      targetContract: quote.verify.verifierAddress,
+      targetContract: swapVerifierAddress,
       onBehalfOfAccount: userAddr,
       value: 0n,
       data: verifierData,
@@ -373,6 +426,8 @@ export const createSupplyBorrowSwapBuilders = (
   const buildRedeemAndSwapPlan = async ({
     vaultAddress: vaultAddr,
     sharesAmount,
+    assetsAmount,
+    outputTokenAddress,
     quote,
     requestedSlippage,
     subAccount,
@@ -380,6 +435,8 @@ export const createSupplyBorrowSwapBuilders = (
   }: {
     vaultAddress: Address
     sharesAmount: bigint
+    assetsAmount: bigint
+    outputTokenAddress: Address
     quote: SwapApiQuote
     requestedSlippage: number
     subAccount?: string
@@ -391,9 +448,32 @@ export const createSupplyBorrowSwapBuilders = (
 
     const userAddr = ctx.address.value as Address
     const redeemFromAddr = subAccount ? (subAccount as Address) : userAddr
-    const swapperAddress = quote.swap.swapperAddress as Address
+    const swapVerifierAddress = ctx.eulerPeripheryAddresses.value.swapVerifier as Address
+    const swapperAddress = ctx.eulerPeripheryAddresses.value.swapper as Address
+    const inputTokenAddress = getVaultAssetAddress(vaultAddr)
 
-    assertSwapperVerifierAllowed(quote.verify.verifierAddress, ctx.eulerPeripheryAddresses.value.swapVerifier)
+    assertSwapQuoteMatchesContext(quote, {
+      knownSwapVerifier: swapVerifierAddress,
+      knownSwapper: swapperAddress,
+      verificationType: SwapVerificationType.TransferMin,
+      swapperMode: SwapperMode.EXACT_IN,
+      isRepay: false,
+      tokenIn: inputTokenAddress,
+      tokenOut: outputTokenAddress,
+      accountIn: redeemFromAddr,
+      accountOut: zeroAddress,
+      vaultIn: vaultAddr,
+      receiver: userAddr,
+      verifierVault: userAddr,
+      verifierAccount: userAddr,
+      amountIn: assetsAmount,
+    })
+
+    const redeemVerifierData = buildSwapVerifierData({ quote, swapperMode: SwapperMode.EXACT_IN, isRepay: false, requestedSlippage })
+    if (redeemVerifierData.toLowerCase() !== quote.verify.verifierData.toLowerCase()) {
+      logWarn('swap-redeem', 'SwapVerifier data mismatch')
+      throw new Error('SwapVerifier data mismatch')
+    }
 
     const hooks = new SaHooksBuilder()
     hooks.addContractInterface(vaultAddr, vaultRedeemAbi)
@@ -413,7 +493,7 @@ export const createSupplyBorrowSwapBuilders = (
     // Swapper multicall
     evcCalls.push({
       targetContract: swapperAddress,
-      onBehalfOfAccount: quote.accountIn as Address,
+      onBehalfOfAccount: redeemFromAddr,
       value: 0n,
       data: encodeFunctionData({
         abi: swapperAbi,
@@ -422,19 +502,8 @@ export const createSupplyBorrowSwapBuilders = (
       }),
     })
 
-    // Verify min output
-    if (quote.verify.type !== SwapVerificationType.TransferMin) {
-      throw new Error('Swap verifier type mismatch')
-    }
-
-    const redeemVerifierData = buildSwapVerifierData({ quote, swapperMode: SwapperMode.EXACT_IN, isRepay: false, requestedSlippage })
-    if (redeemVerifierData.toLowerCase() !== quote.verify.verifierData.toLowerCase()) {
-      logWarn('swap-redeem', 'SwapVerifier data mismatch')
-      throw new Error('SwapVerifier data mismatch')
-    }
-
     evcCalls.push({
-      targetContract: quote.verify.verifierAddress,
+      targetContract: swapVerifierAddress,
       onBehalfOfAccount: userAddr,
       value: 0n,
       data: redeemVerifierData,
@@ -497,13 +566,26 @@ export const createSupplyBorrowSwapBuilders = (
     const userAddr = ctx.address.value as Address
     const evcAddress = ctx.eulerCoreAddresses.value.evc as Address
     const swapVerifierAddress = ctx.eulerPeripheryAddresses.value.swapVerifier as Address
+    const swapperAddress = ctx.eulerPeripheryAddresses.value.swapper as Address
     const borrowVaultAddr = borrowVaultAddress
+    const borrowTokenAddress = getVaultAssetAddress(borrowVaultAddr)
 
-    assertSwapperVerifierAllowed(quote.verify.verifierAddress, ctx.eulerPeripheryAddresses.value.swapVerifier)
-
-    if (quote.verify.type !== SwapVerificationType.DebtMax) {
-      throw new Error('Swap verifier type mismatch')
-    }
+    assertSwapQuoteMatchesContext(quote, {
+      knownSwapVerifier: swapVerifierAddress,
+      knownSwapper: swapperAddress,
+      verificationType: SwapVerificationType.DebtMax,
+      swapperMode,
+      isRepay: true,
+      tokenIn: inputTokenAddress,
+      tokenOut: borrowTokenAddress,
+      accountIn: zeroAddress,
+      accountOut: subAccount,
+      vaultIn: zeroAddress,
+      receiver: borrowVaultAddr,
+      verifierVault: borrowVaultAddr,
+      verifierAccount: subAccount,
+      amountIn: swapperMode === SwapperMode.EXACT_IN ? inputAmount : undefined,
+    })
 
     const verifierData = buildSwapVerifierData({ quote, swapperMode, isRepay: true, requestedSlippage, targetDebt, currentDebt })
     if (verifierData.toLowerCase() !== quote.verify.verifierData.toLowerCase()) {
@@ -521,7 +603,7 @@ export const createSupplyBorrowSwapBuilders = (
 
     const hooks = new SaHooksBuilder()
     hooks.addContractInterface(swapVerifierAddress, [...transferFromSenderAbi, ...swapVerifierAbi])
-    hooks.addContractInterface(quote.swap.swapperAddress, swapperAbi)
+    hooks.addContractInterface(swapperAddress, swapperAbi)
 
     if (isFullRepay) {
       hooks.addContractInterface(borrowVaultAddr, evcDisableControllerAbi)
@@ -552,12 +634,12 @@ export const createSupplyBorrowSwapBuilders = (
       targetContract: swapVerifierAddress,
       onBehalfOfAccount: userAddr,
       value: 0n,
-      data: hooks.getDataForCall(swapVerifierAddress, 'transferFromSender', [inputTokenAddress, inputAmount, quote.swap.swapperAddress]) as Hash,
+      data: hooks.getDataForCall(swapVerifierAddress, 'transferFromSender', [inputTokenAddress, inputAmount, swapperAddress]) as Hash,
     })
 
     // Swapper multicall
     evcCalls.push({
-      targetContract: quote.swap.swapperAddress,
+      targetContract: swapperAddress,
       onBehalfOfAccount: userAddr,
       value: 0n,
       data: encodeFunctionData({
@@ -569,8 +651,8 @@ export const createSupplyBorrowSwapBuilders = (
 
     // Verify debt max — handles skim + repay internally
     evcCalls.push({
-      targetContract: quote.verify.verifierAddress,
-      onBehalfOfAccount: quote.verify.account,
+      targetContract: swapVerifierAddress,
+      onBehalfOfAccount: subAccount,
       value: 0n,
       data: verifierData,
     })

--- a/pages/lend/[vault]/[subAccount]/withdraw.vue
+++ b/pages/lend/[vault]/[subAccount]/withdraw.vue
@@ -357,6 +357,8 @@ const submit = async () => {
             plan.value = await buildRedeemAndSwapPlan({
               vaultAddress: vaultAddress as Address,
               sharesAmount: sharesBalance.value,
+              assetsAmount: assetsBalance.value,
+              outputTokenAddress: selectedOutputAsset.value!.address as Address,
               quote: swapSelectedQuote.value,
               requestedSlippage: swapSlippage.value,
               subAccount: subAccount.value,
@@ -366,6 +368,7 @@ const submit = async () => {
             plan.value = await buildWithdrawAndSwapPlan({
               vaultAddress: vaultAddress as Address,
               assetsAmount: amountFixed.value.value,
+              outputTokenAddress: selectedOutputAsset.value!.address as Address,
               quote: swapSelectedQuote.value,
               requestedSlippage: swapSlippage.value,
               subAccount: subAccount.value,
@@ -428,6 +431,8 @@ const send = async () => {
         txPlan = await buildRedeemAndSwapPlan({
           vaultAddress: vaultAddress as Address,
           sharesAmount: sharesBalance.value,
+          assetsAmount: assetsBalance.value,
+          outputTokenAddress: selectedOutputAsset.value!.address as Address,
           quote,
           requestedSlippage: swapSlippage.value,
           subAccount: subAccount.value,
@@ -437,6 +442,7 @@ const send = async () => {
         txPlan = await buildWithdrawAndSwapPlan({
           vaultAddress: vaultAddress as Address,
           assetsAmount: amountFixed.value.value,
+          outputTokenAddress: selectedOutputAsset.value!.address as Address,
           quote,
           requestedSlippage: swapSlippage.value,
           subAccount: subAccount.value,

--- a/pages/lend/[vault]/index.vue
+++ b/pages/lend/[vault]/index.vue
@@ -387,7 +387,7 @@ const load = async () => {
 }
 
 const buildSwapSupplyPlanFromQuote = async (quote: SwapApiQuote, options: { includePermit2Call?: boolean } = {}): Promise<TxPlan> => {
-  if (!selectedAsset.value) {
+  if (!selectedAsset.value || !asset.value) {
     throw new Error('No selected asset')
   }
   const isNative = isNativeCurrencyAddress(selectedAsset.value.address)
@@ -399,6 +399,8 @@ const buildSwapSupplyPlanFromQuote = async (quote: SwapApiQuote, options: { incl
   return buildSwapAndSupplyPlan({
     inputTokenAddress: (wrappedAddress || selectedAsset.value.address) as Address,
     inputAmount,
+    outputVaultAddress: vaultAddress as Address,
+    outputTokenAddress: asset.value.address as Address,
     quote,
     requestedSlippage: swapSlippage.value,
     includePermit2Call: options.includePermit2Call,

--- a/pages/position/[number]/supply.vue
+++ b/pages/position/[number]/supply.vue
@@ -96,8 +96,8 @@ const form = useCollateralForm({
     })
   },
 
-  buildSwapPlan: async (quote: SwapApiQuote, { slippage, includePermit2Call }) => {
-    if (!selectedAsset.value || !form.collateralVault.value) {
+  buildSwapPlan: async (quote: SwapApiQuote, { vaultAddress, slippage, subAccount, includePermit2Call }) => {
+    if (!selectedAsset.value || !form.asset.value || !form.collateralVault.value) {
       throw new Error('No selected asset or vault')
     }
     const isNative = isNativeCurrencyAddress(selectedAsset.value.address)
@@ -109,6 +109,9 @@ const form = useCollateralForm({
     return buildSwapAndSupplyPlan({
       inputTokenAddress: (wrappedAddress || selectedAsset.value.address) as Address,
       inputAmount,
+      outputVaultAddress: vaultAddress as Address,
+      outputTokenAddress: form.asset.value.address as Address,
+      accountOut: subAccount ? (subAccount as Address) : undefined,
       quote,
       requestedSlippage: slippage,
       includePermit2Call,

--- a/pages/position/[number]/withdraw.vue
+++ b/pages/position/[number]/withdraw.vue
@@ -95,10 +95,14 @@ const form = useCollateralForm({
   },
 
   buildSwapPlan: async (quote: SwapApiQuote, { vaultAddress, amountNano, slippage, subAccount }) => {
+    if (!selectedOutputAsset.value) {
+      throw new Error('No selected output asset')
+    }
     const hasBorrows = (form.position.value?.borrowed || 0n) > 0n
     return buildWithdrawAndSwapPlan({
       vaultAddress: vaultAddress as Address,
       assetsAmount: amountNano,
+      outputTokenAddress: selectedOutputAsset.value.address as Address,
       quote,
       requestedSlippage: slippage,
       subAccount,

--- a/tests/utils/swap-context-validation.test.ts
+++ b/tests/utils/swap-context-validation.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from 'vitest'
+import { zeroAddress, type Address } from 'viem'
+import { type SwapApiQuote, SwapperMode, SwapVerificationType } from '~/entities/swap'
+import { assertSwapQuoteMatchesContext } from '~/utils/swap-validation'
+
+const KNOWN_VERIFIER = '0x0000000000000000000000000000000000000001' as Address
+const KNOWN_SWAPPER = '0x0000000000000000000000000000000000000002' as Address
+const TOKEN_IN = '0x0000000000000000000000000000000000000003' as Address
+const TOKEN_OUT = '0x0000000000000000000000000000000000000004' as Address
+const ACCOUNT_OUT = '0x0000000000000000000000000000000000000005' as Address
+const RECEIVER = '0x0000000000000000000000000000000000000006' as Address
+const OTHER = '0x0000000000000000000000000000000000000007' as Address
+
+const makeQuote = (overrides: Partial<SwapApiQuote> = {}): SwapApiQuote => ({
+  amountIn: '1000',
+  amountInMax: '1000',
+  amountOut: '950',
+  amountOutMin: '945',
+  accountIn: zeroAddress,
+  accountOut: ACCOUNT_OUT,
+  vaultIn: zeroAddress,
+  receiver: RECEIVER,
+  tokenIn: {
+    address: TOKEN_IN,
+    chainId: 1,
+    decimals: 18,
+    logoURI: '',
+    name: 'Token In',
+    symbol: 'TIN',
+  },
+  tokenOut: {
+    address: TOKEN_OUT,
+    chainId: 1,
+    decimals: 18,
+    logoURI: '',
+    name: 'Token Out',
+    symbol: 'TOUT',
+  },
+  slippage: 0.5,
+  swap: {
+    swapperAddress: KNOWN_SWAPPER,
+    swapperData: '0x',
+    multicallItems: [],
+  },
+  verify: {
+    verifierAddress: KNOWN_VERIFIER,
+    verifierData: '0x',
+    type: SwapVerificationType.SkimMin,
+    vault: RECEIVER,
+    account: ACCOUNT_OUT,
+    amount: '945',
+    deadline: 123,
+  },
+  route: [{ providerName: 'test' }],
+  ...overrides,
+}) as SwapApiQuote
+
+const expectedContext = {
+  knownSwapVerifier: KNOWN_VERIFIER,
+  knownSwapper: KNOWN_SWAPPER,
+  verificationType: SwapVerificationType.SkimMin,
+  swapperMode: SwapperMode.EXACT_IN,
+  isRepay: false,
+  tokenIn: TOKEN_IN,
+  tokenOut: TOKEN_OUT,
+  accountIn: zeroAddress,
+  accountOut: ACCOUNT_OUT,
+  vaultIn: zeroAddress,
+  receiver: RECEIVER,
+  verifierVault: RECEIVER,
+  verifierAccount: ACCOUNT_OUT,
+  amountIn: 1000n,
+}
+
+describe('swap quote context validation', () => {
+  it('accepts a quote bound to the expected operation context', () => {
+    expect(() => assertSwapQuoteMatchesContext(makeQuote(), expectedContext)).not.toThrow()
+  })
+
+  it('rejects quote-controlled swapper changes', () => {
+    expect(() =>
+      assertSwapQuoteMatchesContext(makeQuote({
+        swap: {
+          swapperAddress: OTHER,
+          swapperData: '0x',
+          multicallItems: [],
+        },
+      }), expectedContext),
+    ).toThrow('Swap quote swapper address mismatch')
+  })
+
+  it('rejects quote-controlled verifier changes', () => {
+    expect(() =>
+      assertSwapQuoteMatchesContext(makeQuote({
+        verify: {
+          ...makeQuote().verify,
+          verifierAddress: OTHER,
+        },
+      }), expectedContext),
+    ).toThrow('Unknown swap verifier address')
+  })
+
+  it('rejects verifier payload target mismatches', () => {
+    expect(() =>
+      assertSwapQuoteMatchesContext(makeQuote({
+        verify: {
+          ...makeQuote().verify,
+          vault: OTHER,
+        },
+      }), expectedContext),
+    ).toThrow('Swap quote verifier vault mismatch')
+
+    expect(() =>
+      assertSwapQuoteMatchesContext(makeQuote({
+        verify: {
+          ...makeQuote().verify,
+          account: OTHER,
+        },
+      }), expectedContext),
+    ).toThrow('Swap quote verifier account mismatch')
+  })
+
+  it('rejects account, receiver, token, and amount mismatches', () => {
+    expect(() => assertSwapQuoteMatchesContext(makeQuote({ accountOut: OTHER }), expectedContext))
+      .toThrow('Swap quote accountOut mismatch')
+
+    expect(() => assertSwapQuoteMatchesContext(makeQuote({ receiver: OTHER }), expectedContext))
+      .toThrow('Swap quote receiver mismatch')
+
+    expect(() =>
+      assertSwapQuoteMatchesContext(makeQuote({
+        tokenOut: {
+          ...makeQuote().tokenOut,
+          address: OTHER,
+        },
+      }), expectedContext),
+    ).toThrow('Swap quote tokenOut mismatch')
+
+    expect(() => assertSwapQuoteMatchesContext(makeQuote({ amountIn: '999' }), expectedContext))
+      .toThrow('Swap quote amountIn mismatch')
+  })
+
+  it('rejects swap mode and repay context mismatches', () => {
+    expect(() =>
+      assertSwapQuoteMatchesContext(makeQuote({
+        verify: {
+          ...makeQuote().verify,
+          type: SwapVerificationType.TransferMin,
+        },
+      }), expectedContext),
+    ).toThrow('Swap verifier type mismatch')
+
+    expect(() =>
+      assertSwapQuoteMatchesContext(makeQuote({
+        verify: {
+          ...makeQuote().verify,
+          type: SwapVerificationType.DebtMax,
+        },
+      }), {
+        ...expectedContext,
+        verificationType: SwapVerificationType.DebtMax,
+      }),
+    ).toThrow('Swap quote repay mode mismatch')
+  })
+})

--- a/utils/swap-validation.ts
+++ b/utils/swap-validation.ts
@@ -1,3 +1,7 @@
+import type { Address } from 'viem'
+import { type SwapApiQuote, SwapperMode, SwapVerificationType } from '~/entities/swap'
+import { normalizeAddress } from '~/utils/normalizeAddress'
+
 export function assertSwapperVerifierAllowed(
   swapVerifierAddress: string,
   knownSwapVerifier: string | undefined,
@@ -9,5 +13,89 @@ export function assertSwapperVerifierAllowed(
     throw new Error(
       `Unknown swap verifier address: ${swapVerifierAddress}. Expected: ${knownSwapVerifier}`,
     )
+  }
+}
+
+export interface SwapQuoteExpectedContext {
+  knownSwapVerifier: string | undefined
+  knownSwapper: string | undefined
+  verificationType: SwapVerificationType
+  swapperMode: SwapperMode
+  isRepay: boolean
+  tokenIn?: Address
+  tokenOut?: Address
+  accountIn?: Address
+  accountOut?: Address
+  vaultIn?: Address
+  receiver?: Address
+  verifierVault?: Address
+  verifierAccount?: Address
+  amountIn?: bigint
+}
+
+const getTokenAddress = (quote: SwapApiQuote, side: 'tokenIn' | 'tokenOut') =>
+  quote[side].address || quote[side].addressInfo
+
+const assertAddressEqual = (
+  label: string,
+  actual: string | undefined,
+  expected: string | undefined,
+) => {
+  if (!expected) return
+  if (!actual) {
+    throw new Error(`Swap quote ${label} missing`)
+  }
+  if (normalizeAddress(actual).toLowerCase() !== normalizeAddress(expected).toLowerCase()) {
+    throw new Error(`Swap quote ${label} mismatch`)
+  }
+}
+
+const assertAmountEqual = (
+  label: string,
+  actual: string | undefined,
+  expected: bigint | undefined,
+) => {
+  if (expected === undefined) return
+  if (actual === undefined || actual === '') {
+    throw new Error(`Swap quote ${label} missing`)
+  }
+  if (BigInt(actual) !== expected) {
+    throw new Error(`Swap quote ${label} mismatch`)
+  }
+}
+
+export function assertSwapQuoteMatchesContext(
+  quote: SwapApiQuote,
+  expected: SwapQuoteExpectedContext,
+): void {
+  assertSwapperVerifierAllowed(quote.verify.verifierAddress, expected.knownSwapVerifier)
+
+  if (!expected.knownSwapper) {
+    throw new Error('Known swapper address not configured')
+  }
+  assertAddressEqual('swapper address', quote.swap.swapperAddress, expected.knownSwapper)
+
+  if (quote.verify.type !== expected.verificationType) {
+    throw new Error('Swap verifier type mismatch')
+  }
+
+  assertAddressEqual('tokenIn', getTokenAddress(quote, 'tokenIn'), expected.tokenIn)
+  assertAddressEqual('tokenOut', getTokenAddress(quote, 'tokenOut'), expected.tokenOut)
+  assertAddressEqual('accountIn', quote.accountIn, expected.accountIn)
+  assertAddressEqual('accountOut', quote.accountOut, expected.accountOut)
+  assertAddressEqual('vaultIn', quote.vaultIn, expected.vaultIn)
+  assertAddressEqual('receiver', quote.receiver, expected.receiver)
+  assertAddressEqual('verifier vault', quote.verify.vault, expected.verifierVault)
+  assertAddressEqual('verifier account', quote.verify.account, expected.verifierAccount)
+
+  if (expected.swapperMode === SwapperMode.EXACT_IN) {
+    assertAmountEqual('amountIn', quote.amountIn, expected.amountIn)
+  }
+
+  if (expected.isRepay && quote.verify.type !== SwapVerificationType.DebtMax) {
+    throw new Error('Swap quote repay mode mismatch')
+  }
+  if (!expected.isRepay && quote.verify.type === SwapVerificationType.DebtMax) {
+    throw new Error('Swap quote repay mode mismatch')
   }
 }


### PR DESCRIPTION
## Summary
- Bind swap quotes to the operation context before EVC calls are generated, so quote-controlled vault, account, receiver, token, swapper, and verifier fields cannot drift from the intended transaction.
- Use configured periphery swapper/verifier addresses when constructing swap calls after validation.

## Changes
- Add shared swap quote context validation for configured swapper/verifier, token in/out, account in/out, vault/receiver, verifier payload fields, and exact input amounts.
- Apply validation across wallet supply, borrow with supplied collateral, withdraw/redeem with swap, and wallet repay swap builders.
- Pass trusted output vault/token and redeem asset amounts from page call sites into the builders.
- Cover quote-context mismatches with focused unit tests.

## Test plan
- [x] `npm run test:run -- tests/utils/swap-context-validation.test.ts tests/utils/swap-slippage-validation.test.ts`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] Local smoke: started Nuxt dev server and confirmed affected supply/withdraw/lend routes returned HTTP 200 without Nuxt error markers.
