### PR TITLE
fix: invert oracle price when label direction flips base/quote

### DIFF
--- a/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
@@ -55,8 +55,6 @@ const {
 } = useRewardsApy()
 const { oracleAdapters, loadAllOracleAdapters } = useEulerLabels()
 const { chainId } = useEulerAddresses()
-const { buildKnownSymbols, resolveSymbol: resolveTokenSymbol } = useTokenSymbolResolver()
-
 const hoveredCell = ref<{
   collateralAddr: string
   liabilityAddr: string
@@ -241,6 +239,8 @@ interface AdapterView {
   name: string
   base: Address
   quote: Address
+  metaBase?: Address
+  metaQuote?: Address
   provider: string
   methodology?: string
   logo?: string
@@ -261,6 +261,8 @@ const enrichAdapter = (adapter: OracleAdapterEntry): AdapterView => {
     name,
     base: adapter.base,
     quote: adapter.quote,
+    metaBase: meta?.base,
+    metaQuote: meta?.quote,
     provider,
     methodology: meta?.methodology || (isERC4626 ? 'Exchange Rate' : undefined),
     logo: getOracleProviderLogo(provider, name),
@@ -367,13 +369,11 @@ const tooltipPriceText = computed((): string | null => {
   const key = `${ctx.view.oracle.toLowerCase()}:${ctx.view.base.toLowerCase()}:${ctx.view.quote.toLowerCase()}`
   const info = oraclePrices.value.get(key)
   if (!info?.success) return null
-  const symbols = buildKnownSymbols()
   const invert = shouldInvertOraclePrice(
-    ctx.view.label?.primary,
+    ctx.view.metaBase,
+    ctx.view.metaQuote,
     ctx.view.base,
     ctx.view.quote,
-    resolveTokenSymbol(ctx.view.base, symbols),
-    resolveTokenSymbol(ctx.view.quote, symbols),
   )
   const rate = invert && info.rate > 0 ? 1 / info.rate : info.rate
   return formatNumber(rate, 4)

--- a/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
@@ -370,6 +370,8 @@ const tooltipPriceText = computed((): string | null => {
   const symbols = buildKnownSymbols()
   const invert = shouldInvertOraclePrice(
     ctx.view.label?.primary,
+    ctx.view.base,
+    ctx.view.quote,
     resolveTokenSymbol(ctx.view.base, symbols),
     resolveTokenSymbol(ctx.view.quote, symbols),
   )

--- a/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
@@ -55,6 +55,7 @@ const {
 } = useRewardsApy()
 const { oracleAdapters, loadAllOracleAdapters } = useEulerLabels()
 const { chainId } = useEulerAddresses()
+
 const hoveredCell = ref<{
   collateralAddr: string
   liabilityAddr: string
@@ -369,12 +370,12 @@ const tooltipPriceText = computed((): string | null => {
   const key = `${ctx.view.oracle.toLowerCase()}:${ctx.view.base.toLowerCase()}:${ctx.view.quote.toLowerCase()}`
   const info = oraclePrices.value.get(key)
   if (!info?.success) return null
-  const invert = shouldInvertOraclePrice(
-    ctx.view.metaBase,
-    ctx.view.metaQuote,
-    ctx.view.base,
-    ctx.view.quote,
-  )
+  const invert = shouldInvertOraclePrice({
+    metaBase: ctx.view.metaBase,
+    metaQuote: ctx.view.metaQuote,
+    callerBase: ctx.view.base,
+    callerQuote: ctx.view.quote,
+  })
   const rate = invert && info.rate > 0 ? 1 / info.rate : info.rate
   return formatNumber(rate, 4)
 })

--- a/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
@@ -29,6 +29,7 @@ import {
 import { getOracleProviderLogo } from '~/entities/oracle-providers'
 import { getExplorerLink } from '~/utils/block-explorer'
 import { truncate, formatNumber } from '~/utils/string-utils'
+import { shouldInvertOraclePrice } from '~/utils/oracle-label'
 import { useOracleAdapterPrices } from '~/composables/useOracleAdapterPrices'
 
 const props = defineProps<{
@@ -54,6 +55,7 @@ const {
 } = useRewardsApy()
 const { oracleAdapters, loadAllOracleAdapters } = useEulerLabels()
 const { chainId } = useEulerAddresses()
+const { buildKnownSymbols, resolveSymbol: resolveTokenSymbol } = useTokenSymbolResolver()
 
 const hoveredCell = ref<{
   collateralAddr: string
@@ -365,7 +367,14 @@ const tooltipPriceText = computed((): string | null => {
   const key = `${ctx.view.oracle.toLowerCase()}:${ctx.view.base.toLowerCase()}:${ctx.view.quote.toLowerCase()}`
   const info = oraclePrices.value.get(key)
   if (!info?.success) return null
-  return formatNumber(info.rate, 4)
+  const symbols = buildKnownSymbols()
+  const invert = shouldInvertOraclePrice(
+    ctx.view.label?.primary,
+    resolveTokenSymbol(ctx.view.base, symbols),
+    resolveTokenSymbol(ctx.view.quote, symbols),
+  )
+  const rate = invert && info.rate > 0 ? 1 / info.rate : info.rate
+  return formatNumber(rate, 4)
 })
 
 const tooltipPriceLoading = computed(() => oraclePricesLoading.value && !oraclePrices.value.size)

--- a/components/entities/vault/overview/VaultOverviewBlockOracleAdapters.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockOracleAdapters.vue
@@ -95,9 +95,13 @@ const adapterViews = computed(() => adapters.value.map((adapter) => {
   const name = meta?.name || adapter.name
   const checks = meta?.checks
   const labelPrimary = meta?.label?.split('(')[0].trimEnd()
-  const invertPrice = labelPrimary
-    ? shouldInvertOraclePrice(labelPrimary, resolveSymbol(adapter.base), resolveSymbol(adapter.quote))
-    : false
+  const invertPrice = shouldInvertOraclePrice(
+    labelPrimary,
+    adapter.base,
+    adapter.quote,
+    resolveSymbol(adapter.base),
+    resolveSymbol(adapter.quote),
+  )
 
   return {
     ...adapter,

--- a/components/entities/vault/overview/VaultOverviewBlockOracleAdapters.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockOracleAdapters.vue
@@ -96,11 +96,10 @@ const adapterViews = computed(() => adapters.value.map((adapter) => {
   const checks = meta?.checks
   const labelPrimary = meta?.label?.split('(')[0].trimEnd()
   const invertPrice = shouldInvertOraclePrice(
-    labelPrimary,
+    meta?.base,
+    meta?.quote,
     adapter.base,
     adapter.quote,
-    resolveSymbol(adapter.base),
-    resolveSymbol(adapter.quote),
   )
 
   return {

--- a/components/entities/vault/overview/VaultOverviewBlockOracleAdapters.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockOracleAdapters.vue
@@ -94,13 +94,12 @@ const adapterViews = computed(() => adapters.value.map((adapter) => {
   const provider = meta?.provider || adapter.name
   const name = meta?.name || adapter.name
   const checks = meta?.checks
-  const labelPrimary = meta?.label?.split('(')[0].trimEnd()
-  const invertPrice = shouldInvertOraclePrice(
-    meta?.base,
-    meta?.quote,
-    adapter.base,
-    adapter.quote,
-  )
+  const invertPrice = shouldInvertOraclePrice({
+    metaBase: meta?.base,
+    metaQuote: meta?.quote,
+    callerBase: adapter.base,
+    callerQuote: adapter.quote,
+  })
 
   return {
     ...adapter,
@@ -109,7 +108,10 @@ const adapterViews = computed(() => adapters.value.map((adapter) => {
     methodology: meta?.methodology || (isERC4626 ? 'Exchange Rate' : undefined),
     logo: getOracleProviderLogo(provider, name),
     label: meta?.label
-      ? { primary: labelPrimary ?? '', suffix: meta.label.includes('(') ? meta.label.slice(meta.label.indexOf('(')).trim() : undefined }
+      ? {
+          primary: meta.label.split('(')[0].trimEnd(),
+          suffix: meta.label.includes('(') ? meta.label.slice(meta.label.indexOf('(')).trim() : undefined,
+        }
       : undefined,
     invertPrice,
     checks,
@@ -153,7 +155,7 @@ const isAdapterPriceFailed = (adapter: OracleAdapterEntry) => {
   return !info?.success
 }
 
-const formatAdapterPrice = (adapter: OracleAdapterEntry & { invertPrice?: boolean }) => {
+const formatAdapterPrice = (adapter: OracleAdapterEntry & { invertPrice: boolean }) => {
   const key = getAdapterKey(adapter)
   const info = adapterPrices.value.get(key)
   if (!info?.success) return '-'

--- a/components/entities/vault/overview/VaultOverviewBlockOracleAdapters.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockOracleAdapters.vue
@@ -6,6 +6,7 @@ import { collectOracleAdapters, getChecksStatus, OracleAdapterCheckSeverity, typ
 import { getOracleProviderLogo } from '~/entities/oracle-providers'
 import { getExplorerLink } from '~/utils/block-explorer'
 import { formatNumber } from '~/utils/string-utils'
+import { shouldInvertOraclePrice } from '~/utils/oracle-label'
 import { useOracleAdapterPrices } from '~/composables/useOracleAdapterPrices'
 
 const props = defineProps<{
@@ -93,6 +94,10 @@ const adapterViews = computed(() => adapters.value.map((adapter) => {
   const provider = meta?.provider || adapter.name
   const name = meta?.name || adapter.name
   const checks = meta?.checks
+  const labelPrimary = meta?.label?.split('(')[0].trimEnd()
+  const invertPrice = labelPrimary
+    ? shouldInvertOraclePrice(labelPrimary, resolveSymbol(adapter.base), resolveSymbol(adapter.quote))
+    : false
 
   return {
     ...adapter,
@@ -101,8 +106,9 @@ const adapterViews = computed(() => adapters.value.map((adapter) => {
     methodology: meta?.methodology || (isERC4626 ? 'Exchange Rate' : undefined),
     logo: getOracleProviderLogo(provider, name),
     label: meta?.label
-      ? { primary: meta.label.split('(')[0].trimEnd(), suffix: meta.label.includes('(') ? meta.label.slice(meta.label.indexOf('(')).trim() : undefined }
+      ? { primary: labelPrimary ?? '', suffix: meta.label.includes('(') ? meta.label.slice(meta.label.indexOf('(')).trim() : undefined }
       : undefined,
+    invertPrice,
     checks,
     checksStatus: getChecksStatus(checks),
     failedChecks: checks?.filter(c => !c.pass) ?? [],
@@ -144,11 +150,12 @@ const isAdapterPriceFailed = (adapter: OracleAdapterEntry) => {
   return !info?.success
 }
 
-const formatAdapterPrice = (adapter: OracleAdapterEntry) => {
+const formatAdapterPrice = (adapter: OracleAdapterEntry & { invertPrice?: boolean }) => {
   const key = getAdapterKey(adapter)
   const info = adapterPrices.value.get(key)
   if (!info?.success) return '-'
-  return formatNumber(info.rate, 4)
+  const rate = adapter.invertPrice && info.rate > 0 ? 1 / info.rate : info.rate
+  return formatNumber(rate, 4)
 }
 
 const hoveredChecksAdapter = ref<(typeof adapterViews.value)[0] | null>(null)

--- a/composables/useOracleAdapterPrices.ts
+++ b/composables/useOracleAdapterPrices.ts
@@ -217,21 +217,6 @@ const decodePriceResults = (
       const quoteDecimals = decimals.get(adapter.quote.toLowerCase()) ?? 18
       const rate = nanoToValue(outAmount, quoteDecimals)
 
-      // TEMP debug — remove after diagnosing the STRC/USD price.
-      if (typeof window !== 'undefined') {
-        // eslint-disable-next-line no-console
-        console.log('[adapterPrice]', {
-          oracle: adapter.oracle,
-          name: adapter.name,
-          base: adapter.base,
-          quote: adapter.quote,
-          baseDecimals: decimals.get(adapter.base.toLowerCase()),
-          quoteDecimals,
-          outAmount: outAmount.toString(),
-          rate,
-        })
-      }
-
       prices.set(key, { rate, success: true })
     }
     catch {

--- a/composables/useOracleAdapterPrices.ts
+++ b/composables/useOracleAdapterPrices.ts
@@ -217,6 +217,21 @@ const decodePriceResults = (
       const quoteDecimals = decimals.get(adapter.quote.toLowerCase()) ?? 18
       const rate = nanoToValue(outAmount, quoteDecimals)
 
+      // TEMP debug — remove after diagnosing the STRC/USD price.
+      if (typeof window !== 'undefined') {
+        // eslint-disable-next-line no-console
+        console.log('[adapterPrice]', {
+          oracle: adapter.oracle,
+          name: adapter.name,
+          base: adapter.base,
+          quote: adapter.quote,
+          baseDecimals: decimals.get(adapter.base.toLowerCase()),
+          quoteDecimals,
+          outAmount: outAmount.toString(),
+          rate,
+        })
+      }
+
       prices.set(key, { rate, success: true })
     }
     catch {

--- a/tests/utils/oracle-label.test.ts
+++ b/tests/utils/oracle-label.test.ts
@@ -1,18 +1,14 @@
 import { describe, it, expect } from 'vitest'
 import type { Address } from 'viem'
 import { parseOracleLabelPair, shouldInvertOraclePrice } from '~/utils/oracle-label'
-import { USD_ADDRESS, EUR_ADDRESS, BTC_ADDRESS, ETH_ADDRESS } from '~/entities/constants'
+import { USD_ADDRESS } from '~/entities/constants'
 
-// Arbitrary ERC20 addresses for testing — values are not checked, only whether
-// the helper treats them as designators (the designator set is hard-coded).
+// Real-ish addresses for readability. The helper only compares them case-
+// insensitively, so the exact values don't matter beyond being distinct.
 const STRCx: Address = '0x1Aad217B8F78dbA5E6693460e8470F8b1A3977f3'
-const wSTRCx: Address = '0x0B2456017C5Df2dFc0289740C4b352049892780C'
 const WETH: Address = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2'
 const stETH: Address = '0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84'
-const wstETH: Address = '0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0'
 const USDC: Address = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'
-const USDT: Address = '0xdAC17F958D2ee523a2206206994597C13D831ec7'
-const BTCB: Address = '0x0000000000000000000000000000000000BBccBB'
 
 describe('parseOracleLabelPair', () => {
   it('parses a slash-separated pair', () => {
@@ -37,89 +33,43 @@ describe('parseOracleLabelPair', () => {
 })
 
 describe('shouldInvertOraclePrice', () => {
-  describe('designator-address anchoring', () => {
-    it('inverts when adapter.base is a designator and quote is an ERC20', () => {
-      // STRC / USD adapter wired (USD, STRCx) on chain.
-      expect(shouldInvertOraclePrice('STRC / USD', USD_ADDRESS, STRCx, 'USD', 'STRCx')).toBe(true)
-    })
-
-    it('inverts when base is the USD designator regardless of label parseability', () => {
-      // Symbol hasn't resolved yet — quoteSymbol is the shortened address.
-      // The address anchor still tells us to invert.
-      expect(shouldInvertOraclePrice('STRC / USD', USD_ADDRESS, STRCx, 'USD', '0x1Aad…7f3')).toBe(true)
-    })
-
-    it('inverts when base is the USD designator even with an empty label', () => {
-      expect(shouldInvertOraclePrice(undefined, USD_ADDRESS, STRCx, 'USD', 'STRCx')).toBe(true)
-    })
-
-    it('does not invert when adapter.quote is the designator', () => {
-      // Natural wiring: asset/fiat with quote = USD.
-      expect(shouldInvertOraclePrice('ETH / USD', WETH, USD_ADDRESS, 'WETH', 'USD')).toBe(false)
-    })
-
-    it('inverts for BTC designator on the base side', () => {
-      expect(shouldInvertOraclePrice('WBTC / BTC', BTC_ADDRESS, wSTRCx, 'BTC', 'WBTC')).toBe(true)
-    })
-
-    it('does not invert for ETH designator on the quote side', () => {
-      // wstETH / ETH with adapter wired (wstETH, ETH) — natural direction.
-      expect(shouldInvertOraclePrice('wstETH / ETH', wstETH, ETH_ADDRESS, 'wstETH', 'ETH')).toBe(false)
-    })
+  it('inverts when the caller direction is opposite to the adapter wiring', () => {
+    // Adapter wired on-chain (USD, STRCx). Router resolved as (STRCx, USD).
+    // The leaf is being called in the inverse direction → invert displayed rate.
+    expect(shouldInvertOraclePrice(USD_ADDRESS, STRCx, STRCx, USD_ADDRESS)).toBe(true)
   })
 
-  describe('symbol-based fallback (no designator on either side)', () => {
-    it('returns false when neither side is a designator and the label cannot be parsed', () => {
-      expect(shouldInvertOraclePrice(undefined, WETH, USDC, 'WETH', 'USDC')).toBe(false)
-    })
-
-    it('handles ERC20-only pair via symbol scoring', () => {
-      // Hypothetical "WETH / USDC" wired as (USDC, WETH) — needs invert.
-      expect(shouldInvertOraclePrice('WETH / USDC', USDC, WETH, 'USDC', 'WETH')).toBe(true)
-    })
-
-    it('does not invert an aligned ERC20-only pair', () => {
-      expect(shouldInvertOraclePrice('WETH / USDC', WETH, USDC, 'WETH', 'USDC')).toBe(false)
-    })
-
-    it('breaks alias ambiguity in favour of exact matches', () => {
-      // Both label sides loosely match both wirings (stETH ↔ ETH-string),
-      // but exact matches outscore loose ones — inversion is chosen.
-      expect(shouldInvertOraclePrice('wstETH / stETH', stETH, wstETH, 'stETH', 'wstETH')).toBe(true)
-      expect(shouldInvertOraclePrice('wstETH / stETH', wstETH, stETH, 'wstETH', 'stETH')).toBe(false)
-    })
+  it('does not invert when the caller direction matches the adapter wiring', () => {
+    // Naturally wired ETH/USD: adapter base = WETH, quote = USD, caller asks (WETH, USD).
+    expect(shouldInvertOraclePrice(WETH, USD_ADDRESS, WETH, USD_ADDRESS)).toBe(false)
   })
 
-  describe('false-positive guards', () => {
-    it('does not match USD substring inside USDC', () => {
-      // Both sides are ERC20 here, fallback path. "USD" inside "USDC" rejected.
-      expect(shouldInvertOraclePrice('USDC / USD', USDC, USDC, 'USDC', 'USD')).toBe(false)
-    })
-
-    it('does not match BTC inside BTCB without a leading marker', () => {
-      // BTCB is a real address; designator anchor (BTC) is on neither side
-      // since we pass BTCB and USDC, not BTC_ADDRESS.
-      expect(shouldInvertOraclePrice('BTC / USD', USDC, BTCB, 'USD', 'BTCB')).toBe(false)
-    })
-
-    it('does not invert two unrelated stablecoins that share a prefix', () => {
-      expect(shouldInvertOraclePrice('USDC / USD', USDC, USDT, 'USDC', 'USDT')).toBe(false)
-    })
+  it('handles a wstETH / stETH adapter where caller flips the wiring', () => {
+    // Adapter wired (wstETH, stETH), router resolves caller direction (stETH, wstETH).
+    expect(shouldInvertOraclePrice(WETH, stETH, stETH, WETH)).toBe(true)
   })
 
-  describe('case and whitespace tolerance', () => {
-    it('is case-insensitive for symbol fallback', () => {
-      expect(shouldInvertOraclePrice('strc / usd', USD_ADDRESS, STRCx, 'usd', 'strcx')).toBe(true)
-    })
-
-    it('tolerates extra whitespace in the label', () => {
-      expect(shouldInvertOraclePrice('  STRC  /  USD  ', USD_ADDRESS, STRCx, 'USD', 'STRCx')).toBe(true)
-    })
+  it('returns false when meta base is missing', () => {
+    expect(shouldInvertOraclePrice(undefined, STRCx, STRCx, USD_ADDRESS)).toBe(false)
   })
 
-  describe('uses EUR designator as well', () => {
-    it('inverts when EUR is on the base side', () => {
-      expect(shouldInvertOraclePrice('XAU / EUR', EUR_ADDRESS, STRCx, 'EUR', 'XAU')).toBe(true)
-    })
+  it('returns false when meta quote is missing', () => {
+    expect(shouldInvertOraclePrice(USD_ADDRESS, undefined, STRCx, USD_ADDRESS)).toBe(false)
+  })
+
+  it('returns false for an unexpected pairing that matches neither direction', () => {
+    // meta (USD, STRCx), caller (USDC, WETH) — completely unrelated, no inversion guess.
+    expect(shouldInvertOraclePrice(USD_ADDRESS, STRCx, USDC, WETH)).toBe(false)
+  })
+
+  it('compares addresses case-insensitively', () => {
+    expect(
+      shouldInvertOraclePrice(
+        USD_ADDRESS.toUpperCase() as Address,
+        STRCx.toLowerCase() as Address,
+        STRCx.toUpperCase() as Address,
+        USD_ADDRESS.toLowerCase() as Address,
+      ),
+    ).toBe(true)
   })
 })

--- a/tests/utils/oracle-label.test.ts
+++ b/tests/utils/oracle-label.test.ts
@@ -1,75 +1,86 @@
 import { describe, it, expect } from 'vitest'
 import type { Address } from 'viem'
-import { parseOracleLabelPair, shouldInvertOraclePrice } from '~/utils/oracle-label'
+import { shouldInvertOraclePrice } from '~/utils/oracle-label'
 import { USD_ADDRESS } from '~/entities/constants'
 
-// Real-ish addresses for readability. The helper only compares them case-
-// insensitively, so the exact values don't matter beyond being distinct.
 const STRCx: Address = '0x1Aad217B8F78dbA5E6693460e8470F8b1A3977f3'
 const WETH: Address = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2'
 const stETH: Address = '0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84'
 const USDC: Address = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'
 
-describe('parseOracleLabelPair', () => {
-  it('parses a slash-separated pair', () => {
-    expect(parseOracleLabelPair('STRC / USD')).toEqual(['STRC', 'USD'])
-  })
-
-  it('trims whitespace around each side', () => {
-    expect(parseOracleLabelPair('  ETH  /  USD  ')).toEqual(['ETH', 'USD'])
-  })
-
-  it('returns null for undefined input', () => {
-    expect(parseOracleLabelPair(undefined)).toBeNull()
-  })
-
-  it('returns null when the separator is missing', () => {
-    expect(parseOracleLabelPair('STRCUSD')).toBeNull()
-  })
-
-  it('returns null when there are more than two segments', () => {
-    expect(parseOracleLabelPair('A / B / C')).toBeNull()
-  })
-})
-
 describe('shouldInvertOraclePrice', () => {
   it('inverts when the caller direction is opposite to the adapter wiring', () => {
     // Adapter wired on-chain (USD, STRCx). Router resolved as (STRCx, USD).
-    // The leaf is being called in the inverse direction → invert displayed rate.
-    expect(shouldInvertOraclePrice(USD_ADDRESS, STRCx, STRCx, USD_ADDRESS)).toBe(true)
+    // The leaf is being called inverse → invert displayed rate.
+    expect(shouldInvertOraclePrice({
+      metaBase: USD_ADDRESS,
+      metaQuote: STRCx,
+      callerBase: STRCx,
+      callerQuote: USD_ADDRESS,
+    })).toBe(true)
   })
 
   it('does not invert when the caller direction matches the adapter wiring', () => {
     // Naturally wired ETH/USD: adapter base = WETH, quote = USD, caller asks (WETH, USD).
-    expect(shouldInvertOraclePrice(WETH, USD_ADDRESS, WETH, USD_ADDRESS)).toBe(false)
+    expect(shouldInvertOraclePrice({
+      metaBase: WETH,
+      metaQuote: USD_ADDRESS,
+      callerBase: WETH,
+      callerQuote: USD_ADDRESS,
+    })).toBe(false)
   })
 
-  it('handles a wstETH / stETH adapter where caller flips the wiring', () => {
-    // Adapter wired (wstETH, stETH), router resolves caller direction (stETH, wstETH).
-    expect(shouldInvertOraclePrice(WETH, stETH, stETH, WETH)).toBe(true)
+  it('inverts a wstETH/stETH adapter when caller flips the wiring', () => {
+    expect(shouldInvertOraclePrice({
+      metaBase: WETH,
+      metaQuote: stETH,
+      callerBase: stETH,
+      callerQuote: WETH,
+    })).toBe(true)
   })
 
-  it('returns false when meta base is missing', () => {
-    expect(shouldInvertOraclePrice(undefined, STRCx, STRCx, USD_ADDRESS)).toBe(false)
+  it('returns false when meta base is missing (e.g. ERC4626 synthetic adapter)', () => {
+    expect(shouldInvertOraclePrice({
+      metaBase: undefined,
+      metaQuote: STRCx,
+      callerBase: STRCx,
+      callerQuote: USD_ADDRESS,
+    })).toBe(false)
   })
 
   it('returns false when meta quote is missing', () => {
-    expect(shouldInvertOraclePrice(USD_ADDRESS, undefined, STRCx, USD_ADDRESS)).toBe(false)
+    expect(shouldInvertOraclePrice({
+      metaBase: USD_ADDRESS,
+      metaQuote: undefined,
+      callerBase: STRCx,
+      callerQuote: USD_ADDRESS,
+    })).toBe(false)
   })
 
-  it('returns false for an unexpected pairing that matches neither direction', () => {
-    // meta (USD, STRCx), caller (USDC, WETH) — completely unrelated, no inversion guess.
-    expect(shouldInvertOraclePrice(USD_ADDRESS, STRCx, USDC, WETH)).toBe(false)
+  it('returns false when the caller pair matches the wiring in neither direction', () => {
+    expect(shouldInvertOraclePrice({
+      metaBase: USD_ADDRESS,
+      metaQuote: STRCx,
+      callerBase: USDC,
+      callerQuote: WETH,
+    })).toBe(false)
+  })
+
+  it('returns false when both meta sides are the same address (degenerate)', () => {
+    expect(shouldInvertOraclePrice({
+      metaBase: USD_ADDRESS,
+      metaQuote: USD_ADDRESS,
+      callerBase: USD_ADDRESS,
+      callerQuote: USD_ADDRESS,
+    })).toBe(false)
   })
 
   it('compares addresses case-insensitively', () => {
-    expect(
-      shouldInvertOraclePrice(
-        USD_ADDRESS.toUpperCase() as Address,
-        STRCx.toLowerCase() as Address,
-        STRCx.toUpperCase() as Address,
-        USD_ADDRESS.toLowerCase() as Address,
-      ),
-    ).toBe(true)
+    expect(shouldInvertOraclePrice({
+      metaBase: USD_ADDRESS.toUpperCase() as Address,
+      metaQuote: STRCx.toLowerCase() as Address,
+      callerBase: STRCx.toUpperCase() as Address,
+      callerQuote: USD_ADDRESS.toLowerCase() as Address,
+    })).toBe(true)
   })
 })

--- a/tests/utils/oracle-label.test.ts
+++ b/tests/utils/oracle-label.test.ts
@@ -69,6 +69,30 @@ describe('shouldInvertOraclePrice', () => {
     })
   })
 
+  describe('wrapper / core aliases on both sides', () => {
+    // Both label sides match both wiring sides loosely — exact matches must
+    // win the tie so the flipped direction is chosen.
+    it('inverts stETH / ETH when adapter wiring is (ETH, stETH)', () => {
+      expect(shouldInvertOraclePrice('stETH / ETH', 'ETH', 'stETH')).toBe(true)
+    })
+
+    it('does not invert stETH / ETH when adapter wiring is (stETH, ETH)', () => {
+      expect(shouldInvertOraclePrice('stETH / ETH', 'stETH', 'ETH')).toBe(false)
+    })
+
+    it('inverts wstETH / stETH when adapter wiring is (stETH, wstETH)', () => {
+      expect(shouldInvertOraclePrice('wstETH / stETH', 'stETH', 'wstETH')).toBe(true)
+    })
+
+    it('does not invert wstETH / stETH when adapter wiring is (wstETH, stETH)', () => {
+      expect(shouldInvertOraclePrice('wstETH / stETH', 'wstETH', 'stETH')).toBe(false)
+    })
+
+    it('inverts wSTRCx / STRCx when adapter wiring is (STRCx, wSTRCx)', () => {
+      expect(shouldInvertOraclePrice('wSTRCx / STRCx', 'STRCx', 'wSTRCx')).toBe(true)
+    })
+  })
+
   describe('false-positive guards', () => {
     it('does not match USD against USDC', () => {
       // "USDC / USD" with adapter base=USDC, quote=USD: aligned → no invert.

--- a/tests/utils/oracle-label.test.ts
+++ b/tests/utils/oracle-label.test.ts
@@ -1,5 +1,18 @@
 import { describe, it, expect } from 'vitest'
+import type { Address } from 'viem'
 import { parseOracleLabelPair, shouldInvertOraclePrice } from '~/utils/oracle-label'
+import { USD_ADDRESS, EUR_ADDRESS, BTC_ADDRESS, ETH_ADDRESS } from '~/entities/constants'
+
+// Arbitrary ERC20 addresses for testing — values are not checked, only whether
+// the helper treats them as designators (the designator set is hard-coded).
+const STRCx: Address = '0x1Aad217B8F78dbA5E6693460e8470F8b1A3977f3'
+const wSTRCx: Address = '0x0B2456017C5Df2dFc0289740C4b352049892780C'
+const WETH: Address = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2'
+const stETH: Address = '0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84'
+const wstETH: Address = '0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0'
+const USDC: Address = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'
+const USDT: Address = '0xdAC17F958D2ee523a2206206994597C13D831ec7'
+const BTCB: Address = '0x0000000000000000000000000000000000BBccBB'
 
 describe('parseOracleLabelPair', () => {
   it('parses a slash-separated pair', () => {
@@ -24,101 +37,89 @@ describe('parseOracleLabelPair', () => {
 })
 
 describe('shouldInvertOraclePrice', () => {
-  describe('no label parses', () => {
-    it('returns false when label is undefined', () => {
-      expect(shouldInvertOraclePrice(undefined, 'USD', 'STRCx')).toBe(false)
+  describe('designator-address anchoring', () => {
+    it('inverts when adapter.base is a designator and quote is an ERC20', () => {
+      // STRC / USD adapter wired (USD, STRCx) on chain.
+      expect(shouldInvertOraclePrice('STRC / USD', USD_ADDRESS, STRCx, 'USD', 'STRCx')).toBe(true)
     })
 
-    it('returns false when label cannot be parsed', () => {
-      expect(shouldInvertOraclePrice('STRCUSD', 'USD', 'STRCx')).toBe(false)
-    })
-  })
-
-  describe('label aligned with adapter wiring', () => {
-    it('does not invert when label and wiring agree', () => {
-      // adapter.base=ETH-wrapper, adapter.quote=USD, label="ETH / USD"
-      // getQuote returns USD per ETH, label means USD per ETH — agree.
-      expect(shouldInvertOraclePrice('ETH / USD', 'WETH', 'USD')).toBe(false)
+    it('inverts when base is the USD designator regardless of label parseability', () => {
+      // Symbol hasn't resolved yet — quoteSymbol is the shortened address.
+      // The address anchor still tells us to invert.
+      expect(shouldInvertOraclePrice('STRC / USD', USD_ADDRESS, STRCx, 'USD', '0x1Aad…7f3')).toBe(true)
     })
 
-    it('does not invert when wrapped quote is on the right', () => {
-      // adapter.base=USDC, adapter.quote=USDC.e wrapper — extremely contrived,
-      // but it exercises the right-side wrapper match.
-      expect(shouldInvertOraclePrice('USDC / USDC.e', 'USDC', 'USDC.e')).toBe(false)
-    })
-  })
-
-  describe('label flipped relative to adapter wiring', () => {
-    it('inverts when STRCx is on the quote side', () => {
-      // The original failing case from the PR description.
-      expect(shouldInvertOraclePrice('STRC / USD', 'USD', 'STRCx')).toBe(true)
+    it('inverts when base is the USD designator even with an empty label', () => {
+      expect(shouldInvertOraclePrice(undefined, USD_ADDRESS, STRCx, 'USD', 'STRCx')).toBe(true)
     })
 
-    it('inverts when wSTRCx is on the quote side', () => {
-      // The case the previous fix missed — prefix wrapper marker.
-      expect(shouldInvertOraclePrice('STRC / USD', 'USD', 'wSTRCx')).toBe(true)
+    it('does not invert when adapter.quote is the designator', () => {
+      // Natural wiring: asset/fiat with quote = USD.
+      expect(shouldInvertOraclePrice('ETH / USD', WETH, USD_ADDRESS, 'WETH', 'USD')).toBe(false)
     })
 
-    it('inverts for wstETH wrapped around ETH', () => {
-      // Long leading marker "wst" on a 3-letter core.
-      expect(shouldInvertOraclePrice('ETH / USD', 'USD', 'wstETH')).toBe(true)
+    it('inverts for BTC designator on the base side', () => {
+      expect(shouldInvertOraclePrice('WBTC / BTC', BTC_ADDRESS, wSTRCx, 'BTC', 'WBTC')).toBe(true)
     })
 
-    it('inverts for WETH wrapped around ETH', () => {
-      expect(shouldInvertOraclePrice('ETH / USD', 'USD', 'WETH')).toBe(true)
+    it('does not invert for ETH designator on the quote side', () => {
+      // wstETH / ETH with adapter wired (wstETH, ETH) — natural direction.
+      expect(shouldInvertOraclePrice('wstETH / ETH', wstETH, ETH_ADDRESS, 'wstETH', 'ETH')).toBe(false)
     })
   })
 
-  describe('wrapper / core aliases on both sides', () => {
-    // Both label sides match both wiring sides loosely — exact matches must
-    // win the tie so the flipped direction is chosen.
-    it('inverts stETH / ETH when adapter wiring is (ETH, stETH)', () => {
-      expect(shouldInvertOraclePrice('stETH / ETH', 'ETH', 'stETH')).toBe(true)
+  describe('symbol-based fallback (no designator on either side)', () => {
+    it('returns false when neither side is a designator and the label cannot be parsed', () => {
+      expect(shouldInvertOraclePrice(undefined, WETH, USDC, 'WETH', 'USDC')).toBe(false)
     })
 
-    it('does not invert stETH / ETH when adapter wiring is (stETH, ETH)', () => {
-      expect(shouldInvertOraclePrice('stETH / ETH', 'stETH', 'ETH')).toBe(false)
+    it('handles ERC20-only pair via symbol scoring', () => {
+      // Hypothetical "WETH / USDC" wired as (USDC, WETH) — needs invert.
+      expect(shouldInvertOraclePrice('WETH / USDC', USDC, WETH, 'USDC', 'WETH')).toBe(true)
     })
 
-    it('inverts wstETH / stETH when adapter wiring is (stETH, wstETH)', () => {
-      expect(shouldInvertOraclePrice('wstETH / stETH', 'stETH', 'wstETH')).toBe(true)
+    it('does not invert an aligned ERC20-only pair', () => {
+      expect(shouldInvertOraclePrice('WETH / USDC', WETH, USDC, 'WETH', 'USDC')).toBe(false)
     })
 
-    it('does not invert wstETH / stETH when adapter wiring is (wstETH, stETH)', () => {
-      expect(shouldInvertOraclePrice('wstETH / stETH', 'wstETH', 'stETH')).toBe(false)
-    })
-
-    it('inverts wSTRCx / STRCx when adapter wiring is (STRCx, wSTRCx)', () => {
-      expect(shouldInvertOraclePrice('wSTRCx / STRCx', 'STRCx', 'wSTRCx')).toBe(true)
+    it('breaks alias ambiguity in favour of exact matches', () => {
+      // Both label sides loosely match both wirings (stETH ↔ ETH-string),
+      // but exact matches outscore loose ones — inversion is chosen.
+      expect(shouldInvertOraclePrice('wstETH / stETH', stETH, wstETH, 'stETH', 'wstETH')).toBe(true)
+      expect(shouldInvertOraclePrice('wstETH / stETH', wstETH, stETH, 'wstETH', 'stETH')).toBe(false)
     })
   })
 
   describe('false-positive guards', () => {
-    it('does not match USD against USDC', () => {
-      // "USDC / USD" with adapter base=USDC, quote=USD: aligned → no invert.
-      // Should not get confused by "USD" being a prefix of "USDC".
-      expect(shouldInvertOraclePrice('USDC / USD', 'USDC', 'USD')).toBe(false)
+    it('does not match USD substring inside USDC', () => {
+      // Both sides are ERC20 here, fallback path. "USD" inside "USDC" rejected.
+      expect(shouldInvertOraclePrice('USDC / USD', USDC, USDC, 'USDC', 'USD')).toBe(false)
     })
 
-    it('does not match BTC against BTCB without a leading marker', () => {
-      // BTCB (no leading marker) should NOT be treated as a BTC wrapper here.
-      // If both wirings fail to match, fall back to no inversion.
-      expect(shouldInvertOraclePrice('BTC / USD', 'USD', 'BTCB')).toBe(false)
+    it('does not match BTC inside BTCB without a leading marker', () => {
+      // BTCB is a real address; designator anchor (BTC) is on neither side
+      // since we pass BTCB and USDC, not BTC_ADDRESS.
+      expect(shouldInvertOraclePrice('BTC / USD', USDC, BTCB, 'USD', 'BTCB')).toBe(false)
     })
 
-    it('does not match unrelated symbols that happen to share a prefix', () => {
-      // "USDC" and "USDT" share a long prefix but are distinct assets.
-      expect(shouldInvertOraclePrice('USDC / USD', 'USD', 'USDT')).toBe(false)
+    it('does not invert two unrelated stablecoins that share a prefix', () => {
+      expect(shouldInvertOraclePrice('USDC / USD', USDC, USDT, 'USDC', 'USDT')).toBe(false)
     })
   })
 
   describe('case and whitespace tolerance', () => {
-    it('is case-insensitive', () => {
-      expect(shouldInvertOraclePrice('strc / usd', 'USD', 'STRCx')).toBe(true)
+    it('is case-insensitive for symbol fallback', () => {
+      expect(shouldInvertOraclePrice('strc / usd', USD_ADDRESS, STRCx, 'usd', 'strcx')).toBe(true)
     })
 
-    it('tolerates extra whitespace', () => {
-      expect(shouldInvertOraclePrice('  STRC  /  USD  ', 'USD', 'STRCx')).toBe(true)
+    it('tolerates extra whitespace in the label', () => {
+      expect(shouldInvertOraclePrice('  STRC  /  USD  ', USD_ADDRESS, STRCx, 'USD', 'STRCx')).toBe(true)
+    })
+  })
+
+  describe('uses EUR designator as well', () => {
+    it('inverts when EUR is on the base side', () => {
+      expect(shouldInvertOraclePrice('XAU / EUR', EUR_ADDRESS, STRCx, 'EUR', 'XAU')).toBe(true)
     })
   })
 })

--- a/tests/utils/oracle-label.test.ts
+++ b/tests/utils/oracle-label.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest'
+import { parseOracleLabelPair, shouldInvertOraclePrice } from '~/utils/oracle-label'
+
+describe('parseOracleLabelPair', () => {
+  it('parses a slash-separated pair', () => {
+    expect(parseOracleLabelPair('STRC / USD')).toEqual(['STRC', 'USD'])
+  })
+
+  it('trims whitespace around each side', () => {
+    expect(parseOracleLabelPair('  ETH  /  USD  ')).toEqual(['ETH', 'USD'])
+  })
+
+  it('returns null for undefined input', () => {
+    expect(parseOracleLabelPair(undefined)).toBeNull()
+  })
+
+  it('returns null when the separator is missing', () => {
+    expect(parseOracleLabelPair('STRCUSD')).toBeNull()
+  })
+
+  it('returns null when there are more than two segments', () => {
+    expect(parseOracleLabelPair('A / B / C')).toBeNull()
+  })
+})
+
+describe('shouldInvertOraclePrice', () => {
+  describe('no label parses', () => {
+    it('returns false when label is undefined', () => {
+      expect(shouldInvertOraclePrice(undefined, 'USD', 'STRCx')).toBe(false)
+    })
+
+    it('returns false when label cannot be parsed', () => {
+      expect(shouldInvertOraclePrice('STRCUSD', 'USD', 'STRCx')).toBe(false)
+    })
+  })
+
+  describe('label aligned with adapter wiring', () => {
+    it('does not invert when label and wiring agree', () => {
+      // adapter.base=ETH-wrapper, adapter.quote=USD, label="ETH / USD"
+      // getQuote returns USD per ETH, label means USD per ETH — agree.
+      expect(shouldInvertOraclePrice('ETH / USD', 'WETH', 'USD')).toBe(false)
+    })
+
+    it('does not invert when wrapped quote is on the right', () => {
+      // adapter.base=USDC, adapter.quote=USDC.e wrapper — extremely contrived,
+      // but it exercises the right-side wrapper match.
+      expect(shouldInvertOraclePrice('USDC / USDC.e', 'USDC', 'USDC.e')).toBe(false)
+    })
+  })
+
+  describe('label flipped relative to adapter wiring', () => {
+    it('inverts when STRCx is on the quote side', () => {
+      // The original failing case from the PR description.
+      expect(shouldInvertOraclePrice('STRC / USD', 'USD', 'STRCx')).toBe(true)
+    })
+
+    it('inverts when wSTRCx is on the quote side', () => {
+      // The case the previous fix missed — prefix wrapper marker.
+      expect(shouldInvertOraclePrice('STRC / USD', 'USD', 'wSTRCx')).toBe(true)
+    })
+
+    it('inverts for wstETH wrapped around ETH', () => {
+      // Long leading marker "wst" on a 3-letter core.
+      expect(shouldInvertOraclePrice('ETH / USD', 'USD', 'wstETH')).toBe(true)
+    })
+
+    it('inverts for WETH wrapped around ETH', () => {
+      expect(shouldInvertOraclePrice('ETH / USD', 'USD', 'WETH')).toBe(true)
+    })
+  })
+
+  describe('false-positive guards', () => {
+    it('does not match USD against USDC', () => {
+      // "USDC / USD" with adapter base=USDC, quote=USD: aligned → no invert.
+      // Should not get confused by "USD" being a prefix of "USDC".
+      expect(shouldInvertOraclePrice('USDC / USD', 'USDC', 'USD')).toBe(false)
+    })
+
+    it('does not match BTC against BTCB without a leading marker', () => {
+      // BTCB (no leading marker) should NOT be treated as a BTC wrapper here.
+      // If both wirings fail to match, fall back to no inversion.
+      expect(shouldInvertOraclePrice('BTC / USD', 'USD', 'BTCB')).toBe(false)
+    })
+
+    it('does not match unrelated symbols that happen to share a prefix', () => {
+      // "USDC" and "USDT" share a long prefix but are distinct assets.
+      expect(shouldInvertOraclePrice('USDC / USD', 'USD', 'USDT')).toBe(false)
+    })
+  })
+
+  describe('case and whitespace tolerance', () => {
+    it('is case-insensitive', () => {
+      expect(shouldInvertOraclePrice('strc / usd', 'USD', 'STRCx')).toBe(true)
+    })
+
+    it('tolerates extra whitespace', () => {
+      expect(shouldInvertOraclePrice('  STRC  /  USD  ', 'USD', 'STRCx')).toBe(true)
+    })
+  })
+})

--- a/utils/oracle-label.ts
+++ b/utils/oracle-label.ts
@@ -1,18 +1,31 @@
+import type { Address } from 'viem'
+import { USD_ADDRESS, EUR_ADDRESS, BTC_ADDRESS, ETH_ADDRESS } from '~/entities/constants'
+
+// Special designator addresses that stand for an FX-style denomination unit
+// (USD, EUR, BTC, ETH) rather than a real ERC20. When the adapter is wired
+// with one of these on one side, that side is the "currency" and the other
+// is the asset being priced — giving us an unambiguous direction without
+// having to parse symbols out of the label.
+const DESIGNATOR_ADDRESSES = new Set<string>([
+  USD_ADDRESS.toLowerCase(),
+  EUR_ADDRESS.toLowerCase(),
+  BTC_ADDRESS.toLowerCase(),
+  ETH_ADDRESS.toLowerCase(),
+])
+
+const isDesignator = (address: Address | string): boolean =>
+  DESIGNATOR_ADDRESSES.has(address.toLowerCase())
+
 // Symbol comparison scores (higher is more confident):
-//   2 = exact match (e.g. "USD" ↔ "USD")
+//   2 = exact match
 //   1 = loose match — one symbol is a wrapped variant of the other
-//       (e.g. "STRC" ↔ "STRCx", "ETH" ↔ "wstETH")
 //   0 = no match
 //
 // Wrapped ERC20s usually keep the underlying asset's symbol as a contiguous
 // core, padded by a short prefix and/or suffix marker — e.g. "STRC" → "STRCx",
-// "STRC" → "wSTRCx", "ETH" → "WETH", "ETH" → "wstETH".
-//
-// The score lets a caller choose between competing directions: when the
-// adapter's base and quote are aliases of each other (stETH vs ETH, wSTRCx vs
-// STRCx), both label sides can match both wirings loosely, and a boolean
-// "matches?" check would tie. Preferring the higher-score direction breaks
-// the tie correctly because exact matches outrank loose ones.
+// "STRC" → "wSTRCx", "ETH" → "WETH", "ETH" → "wstETH". The score lets a caller
+// break a tie when both label sides loosely match both wirings (stETH ↔ ETH,
+// wSTRCx ↔ STRCx) — exact matches outrank loose ones.
 const symbolMatchScore = (labelSym: string, addressSym: string): 0 | 1 | 2 => {
   const a = labelSym.trim().toLowerCase()
   const b = addressSym.trim().toLowerCase()
@@ -47,26 +60,37 @@ export const parseOracleLabelPair = (labelPrimary: string | undefined): [string,
   return [parts[0], parts[1]]
 }
 
-// The adapter's getQuote returns "quote per base" given the on-chain wiring,
-// but oracle-checks labels follow the "X / Y = Y per X" FX convention regardless
-// of which side was assigned as base. When the label flips the symbols relative
-// to the wiring, invert the rate so the displayed number matches the displayed name.
+// The adapter's getQuote returns "quote per base" for the wiring the UI calls.
+// We want the displayed price to read in the natural human direction (asset
+// priced in its denomination), so we may need to invert.
 //
-// Direction is decided by scoring both pairings of label symbols against adapter
-// (base, quote) symbols and picking the higher-scoring one. This handles cases
-// where each label side could loosely match either wiring side (e.g. "stETH /
-// ETH" with adapter base=ETH, quote=stETH) — the exact-match pairing wins.
+// Decision flow:
+//  1. If exactly one wiring side is an FX designator (USD/EUR/BTC/ETH), use it
+//     as an anchor — the designator is always the denomination. Invert when
+//     the denomination is on the BASE side. This requires no label parsing
+//     and works even if the ERC20 symbol hasn't been resolved yet.
+//  2. Otherwise (both designators or both ERC20s) fall back to scoring the
+//     label symbols against the resolved wiring symbols.
 export const shouldInvertOraclePrice = (
   labelPrimary: string | undefined,
+  baseAddress: Address | string,
+  quoteAddress: Address | string,
   baseSymbol: string,
   quoteSymbol: string,
 ): boolean => {
+  const baseIsDesignator = isDesignator(baseAddress)
+  const quoteIsDesignator = isDesignator(quoteAddress)
+
+  if (baseIsDesignator !== quoteIsDesignator) {
+    return baseIsDesignator
+  }
+
   const pair = parseOracleLabelPair(labelPrimary)
   if (!pair) return false
   const [left, right] = pair
 
   // A direction only counts when BOTH sides have a non-zero score —
-  // otherwise a single exact match (e.g. only the quote side matches)
+  // otherwise a single accidental exact match (e.g. only the quote side)
   // would flip the price on weak evidence.
   const directLeft = symbolMatchScore(left, baseSymbol)
   const directRight = symbolMatchScore(right, quoteSymbol)

--- a/utils/oracle-label.ts
+++ b/utils/oracle-label.ts
@@ -1,12 +1,36 @@
-// Label symbols frequently drop a trailing wrapper marker (e.g. "STRC" for
-// ERC20 "STRCx"), so the resolved ERC20 symbol is allowed to be longer than
-// the label symbol — never the other way, to avoid false positives between
-// unrelated symbols that happen to share a prefix (e.g. "USDC" vs "USD").
+// Wrapped ERC20s usually keep the underlying asset's symbol as a contiguous
+// core, padded by a short prefix and/or suffix marker — e.g. "STRC" → "STRCx"
+// (suffix "x"), "STRC" → "wSTRCx" (prefix "w" + suffix "x"), "ETH" → "WETH"
+// (prefix "W"), "ETH" → "wstETH" (prefix "wst").
+//
+// Match if one symbol contains the other as such a core, but reject matches
+// where a 3-letter symbol bleeds into a longer one without a leading marker
+// — that's the "USD" ⊂ "USDC" / "BTC" ⊂ "BTCB" case, which should not match.
 const symbolsMatch = (labelSym: string, addressSym: string): boolean => {
   const a = labelSym.trim().toLowerCase()
   const b = addressSym.trim().toLowerCase()
   if (!a || !b) return false
-  return a === b || b.startsWith(a)
+  if (a === b) return true
+
+  const core = a.length <= b.length ? a : b
+  const wrapped = a.length <= b.length ? b : a
+  const idx = wrapped.indexOf(core)
+  if (idx === -1) return false
+
+  const prefixLen = idx
+  const suffixLen = wrapped.length - idx - core.length
+
+  // Cap the wrapping markers — without an upper bound, "ETH" would match
+  // anything that happens to contain it as a substring.
+  if (prefixLen > 3 || suffixLen > 3) return false
+
+  // Designator-like 3-letter symbols (USD, EUR, BTC, ETH, ...) need a real
+  // leading marker to disambiguate from longer tickers built on the same
+  // letters. "USDC" starts with "USD" with no marker → reject. "WETH" / "stETH"
+  // have a leading w/st marker → accept.
+  if (core.length < 4 && prefixLen === 0) return false
+
+  return true
 }
 
 export const parseOracleLabelPair = (labelPrimary: string | undefined): [string, string] | null => {

--- a/utils/oracle-label.ts
+++ b/utils/oracle-label.ts
@@ -1,0 +1,34 @@
+// Label symbols frequently drop a trailing wrapper marker (e.g. "STRC" for
+// ERC20 "STRCx"), so the resolved ERC20 symbol is allowed to be longer than
+// the label symbol — never the other way, to avoid false positives between
+// unrelated symbols that happen to share a prefix (e.g. "USDC" vs "USD").
+const symbolsMatch = (labelSym: string, addressSym: string): boolean => {
+  const a = labelSym.trim().toLowerCase()
+  const b = addressSym.trim().toLowerCase()
+  if (!a || !b) return false
+  return a === b || b.startsWith(a)
+}
+
+export const parseOracleLabelPair = (labelPrimary: string | undefined): [string, string] | null => {
+  if (!labelPrimary) return null
+  const parts = labelPrimary.split('/').map(s => s.trim()).filter(Boolean)
+  if (parts.length !== 2) return null
+  return [parts[0], parts[1]]
+}
+
+// The adapter's getQuote returns "quote per base" given the on-chain wiring,
+// but oracle-checks labels follow the "X / Y = Y per X" FX convention regardless
+// of which side was assigned as base. When the label flips the symbols relative
+// to the wiring, invert the rate so the displayed number matches the displayed name.
+export const shouldInvertOraclePrice = (
+  labelPrimary: string | undefined,
+  baseSymbol: string,
+  quoteSymbol: string,
+): boolean => {
+  const pair = parseOracleLabelPair(labelPrimary)
+  if (!pair) return false
+  const [left, right] = pair
+  const directMatch = symbolsMatch(left, baseSymbol) && symbolsMatch(right, quoteSymbol)
+  if (directMatch) return false
+  return symbolsMatch(left, quoteSymbol) && symbolsMatch(right, baseSymbol)
+}

--- a/utils/oracle-label.ts
+++ b/utils/oracle-label.ts
@@ -1,57 +1,4 @@
 import type { Address } from 'viem'
-import { USD_ADDRESS, EUR_ADDRESS, BTC_ADDRESS, ETH_ADDRESS } from '~/entities/constants'
-
-// Special designator addresses that stand for an FX-style denomination unit
-// (USD, EUR, BTC, ETH) rather than a real ERC20. When the adapter is wired
-// with one of these on one side, that side is the "currency" and the other
-// is the asset being priced — giving us an unambiguous direction without
-// having to parse symbols out of the label.
-const DESIGNATOR_ADDRESSES = new Set<string>([
-  USD_ADDRESS.toLowerCase(),
-  EUR_ADDRESS.toLowerCase(),
-  BTC_ADDRESS.toLowerCase(),
-  ETH_ADDRESS.toLowerCase(),
-])
-
-const isDesignator = (address: Address | string): boolean =>
-  DESIGNATOR_ADDRESSES.has(address.toLowerCase())
-
-// Symbol comparison scores (higher is more confident):
-//   2 = exact match
-//   1 = loose match — one symbol is a wrapped variant of the other
-//   0 = no match
-//
-// Wrapped ERC20s usually keep the underlying asset's symbol as a contiguous
-// core, padded by a short prefix and/or suffix marker — e.g. "STRC" → "STRCx",
-// "STRC" → "wSTRCx", "ETH" → "WETH", "ETH" → "wstETH". The score lets a caller
-// break a tie when both label sides loosely match both wirings (stETH ↔ ETH,
-// wSTRCx ↔ STRCx) — exact matches outrank loose ones.
-const symbolMatchScore = (labelSym: string, addressSym: string): 0 | 1 | 2 => {
-  const a = labelSym.trim().toLowerCase()
-  const b = addressSym.trim().toLowerCase()
-  if (!a || !b) return 0
-  if (a === b) return 2
-
-  const core = a.length <= b.length ? a : b
-  const wrapped = a.length <= b.length ? b : a
-  const idx = wrapped.indexOf(core)
-  if (idx === -1) return 0
-
-  const prefixLen = idx
-  const suffixLen = wrapped.length - idx - core.length
-
-  // Cap the wrapping markers — without an upper bound, "ETH" would match
-  // anything that happens to contain it as a substring.
-  if (prefixLen > 3 || suffixLen > 3) return 0
-
-  // Designator-length 3-letter symbols (USD, EUR, BTC, ETH, ...) need a real
-  // leading marker to disambiguate from longer tickers built on the same
-  // letters. "USDC" starts with "USD" with no marker → reject. "WETH" / "stETH"
-  // have a leading w/st marker → accept.
-  if (core.length < 4 && prefixLen === 0) return 0
-
-  return 1
-}
 
 export const parseOracleLabelPair = (labelPrimary: string | undefined): [string, string] | null => {
   if (!labelPrimary) return null
@@ -60,68 +7,32 @@ export const parseOracleLabelPair = (labelPrimary: string | undefined): [string,
   return [parts[0], parts[1]]
 }
 
-// The adapter's getQuote returns "quote per base" for the wiring the UI calls.
-// We want the displayed price to read in the natural human direction (asset
-// priced in its denomination), so we may need to invert.
+// Each oracle adapter has its own on-chain (base, quote) wiring (from the
+// oracle-checks metadata). Its `getQuote(amount, base, quote)` returns the
+// natural feed direction when called in that wired order; calling it with the
+// arguments swapped returns the inverse.
 //
-// Decision flow:
-//  1. If exactly one wiring side is an FX designator (USD/EUR/BTC/ETH), use it
-//     as an anchor — the designator is always the denomination. Invert when
-//     the denomination is on the BASE side. This requires no label parsing
-//     and works even if the ERC20 symbol hasn't been resolved yet.
-//  2. Otherwise (both designators or both ERC20s) fall back to scoring the
-//     label symbols against the resolved wiring symbols.
+// The router resolves vault assets through ERC4626 unwraps, cross adapters,
+// etc., and ends up calling each leaf adapter with the (base, quote) pair the
+// router wants. That pair may match the adapter's wiring or be flipped — when
+// it's flipped, the displayed rate is the inverse of the feed's natural number
+// and we need to invert it back so the displayed price reads in the direction
+// the label implies.
+const sameDirection = (
+  a: Address | string,
+  b: Address | string,
+  c: Address | string,
+  d: Address | string,
+): boolean => a.toLowerCase() === c.toLowerCase() && b.toLowerCase() === d.toLowerCase()
+
 export const shouldInvertOraclePrice = (
-  labelPrimary: string | undefined,
-  baseAddress: Address | string,
-  quoteAddress: Address | string,
-  baseSymbol: string,
-  quoteSymbol: string,
+  metaBase: Address | string | undefined,
+  metaQuote: Address | string | undefined,
+  callerBase: Address | string,
+  callerQuote: Address | string,
 ): boolean => {
-  const baseIsDesignator = isDesignator(baseAddress)
-  const quoteIsDesignator = isDesignator(quoteAddress)
-
-  let result: boolean
-  let path: string
-
-  if (baseIsDesignator !== quoteIsDesignator) {
-    result = baseIsDesignator
-    path = 'designator-anchor'
-  }
-  else {
-    const pair = parseOracleLabelPair(labelPrimary)
-    if (!pair) {
-      result = false
-      path = 'no-label-parse'
-    }
-    else {
-      const [left, right] = pair
-      const directLeft = symbolMatchScore(left, baseSymbol)
-      const directRight = symbolMatchScore(right, quoteSymbol)
-      const flippedLeft = symbolMatchScore(left, quoteSymbol)
-      const flippedRight = symbolMatchScore(right, baseSymbol)
-      const directScore = directLeft && directRight ? directLeft + directRight : 0
-      const flippedScore = flippedLeft && flippedRight ? flippedLeft + flippedRight : 0
-      result = flippedScore > directScore
-      path = `symbol-score direct=${directScore} flipped=${flippedScore}`
-    }
-  }
-
-  if (typeof window !== 'undefined') {
-    // TEMP debug — remove after diagnosing the wSTRCx/STRC display.
-    // eslint-disable-next-line no-console
-    console.log('[shouldInvertOraclePrice]', {
-      labelPrimary,
-      baseAddress,
-      quoteAddress,
-      baseSymbol,
-      quoteSymbol,
-      baseIsDesignator,
-      quoteIsDesignator,
-      path,
-      result,
-    })
-  }
-
-  return result
+  if (!metaBase || !metaQuote) return false
+  if (sameDirection(callerBase, callerQuote, metaBase, metaQuote)) return false
+  if (sameDirection(callerBase, callerQuote, metaQuote, metaBase)) return true
+  return false
 }

--- a/utils/oracle-label.ts
+++ b/utils/oracle-label.ts
@@ -1,23 +1,31 @@
 import type { Address } from 'viem'
 
-export const parseOracleLabelPair = (labelPrimary: string | undefined): [string, string] | null => {
-  if (!labelPrimary) return null
-  const parts = labelPrimary.split('/').map(s => s.trim()).filter(Boolean)
-  if (parts.length !== 2) return null
-  return [parts[0], parts[1]]
+// Each oracle adapter has its own on-chain (base, quote) wiring (recorded in
+// the oracle-checks metadata as `meta.base` / `meta.quote`). Its
+// `getQuote(amount, base, quote)` returns the natural feed direction when
+// called in the wired order; the args swapped returns the inverse.
+//
+// The EulerRouter resolves vault assets through ERC-4626 unwraps and cross
+// adapters and ends up calling each leaf adapter in the direction the router
+// needs. That direction may match the adapter's wiring or be flipped — when
+// it's flipped, the displayed rate is the inverse of the feed's natural
+// number and we want to invert it so the price reads in the direction the
+// label implies.
+//
+// We compare addresses (not symbols) because that is unambiguous; this also
+// avoids depending on async ERC20 symbol() resolution for assets that aren't
+// registered vault assets (e.g. STRCx underlying a wSTRCx vault).
+type InvertArgs = {
+  /** Adapter's on-chain base (from oracle-checks `meta.base`). */
+  metaBase: Address | string | undefined
+  /** Adapter's on-chain quote (from oracle-checks `meta.quote`). */
+  metaQuote: Address | string | undefined
+  /** Direction the router actually calls the adapter with (`OracleAdapterEntry.base`). */
+  callerBase: Address | string
+  /** Direction the router actually calls the adapter with (`OracleAdapterEntry.quote`). */
+  callerQuote: Address | string
 }
 
-// Each oracle adapter has its own on-chain (base, quote) wiring (from the
-// oracle-checks metadata). Its `getQuote(amount, base, quote)` returns the
-// natural feed direction when called in that wired order; calling it with the
-// arguments swapped returns the inverse.
-//
-// The router resolves vault assets through ERC4626 unwraps, cross adapters,
-// etc., and ends up calling each leaf adapter with the (base, quote) pair the
-// router wants. That pair may match the adapter's wiring or be flipped — when
-// it's flipped, the displayed rate is the inverse of the feed's natural number
-// and we need to invert it back so the displayed price reads in the direction
-// the label implies.
 const sameDirection = (
   a: Address | string,
   b: Address | string,
@@ -25,14 +33,16 @@ const sameDirection = (
   d: Address | string,
 ): boolean => a.toLowerCase() === c.toLowerCase() && b.toLowerCase() === d.toLowerCase()
 
-export const shouldInvertOraclePrice = (
-  metaBase: Address | string | undefined,
-  metaQuote: Address | string | undefined,
-  callerBase: Address | string,
-  callerQuote: Address | string,
-): boolean => {
+export const shouldInvertOraclePrice = ({
+  metaBase,
+  metaQuote,
+  callerBase,
+  callerQuote,
+}: InvertArgs): boolean => {
   if (!metaBase || !metaQuote) return false
   if (sameDirection(callerBase, callerQuote, metaBase, metaQuote)) return false
   if (sameDirection(callerBase, callerQuote, metaQuote, metaBase)) return true
+  // Caller pair doesn't line up with the wiring in either direction —
+  // unexpected (no-match fallback). Don't flip.
   return false
 }

--- a/utils/oracle-label.ts
+++ b/utils/oracle-label.ts
@@ -1,36 +1,43 @@
-// Wrapped ERC20s usually keep the underlying asset's symbol as a contiguous
-// core, padded by a short prefix and/or suffix marker — e.g. "STRC" → "STRCx"
-// (suffix "x"), "STRC" → "wSTRCx" (prefix "w" + suffix "x"), "ETH" → "WETH"
-// (prefix "W"), "ETH" → "wstETH" (prefix "wst").
+// Symbol comparison scores (higher is more confident):
+//   2 = exact match (e.g. "USD" ↔ "USD")
+//   1 = loose match — one symbol is a wrapped variant of the other
+//       (e.g. "STRC" ↔ "STRCx", "ETH" ↔ "wstETH")
+//   0 = no match
 //
-// Match if one symbol contains the other as such a core, but reject matches
-// where a 3-letter symbol bleeds into a longer one without a leading marker
-// — that's the "USD" ⊂ "USDC" / "BTC" ⊂ "BTCB" case, which should not match.
-const symbolsMatch = (labelSym: string, addressSym: string): boolean => {
+// Wrapped ERC20s usually keep the underlying asset's symbol as a contiguous
+// core, padded by a short prefix and/or suffix marker — e.g. "STRC" → "STRCx",
+// "STRC" → "wSTRCx", "ETH" → "WETH", "ETH" → "wstETH".
+//
+// The score lets a caller choose between competing directions: when the
+// adapter's base and quote are aliases of each other (stETH vs ETH, wSTRCx vs
+// STRCx), both label sides can match both wirings loosely, and a boolean
+// "matches?" check would tie. Preferring the higher-score direction breaks
+// the tie correctly because exact matches outrank loose ones.
+const symbolMatchScore = (labelSym: string, addressSym: string): 0 | 1 | 2 => {
   const a = labelSym.trim().toLowerCase()
   const b = addressSym.trim().toLowerCase()
-  if (!a || !b) return false
-  if (a === b) return true
+  if (!a || !b) return 0
+  if (a === b) return 2
 
   const core = a.length <= b.length ? a : b
   const wrapped = a.length <= b.length ? b : a
   const idx = wrapped.indexOf(core)
-  if (idx === -1) return false
+  if (idx === -1) return 0
 
   const prefixLen = idx
   const suffixLen = wrapped.length - idx - core.length
 
   // Cap the wrapping markers — without an upper bound, "ETH" would match
   // anything that happens to contain it as a substring.
-  if (prefixLen > 3 || suffixLen > 3) return false
+  if (prefixLen > 3 || suffixLen > 3) return 0
 
-  // Designator-like 3-letter symbols (USD, EUR, BTC, ETH, ...) need a real
+  // Designator-length 3-letter symbols (USD, EUR, BTC, ETH, ...) need a real
   // leading marker to disambiguate from longer tickers built on the same
   // letters. "USDC" starts with "USD" with no marker → reject. "WETH" / "stETH"
   // have a leading w/st marker → accept.
-  if (core.length < 4 && prefixLen === 0) return false
+  if (core.length < 4 && prefixLen === 0) return 0
 
-  return true
+  return 1
 }
 
 export const parseOracleLabelPair = (labelPrimary: string | undefined): [string, string] | null => {
@@ -44,6 +51,11 @@ export const parseOracleLabelPair = (labelPrimary: string | undefined): [string,
 // but oracle-checks labels follow the "X / Y = Y per X" FX convention regardless
 // of which side was assigned as base. When the label flips the symbols relative
 // to the wiring, invert the rate so the displayed number matches the displayed name.
+//
+// Direction is decided by scoring both pairings of label symbols against adapter
+// (base, quote) symbols and picking the higher-scoring one. This handles cases
+// where each label side could loosely match either wiring side (e.g. "stETH /
+// ETH" with adapter base=ETH, quote=stETH) — the exact-match pairing wins.
 export const shouldInvertOraclePrice = (
   labelPrimary: string | undefined,
   baseSymbol: string,
@@ -52,7 +64,16 @@ export const shouldInvertOraclePrice = (
   const pair = parseOracleLabelPair(labelPrimary)
   if (!pair) return false
   const [left, right] = pair
-  const directMatch = symbolsMatch(left, baseSymbol) && symbolsMatch(right, quoteSymbol)
-  if (directMatch) return false
-  return symbolsMatch(left, quoteSymbol) && symbolsMatch(right, baseSymbol)
+
+  // A direction only counts when BOTH sides have a non-zero score —
+  // otherwise a single exact match (e.g. only the quote side matches)
+  // would flip the price on weak evidence.
+  const directLeft = symbolMatchScore(left, baseSymbol)
+  const directRight = symbolMatchScore(right, quoteSymbol)
+  const flippedLeft = symbolMatchScore(left, quoteSymbol)
+  const flippedRight = symbolMatchScore(right, baseSymbol)
+  const directScore = directLeft && directRight ? directLeft + directRight : 0
+  const flippedScore = flippedLeft && flippedRight ? flippedLeft + flippedRight : 0
+
+  return flippedScore > directScore
 }

--- a/utils/oracle-label.ts
+++ b/utils/oracle-label.ts
@@ -81,23 +81,47 @@ export const shouldInvertOraclePrice = (
   const baseIsDesignator = isDesignator(baseAddress)
   const quoteIsDesignator = isDesignator(quoteAddress)
 
+  let result: boolean
+  let path: string
+
   if (baseIsDesignator !== quoteIsDesignator) {
-    return baseIsDesignator
+    result = baseIsDesignator
+    path = 'designator-anchor'
+  }
+  else {
+    const pair = parseOracleLabelPair(labelPrimary)
+    if (!pair) {
+      result = false
+      path = 'no-label-parse'
+    }
+    else {
+      const [left, right] = pair
+      const directLeft = symbolMatchScore(left, baseSymbol)
+      const directRight = symbolMatchScore(right, quoteSymbol)
+      const flippedLeft = symbolMatchScore(left, quoteSymbol)
+      const flippedRight = symbolMatchScore(right, baseSymbol)
+      const directScore = directLeft && directRight ? directLeft + directRight : 0
+      const flippedScore = flippedLeft && flippedRight ? flippedLeft + flippedRight : 0
+      result = flippedScore > directScore
+      path = `symbol-score direct=${directScore} flipped=${flippedScore}`
+    }
   }
 
-  const pair = parseOracleLabelPair(labelPrimary)
-  if (!pair) return false
-  const [left, right] = pair
+  if (typeof window !== 'undefined') {
+    // TEMP debug — remove after diagnosing the wSTRCx/STRC display.
+    // eslint-disable-next-line no-console
+    console.log('[shouldInvertOraclePrice]', {
+      labelPrimary,
+      baseAddress,
+      quoteAddress,
+      baseSymbol,
+      quoteSymbol,
+      baseIsDesignator,
+      quoteIsDesignator,
+      path,
+      result,
+    })
+  }
 
-  // A direction only counts when BOTH sides have a non-zero score —
-  // otherwise a single accidental exact match (e.g. only the quote side)
-  // would flip the price on weak evidence.
-  const directLeft = symbolMatchScore(left, baseSymbol)
-  const directRight = symbolMatchScore(right, quoteSymbol)
-  const flippedLeft = symbolMatchScore(left, quoteSymbol)
-  const flippedRight = symbolMatchScore(right, baseSymbol)
-  const directScore = directLeft && directRight ? directLeft + directRight : 0
-  const flippedScore = flippedLeft && flippedRight ? flippedLeft + flippedRight : 0
-
-  return flippedScore > directScore
+  return result
 }


### PR DESCRIPTION
## Summary
- Oracle adapter rows in the vault overview and discovery matrix tooltip can display a price whose direction contradicts the displayed pair label, because the EulerRouter sometimes calls a leaf adapter in the inverse of its on-chain wiring (e.g. wSTRCx is unwrapped to STRCx and the router then asks the `0xe441…Aa4e` Chainlink leaf for `getQuote(STRCx, USD)`, but the adapter is wired on-chain as `base=USD, quote=STRCx`).
- When that happens the returned rate is the inverse of the feed's natural direction (e.g. `0.01` instead of `~100`), so the displayed price contradicts the `STRC / USD` label.
- Detect the flipped direction by comparing the caller's `(base, quote)` against the adapter's on-chain wiring from oracle-checks metadata (`meta.base` / `meta.quote`). When they're swapped, invert the displayed rate.

## Approach
- New `utils/oracle-label.ts` exporting `shouldInvertOraclePrice({ metaBase, metaQuote, callerBase, callerQuote })`. The decision is a pure address comparison:
  - `(callerBase, callerQuote) == (metaBase, metaQuote)` → don't invert (forward call).
  - `(callerBase, callerQuote) == (metaQuote, metaBase)` → invert (inverse call).
  - Anything else (meta missing, e.g. synthetic ERC4626Vault adapters; or wiring doesn't line up at all) → don't invert.
- Wired into both call sites that render an adapter rate:
  - `components/entities/vault/overview/VaultOverviewBlockOracleAdapters.vue` (oracle card on the vault overview).
  - `components/entities/vault/discovery/DiscoveryMarketMatrix.vue` (oracle tooltip on the market matrix).

This intentionally avoids label-string parsing and fuzzy wrapper-symbol matching, which earlier attempts struggled with for cases like `STRC` ↔ `STRCx` ↔ `wSTRCx` and the symmetric `stETH` ↔ `ETH` ambiguity, and which also broke when ERC20 `symbol()` resolution hadn't yet returned for assets that aren't registered vault assets.

## Test plan
- [ ] Visit the wSTRCx borrow vault — verify the `STRC / USD (0.1%, 86400s)` oracle row shows a price near `100`, not `0.01`.
- [ ] Spot-check a vault whose Chainlink adapter is naturally wired (e.g. `WBTC / USD` with `base=WBTC, quote=USD`) — price unchanged.
- [ ] Confirm the wSTRCx/STRCx ERC4626Vault row continues to show its share→asset rate (`~1.0314`), unchanged.
- [ ] Open the discovery matrix oracle tooltip on the wSTRCx market — same flipped-then-corrected price displayed.
- [ ] `npm test` — the new `tests/utils/oracle-label.test.ts` suite covers the wSTRCx-style flip, the natural-wiring case, the wstETH/stETH symmetric-alias case, missing meta (ERC4626), no-match fallback, and case-insensitive address comparison.