### PR TITLE
fix: show product name (not vault override) in vault overview Market field

### DIFF
--- a/components/entities/vault/overview/SecuritizeVaultOverview.vue
+++ b/components/entities/vault/overview/SecuritizeVaultOverview.vue
@@ -3,7 +3,7 @@ import { getAddress, maxUint256, type Address } from 'viem'
 import { logWarn } from '~/utils/errorHandling'
 import type { SecuritizeVault, Vault, VaultCollateralLTV } from '~/entities/vault'
 import { useEulerEntitiesOfVault } from '~/composables/useEulerLabels'
-import { getProductKeyByVault } from '~/utils/eulerLabelsUtils'
+import { getProductByVault, getProductKeyByVault } from '~/utils/eulerLabelsUtils'
 import { useVaultRegistry } from '~/composables/useVaultRegistry'
 import { getEulerLabelEntityLogo } from '~/entities/euler/labels'
 import { isVaultBlockedByCountry } from '~/composables/useGeoBlock'
@@ -36,6 +36,7 @@ const entities = useEulerEntitiesOfVault(vault as unknown as Vault)
 const isGovernorVerified = computed(() => isVaultGovernorVerified(vault as unknown as Vault))
 const isGovernanceLimited = computed(() => product.isGovernanceLimited && isGovernorVerified.value)
 const marketProductKey = computed(() => getProductKeyByVault(vault.address))
+const marketProductName = computed(() => getProductByVault(vault.address).name)
 
 const isDeprecated = computed(() => {
   return product.deprecatedVaults?.includes(vaultAddress.value) ?? false
@@ -206,10 +207,10 @@ const supplyCapPercentageDisplay = computed(() => {
             :to="{ name: 'explore-market', params: { market: marketProductKey }, query: { network: route.query.network } }"
             class="text-p2 text-content-primary hover:text-accent-600 underline transition-colors"
           >
-            {{ product.name }}
+            {{ marketProductName }}
           </NuxtLink>
           <template v-else>
-            {{ product.name || '-' }}
+            {{ marketProductName || '-' }}
           </template>
         </VaultOverviewLabelValue>
         <VaultOverviewLabelValue

--- a/components/entities/vault/overview/VaultOverviewBlockGeneral.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockGeneral.vue
@@ -3,7 +3,7 @@ import { getAddress } from 'viem'
 import type { Vault } from '~/entities/vault'
 import { formatAssetValue } from '~/services/pricing/priceProvider'
 import { useEulerEntitiesOfVault, useEulerProductOfVault } from '~/composables/useEulerLabels'
-import { getProductKeyByVault } from '~/utils/eulerLabelsUtils'
+import { getProductByVault, getProductKeyByVault } from '~/utils/eulerLabelsUtils'
 import { getEulerLabelEntityLogo } from '~/entities/euler/labels'
 import { isVaultBlockedByCountry } from '~/composables/useGeoBlock'
 import { autoLink } from '~/utils/autoLink'
@@ -19,6 +19,7 @@ const vaultAddress = computed(() => getAddress(vault.address))
 const product = useEulerProductOfVault(vaultAddress)
 const entities = useEulerEntitiesOfVault(vault)
 const marketProductKey = computed(() => getProductKeyByVault(vault.address))
+const marketProductName = computed(() => getProductByVault(vault.address).name)
 const description = computed(() => {
   return product.vaultOverrides?.[vaultAddress.value]?.description ?? product.description
 })
@@ -98,10 +99,10 @@ watchEffect(async () => {
             :to="{ name: 'explore-market', params: { market: marketProductKey }, query: { network: route.query.network } }"
             class="text-p2 text-content-primary hover:text-accent-600 underline transition-colors"
           >
-            {{ product.name }}
+            {{ marketProductName }}
           </NuxtLink>
           <template v-else>
-            {{ product.name || '-' }}
+            {{ marketProductName || '-' }}
           </template>
         </VaultOverviewLabelValue>
         <VaultOverviewLabelValue


### PR DESCRIPTION
## Summary

The **Market** field in the vault overview was showing the per-vault `vaultOverrides[address].name` (e.g. "AUSD - wSTRCx") instead of the actual product name. The Market label should always identify the product the vault belongs to, regardless of whether the vault has a custom display name override.

## Cause

`useEulerProductOfVault` returns the product with `applyVaultOverrides` applied, which replaces `product.name` with the per-vault override when one is defined. The Market label was reading from that overridden product.

## Fix

Added a `marketProductName` computed in both `VaultOverviewBlockGeneral.vue` and `SecuritizeVaultOverview.vue` that reads `getProductByVault(vault.address).name` directly, bypassing the override layer. Other uses of `product.name` / `product.description` on these screens (description text, deprecation state, governance limits, etc.) continue to use the overridden product as intended.

## Test plan

- [ ] Open a vault that has a `vaultOverrides[].name` set (e.g. the Cassa RWA wSTRCx/AUSD market from the report) — Market field shows the product name, not the vault override.
- [ ] Open a vault without overrides — Market field unchanged.
- [ ] Open a Securitize vault — same verification applies.
- [ ] Confirm the rest of the page (header avatars, description, vault type chip) is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated market product name display logic in vault overview components to use consistent data sources, ensuring accurate market information is shown across different vault scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/euler-xyz/euler-lite/pull/433)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->