### PR TITLE
feat(merkl): support EULER_BORROW_FROM_COLLATERAL and EULER_MULTI_BORROW_FROM_COLLATERAL

### DIFF
--- a/composables/useMerkl.ts
+++ b/composables/useMerkl.ts
@@ -101,7 +101,9 @@ const processOpportunitiesToCampaigns = (
   opType: 'EULER' | 'ERC20LOGPROCESSOR',
 ): Map<string, RewardCampaign[]> => {
   const campaignMap = new Map<string, RewardCampaign[]>()
-  const now = Math.floor(Date.now() / 1000)
+  // TEMPORARY: `now` removed alongside the endTimestamp filter while
+  // test=true is active. Restore `const now = Math.floor(Date.now() / 1000)`
+  // when the zero-APR / status filters are re-introduced.
 
   for (const opportunity of opportunities) {
     // TEMPORARY: status check relaxed while the upstream URL passes
@@ -129,8 +131,11 @@ const processOpportunitiesToCampaigns = (
 
       const apr = aprs.get(campaign.campaignId) || 0
 
-      // Skip active campaigns with no APR
-      if (campaign.endTimestamp > now && !apr) continue
+      // TEMPORARY: zero-APR skip relaxed while test=true is active. Test
+      // campaigns frequently report apr=0 (no real liquidity has used them
+      // yet), but they still need to surface so we can verify the wiring.
+      // Restore `if (campaign.endTimestamp > now && !apr) continue` when
+      // test=true is removed.
 
       const vaultAddress = opType === 'ERC20LOGPROCESSOR'
         ? (campaign.params.targetToken).toLowerCase()
@@ -167,7 +172,7 @@ const processMultiLendBorrowOpportunities = (
   opportunities: Opportunity[],
 ): Map<string, RewardCampaign[]> => {
   const campaignMap = new Map<string, RewardCampaign[]>()
-  const now = Math.floor(Date.now() / 1000)
+  // TEMPORARY: see processOpportunitiesToCampaigns.
 
   for (const opportunity of opportunities) {
     // TEMPORARY: see processOpportunitiesToCampaigns for rationale.
@@ -195,7 +200,8 @@ const processMultiLendBorrowOpportunities = (
       // MULTILENDBORROW that breakdown can be absent/zero while the top-level
       // campaign.apr is populated, so fall back to it.
       const apr = aprs.get(campaign.campaignId) || campaign.apr || 0
-      if (campaign.endTimestamp > now && !apr) continue
+      // TEMPORARY: see processOpportunitiesToCampaigns — zero-APR skip
+      // relaxed while test=true is active.
 
       for (const market of markets) {
         const vaultAddress = (
@@ -243,7 +249,7 @@ export const processBorrowFromCollateralOpportunities = (
   opType: 'EULER_BORROW_FROM_COLLATERAL' | 'EULER_MULTI_BORROW_FROM_COLLATERAL',
 ): Map<string, RewardCampaign[]> => {
   const campaignMap = new Map<string, RewardCampaign[]>()
-  const now = Math.floor(Date.now() / 1000)
+  // TEMPORARY: see processOpportunitiesToCampaigns.
 
   for (const opportunity of opportunities) {
     // TEMPORARY: see processOpportunitiesToCampaigns for rationale.
@@ -260,7 +266,8 @@ export const processBorrowFromCollateralOpportunities = (
       // Mirror the MULTILENDBORROW fallback: breakdown can be absent or zero
       // while campaign.apr is populated.
       const apr = aprs.get(campaign.campaignId) || campaign.apr || 0
-      if (campaign.endTimestamp > now && !apr) continue
+      // TEMPORARY: see processOpportunitiesToCampaigns — zero-APR skip
+      // relaxed while test=true is active.
 
       const pairs: { vault: string, collateral: string }[] = []
 

--- a/composables/useMerkl.ts
+++ b/composables/useMerkl.ts
@@ -104,11 +104,7 @@ const processOpportunitiesToCampaigns = (
   const now = Math.floor(Date.now() / 1000)
 
   for (const opportunity of opportunities) {
-    // TEMPORARY: status check relaxed while the upstream URL passes
-    // `&test=true`. Merkl marks test opportunities as PAST even when their
-    // campaigns are active; the per-campaign `endTimestamp > now` filter
-    // below already drops truly expired campaigns. Restore the
-    // `status !== 'LIVE'` filter when test=true is removed.
+    if (opportunity.status !== 'LIVE') continue
     if (!opportunity.campaigns?.length) continue
     if (!opportunity.aprRecord?.breakdowns) continue
 
@@ -170,7 +166,7 @@ const processMultiLendBorrowOpportunities = (
   const now = Math.floor(Date.now() / 1000)
 
   for (const opportunity of opportunities) {
-    // TEMPORARY: see processOpportunitiesToCampaigns for rationale.
+    if (opportunity.status !== 'LIVE') continue
     if (!opportunity.campaigns?.length) continue
 
     const side: RewardCampaignType | null
@@ -246,7 +242,7 @@ export const processBorrowFromCollateralOpportunities = (
   const now = Math.floor(Date.now() / 1000)
 
   for (const opportunity of opportunities) {
-    // TEMPORARY: see processOpportunitiesToCampaigns for rationale.
+    if (opportunity.status !== 'LIVE') continue
     if (!opportunity.campaigns?.length) continue
 
     const aprs = new Map<string, number>()

--- a/composables/useMerkl.ts
+++ b/composables/useMerkl.ts
@@ -336,13 +336,13 @@ const loadOpportunities = async (chainId: number, isInitialLoading = true, force
       }
     }
 
-    mergeInto(processOpportunitiesToCampaigns(res.opportunities.euler, 'EULER'))
-    mergeInto(processOpportunitiesToCampaigns(res.opportunities.erc20logprocessor, 'ERC20LOGPROCESSOR'))
-    mergeInto(processMultiLendBorrowOpportunities(res.opportunities.multilendborrow))
+    mergeInto(processOpportunitiesToCampaigns(res.opportunities.euler ?? [], 'EULER'))
+    mergeInto(processOpportunitiesToCampaigns(res.opportunities.erc20logprocessor ?? [], 'ERC20LOGPROCESSOR'))
+    mergeInto(processMultiLendBorrowOpportunities(res.opportunities.multilendborrow ?? []))
     mergeInto(processBorrowFromCollateralOpportunities(
-      res.opportunities.euler_borrow_from_collateral, 'EULER_BORROW_FROM_COLLATERAL'))
+      res.opportunities.euler_borrow_from_collateral ?? [], 'EULER_BORROW_FROM_COLLATERAL'))
     mergeInto(processBorrowFromCollateralOpportunities(
-      res.opportunities.euler_multi_borrow_from_collateral, 'EULER_MULTI_BORROW_FROM_COLLATERAL'))
+      res.opportunities.euler_multi_borrow_from_collateral ?? [], 'EULER_MULTI_BORROW_FROM_COLLATERAL'))
 
     merklCampaigns.value = merged
     cacheState.opportunities = { chainId, timestamp: Date.now() }

--- a/composables/useMerkl.ts
+++ b/composables/useMerkl.ts
@@ -101,9 +101,7 @@ const processOpportunitiesToCampaigns = (
   opType: 'EULER' | 'ERC20LOGPROCESSOR',
 ): Map<string, RewardCampaign[]> => {
   const campaignMap = new Map<string, RewardCampaign[]>()
-  // TEMPORARY: `now` removed alongside the endTimestamp filter while
-  // test=true is active. Restore `const now = Math.floor(Date.now() / 1000)`
-  // when the zero-APR / status filters are re-introduced.
+  const now = Math.floor(Date.now() / 1000)
 
   for (const opportunity of opportunities) {
     // TEMPORARY: status check relaxed while the upstream URL passes
@@ -131,11 +129,8 @@ const processOpportunitiesToCampaigns = (
 
       const apr = aprs.get(campaign.campaignId) || 0
 
-      // TEMPORARY: zero-APR skip relaxed while test=true is active. Test
-      // campaigns frequently report apr=0 (no real liquidity has used them
-      // yet), but they still need to surface so we can verify the wiring.
-      // Restore `if (campaign.endTimestamp > now && !apr) continue` when
-      // test=true is removed.
+      // Skip active campaigns with no APR
+      if (campaign.endTimestamp > now && !apr) continue
 
       const vaultAddress = opType === 'ERC20LOGPROCESSOR'
         ? (campaign.params.targetToken).toLowerCase()
@@ -172,7 +167,7 @@ const processMultiLendBorrowOpportunities = (
   opportunities: Opportunity[],
 ): Map<string, RewardCampaign[]> => {
   const campaignMap = new Map<string, RewardCampaign[]>()
-  // TEMPORARY: see processOpportunitiesToCampaigns.
+  const now = Math.floor(Date.now() / 1000)
 
   for (const opportunity of opportunities) {
     // TEMPORARY: see processOpportunitiesToCampaigns for rationale.
@@ -200,8 +195,7 @@ const processMultiLendBorrowOpportunities = (
       // MULTILENDBORROW that breakdown can be absent/zero while the top-level
       // campaign.apr is populated, so fall back to it.
       const apr = aprs.get(campaign.campaignId) || campaign.apr || 0
-      // TEMPORARY: see processOpportunitiesToCampaigns — zero-APR skip
-      // relaxed while test=true is active.
+      if (campaign.endTimestamp > now && !apr) continue
 
       for (const market of markets) {
         const vaultAddress = (
@@ -249,7 +243,7 @@ export const processBorrowFromCollateralOpportunities = (
   opType: 'EULER_BORROW_FROM_COLLATERAL' | 'EULER_MULTI_BORROW_FROM_COLLATERAL',
 ): Map<string, RewardCampaign[]> => {
   const campaignMap = new Map<string, RewardCampaign[]>()
-  // TEMPORARY: see processOpportunitiesToCampaigns.
+  const now = Math.floor(Date.now() / 1000)
 
   for (const opportunity of opportunities) {
     // TEMPORARY: see processOpportunitiesToCampaigns for rationale.
@@ -266,8 +260,7 @@ export const processBorrowFromCollateralOpportunities = (
       // Mirror the MULTILENDBORROW fallback: breakdown can be absent or zero
       // while campaign.apr is populated.
       const apr = aprs.get(campaign.campaignId) || campaign.apr || 0
-      // TEMPORARY: see processOpportunitiesToCampaigns — zero-APR skip
-      // relaxed while test=true is active.
+      if (campaign.endTimestamp > now && !apr) continue
 
       const pairs: { vault: string, collateral: string }[] = []
 

--- a/composables/useMerkl.ts
+++ b/composables/useMerkl.ts
@@ -3,7 +3,13 @@ import type { Address } from 'viem'
 import axios from 'axios'
 
 import { merklDistributorABI } from '~/abis/merkl'
-import type { Opportunity, Reward, RewardsResponseItem } from '~/entities/merkl'
+import type {
+  MerklOpportunityType,
+  MerklResponseKey,
+  Opportunity,
+  Reward,
+  RewardsResponseItem,
+} from '~/entities/merkl'
 import type { RewardCampaign, RewardCampaignType } from '~/entities/reward-campaign'
 import { mapMerklSubType } from '~/entities/reward-campaign'
 import type { TxPlan } from '~/entities/txPlan'
@@ -54,27 +60,14 @@ let latestOpportunitiesRequestId = 0
 let latestRewardsRequestId = 0
 
 interface MerklProxyResponse {
-  opportunities: {
-    euler: Opportunity[]
-    multilendborrow: Opportunity[]
-    erc20logprocessor: Opportunity[]
-    euler_borrow_from_collateral: Opportunity[]
-    euler_multi_borrow_from_collateral: Opportunity[]
-  }
+  opportunities: Record<MerklResponseKey, Opportunity[]>
 }
 
 const MERKL_EULER_SOURCE_URL = 'https://app.merkl.xyz/?protocol=euler'
 
-type MerklOpportunityKind
-  = | 'EULER'
-    | 'ERC20LOGPROCESSOR'
-    | 'MULTILENDBORROW'
-    | 'EULER_BORROW_FROM_COLLATERAL'
-    | 'EULER_MULTI_BORROW_FROM_COLLATERAL'
-
 const merklOpportunityUrl = (
   opportunity: Opportunity,
-  type: MerklOpportunityKind,
+  type: MerklOpportunityType,
 ): string => {
   if (!opportunity.identifier) return MERKL_EULER_SOURCE_URL
 

--- a/composables/useMerkl.ts
+++ b/composables/useMerkl.ts
@@ -104,7 +104,11 @@ const processOpportunitiesToCampaigns = (
   const now = Math.floor(Date.now() / 1000)
 
   for (const opportunity of opportunities) {
-    if (opportunity.status !== 'LIVE') continue
+    // TEMPORARY: status check relaxed while the upstream URL passes
+    // `&test=true`. Merkl marks test opportunities as PAST even when their
+    // campaigns are active; the per-campaign `endTimestamp > now` filter
+    // below already drops truly expired campaigns. Restore the
+    // `status !== 'LIVE'` filter when test=true is removed.
     if (!opportunity.campaigns?.length) continue
     if (!opportunity.aprRecord?.breakdowns) continue
 
@@ -166,7 +170,7 @@ const processMultiLendBorrowOpportunities = (
   const now = Math.floor(Date.now() / 1000)
 
   for (const opportunity of opportunities) {
-    if (opportunity.status !== 'LIVE') continue
+    // TEMPORARY: see processOpportunitiesToCampaigns for rationale.
     if (!opportunity.campaigns?.length) continue
 
     const side: RewardCampaignType | null
@@ -242,7 +246,7 @@ export const processBorrowFromCollateralOpportunities = (
   const now = Math.floor(Date.now() / 1000)
 
   for (const opportunity of opportunities) {
-    if (opportunity.status !== 'LIVE') continue
+    // TEMPORARY: see processOpportunitiesToCampaigns for rationale.
     if (!opportunity.campaigns?.length) continue
 
     const aprs = new Map<string, number>()

--- a/composables/useMerkl.ts
+++ b/composables/useMerkl.ts
@@ -58,14 +58,23 @@ interface MerklProxyResponse {
     euler: Opportunity[]
     multilendborrow: Opportunity[]
     erc20logprocessor: Opportunity[]
+    euler_borrow_from_collateral: Opportunity[]
+    euler_multi_borrow_from_collateral: Opportunity[]
   }
 }
 
 const MERKL_EULER_SOURCE_URL = 'https://app.merkl.xyz/?protocol=euler'
 
+type MerklOpportunityKind
+  = | 'EULER'
+    | 'ERC20LOGPROCESSOR'
+    | 'MULTILENDBORROW'
+    | 'EULER_BORROW_FROM_COLLATERAL'
+    | 'EULER_MULTI_BORROW_FROM_COLLATERAL'
+
 const merklOpportunityUrl = (
   opportunity: Opportunity,
-  type: 'EULER' | 'ERC20LOGPROCESSOR' | 'MULTILENDBORROW',
+  type: MerklOpportunityKind,
 ): string => {
   if (!opportunity.identifier) return MERKL_EULER_SOURCE_URL
 
@@ -77,7 +86,7 @@ const merklOpportunityUrl = (
 }
 
 // Public campaign data flows through `/api/rewards/merkl`, which warms the
-// three Merkl opportunity types server-side and returns one CDN-cacheable
+// Merkl opportunity types server-side and returns one CDN-cacheable
 // GET. User-specific /users/{addr}/rewards stays direct (per-wallet data
 // not safe to put on a shared cache).
 //
@@ -218,6 +227,87 @@ const processMultiLendBorrowOpportunities = (
   return campaignMap
 }
 
+// EULER_BORROW_FROM_COLLATERAL (single vault) and
+// EULER_MULTI_BORROW_FROM_COLLATERAL (multiple vaults) share a params shape:
+// each campaign carries `params.vaults[]`, where every entry pairs one borrow
+// vault (evkAddress) with the list of collateral vaults (collaterals[].tokenAddress)
+// eligible for the reward. We fan out one RewardCampaign per (vault, collateral)
+// pair using the existing `euler_borrow_collateral` type so the existing
+// per-collateral filter in useRewardsApy picks them up unchanged.
+//
+// Defensive fallback: if `params.vaults` is absent but the flat
+// `evkAddress` + `collateralAddress` pair is present, treat it as a single
+// pair. Keeps us forward-compatible if EULER_BORROW_FROM_COLLATERAL ships
+// with the legacy params layout.
+//
+// Exported for unit tests; the public surface is the `useMerkl` composable.
+export const processBorrowFromCollateralOpportunities = (
+  opportunities: Opportunity[],
+  opType: 'EULER_BORROW_FROM_COLLATERAL' | 'EULER_MULTI_BORROW_FROM_COLLATERAL',
+): Map<string, RewardCampaign[]> => {
+  const campaignMap = new Map<string, RewardCampaign[]>()
+  const now = Math.floor(Date.now() / 1000)
+
+  for (const opportunity of opportunities) {
+    if (opportunity.status !== 'LIVE') continue
+    if (!opportunity.campaigns?.length) continue
+
+    const aprs = new Map<string, number>()
+    for (const breakdown of opportunity.aprRecord?.breakdowns ?? []) {
+      aprs.set(breakdown.identifier, breakdown.value)
+    }
+
+    for (const campaign of opportunity.campaigns) {
+      if (!campaign.rewardToken) continue
+
+      // Mirror the MULTILENDBORROW fallback: breakdown can be absent or zero
+      // while campaign.apr is populated.
+      const apr = aprs.get(campaign.campaignId) || campaign.apr || 0
+      if (campaign.endTimestamp > now && !apr) continue
+
+      const pairs: { vault: string, collateral: string }[] = []
+
+      const vaults = campaign.params?.vaults
+      if (vaults?.length) {
+        for (const vault of vaults) {
+          const vaultAddress = vault.evkAddress?.toLowerCase()
+          if (!vaultAddress) continue
+          for (const collateral of vault.collaterals ?? []) {
+            const collateralAddress = collateral.tokenAddress?.toLowerCase()
+            if (!collateralAddress) continue
+            pairs.push({ vault: vaultAddress, collateral: collateralAddress })
+          }
+        }
+      }
+      else if (campaign.params?.evkAddress && campaign.params?.collateralAddress) {
+        pairs.push({
+          vault: campaign.params.evkAddress.toLowerCase(),
+          collateral: campaign.params.collateralAddress.toLowerCase(),
+        })
+      }
+
+      for (const { vault, collateral } of pairs) {
+        const rewardCampaign: RewardCampaign = {
+          vault,
+          collateral,
+          type: 'euler_borrow_collateral',
+          apr,
+          provider: 'merkl',
+          endTimestamp: campaign.endTimestamp,
+          rewardToken: { symbol: campaign.rewardToken.symbol, icon: campaign.rewardToken.icon },
+          sourceUrl: merklOpportunityUrl(opportunity, opType),
+        }
+
+        const existing = campaignMap.get(vault)
+        if (existing) existing.push(rewardCampaign)
+        else campaignMap.set(vault, [rewardCampaign])
+      }
+    }
+  }
+
+  return campaignMap
+}
+
 const loadOpportunities = async (chainId: number, isInitialLoading = true, forceRefresh = false) => {
   const now = Date.now()
   // Skip if cached and not expired
@@ -235,10 +325,9 @@ const loadOpportunities = async (chainId: number, isInitialLoading = true, force
       isOpportunitiesLoading.value = true
     }
 
-    // Server proxy returns the three Merkl opportunity types already
-    // paginated and (for ERC20LOGPROCESSOR) already filtered against the
-    // chain's earn-vault label set — so this composable just merges and
-    // transforms.
+    // Server proxy returns the Merkl opportunity types already paginated
+    // and (for ERC20LOGPROCESSOR) already filtered against the chain's
+    // earn-vault label set — so this composable just merges and transforms.
     const res = await fetchMerklProxy(chainId)
     if (!res) return
 
@@ -257,6 +346,10 @@ const loadOpportunities = async (chainId: number, isInitialLoading = true, force
     mergeInto(processOpportunitiesToCampaigns(res.opportunities.euler, 'EULER'))
     mergeInto(processOpportunitiesToCampaigns(res.opportunities.erc20logprocessor, 'ERC20LOGPROCESSOR'))
     mergeInto(processMultiLendBorrowOpportunities(res.opportunities.multilendborrow))
+    mergeInto(processBorrowFromCollateralOpportunities(
+      res.opportunities.euler_borrow_from_collateral, 'EULER_BORROW_FROM_COLLATERAL'))
+    mergeInto(processBorrowFromCollateralOpportunities(
+      res.opportunities.euler_multi_borrow_from_collateral, 'EULER_MULTI_BORROW_FROM_COLLATERAL'))
 
     merklCampaigns.value = merged
     cacheState.opportunities = { chainId, timestamp: Date.now() }

--- a/entities/merkl.ts
+++ b/entities/merkl.ts
@@ -127,6 +127,15 @@ export interface Opportunity {
           targetToken: string
         }
       }[]
+      // Used by EULER_BORROW_FROM_COLLATERAL (single entry) and
+      // EULER_MULTI_BORROW_FROM_COLLATERAL (multiple entries). Each vault
+      // pairs a borrow vault (evkAddress) with the list of collateral vaults
+      // eligible for the reward (collaterals[].tokenAddress is the EVK
+      // collateral vault address, not the underlying).
+      vaults?: {
+        evkAddress: string
+        collaterals?: { tokenAddress: string }[]
+      }[]
     }
     createdAt: string
   }[]

--- a/entities/merkl.ts
+++ b/entities/merkl.ts
@@ -194,3 +194,23 @@ export interface RewardToken {
   price: number | null
   minimumAmountPerHour: string
 }
+
+export type MerklOpportunityType
+  = | 'EULER'
+    | 'MULTILENDBORROW'
+    | 'ERC20LOGPROCESSOR'
+    | 'EULER_BORROW_FROM_COLLATERAL'
+    | 'EULER_MULTI_BORROW_FROM_COLLATERAL'
+
+// Single source of truth for the proxy response shape and warm-cache fan-out.
+// Lowercase keys (`Lowercase<MerklOpportunityType>`) are derived from these
+// values so reordering this list cannot silently swap response payloads.
+export const MERKL_TYPES: readonly MerklOpportunityType[] = [
+  'EULER',
+  'MULTILENDBORROW',
+  'ERC20LOGPROCESSOR',
+  'EULER_BORROW_FROM_COLLATERAL',
+  'EULER_MULTI_BORROW_FROM_COLLATERAL',
+] as const
+
+export type MerklResponseKey = Lowercase<MerklOpportunityType>

--- a/server/api/rewards/merkl.get.ts
+++ b/server/api/rewards/merkl.get.ts
@@ -27,25 +27,21 @@ import { reportStatus } from '~/server/utils/log'
 import { resolveChainId } from '~/server/utils/resolve-chain-id'
 import {
   type CachedEntry,
-  type MerklOpportunityType,
   readMerklType,
   refreshMerklType,
   scheduleRevalidation,
 } from '~/server/utils/rewards-cache'
+import {
+  MERKL_TYPES,
+  type MerklOpportunityType,
+  type MerklResponseKey,
+} from '~/entities/merkl'
 
 const rateLimiter = createRateLimiter({
   max: 1000,
   windowMs: 60_000,
   label: 'rewards-merkl-proxy',
 })
-
-const MERKL_TYPES: MerklOpportunityType[] = [
-  'EULER',
-  'MULTILENDBORROW',
-  'ERC20LOGPROCESSOR',
-  'EULER_BORROW_FROM_COLLATERAL',
-  'EULER_MULTI_BORROW_FROM_COLLATERAL',
-]
 
 const resolveOpportunity = async (
   chainId: number,
@@ -69,15 +65,16 @@ export default defineEventHandler(async (event) => {
     MERKL_TYPES.map(type => resolveOpportunity(chainId, type)),
   )
 
-  const euler = results[0].status === 'fulfilled' ? results[0].value : []
-  const multi = results[1].status === 'fulfilled' ? results[1].value : []
-  const erc20 = results[2].status === 'fulfilled' ? results[2].value : []
-  const borrowFromCollateral = results[3].status === 'fulfilled' ? results[3].value : []
-  const multiBorrowFromCollateral = results[4].status === 'fulfilled' ? results[4].value : []
-
-  // Log individual failures on state transition but don't fail the whole response
+  // Build the response by iterating MERKL_TYPES — the response key is derived
+  // from each type (`.toLowerCase()`), so reordering MERKL_TYPES cannot
+  // silently mis-assign payloads to keys.
+  const opportunities = {} as Record<MerklResponseKey, unknown[]>
   for (const [i, type] of MERKL_TYPES.entries()) {
     const result = results[i]
+    const key = type.toLowerCase() as MerklResponseKey
+    opportunities[key] = result.status === 'fulfilled' ? result.value : []
+
+    // Log individual failures on state transition but don't fail the whole response
     if (result.status === 'rejected') {
       const msg = result.reason instanceof Error ? result.reason.message : String(result.reason)
       reportStatus('rewards-merkl', `cold-path:${type}:${chainId}`, `failed:${msg}`,
@@ -97,18 +94,7 @@ export default defineEventHandler(async (event) => {
   // polls between warm cycles skips Nitro entirely for most hits.
   setResponseHeader(event, 'Cache-Control', 'public, max-age=30, stale-while-revalidate=30')
 
-  return {
-    opportunities: {
-      euler,
-      multilendborrow: multi,
-      erc20logprocessor: erc20,
-      euler_borrow_from_collateral: borrowFromCollateral,
-      euler_multi_borrow_from_collateral: multiBorrowFromCollateral,
-    },
-  }
+  return { opportunities }
 })
 
-// Referenced so the warm-cache plugin can pre-populate each type without
-// re-declaring the list.
-export { MERKL_TYPES }
 export type { CachedEntry }

--- a/server/api/rewards/merkl.get.ts
+++ b/server/api/rewards/merkl.get.ts
@@ -1,10 +1,11 @@
 /**
  * Read-only proxy for Merkl opportunity (campaign) data.
  *
- * Consolidates the three opportunity types (EULER, MULTILENDBORROW,
- * ERC20LOGPROCESSOR) — each paginated internally up to 10x100 items —
- * into a single response so useMerkl() makes one proxy call per chain
- * instead of 3+ on every tick.
+ * Consolidates the Merkl opportunity types (EULER, MULTILENDBORROW,
+ * ERC20LOGPROCESSOR, EULER_BORROW_FROM_COLLATERAL,
+ * EULER_MULTI_BORROW_FROM_COLLATERAL) — each paginated internally up to
+ * 10x100 items — into a single response so useMerkl() makes one proxy
+ * call per chain instead of 5+ on every tick.
  *
  * Merkl's global `/tokens/reward` payload is NOT returned here. It's
  * a 4th source inside `/api/token-list` (see fetchMerkl there), covering
@@ -38,7 +39,13 @@ const rateLimiter = createRateLimiter({
   label: 'rewards-merkl-proxy',
 })
 
-const MERKL_TYPES: MerklOpportunityType[] = ['EULER', 'MULTILENDBORROW', 'ERC20LOGPROCESSOR']
+const MERKL_TYPES: MerklOpportunityType[] = [
+  'EULER',
+  'MULTILENDBORROW',
+  'ERC20LOGPROCESSOR',
+  'EULER_BORROW_FROM_COLLATERAL',
+  'EULER_MULTI_BORROW_FROM_COLLATERAL',
+]
 
 const resolveOpportunity = async (
   chainId: number,
@@ -58,15 +65,15 @@ export default defineEventHandler(async (event) => {
 
   const chainId = resolveChainId(event)
 
-  const results = await Promise.allSettled([
-    resolveOpportunity(chainId, 'EULER'),
-    resolveOpportunity(chainId, 'MULTILENDBORROW'),
-    resolveOpportunity(chainId, 'ERC20LOGPROCESSOR'),
-  ])
+  const results = await Promise.allSettled(
+    MERKL_TYPES.map(type => resolveOpportunity(chainId, type)),
+  )
 
   const euler = results[0].status === 'fulfilled' ? results[0].value : []
   const multi = results[1].status === 'fulfilled' ? results[1].value : []
   const erc20 = results[2].status === 'fulfilled' ? results[2].value : []
+  const borrowFromCollateral = results[3].status === 'fulfilled' ? results[3].value : []
+  const multiBorrowFromCollateral = results[4].status === 'fulfilled' ? results[4].value : []
 
   // Log individual failures on state transition but don't fail the whole response
   for (const [i, type] of MERKL_TYPES.entries()) {
@@ -81,7 +88,7 @@ export default defineEventHandler(async (event) => {
     }
   }
 
-  // Only fail if all three subtypes failed — partial data is better than none
+  // Only fail if every subtype failed — partial data is better than none
   if (results.every(r => r.status === 'rejected')) {
     throw createError({ statusCode: 502, statusMessage: 'Merkl upstream error' })
   }
@@ -95,6 +102,8 @@ export default defineEventHandler(async (event) => {
       euler,
       multilendborrow: multi,
       erc20logprocessor: erc20,
+      euler_borrow_from_collateral: borrowFromCollateral,
+      euler_multi_borrow_from_collateral: multiBorrowFromCollateral,
     },
   }
 })

--- a/server/plugins/warm-cache.ts
+++ b/server/plugins/warm-cache.ts
@@ -17,7 +17,7 @@
  *   • Global (parallel with the chain loop): /api/euler-chains and
  *     cross-chain `all/assets.json`.
  *   • Per-chain (serialized one chain at a time): labels, token-list,
- *     intrinsic-apy, vault-categories, Merkl opportunities × 3,
+ *     intrinsic-apy, vault-categories, Merkl opportunities × 5,
  *     Brevis campaigns, Fuul × 2, refreshChainVaults(chainId). Tasks
  *     within a single chain still run in parallel.
  *
@@ -62,7 +62,13 @@ import {
 
 const REWARM_INTERVAL_MS = 5 * 60_000
 
-const MERKL_TYPES: MerklOpportunityType[] = ['EULER', 'MULTILENDBORROW', 'ERC20LOGPROCESSOR']
+const MERKL_TYPES: MerklOpportunityType[] = [
+  'EULER',
+  'MULTILENDBORROW',
+  'ERC20LOGPROCESSOR',
+  'EULER_BORROW_FROM_COLLATERAL',
+  'EULER_MULTI_BORROW_FROM_COLLATERAL',
+]
 const FUUL_PROTOCOLS: FuulProtocol[] = ['euler', 'euler-looping']
 
 // Nitro dev mode re-imports server plugins across its double-init (Vite

--- a/server/plugins/warm-cache.ts
+++ b/server/plugins/warm-cache.ts
@@ -54,21 +54,14 @@ import { refreshVaultCategories } from '../utils/vault-categories-store'
 import { refreshIntrinsicApyForChain } from '../utils/intrinsic-apy'
 import {
   type FuulProtocol,
-  type MerklOpportunityType,
   refreshBrevisCampaigns,
   refreshFuulProtocol,
   refreshMerklType,
 } from '../utils/rewards-cache'
+import { MERKL_TYPES } from '~/entities/merkl'
 
 const REWARM_INTERVAL_MS = 5 * 60_000
 
-const MERKL_TYPES: MerklOpportunityType[] = [
-  'EULER',
-  'MULTILENDBORROW',
-  'ERC20LOGPROCESSOR',
-  'EULER_BORROW_FROM_COLLATERAL',
-  'EULER_MULTI_BORROW_FROM_COLLATERAL',
-]
 const FUUL_PROTOCOLS: FuulProtocol[] = ['euler', 'euler-looping']
 
 // Nitro dev mode re-imports server plugins across its double-init (Vite

--- a/server/utils/rewards-cache.ts
+++ b/server/utils/rewards-cache.ts
@@ -27,6 +27,7 @@ import {
   FUUL_API_BASE_URL,
   MERKL_API_BASE_URL,
 } from '~/entities/constants'
+import type { MerklOpportunityType } from '~/entities/merkl'
 
 const CACHE_TTL_MS = 5 * 60_000
 /** Wall-clock budget for a full paginated Merkl request (all pages combined). */
@@ -38,13 +39,10 @@ const MERKL_PAGE_SIZE = 100
 // silent truncation.
 const MAX_MERKL_PAGES = 10
 
-export type MerklOpportunityType
-  = | 'EULER'
-    | 'MULTILENDBORROW'
-    | 'ERC20LOGPROCESSOR'
-    | 'EULER_BORROW_FROM_COLLATERAL'
-    | 'EULER_MULTI_BORROW_FROM_COLLATERAL'
 export type FuulProtocol = 'euler' | 'euler-looping'
+
+// Re-export so other server modules can keep importing from this file.
+export type { MerklOpportunityType }
 
 // Upstream response is unknown — server never interprets shape.
 const rewardsCache = createTtlCache<unknown>({ ttlMs: CACHE_TTL_MS, maxEntries: 500 })

--- a/server/utils/rewards-cache.ts
+++ b/server/utils/rewards-cache.ts
@@ -83,8 +83,10 @@ const filterErc20LogProcessor = (
 }
 
 const fetchMerklType = async (chainId: number, type: MerklOpportunityType): Promise<unknown[]> => {
-  // Production Merkl URL — no `&test=true` debug flag.
-  const baseUrl = `${MERKL_API_BASE_URL}/opportunities/?chainId=${chainId}&type=${type}&campaigns=true`
+  // `&test=true` surfaces Merkl's dry-run campaigns alongside real ones.
+  // Temporary while the new opportunity types are being rolled out — REMOVE
+  // BEFORE PRODUCTION RELEASE.
+  const baseUrl = `${MERKL_API_BASE_URL}/opportunities/?chainId=${chainId}&type=${type}&campaigns=true&test=true`
   const collected: unknown[] = []
 
   for (let page = 0; page < MAX_MERKL_PAGES; page++) {

--- a/server/utils/rewards-cache.ts
+++ b/server/utils/rewards-cache.ts
@@ -83,10 +83,8 @@ const filterErc20LogProcessor = (
 }
 
 const fetchMerklType = async (chainId: number, type: MerklOpportunityType): Promise<unknown[]> => {
-  // `&test=true` surfaces Merkl's dry-run campaigns alongside real ones.
-  // Temporary while the new opportunity types are being rolled out — REMOVE
-  // BEFORE PRODUCTION RELEASE.
-  const baseUrl = `${MERKL_API_BASE_URL}/opportunities/?chainId=${chainId}&type=${type}&campaigns=true&test=true`
+  // Production Merkl URL — no `&test=true` debug flag.
+  const baseUrl = `${MERKL_API_BASE_URL}/opportunities/?chainId=${chainId}&type=${type}&campaigns=true`
   const collected: unknown[] = []
 
   for (let page = 0; page < MAX_MERKL_PAGES; page++) {

--- a/server/utils/rewards-cache.ts
+++ b/server/utils/rewards-cache.ts
@@ -38,7 +38,12 @@ const MERKL_PAGE_SIZE = 100
 // silent truncation.
 const MAX_MERKL_PAGES = 10
 
-export type MerklOpportunityType = 'EULER' | 'MULTILENDBORROW' | 'ERC20LOGPROCESSOR'
+export type MerklOpportunityType
+  = | 'EULER'
+    | 'MULTILENDBORROW'
+    | 'ERC20LOGPROCESSOR'
+    | 'EULER_BORROW_FROM_COLLATERAL'
+    | 'EULER_MULTI_BORROW_FROM_COLLATERAL'
 export type FuulProtocol = 'euler' | 'euler-looping'
 
 // Upstream response is unknown — server never interprets shape.

--- a/tests/composables/useMerkl-processors.test.ts
+++ b/tests/composables/useMerkl-processors.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Unit test for the EULER_BORROW_FROM_COLLATERAL /
+ * EULER_MULTI_BORROW_FROM_COLLATERAL processor in useMerkl.
+ *
+ * Fixture mirrors a trimmed slice of the live Merkl opportunity
+ * `f8f41d9ced97a082` on mainnet: two vaults, 7 + 1 collaterals → 8 emitted
+ * RewardCampaign rows under the existing `euler_borrow_collateral` type.
+ *
+ * Also covers the defensive flat-shape fallback used if
+ * EULER_BORROW_FROM_COLLATERAL ever ships with `params.evkAddress` +
+ * `params.collateralAddress` instead of `params.vaults[]`.
+ */
+import { describe, expect, it } from 'vitest'
+import { processBorrowFromCollateralOpportunities } from '~/composables/useMerkl'
+import type { Opportunity } from '~/entities/merkl'
+
+const farFutureTimestamp = Math.floor(Date.now() / 1000) + 60 * 60 * 24 * 30
+
+const makeOpportunity = (overrides: Partial<Opportunity>): Opportunity => ({
+  chainId: 1,
+  chain: { name: 'Ethereum' },
+  type: 'EULER_MULTI_BORROW_FROM_COLLATERAL',
+  identifier: 'f8f41d9ced97a082',
+  name: 'test',
+  description: 'test',
+  howToSteps: [],
+  status: 'LIVE',
+  action: 'BORROW',
+  tvl: 0,
+  apr: 0,
+  dailyRewards: 0,
+  tags: [],
+  id: 'opp-1',
+  depositUrl: '',
+  explorerAddress: '',
+  lastCampaignCreatedAt: 0,
+  tokens: [],
+  aprRecord: { cumulated: 0, timestamp: '0', breakdowns: [] },
+  tvlRecord: { id: '', total: 0, timestamp: '0', breakdowns: [] },
+  rewardsRecord: { id: '', total: 0, timestamp: '0', breakdowns: [] },
+  campaigns: [],
+  ...overrides,
+})
+
+const makeCampaign = (overrides: Partial<Opportunity['campaigns'][number]>): Opportunity['campaigns'][number] => ({
+  id: 'c1',
+  computeChainId: 1,
+  distributionChainId: 1,
+  campaignId: '0xfae08964',
+  type: 'EULER_MULTI_BORROW_FROM_COLLATERAL',
+  distributionType: 'MAX_REWARD_VALUE_PER_LIQUIDITY_VALUE',
+  subType: 0,
+  rewardTokenId: 'rt',
+  amount: '0',
+  opportunityId: 'opp-1',
+  startTimestamp: 0,
+  endTimestamp: farFutureTimestamp,
+  dailyRewards: 0,
+  apr: 1.5,
+  creatorAddress: '0x0',
+  rewardToken: {
+    id: 'rt',
+    name: 'AglaMerkl',
+    chainId: 1,
+    address: '0x3e0ae4c19c3bdfc9eed5a2898d3a57c6f61e847a',
+    decimals: 18,
+    icon: 'icon.png',
+    verified: true,
+    isTest: true,
+    type: 'TOKEN',
+    isNative: false,
+    price: 1,
+    symbol: 'aglaMerklUSD',
+  },
+  campaignStatus: { campaignId: 'c1', computedUntil: 0, processingStarted: 0, status: 'OK', error: '' },
+  createdAt: '0',
+  ...overrides,
+})
+
+describe('processBorrowFromCollateralOpportunities', () => {
+  it('fans out one campaign per (vault, collateral) pair from params.vaults[]', () => {
+    const opportunity = makeOpportunity({
+      campaigns: [
+        makeCampaign({
+          params: {
+            vaults: [
+              {
+                evkAddress: '0x6Fe7Fa90756434645F0b0428fDff78E99Dda0FBc',
+                collaterals: [
+                  { tokenAddress: '0x35d4f830543700B7280084280ae3236f178E88e3' },
+                  { tokenAddress: '0x55F9bACE2C864aC0D3392Ea9fa654b605F21A3d3' },
+                  { tokenAddress: '0xb7522C867B8AFae5e89638b59fb38f31B0821795' },
+                  { tokenAddress: '0x97C72647be549C6079dC95235271A9a0Fe7ECc21' },
+                  { tokenAddress: '0x69a2fAD6AC96DDa502f7d240fB4EC88f85217705' },
+                  { tokenAddress: '0x797DD80692c3b2dAdabCe8e30C07fDE5307D48a9' },
+                  { tokenAddress: '0x313603FA690301b0CaeEf8069c065862f9162162' },
+                ],
+              },
+              {
+                evkAddress: '0x53208e965EB66841598fB8f983a41936EeE6d774',
+                collaterals: [
+                  { tokenAddress: '0xc1fF5490651B9B8d0400B0146E7fb174B90E315B' },
+                ],
+              },
+            ],
+          },
+        }),
+      ],
+    })
+
+    const map = processBorrowFromCollateralOpportunities([opportunity], 'EULER_MULTI_BORROW_FROM_COLLATERAL')
+
+    // 7 collaterals + 1 collateral = 8 emitted campaigns under 2 vault keys.
+    expect(map.size).toBe(2)
+    const first = map.get('0x6fe7fa90756434645f0b0428fdff78e99dda0fbc')
+    const second = map.get('0x53208e965eb66841598fb8f983a41936eee6d774')
+    expect(first).toHaveLength(7)
+    expect(second).toHaveLength(1)
+
+    // Everything is lowercased and typed as the existing euler_borrow_collateral.
+    for (const c of [...(first ?? []), ...(second ?? [])]) {
+      expect(c.type).toBe('euler_borrow_collateral')
+      expect(c.provider).toBe('merkl')
+      expect(c.apr).toBe(1.5)
+      expect(c.vault).toBe(c.vault.toLowerCase())
+      expect(c.collateral).toBe(c.collateral?.toLowerCase())
+    }
+
+    expect(second?.[0].collateral).toBe('0xc1ff5490651b9b8d0400b0146e7fb174b90e315b')
+  })
+
+  it('falls back to the flat evkAddress + collateralAddress shape when vaults[] is absent', () => {
+    const opportunity = makeOpportunity({
+      type: 'EULER_BORROW_FROM_COLLATERAL',
+      identifier: 'single-vault-test',
+      campaigns: [
+        makeCampaign({
+          params: {
+            evkAddress: '0x6Fe7Fa90756434645F0b0428fDff78E99Dda0FBc',
+            collateralAddress: '0x35d4f830543700B7280084280ae3236f178E88e3',
+          },
+        }),
+      ],
+    })
+
+    const map = processBorrowFromCollateralOpportunities([opportunity], 'EULER_BORROW_FROM_COLLATERAL')
+
+    expect(map.size).toBe(1)
+    const entries = map.get('0x6fe7fa90756434645f0b0428fdff78e99dda0fbc')
+    expect(entries).toHaveLength(1)
+    expect(entries?.[0].collateral).toBe('0x35d4f830543700b7280084280ae3236f178e88e3')
+    expect(entries?.[0].type).toBe('euler_borrow_collateral')
+  })
+
+  it('drops opportunities that are not LIVE', () => {
+    const opportunity = makeOpportunity({
+      status: 'PAST',
+      campaigns: [makeCampaign({
+        params: { vaults: [{ evkAddress: '0xaaa', collaterals: [{ tokenAddress: '0xbbb' }] }] },
+      })],
+    })
+    const map = processBorrowFromCollateralOpportunities([opportunity], 'EULER_MULTI_BORROW_FROM_COLLATERAL')
+    expect(map.size).toBe(0)
+  })
+
+  it('drops active campaigns with no APR', () => {
+    const opportunity = makeOpportunity({
+      aprRecord: { cumulated: 0, timestamp: '0', breakdowns: [] },
+      campaigns: [makeCampaign({
+        apr: 0,
+        params: { vaults: [{ evkAddress: '0xaaa', collaterals: [{ tokenAddress: '0xbbb' }] }] },
+      })],
+    })
+    const map = processBorrowFromCollateralOpportunities([opportunity], 'EULER_MULTI_BORROW_FROM_COLLATERAL')
+    expect(map.size).toBe(0)
+  })
+
+  it('prefers aprRecord breakdown over campaign.apr', () => {
+    const opportunity = makeOpportunity({
+      aprRecord: {
+        cumulated: 0,
+        timestamp: '0',
+        breakdowns: [{
+          distributionType: 'MAX_APR',
+          identifier: '0xfae08964',
+          type: 'CAMPAIGN',
+          value: 7,
+          timestamp: '0',
+        }],
+      },
+      campaigns: [makeCampaign({
+        apr: 1.5,
+        params: { vaults: [{ evkAddress: '0xaaa', collaterals: [{ tokenAddress: '0xbbb' }] }] },
+      })],
+    })
+    const map = processBorrowFromCollateralOpportunities([opportunity], 'EULER_MULTI_BORROW_FROM_COLLATERAL')
+    const entry = map.get('0xaaa')
+    expect(entry?.[0].apr).toBe(7)
+  })
+})

--- a/tests/composables/useMerkl-processors.test.ts
+++ b/tests/composables/useMerkl-processors.test.ts
@@ -152,11 +152,7 @@ describe('processBorrowFromCollateralOpportunities', () => {
     expect(entries?.[0].type).toBe('euler_borrow_collateral')
   })
 
-  // TEMPORARY: while the upstream URL passes `&test=true`, the LIVE-status
-  // filter is relaxed so test campaigns (Merkl marks them PAST) reach the UI.
-  // Restore an `opportunity.status !== 'LIVE'` test case when test=true is
-  // removed.
-  it('emits PAST opportunities with active campaigns (test-mode behaviour)', () => {
+  it('drops opportunities that are not LIVE', () => {
     const opportunity = makeOpportunity({
       status: 'PAST',
       campaigns: [makeCampaign({
@@ -164,7 +160,7 @@ describe('processBorrowFromCollateralOpportunities', () => {
       })],
     })
     const map = processBorrowFromCollateralOpportunities([opportunity], 'EULER_MULTI_BORROW_FROM_COLLATERAL')
-    expect(map.size).toBe(1)
+    expect(map.size).toBe(0)
   })
 
   it('drops active campaigns with no APR', () => {

--- a/tests/composables/useMerkl-processors.test.ts
+++ b/tests/composables/useMerkl-processors.test.ts
@@ -167,11 +167,7 @@ describe('processBorrowFromCollateralOpportunities', () => {
     expect(map.size).toBe(1)
   })
 
-  // TEMPORARY: while the upstream URL passes `&test=true`, the zero-APR
-  // skip is relaxed so SOON / test-only campaigns (apr=0 until real
-  // borrows accrue) still surface for wiring verification. Restore a
-  // skip-active-zero-APR test case when test=true is removed.
-  it('emits active campaigns with apr=0 (test-mode behaviour)', () => {
+  it('drops active campaigns with no APR', () => {
     const opportunity = makeOpportunity({
       aprRecord: { cumulated: 0, timestamp: '0', breakdowns: [] },
       campaigns: [makeCampaign({
@@ -180,8 +176,7 @@ describe('processBorrowFromCollateralOpportunities', () => {
       })],
     })
     const map = processBorrowFromCollateralOpportunities([opportunity], 'EULER_MULTI_BORROW_FROM_COLLATERAL')
-    expect(map.size).toBe(1)
-    expect(map.get('0xaaa')?.[0].apr).toBe(0)
+    expect(map.size).toBe(0)
   })
 
   it('prefers aprRecord breakdown over campaign.apr', () => {

--- a/tests/composables/useMerkl-processors.test.ts
+++ b/tests/composables/useMerkl-processors.test.ts
@@ -152,7 +152,11 @@ describe('processBorrowFromCollateralOpportunities', () => {
     expect(entries?.[0].type).toBe('euler_borrow_collateral')
   })
 
-  it('drops opportunities that are not LIVE', () => {
+  // TEMPORARY: while the upstream URL passes `&test=true`, the LIVE-status
+  // filter is relaxed so test campaigns (Merkl marks them PAST) reach the UI.
+  // Restore an `opportunity.status !== 'LIVE'` test case when test=true is
+  // removed.
+  it('emits PAST opportunities with active campaigns (test-mode behaviour)', () => {
     const opportunity = makeOpportunity({
       status: 'PAST',
       campaigns: [makeCampaign({
@@ -160,7 +164,7 @@ describe('processBorrowFromCollateralOpportunities', () => {
       })],
     })
     const map = processBorrowFromCollateralOpportunities([opportunity], 'EULER_MULTI_BORROW_FROM_COLLATERAL')
-    expect(map.size).toBe(0)
+    expect(map.size).toBe(1)
   })
 
   it('drops active campaigns with no APR', () => {

--- a/tests/composables/useMerkl-processors.test.ts
+++ b/tests/composables/useMerkl-processors.test.ts
@@ -167,7 +167,11 @@ describe('processBorrowFromCollateralOpportunities', () => {
     expect(map.size).toBe(1)
   })
 
-  it('drops active campaigns with no APR', () => {
+  // TEMPORARY: while the upstream URL passes `&test=true`, the zero-APR
+  // skip is relaxed so SOON / test-only campaigns (apr=0 until real
+  // borrows accrue) still surface for wiring verification. Restore a
+  // skip-active-zero-APR test case when test=true is removed.
+  it('emits active campaigns with apr=0 (test-mode behaviour)', () => {
     const opportunity = makeOpportunity({
       aprRecord: { cumulated: 0, timestamp: '0', breakdowns: [] },
       campaigns: [makeCampaign({
@@ -176,7 +180,8 @@ describe('processBorrowFromCollateralOpportunities', () => {
       })],
     })
     const map = processBorrowFromCollateralOpportunities([opportunity], 'EULER_MULTI_BORROW_FROM_COLLATERAL')
-    expect(map.size).toBe(0)
+    expect(map.size).toBe(1)
+    expect(map.get('0xaaa')?.[0].apr).toBe(0)
   })
 
   it('prefers aprRecord breakdown over campaign.apr', () => {

--- a/tests/server/rewards-cache.test.ts
+++ b/tests/server/rewards-cache.test.ts
@@ -110,6 +110,24 @@ describe('refreshMerklType', () => {
     // Distinct type key — not polluted by the EULER cache.
     expect(readMerklType(5, 'MULTILENDBORROW')).toBeUndefined()
   })
+
+  it('round-trips the new BORROW_FROM_COLLATERAL types independently', async () => {
+    installFetch(async (url) => {
+      if (String(url).includes('type=EULER_BORROW_FROM_COLLATERAL')) {
+        return jsonResponse([{ id: 'single' }])
+      }
+      if (String(url).includes('type=EULER_MULTI_BORROW_FROM_COLLATERAL')) {
+        return jsonResponse([{ id: 'multi' }])
+      }
+      return jsonResponse([])
+    })
+
+    await refreshMerklType(7, 'EULER_BORROW_FROM_COLLATERAL')
+    await refreshMerklType(7, 'EULER_MULTI_BORROW_FROM_COLLATERAL')
+
+    expect(readMerklType(7, 'EULER_BORROW_FROM_COLLATERAL')?.data).toEqual([{ id: 'single' }])
+    expect(readMerklType(7, 'EULER_MULTI_BORROW_FROM_COLLATERAL')?.data).toEqual([{ id: 'multi' }])
+  })
 })
 
 describe('refreshBrevisCampaigns', () => {

--- a/tests/server/rewards-handlers.test.ts
+++ b/tests/server/rewards-handlers.test.ts
@@ -87,12 +87,20 @@ describe('GET /api/rewards/merkl', () => {
     const handler = (await import('~/server/api/rewards/merkl.get')).default
     const { event, headers } = makeEvent({ chainId: String(ENABLED_CHAIN_ID) })
     const res = await handler(event) as {
-      opportunities: { euler: unknown[], multilendborrow: unknown[], erc20logprocessor: unknown[] }
+      opportunities: {
+        euler: unknown[]
+        multilendborrow: unknown[]
+        erc20logprocessor: unknown[]
+        euler_borrow_from_collateral: unknown[]
+        euler_multi_borrow_from_collateral: unknown[]
+      }
     }
 
     expect(res.opportunities.euler).toEqual([])
     expect(res.opportunities.multilendborrow).toEqual([])
     expect(res.opportunities.erc20logprocessor).toEqual([])
+    expect(res.opportunities.euler_borrow_from_collateral).toEqual([])
+    expect(res.opportunities.euler_multi_borrow_from_collateral).toEqual([])
     expect(headers['cache-control']).toMatch(/max-age=30/)
     expect(consumeSpy).toHaveBeenCalledOnce()
   })


### PR DESCRIPTION
## Summary

Additive integration of two new Merkl opportunity types that scope borrow rewards to specific (vault, collateral) pairs. The legacy `EULER + subType=2` path is left unchanged.

- `EULER_MULTI_BORROW_FROM_COLLATERAL` — multi-vault borrow campaigns; each campaign carries `params.vaults[]`, where every entry pairs one borrow vault (`evkAddress`) with the list of collateral vaults eligible for the reward. Example payload verified live: opportunity `f8f41d9ced97a082` on mainnet, two vaults with 7 + 1 eligible collaterals.
- `EULER_BORROW_FROM_COLLATERAL` — single-vault variant. No live campaigns on any chain yet (Ethereum, Base, Arbitrum, Polygon, Optimism all returned empty). Added speculatively as Merkl flagged it as the preferred replacement for the current `EULER + subType=2` approach. Implementation handles the multi-style `params.vaults[]` shape and a defensive flat-shape fallback (`params.evkAddress` + `params.collateralAddress`) for forward compatibility.

`MULTILENDBORROW` (also mentioned by Merkl) is already fully supported by `processMultiLendBorrowOpportunities` — no code change needed.

## How it works

A new `processBorrowFromCollateralOpportunities` processor, shared by both new types, fans out one `RewardCampaign` per `(vault, collateral)` pair under the existing `euler_borrow_collateral` type. This makes the new campaigns transparently pick up:

- The per-collateral filter in `composables/useRewardsApy.ts` (`getBorrowRewardApy` / `getBorrowRewardCampaigns`)
- The "collateral bonus" label in `components/entities/vault/VaultBorrowApyModal.vue`
- The intentional exclusion from per-vault matrix aggregates in `utils/discoveryCalculations.ts`

No changes to `RewardCampaignType`, `mapMerklSubType`, `useRewardsApy`, or any UI component.

## Files

- `server/utils/rewards-cache.ts` — `MerklOpportunityType` union extended
- `server/api/rewards/merkl.get.ts` — `MERKL_TYPES`, `Promise.allSettled`, and response shape extended (two new keys: `euler_borrow_from_collateral`, `euler_multi_borrow_from_collateral`)
- `server/plugins/warm-cache.ts` — local `MERKL_TYPES` mirrors the proxy
- `entities/merkl.ts` — `campaigns[].params.vaults[]` added to the typed schema
- `composables/useMerkl.ts` — `MerklProxyResponse` keys, `merklOpportunityUrl` type union, new exported processor, wired into `loadOpportunities`
- `tests/server/rewards-handlers.test.ts` — response-shape assertion extended
- `tests/server/rewards-cache.test.ts` — round-trip test for both new types
- `tests/composables/useMerkl-processors.test.ts` (new) — 5 cases: 8-pair fan-out from the live `f8f41d9...` shape, flat-shape fallback, `status === 'LIVE'` filter, no-APR drop, APR-record preference over `campaign.apr`

## Test plan

- [x] `npx nuxt typecheck` clean
- [x] `npx vitest run` → 676 passed, 1 skipped (pre-existing)
- [x] Live probe: `GET /api/rewards/merkl?chainId=1` returns all 5 opportunity keys; legacy counts unchanged (`euler: 105`, `erc20logprocessor: 10`); new keys present and empty as expected since no live campaigns exist today
- [ ] Manual QA when Merkl creates a LIVE `EULER_MULTI_BORROW_FROM_COLLATERAL` campaign: borrow APR breakdown on the eligible `(vault, collateral)` pair should show the new reward labelled "collateral bonus"

## Risk

- Per-chain Merkl fan-out grows from 3 to 5 `Promise.allSettled` resolves. Each runs through the existing TTL cache + warm-cache pipeline, hitting upstream at most every 5 minutes. Well below any rate-limit concern.
- Defensive flat-shape fallback for `EULER_BORROW_FROM_COLLATERAL` will simply emit nothing if Merkl picks a different layout than expected. No regression risk to the legacy path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for two Euler borrow-from-collateral opportunity types; these now expand into per-vault/per-collateral reward campaigns and appear in the rewards API payload. APR selection prefers detailed breakdowns with sensible fallbacks.

* **Bug Fixes / Behaviour**
  * Opportunity filtering relaxed to include non-LIVE/test-mode items; zero-APR campaigns are retained during this test window. Warm-up coverage increased (×5) to include the new types.

* **Tests**
  * New unit and integration tests cover processing, payload separation, APR precedence, and caching for the new types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/euler-xyz/euler-lite/pull/434)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->