### PR TITLE
fix: reject repeated metadata productId

### DIFF
--- a/server/api/public/metadata.get.ts
+++ b/server/api/public/metadata.get.ts
@@ -4,10 +4,9 @@ import { createRateLimiter } from '~/server/utils/rate-limit'
 import { resolveRpcUrl } from '~/server/utils/rpc'
 import { getChainVaultMetadata, type VaultMetadata } from '~/server/utils/vault-metadata'
 import { logger } from '~/server/utils/logger'
+import { parsePublicMetadataProductId } from '~/server/utils/public-metadata-query'
 
 const MAX_ADDRESSES = 100
-const PRODUCT_ID_MAX_LEN = 100
-const PRODUCT_ID_PATTERN = /^[a-zA-Z0-9_-]+$/
 
 const rateLimiter = createRateLimiter({
   max: 100,
@@ -49,13 +48,7 @@ export default defineEventHandler(async (event) => {
   // equals this value are returned. Combines with `addresses` lookup mode:
   // an address that matches by lookup but belongs to a different product
   // returns `null`, matching the contract for unknown addresses.
-  let productId: string | null = null
-  if (typeof query.productId === 'string' && query.productId.length > 0) {
-    if (query.productId.length > PRODUCT_ID_MAX_LEN || !PRODUCT_ID_PATTERN.test(query.productId)) {
-      throw createError({ statusCode: 400, statusMessage: 'Invalid productId' })
-    }
-    productId = query.productId
-  }
+  const productId = parsePublicMetadataProductId(query.productId)
 
   let metadataMap: Map<string, VaultMetadata>
   try {

--- a/server/utils/public-metadata-query.ts
+++ b/server/utils/public-metadata-query.ts
@@ -1,0 +1,20 @@
+import { createError } from 'h3'
+
+const PRODUCT_ID_MAX_LEN = 100
+const PRODUCT_ID_PATTERN = /^[a-zA-Z0-9_-]+$/
+
+export const parsePublicMetadataProductId = (rawProductId: unknown): string | null => {
+  if (Array.isArray(rawProductId)) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid productId' })
+  }
+
+  if (typeof rawProductId !== 'string' || rawProductId.length === 0) {
+    return null
+  }
+
+  if (rawProductId.length > PRODUCT_ID_MAX_LEN || !PRODUCT_ID_PATTERN.test(rawProductId)) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid productId' })
+  }
+
+  return rawProductId
+}

--- a/tests/server/public-metadata-query.test.ts
+++ b/tests/server/public-metadata-query.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { parsePublicMetadataProductId } from '~/server/utils/public-metadata-query'
+
+describe('parsePublicMetadataProductId', () => {
+  it('returns null when productId is omitted or empty', () => {
+    expect(parsePublicMetadataProductId(undefined)).toBe(null)
+    expect(parsePublicMetadataProductId('')).toBe(null)
+  })
+
+  it('accepts a valid productId', () => {
+    expect(parsePublicMetadataProductId('euler-prime')).toBe('euler-prime')
+    expect(parsePublicMetadataProductId('Euler_Prime_1')).toBe('Euler_Prime_1')
+  })
+
+  it('rejects invalid productId values', () => {
+    expect(() => parsePublicMetadataProductId('bad.dot')).toThrow('Invalid productId')
+    expect(() => parsePublicMetadataProductId('x'.repeat(101))).toThrow('Invalid productId')
+  })
+
+  it('rejects repeated productId query params instead of treating the filter as absent', () => {
+    expect(() => parsePublicMetadataProductId(['euler-prime', 'bad.dot'])).toThrow('Invalid productId')
+    expect(() => parsePublicMetadataProductId(['bad.dot', 'euler-prime'])).toThrow('Invalid productId')
+  })
+})


### PR DESCRIPTION
## Summary
- reject repeated `productId` query params for `/api/public/metadata`
- keep valid single `productId` parsing behavior unchanged
- add focused coverage for omitted, valid, invalid, and repeated `productId` inputs

## Test plan
- `npm run test:run -- --run tests/server/public-metadata-query.test.ts`
- `npm run test:run`
- `npm run lint` with Node 24
- `npm run typecheck` with Node 24
- `npm run build` with Node 24

## Visual check performed before this fix
On the PR #431 Railway preview, opened all 14 metadata-only vault detail routes with `showAll=true`; every route rendered `Risk manager → Unknown` and `Deprecated`. Also checked a Rezerve list probe, which rendered the visible cards as `Unknown`. This matches the endpoint semantics: metadata may show deprecated display labels, while governance/entity assertion is suppressed.
