### PR TITLE
fix: pick primary collateral by value for borrow position label

### DIFF
--- a/utils/accountPositionHelpers.ts
+++ b/utils/accountPositionHelpers.ts
@@ -92,10 +92,15 @@ export const resolvePositionCollaterals = (liquidityInfo: LensLiquidityInfo, fal
     || liquidityInfo?.collateralValuesLiquidation
     || liquidityInfo?.collateralValuesBorrowing
 
+  // Sort by value descending so the largest collateral is treated as primary
   if (infoCollaterals.length && Array.isArray(values) && values.length === infoCollaterals.length) {
-    const withValue = infoCollaterals.filter((_: string, idx: number) => toBigInt(values[idx]) > 0n)
-    if (withValue.length) {
-      return withValue
+    const ranked = infoCollaterals
+      .map((addr, idx) => ({ addr, value: toBigInt(values[idx]) }))
+      .filter(({ value }) => value > 0n)
+      .sort((a, b) => (a.value === b.value ? 0 : a.value > b.value ? -1 : 1))
+      .map(({ addr }) => addr)
+    if (ranked.length) {
+      return ranked
     }
   }
 


### PR DESCRIPTION
## Summary

The position pair label (e.g. `USDC & others/wstETH`) and a few downstream flows derive their primary collateral from the first entry returned by `resolvePositionCollaterals`. That order used to follow whatever the lens / EVC enabled-collateral list returned, so the displayed collateral had no relation to which one contributed the most value — a position dominated by other collaterals could still be labeled as `USDC & others/...` simply because USDC was enabled first.

This sorts the resolved collateral list by raw value descending, so the largest-contributing collateral is treated as primary everywhere it matters (label, single-collateral fallback, etc.).

- `utils/accountPositionHelpers.ts` — sort `resolvePositionCollaterals` output by `collateralValuesRaw` (with fallbacks) descending, keeping the existing zero-filter and queryFailure fallback semantics.

No other call sites depend on the previous ordering — they all treat `collaterals` as an unordered list (length checks, iteration, Set membership).

## Test plan

- [ ] Open a borrow position with multiple enabled collaterals where the largest collateral is not first in the EVC-enabled list
- [ ] Verify the label shows `<largest>/<borrow>` with `& others` only when there are multiple non-zero collaterals
- [ ] Verify positions with a single collateral still show `<collateral>/<borrow>` (no `& others`)
- [ ] Verify positions in `queryFailure` state still fall back to the EVC enabled list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced collateral ordering logic to prioritize positions by their corresponding values in descending order, with the largest collateral now treated as primary. Non-positive values are filtered out during the ranking process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/euler-xyz/euler-lite/pull/437)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->