### PR TITLE
fix/remove-excluded-swap-providers

### DIFF
--- a/composables/useSwapApi.ts
+++ b/composables/useSwapApi.ts
@@ -8,7 +8,7 @@ import {
   type SwapApiResponse,
   SwapperMode,
 } from '~/entities/swap'
-import { EXCLUDED_SWAP_PROVIDERS, SWAP_DEFAULT_DEADLINE_SECONDS } from '~/entities/constants'
+import { SWAP_DEFAULT_DEADLINE_SECONDS } from '~/entities/constants'
 import { COWSWAP_PROVIDER_NAME, isCowSwapSupportedChain } from '~/entities/cowswap'
 
 export interface SwapApiRequestInput {
@@ -170,8 +170,7 @@ export const useSwapApi = () => {
       const includeCow = options?.includeCowSwap && isCowSwapSupportedChain(chainId.value ?? 0)
       return providers.filter((p) => {
         const normalized = p.toLowerCase()
-        return !EXCLUDED_SWAP_PROVIDERS.has(normalized)
-          && (normalized !== COWSWAP_PROVIDER_NAME || includeCow)
+        return normalized !== COWSWAP_PROVIDER_NAME || includeCow
       })
     }
     catch (error) {

--- a/entities/constants.ts
+++ b/entities/constants.ts
@@ -54,7 +54,6 @@ export const TTL_LIQUIDATION = -BigInt(1)
 export const TTL_ERROR = -BigInt(2)
 
 export { CACHE_TTL_15S_MS as DEFAULT_PRICE_CACHE_TTL_MS } from './tuning-constants'
-export const EXCLUDED_SWAP_PROVIDERS = new Set<string>([])
 export const SWAP_DEFAULT_DEADLINE_SECONDS = 1800
 export const SLIPPAGE_STORAGE_KEY = 'swap-slippage'
 export const PERMIT2_PREFERENCE_STORAGE_KEY = 'permit2-enabled'


### PR DESCRIPTION
## Summary
- Remove the unused excluded swap providers constant so swap providers are no longer filtered through a static denylist.
- Keep CoW provider availability controlled by the existing includeCowSwap and supported-chain gate.

## Changes
- Delete the EXCLUDED_SWAP_PROVIDERS export from constants.
- Simplify getSwapProviders filtering to only handle CoW provider gating.

## Test plan
- [x] npm run test:run -- tests/composables/useSwapQuotesParallel.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified swap provider filtering logic by removing previous exclusion-based filtering while maintaining conditional CowSwap availability based on user settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/euler-xyz/euler-lite/pull/443)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->