### PR TITLE
Fix savings repay test swap quote stubs

### DIFF
--- a/tests/composables/useSavingsRepay.test.ts
+++ b/tests/composables/useSavingsRepay.test.ts
@@ -154,6 +154,11 @@ describe('useSavingsRepay', () => {
       getSwapProviders: vi.fn(async () => []),
       getSwapQuotes: vi.fn(async () => []),
     }))
+    vi.stubGlobal('useRpcClient', () => ({ client: ref(null) }))
+    vi.stubGlobal('useWagmi', () => ({
+      address: ref(USER),
+      chain: ref({ nativeCurrency: { decimals: 18 } }),
+    }))
   })
 
   afterEach(() => {


### PR DESCRIPTION
## Summary
- Keep the savings repay composable test isolated after the swap quote composable started reading wallet and RPC context.
- Restore the release preflight test suite by stubbing the additional globals used through the repay quote path.

## Changes
- Add inert useRpcClient and useWagmi globals to the savings repay test setup.
- Reuse the same stub shape used by the swap quote composable tests.

## Test plan
- [x] npm run test:run -- tests/composables/useSavingsRepay.test.ts
- [x] npm run test:run
- [x] npm run typecheck
- [x] npm run lint