### PR TITLE
fix: hide cyclical note badge on unverified vaults

### DIFF
--- a/components/entities/vault/VaultBorrowItem.vue
+++ b/components/entities/vault/VaultBorrowItem.vue
@@ -287,7 +287,7 @@ const linkPath = computed(() => ({
               />
               Recently added
             </span>
-            <KeyringBadge v-if="isKeyring" />
+            <KeyringBadge v-if="isKeyring && !isAnyGovernorUnverified" />
             <GovernanceLimitedBadge v-if="isAnyGovernanceLimited" />
             <CyclicalNoteBadge v-if="isCyclicalNote && !isAnyGovernorUnverified" />
             <RestrictedBadge

--- a/components/entities/vault/VaultBorrowItem.vue
+++ b/components/entities/vault/VaultBorrowItem.vue
@@ -289,7 +289,7 @@ const linkPath = computed(() => ({
             </span>
             <KeyringBadge v-if="isKeyring" />
             <GovernanceLimitedBadge v-if="isAnyGovernanceLimited" />
-            <CyclicalNoteBadge v-if="isCyclicalNote" />
+            <CyclicalNoteBadge v-if="isCyclicalNote && !isAnyGovernorUnverified" />
             <RestrictedBadge
               v-if="isGeoBlocked"
               variant="blocked"

--- a/components/entities/vault/VaultItem.vue
+++ b/components/entities/vault/VaultItem.vue
@@ -185,7 +185,7 @@ watchEffect(async () => {
           </span>
           <KeyringBadge v-if="isKeyring" />
           <GovernanceLimitedBadge v-if="isGovernanceLimited" />
-          <CyclicalNoteBadge v-if="isCyclicalNote" />
+          <CyclicalNoteBadge v-if="isCyclicalNote && isGovernorVerified" />
           <RestrictedBadge v-if="isGeoBlocked" />
           <span
             v-if="isDeprecated"

--- a/components/entities/vault/VaultItem.vue
+++ b/components/entities/vault/VaultItem.vue
@@ -183,7 +183,7 @@ watchEffect(async () => {
             />
             Recently added
           </span>
-          <KeyringBadge v-if="isKeyring" />
+          <KeyringBadge v-if="isKeyring && isGovernorVerified" />
           <GovernanceLimitedBadge v-if="isGovernanceLimited" />
           <CyclicalNoteBadge v-if="isCyclicalNote && isGovernorVerified" />
           <RestrictedBadge v-if="isGeoBlocked" />

--- a/components/entities/vault/VaultTypeBadges.vue
+++ b/components/entities/vault/VaultTypeBadges.vue
@@ -80,7 +80,7 @@ const isCyclicalNote = computed(() => {
       size="large"
     />
     <CyclicalNoteBadge
-      v-if="isCyclicalNote"
+      v-if="isCyclicalNote && isVerified"
       size="large"
     />
   </div>


### PR DESCRIPTION
## Summary

If a vault is flagged as **Unknown** (no `governorAdmin`, not in the labels repo, or no recognised risk-manager entity), `VaultTypeBadges` already suppresses the entity-branding chip, `KeyringBadge`, and `GovernanceLimitedBadge` — all gated on `isVerified`. `CyclicalNoteBadge` was the one badge that wasn't, so an unknown WETH vault would render "Unknown" and "Cyclical note" side-by-side, implying a level of categorisation we don't actually grant unverified vaults.

Add the same `isVerified` gate so an unknown vault shows just **Unknown**.

## Test plan

- [ ] Visit a vault overview for an unverified vault whose IRM is the fixed-cyclical-binary variant — confirm the "Vault type" row shows only "Unknown" (no "Cyclical note" alongside).
- [ ] Visit a verified vault that is a cyclical note — confirm "Cyclical note" still renders.
- [ ] Visit any verified vault that isn't a cyclical note — confirm no regression (badge still doesn't show).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened badge display logic: verification, keyring, and cyclical-note badges now only appear when governance verification is satisfied, preventing incorrect or misleading badges in vault and borrow item headers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/euler-xyz/euler-lite/pull/447)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->