### PR TITLE
fix: filter merkl rewards by campaign whitelist / blacklist

### DIFF
--- a/composables/useMerkl.ts
+++ b/composables/useMerkl.ts
@@ -94,6 +94,16 @@ const fetchMerklProxy = (chainId: number): Promise<MerklProxyResponse | null> =>
         return null
       }))
 
+// Merkl campaigns can carry a `params.whitelist` (only these recipients earn)
+// or `params.blacklist` (these recipients don't earn). We don't drop campaigns
+// here — discovery views show the unfiltered APR — but we lowercase the lists
+// onto the emitted `RewardCampaign` so `useRewardsApy` can filter per the
+// connected/spied address.
+const normalizeAddressList = (list: readonly string[] | undefined): string[] | undefined => {
+  if (!list?.length) return undefined
+  return list.map(a => a.toLowerCase())
+}
+
 const processOpportunitiesToCampaigns = (
   opportunities: Opportunity[],
   opType: 'EULER' | 'ERC20LOGPROCESSOR',
@@ -143,6 +153,8 @@ const processOpportunitiesToCampaigns = (
         endTimestamp: campaign.endTimestamp,
         rewardToken: { symbol: campaign.rewardToken.symbol, icon: campaign.rewardToken.icon },
         sourceUrl: merklOpportunityUrl(opportunity, opType),
+        whitelist: normalizeAddressList(campaign.params.whitelist),
+        blacklist: normalizeAddressList(campaign.params.blacklist),
       }
 
       const existing = campaignMap.get(vaultAddress)
@@ -184,6 +196,9 @@ const processMultiLendBorrowOpportunities = (
       const markets = campaign.params?.markets
       if (!markets?.length || !campaign.rewardToken) continue
 
+      const whitelist = normalizeAddressList(campaign.params?.whitelist)
+      const blacklist = normalizeAddressList(campaign.params?.blacklist)
+
       // Merkl provides a single campaign-level APR (keyed by campaignId in
       // aprRecord.breakdowns), shared across all markets under MAX_APR. For
       // MULTILENDBORROW that breakdown can be absent/zero while the top-level
@@ -206,6 +221,8 @@ const processMultiLendBorrowOpportunities = (
           endTimestamp: campaign.endTimestamp,
           rewardToken: { symbol: campaign.rewardToken.symbol, icon: campaign.rewardToken.icon },
           sourceUrl: merklOpportunityUrl(opportunity, 'MULTILENDBORROW'),
+          whitelist,
+          blacklist,
         }
 
         const existing = campaignMap.get(vaultAddress)

--- a/composables/useRewardsApy.ts
+++ b/composables/useRewardsApy.ts
@@ -14,9 +14,8 @@ export const useRewardsApy = () => {
 
   // Active address for whitelist/blacklist filtering: spy mode wins (we want
   // to see what the spied user actually earns), otherwise the connected
-  // wallet. When neither is set, whitelisted campaigns still get filtered out
-  // — an unidentified visitor is definitionally not on any whitelist, so
-  // crediting their APR with whitelist-only campaigns would be misleading.
+  // wallet. When neither is set the filter is a no-op — discovery surfaces
+  // keep the full "headline" APR visible to unconnected visitors.
   const eligibilityAddress = computed(() =>
     spyAddress.value || connectedAddress.value || undefined,
   )

--- a/composables/useRewardsApy.ts
+++ b/composables/useRewardsApy.ts
@@ -1,4 +1,5 @@
-import type { RewardCampaign } from '~/entities/reward-campaign'
+import { useAccount } from '@wagmi/vue'
+import { isCampaignEligibleForAddress, type RewardCampaign } from '~/entities/reward-campaign'
 
 export const useRewardsApy = () => {
   const { settings } = useUserSettings()
@@ -6,26 +7,38 @@ export const useRewardsApy = () => {
   const { merklCampaigns, getMerklCampaignsForVault } = useMerkl()
   const { brevisCampaigns, getBrevisCampaignsForVault } = useBrevis()
   const { fuulCampaigns, getFuulCampaignsForVault } = useFuul()
+  const { address: connectedAddress } = useAccount()
+  const { spyAddress } = useSpyMode()
 
   const isEnabled = computed(() => settings.value.enableRewardsApy)
+
+  // Active address for whitelist/blacklist filtering: spy mode wins (we want
+  // to see what the spied user actually earns), otherwise the connected
+  // wallet. When neither is set, whitelisted campaigns still get filtered out
+  // — an unidentified visitor is definitionally not on any whitelist, so
+  // crediting their APR with whitelist-only campaigns would be misleading.
+  const eligibilityAddress = computed(() =>
+    spyAddress.value || connectedAddress.value || undefined,
+  )
 
   // Reactive version counter — bumps when any underlying data or settings change.
   // Consumers should read `version.value` in the sync phase of watchEffect(async)
   // to ensure they re-run when reward data updates.
   const _versionCounter = ref(0)
   watch(
-    [isEnabled, merklCampaigns, brevisCampaigns, fuulCampaigns],
+    [isEnabled, merklCampaigns, brevisCampaigns, fuulCampaigns, eligibilityAddress],
     () => { _versionCounter.value++ },
   )
   const version = computed(() => _versionCounter.value)
 
   const getCampaignsForVault = (vaultAddress: string): RewardCampaign[] => {
     if (!isEnabled.value) return []
+    const addr = eligibilityAddress.value
     return [
       ...(enableMerkl ? getMerklCampaignsForVault(vaultAddress) : []),
       ...(enableIncentra ? getBrevisCampaignsForVault(vaultAddress) : []),
       ...(enableFuul ? getFuulCampaignsForVault(vaultAddress) : []),
-    ]
+    ].filter(c => isCampaignEligibleForAddress(c, addr))
   }
 
   const getSupplyRewardApy = (vaultAddress: string): number => {

--- a/entities/merkl.ts
+++ b/entities/merkl.ts
@@ -121,6 +121,10 @@ export interface Opportunity {
       evkAddress?: string
       targetToken?: string
       collateralAddress?: string
+      // When non-empty, only these recipient addresses earn the campaign
+      // rewards — displaying the APR to everyone would be misleading.
+      whitelist?: string[]
+      blacklist?: string[]
       markets?: {
         campaignParameters: {
           evkAddress?: string

--- a/entities/reward-campaign.ts
+++ b/entities/reward-campaign.ts
@@ -15,8 +15,9 @@ export interface RewardCampaign {
   minMultiplier?: number
   maxMultiplier?: number
   // Address lists honoured by the campaign distributor, stored lowercase.
-  // - `whitelist` (when non-empty): only these recipients earn.
-  // - `blacklist`: these recipients never earn.
+  // - `whitelist` (when non-empty): only these recipients earn; it takes
+  //   precedence over blacklist.
+  // - `blacklist`: these recipients do not earn when there is no whitelist.
   whitelist?: string[]
   blacklist?: string[]
 }
@@ -29,6 +30,8 @@ export interface RewardCampaign {
  *     unidentified visitor is definitionally NOT on it, so they're ineligible.
  *   - A blacklist is an explicit deny-list; an unidentified visitor can't be
  *     on it, so they pass the blacklist check.
+ *   - When both are present, whitelist precedence matches Merkl's campaign
+ *     semantics: whitelist membership is sufficient for eligibility.
  *
  * Net result: discovery surfaces (no wallet connected) hide whitelisted
  * campaigns from the headline APR — they're not earnable by an arbitrary
@@ -39,7 +42,7 @@ export const isCampaignEligibleForAddress = (
   userAddress: string | undefined | null,
 ): boolean => {
   const addr = userAddress ? userAddress.toLowerCase() : ''
-  if (campaign.whitelist?.length && !campaign.whitelist.includes(addr)) return false
+  if (campaign.whitelist?.length) return campaign.whitelist.includes(addr)
   if (addr && campaign.blacklist?.includes(addr)) return false
   return true
 }

--- a/entities/reward-campaign.ts
+++ b/entities/reward-campaign.ts
@@ -24,23 +24,20 @@ export interface RewardCampaign {
 /**
  * Decide whether `userAddress` is eligible to earn the campaign.
  *
- * The helper is symmetric in how it handles a missing address:
- *   - A campaign with a non-empty whitelist is an explicit allow-list; an
- *     unidentified visitor is definitionally NOT on it, so they're ineligible.
- *   - A blacklist is an explicit deny-list; an unidentified visitor can't be
- *     on it, so they pass the blacklist check.
- *
- * Net result: discovery surfaces (no wallet connected) hide whitelisted
- * campaigns from the headline APR — they're not earnable by an arbitrary
- * visitor — but blacklists alone don't suppress anything.
+ * Without a connected wallet we can't tell who the visitor is, so we keep the
+ * full "headline" APR visible — discovery surfaces still advertise the
+ * upside. Once a wallet (or spy address) is in scope we filter strictly:
+ *   - non-empty whitelist + user not on it → ineligible
+ *   - user on the blacklist → ineligible
  */
 export const isCampaignEligibleForAddress = (
   campaign: Pick<RewardCampaign, 'whitelist' | 'blacklist'>,
   userAddress: string | undefined | null,
 ): boolean => {
-  const addr = userAddress ? userAddress.toLowerCase() : ''
+  if (!userAddress) return true
+  const addr = userAddress.toLowerCase()
   if (campaign.whitelist?.length && !campaign.whitelist.includes(addr)) return false
-  if (addr && campaign.blacklist?.includes(addr)) return false
+  if (campaign.blacklist?.includes(addr)) return false
   return true
 }
 

--- a/entities/reward-campaign.ts
+++ b/entities/reward-campaign.ts
@@ -14,6 +14,34 @@ export interface RewardCampaign {
   sourceUrl?: string
   minMultiplier?: number
   maxMultiplier?: number
+  // Address lists honoured by the campaign distributor, stored lowercase.
+  // - `whitelist` (when non-empty): only these recipients earn.
+  // - `blacklist`: these recipients never earn.
+  whitelist?: string[]
+  blacklist?: string[]
+}
+
+/**
+ * Decide whether `userAddress` is eligible to earn the campaign.
+ *
+ * The helper is symmetric in how it handles a missing address:
+ *   - A campaign with a non-empty whitelist is an explicit allow-list; an
+ *     unidentified visitor is definitionally NOT on it, so they're ineligible.
+ *   - A blacklist is an explicit deny-list; an unidentified visitor can't be
+ *     on it, so they pass the blacklist check.
+ *
+ * Net result: discovery surfaces (no wallet connected) hide whitelisted
+ * campaigns from the headline APR — they're not earnable by an arbitrary
+ * visitor — but blacklists alone don't suppress anything.
+ */
+export const isCampaignEligibleForAddress = (
+  campaign: Pick<RewardCampaign, 'whitelist' | 'blacklist'>,
+  userAddress: string | undefined | null,
+): boolean => {
+  const addr = userAddress ? userAddress.toLowerCase() : ''
+  if (campaign.whitelist?.length && !campaign.whitelist.includes(addr)) return false
+  if (addr && campaign.blacklist?.includes(addr)) return false
+  return true
 }
 
 // Merkl subType is a positional index: 0 = euler_lend, 1 = euler_borrow, 2 = euler_borrow_collateral

--- a/tests/entities/reward-campaign.test.ts
+++ b/tests/entities/reward-campaign.test.ts
@@ -34,10 +34,13 @@ describe('isCampaignEligibleForAddress', () => {
     expect(isCampaignEligibleForAddress(c, USER)).toBe(false)
   })
 
-  it('rejects an unidentified visitor when the campaign has a whitelist', () => {
-    const c = makeCampaign({ whitelist: [USER.toLowerCase()] })
-    expect(isCampaignEligibleForAddress(c, undefined)).toBe(false)
-    expect(isCampaignEligibleForAddress(c, '')).toBe(false)
+  it('passes an unidentified visitor unconditionally', () => {
+    const whitelistOnly = makeCampaign({ whitelist: [USER.toLowerCase()] })
+    const blacklistOnly = makeCampaign({ blacklist: [USER.toLowerCase()] })
+    for (const addr of [undefined, null, '']) {
+      expect(isCampaignEligibleForAddress(whitelistOnly, addr)).toBe(true)
+      expect(isCampaignEligibleForAddress(blacklistOnly, addr)).toBe(true)
+    }
   })
 
   it('treats an empty whitelist as "no restriction"', () => {
@@ -49,11 +52,6 @@ describe('isCampaignEligibleForAddress', () => {
   it('rejects an address on the blacklist (case-insensitive)', () => {
     const c = makeCampaign({ blacklist: [USER.toLowerCase()] })
     expect(isCampaignEligibleForAddress(c, USER)).toBe(false)
-  })
-
-  it('passes an unidentified visitor against a blacklist-only campaign', () => {
-    const c = makeCampaign({ blacklist: [USER.toLowerCase()] })
-    expect(isCampaignEligibleForAddress(c, undefined)).toBe(true)
   })
 
   it('blacklist takes precedence over whitelist', () => {

--- a/tests/entities/reward-campaign.test.ts
+++ b/tests/entities/reward-campaign.test.ts
@@ -56,11 +56,11 @@ describe('isCampaignEligibleForAddress', () => {
     expect(isCampaignEligibleForAddress(c, undefined)).toBe(true)
   })
 
-  it('blacklist takes precedence over whitelist', () => {
+  it('whitelist takes precedence over blacklist', () => {
     const c = makeCampaign({
       whitelist: [USER.toLowerCase()],
       blacklist: [USER.toLowerCase()],
     })
-    expect(isCampaignEligibleForAddress(c, USER)).toBe(false)
+    expect(isCampaignEligibleForAddress(c, USER)).toBe(true)
   })
 })

--- a/tests/entities/reward-campaign.test.ts
+++ b/tests/entities/reward-campaign.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import { isCampaignEligibleForAddress, type RewardCampaign } from '~/entities/reward-campaign'
+
+const USER = '0xAaAa00000000000000000000000000000000aAaA'
+const OTHER = '0xBbBb00000000000000000000000000000000bBbB'
+
+const makeCampaign = (overrides: Partial<RewardCampaign> = {}): RewardCampaign => ({
+  vault: '0xvault',
+  type: 'euler_lend',
+  apr: 1,
+  provider: 'merkl',
+  endTimestamp: 0,
+  ...overrides,
+})
+
+describe('isCampaignEligibleForAddress', () => {
+  it('passes a plain campaign for a connected wallet', () => {
+    expect(isCampaignEligibleForAddress(makeCampaign(), USER)).toBe(true)
+  })
+
+  it('passes a plain campaign for an unidentified visitor', () => {
+    expect(isCampaignEligibleForAddress(makeCampaign(), undefined)).toBe(true)
+    expect(isCampaignEligibleForAddress(makeCampaign(), null)).toBe(true)
+    expect(isCampaignEligibleForAddress(makeCampaign(), '')).toBe(true)
+  })
+
+  it('admits an address on the whitelist (case-insensitive)', () => {
+    const c = makeCampaign({ whitelist: [USER.toLowerCase()] })
+    expect(isCampaignEligibleForAddress(c, USER)).toBe(true)
+  })
+
+  it('rejects an address absent from the whitelist', () => {
+    const c = makeCampaign({ whitelist: [OTHER.toLowerCase()] })
+    expect(isCampaignEligibleForAddress(c, USER)).toBe(false)
+  })
+
+  it('rejects an unidentified visitor when the campaign has a whitelist', () => {
+    const c = makeCampaign({ whitelist: [USER.toLowerCase()] })
+    expect(isCampaignEligibleForAddress(c, undefined)).toBe(false)
+    expect(isCampaignEligibleForAddress(c, '')).toBe(false)
+  })
+
+  it('treats an empty whitelist as "no restriction"', () => {
+    const c = makeCampaign({ whitelist: [] })
+    expect(isCampaignEligibleForAddress(c, USER)).toBe(true)
+    expect(isCampaignEligibleForAddress(c, undefined)).toBe(true)
+  })
+
+  it('rejects an address on the blacklist (case-insensitive)', () => {
+    const c = makeCampaign({ blacklist: [USER.toLowerCase()] })
+    expect(isCampaignEligibleForAddress(c, USER)).toBe(false)
+  })
+
+  it('passes an unidentified visitor against a blacklist-only campaign', () => {
+    const c = makeCampaign({ blacklist: [USER.toLowerCase()] })
+    expect(isCampaignEligibleForAddress(c, undefined)).toBe(true)
+  })
+
+  it('blacklist takes precedence over whitelist', () => {
+    const c = makeCampaign({
+      whitelist: [USER.toLowerCase()],
+      blacklist: [USER.toLowerCase()],
+    })
+    expect(isCampaignEligibleForAddress(c, USER)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Merkl campaigns can carry `params.whitelist` (only these recipients earn) and `params.blacklist` (these recipients don't earn). Today we feed every campaign's APR into the per-vault reward APR aggregator, so the lend / borrow / earn / portfolio screens advertise rewards that many connected wallets will never actually receive — spotted on the live [Sentora PYUSD opportunity](https://app.merkl.xyz/opportunities/ethereum/EULER/0xba98fC35C9dfd69178AD5dcE9FA29c64554783b5) where the live campaigns each whitelist ~25–40 addresses.

The fix routes per-user eligibility through one helper instead of dropping campaigns at ingest time:

- **`entities/reward-campaign.ts`** — add `whitelist?: string[]` / `blacklist?: string[]` to `RewardCampaign` (stored lowercase) and expose `isCampaignEligibleForAddress(campaign, userAddress)`. Without a wallet in scope the helper passes everything through (discovery surfaces still show the headline APR). Once an address is in scope:
  - non-empty whitelist → eligibility is exactly whitelist membership (whitelist takes precedence over blacklist, matching Merkl's on-chain semantics);
  - otherwise, blacklist membership disqualifies.
- **`composables/useMerkl.ts`** — `processOpportunitiesToCampaigns` and `processMultiLendBorrowOpportunities` no longer drop campaigns; they propagate the lowercased whitelist/blacklist onto every emitted `RewardCampaign`.
- **`composables/useRewardsApy.ts`** — read `useAccount().address` and `useSpyMode().spyAddress` (spy wins, so we see what the spied user actually earns), filter every `getCampaignsForVault` result through `isCampaignEligibleForAddress`, and add the eligibility address to the reactive version counter so APR re-renders on connect / disconnect / spy.

Net behaviour: unconnected visitor sees the same headline APR as today; connected wallet sees only the campaigns it can actually earn.

## Test plan

- [ ] On a vault with at least one whitelisted Merkl campaign (e.g. the Sentora PYUSD opportunity above) confirm the reward APR shown while disconnected matches the headline; connect a wallet that's NOT on the whitelist and confirm the reward APR drops to reflect only the eligible campaigns.
- [ ] Connect a wallet that IS on the whitelist (or spy on a whitelisted address) and confirm the campaign is credited back into the APR.
- [ ] Add a blacklist-only campaign in staging (or simulate via a stub) and confirm a blacklisted wallet drops it while an unrelated wallet still sees it.
- [ ] Verify the portfolio's Net APY / ROE updates reactively when the connected wallet changes — no stale APR after disconnect.
- [ ] `npm run test --run tests/entities/reward-campaign.test.ts` — 8 cases cover the helper (case-insensitive matching, whitelist precedence, etc.).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Campaigns can include normalized whitelist and blacklist recipient lists (case-insensitive).
  * Campaign availability is now filtered by your connected wallet, with spy-mode address taking precedence.

* **Tests**
  * Added tests covering whitelist/blacklist behavior, case-insensitive matching, unidentified visitor handling, and whitelist-over-blacklist precedence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/euler-xyz/euler-lite/pull/448)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->