### PR TITLE
fix: prevent moooler audio race

### DIFF
--- a/components/entities/operation/CowSwapReviewModal.vue
+++ b/components/entities/operation/CowSwapReviewModal.vue
@@ -9,7 +9,7 @@ import {
   type CowSwapOrderStatus,
 } from '~/entities/cowswap'
 import { resolveCowSwapReviewState } from './cowSwapReviewState'
-import { playMooolerSound } from '~/utils/moooler-sound'
+import { playMooolerSound, prepareMooolerSound } from '~/utils/moooler-sound'
 
 const props = defineProps<{
   signSteps: DisplayStep[]
@@ -56,6 +56,7 @@ const staleQuoteThresholdMs = 3 * 60 * 1000
 let nowTimer: ReturnType<typeof setInterval> | undefined
 
 onMounted(() => {
+  prepareMooolerSound()
   nowTimer = setInterval(() => {
     nowMs.value = Date.now()
   }, 1000)
@@ -95,6 +96,8 @@ const isSwapQuoteStale = computed(() =>
 const internalSubmitting = ref(false)
 const hasUnresolvedSubmittedOrder = computed(() => reviewState.value.hasUnresolvedSubmittedOrder)
 const canClose = computed(() => !internalSubmitting.value && !hasUnresolvedSubmittedOrder.value)
+const isOrderSubmitted = computed(() => props.executionStatus === 'submitted')
+const hasPlayedMooolerSound = ref(false)
 
 watch(
   canClose,
@@ -102,8 +105,11 @@ watch(
   { immediate: true },
 )
 
-watch(isSubmitted, (value, prev) => {
-  if (value && !prev) playMooolerSound()
+watch(isOrderSubmitted, (value, prev) => {
+  if (value && !prev && !hasPlayedMooolerSound.value) {
+    hasPlayedMooolerSound.value = true
+    playMooolerSound()
+  }
 })
 
 const handleClose = () => {

--- a/utils/moooler-sound.ts
+++ b/utils/moooler-sound.ts
@@ -2,13 +2,35 @@ import { logWarn } from './errorHandling'
 
 let mooolerAudio: HTMLAudioElement | null = null
 let mooolerUnlocked = false
+let mooolerUnlocking = false
+let mooolerUnlockCleanup: (() => void) | null = null
 
-if (typeof window !== 'undefined') {
+const getMooolerAudio = () => {
+  if (typeof window === 'undefined') return null
+  if (mooolerAudio) return mooolerAudio
   mooolerAudio = new Audio('/sounds/moooler.wav')
   mooolerAudio.preload = 'auto'
+  return mooolerAudio
+}
+
+export const prepareMooolerSound = () => {
+  const audio = getMooolerAudio()
+  if (!audio || mooolerUnlocked || mooolerUnlocking || mooolerUnlockCleanup) return
+
+  const pointerEvent: keyof WindowEventMap = typeof PointerEvent === 'undefined' ? 'touchstart' : 'pointerdown'
+  const events: Array<keyof WindowEventMap> = [pointerEvent, 'keydown']
+
+  const removeUnlockListeners = () => {
+    for (const ev of events) {
+      window.removeEventListener(ev, unlock, { capture: true })
+    }
+    mooolerUnlockCleanup = null
+  }
 
   const unlock = () => {
-    if (!mooolerAudio || mooolerUnlocked) return
+    if (!mooolerAudio || mooolerUnlocked || mooolerUnlocking) return
+    mooolerUnlocking = true
+    removeUnlockListeners()
     const prevVolume = mooolerAudio.volume
     mooolerAudio.volume = 0
     mooolerAudio.play().then(() => {
@@ -18,16 +40,18 @@ if (typeof window !== 'undefined') {
       mooolerUnlocked = true
     }).catch(() => {
       if (mooolerAudio) mooolerAudio.volume = prevVolume
+      mooolerUnlocking = false
     })
   }
 
-  const events: Array<keyof WindowEventMap> = ['pointerdown', 'keydown', 'touchstart']
+  mooolerUnlockCleanup = removeUnlockListeners
   for (const ev of events) {
-    window.addEventListener(ev, unlock, { capture: true, passive: true })
+    window.addEventListener(ev, unlock, { capture: true, passive: true, once: true })
   }
 }
 
 export const playMooolerSound = () => {
+  const mooolerAudio = getMooolerAudio()
   if (!mooolerAudio) return
   try {
     mooolerAudio.currentTime = 0


### PR DESCRIPTION
## Summary
- Prevent the Moooler sound from firing during mobile pre-submit taps in the CoW review flow.
- Keep the sound tied to the submitted waiting-for-fill screen and limit playback to once per review modal/order lifecycle.

## Changes
- Lazily prepares the Moooler audio only when the CoW review modal mounts.
- Makes the browser audio unlock one-shot and single-flight to avoid mobile pointer/touch event races.
- Plays the sound only when executionStatus transitions to submitted and suppresses repeat playback when cancel returns the flow from cancelling back to submitted.

## Test plan
- [x] npm run typecheck
- [x] npm run test:run -- tests/components/cowSwapReviewState.test.ts
- [x] npm run lint -- utils/moooler-sound.ts components/entities/operation/CowSwapReviewModal.vue
- [x] Mobile smoke: reached the review multiply button and confirmed no sound before submit
- [x] Desktop smoke: submit to waiting-for-fill screen, then press cancel and confirm no second sound

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sound now plays only when an order truly transitions to submitted, avoiding false triggers and duplicate playback.
  * Improved unlock and playback error handling to reduce blocked or failed audio attempts.

* **New Features**
  * Audio is prepared on modal open and unlocked via user interactions (keyboard/touch/pointer) for more reliable playback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/euler-xyz/euler-lite/pull/450)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->