### PR TITLE
fix: validate CoW quote bindings

### DIFF
--- a/composables/borrow/useMultiplyCowSwap.ts
+++ b/composables/borrow/useMultiplyCowSwap.ts
@@ -11,7 +11,6 @@ import {
   getCowSwapQuoteOrderAmounts,
   getCowSwapChainConfig,
   isCowProvider,
-  isCowQuote,
   isCowSwapSupportedChain,
 } from '~/entities/cowswap'
 import { useCowSwapOpenPositionExecution, useCowSwapOrderStatus, openCowSwapReviewModal, buildApprovalSignSteps } from '~/composables/cowswap'
@@ -29,6 +28,7 @@ const convertVaultSharesToAssets = (vault: Vault, sharesAmount: bigint): bigint 
 
 interface UseMultiplyCowSwapOptions {
   multiplySelectedProvider: ComputedRef<string | null>
+  multiplyEffectiveProvider: ComputedRef<string | null>
   multiplyEffectiveQuote: ComputedRef<SwapApiQuote | null>
   multiplySelectedQuote: ComputedRef<SwapApiQuote | null>
   multiplyEffectiveQuoteFetchedAt: ComputedRef<number | null>
@@ -62,7 +62,7 @@ export const useMultiplyCowSwap = (options: UseMultiplyCowSwapOptions) => {
 
   const isCowSwapProvider = computed(() =>
     isCowProvider(options.multiplySelectedProvider.value)
-    || (!options.multiplySelectedProvider.value && isCowQuote(options.multiplyEffectiveQuote.value)),
+    || (!options.multiplySelectedProvider.value && isCowProvider(options.multiplyEffectiveProvider.value)),
   )
 
   const cowSwapStatusLabel = computed(() => {
@@ -139,7 +139,13 @@ export const useMultiplyCowSwap = (options: UseMultiplyCowSwapOptions) => {
     }
 
     const supplyAmountNano = valueToNano(options.multiplyInputAmount.value || '0', supplyVault.asset.decimals)
-    const validTo = Math.floor(Date.now() / 1000) + COWSWAP_ORDER_DEADLINE_SECONDS
+    const validTo = quote.providerData?.appDataDeadline ?? Math.floor(Date.now() / 1000) + COWSWAP_ORDER_DEADLINE_SECONDS
+    const expectedSellAmount = options.multiplyDebtAmountNano.value
+
+    if (!quote.providerData?.appData) {
+      error('Invalid quote: missing CoW appData')
+      return
+    }
 
     const orderAmounts = getCowSwapQuoteOrderAmounts(quote, {
       slippage: options.multiplySlippage.value,
@@ -150,14 +156,31 @@ export const useMultiplyCowSwap = (options: UseMultiplyCowSwapOptions) => {
       return
     }
     const { sellAmount, buyAmount } = orderAmounts
+    const rawOrderAmounts = getCowSwapQuoteOrderAmounts(quote)
+    if (!rawOrderAmounts) {
+      error('Invalid quote: missing CoW order amounts')
+      return
+    }
+    if (sellAmount !== expectedSellAmount) {
+      error('Quote is stale. Refresh quote and try again.')
+      return
+    }
+    if (convertVaultSharesToAssets(longVault, rawOrderAmounts.buyAmount) !== BigInt(quote.amountOut || 0)) {
+      error('Quote is stale. Refresh quote and try again.')
+      return
+    }
 
     const cowParams: CowSwapOpenPositionExecuteParams = {
       chainId,
+      quote,
+      expectedSellAmount,
+      expectedAppData: quote.providerData.appData,
       sellToken: shortVault.asset.address as Address,
       buyToken: longVault.address as Address,
       sellAmount,
       buyAmount,
       quoteId: quote.providerData?.quoteId,
+      slippage: options.multiplySlippage.value,
       slippageBips: Math.round(options.multiplySlippage.value * 100),
       validTo,
       collateralToken: supplyVault.asset.address as Address,
@@ -168,7 +191,7 @@ export const useMultiplyCowSwap = (options: UseMultiplyCowSwapOptions) => {
         collateralVault: supplyVault.address as Address,
         borrowVault: shortVault.address as Address,
         collateralAmount: supplyAmountNano,
-        borrowAmount: sellAmount,
+        borrowAmount: expectedSellAmount,
       },
     }
 

--- a/composables/borrow/useMultiplyForm.ts
+++ b/composables/borrow/useMultiplyForm.ts
@@ -43,7 +43,6 @@ import { useMultiplyCollateralOptions } from '~/composables/useMultiplyCollatera
 import { useSwapQuotesParallel } from '~/composables/useSwapQuotesParallel'
 import { useEulerProductOfVault } from '~/composables/useEulerLabels'
 import { findBlockingDisabledOp, OP_BORROW, OP_DEPOSIT, OP_SKIM, OP_TRANSFER, type PlannedOp } from '~/utils/vault-hooks'
-import { getNewSubAccount } from '~/entities/account'
 
 type MultiplyPlanParamsCommon = {
   supplyVaultAddress: string
@@ -119,6 +118,7 @@ export const useMultiplyForm = (options: UseMultiplyFormOptions) => {
     selectedProvider: multiplySelectedProvider,
     selectedQuote: multiplySelectedQuote,
     effectiveQuote: multiplyEffectiveQuote,
+    effectiveProvider: multiplyEffectiveProvider,
     effectiveQuoteFetchedAt: multiplyEffectiveQuoteFetchedAt,
     providersCount: multiplyProvidersCount,
     isLoading: isMultiplyQuoteLoading,
@@ -694,21 +694,13 @@ export const useMultiplyForm = (options: UseMultiplyFormOptions) => {
 
     const quoteDeadline = Math.floor(Date.now() / 1000) + COWSWAP_ORDER_DEADLINE_SECONDS
     const cowProviderExtraData = { ...COWSWAP_PROVIDER_EXTRA_DATA.openPosition }
-    let cowAccount: Address | null = null
+    cowProviderExtraData.appDataDeadline = quoteDeadline
     const chainConfig = getCowSwapChainConfig(chainId.value ?? 0)
-    if (chainConfig && address.value) {
-      try {
-        cowAccount = await getNewSubAccount(address.value, multiplyShortVault.value.address) as Address
-      }
-      catch (e) {
-        logWarn('multiply/cowswap/resolveQuoteSubaccount', e)
-      }
-    }
-    if (chainConfig && cowAccount) {
+    if (chainConfig) {
       cowProviderExtraData.appData = buildOpenPositionQuoteAppData(
         {
           owner: (address.value || zeroAddress) as Address,
-          account: cowAccount,
+          account,
           deadline: quoteDeadline,
           collateralVault: multiplySupplyVault.value.address as Address,
           borrowVault: multiplyShortVault.value.address as Address,
@@ -737,9 +729,9 @@ export const useMultiplyForm = (options: UseMultiplyFormOptions) => {
     }
     await requestMultiplyQuotes(requestParams, {
       errorMessage: 'Unable to fetch swap quote. Multiply feature is not available for this asset.',
-      providerExtraData: cowAccount ? { cow: cowProviderExtraData } : undefined,
-      providerParams: cowAccount
-        ? { cow: { accountIn: cowAccount, accountOut: cowAccount } }
+      providerExtraData: cowProviderExtraData.appData ? { cow: cowProviderExtraData } : undefined,
+      providerParams: cowProviderExtraData.appData
+        ? { cow: { accountIn: account, accountOut: account } }
         : undefined,
     })
   }, 500)
@@ -824,6 +816,7 @@ export const useMultiplyForm = (options: UseMultiplyFormOptions) => {
   // --- CowSwap ---
   const cowSwap = useMultiplyCowSwap({
     multiplySelectedProvider: computed(() => multiplySelectedProvider.value),
+    multiplyEffectiveProvider: computed(() => multiplyEffectiveProvider.value),
     multiplyEffectiveQuote: computed(() => multiplyEffectiveQuote.value),
     multiplySelectedQuote: computed(() => multiplySelectedQuote.value),
     multiplyEffectiveQuoteFetchedAt: computed(() => multiplyEffectiveQuoteFetchedAt.value),

--- a/composables/cowswap/useCowSwapClosePositionExecution.ts
+++ b/composables/cowswap/useCowSwapClosePositionExecution.ts
@@ -6,6 +6,7 @@ import {
   type CowSwapOrderUid,
   getCowSwapChainConfig,
   buildClosePositionWrapperData,
+  buildClosePositionQuoteAppData,
   buildCowSwapAppData,
   buildCowSwapOrderTypedData,
   buildCowSwapOrderPayload,
@@ -14,6 +15,7 @@ import {
   verifyInboxDomainSeparator,
   INBOX_DOMAIN_NAME,
   INBOX_DOMAIN_VERSION,
+  validateCowSwapQuoteOrderAmounts,
 } from '~/entities/cowswap'
 import { useCowSwapExecutionCore } from './useCowSwapExecutionCore'
 
@@ -46,6 +48,22 @@ export const useCowSwapClosePositionExecution = () => {
     core.error.value = null
 
     try {
+      validateCowSwapQuoteOrderAmounts(params.quote, {
+        sellAmount: params.sellAmount,
+        buyAmount: params.buyAmount,
+        slippage: params.slippage,
+        slippageTarget: params.orderKind === 'buy' ? 'sellAmount' : 'buyAmount',
+        maxSellAmount: params.maxSellAmount,
+        expectedSellAmount: params.expectedSellAmount,
+        expectedBuyAmount: params.expectedBuyAmount,
+        expectedAppData: params.expectedAppData,
+        actualAppData: buildClosePositionQuoteAppData(
+          params.wrapper,
+          chainConfig.closePositionWrapper,
+          params.slippageBips,
+        ),
+      })
+
       // Step 1: Fetch Inbox address and domain separator
       core.status.value = 'fetching_inbox'
 

--- a/composables/cowswap/useCowSwapCollateralSwapExecution.ts
+++ b/composables/cowswap/useCowSwapCollateralSwapExecution.ts
@@ -5,9 +5,11 @@ import {
   type CowSwapOrderUid,
   getCowSwapChainConfig,
   buildCollateralSwapWrapperData,
+  buildCollateralSwapQuoteAppData,
   buildCowSwapAppData,
   buildCowSwapOrderTypedData,
   buildCowSwapOrderPayload,
+  validateCowSwapQuoteOrderAmounts,
 } from '~/entities/cowswap'
 import { useCowSwapExecutionCore } from './useCowSwapExecutionCore'
 
@@ -30,6 +32,20 @@ export const useCowSwapCollateralSwapExecution = () => {
     core.error.value = null
 
     try {
+      validateCowSwapQuoteOrderAmounts(params.quote, {
+        sellAmount: params.sellAmount,
+        buyAmount: params.buyAmount,
+        slippage: params.slippage,
+        slippageTarget: 'buyAmount',
+        expectedSellAmount: params.expectedSellAmount,
+        expectedAppData: params.expectedAppData,
+        actualAppData: buildCollateralSwapQuoteAppData(
+          params.wrapper,
+          chainConfig.collateralSwapWrapper,
+          params.slippageBips,
+        ),
+      })
+
       // Approve fromVault shares → vaultRelayer (so settlement can pull vault shares from owner)
       core.status.value = 'approving_collateral'
       await core.safeApprove(params.sellToken, chainConfig.vaultRelayer, params.sellAmount)

--- a/composables/cowswap/useCowSwapOpenPositionExecution.ts
+++ b/composables/cowswap/useCowSwapOpenPositionExecution.ts
@@ -5,9 +5,11 @@ import {
   type CowSwapOrderUid,
   getCowSwapChainConfig,
   buildOpenPositionWrapperData,
+  buildOpenPositionQuoteAppData,
   buildCowSwapAppData,
   buildCowSwapOrderTypedData,
   buildCowSwapOrderPayload,
+  validateCowSwapQuoteOrderAmounts,
 } from '~/entities/cowswap'
 import { useCowSwapExecutionCore } from './useCowSwapExecutionCore'
 
@@ -30,6 +32,20 @@ export const useCowSwapOpenPositionExecution = () => {
     core.error.value = null
 
     try {
+      validateCowSwapQuoteOrderAmounts(params.quote, {
+        sellAmount: params.sellAmount,
+        buyAmount: params.buyAmount,
+        slippage: params.slippage,
+        slippageTarget: 'buyAmount',
+        expectedSellAmount: params.expectedSellAmount,
+        expectedAppData: params.expectedAppData,
+        actualAppData: buildOpenPositionQuoteAppData(
+          params.wrapper,
+          chainConfig.openPositionWrapper,
+          params.slippageBips,
+        ),
+      })
+
       // Approve collateral token → vault + sell token → vault relayer
       core.status.value = 'approving_collateral'
 

--- a/composables/repay/closePositionShares.ts
+++ b/composables/repay/closePositionShares.ts
@@ -1,0 +1,27 @@
+import { previewWithdraw, type Vault } from '~/entities/vault'
+
+type ClosePositionCollateralSharesParams = {
+  sourceVault: Vault | undefined
+  sourceAssets: bigint
+  sourceShares: bigint
+  assetsAmount: bigint
+}
+
+export const getClosePositionCollateralShares = async ({
+  sourceVault,
+  sourceAssets,
+  sourceShares,
+  assetsAmount,
+}: ClosePositionCollateralSharesParams): Promise<bigint> => {
+  if (!sourceVault || assetsAmount <= 0n) return 0n
+
+  if (assetsAmount < sourceAssets) {
+    const withdrawShares = await previewWithdraw(sourceVault.address, assetsAmount)
+    return sourceShares > 0n && withdrawShares > sourceShares
+      ? sourceShares
+      : withdrawShares
+  }
+
+  if (sourceShares > 0n) return sourceShares
+  return previewWithdraw(sourceVault.address, assetsAmount)
+}

--- a/composables/repay/useCollateralSwapRepay.ts
+++ b/composables/repay/useCollateralSwapRepay.ts
@@ -29,6 +29,7 @@ import { createRaceGuard } from '~/utils/race-guard'
 import { findBlockingDisabledOp, OP_REPAY, OP_REPAY_WITH_SHARES, OP_SKIM, OP_TRANSFER, OP_WITHDRAW, type PlannedOp } from '~/utils/vault-hooks'
 import { getPlanHookDisabledWarning, getUtilisationWarning, type VaultWarning } from '~/composables/useVaultWarnings'
 import { formatNumber, trimTrailingZeros } from '~/utils/string-utils'
+import { getClosePositionCollateralShares } from '~/composables/repay/closePositionShares'
 
 interface UseCollateralSwapRepayOptions {
   position: Ref<AccountBorrowPosition | undefined>
@@ -169,6 +170,21 @@ export const useCollateralSwapRepay = (options: UseCollateralSwapRepayOptions) =
       logWarn('collateralSwapRepay/cowswap/inboxExists', err)
       return false
     }
+  }
+
+  const getClosePositionExpectedSellAmount = async (assetsAmount: bigint): Promise<bigint> => {
+    return getClosePositionCollateralShares({
+      sourceVault: sourceVault.value,
+      sourceAssets: sourceAssets.value,
+      sourceShares: sourceShares.value,
+      assetsAmount,
+    })
+  }
+
+  const convertSourceSharesToAssets = (sharesAmount: bigint): bigint => {
+    const vault = sourceVault.value
+    if (!vault || vault.totalShares <= 0n) return sharesAmount
+    return (sharesAmount * vault.totalAssets) / vault.totalShares
   }
 
   // --- Swap details ---
@@ -467,7 +483,8 @@ export const useCollateralSwapRepay = (options: UseCollateralSwapRepayOptions) =
     const chainConfig = getCowSwapChainConfig(chainId)
     if (!chainConfig) return
 
-    const validTo = Math.floor(Date.now() / 1000) + COWSWAP_ORDER_DEADLINE_SECONDS
+    const quote = core.quotes.selectedQuote.value
+    const validTo = quote.providerData?.appDataDeadline ?? Math.floor(Date.now() / 1000) + COWSWAP_ORDER_DEADLINE_SECONDS
     const swapMode = core.direction.value
     const isTargetDebt = swapMode === SwapperMode.TARGET_DEBT
 
@@ -475,26 +492,81 @@ export const useCollateralSwapRepay = (options: UseCollateralSwapRepayOptions) =
     // and the wrapper returns any unused collateral to the subaccount.
     const orderKind: 'buy' | 'sell' = isTargetDebt ? 'buy' : 'sell'
 
-    const quote = core.quotes.selectedQuote.value
+    const expectedSellAmount = orderKind === 'sell'
+      ? await getClosePositionExpectedSellAmount(valueToNano(core.amount.value || '0', sourceVault.value.asset.decimals))
+      : undefined
+    const targetDebtCollateralAmount = orderKind === 'buy'
+      ? await getClosePositionExpectedSellAmount(sourceBalance.value)
+      : undefined
+    const wrapperCollateralAmount = targetDebtCollateralAmount ?? expectedSellAmount
+    const maxSellAmount = targetDebtCollateralAmount && targetDebtCollateralAmount > 0n
+      ? targetDebtCollateralAmount
+      : undefined
+    const expectedBuyAmount = orderKind === 'buy'
+      ? valueToNano(core.debtAmount.value || '0', borrowVault.value.asset.decimals)
+      : undefined
+    const rawOrderAmounts = getCowSwapQuoteOrderAmounts(quote)
     const orderAmounts = getCowSwapQuoteOrderAmounts(quote, {
       slippage: slippage.value,
-      slippageTarget: 'sellAmount',
-      maxSellAmount: isTargetDebt && sourceShares.value > 0n ? sourceShares.value : undefined,
+      slippageTarget: orderKind === 'buy' ? 'sellAmount' : 'buyAmount',
+      maxSellAmount,
     })
-    if (!orderAmounts) {
+    if (!rawOrderAmounts || !orderAmounts) {
       error('Invalid quote: missing CoW order amounts')
       return
     }
+    if (!quote.providerData?.appData) {
+      error('Invalid quote: missing CoW appData')
+      return
+    }
     const { sellAmount, buyAmount } = orderAmounts
+    if (expectedSellAmount !== undefined && sellAmount !== expectedSellAmount) {
+      error('Quote is stale. Refresh quote and try again.')
+      return
+    }
+    if (expectedBuyAmount !== undefined && buyAmount !== expectedBuyAmount) {
+      error('Quote is stale. Refresh quote and try again.')
+      return
+    }
+    if (orderKind === 'sell') {
+      const displayedBuyAmount = BigInt(quote.amountOut || 0)
+      const displayedBuyMin = BigInt(quote.amountOutMin || 0)
+      if (displayedBuyAmount > 0n && rawOrderAmounts.buyAmount !== displayedBuyAmount) {
+        error('Quote is stale. Refresh quote and try again.')
+        return
+      }
+      if (displayedBuyMin > 0n && buyAmount !== displayedBuyMin) {
+        error('Quote is stale. Refresh quote and try again.')
+        return
+      }
+    }
+    else {
+      const displayedSellAmount = BigInt(quote.amountIn || 0)
+      const displayedSellMax = BigInt(quote.amountInMax || 0)
+      if (displayedSellAmount > 0n && convertSourceSharesToAssets(rawOrderAmounts.sellAmount) > displayedSellAmount) {
+        error('Quote is stale. Refresh quote and try again.')
+        return
+      }
+      if (displayedSellMax > 0n && convertSourceSharesToAssets(sellAmount) > displayedSellMax) {
+        error('Quote is stale. Refresh quote and try again.')
+        return
+      }
+    }
 
     const cowParams: CowSwapClosePositionExecuteParams = {
       chainId,
+      quote,
+      expectedSellAmount,
+      expectedBuyAmount,
+      expectedAppData: quote.providerData.appData,
       sellToken: sourceVault.value.address as Address,
       buyToken: borrowVault.value.asset.address as Address,
       sellAmount,
       buyAmount,
       quoteId: quote.providerData?.quoteId,
+      slippage: slippage.value,
       slippageBips: Math.round(slippage.value * 100),
+      maxSellAmount,
       validTo,
       orderKind,
       wrapper: {
@@ -503,7 +575,7 @@ export const useCollateralSwapRepay = (options: UseCollateralSwapRepayOptions) =
         deadline: validTo,
         borrowVault: borrowVault.value.address as Address,
         collateralVault: sourceVault.value.address as Address,
-        collateralAmount: sellAmount,
+        collateralAmount: wrapperCollateralAmount ?? sellAmount,
       },
     }
 

--- a/composables/repay/useRepaySwapCore.ts
+++ b/composables/repay/useRepaySwapCore.ts
@@ -1,7 +1,7 @@
 import type { Ref, ComputedRef } from 'vue'
 import { useAccount } from '@wagmi/vue'
 import { formatUnits, zeroAddress, type Address } from 'viem'
-import { previewWithdraw, type Vault, type SecuritizeVault } from '~/entities/vault'
+import type { Vault, SecuritizeVault } from '~/entities/vault'
 import { getAssetUsdValue } from '~/services/pricing/priceProvider'
 import type { AccountBorrowPosition } from '~/entities/account'
 import { type SwapApiQuote, SwapperMode } from '~/entities/swap'
@@ -12,6 +12,7 @@ import { trimTrailingZeros } from '~/utils/string-utils'
 import { normalizeAddressOrEmpty } from '~/utils/accountPositionHelpers'
 import { amountToPercent, percentToAmountNano } from '~/utils/repayUtils'
 import { createRaceGuard } from '~/utils/race-guard'
+import { getClosePositionCollateralShares } from '~/composables/repay/closePositionShares'
 
 interface QuoteAccounts {
   accountIn: Address
@@ -291,18 +292,40 @@ export const useRepaySwapCore = (options: UseRepaySwapCoreOptions) => {
     quotes.selectProvider(provider)
   }
 
-  const getClosePositionQuoteCollateralAmount = async (): Promise<bigint> => {
-    if (!sourceVault.value || sourceBalance.value <= 0n) return 0n
+  const getClosePositionQuoteCollateralAmount = async (assetsAmount = sourceBalance.value): Promise<bigint> => {
+    return getClosePositionCollateralShares({
+      sourceVault: sourceVault.value,
+      sourceAssets: sourceAssets.value,
+      sourceShares: sourceShares.value,
+      assetsAmount,
+    })
+  }
 
-    if (sourceBalance.value < sourceAssets.value) {
-      const withdrawShares = await previewWithdraw(sourceVault.value.address, sourceBalance.value)
-      return sourceShares.value > 0n && withdrawShares > sourceShares.value
-        ? sourceShares.value
-        : withdrawShares
-    }
+  const buildClosePositionCowProviderExtraData = async (
+    collateralAssetsAmount: bigint,
+    account: Address,
+  ) => {
+    const providerExtraData = { ...COWSWAP_PROVIDER_EXTRA_DATA.closePosition }
+    const chainConfig = getCowSwapChainConfig(chainId.value ?? 0)
+    if (!chainConfig) return providerExtraData
 
-    if (sourceShares.value > 0n) return sourceShares.value
-    return previewWithdraw(sourceVault.value.address, sourceBalance.value)
+    const quoteDeadline = Math.floor(Date.now() / 1000) + COWSWAP_ORDER_DEADLINE_SECONDS
+    providerExtraData.appDataDeadline = quoteDeadline
+    const sourceSharesAmount = await getClosePositionQuoteCollateralAmount(collateralAssetsAmount)
+    providerExtraData.appData = buildClosePositionQuoteAppData(
+      {
+        owner: (address.value || zeroAddress) as Address,
+        account,
+        deadline: quoteDeadline,
+        borrowVault: borrowVault.value!.address as Address,
+        collateralVault: sourceVault.value!.address as Address,
+        collateralAmount: sourceSharesAmount,
+      },
+      chainConfig.closePositionWrapper,
+      Math.round(slippage.value * 100),
+    )
+
+    return providerExtraData
   }
 
   // --- Quote request ---
@@ -364,6 +387,7 @@ export const useRepaySwapCore = (options: UseRepaySwapCoreOptions) => {
         isRepay: true,
         targetDebt: 0n,
         currentDebt,
+        providerExtraData: await buildClosePositionCowProviderExtraData(parsedAmount, accountIn),
       })
       return
     }
@@ -385,24 +409,7 @@ export const useRepaySwapCore = (options: UseRepaySwapCoreOptions) => {
       return
     }
     const targetDebt = parsedAmount >= currentDebt ? 0n : currentDebt - parsedAmount
-    const quoteDeadline = Math.floor(Date.now() / 1000) + COWSWAP_ORDER_DEADLINE_SECONDS
-    const cowProviderExtraData = { ...COWSWAP_PROVIDER_EXTRA_DATA.closePosition }
-    const chainConfig = getCowSwapChainConfig(chainId.value ?? 0)
-    if (chainConfig) {
-      const sourceSharesAmount = await getClosePositionQuoteCollateralAmount()
-      cowProviderExtraData.appData = buildClosePositionQuoteAppData(
-        {
-          owner: (address.value || zeroAddress) as Address,
-          account: accountIn,
-          deadline: quoteDeadline,
-          borrowVault: borrowVault.value.address as Address,
-          collateralVault: sourceVault.value.address as Address,
-          collateralAmount: sourceSharesAmount,
-        },
-        chainConfig.closePositionWrapper,
-        Math.round(slippage.value * 100),
-      )
-    }
+    const cowProviderExtraData = await buildClosePositionCowProviderExtraData(sourceBalance.value, accountIn)
     await quotes.targetDebtQuotes.requestQuotes({
       tokenIn: sourceVault.value.asset.address as Address,
       tokenOut: borrowVault.value.asset.address as Address,

--- a/composables/useSwapQuotesParallel.ts
+++ b/composables/useSwapQuotesParallel.ts
@@ -15,7 +15,7 @@ import {
 } from '~/utils/swapQuotes'
 import { createRaceGuard } from '~/utils/race-guard'
 import { isAbortError, logWarn } from '~/utils/errorHandling'
-import { isCowProvider, isCowProviderOrQuote } from '~/entities/cowswap'
+import { isCowProvider } from '~/entities/cowswap'
 import { getTokenUsdValue } from '~/services/pricing/priceProvider'
 import { resolveWrappedNativeAddress } from '~/utils/native-currency'
 import { shouldDiscardQuoteOnEstimateGasError } from '~/utils/tx-errors'
@@ -81,6 +81,7 @@ export const useSwapQuotesParallel = (options: SwapQuotesParallelOptions) => {
     return next
   })
   const effectiveQuote = computed(() => effectiveQuoteCard.value?.quote || null)
+  const effectiveProvider = computed(() => effectiveQuoteCard.value?.provider || null)
   const effectiveQuoteFetchedAt = computed(() => effectiveQuoteCard.value?.fetchedAt || null)
   const statusLabel = computed(() => {
     if (!providersCount.value) {
@@ -160,7 +161,7 @@ export const useSwapQuotesParallel = (options: SwapQuotesParallelOptions) => {
   ): Promise<SwapQuoteCard | null> => {
     const amountUsdPromise = getAmountUsd(quote).catch(() => undefined)
 
-    if (isCowProviderOrQuote(provider, quote)) {
+    if (isCowProvider(provider)) {
       return {
         provider,
         quote,
@@ -251,6 +252,25 @@ export const useSwapQuotesParallel = (options: SwapQuotesParallelOptions) => {
       ?? (isCowProvider(provider) ? params.providerExtraData : undefined)
   }
 
+  const bindQuoteRequestMetadata = (
+    provider: string,
+    quote: SwapApiQuote,
+    params: SwapApiRequestInput,
+    providerExtraData: SwapApiProviderExtraData | undefined,
+  ): SwapApiQuote => {
+    if (!isCowProvider(provider) || !providerExtraData) return quote
+
+    return {
+      ...quote,
+      providerData: {
+        ...quote.providerData,
+        appData: providerExtraData.appData,
+        appDataDeadline: providerExtraData.appDataDeadline,
+        requestAmount: params.amount?.toString(),
+      },
+    }
+  }
+
   const getProviderParams = (
     provider: string,
     requestOptions: SwapQuotesRequestOptions,
@@ -327,10 +347,11 @@ export const useSwapQuotesParallel = (options: SwapQuotesParallelOptions) => {
             ...params,
             ...getProviderParams(provider, requestOptions),
           }
+          const providerExtraData = getProviderExtraData(provider, providerParams, requestOptions)
           const data = await getSwapQuotes({
             ...providerParams,
             provider,
-            providerExtraData: getProviderExtraData(provider, providerParams, requestOptions),
+            providerExtraData,
           }, { signal: controller.signal })
 
           if (guard.isStale(gen)) {
@@ -339,7 +360,8 @@ export const useSwapQuotesParallel = (options: SwapQuotesParallelOptions) => {
 
           const best = pickBestQuote(data, options.amountField, options.compare)
           if (best) {
-            const card = await enrichQuoteCard(provider, best, providerParams, client, gasPricePromise)
+            const boundQuote = bindQuoteRequestMetadata(provider, best, providerParams, providerExtraData)
+            const card = await enrichQuoteCard(provider, boundQuote, providerParams, client, gasPricePromise)
             if (guard.isStale(gen) || !card) {
               return
             }
@@ -429,6 +451,7 @@ export const useSwapQuotesParallel = (options: SwapQuotesParallelOptions) => {
     selectedQuote,
     selectedQuoteFetchedAt,
     effectiveQuote,
+    effectiveProvider,
     effectiveQuoteFetchedAt,
     providersCount,
     providersFetchedCount,

--- a/entities/cowswap/quote-utils.ts
+++ b/entities/cowswap/quote-utils.ts
@@ -1,4 +1,5 @@
 import type { SwapApiQuote } from '~/entities/swap'
+import { MAX_SLIPPAGE } from '~/entities/constants'
 
 const parseBigIntAmount = (value: unknown): bigint | undefined => {
   if (typeof value === 'bigint') {
@@ -31,6 +32,17 @@ type CowSwapQuoteOrderAmountOptions = {
   slippage?: number
   slippageTarget?: CowSwapQuoteSlippageTarget
   maxSellAmount?: bigint
+}
+
+type CowSwapQuoteOrderAmountValidationOptions = Omit<CowSwapQuoteOrderAmountOptions, 'slippage' | 'slippageTarget'> & {
+  slippage: number
+  slippageTarget: CowSwapQuoteSlippageTarget
+  sellAmount: bigint
+  buyAmount: bigint
+  expectedSellAmount?: bigint
+  expectedBuyAmount?: bigint
+  expectedAppData?: string
+  actualAppData?: string
 }
 
 const parseSlippagePercent = (slippage: number): { slippageUnits: bigint, denominator: bigint } => {
@@ -67,6 +79,10 @@ export const getCowSwapQuoteOrderAmounts = (
   quote?: Pick<SwapApiQuote, 'providerData'> | null,
   options: CowSwapQuoteOrderAmountOptions = {},
 ): CowSwapQuoteOrderAmounts | undefined => {
+  if (!isValidCowSwapSlippage(options.slippage)) {
+    return undefined
+  }
+
   const providerData = quote?.providerData
   const quoteSellAmount = parseBigIntAmount(providerData?.sellAmount)
   const buyAmount = parseBigIntAmount(providerData?.buyAmount)
@@ -95,5 +111,71 @@ export const getCowSwapQuoteOrderAmounts = (
     sellAmount: adjustedSellAmount,
     buyAmount: adjustedBuyAmount,
     feeAmount,
+  }
+}
+
+export const validateCowSwapQuoteOrderAmounts = (
+  quote: Pick<SwapApiQuote, 'amountIn' | 'amountInMax' | 'amountOut' | 'amountOutMin' | 'providerData'>,
+  options: CowSwapQuoteOrderAmountValidationOptions,
+): CowSwapQuoteOrderAmounts => {
+  assertValidCowSwapSlippage(options.slippage)
+
+  const orderAmounts = getCowSwapQuoteOrderAmounts(quote, options)
+  if (!orderAmounts) {
+    throw new Error('Invalid CoW quote: missing order amounts')
+  }
+
+  if (options.sellAmount !== orderAmounts.sellAmount || options.buyAmount !== orderAmounts.buyAmount) {
+    throw new Error('CoW order amounts do not match selected quote')
+  }
+  if (options.actualAppData !== undefined && !options.expectedAppData) {
+    throw new Error('CoW quote appData is missing request binding')
+  }
+  if (options.expectedAppData !== undefined && options.actualAppData !== options.expectedAppData) {
+    throw new Error('CoW quote appData does not match requested order')
+  }
+
+  assertCowSwapProviderAmountsMatchQuote(quote, orderAmounts, options)
+
+  return orderAmounts
+}
+
+const isValidCowSwapSlippage = (slippage: number | undefined): boolean => (
+  slippage === undefined
+  || (Number.isFinite(slippage) && slippage >= 0 && slippage <= MAX_SLIPPAGE)
+)
+
+const assertValidCowSwapSlippage = (slippage: number | undefined): void => {
+  if (slippage === undefined || !isValidCowSwapSlippage(slippage)) {
+    throw new Error('Valid slippage between 0 and 50% must be provided for CoW swap')
+  }
+}
+
+const assertCowSwapProviderAmountsMatchQuote = (
+  quote: Pick<SwapApiQuote, 'amountIn' | 'amountInMax' | 'amountOut' | 'amountOutMin' | 'providerData'>,
+  orderAmounts: CowSwapQuoteOrderAmounts,
+  options: CowSwapQuoteOrderAmountValidationOptions,
+): void => {
+  const providerSellAmount = parseBigIntAmount(quote.providerData?.sellAmount)
+  const providerBuyAmount = parseBigIntAmount(quote.providerData?.buyAmount)
+  const providerFeeAmount = parseBigIntAmount(quote.providerData?.feeAmount)
+
+  if (providerSellAmount === undefined || providerBuyAmount === undefined || providerFeeAmount === undefined) {
+    throw new Error('Invalid CoW quote: missing order amounts')
+  }
+
+  const rawOrderSellAmount = providerSellAmount + providerFeeAmount
+  if (options.expectedSellAmount !== undefined && rawOrderSellAmount !== options.expectedSellAmount) {
+    throw new Error('CoW quote sell amount does not match requested amount')
+  }
+  if (options.expectedBuyAmount !== undefined && providerBuyAmount !== options.expectedBuyAmount) {
+    throw new Error('CoW quote buy amount does not match requested amount')
+  }
+
+  if (options.slippageTarget === 'sellAmount') {
+    const maxSellAmount = options.maxSellAmount
+    if (maxSellAmount !== undefined && maxSellAmount < rawOrderSellAmount) {
+      throw new Error('CoW order sell amount is below quoted sell amount')
+    }
   }
 }

--- a/entities/cowswap/types.ts
+++ b/entities/cowswap/types.ts
@@ -1,4 +1,5 @@
 import type { Address, Hex } from 'viem'
+import type { SwapApiQuote } from '~/entities/swap'
 
 export type CowSwapOrderKind = 'sell' | 'buy'
 
@@ -74,11 +75,15 @@ export type CowSwapOpenPositionParams = {
 
 export type CowSwapOpenPositionExecuteParams = {
   chainId: number
+  quote: SwapApiQuote
+  expectedSellAmount: bigint
+  expectedAppData?: string
   sellToken: Address
   buyToken: Address
   sellAmount: bigint
   buyAmount: bigint
   quoteId?: number
+  slippage: number
   slippageBips: number
   validTo: number
   collateralToken: Address
@@ -99,11 +104,15 @@ export type CowSwapCollateralSwapParams = {
 
 export type CowSwapCollateralSwapExecuteParams = {
   chainId: number
+  quote: SwapApiQuote
+  expectedSellAmount: bigint
+  expectedAppData?: string
   sellToken: Address
   buyToken: Address
   sellAmount: bigint
   buyAmount: bigint
   quoteId?: number
+  slippage: number
   slippageBips: number
   validTo: number
   wrapper: CowSwapCollateralSwapParams
@@ -122,12 +131,18 @@ export type CowSwapClosePositionParams = {
 
 export type CowSwapClosePositionExecuteParams = {
   chainId: number
+  quote: SwapApiQuote
+  expectedSellAmount?: bigint
+  expectedBuyAmount?: bigint
+  expectedAppData?: string
   sellToken: Address
   buyToken: Address
   sellAmount: bigint
   buyAmount: bigint
   quoteId?: number
+  slippage: number
   slippageBips: number
+  maxSellAmount?: bigint
   validTo: number
   orderKind: 'buy' | 'sell'
   wrapper: CowSwapClosePositionParams

--- a/entities/swap.ts
+++ b/entities/swap.ts
@@ -54,6 +54,9 @@ export interface SwapApiProviderData {
   sellAmount?: string
   buyAmount?: string
   feeAmount?: string
+  appData?: string
+  appDataDeadline?: number
+  requestAmount?: string
 }
 
 export type SwapApiProviderExtraDataType = 'openPosition' | 'closePosition' | 'collateralSwap'
@@ -62,6 +65,7 @@ export interface SwapApiProviderExtraData {
   type: SwapApiProviderExtraDataType
   swapCollateralSharesAmountIn?: bigint
   appData?: string
+  appDataDeadline?: number
 }
 
 export interface SwapApiQuote {

--- a/pages/position/[number]/collateral/swap.vue
+++ b/pages/position/[number]/collateral/swap.vue
@@ -24,7 +24,7 @@ import { nanoToValue } from '~/utils/crypto-utils'
 import { useModal } from '~/components/ui/composables/useModal'
 import { useSwapPageLogic } from '~/composables/useSwapPageLogic'
 import type { DisabledReasonInfo } from '~/components/entities/vault/form/types'
-import { COWSWAP_ORDER_DEADLINE_SECONDS, COWSWAP_PROVIDER_EXTRA_DATA, buildCollateralSwapQuoteAppData, type CowSwapCollateralSwapExecuteParams, getCowSwapChainConfig, getCowSwapQuoteOrderAmounts, isCowProvider } from '~/entities/cowswap'
+import { COWSWAP_ORDER_DEADLINE_SECONDS, COWSWAP_PROVIDER_EXTRA_DATA, buildCollateralSwapQuoteAppData, type CowSwapCollateralSwapExecuteParams, getCowSwapChainConfig, getCowSwapQuoteOrderAmounts, isCowProvider, validateCowSwapQuoteOrderAmounts } from '~/entities/cowswap'
 import { useCowSwapCollateralSwapExecution, useCowSwapOrderStatus, openCowSwapReviewModal, buildApprovalSignSteps } from '~/composables/cowswap'
 
 const route = useRoute()
@@ -149,6 +149,7 @@ const swap = useSwapPageLogic({
     if (swapCollateralSharesAmountIn <= 0n) return null
     const quoteDeadline = Math.floor(Date.now() / 1000) + COWSWAP_ORDER_DEADLINE_SECONDS
     const providerExtraData = COWSWAP_PROVIDER_EXTRA_DATA.collateralSwap(swapCollateralSharesAmountIn)
+    providerExtraData.appDataDeadline = quoteDeadline
     const chainConfig = getCowSwapChainConfig(currentChainId.value ?? 0)
     if (chainConfig) {
       providerExtraData.appData = buildCollateralSwapQuoteAppData(
@@ -270,9 +271,32 @@ const cowSwapErrorText = computed(() => {
   // Sell amount must not exceed collateral balance
   const inputNano = valueToNano(fromAmount.value || '0', fromVault.value.asset.decimals)
   if (inputNano > balance.value) return 'Sell amount exceeds collateral balance'
+  const expectedSellAmount = getSwapCollateralSharesAmountIn(inputNano)
 
-  if (!getCowSwapQuoteOrderAmounts(selectedQuote.value, { slippage: slippage.value, slippageTarget: 'buyAmount' })) {
+  const orderAmounts = getCowSwapQuoteOrderAmounts(selectedQuote.value, { slippage: slippage.value, slippageTarget: 'buyAmount' })
+  if (!orderAmounts) {
     return 'Invalid CoW quote: missing order amounts'
+  }
+  if (!selectedQuote.value.providerData?.appData) {
+    return 'Invalid CoW quote: missing appData'
+  }
+  const rawOrderAmounts = getCowSwapQuoteOrderAmounts(selectedQuote.value)
+  if (!rawOrderAmounts) {
+    return 'Invalid CoW quote: missing order amounts'
+  }
+  if (convertVaultSharesToAssets(toVault.value, rawOrderAmounts.buyAmount) !== BigInt(selectedQuote.value.amountOut || 0)) {
+    return 'CoW quote buy amount does not match displayed amount'
+  }
+  try {
+    validateCowSwapQuoteOrderAmounts(selectedQuote.value, {
+      ...orderAmounts,
+      slippage: slippage.value,
+      slippageTarget: 'buyAmount',
+      expectedSellAmount,
+    })
+  }
+  catch (err) {
+    return err instanceof Error ? err.message : 'Invalid CoW quote'
   }
 
   // Destination vault supply cap
@@ -302,7 +326,10 @@ const submitCowSwapCollateralSwap = async () => {
   const chainConfig = getCowSwapChainConfig(chainId)
   if (!chainConfig) return
 
-  const validTo = Math.floor(Date.now() / 1000) + COWSWAP_ORDER_DEADLINE_SECONDS
+  const validTo = selectedQuote.value.providerData?.appDataDeadline ?? Math.floor(Date.now() / 1000) + COWSWAP_ORDER_DEADLINE_SECONDS
+  const expectedSellAmount = getSwapCollateralSharesAmountIn(
+    valueToNano(fromAmount.value || '0', fromVault.value.asset.decimals),
+  )
 
   const orderAmounts = getCowSwapQuoteOrderAmounts(selectedQuote.value, {
     slippage: slippage.value,
@@ -312,15 +339,28 @@ const submitCowSwapCollateralSwap = async () => {
     logWarn('collateralSwap/cowswap/orderAmounts', new Error('Invalid CoW quote: missing order amounts'))
     return
   }
+  if (!selectedQuote.value.providerData?.appData) {
+    logWarn('collateralSwap/cowswap/orderAmounts', new Error('Invalid CoW quote: missing appData'))
+    return
+  }
   const { sellAmount, buyAmount } = orderAmounts
+  const rawOrderAmounts = getCowSwapQuoteOrderAmounts(selectedQuote.value)
+  if (!rawOrderAmounts || convertVaultSharesToAssets(toVault.value, rawOrderAmounts.buyAmount) !== BigInt(selectedQuote.value.amountOut || 0)) {
+    logWarn('collateralSwap/cowswap/orderAmounts', new Error('CoW quote buy amount does not match displayed amount'))
+    return
+  }
 
   const cowParams: CowSwapCollateralSwapExecuteParams = {
     chainId,
+    quote: selectedQuote.value,
+    expectedSellAmount,
+    expectedAppData: selectedQuote.value.providerData.appData,
     sellToken: fromVault.value.address as Address,
     buyToken: toVault.value.address as Address,
     sellAmount,
     buyAmount,
     quoteId: selectedQuote.value.providerData?.quoteId,
+    slippage: slippage.value,
     slippageBips: Math.round(slippage.value * 100),
     validTo,
     wrapper: {
@@ -329,7 +369,7 @@ const submitCowSwapCollateralSwap = async () => {
       deadline: validTo,
       fromVault: fromVault.value.address as Address,
       toVault: toVault.value.address as Address,
-      fromAmount: sellAmount,
+      fromAmount: expectedSellAmount,
       disableSourceCollateral: isMaxSwap.value,
     },
   }

--- a/tests/composables/cowswap-caller-validation.test.ts
+++ b/tests/composables/cowswap-caller-validation.test.ts
@@ -1,0 +1,460 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { computed, ref, watch, watchEffect } from 'vue'
+import type { Address } from 'viem'
+import type { Vault } from '~/entities/vault'
+import type { AccountBorrowPosition } from '~/entities/account'
+import type { SwapApiQuote } from '~/entities/swap'
+import { SwapperMode } from '~/entities/swap'
+import { useMultiplyCowSwap } from '~/composables/borrow/useMultiplyCowSwap'
+import { useCollateralSwapRepay } from '~/composables/repay/useCollateralSwapRepay'
+
+const { mocks, USER, SUBACCOUNT, SHORT_VAULT } = vi.hoisted(() => ({
+  USER: '0x0000000000000000000000000000000000000001',
+  SUBACCOUNT: '0x0000000000000000000000000000000000000002',
+  SHORT_VAULT: '0x0000000000000000000000000000000000000012',
+  mocks: {
+    openCowSwapReviewModal: vi.fn(),
+    toastError: vi.fn(),
+    getNewSubAccount: vi.fn(),
+    getClosePositionCollateralShares: vi.fn(),
+    readContract: vi.fn(),
+    getCode: vi.fn(),
+    vaultAccountInfo: { assets: 0n, shares: 0n },
+    repayCore: null as unknown,
+  },
+}))
+
+vi.mock('@wagmi/vue', () => ({
+  useAccount: () => ({
+    isConnected: ref(true),
+    address: ref(USER),
+  }),
+}))
+
+vi.mock('#components', () => ({
+  OperationReviewModal: {},
+}))
+
+vi.mock('~/entities/account', () => ({
+  getNewSubAccount: mocks.getNewSubAccount,
+}))
+
+vi.mock('~/components/ui/composables/useModal', () => ({
+  useModal: () => ({
+    open: vi.fn(),
+    close: vi.fn(),
+  }),
+}))
+
+vi.mock('~/components/ui/composables/useToast', () => ({
+  useToast: () => ({
+    error: mocks.toastError,
+  }),
+}))
+
+vi.mock('~/composables/cowswap', () => ({
+  useCowSwapOpenPositionExecution: () => ({
+    reset: vi.fn(),
+    status: ref('idle'),
+    orderUid: ref(undefined),
+  }),
+  useCowSwapClosePositionExecution: () => ({
+    reset: vi.fn(),
+    status: ref('idle'),
+    orderUid: ref(undefined),
+  }),
+  useCowSwapOrderStatus: () => ({
+    orderStatus: ref(null),
+  }),
+  buildApprovalSignSteps: ({ startIndex }: { startIndex: number }) => ({
+    steps: [],
+    nextIndex: startIndex,
+  }),
+  openCowSwapReviewModal: mocks.openCowSwapReviewModal,
+}))
+
+vi.mock('~/composables/repay/closePositionShares', () => ({
+  getClosePositionCollateralShares: mocks.getClosePositionCollateralShares,
+}))
+
+vi.mock('~/composables/repay/useRepaySwapCore', () => ({
+  useRepaySwapCore: () => mocks.repayCore,
+}))
+
+vi.mock('~/composables/repay/useRepaySwapDetails', () => ({
+  useRepaySwapDetails: () => ({
+    currentPrice: ref(null),
+    summary: ref([]),
+    priceImpact: ref(null),
+    leveragedPriceImpact: ref(null),
+    routedVia: ref(null),
+    routeEmptyMessage: ref(null),
+    routeItems: ref([]),
+  }),
+}))
+
+vi.mock('~/composables/repay/useRepayHealthMetrics', () => ({
+  useRepayHealthMetrics: () => ({
+    roeBefore: ref(null),
+    roeAfter: ref(null),
+    currentHealth: ref(null),
+    currentLtv: ref(null),
+    currentLiquidationLtv: ref(null),
+    nextLtv: ref(null),
+    nextHealth: ref(null),
+    currentLiquidationPrice: ref(null),
+    nextLiquidationPrice: ref(null),
+  }),
+}))
+
+vi.mock('~/composables/useSwapCollateralOptions', () => ({
+  useSwapCollateralOptions: () => ({
+    collateralOptions: ref([]),
+    collateralVaults: ref([]),
+  }),
+}))
+
+vi.mock('~/composables/useEulerLabels', () => ({
+  useEulerProductOfVault: () => computed(() => ({ name: 'Euler Test' })),
+}))
+
+vi.mock('~/services/pricing/priceProvider', () => ({
+  getAssetUsdValue: vi.fn(async () => null),
+  getAssetOraclePrice: vi.fn(() => 1n),
+  conservativePriceRatioNumber: vi.fn(() => 1),
+}))
+
+const addr = (suffix: string) => `0x${suffix.padStart(40, '0')}` as Address
+const lensAddresses = {
+  accountLens: addr('ee'),
+  eulerEarnVaultLens: addr('ef'),
+  irmLens: addr('f0'),
+  oracleLens: addr('f1'),
+  utilsLens: addr('f2'),
+  vaultLens: addr('f3'),
+}
+
+const makeVault = (
+  suffix: string,
+  symbol: string,
+  overrides: Partial<Vault> = {},
+): Vault => ({
+  address: addr(suffix),
+  symbol: `${symbol}v`,
+  decimals: 18n,
+  totalAssets: 2_000n,
+  totalShares: 1_000n,
+  totalCash: 10_000n,
+  supply: 0n,
+  supplyCap: 0n,
+  interestRateInfo: { supplyAPY: 0n, borrowAPY: 0n },
+  collateralLTVs: [],
+  asset: {
+    address: addr(`${suffix}a`),
+    chainId: 1,
+    decimals: 0,
+    logoURI: '',
+    name: symbol,
+    symbol,
+  },
+  ...overrides,
+} as unknown as Vault)
+
+const makeQuote = (overrides: Partial<SwapApiQuote> = {}): SwapApiQuote => ({
+  amountIn: '1000',
+  amountInMax: '1000',
+  amountOut: '1000',
+  amountOutMin: '995',
+  accountIn: SUBACCOUNT as Address,
+  accountOut: SUBACCOUNT as Address,
+  vaultIn: addr('b1'),
+  receiver: addr('b2'),
+  tokenIn: { address: addr('a1'), chainId: 1, decimals: 18, logoURI: '', name: 'In', symbol: 'IN' },
+  tokenOut: { address: addr('a2'), chainId: 1, decimals: 18, logoURI: '', name: 'Out', symbol: 'OUT' },
+  route: [{ providerName: 'cow' }],
+  providerData: {
+    sellAmount: '1000',
+    buyAmount: '500',
+    feeAmount: '0',
+    appData: '{"bound":true}',
+    appDataDeadline: 12345,
+  },
+  ...overrides,
+} as SwapApiQuote)
+
+const makePosition = (
+  borrowVault: Vault,
+  collateralVault: Vault,
+  supplied: bigint,
+): AccountBorrowPosition => ({
+  borrow: borrowVault as AccountBorrowPosition['borrow'],
+  collateral: collateralVault as AccountBorrowPosition['collateral'],
+  subAccount: SUBACCOUNT,
+  borrowed: 1_000n,
+  supplied,
+  collaterals: [],
+  health: 0n,
+  userLTV: 0n,
+  price: 0n,
+  borrowLTV: 0n,
+  liquidationLTV: 0n,
+  liabilityValueBorrowing: 0n,
+  liabilityValueLiquidation: 0n,
+  timeToLiquidation: 0n,
+  collateralValueLiquidation: 0n,
+})
+
+const makeRepayCore = (quote: SwapApiQuote, direction = SwapperMode.TARGET_DEBT) => {
+  const directionRef = ref(direction)
+  return {
+    amount: ref(direction === SwapperMode.EXACT_IN ? '1000' : '1000'),
+    debtAmount: ref(direction === SwapperMode.TARGET_DEBT ? '500' : '500'),
+    direction: directionRef,
+    debtPercent: ref(0),
+    quotes: {
+      selectedProvider: ref('cow'),
+      selectedQuote: ref(quote),
+      effectiveQuoteFetchedAt: ref(777),
+      quoteError: ref(null),
+    },
+    isSameAsset: computed(() => false),
+    isRepayExceedsDebt: computed(() => false),
+    spent: ref(null),
+    debtRepaid: ref(null),
+    resetCore: vi.fn(),
+    onAmountInput: vi.fn(),
+    onDebtInput: vi.fn(),
+    onPercentInput: vi.fn(),
+    onRefreshQuotes: vi.fn(),
+    onSourceMax: vi.fn(),
+    onProviderSelect: vi.fn(),
+    onSourceVaultChange: vi.fn(),
+  }
+}
+
+describe('CoW caller validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubGlobal('ref', ref)
+    vi.stubGlobal('computed', computed)
+    vi.stubGlobal('watch', watch)
+    vi.stubGlobal('watchEffect', watchEffect)
+    vi.stubGlobal('valueToNano', (value: string) => BigInt(value || '0'))
+    vi.stubGlobal('useRouter', () => ({ replace: vi.fn() }))
+    vi.stubGlobal('usePriceInvert', () => ({ autoInvert: vi.fn() }))
+    vi.stubGlobal('useEulerAddresses', () => ({
+      chainId: ref(1),
+      eulerLensAddresses: ref(lensAddresses),
+      isReady: ref(true),
+      loadEulerConfig: vi.fn(),
+    }))
+    vi.stubGlobal('useRpcClient', () => ({
+      client: ref({
+        readContract: mocks.readContract,
+        getCode: mocks.getCode,
+      }),
+    }))
+    vi.stubGlobal('useEulerOperations', () => ({
+      buildSwapPlan: vi.fn(),
+      buildSameAssetRepayPlan: vi.fn(),
+      buildSameAssetFullRepayPlan: vi.fn(),
+      buildSwapFullRepayPlan: vi.fn(),
+      executeTxPlan: vi.fn(),
+    }))
+    vi.stubGlobal('useTxFinalization', () => ({ finalizeTxAndRedirect: vi.fn() }))
+    vi.stubGlobal('useEulerAccount', () => ({ refreshAllPositions: vi.fn() }))
+    vi.stubGlobal('useIntrinsicApy', () => ({
+      withIntrinsicSupplyApy: vi.fn((value: number) => value),
+      withIntrinsicBorrowApy: vi.fn((value: number) => value),
+    }))
+    vi.stubGlobal('useRewardsApy', () => ({
+      getSupplyRewardApy: vi.fn(() => 0),
+      getBorrowRewardApy: vi.fn(() => 0),
+    }))
+
+    mocks.getNewSubAccount.mockResolvedValue(SUBACCOUNT)
+    mocks.getClosePositionCollateralShares.mockImplementation(async ({ assetsAmount }: { assetsAmount: bigint }) => assetsAmount)
+    mocks.vaultAccountInfo = { assets: 0n, shares: 0n }
+    mocks.readContract.mockImplementation(async ({ functionName }: { functionName: string }) => {
+      if (functionName === 'getVaultAccountInfo') return mocks.vaultAccountInfo
+      if (functionName === 'getInboxAddressAndDomainSeparator') return [addr('f1'), '0x']
+      return 0n
+    })
+    mocks.getCode.mockResolvedValue('0x')
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('blocks multiply CoW submit when raw buy shares do not match displayed underlying output', async () => {
+    const supplyVault = makeVault('11', 'SUP', { totalAssets: 1_000n, totalShares: 1_000n })
+    const longVault = makeVault('12', 'LONG', { totalAssets: 2_000n, totalShares: 1_000n })
+    const shortVault = makeVault('13', 'SHORT', { address: SHORT_VAULT as Address, totalAssets: 1_000n, totalShares: 1_000n })
+    const quote = makeQuote({ amountOut: '999' })
+
+    const multiply = useMultiplyCowSwap({
+      multiplySelectedProvider: computed(() => 'cow'),
+      multiplyEffectiveProvider: computed(() => 'cow'),
+      multiplyEffectiveQuote: computed(() => quote),
+      multiplySelectedQuote: computed(() => quote),
+      multiplyEffectiveQuoteFetchedAt: computed(() => 777),
+      multiplySlippage: ref(0),
+      multiplySupplyVault: computed(() => supplyVault),
+      multiplyLongVault: computed(() => longVault),
+      multiplyShortVault: computed(() => shortVault),
+      multiplySupplyProduct: computed(() => ({ name: 'Supply' })),
+      multiplyShortProduct: computed(() => ({ name: 'Borrow' })),
+      multiplyInputAmount: ref('1'),
+      multiplyShortAmount: computed(() => '1000'),
+      multiplyLongAmount: computed(() => '1000'),
+      multiplyDebtAmountNano: computed(() => 1000n),
+      multiplyErrorText: computed(() => null),
+      resolvePendingSubAccount: vi.fn(async () => SUBACCOUNT),
+      refreshAllPositions: vi.fn(),
+      eulerLensAddresses: ref(lensAddresses),
+    })
+
+    await multiply.submitCowSwapMultiply()
+
+    expect(mocks.toastError).toHaveBeenCalledWith('Quote is stale. Refresh quote and try again.')
+    expect(mocks.openCowSwapReviewModal).not.toHaveBeenCalled()
+  })
+
+  it('passes request-bound appData and expected sell amount into multiply CoW execution params', async () => {
+    const supplyVault = makeVault('21', 'SUP', { totalAssets: 1_000n, totalShares: 1_000n })
+    const longVault = makeVault('22', 'LONG', { totalAssets: 2_000n, totalShares: 1_000n })
+    const shortVault = makeVault('23', 'SHORT', { address: SHORT_VAULT as Address, totalAssets: 1_000n, totalShares: 1_000n })
+    const quote = makeQuote({ amountOut: '1000' })
+
+    const multiply = useMultiplyCowSwap({
+      multiplySelectedProvider: computed(() => 'cow'),
+      multiplyEffectiveProvider: computed(() => 'cow'),
+      multiplyEffectiveQuote: computed(() => quote),
+      multiplySelectedQuote: computed(() => quote),
+      multiplyEffectiveQuoteFetchedAt: computed(() => 777),
+      multiplySlippage: ref(0),
+      multiplySupplyVault: computed(() => supplyVault),
+      multiplyLongVault: computed(() => longVault),
+      multiplyShortVault: computed(() => shortVault),
+      multiplySupplyProduct: computed(() => ({ name: 'Supply' })),
+      multiplyShortProduct: computed(() => ({ name: 'Borrow' })),
+      multiplyInputAmount: ref('1'),
+      multiplyShortAmount: computed(() => '1000'),
+      multiplyLongAmount: computed(() => '1000'),
+      multiplyDebtAmountNano: computed(() => 1000n),
+      multiplyErrorText: computed(() => null),
+      resolvePendingSubAccount: vi.fn(async () => SUBACCOUNT),
+      refreshAllPositions: vi.fn(),
+      eulerLensAddresses: ref(lensAddresses),
+    })
+
+    await multiply.submitCowSwapMultiply()
+
+    const executeParams = mocks.openCowSwapReviewModal.mock.calls[0]?.[1].executeParams
+    expect(executeParams).toMatchObject({
+      expectedSellAmount: 1000n,
+      expectedAppData: '{"bound":true}',
+      sellAmount: 1000n,
+      buyAmount: 500n,
+      validTo: 12345,
+    })
+    expect(executeParams.wrapper.borrowAmount).toBe(1000n)
+    expect(executeParams.wrapper.account).toBe(SUBACCOUNT)
+  })
+
+  it('wires target-debt close params from the selected quote into the CoW review modal', async () => {
+    const sourceVault = makeVault('31', 'COL', { totalAssets: 2_000n, totalShares: 1_000n })
+    const borrowVault = makeVault('32', 'DEBT', { totalAssets: 1_000n, totalShares: 1_000n })
+    const quote = makeQuote({
+      amountIn: '1000',
+      amountInMax: '1000',
+      amountOut: '500',
+      amountOutMin: '500',
+      providerData: {
+        sellAmount: '500',
+        buyAmount: '500',
+        feeAmount: '0',
+        appData: '{"close":true}',
+        appDataDeadline: 45678,
+      },
+    })
+    mocks.repayCore = makeRepayCore(quote, SwapperMode.TARGET_DEBT)
+
+    const repay = useCollateralSwapRepay({
+      position: ref(makePosition(borrowVault, sourceVault, 500n)),
+      borrowVault: computed(() => borrowVault as AccountBorrowPosition['borrow']),
+      collateralVault: computed(() => sourceVault as AccountBorrowPosition['collateral']),
+      formTab: ref('collateral'),
+      plan: ref(null),
+      isSubmitting: ref(false),
+      isPreparing: ref(false),
+      slippage: ref(0),
+      clearSimulationError: vi.fn(),
+      runSimulation: vi.fn(),
+      getCurrentDebt: () => 1_000n,
+      isEligibleForLiquidation: computed(() => false),
+    })
+    repay.initVault(sourceVault)
+    mocks.vaultAccountInfo = { assets: 500n, shares: 500n }
+    await repay.updateSourceBalance()
+
+    await repay.submit()
+
+    const executeParams = mocks.openCowSwapReviewModal.mock.calls[0]?.[1].executeParams
+    expect(executeParams).toMatchObject({
+      expectedBuyAmount: 500n,
+      expectedAppData: '{"close":true}',
+      sellAmount: 500n,
+      buyAmount: 500n,
+      maxSellAmount: 500n,
+      validTo: 45678,
+      orderKind: 'buy',
+    })
+    expect(executeParams.wrapper.collateralAmount).toBe(500n)
+    expect(executeParams.wrapper.account).toBe(SUBACCOUNT)
+  })
+
+  it('blocks exact-in close when signed buy amount diverges from displayed repay output', async () => {
+    const sourceVault = makeVault('41', 'COL', { totalAssets: 1_000n, totalShares: 1_000n })
+    const borrowVault = makeVault('42', 'DEBT', { totalAssets: 1_000n, totalShares: 1_000n })
+    const quote = makeQuote({
+      amountIn: '1000',
+      amountInMax: '1000',
+      amountOut: '501',
+      amountOutMin: '500',
+      providerData: {
+        sellAmount: '1000',
+        buyAmount: '500',
+        feeAmount: '0',
+        appData: '{"close":true}',
+        appDataDeadline: 45678,
+      },
+    })
+    mocks.repayCore = makeRepayCore(quote, SwapperMode.EXACT_IN)
+
+    const repay = useCollateralSwapRepay({
+      position: ref(makePosition(borrowVault, sourceVault, 1_000n)),
+      borrowVault: computed(() => borrowVault as AccountBorrowPosition['borrow']),
+      collateralVault: computed(() => sourceVault as AccountBorrowPosition['collateral']),
+      formTab: ref('collateral'),
+      plan: ref(null),
+      isSubmitting: ref(false),
+      isPreparing: ref(false),
+      slippage: ref(0),
+      clearSimulationError: vi.fn(),
+      runSimulation: vi.fn(),
+      getCurrentDebt: () => 1_000n,
+      isEligibleForLiquidation: computed(() => false),
+    })
+    repay.initVault(sourceVault)
+    mocks.vaultAccountInfo = { assets: 1_000n, shares: 1_000n }
+    await repay.updateSourceBalance()
+
+    await repay.submit()
+
+    expect(mocks.toastError).toHaveBeenCalledWith('Quote is stale. Refresh quote and try again.')
+    expect(mocks.openCowSwapReviewModal).not.toHaveBeenCalled()
+  })
+})

--- a/tests/composables/cowswap-execution-validation.test.ts
+++ b/tests/composables/cowswap-execution-validation.test.ts
@@ -1,0 +1,264 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Address } from 'viem'
+import type {
+  CowSwapClosePositionExecuteParams,
+  CowSwapCollateralSwapExecuteParams,
+  CowSwapOpenPositionExecuteParams,
+} from '~/entities/cowswap'
+import {
+  buildClosePositionQuoteAppData,
+  buildCollateralSwapQuoteAppData,
+  buildOpenPositionQuoteAppData,
+  getCowSwapChainConfig,
+} from '~/entities/cowswap'
+import type { SwapApiQuote } from '~/entities/swap'
+import { SwapVerificationType } from '~/entities/swap'
+import { useCowSwapClosePositionExecution } from '~/composables/cowswap/useCowSwapClosePositionExecution'
+import { useCowSwapCollateralSwapExecution } from '~/composables/cowswap/useCowSwapCollateralSwapExecution'
+import { useCowSwapOpenPositionExecution } from '~/composables/cowswap/useCowSwapOpenPositionExecution'
+
+const { core } = vi.hoisted(() => ({
+  core: {
+    requireWallet: vi.fn(),
+    requireRpc: vi.fn(),
+    configureCowApiCancellation: vi.fn(),
+    configurePermitCancellation: vi.fn(),
+    safeApprove: vi.fn(),
+    fetchNonceAndPermitData: vi.fn(),
+    signEvcPermit: vi.fn(),
+    signOrderTypedData: vi.fn(),
+    submitAndFinalize: vi.fn(),
+    writeContractAndWait: vi.fn(),
+    cancelOrder: vi.fn(),
+    reset: vi.fn(),
+    status: { value: 'idle' },
+    orderUid: { value: undefined },
+    isPending: { value: false },
+    explorerUrl: { value: undefined },
+    error: { value: null as Error | null },
+    locallyCancelled: { value: false },
+    cancellationStatus: { value: 'none' },
+    cancelMode: { value: undefined },
+  },
+}))
+
+vi.mock('~/composables/cowswap/useCowSwapExecutionCore', () => ({
+  useCowSwapExecutionCore: () => core,
+}))
+
+const addr = (suffix: string) => `0x${suffix.padStart(40, '0')}` as Address
+const chainConfig = getCowSwapChainConfig(1)!
+
+const makeQuote = (): SwapApiQuote => ({
+  amountIn: '1007',
+  amountInMax: '1013',
+  amountOut: '2500',
+  amountOutMin: '2487',
+  accountIn: addr('1'),
+  accountOut: addr('1'),
+  vaultIn: addr('2'),
+  receiver: addr('3'),
+  tokenIn: { address: addr('4'), chainId: 1, decimals: 18, logoURI: '', name: 'In', symbol: 'IN' },
+  tokenOut: { address: addr('5'), chainId: 1, decimals: 18, logoURI: '', name: 'Out', symbol: 'OUT' },
+  slippage: 0.5,
+  swap: { swapperAddress: addr('6'), swapperData: '0x', multicallItems: [] },
+  verify: {
+    verifierAddress: addr('7'),
+    verifierData: '0x',
+    type: SwapVerificationType.SkimMin,
+    vault: addr('8'),
+    account: addr('1'),
+    amount: '0',
+    deadline: 0,
+  },
+  route: [{ providerName: 'cow' }],
+  providerData: {
+    sellAmount: '1000',
+    buyAmount: '2500',
+    feeAmount: '7',
+  },
+})
+
+describe('CowSwap execution quote validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    core.requireWallet.mockReturnValue(addr('9'))
+    core.requireRpc.mockReturnValue({
+      readContract: vi.fn(),
+      getCode: vi.fn(),
+      getBlockNumber: vi.fn(),
+    })
+    core.status.value = 'idle'
+    core.error.value = null
+  })
+
+  it('rejects open-position stale sell amount before approvals', async () => {
+    const execution = useCowSwapOpenPositionExecution()
+    const params: CowSwapOpenPositionExecuteParams = {
+      chainId: 1,
+      quote: makeQuote(),
+      expectedSellAmount: 1006n,
+      sellToken: addr('4'),
+      buyToken: addr('5'),
+      sellAmount: 1007n,
+      buyAmount: 2487n,
+      slippage: 0.5,
+      slippageBips: 50,
+      validTo: 100,
+      collateralToken: addr('10'),
+      wrapper: {
+        owner: addr('9'),
+        account: addr('1'),
+        deadline: 100,
+        collateralVault: addr('11'),
+        borrowVault: addr('2'),
+        collateralAmount: 1n,
+        borrowAmount: 1006n,
+      },
+    }
+    params.expectedAppData = buildOpenPositionQuoteAppData(
+      params.wrapper,
+      chainConfig.openPositionWrapper,
+      params.slippageBips,
+    )
+    params.quote.providerData!.appData = params.expectedAppData
+
+    await expect(execution.executeAsync(params)).rejects.toThrow('CoW quote sell amount does not match requested amount')
+    expect(core.safeApprove).not.toHaveBeenCalled()
+    expect(core.fetchNonceAndPermitData).not.toHaveBeenCalled()
+    expect(core.error.value?.message).toBe('CoW quote sell amount does not match requested amount')
+  })
+
+  it('rejects collateral-swap stale sell amount before approvals', async () => {
+    const execution = useCowSwapCollateralSwapExecution()
+    const params: CowSwapCollateralSwapExecuteParams = {
+      chainId: 1,
+      quote: makeQuote(),
+      expectedSellAmount: 1006n,
+      sellToken: addr('4'),
+      buyToken: addr('5'),
+      sellAmount: 1007n,
+      buyAmount: 2487n,
+      slippage: 0.5,
+      slippageBips: 50,
+      validTo: 100,
+      wrapper: {
+        owner: addr('9'),
+        account: addr('1'),
+        deadline: 100,
+        fromVault: addr('2'),
+        toVault: addr('3'),
+        fromAmount: 1006n,
+        disableSourceCollateral: false,
+      },
+    }
+    params.expectedAppData = buildCollateralSwapQuoteAppData(
+      params.wrapper,
+      chainConfig.collateralSwapWrapper,
+      params.slippageBips,
+    )
+    params.quote.providerData!.appData = params.expectedAppData
+
+    await expect(execution.executeAsync(params)).rejects.toThrow('CoW quote sell amount does not match requested amount')
+    expect(core.safeApprove).not.toHaveBeenCalled()
+    expect(core.fetchNonceAndPermitData).not.toHaveBeenCalled()
+    expect(core.error.value?.message).toBe('CoW quote sell amount does not match requested amount')
+  })
+
+  it('rejects close-position target-debt stale buy amount before inbox reads', async () => {
+    const execution = useCowSwapClosePositionExecution()
+    const params: CowSwapClosePositionExecuteParams = {
+      chainId: 1,
+      quote: makeQuote(),
+      expectedBuyAmount: 2499n,
+      sellToken: addr('4'),
+      buyToken: addr('5'),
+      sellAmount: 1013n,
+      buyAmount: 2500n,
+      slippage: 0.5,
+      slippageBips: 50,
+      validTo: 100,
+      orderKind: 'buy',
+      wrapper: {
+        owner: addr('9'),
+        account: addr('1'),
+        deadline: 100,
+        borrowVault: addr('2'),
+        collateralVault: addr('3'),
+        collateralAmount: 1013n,
+      },
+    }
+    params.expectedAppData = buildClosePositionQuoteAppData(
+      params.wrapper,
+      chainConfig.closePositionWrapper,
+      params.slippageBips,
+    )
+    params.quote.providerData!.appData = params.expectedAppData
+
+    await expect(execution.executeAsync(params)).rejects.toThrow('CoW quote buy amount does not match requested amount')
+    expect(core.requireRpc().readContract).not.toHaveBeenCalled()
+    expect(core.fetchNonceAndPermitData).not.toHaveBeenCalled()
+    expect(core.error.value?.message).toBe('CoW quote buy amount does not match requested amount')
+  })
+
+  it('rejects close-position orders missing appData binding before inbox reads', async () => {
+    const execution = useCowSwapClosePositionExecution()
+    const params: CowSwapClosePositionExecuteParams = {
+      chainId: 1,
+      quote: makeQuote(),
+      sellToken: addr('4'),
+      buyToken: addr('5'),
+      sellAmount: 1013n,
+      buyAmount: 2500n,
+      slippage: 0.5,
+      slippageBips: 50,
+      validTo: 100,
+      orderKind: 'buy',
+      wrapper: {
+        owner: addr('9'),
+        account: addr('1'),
+        deadline: 100,
+        borrowVault: addr('2'),
+        collateralVault: addr('3'),
+        collateralAmount: 1013n,
+      },
+    }
+
+    await expect(execution.executeAsync(params)).rejects.toThrow('CoW quote appData is missing request binding')
+    expect(core.requireRpc().readContract).not.toHaveBeenCalled()
+    expect(core.fetchNonceAndPermitData).not.toHaveBeenCalled()
+    expect(core.error.value?.message).toBe('CoW quote appData is missing request binding')
+  })
+
+  it('rejects close-position stale appData before inbox reads', async () => {
+    const execution = useCowSwapClosePositionExecution()
+    const params: CowSwapClosePositionExecuteParams = {
+      chainId: 1,
+      quote: makeQuote(),
+      expectedBuyAmount: 2500n,
+      expectedAppData: '{"stale":true}',
+      sellToken: addr('4'),
+      buyToken: addr('5'),
+      sellAmount: 1013n,
+      buyAmount: 2500n,
+      slippage: 0.5,
+      slippageBips: 50,
+      validTo: 100,
+      orderKind: 'buy',
+      wrapper: {
+        owner: addr('9'),
+        account: addr('1'),
+        deadline: 100,
+        borrowVault: addr('2'),
+        collateralVault: addr('3'),
+        collateralAmount: 1013n,
+      },
+    }
+    params.quote.providerData!.appData = params.expectedAppData
+
+    await expect(execution.executeAsync(params)).rejects.toThrow('CoW quote appData does not match requested order')
+    expect(core.requireRpc().readContract).not.toHaveBeenCalled()
+    expect(core.fetchNonceAndPermitData).not.toHaveBeenCalled()
+    expect(core.error.value?.message).toBe('CoW quote appData does not match requested order')
+  })
+})

--- a/tests/composables/useSavingsRepay.test.ts
+++ b/tests/composables/useSavingsRepay.test.ts
@@ -147,7 +147,12 @@ describe('useSavingsRepay', () => {
       executeTxPlan: vi.fn(),
     }))
     vi.stubGlobal('useEulerAccount', () => ({ refreshAllPositions: vi.fn() }))
-    vi.stubGlobal('useEulerAddresses', () => ({ eulerLensAddresses: ref({}) }))
+    vi.stubGlobal('useEulerAddresses', () => ({ eulerLensAddresses: ref({}), chainId: ref(1) }))
+    vi.stubGlobal('useRpcClient', () => ({ client: ref(null) }))
+    vi.stubGlobal('useWagmi', () => ({
+      address: ref(USER),
+      chain: ref({ nativeCurrency: { decimals: 18 } }),
+    }))
     vi.stubGlobal('useVaultRegistry', () => ({ getVault: vi.fn() }))
     vi.stubGlobal('useTxFinalization', () => ({ finalizeTxAndRedirect: vi.fn() }))
     vi.stubGlobal('useSwapApi', () => ({

--- a/tests/composables/useSwapQuotesParallel.test.ts
+++ b/tests/composables/useSwapQuotesParallel.test.ts
@@ -60,6 +60,7 @@ describe('useSwapQuotesParallel', () => {
 
     expect(quotes.selectedProvider.value).toBe('first')
     expect(quotes.selectedQuote.value).toBe(quotes.effectiveQuote.value)
+    expect(quotes.effectiveProvider.value).toBe('first')
     expect(changes).toEqual([])
   })
 
@@ -83,6 +84,7 @@ describe('useSwapQuotesParallel', () => {
     await nextTick()
 
     expect(quotes.selectedProvider.value).toBe('other')
+    expect(quotes.effectiveProvider.value).toBe('other')
     expect(quotes.effectiveQuote.value?.amountOut).toBe('200')
     expect(changes).toHaveLength(1)
   })
@@ -91,7 +93,7 @@ describe('useSwapQuotesParallel', () => {
     const cowQuote = makeQuote('100', '300')
     const otherQuote = makeQuote('100', '200')
     const cowAccount = '0x00000000000000000000000000000000000000c0'
-    const cowProviderExtraData = { type: 'openPosition' as const, appData: '{}' }
+    const cowProviderExtraData = { type: 'openPosition' as const, appData: '{}', appDataDeadline: 12345 }
     getSwapProviders.mockResolvedValue(['cow', 'other'])
     getSwapQuotes.mockImplementation(({ provider }: { provider: string }) =>
       Promise.resolve([provider === 'cow' ? cowQuote : otherQuote]),
@@ -119,11 +121,33 @@ describe('useSwapQuotesParallel', () => {
       accountOut: cowAccount,
       providerExtraData: cowProviderExtraData,
     })
+    expect(quotes.quoteCards.value.find(card => card.provider === 'cow')?.quote.providerData).toMatchObject({
+      appData: '{}',
+      appDataDeadline: 12345,
+      requestAmount: requestParams.amount.toString(),
+    })
     expect(otherCall).toMatchObject({
       provider: 'other',
       accountIn: requestParams.accountIn,
       accountOut: requestParams.accountOut,
     })
     expect(otherCall.providerExtraData).toBeUndefined()
+  })
+
+  it('does not treat route provider names as trusted CoW provider identity', async () => {
+    const spoofedQuote = {
+      ...makeQuote('100', '300'),
+      route: [{ providerName: 'cow' }],
+    } as SwapApiQuote
+    getSwapProviders.mockResolvedValue(['other'])
+    getSwapQuotes.mockResolvedValue([spoofedQuote])
+
+    const quotes = useSwapQuotesParallel({ amountField: 'amountOut', compare: 'max', includeCowSwap: true })
+    await quotes.requestQuotes(requestParams)
+    await flushPromises()
+    await nextTick()
+
+    expect(quotes.effectiveProvider.value).toBe('other')
+    expect(quotes.sortedQuoteCards.value[0]?.isGasless).toBeUndefined()
   })
 })

--- a/tests/entities/cowswap/quote-utils.test.ts
+++ b/tests/entities/cowswap/quote-utils.test.ts
@@ -1,5 +1,18 @@
 import { describe, expect, it } from 'vitest'
-import { getCowSwapQuoteOrderAmounts } from '~/entities/cowswap/quote-utils'
+import { getCowSwapQuoteOrderAmounts, validateCowSwapQuoteOrderAmounts } from '~/entities/cowswap/quote-utils'
+
+const makeQuote = (overrides = {}) => ({
+  amountIn: '1007',
+  amountInMax: '1013',
+  amountOut: '2500',
+  amountOutMin: '2487',
+  providerData: {
+    sellAmount: '1000',
+    buyAmount: '2500',
+    feeAmount: '7',
+  },
+  ...overrides,
+})
 
 describe('getCowSwapQuoteOrderAmounts', () => {
   it('uses raw CoW provider amounts and folds fee into order sell amount', () => {
@@ -73,5 +86,175 @@ describe('getCowSwapQuoteOrderAmounts', () => {
         feeAmount: '0',
       },
     })).toBeUndefined()
+  })
+
+  it('rejects invalid slippage', () => {
+    expect(getCowSwapQuoteOrderAmounts(makeQuote(), {
+      slippage: 50.1,
+      slippageTarget: 'buyAmount',
+    })).toBeUndefined()
+  })
+})
+
+describe('validateCowSwapQuoteOrderAmounts', () => {
+  it('accepts quote-bound exact-in order amounts', () => {
+    expect(validateCowSwapQuoteOrderAmounts(makeQuote(), {
+      sellAmount: 1007n,
+      buyAmount: 2487n,
+      slippage: 0.5,
+      slippageTarget: 'buyAmount',
+    })).toEqual({
+      sellAmount: 1007n,
+      buyAmount: 2487n,
+      feeAmount: 7n,
+    })
+  })
+
+  it('accepts quote-bound target-debt order amounts', () => {
+    expect(validateCowSwapQuoteOrderAmounts(makeQuote(), {
+      sellAmount: 1013n,
+      buyAmount: 2500n,
+      slippage: 0.5,
+      slippageTarget: 'sellAmount',
+    })).toEqual({
+      sellAmount: 1013n,
+      buyAmount: 2500n,
+      feeAmount: 7n,
+    })
+  })
+
+  it('accepts exact-in order amounts bound to the requested sell amount', () => {
+    expect(validateCowSwapQuoteOrderAmounts(makeQuote(), {
+      sellAmount: 1007n,
+      buyAmount: 2487n,
+      slippage: 0.5,
+      slippageTarget: 'buyAmount',
+      expectedSellAmount: 1007n,
+    })).toEqual({
+      sellAmount: 1007n,
+      buyAmount: 2487n,
+      feeAmount: 7n,
+    })
+  })
+
+  it('rejects submitted amounts that differ from the selected quote', () => {
+    expect(() => validateCowSwapQuoteOrderAmounts(makeQuote(), {
+      sellAmount: 1007n,
+      buyAmount: 2486n,
+      slippage: 0.5,
+      slippageTarget: 'buyAmount',
+    })).toThrow('CoW order amounts do not match selected quote')
+  })
+
+  it('rejects exact-in order amounts that differ from the requested sell amount', () => {
+    expect(() => validateCowSwapQuoteOrderAmounts(makeQuote(), {
+      sellAmount: 1007n,
+      buyAmount: 2487n,
+      slippage: 0.5,
+      slippageTarget: 'buyAmount',
+      expectedSellAmount: 1006n,
+    })).toThrow('CoW quote sell amount does not match requested amount')
+  })
+
+  it('accepts raw provider amounts when display quote amounts use different units', () => {
+    expect(validateCowSwapQuoteOrderAmounts(makeQuote({ amountIn: '1', amountOut: '2' }), {
+      sellAmount: 1007n,
+      buyAmount: 2487n,
+      slippage: 0.5,
+      slippageTarget: 'buyAmount',
+    })).toEqual({
+      sellAmount: 1007n,
+      buyAmount: 2487n,
+      feeAmount: 7n,
+    })
+  })
+
+  it('rejects target-debt order amounts that differ from the requested buy amount', () => {
+    expect(() => validateCowSwapQuoteOrderAmounts(makeQuote(), {
+      sellAmount: 1013n,
+      buyAmount: 2500n,
+      slippage: 0.5,
+      slippageTarget: 'sellAmount',
+      expectedBuyAmount: 2499n,
+    })).toThrow('CoW quote buy amount does not match requested amount')
+  })
+
+  it('rejects appData that differs from the quote request', () => {
+    expect(() => validateCowSwapQuoteOrderAmounts(makeQuote(), {
+      sellAmount: 1007n,
+      buyAmount: 2487n,
+      slippage: 0.5,
+      slippageTarget: 'buyAmount',
+      expectedAppData: '{"quoted":true}',
+      actualAppData: '{"quoted":false}',
+    })).toThrow('CoW quote appData does not match requested order')
+  })
+
+  it('rejects execution validation when appData request binding is missing', () => {
+    expect(() => validateCowSwapQuoteOrderAmounts(makeQuote(), {
+      sellAmount: 1007n,
+      buyAmount: 2487n,
+      slippage: 0.5,
+      slippageTarget: 'buyAmount',
+      actualAppData: '{"quoted":true}',
+    })).toThrow('CoW quote appData is missing request binding')
+  })
+
+  it('accepts capped target-debt sell amounts within requested slippage', () => {
+    expect(() => validateCowSwapQuoteOrderAmounts(makeQuote(), {
+      sellAmount: 1010n,
+      buyAmount: 2500n,
+      slippage: 0.5,
+      slippageTarget: 'sellAmount',
+      maxSellAmount: 1010n,
+      expectedSellAmount: 1007n,
+    })).not.toThrow()
+  })
+
+  it('accepts capped target-debt sell amounts that still cover the quoted sell amount', () => {
+    expect(validateCowSwapQuoteOrderAmounts(makeQuote(), {
+      sellAmount: 1010n,
+      buyAmount: 2500n,
+      slippage: 0.5,
+      slippageTarget: 'sellAmount',
+      maxSellAmount: 1010n,
+    })).toEqual({
+      sellAmount: 1010n,
+      buyAmount: 2500n,
+      feeAmount: 7n,
+    })
+  })
+
+  it('rejects capped target-debt sell amounts below the quoted sell amount', () => {
+    expect(() => validateCowSwapQuoteOrderAmounts(makeQuote(), {
+      sellAmount: 1000n,
+      buyAmount: 2500n,
+      slippage: 0.5,
+      slippageTarget: 'sellAmount',
+      maxSellAmount: 1000n,
+    })).toThrow('CoW order sell amount is below quoted sell amount')
+  })
+
+  it('rejects non-finite or excessive slippage', () => {
+    expect(() => validateCowSwapQuoteOrderAmounts(makeQuote(), {
+      sellAmount: 1007n,
+      buyAmount: 2487n,
+      slippage: undefined as unknown as number,
+      slippageTarget: 'buyAmount',
+    })).toThrow('Valid slippage between 0 and 50% must be provided for CoW swap')
+
+    expect(() => validateCowSwapQuoteOrderAmounts(makeQuote(), {
+      sellAmount: 1007n,
+      buyAmount: 2487n,
+      slippage: Number.POSITIVE_INFINITY,
+      slippageTarget: 'buyAmount',
+    })).toThrow('Valid slippage between 0 and 50% must be provided for CoW swap')
+
+    expect(() => validateCowSwapQuoteOrderAmounts(makeQuote(), {
+      sellAmount: 1007n,
+      buyAmount: 2487n,
+      slippage: 50.1,
+      slippageTarget: 'buyAmount',
+    })).toThrow('Valid slippage between 0 and 50% must be provided for CoW swap')
   })
 })


### PR DESCRIPTION
## Summary
- Harden CoW swap submissions so signed order amounts, displayed quote amounts, and request appData remain bound together.
- Apply the validation consistently across multiply, collateral swap, and close-position repay CoW flows.
- Add regression coverage for quote metadata binding, execution validation, and caller-level stale quote guards.

## Changes
- Add CoW quote order amount validation for sell/buy/fee amounts, slippage bounds, appData binding, expected sell/buy amounts, and target-debt sell caps.
- Bind CoW quote request metadata in `useSwapQuotesParallel`, including appData, appData deadline, and request amount.
- Require submit paths to reject missing appData and stale displayed-vs-signed amounts before opening CoW review modals.
- Share close-position collateral share calculation between quote and submit paths.

## Test plan
- [x] `npm run test:run -- tests/composables/cowswap-caller-validation.test.ts tests/composables/cowswap-execution-validation.test.ts tests/entities/cowswap/quote-utils.test.ts`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test:run`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced quote validation to prevent stale or mismatched quotes in multiply, collateral swap, and close position operations.
  * Strengthened deadline tracking for swap order processing.

* **New Features**
  * Implemented comprehensive quote freshness validation comparing expected versus actual swap amounts.
  * Added consistent app data validation across swap operation types.

* **Tests**
  * Added validation test coverage for multiply and repay swap flows.
  * Added validation test coverage for swap execution operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/euler-xyz/euler-lite/pull/451)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->