### PR TITLE
fix: preserve Merkl collateral reward eligibility

### DIFF
--- a/composables/useMerkl.ts
+++ b/composables/useMerkl.ts
@@ -275,6 +275,9 @@ export const processBorrowFromCollateralOpportunities = (
       const apr = aprs.get(campaign.campaignId) || campaign.apr || 0
       if (campaign.endTimestamp > now && !apr) continue
 
+      const whitelist = normalizeAddressList(campaign.params?.whitelist)
+      const blacklist = normalizeAddressList(campaign.params?.blacklist)
+
       const pairs: { vault: string, collateral: string }[] = []
 
       const vaults = campaign.params?.vaults
@@ -306,6 +309,8 @@ export const processBorrowFromCollateralOpportunities = (
           endTimestamp: campaign.endTimestamp,
           rewardToken: { symbol: campaign.rewardToken.symbol, icon: campaign.rewardToken.icon },
           sourceUrl: merklOpportunityUrl(opportunity, opType),
+          whitelist,
+          blacklist,
         }
 
         const existing = campaignMap.get(vault)

--- a/tests/composables/useMerkl-processors.test.ts
+++ b/tests/composables/useMerkl-processors.test.ts
@@ -83,6 +83,8 @@ describe('processBorrowFromCollateralOpportunities', () => {
       campaigns: [
         makeCampaign({
           params: {
+            whitelist: ['0x1111111111111111111111111111111111111111'],
+            blacklist: ['0x2222222222222222222222222222222222222222'],
             vaults: [
               {
                 evkAddress: '0x6Fe7Fa90756434645F0b0428fDff78E99Dda0FBc',
@@ -124,6 +126,8 @@ describe('processBorrowFromCollateralOpportunities', () => {
       expect(c.apr).toBe(1.5)
       expect(c.vault).toBe(c.vault.toLowerCase())
       expect(c.collateral).toBe(c.collateral?.toLowerCase())
+      expect(c.whitelist).toEqual(['0x1111111111111111111111111111111111111111'])
+      expect(c.blacklist).toEqual(['0x2222222222222222222222222222222222222222'])
     }
 
     expect(second?.[0].collateral).toBe('0xc1ff5490651b9b8d0400b0146e7fb174b90e315b')


### PR DESCRIPTION
## Summary

Preserve Merkl whitelist/blacklist metadata when expanding EULER_BORROW_FROM_COLLATERAL and EULER_MULTI_BORROW_FROM_COLLATERAL campaigns into per-pair RewardCampaign rows.

The older Merkl processors already copied these fields, but the borrow-from-collateral processor introduced in #434 did not. After #448, connected wallet and spy-mode reward APY filtering depends on the emitted RewardCampaign whitelist / blacklist fields, so restricted borrow-from-collateral campaigns were still credited to ineligible addresses.

## Changes

- Normalize campaign params whitelist / blacklist once per borrow-from-collateral campaign.
- Attach those lists to every emitted borrow-vault/collateral RewardCampaign.
- Add a regression assertion proving the fan-out preserves both lists.

## Test plan

- `npm run test -- tests/composables/useMerkl-processors.test.ts tests/entities/reward-campaign.test.ts`
- `npm run typecheck`
- `npm run lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Campaign eligibility filtering now properly incorporates whitelist and blacklist parameters for Merkl borrowing opportunities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/euler-xyz/euler-lite/pull/453)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->