### PR TITLE
fix: update cyclical utilization warnings

### DIFF
--- a/components/entities/vault/VaultWarningBanner.vue
+++ b/components/entities/vault/VaultWarningBanner.vue
@@ -6,6 +6,13 @@ const { warnings } = defineProps<{
 }>()
 
 const activeWarnings = computed(() => warnings.filter((w): w is VaultWarning => w !== null))
+
+const getWarningVariant = (warning: VaultWarning) => {
+  if (warning.level === 'critical') return 'error'
+  if (warning.tone === 'success') return 'success'
+  if (warning.level === 'info') return 'info'
+  return 'warning'
+}
 </script>
 
 <template>
@@ -18,7 +25,7 @@ const activeWarnings = computed(() => warnings.filter((w): w is VaultWarning => 
       :key="warning.title"
       :title="warning.title"
       :description="warning.message"
-      :variant="warning.level === 'critical' ? 'error' : warning.level === 'info' ? 'info' : 'warning'"
+      :variant="getWarningVariant(warning)"
       size="compact"
     />
   </div>

--- a/components/entities/vault/VaultWarningIcon.vue
+++ b/components/entities/vault/VaultWarningIcon.vue
@@ -25,6 +25,23 @@ const highestLevel = computed<WarningLevel | null>(() => {
 const sections = computed(() =>
   warnings.value.map(w => ({ title: w.title, text: w.message })),
 )
+
+const hasOnlySuccessToneInfo = computed(() =>
+  warnings.value.length > 0 && warnings.value.every(w => w.level === 'info' && w.tone === 'success'),
+)
+
+const iconClass = computed(() => {
+  switch (highestLevel.value) {
+    case 'critical':
+      return '[--ui-footnote-icon-color:var(--error-500)]'
+    case 'info':
+      return hasOnlySuccessToneInfo.value
+        ? '[--ui-footnote-icon-color:var(--success-500)]'
+        : '[--ui-footnote-icon-color:var(--warning-500)]'
+    default:
+      return '[--ui-footnote-icon-color:var(--warning-500)]'
+  }
+})
 </script>
 
 <template>
@@ -33,8 +50,6 @@ const sections = computed(() =>
     :icon="highestLevel === 'info' ? 'info-circle' : 'warning'"
     :sections="sections"
     :tooltip-placement="tooltipPlacement"
-    :class="highestLevel === 'critical'
-      ? '[--ui-footnote-icon-color:var(--error-500)]'
-      : '[--ui-footnote-icon-color:var(--warning-500)]'"
+    :class="iconClass"
   />
 </template>

--- a/composables/useVaultWarnings.ts
+++ b/composables/useVaultWarnings.ts
@@ -88,7 +88,7 @@ const utilisationMessages: Record<WarningContext, Record<'high' | 'critical', { 
 
 const targetUtilisationMessage = {
   title: 'Target utilisation',
-  message: 'This market is designed to run near 100% utilisation. Higher utilisation means higher depositor APY.',
+  message: 'Cyclical Note markets are designed to run near full utilization. Withdrawal liquidity opens up at the end of each cycle, when borrowers are pushed to repay.',
 }
 
 const getUtilisationLevel = (utilisation: number): 'high' | 'critical' | null => {

--- a/composables/useVaultWarnings.ts
+++ b/composables/useVaultWarnings.ts
@@ -18,7 +18,7 @@ import {
 } from '~/utils/vault-hooks'
 
 export type WarningLevel = 'info' | 'high' | 'critical'
-export type WarningContext = 'lend' | 'borrow' | 'repay' | 'withdraw' | 'general'
+export type WarningContext = 'lend' | 'borrow' | 'repay' | 'general'
 
 export interface VaultWarning {
   level: WarningLevel
@@ -64,16 +64,6 @@ const utilisationMessages: Record<WarningContext, Record<'high' | 'critical', { 
       message: 'Utilisation is critically high on this collateral market. Available liquidity is near zero, so repaying with collateral may fail.',
     },
   },
-  withdraw: {
-    high: {
-      title: 'High utilisation',
-      message: 'Utilisation is high on this market. Available liquidity is limited, which may affect your ability to withdraw.',
-    },
-    critical: {
-      title: 'Critical utilisation',
-      message: 'Utilisation is critically high. Nearly all liquidity has been borrowed. Withdrawals may fail until borrowers repay.',
-    },
-  },
   general: {
     high: {
       title: 'High utilisation',
@@ -115,7 +105,7 @@ export const getUtilisationWarning = (
   const level = getUtilisationLevel(utilisation)
   if (!level) return null
 
-  if (context !== 'repay' && context !== 'withdraw' && isCyclicalNoteVault(vault)) {
+  if (context !== 'repay' && isCyclicalNoteVault(vault)) {
     return { level: 'info', tone: 'success', ...targetUtilisationMessage }
   }
 

--- a/composables/useVaultWarnings.ts
+++ b/composables/useVaultWarnings.ts
@@ -1,4 +1,4 @@
-import { getVaultUtilization, getSupplyCapPercentage, getBorrowCapPercentage, isEVKVault, type SecuritizeVault, type Vault } from '~/entities/vault'
+import { getVaultUtilization, getSupplyCapPercentage, getBorrowCapPercentage, isCyclicalNoteVault, isEVKVault, type SecuritizeVault, type Vault } from '~/entities/vault'
 import {
   findBlockingDisabledOp,
   getOpMeta,
@@ -18,12 +18,13 @@ import {
 } from '~/utils/vault-hooks'
 
 export type WarningLevel = 'info' | 'high' | 'critical'
-export type WarningContext = 'lend' | 'borrow' | 'repay' | 'general'
+export type WarningContext = 'lend' | 'borrow' | 'repay' | 'withdraw' | 'general'
 
 export interface VaultWarning {
   level: WarningLevel
   title: string
   message: string
+  tone?: 'success'
 }
 
 const UTILISATION_HIGH = 95
@@ -63,6 +64,16 @@ const utilisationMessages: Record<WarningContext, Record<'high' | 'critical', { 
       message: 'Utilisation is critically high on this collateral market. Available liquidity is near zero, so repaying with collateral may fail.',
     },
   },
+  withdraw: {
+    high: {
+      title: 'High utilisation',
+      message: 'Utilisation is high on this market. Available liquidity is limited, which may affect your ability to withdraw.',
+    },
+    critical: {
+      title: 'Critical utilisation',
+      message: 'Utilisation is critically high. Nearly all liquidity has been borrowed. Withdrawals may fail until borrowers repay.',
+    },
+  },
   general: {
     high: {
       title: 'High utilisation',
@@ -73,6 +84,11 @@ const utilisationMessages: Record<WarningContext, Record<'high' | 'critical', { 
       message: 'Utilisation is critically high. Nearly all available liquidity has been borrowed.',
     },
   },
+}
+
+const targetUtilisationMessage = {
+  title: 'Target utilisation',
+  message: 'This market is designed to run near 100% utilisation. Higher utilisation means higher depositor APY.',
 }
 
 const getUtilisationLevel = (utilisation: number): 'high' | 'critical' | null => {
@@ -98,6 +114,10 @@ export const getUtilisationWarning = (
   const utilisation = getVaultUtilization(vault)
   const level = getUtilisationLevel(utilisation)
   if (!level) return null
+
+  if (context !== 'repay' && context !== 'withdraw' && isCyclicalNoteVault(vault)) {
+    return { level: 'info', tone: 'success', ...targetUtilisationMessage }
+  }
 
   const { title, message } = utilisationMessages[context][level]
   return { level, title, message }

--- a/pages/lend/[vault]/[subAccount]/withdraw.vue
+++ b/pages/lend/[vault]/[subAccount]/withdraw.vue
@@ -71,7 +71,7 @@ const withdrawWarnings = computed(() => {
   if (!vault.value || isSecuritizeVaultType.value) return []
   return [
     getHookDisabledWarning(vault.value as Vault, effectiveWithdrawOp.value),
-    getUtilisationWarning(vault.value as Vault, 'lend'),
+    getUtilisationWarning(vault.value as Vault, 'withdraw'),
   ]
 })
 const assetsBalance = ref(0n)

--- a/pages/lend/[vault]/[subAccount]/withdraw.vue
+++ b/pages/lend/[vault]/[subAccount]/withdraw.vue
@@ -71,7 +71,7 @@ const withdrawWarnings = computed(() => {
   if (!vault.value || isSecuritizeVaultType.value) return []
   return [
     getHookDisabledWarning(vault.value as Vault, effectiveWithdrawOp.value),
-    getUtilisationWarning(vault.value as Vault, 'withdraw'),
+    getUtilisationWarning(vault.value as Vault, 'lend'),
   ]
 })
 const assetsBalance = ref(0n)

--- a/tests/composables/useVaultWarnings.test.ts
+++ b/tests/composables/useVaultWarnings.test.ts
@@ -65,19 +65,6 @@ describe('getUtilisationWarning', () => {
     })
   })
 
-  it('keeps liquidity constraint copy for highly utilised cyclical withdraw flows', () => {
-    const warning = getUtilisationWarning(
-      makeUtilisedVault(100n, 99n, INTEREST_RATE_MODEL_TYPE.FIXED_CYCLICAL_BINARY),
-      'withdraw',
-    )
-
-    expect(warning).toEqual({
-      level: 'critical',
-      title: 'Critical utilisation',
-      message: 'Utilisation is critically high. Nearly all liquidity has been borrowed. Withdrawals may fail until borrowers repay.',
-    })
-  })
-
   it('does not show target utilisation info below the shared utilisation threshold', () => {
     const warning = getUtilisationWarning(
       makeUtilisedVault(100n, 94n, INTEREST_RATE_MODEL_TYPE.FIXED_CYCLICAL_BINARY),

--- a/tests/composables/useVaultWarnings.test.ts
+++ b/tests/composables/useVaultWarnings.test.ts
@@ -47,7 +47,7 @@ describe('getUtilisationWarning', () => {
         level: 'info',
         tone: 'success',
         title: 'Target utilisation',
-        message: 'This market is designed to run near 100% utilisation. Higher utilisation means higher depositor APY.',
+        message: 'Cyclical Note markets are designed to run near full utilization. Withdrawal liquidity opens up at the end of each cycle, when borrowers are pushed to repay.',
       })
     },
   )

--- a/tests/composables/useVaultWarnings.test.ts
+++ b/tests/composables/useVaultWarnings.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import { getCollateralSupplyCapWarning } from '~/composables/useVaultWarnings'
+import { getCollateralSupplyCapWarning, getUtilisationWarning } from '~/composables/useVaultWarnings'
+import { INTEREST_RATE_MODEL_TYPE } from '~/entities/constants'
 import type { SecuritizeVault, Vault } from '~/entities/vault'
 
 const makeVault = (supply: bigint, supplyCap: bigint): Vault =>
@@ -7,6 +8,85 @@ const makeVault = (supply: bigint, supplyCap: bigint): Vault =>
     supply,
     supplyCap,
   }) as Vault
+
+const makeUtilisedVault = (
+  totalAssets: bigint,
+  borrow: bigint,
+  interestRateModelType: number = INTEREST_RATE_MODEL_TYPE.KINK,
+): Vault =>
+  ({
+    totalAssets,
+    borrow,
+    irmInfo: {
+      interestRateModelInfo: {
+        interestRateModelType,
+      },
+    },
+  }) as Vault
+
+describe('getUtilisationWarning', () => {
+  it('returns the standard high utilisation warning for non-cyclical borrow markets', () => {
+    const warning = getUtilisationWarning(makeUtilisedVault(100n, 95n), 'borrow')
+
+    expect(warning).toEqual({
+      level: 'high',
+      title: 'High utilisation',
+      message: 'Utilisation is high on this market. Interest rates are elevated and may be volatile.',
+    })
+  })
+
+  it.each(['borrow', 'lend', 'general'] as const)(
+    'returns target utilisation info for highly utilised cyclical note markets in %s context',
+    (context) => {
+      const warning = getUtilisationWarning(
+        makeUtilisedVault(100n, 99n, INTEREST_RATE_MODEL_TYPE.FIXED_CYCLICAL_BINARY),
+        context,
+      )
+
+      expect(warning).toEqual({
+        level: 'info',
+        tone: 'success',
+        title: 'Target utilisation',
+        message: 'This market is designed to run near 100% utilisation. Higher utilisation means higher depositor APY.',
+      })
+    },
+  )
+
+  it('keeps liquidity constraint copy for highly utilised cyclical repay sources', () => {
+    const warning = getUtilisationWarning(
+      makeUtilisedVault(100n, 99n, INTEREST_RATE_MODEL_TYPE.FIXED_CYCLICAL_BINARY),
+      'repay',
+    )
+
+    expect(warning).toEqual({
+      level: 'critical',
+      title: 'Critical utilisation',
+      message: 'Utilisation is critically high on this collateral market. Available liquidity is near zero, so repaying with collateral may fail.',
+    })
+  })
+
+  it('keeps liquidity constraint copy for highly utilised cyclical withdraw flows', () => {
+    const warning = getUtilisationWarning(
+      makeUtilisedVault(100n, 99n, INTEREST_RATE_MODEL_TYPE.FIXED_CYCLICAL_BINARY),
+      'withdraw',
+    )
+
+    expect(warning).toEqual({
+      level: 'critical',
+      title: 'Critical utilisation',
+      message: 'Utilisation is critically high. Nearly all liquidity has been borrowed. Withdrawals may fail until borrowers repay.',
+    })
+  })
+
+  it('does not show target utilisation info below the shared utilisation threshold', () => {
+    const warning = getUtilisationWarning(
+      makeUtilisedVault(100n, 94n, INTEREST_RATE_MODEL_TYPE.FIXED_CYCLICAL_BINARY),
+      'borrow',
+    )
+
+    expect(warning).toBeNull()
+  })
+})
 
 describe('getCollateralSupplyCapWarning', () => {
   it('returns collateral-specific copy when an EVK collateral supply cap is near its limit', () => {


### PR DESCRIPTION
## Summary
- Replace the high-utilisation warning on cyclical fixed-rate markets with target-utilisation info so expected near-full utilisation is not presented as a risk.
- Preserve liquidity-risk warnings for withdraw and repay flows, where low cash availability can still affect the action.

## Changes
- Add a success tone for target-utilisation warnings and render it through the existing warning banner/icon surfaces.
- Add a withdraw warning context so the lend/depositor view can use target-utilisation copy while withdrawal keeps the liquidity warning.
- Extend utilisation warning tests across cyclical, non-cyclical, repay, withdraw, and below-threshold cases.

## Test plan
- [x] npm run test:run -- tests/composables/useVaultWarnings.test.ts tests/entities/vault/utils.test.ts
- [x] npm run lint
- [x] npm run typecheck
- [x] Smoke-tested non-cyclical high-util lend and spy withdraw flows on localhost:3000


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cyclical-note vaults now display success-toned target utilisation messaging in specific scenarios

* **Improvements**
  * Enhanced warning icon color selection based on utilisation context
  * Optimized toast variant mapping for warnings

* **Tests**
  * Added comprehensive tests for utilisation warning scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/euler-xyz/euler-lite/pull/462?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->