### PR TITLE
feat: support IRMFixedCyclicalBinaryMonthly

### DIFF
--- a/components/entities/vault/overview/VaultOverviewBlockCyclicalIRM.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockCyclicalIRM.vue
@@ -203,14 +203,8 @@ const cyclePositionPercent = computed(() => {
   return Math.min(Math.max(pct, 0), 100)
 })
 
-const fixedFillPercent = computed(() =>
-  Math.min(cyclePositionPercent.value, fixedRatePercent.value),
-)
-
-const repaymentFillPercent = computed(() => {
-  if (isInFixedRate.value) return 0
-  return cyclePositionPercent.value - fixedRatePercent.value
-})
+const progressPercentLabel = computed(() => `${Math.round(cyclePositionPercent.value)}%`)
+const repaymentEndCapPercent = computed(() => 100 - fixedRatePercent.value)
 
 // SPY (27 decimal, per-second) to APY percentage
 const spyToApy = (spy: bigint): number => {
@@ -293,57 +287,29 @@ const formatDuration = (seconds: bigint): string => {
   return pluralize(Math.max(1, roundToUnit(seconds, unit)), unit.label)
 }
 
-const formatProgressTickLabel = (seconds: bigint, unit: DurationUnit): string => {
-  const value = roundToUnit(seconds, unit)
-  return `${unit.label[0].toUpperCase()}${unit.label.slice(1)} ${value}`
-}
-
-// Tick marks at 0%, 50%, 100% of the fixed rate period. The 100% mark sits
-// at the phase boundary on the bar, and the repayment portion continues past.
-const progressTicks = computed(() => {
-  const totalDuration = currentCycle.value?.primaryDurationSec ?? 0n
-  const fixedEnd = fixedRatePercent.value
-  const unit = selectDurationUnit(totalDuration, 2n)
-  return [
-    { label: formatProgressTickLabel(0n, unit), pct: '0%', position: '0%' },
-    { label: formatProgressTickLabel(totalDuration / 2n, unit), pct: '50%', position: `${fixedEnd / 2}%` },
-    { label: formatProgressTickLabel(totalDuration, unit), pct: '100%', position: `${fixedEnd}%` },
-  ]
-})
-
-const phaseLabel = computed(() => {
-  return isInFixedRate.value ? 'Fixed rate period' : 'Repayment window'
-})
-
-const phaseProgressLabel = computed(() => {
+const progressDayLabel = computed(() => {
   const duration = currentPhaseDurationSec.value
-  if (duration <= 0n) return 'second 0 of 0'
-
-  const unit = selectDurationUnit(duration, 2n)
+  if (duration <= 0n) return 'D0 / 0'
   const elapsed = elapsedInPhase.value > duration ? duration : elapsedInPhase.value
-  const elapsedUnits = Math.floor(Number(elapsed) / Number(unit.seconds))
-  const totalUnits = Math.max(1, ceilToUnit(duration, unit))
+  const elapsedDays = Math.floor(Number(elapsed) / Number(DURATION_UNITS[0].seconds))
+  const totalDays = Math.max(1, ceilToUnit(duration, DURATION_UNITS[0]))
 
-  return `${unit.label} ${elapsedUnits} of ${totalUnits}`
+  return `D${elapsedDays} / ${totalDays}`
 })
 </script>
 
 <template>
-  <div
+  <section
     v-if="hasValidIRM && currentCycle"
-    class="bg-surface-secondary rounded-xl flex flex-col gap-16 p-24 shadow-card"
+    class="bg-surface-secondary rounded-xl flex flex-col gap-24 p-24 shadow-card"
   >
-    <!-- Header -->
-    <div class="flex items-center gap-8">
-      <p class="text-h3 text-content-primary">
+    <header class="flex items-center justify-between gap-16">
+      <h2 class="text-h3 text-content-primary">
         Interest rate model
-      </p>
-      <div class="cyclical-chip inline-flex items-center py-4 px-8 rounded-8 text-[13px] font-medium">
-        Cyclical note
-      </div>
-    </div>
+      </h2>
+      <CyclicalNoteBadge />
+    </header>
 
-    <!-- Pre-start notice -->
     <div
       v-if="currentCycle.preStartTimestamp !== null"
       class="text-p3 text-content-secondary"
@@ -351,177 +317,165 @@ const phaseProgressLabel = computed(() => {
       First cycle starts {{ formatCyclicalDate(currentCycle.preStartTimestamp) }}
     </div>
 
-    <!-- Current cycle -->
     <div
       v-if="hasStarted"
-      class="flex flex-col gap-12"
+      class="cyclical-irm-grid"
     >
-      <p class="text-p3 text-content-tertiary font-medium uppercase tracking-wide text-[11px]">
-        Cycle
-      </p>
-      <div class="grid grid-cols-1 sm:grid-cols-3 gap-16">
-        <VaultOverviewLabelValue label="Fixed rate cycle">
-          <span class="text-p3 text-content-primary">
-            {{ formatCyclicalDate(fixedRateStart) }}<br>{{ formatCyclicalDate(fixedRateEnd) }}
-          </span>
-        </VaultOverviewLabelValue>
-        <VaultOverviewLabelValue label="Repayment window">
-          <span class="text-p3 text-content-primary">
-            {{ formatCyclicalDate(repaymentWindowStart) }}<br>{{ formatCyclicalDate(repaymentWindowEnd) }}
-          </span>
-        </VaultOverviewLabelValue>
-        <VaultOverviewLabelValue label="Cycle length">
-          <span class="text-p3 text-content-primary">
-            {{ formatDuration(currentCycle.primaryDurationSec) }} / {{ formatDuration(currentCycle.secondaryDurationSec) }}
-          </span>
-        </VaultOverviewLabelValue>
+      <div>
+        <p class="mb-10 text-p2 text-content-tertiary">
+          Fixed period
+        </p>
+        <dl class="flex flex-col">
+          <div class="cyclical-irm-row">
+            <dt>Start</dt>
+            <dd>{{ formatCyclicalDate(fixedRateStart) }}</dd>
+          </div>
+          <div class="cyclical-irm-row">
+            <dt>End</dt>
+            <dd>{{ formatCyclicalDate(fixedRateEnd) }}</dd>
+          </div>
+          <div class="cyclical-irm-row">
+            <dt>Length</dt>
+            <dd>{{ formatDuration(currentCycle.primaryDurationSec) }}</dd>
+          </div>
+          <div class="cyclical-irm-row">
+            <dt>APY</dt>
+            <dd class="!font-semibold !text-accent-500">
+              {{ formatPercent(fixedBorrowAPY) }}%
+            </dd>
+          </div>
+        </dl>
       </div>
-    </div>
 
-    <!-- Parameters -->
-    <div class="flex flex-col gap-12">
-      <p class="text-p3 text-content-tertiary font-medium uppercase tracking-wide text-[11px]">
-        Parameters
-      </p>
-      <div class="grid grid-cols-1 sm:grid-cols-3 gap-16">
-        <VaultOverviewLabelValue label="Fixed APY">
-          <span class="text-p3 text-content-primary">
-            {{ formatPercent(fixedBorrowAPY) }}%
-          </span>
-        </VaultOverviewLabelValue>
-        <VaultOverviewLabelValue label="Repayment APY">
-          <span class="text-p3 text-content-primary">
-            {{ formatPercent(repaymentBorrowAPY) }}%
-          </span>
-        </VaultOverviewLabelValue>
-      </div>
-    </div>
+      <div
+        class="cyclical-irm-divider"
+        aria-hidden="true"
+      />
 
-    <!-- Progress -->
-    <div
-      v-if="hasStarted"
-      class="flex flex-col gap-12 mt-12"
-    >
-      <p class="text-p3 text-content-tertiary font-medium uppercase tracking-wide text-[11px]">
-        Progress
-      </p>
-      <!-- Legend -->
-      <div class="flex items-center gap-16 text-[12px] text-content-secondary">
-        <span class="flex items-center gap-4">
-          <span class="inline-block w-8 h-8 rounded-full bg-accent-500" />
-          Fixed rate period
-        </span>
-        <span class="flex items-center gap-4">
-          <span class="inline-block w-8 h-8 rounded-full cyclical-repayment-dot" />
+      <div>
+        <p class="mb-10 text-p2 text-content-tertiary">
           Repayment window
-        </span>
+        </p>
+        <dl class="flex flex-col">
+          <div class="cyclical-irm-row">
+            <dt>Start</dt>
+            <dd>{{ formatCyclicalDate(repaymentWindowStart) }}</dd>
+          </div>
+          <div class="cyclical-irm-row">
+            <dt>End</dt>
+            <dd>{{ formatCyclicalDate(repaymentWindowEnd) }}</dd>
+          </div>
+          <div class="cyclical-irm-row">
+            <dt>Length</dt>
+            <dd>{{ formatDuration(currentCycle.secondaryDurationSec) }}</dd>
+          </div>
+          <div class="cyclical-irm-row">
+            <dt>APY</dt>
+            <dd class="!font-semibold !text-warning-500">
+              {{ formatPercent(repaymentBorrowAPY) }}%
+            </dd>
+          </div>
+        </dl>
       </div>
+    </div>
 
-      <!-- Tick labels -->
-      <div class="relative h-16 text-[11px] text-content-tertiary whitespace-nowrap">
-        <span
-          v-for="tick in progressTicks"
-          :key="tick.pct"
-          class="absolute -translate-x-1/2 select-none"
-          :class="{ '!translate-x-0': tick.pct === '0%' }"
-          :style="{ left: tick.position }"
-        >
-          {{ tick.label }} ({{ tick.pct }})
-        </span>
-      </div>
-
-      <!-- Bar -->
-      <div class="cyclical-progress">
-        <div class="cyclical-progress__track">
-          <div
-            class="cyclical-progress__fixed"
-            :style="{ width: `${fixedFillPercent}%` }"
-          />
-          <div
-            v-if="!isInFixedRate"
-            class="cyclical-progress__repayment"
-            :style="{ left: `${fixedRatePercent}%`, width: `${repaymentFillPercent}%` }"
-          />
-          <div
-            class="cyclical-progress__divider"
-            :style="{ left: `${fixedRatePercent}%` }"
-          />
-        </div>
+    <footer
+      v-if="hasStarted"
+      class="flex items-center gap-12"
+    >
+      <span class="min-w-[60px] text-p5 text-content-secondary tabular-nums">{{ progressDayLabel }}</span>
+      <div class="cyclical-irm-progress">
         <div
-          class="cyclical-progress__cursor"
-          :style="{ left: `${cyclePositionPercent}%` }"
+          class="cyclical-irm-progress__fill"
+          :style="{ width: `${cyclePositionPercent}%` }"
+        />
+        <div
+          class="cyclical-irm-progress__repay"
+          :style="{ width: `${repaymentEndCapPercent}%` }"
         />
       </div>
-
-      <!-- Status text -->
-      <div class="text-[12px] text-content-secondary">
-        {{ phaseLabel }} {{ phaseProgressLabel }}
-      </div>
-    </div>
-  </div>
+      <span class="min-w-36 text-right text-p5 text-content-tertiary tabular-nums">{{ progressPercentLabel }}</span>
+    </footer>
+  </section>
 </template>
 
 <style lang="scss" scoped>
-.cyclical-chip {
-  background-color: rgba(var(--accent-rgb), 0.15);
-  color: var(--accent-600);
+.cyclical-irm-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 1px minmax(0, 1fr);
+  gap: 24px;
+}
 
-  [data-theme="dark"] & {
-    background-color: rgba(var(--accent-rgb), 0.2);
-    color: var(--accent-500);
+.cyclical-irm-divider {
+  width: 1px;
+  background: var(--border-subtle);
+}
+
+.cyclical-irm-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 9px 0;
+  border-bottom: 1px dashed var(--border-subtle);
+
+  &:last-child {
+    border-bottom: 0;
+  }
+
+  dt,
+  dd {
+    margin: 0;
+  }
+
+  dt {
+    flex: 0 0 auto;
+    color: var(--text-tertiary);
+    font-size: 14px;
+    line-height: 20px;
+  }
+
+  dd {
+    min-width: 0;
+    color: var(--text-primary);
+    font-size: 14px;
+    line-height: 20px;
+    text-align: right;
+    font-variant-numeric: tabular-nums;
   }
 }
 
-.cyclical-repayment-dot {
-  background-color: var(--warning-500);
-}
-
-.cyclical-repayment-text {
-  color: var(--warning-500);
-}
-
-.cyclical-progress {
+.cyclical-irm-progress {
   position: relative;
-  height: 10px;
+  flex: 1;
+  height: 4px;
+  overflow: hidden;
+  border-radius: 2px;
+  background: var(--ui-progress-background-color);
+}
 
-  &__track {
-    position: relative;
-    height: 100%;
-    border-radius: 100px;
-    background-color: var(--ui-progress-background-color);
-    overflow: hidden;
+.cyclical-irm-progress__fill {
+  position: absolute;
+  inset: 0 auto 0 0;
+  max-width: 100%;
+  background: var(--accent-500);
+}
+
+.cyclical-irm-progress__repay {
+  position: absolute;
+  inset: 0 0 0 auto;
+  background: var(--warning-500);
+}
+
+@media (max-width: 640px) {
+  .cyclical-irm-grid {
+    grid-template-columns: 1fr;
+    gap: 18px;
   }
 
-  &__fixed {
-    height: 100%;
-    background-color: var(--accent-500);
-  }
-
-  &__repayment {
-    position: absolute;
-    top: 0;
-    height: 100%;
-    background-color: var(--warning-500);
-  }
-
-  &__divider {
-    position: absolute;
-    top: 0;
-    width: 2px;
-    height: 100%;
-    background-color: var(--text-primary);
-    opacity: 0.3;
-    transform: translateX(-50%);
-  }
-
-  &__cursor {
-    position: absolute;
-    top: -2px;
-    width: 3px;
-    height: 14px;
-    background-color: var(--text-primary);
-    border-radius: 2px;
-    transform: translateX(-50%);
+  .cyclical-irm-divider {
+    width: 100%;
+    height: 1px;
   }
 }
 </style>

--- a/components/entities/vault/overview/VaultOverviewBlockCyclicalIRM.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockCyclicalIRM.vue
@@ -1,7 +1,12 @@
 <script setup lang="ts">
 import { decodeAbiParameters, formatUnits, zeroAddress, type Hex } from 'viem'
-import { FIXED_CYCLICAL_BINARY_IRM_COMPONENTS, SECONDS_IN_YEAR } from '~/entities/constants'
-import type { Vault, SecuritizeVault, CyclicalNoteInfo } from '~/entities/vault'
+import {
+  FIXED_CYCLICAL_BINARY_IRM_COMPONENTS,
+  FIXED_CYCLICAL_BINARY_MONTHLY_IRM_COMPONENTS,
+  INTEREST_RATE_MODEL_TYPE,
+  SECONDS_IN_YEAR,
+} from '~/entities/constants'
+import type { Vault, SecuritizeVault, CyclicalNoteInfo, CyclicalNoteMonthlyInfo } from '~/entities/vault'
 import { hasCollateralExposure } from '~/entities/vault'
 import { useVaultRegistry } from '~/composables/useVaultRegistry'
 
@@ -21,7 +26,13 @@ const hasValidIRM = computed(() => {
     && vault.interestRateModelAddress !== zeroAddress
 })
 
+const irmType = computed(() => vault.irmInfo?.interestRateModelInfo?.interestRateModelType)
+const isMonthly = computed(() =>
+  irmType.value === INTEREST_RATE_MODEL_TYPE.FIXED_CYCLICAL_BINARY_MONTHLY,
+)
+
 const cyclicalInfo = computed((): CyclicalNoteInfo | null => {
+  if (isMonthly.value) return null
   const params = vault.irmInfo?.interestRateModelInfo?.interestRateModelParams
   if (!params) return null
   try {
@@ -36,33 +47,107 @@ const cyclicalInfo = computed((): CyclicalNoteInfo | null => {
   }
 })
 
+const monthlyInfo = computed((): CyclicalNoteMonthlyInfo | null => {
+  if (!isMonthly.value) return null
+  const params = vault.irmInfo?.interestRateModelInfo?.interestRateModelParams
+  if (!params) return null
+  try {
+    const [decoded] = decodeAbiParameters(
+      [{ type: 'tuple', components: FIXED_CYCLICAL_BINARY_MONTHLY_IRM_COMPONENTS }],
+      params as Hex,
+    )
+    return decoded as CyclicalNoteMonthlyInfo
+  }
+  catch {
+    return null
+  }
+})
+
 const now = useNow({ interval: 1_000 })
 
-const cycleLength = computed(() => {
-  if (!cyclicalInfo.value) return 0n
-  return cyclicalInfo.value.primaryDuration + cyclicalInfo.value.secondaryDuration
+type CurrentCycle = {
+  primaryRate: bigint
+  secondaryRate: bigint
+  startSec: bigint
+  primaryDurationSec: bigint
+  secondaryDurationSec: bigint
+  hasStarted: boolean
+  preStartTimestamp: bigint | null
+}
+
+// Both cyclical IRM variants are normalised into the same shape so the
+// progress/phase/tick logic below is variant-agnostic. The Monthly variant
+// derives the current cycle from calendar dates (UTC), matching the contract.
+const currentCycle = computed((): CurrentCycle | null => {
+  if (isMonthly.value) {
+    const m = monthlyInfo.value
+    if (!m) return null
+    const d = new Date(now.value.getTime())
+    const y = d.getUTCFullYear()
+    const mo = d.getUTCMonth()
+    const day = d.getUTCDate()
+    const startDay = Number(m.cycleStartDay)
+    const cycleStartMs = day >= startDay
+      ? Date.UTC(y, mo, startDay)
+      : Date.UTC(y, mo - 1, startDay)
+    const cycleEndMs = day >= startDay
+      ? Date.UTC(y, mo + 1, startDay)
+      : Date.UTC(y, mo, startDay)
+    const startSec = BigInt(Math.floor(cycleStartMs / 1000))
+    const endSec = BigInt(Math.floor(cycleEndMs / 1000))
+    const secondaryDurationSec = m.secondaryDays * 86_400n
+    const cycleLengthSec = endSec - startSec
+    const primaryDurationSec = cycleLengthSec > secondaryDurationSec
+      ? cycleLengthSec - secondaryDurationSec
+      : 0n
+    return {
+      primaryRate: m.primaryRate,
+      secondaryRate: m.secondaryRate,
+      startSec,
+      primaryDurationSec,
+      secondaryDurationSec,
+      hasStarted: true,
+      preStartTimestamp: null,
+    }
+  }
+  const info = cyclicalInfo.value
+  if (!info) return null
+  const cycleLen = info.primaryDuration + info.secondaryDuration
+  const nowSec = BigInt(Math.floor(now.value.getTime() / 1000))
+  const hasStarted = nowSec >= info.startTimestamp
+  const startSec = hasStarted && cycleLen > 0n
+    ? info.startTimestamp + ((nowSec - info.startTimestamp) / cycleLen) * cycleLen
+    : info.startTimestamp
+  return {
+    primaryRate: info.primaryRate,
+    secondaryRate: info.secondaryRate,
+    startSec,
+    primaryDurationSec: info.primaryDuration,
+    secondaryDurationSec: info.secondaryDuration,
+    hasStarted,
+    preStartTimestamp: hasStarted ? null : info.startTimestamp,
+  }
 })
 
-const hasStarted = computed(() => {
-  const info = cyclicalInfo.value
-  if (!info) return false
-  const nowSec = BigInt(Math.floor(now.value.getTime() / 1000))
-  return nowSec >= info.startTimestamp
+const cycleLength = computed(() => {
+  const c = currentCycle.value
+  if (!c) return 0n
+  return c.primaryDurationSec + c.secondaryDurationSec
 })
+
+const hasStarted = computed(() => currentCycle.value?.hasStarted ?? false)
 
 const currentCycleStart = computed(() => {
-  const info = cyclicalInfo.value
-  if (!info || cycleLength.value === 0n || !hasStarted.value) return 0n
-  const nowSec = BigInt(Math.floor(now.value.getTime() / 1000))
-  const elapsed = nowSec - info.startTimestamp
-  const cycleIndex = elapsed / cycleLength.value
-  return info.startTimestamp + cycleIndex * cycleLength.value
+  const c = currentCycle.value
+  if (!c || !c.hasStarted) return 0n
+  return c.startSec
 })
 
 const fixedRateStart = computed(() => currentCycleStart.value)
 const fixedRateEnd = computed(() => {
-  if (!cyclicalInfo.value) return 0n
-  return currentCycleStart.value + cyclicalInfo.value.primaryDuration
+  const c = currentCycle.value
+  if (!c) return 0n
+  return currentCycleStart.value + c.primaryDurationSec
 })
 const repaymentWindowStart = computed(() => fixedRateEnd.value)
 const repaymentWindowEnd = computed(() => currentCycleStart.value + cycleLength.value)
@@ -74,21 +159,22 @@ const elapsedInCycle = computed(() => {
 })
 
 const isInFixedRate = computed(() => {
-  if (!cyclicalInfo.value) return true
-  return elapsedInCycle.value < cyclicalInfo.value.primaryDuration
+  const c = currentCycle.value
+  if (!c) return true
+  return elapsedInCycle.value < c.primaryDurationSec
 })
 
 const currentPhaseDurationSec = computed(() => {
-  if (!cyclicalInfo.value) return 0n
-  return isInFixedRate.value
-    ? cyclicalInfo.value.primaryDuration
-    : cyclicalInfo.value.secondaryDuration
+  const c = currentCycle.value
+  if (!c) return 0n
+  return isInFixedRate.value ? c.primaryDurationSec : c.secondaryDurationSec
 })
 
 const elapsedInPhase = computed(() => {
-  if (!cyclicalInfo.value) return 0n
+  const c = currentCycle.value
+  if (!c) return 0n
   if (isInFixedRate.value) return elapsedInCycle.value
-  const elapsed = elapsedInCycle.value - cyclicalInfo.value.primaryDuration
+  const elapsed = elapsedInCycle.value - c.primaryDurationSec
   return elapsed < 0n ? 0n : elapsed
 })
 
@@ -96,8 +182,9 @@ const elapsedInPhase = computed(() => {
 // phase boundary, so fixedRatePercent is the position (in % of bar width)
 // of both the boundary and the end-of-fixed-rate tick.
 const fixedRatePercent = computed(() => {
-  if (!cyclicalInfo.value || cycleLength.value === 0n) return 0
-  return (Number(cyclicalInfo.value.primaryDuration) / Number(cycleLength.value)) * 100
+  const c = currentCycle.value
+  if (!c || cycleLength.value === 0n) return 0
+  return (Number(c.primaryDurationSec) / Number(cycleLength.value)) * 100
 })
 
 const cyclePositionPercent = computed(() => {
@@ -122,13 +209,15 @@ const spyToApy = (spy: bigint): number => {
 }
 
 const fixedBorrowAPY = computed(() => {
-  if (!cyclicalInfo.value) return 0
-  return spyToApy(cyclicalInfo.value.primaryRate)
+  const c = currentCycle.value
+  if (!c) return 0
+  return spyToApy(c.primaryRate)
 })
 
 const repaymentBorrowAPY = computed(() => {
-  if (!cyclicalInfo.value) return 0
-  return spyToApy(cyclicalInfo.value.secondaryRate)
+  const c = currentCycle.value
+  if (!c) return 0
+  return spyToApy(c.secondaryRate)
 })
 
 const formatCyclicalDate = (timestamp: bigint): string => {
@@ -202,7 +291,7 @@ const formatProgressTickLabel = (seconds: bigint, unit: DurationUnit): string =>
 // Tick marks at 0%, 50%, 100% of the fixed rate period. The 100% mark sits
 // at the phase boundary on the bar, and the repayment portion continues past.
 const progressTicks = computed(() => {
-  const totalDuration = cyclicalInfo.value?.primaryDuration ?? 0n
+  const totalDuration = currentCycle.value?.primaryDurationSec ?? 0n
   const fixedEnd = fixedRatePercent.value
   const unit = selectDurationUnit(totalDuration, 2n)
   return [
@@ -231,7 +320,7 @@ const phaseProgressLabel = computed(() => {
 
 <template>
   <div
-    v-if="hasValidIRM && cyclicalInfo"
+    v-if="hasValidIRM && currentCycle"
     class="bg-surface-secondary rounded-xl flex flex-col gap-16 p-24 shadow-card"
   >
     <!-- Header -->
@@ -246,10 +335,10 @@ const phaseProgressLabel = computed(() => {
 
     <!-- Pre-start notice -->
     <div
-      v-if="!hasStarted && cyclicalInfo"
+      v-if="currentCycle.preStartTimestamp !== null"
       class="text-p3 text-content-secondary"
     >
-      First cycle starts {{ formatCyclicalDate(cyclicalInfo.startTimestamp) }}
+      First cycle starts {{ formatCyclicalDate(currentCycle.preStartTimestamp) }}
     </div>
 
     <!-- Current cycle -->
@@ -273,7 +362,7 @@ const phaseProgressLabel = computed(() => {
         </VaultOverviewLabelValue>
         <VaultOverviewLabelValue label="Cycle length">
           <span class="text-p3 text-content-primary">
-            {{ formatDuration(cyclicalInfo.primaryDuration) }} / {{ formatDuration(cyclicalInfo.secondaryDuration) }}
+            {{ formatDuration(currentCycle.primaryDurationSec) }} / {{ formatDuration(currentCycle.secondaryDurationSec) }}
           </span>
         </VaultOverviewLabelValue>
       </div>

--- a/components/entities/vault/overview/VaultOverviewBlockCyclicalIRM.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockCyclicalIRM.vue
@@ -75,6 +75,9 @@ type CurrentCycle = {
   preStartTimestamp: bigint | null
 }
 
+const MIN_MONTHLY_CYCLE_START_DAY = 1n
+const MAX_MONTHLY_CYCLE_START_DAY = 31n
+
 // Both cyclical IRM variants are normalised into the same shape so the
 // progress/phase/tick logic below is variant-agnostic. The Monthly variant
 // derives the current cycle from calendar dates (UTC), matching the contract.
@@ -82,6 +85,12 @@ const currentCycle = computed((): CurrentCycle | null => {
   if (isMonthly.value) {
     const m = monthlyInfo.value
     if (!m) return null
+    if (
+      m.cycleStartDay < MIN_MONTHLY_CYCLE_START_DAY
+      || m.cycleStartDay > MAX_MONTHLY_CYCLE_START_DAY
+    ) {
+      return null
+    }
     const d = new Date(now.value.getTime())
     const y = d.getUTCFullYear()
     const mo = d.getUTCMonth()
@@ -93,6 +102,7 @@ const currentCycle = computed((): CurrentCycle | null => {
     const cycleEndMs = day >= startDay
       ? Date.UTC(y, mo + 1, startDay)
       : Date.UTC(y, mo, startDay)
+    if (!Number.isFinite(cycleStartMs) || !Number.isFinite(cycleEndMs)) return null
     const startSec = BigInt(Math.floor(cycleStartMs / 1000))
     const endSec = BigInt(Math.floor(cycleEndMs / 1000))
     const secondaryDurationSec = m.secondaryDays * 86_400n

--- a/components/entities/vault/overview/VaultOverviewBlockCyclicalIRM.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockCyclicalIRM.vue
@@ -78,6 +78,15 @@ type CurrentCycle = {
 const MIN_MONTHLY_CYCLE_START_DAY = 1n
 const MAX_MONTHLY_CYCLE_START_DAY = 31n
 
+const getUTCMonthDayCount = (year: number, month: number): number => {
+  return new Date(Date.UTC(year, month + 1, 0)).getUTCDate()
+}
+
+const getMonthlyCycleBoundaryMs = (year: number, month: number, startDay: number): number => {
+  const effectiveStartDay = Math.min(startDay, getUTCMonthDayCount(year, month))
+  return Date.UTC(year, month, effectiveStartDay)
+}
+
 // Both cyclical IRM variants are normalised into the same shape so the
 // progress/phase/tick logic below is variant-agnostic. The Monthly variant
 // derives the current cycle from calendar dates (UTC), matching the contract.
@@ -94,14 +103,15 @@ const currentCycle = computed((): CurrentCycle | null => {
     const d = new Date(now.value.getTime())
     const y = d.getUTCFullYear()
     const mo = d.getUTCMonth()
-    const day = d.getUTCDate()
     const startDay = Number(m.cycleStartDay)
-    const cycleStartMs = day >= startDay
-      ? Date.UTC(y, mo, startDay)
-      : Date.UTC(y, mo - 1, startDay)
-    const cycleEndMs = day >= startDay
-      ? Date.UTC(y, mo + 1, startDay)
-      : Date.UTC(y, mo, startDay)
+    const currentMonthBoundaryMs = getMonthlyCycleBoundaryMs(y, mo, startDay)
+    const isAfterCurrentMonthBoundary = d.getTime() >= currentMonthBoundaryMs
+    const cycleStartMs = isAfterCurrentMonthBoundary
+      ? currentMonthBoundaryMs
+      : getMonthlyCycleBoundaryMs(y, mo - 1, startDay)
+    const cycleEndMs = isAfterCurrentMonthBoundary
+      ? getMonthlyCycleBoundaryMs(y, mo + 1, startDay)
+      : currentMonthBoundaryMs
     if (!Number.isFinite(cycleStartMs) || !Number.isFinite(cycleEndMs)) return null
     const startSec = BigInt(Math.floor(cycleStartMs / 1000))
     const endSec = BigInt(Math.floor(cycleEndMs / 1000))
@@ -215,27 +225,31 @@ const repaymentBorrowAPY = computed(() => {
   return spyToApy(c.secondaryRate)
 })
 
+const shouldFormatCycleDatesInUTC = computed(() => isMonthly.value)
+
 const formatCyclicalDate = (timestamp: bigint): string => {
   const date = new Date(Number(timestamp) * 1000)
-  const day = date.getDate()
+  const useUTC = shouldFormatCycleDatesInUTC.value
+  const day = useUTC ? date.getUTCDate() : date.getDate()
   const suffix = getDaySuffix(day)
-  const month = date.toLocaleString('en-US', { month: 'short' })
-  const year = date.getFullYear()
-  const hour = date.getHours()
+  const month = date.toLocaleString('en-US', { month: 'short', timeZone: useUTC ? 'UTC' : undefined })
+  const year = useUTC ? date.getUTCFullYear() : date.getFullYear()
+  const hour = useUTC ? date.getUTCHours() : date.getHours()
   const ampm = hour >= 12 ? 'pm' : 'am'
   const hour12 = hour % 12 || 12
-  const min = date.getMinutes()
+  const min = useUTC ? date.getUTCMinutes() : date.getMinutes()
   const timeStr = min === 0 ? `${hour12}${ampm}` : `${hour12}:${String(min).padStart(2, '0')}${ampm}`
   return `${month} ${day}${suffix}, ${year} ${timeStr}`
 }
 
 const formatTimelineDate = (timestamp: bigint): string => {
   const date = new Date(Number(timestamp) * 1000)
-  const month = date.toLocaleString('en-US', { month: 'short' })
-  const day = date.getDate()
-  const year = date.getFullYear()
-  const hours = String(date.getHours()).padStart(2, '0')
-  const minutes = String(date.getMinutes()).padStart(2, '0')
+  const useUTC = shouldFormatCycleDatesInUTC.value
+  const month = date.toLocaleString('en-US', { month: 'short', timeZone: useUTC ? 'UTC' : undefined })
+  const day = useUTC ? date.getUTCDate() : date.getDate()
+  const year = useUTC ? date.getUTCFullYear() : date.getFullYear()
+  const hours = String(useUTC ? date.getUTCHours() : date.getHours()).padStart(2, '0')
+  const minutes = String(useUTC ? date.getUTCMinutes() : date.getMinutes()).padStart(2, '0')
   return `${month} ${day}, ${year} ${hours}:${minutes}`
 }
 

--- a/components/entities/vault/overview/VaultOverviewBlockCyclicalIRM.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockCyclicalIRM.vue
@@ -168,26 +168,6 @@ const elapsedInCycle = computed(() => {
   return elapsed < 0n ? 0n : elapsed
 })
 
-const isInFixedRate = computed(() => {
-  const c = currentCycle.value
-  if (!c) return true
-  return elapsedInCycle.value < c.primaryDurationSec
-})
-
-const currentPhaseDurationSec = computed(() => {
-  const c = currentCycle.value
-  if (!c) return 0n
-  return isInFixedRate.value ? c.primaryDurationSec : c.secondaryDurationSec
-})
-
-const elapsedInPhase = computed(() => {
-  const c = currentCycle.value
-  if (!c) return 0n
-  if (isInFixedRate.value) return elapsedInCycle.value
-  const elapsed = elapsedInCycle.value - c.primaryDurationSec
-  return elapsed < 0n ? 0n : elapsed
-})
-
 // Bar represents the full cycle proportionally. The 100% tick sits at the
 // phase boundary, so fixedRatePercent is the position (in % of bar width)
 // of both the boundary and the end-of-fixed-rate tick.
@@ -203,8 +183,19 @@ const cyclePositionPercent = computed(() => {
   return Math.min(Math.max(pct, 0), 100)
 })
 
-const progressPercentLabel = computed(() => `${Math.round(cyclePositionPercent.value)}%`)
 const repaymentEndCapPercent = computed(() => 100 - fixedRatePercent.value)
+const nowTimestamp = computed(() => BigInt(Math.floor(now.value.getTime() / 1000)))
+const timelineMarkerStyle = computed(() => ({
+  left: `clamp(1px, ${cyclePositionPercent.value}%, calc(100% - 1px))`,
+}))
+const timelineNowStyle = computed(() => ({
+  left: `${cyclePositionPercent.value}%`,
+}))
+const timelineNowAlignment = computed(() => {
+  if (cyclePositionPercent.value < 20) return 'start'
+  if (cyclePositionPercent.value > 80) return 'end'
+  return 'center'
+})
 
 // SPY (27 decimal, per-second) to APY percentage
 const spyToApy = (spy: bigint): number => {
@@ -236,6 +227,16 @@ const formatCyclicalDate = (timestamp: bigint): string => {
   const min = date.getMinutes()
   const timeStr = min === 0 ? `${hour12}${ampm}` : `${hour12}:${String(min).padStart(2, '0')}${ampm}`
   return `${month} ${day}${suffix}, ${year} ${timeStr}`
+}
+
+const formatTimelineDate = (timestamp: bigint): string => {
+  const date = new Date(Number(timestamp) * 1000)
+  const month = date.toLocaleString('en-US', { month: 'short' })
+  const day = date.getDate()
+  const year = date.getFullYear()
+  const hours = String(date.getHours()).padStart(2, '0')
+  const minutes = String(date.getMinutes()).padStart(2, '0')
+  return `${month} ${day}, ${year} ${hours}:${minutes}`
 }
 
 const getDaySuffix = (day: number): string => {
@@ -277,25 +278,11 @@ const roundToUnit = (seconds: bigint, unit: DurationUnit): number => {
   return Math.round(Number(seconds) / Number(unit.seconds))
 }
 
-const ceilToUnit = (seconds: bigint, unit: DurationUnit): number => {
-  return Number((seconds + unit.seconds - 1n) / unit.seconds)
-}
-
 const formatDuration = (seconds: bigint): string => {
   if (seconds <= 0n) return '0 seconds'
   const unit = selectDurationUnit(seconds)
   return pluralize(Math.max(1, roundToUnit(seconds, unit)), unit.label)
 }
-
-const progressDayLabel = computed(() => {
-  const duration = currentPhaseDurationSec.value
-  if (duration <= 0n) return 'D0 / 0'
-  const elapsed = elapsedInPhase.value > duration ? duration : elapsedInPhase.value
-  const elapsedDays = Math.floor(Number(elapsed) / Number(DURATION_UNITS[0].seconds))
-  const totalDays = Math.max(1, ceilToUnit(duration, DURATION_UNITS[0]))
-
-  return `D${elapsedDays} / ${totalDays}`
-})
 </script>
 
 <template>
@@ -381,9 +368,8 @@ const progressDayLabel = computed(() => {
 
     <footer
       v-if="hasStarted"
-      class="flex items-center gap-12"
+      class="cyclical-irm-timeline"
     >
-      <span class="min-w-[60px] text-p5 text-content-secondary tabular-nums">{{ progressDayLabel }}</span>
       <div class="cyclical-irm-progress">
         <div
           class="cyclical-irm-progress__fill"
@@ -393,8 +379,28 @@ const progressDayLabel = computed(() => {
           class="cyclical-irm-progress__repay"
           :style="{ width: `${repaymentEndCapPercent}%` }"
         />
+        <div
+          class="cyclical-irm-progress__marker"
+          :style="timelineMarkerStyle"
+        />
       </div>
-      <span class="min-w-36 text-right text-p5 text-content-tertiary tabular-nums">{{ progressPercentLabel }}</span>
+      <div class="cyclical-irm-timeline__now-row">
+        <span
+          class="cyclical-irm-timeline__now"
+          :class="`cyclical-irm-timeline__now--${timelineNowAlignment}`"
+          :style="timelineNowStyle"
+        >
+          Now: {{ formatTimelineDate(nowTimestamp) }}
+        </span>
+      </div>
+      <div class="cyclical-irm-timeline__bounds">
+        <span class="cyclical-irm-timeline__bound">
+          {{ formatTimelineDate(fixedRateStart) }}
+        </span>
+        <span class="cyclical-irm-timeline__bound cyclical-irm-timeline__bound--end">
+          {{ formatTimelineDate(repaymentWindowEnd) }}
+        </span>
+      </div>
     </footer>
   </section>
 </template>
@@ -445,11 +451,16 @@ const progressDayLabel = computed(() => {
   }
 }
 
+.cyclical-irm-timeline {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding-top: 4px;
+}
+
 .cyclical-irm-progress {
   position: relative;
-  flex: 1;
   height: 4px;
-  overflow: hidden;
   border-radius: 2px;
   background: var(--ui-progress-background-color);
 }
@@ -467,6 +478,69 @@ const progressDayLabel = computed(() => {
   background: var(--warning-500);
 }
 
+.cyclical-irm-progress__marker {
+  position: absolute;
+  top: -5px;
+  width: 2px;
+  height: 14px;
+  border-radius: 2px;
+  background: var(--text-primary);
+  transform: translateX(-50%);
+}
+
+.cyclical-irm-timeline__now-row {
+  position: relative;
+  min-height: 16px;
+  font-size: 12px;
+  line-height: 16px;
+  font-variant-numeric: tabular-nums;
+}
+
+.cyclical-irm-timeline__now {
+  position: absolute;
+  top: 0;
+  max-width: 100%;
+  overflow: hidden;
+  color: var(--text-secondary);
+  font-weight: 500;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cyclical-irm-timeline__now--start {
+  transform: translateX(0);
+}
+
+.cyclical-irm-timeline__now--center {
+  transform: translateX(-50%);
+}
+
+.cyclical-irm-timeline__now--end {
+  transform: translateX(-100%);
+}
+
+.cyclical-irm-timeline__bounds {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  margin-top: -3px;
+  color: var(--text-tertiary);
+  font-size: 12px;
+  line-height: 16px;
+  font-variant-numeric: tabular-nums;
+}
+
+.cyclical-irm-timeline__bound {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cyclical-irm-timeline__bound--end {
+  text-align: right;
+}
+
 @media (max-width: 640px) {
   .cyclical-irm-grid {
     grid-template-columns: 1fr;
@@ -476,6 +550,11 @@ const progressDayLabel = computed(() => {
   .cyclical-irm-divider {
     width: 100%;
     height: 1px;
+  }
+
+  .cyclical-irm-timeline__bounds {
+    flex-direction: column;
+    gap: 2px;
   }
 }
 </style>

--- a/components/entities/vault/overview/VaultOverviewBlockCyclicalIRM.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockCyclicalIRM.vue
@@ -339,7 +339,7 @@ const progressDayLabel = computed(() => {
             <dd>{{ formatDuration(currentCycle.primaryDurationSec) }}</dd>
           </div>
           <div class="cyclical-irm-row">
-            <dt>APY</dt>
+            <dt>Borrow APY</dt>
             <dd class="!font-semibold !text-accent-500">
               {{ formatPercent(fixedBorrowAPY) }}%
             </dd>
@@ -370,7 +370,7 @@ const progressDayLabel = computed(() => {
             <dd>{{ formatDuration(currentCycle.secondaryDurationSec) }}</dd>
           </div>
           <div class="cyclical-irm-row">
-            <dt>APY</dt>
+            <dt>Borrow APY</dt>
             <dd class="!font-semibold !text-warning-500">
               {{ formatPercent(repaymentBorrowAPY) }}%
             </dd>

--- a/components/entities/vault/overview/VaultOverviewBlockIRM.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockIRM.vue
@@ -16,6 +16,7 @@ import {
 import annotationPlugin from 'chartjs-plugin-annotation'
 import { formatUnits, zeroAddress, decodeAbiParameters, type Address, type Abi, type Hex } from 'viem'
 import { logWarn } from '~/utils/errorHandling'
+import { useModal } from '~/components/ui/composables/useModal'
 import {
   INTEREST_RATE_MODEL_TYPE,
   KINK_IRM_COMPONENTS,
@@ -34,6 +35,7 @@ import {
 } from '~/entities/vault'
 import { useVaultRegistry } from '~/composables/useVaultRegistry'
 import { eulerUtilsLensABI, eulerVaultLensABI } from '~/entities/euler/abis'
+import { UiFootnoteModal } from '#components'
 
 // Register Chart.js components
 ChartJS.register(
@@ -61,6 +63,7 @@ const { getChartColors, isDark } = useThemeColors()
 const { client: rpcClient } = useRpcClient()
 const { eulerLensAddresses } = useEulerAddresses()
 const { get: registryGet } = useVaultRegistry()
+const modal = useModal()
 
 // Only render the IRM chart for vaults that have live borrow-side exposure —
 // either currently borrowable, or still accruing interest on existing debt
@@ -216,6 +219,19 @@ const irmTooltip = computed<{ title: string, text: string } | null>(() => {
   }
   return null
 })
+
+const openIRMInfoModal = (event: MouseEvent | KeyboardEvent) => {
+  event.preventDefault()
+  event.stopPropagation()
+  const tooltip = irmTooltip.value
+  if (!tooltip) return
+  modal.open(UiFootnoteModal, {
+    props: {
+      modalTitle: tooltip.title,
+      text: tooltip.text,
+    },
+  })
+}
 
 // Generate cash and borrows data points for chart (0-100% utilization).
 // When `kinkFraction` is provided (in 0..1), injects an extra sample at the
@@ -635,22 +651,30 @@ watch(isDark, async () => {
     v-if="hasValidIRM"
     class="bg-surface-secondary rounded-xl flex flex-col gap-16 p-24 shadow-card"
   >
-    <div class="flex justify-between items-center flex-wrap gap-12">
-      <div class="flex items-center gap-8">
-        <p class="text-h3 text-content-primary">
-          Interest rate model
-        </p>
-        <div class="irm-type-chip inline-flex items-center py-2 px-8 rounded-8 text-[13px] font-medium">
-          {{ irmTypeLabel }}
-        </div>
+    <header class="flex items-center justify-between gap-16">
+      <h2 class="text-h3 text-content-primary">
+        Interest rate model
+      </h2>
+      <div
+        v-if="irmTooltip"
+        class="flex shrink-0 items-center gap-8"
+      >
+        <VaultMetadataTag
+          as="button"
+          icon="pulse"
+          :label="irmTypeLabel"
+          tone="accent"
+          title="Interest rate model details"
+          @click="openIRMInfoModal"
+        />
         <UiFootnote
-          v-if="irmTooltip"
           :title="irmTooltip.title"
           :text="irmTooltip.text"
+          tooltip-placement="top-end"
           class="[--ui-footnote-icon-color:var(--text-muted)] hover:[--ui-footnote-icon-color:var(--text-secondary)]"
         />
       </div>
-    </div>
+    </header>
 
     <div class="relative w-full min-h-400">
       <div
@@ -689,15 +713,3 @@ watch(isDark, async () => {
     </div>
   </div>
 </template>
-
-<style scoped lang="scss">
-.irm-type-chip {
-  background-color: rgba(var(--accent-rgb), 0.15);
-  color: var(--accent-600);
-
-  [data-theme="dark"] & {
-    background-color: rgba(var(--accent-rgb), 0.2);
-    color: var(--accent-500);
-  }
-}
-</style>

--- a/components/entities/vault/overview/VaultOverviewBlockIRM.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockIRM.vue
@@ -81,6 +81,7 @@ const hasValidIRM = computed(() => {
 })
 
 const MAX_UINT32 = 4_294_967_295
+const WAD_TO_SPY_SCALE = 10n ** 9n
 
 // Key borrow APY values derived from the chart data (populated in renderChart)
 const chartRateAtZero = ref<number | null>(null)
@@ -280,12 +281,15 @@ const parseAPY = (apy: bigint): number => {
   return Number(formatUnits(apy, 27)) * 100
 }
 
-// Convert a wad-scaled per-second rate into a properly-compounded APY % by
-// round-tripping through UtilsLens.computeAPYs — same math the vault itself
-// uses, so Min/Max rate cells match on-chain accrual for large rates instead
-// of silently collapsing to APR.
+// Convert a WAD-scaled per-second adaptive rate into a properly-compounded
+// APY % by round-tripping through UtilsLens.computeAPYs. The lens expects the
+// 27-decimal borrowSPY scale returned by vault IRM queries, while adaptive IRM
+// params are decoded as 18-decimal WADs.
 const fetchAdaptiveBorrowAPY = async (wadPerSec: bigint): Promise<number | null> => {
   const utilsLens = eulerLensAddresses.value?.utilsLens
+  if (wadPerSec < 0n) {
+    return null
+  }
   if (!utilsLens || wadPerSec === 0n) {
     return wadPerSec === 0n ? 0 : null
   }
@@ -296,7 +300,7 @@ const fetchAdaptiveBorrowAPY = async (wadPerSec: bigint): Promise<number | null>
       abi: eulerUtilsLensABI as Abi,
       functionName: 'computeAPYs',
       // cash/borrows don't influence borrowAPY; interestFee only affects supplyAPY.
-      args: [wadPerSec, 1n, 0n, 0n],
+      args: [wadPerSec * WAD_TO_SPY_SCALE, 1n, 0n, 0n],
     }) as readonly [bigint, bigint]
     const [borrowAPY] = result
     return Number(formatUnits(borrowAPY, 27)) * 100

--- a/entities/constants.ts
+++ b/entities/constants.ts
@@ -93,6 +93,7 @@ export const INTEREST_RATE_MODEL_TYPE = {
   ADAPTIVE_CURVE: 2,
   KINKY: 3,
   FIXED_CYCLICAL_BINARY: 4,
+  FIXED_CYCLICAL_BINARY_MONTHLY: 5,
 } as const
 
 // EVK Vault.configFlags is a bitmask. CFG_DONT_SOCIALIZE_DEBT is the only
@@ -130,6 +131,13 @@ export const FIXED_CYCLICAL_BINARY_IRM_COMPONENTS = [
   { name: 'primaryDuration', type: 'uint256' },
   { name: 'secondaryDuration', type: 'uint256' },
   { name: 'startTimestamp', type: 'uint256' },
+] as const
+
+export const FIXED_CYCLICAL_BINARY_MONTHLY_IRM_COMPONENTS = [
+  { name: 'primaryRate', type: 'uint256' },
+  { name: 'secondaryRate', type: 'uint256' },
+  { name: 'cycleStartDay', type: 'uint256' },
+  { name: 'secondaryDays', type: 'uint256' },
 ] as const
 
 export const ORACLE_DETAILED_INFO_COMPONENTS = [

--- a/entities/vault/index.ts
+++ b/entities/vault/index.ts
@@ -10,6 +10,7 @@ export type {
   AdaptiveCurveIRMParams,
   KinkyIRMParams,
   CyclicalNoteInfo,
+  CyclicalNoteMonthlyInfo,
   Erc4626Vault,
   SecuritizeVault,
   Vault,

--- a/entities/vault/types.ts
+++ b/entities/vault/types.ts
@@ -52,6 +52,12 @@ export interface CyclicalNoteInfo {
   secondaryDuration: bigint
   startTimestamp: bigint
 }
+export interface CyclicalNoteMonthlyInfo {
+  primaryRate: bigint
+  secondaryRate: bigint
+  cycleStartDay: bigint
+  secondaryDays: bigint
+}
 export interface VaultIRMInfo {
   interestRateModelInfo?: {
     interestRateModelType?: number

--- a/entities/vault/utils.ts
+++ b/entities/vault/utils.ts
@@ -13,7 +13,9 @@ export const isCyclicalNoteVault = (
 ): boolean => {
   if (!vault || !('irmInfo' in vault)) return false
   const type = vault.irmInfo?.interestRateModelInfo?.interestRateModelType
-  return typeof type === 'number' && type === INTEREST_RATE_MODEL_TYPE.FIXED_CYCLICAL_BINARY
+  return typeof type === 'number'
+    && (type === INTEREST_RATE_MODEL_TYPE.FIXED_CYCLICAL_BINARY
+      || type === INTEREST_RATE_MODEL_TYPE.FIXED_CYCLICAL_BINARY_MONTHLY)
 }
 
 export const getBorrowVaultsByMap = (vaultsMap: Map<string, Vault>) => {

--- a/tests/entities/vault/utils.test.ts
+++ b/tests/entities/vault/utils.test.ts
@@ -181,6 +181,18 @@ describe('isCyclicalNoteVault', () => {
     expect(isCyclicalNoteVault(vault)).toBe(true)
   })
 
+  it('returns true for EVK vaults using the monthly cyclical IRM', () => {
+    const vault = {
+      irmInfo: {
+        interestRateModelInfo: {
+          interestRateModelType: INTEREST_RATE_MODEL_TYPE.FIXED_CYCLICAL_BINARY_MONTHLY,
+        },
+      },
+    } as Vault
+
+    expect(isCyclicalNoteVault(vault)).toBe(true)
+  })
+
   it('returns false for non-cyclical EVK vaults', () => {
     const vault = {
       irmInfo: {

--- a/utils/discoveryCalculations.ts
+++ b/utils/discoveryCalculations.ts
@@ -749,6 +749,7 @@ const getIrmTypeLabel = (t: number | undefined): string => {
   if (t === INTEREST_RATE_MODEL_TYPE.ADAPTIVE_CURVE) return 'Adaptive'
   if (t === INTEREST_RATE_MODEL_TYPE.KINKY) return 'Kinky'
   if (t === INTEREST_RATE_MODEL_TYPE.FIXED_CYCLICAL_BINARY) return 'Cyclical note'
+  if (t === INTEREST_RATE_MODEL_TYPE.FIXED_CYCLICAL_BINARY_MONTHLY) return 'Cyclical note'
   return '—'
 }
 


### PR DESCRIPTION
## Summary
- Recognise `IRMFixedCyclicalBinaryMonthly` (lens enum `5`) as a cyclical-note IRM alongside the existing `IRMFixedCyclicalBinary` (enum `4`).
- Decode its 4-field param schema `(primaryRate, secondaryRate, cycleStartDay, secondaryDays)` and derive the current cycle window from UTC calendar dates, matching the contract's `daysUntilNextCycleStart` rule.
- Reuse the existing cyclical badge, info modal, target-utilisation warning suppression, and discovery label by extending `isCyclicalNoteVault()` — no new components, no UI duplication.

## Implementation notes
The variant difference is contained inside `VaultOverviewBlockCyclicalIRM.vue`: both shapes are normalised into a single `currentCycle` object (`primaryRate`, `secondaryRate`, `startSec`, `primaryDurationSec`, `secondaryDurationSec`, `hasStarted`, `preStartTimestamp`) consumed by the existing progress / phase / tick / APY computeds. Template, helpers, and SCSS are unchanged.

For the Monthly variant:
- `currentCycleStart` = `cycleStartDay` of the current month (or previous month if today's UTC day < `cycleStartDay`).
- `currentCycleEnd` = `cycleStartDay` of the next month.
- `secondaryDurationSec` = `secondaryDays * 86_400`; `primaryDurationSec` = remainder of the calendar cycle.
- `hasStarted` is always `true` (no pre-start state) and `preStartTimestamp` is `null`, so the legacy "First cycle starts …" notice is suppressed.

## Test plan
- [x] `npm run typecheck` (and `npx vue-tsc --noEmit`) pass.
- [x] `npm run test:run` — 796/796 pass, including new `isCyclicalNoteVault` case for enum `5`.
- [ ] Manual: open a vault using `IRMFixedCyclicalBinaryMonthly` (or mock `interestRateModelType: 5` with abi-encoded params) and verify:
  - [ ] Cyclical badge renders in `VaultItem`, `VaultBorrowItem`, `VaultTypeBadges`.
  - [ ] `CyclicalNoteInfoModal` opens on click.
  - [ ] Overview block shows the current cycle's calendar date range, fixed/repayment APYs, and a progress bar whose secondary segment is `secondaryDays / cycleLengthDays` of the bar.
  - [ ] High-utilisation warnings are suppressed outside the repay context (target-utilisation info message shown instead).
- [ ] Smoke-check an existing weekly `IRMFixedCyclicalBinary` vault — appearance must be identical to current production.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UI supports a monthly variant of cyclical interest-rate models: detects monthly cycles, normalizes cycle data, shows correct cycle start dates/lengths, unified cycle-driven timeline/progress (including a moving "Now" marker) and displays accurate fixed/repayment APYs.  
  * IRM details now open from a metadata tag as a modal; cycle details and pre-start notice use updated timeline/date formatting and a simplified Fixed period / Repayment window layout.

* **Tests**
  * Added test to ensure monthly cyclical models are detected and handled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/euler-xyz/euler-lite/pull/465?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->