### PR TITLE
fix: hide vertical kink line for kinky IRM chart

### DIFF
--- a/components/entities/vault/overview/VaultOverviewBlockIRM.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockIRM.vue
@@ -457,7 +457,10 @@ const renderChart = async () => {
       },
     }
 
-    if (kinkUtilization !== null && kinkIndex !== null) {
+    // Kinky still injects a sample at the kink so the curve bends sharply there,
+    // but the "kink" utilization isn't a regime boundary the user cares about —
+    // rates curve smoothly past it — so we suppress the vertical annotation.
+    if (kinkUtilization !== null && kinkIndex !== null && decoded?.type === 'kink') {
       const labelsAreClose = Math.abs(currentUtilization - kinkUtilization) < 20
       const currentIsLower = currentUtilization <= kinkUtilization
       const yOffset = labelsAreClose ? 24 : 0


### PR DESCRIPTION
## Summary
- Kinky IRMs curve smoothly through the kink utilization rather than treating it as a regime boundary, so the dashed vertical "Kink" annotation was misleading.
- Gates the kink line annotation to `decoded.type === 'kink'`. The kink sample is still injected into the sweep so the curve bends correctly and the "Rate at kink" readout below the chart still works.

## Test plan
- [ ] Open a vault with a Kinky IRM — verify no vertical kink line/label on the chart, "Rate at kink" still populates.
- [ ] Open a vault with a regular Kink IRM — verify the vertical kink line and "Kink (X%)" label still render.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed vault overview chart to display the kink annotation only for the appropriate interest rate model type, improving accuracy of chart visualization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/euler-xyz/euler-lite/pull/466?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->