### PR TITLE
fix: gate wallet session on address screening

### DIFF
--- a/components/entities/portfolio/PortfolioBorrowItem.vue
+++ b/components/entities/portfolio/PortfolioBorrowItem.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { useAccount } from '@wagmi/vue'
 import { getAddress, type Address, type Abi } from 'viem'
 import { logWarn } from '~/utils/errorHandling'
 import { formatNumber, formatCompactUsdValue, formatExactAmount } from '~/utils/string-utils'
@@ -31,7 +30,7 @@ import { VaultNetApyModal, PortfolioRoeModal } from '#components'
 
 const { position } = defineProps<{ position: AccountBorrowPosition }>()
 
-const { address } = useAccount()
+const { address } = useWagmi()
 const { portfolioAddress } = useEulerAccount()
 const ownerAddress = computed(() => portfolioAddress.value || address.value || '')
 const subAccountIndex = computed(() => {

--- a/components/entities/portfolio/PortfolioEarnItem.vue
+++ b/components/entities/portfolio/PortfolioEarnItem.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { useAccount } from '@wagmi/vue'
 import { getAssetUsdValue, formatAssetValue } from '~/services/pricing/priceProvider'
 import { isVaultBlockedByCountry } from '~/composables/useGeoBlock'
 import { isVaultDeprecated, getVaultNotice } from '~/utils/eulerLabelsUtils'
@@ -13,7 +12,7 @@ import { nanoToValue, roundAndCompactTokens } from '~/utils/crypto-utils'
 const { position } = defineProps<{ position: AccountDepositPosition }>()
 const modal = useModal()
 
-const { address } = useAccount()
+const { address } = useWagmi()
 const { portfolioAddress } = useEulerAccount()
 const ownerAddress = computed(() => portfolioAddress.value || address.value || '')
 const subAccountIndex = computed(() => {

--- a/components/entities/portfolio/PortfolioSavingItem.vue
+++ b/components/entities/portfolio/PortfolioSavingItem.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { useAccount } from '@wagmi/vue'
 import type { Vault } from '~/entities/vault'
 import { getUtilisationWarning } from '~/composables/useVaultWarnings'
 import { getAssetUsdValue, formatAssetValue } from '~/services/pricing/priceProvider'
@@ -14,7 +13,7 @@ import { useModal } from '~/components/ui/composables/useModal'
 const { position } = defineProps<{ position: AccountDepositPosition }>()
 const modal = useModal()
 
-const { address } = useAccount()
+const { address } = useWagmi()
 const { portfolioAddress } = useEulerAccount()
 const ownerAddress = computed(() => portfolioAddress.value || address.value || '')
 const subAccountIndex = computed(() => {

--- a/components/entities/vault/ChooseCollateralModal.vue
+++ b/components/entities/vault/ChooseCollateralModal.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { useAccount } from '@wagmi/vue'
 import { getSubAccountIndex } from '~/entities/account'
 import { getVaultProductName } from '~/utils/eulerLabelsUtils'
 import type { CollateralOption } from '~/entities/vault'
@@ -17,7 +16,7 @@ const { productName, symbol, collateralOptions, selected = 0, title = 'Select co
 }>()
 
 const { isEscrowVault } = useVaultRegistry()
-const { address } = useAccount()
+const { address } = useWagmi()
 const { portfolioAddress } = useEulerAccount()
 
 const searchQuery = ref('')

--- a/components/entities/vault/SecuritizeVaultItem.vue
+++ b/components/entities/vault/SecuritizeVaultItem.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { useAccount } from '@wagmi/vue'
 import type { Vault, SecuritizeVault } from '~/entities/vault'
 import { formatAssetValue } from '~/services/pricing/priceProvider'
 import { isVaultBlockedByCountry } from '~/composables/useGeoBlock'
@@ -10,7 +9,7 @@ import { nanoToValue } from '~/utils/crypto-utils'
 import { VaultSupplyApyModal } from '#components'
 import BaseLoadableContent from '~/components/base/BaseLoadableContent.vue'
 
-const { isConnected } = useAccount()
+const { isConnected } = useWagmi()
 const { vault } = defineProps<{ vault: SecuritizeVault }>()
 
 const vaultAddress = computed(() => vault.address)

--- a/components/entities/vault/VaultEarnItem.vue
+++ b/components/entities/vault/VaultEarnItem.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { useAccount } from '@wagmi/vue'
 import type { EarnVault } from '~/entities/vault'
 import { formatAssetValue } from '~/services/pricing/priceProvider'
 import { useEulerProductOfVault, useEulerEntitiesOfEarnVault } from '~/composables/useEulerLabels'
@@ -11,7 +10,7 @@ import { nanoToValue } from '~/utils/crypto-utils'
 import BaseLoadableContent from '~/components/base/BaseLoadableContent.vue'
 import { VaultSupplyApyModal } from '#components'
 
-const { isConnected } = useAccount()
+const { isConnected } = useWagmi()
 const { vault } = defineProps<{ vault: EarnVault }>()
 const product = useEulerProductOfVault(vault.address)
 const { enableEntityBranding } = useDeployConfig()

--- a/components/entities/vault/VaultItem.vue
+++ b/components/entities/vault/VaultItem.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { useAccount } from '@wagmi/vue'
 import { getAddress } from 'viem'
 import { getVaultUtilization, getCurrentLiquidationLTV, isCyclicalNoteVault, type Vault } from '~/entities/vault'
 import { getUtilisationWarning, getSupplyCapWarning } from '~/composables/useVaultWarnings'
@@ -14,7 +13,7 @@ import BaseLoadableContent from '~/components/base/BaseLoadableContent.vue'
 import { useVaultRegistry } from '~/composables/useVaultRegistry'
 import { VaultSupplyApyModal, VaultCollateralExposureModal } from '#components'
 
-const { isConnected } = useAccount()
+const { isConnected } = useWagmi()
 const { vault } = defineProps<{ vault: Vault }>()
 const vaultAddress = computed(() => vault.address)
 const product = useEulerProductOfVault(vaultAddress)

--- a/components/entities/vault/form/VaultFormSubmit.vue
+++ b/components/entities/vault/form/VaultFormSubmit.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { inject } from 'vue'
-import { useAccount } from '@wagmi/vue'
 import { flip, offset, shift, useFloating } from '@floating-ui/vue'
 
 import { isOperationBlocked, operationBlockReason } from '~/utils/operationGuardRegistry'
@@ -22,7 +21,7 @@ interface KeyringGuardState {
 }
 
 const props = defineProps<{ disabled?: boolean, loading?: boolean, disabledReason?: string, disabledReasonVariant?: DisabledReasonVariant }>()
-const { isConnected } = useAccount()
+const { isConnected } = useWagmi()
 const { isSpyMode } = useSpyMode()
 const { chainId: _chainId } = useEulerAddresses()
 const { chainId, switchChain, connect } = useWagmi()

--- a/components/entities/wallet/WalletDisconnectModal.vue
+++ b/components/entities/wallet/WalletDisconnectModal.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
-import { useAccount, useDisconnect } from '@wagmi/vue'
+import { useDisconnect } from '@wagmi/vue'
 import { getExplorerLink } from '~/utils/block-explorer'
 
 const emits = defineEmits(['close'])
 
-const { address } = useAccount()
+const { address } = useWagmi()
 const { disconnect } = useDisconnect()
 const { chainId } = useEulerAddresses()
 const { isSpyMode, spyAddress, clearSpyMode } = useSpyMode()

--- a/components/layout/TheHeader.vue
+++ b/components/layout/TheHeader.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { onClickOutside } from '@vueuse/core'
 import { offset, useFloating } from '@floating-ui/vue'
-import { useAccount } from '@wagmi/vue'
 import {
   WalletDisconnectModal,
   SelectChainModal,
@@ -15,7 +14,7 @@ import { getChainLogoUrl } from '~/utils/chain-logo'
 const { connect } = useWagmi()
 
 // Wagmi account info
-const { address, isConnected } = useAccount()
+const { address, isConnected } = useWagmi()
 const { chainId, allowedChainIds } = useEulerAddresses()
 const chainLogoSrc = computed(() => getChainLogoUrl(chainId.value))
 const { isSpyMode, spyShortAddress } = useSpyMode()

--- a/composables/borrow/useBorrowForm.ts
+++ b/composables/borrow/useBorrowForm.ts
@@ -1,5 +1,4 @@
 import type { Ref, ComputedRef } from 'vue'
-import { useAccount } from '@wagmi/vue'
 import { getAddress, formatUnits, zeroAddress, type Address } from 'viem'
 import { isNativeCurrencyAddress, isNativeOfWrapped, resolveWrappedNativeAddress, resolveWrappedNativeAsset } from '~/utils/native-currency'
 import { logWarn } from '~/utils/errorHandling'
@@ -88,7 +87,7 @@ export const useBorrowForm = (options: UseBorrowFormOptions) => {
   const modal = useModal()
   const { error } = useToast()
   const { buildBorrowPlan, buildBorrowBySavingPlan, buildSwapAndBorrowPlan, executeTxPlan } = useEulerOperations()
-  const { address, isConnected } = useAccount()
+  const { address, isConnected } = useWagmi()
   const { chainId } = useEulerAddresses()
   const { fetchSingleBalance } = useWallets()
   const { finalizeTxAndRedirect } = useTxFinalization()

--- a/composables/borrow/useMultiplyCowSwap.ts
+++ b/composables/borrow/useMultiplyCowSwap.ts
@@ -1,5 +1,4 @@
 import type { Ref, ComputedRef } from 'vue'
-import { useAccount } from '@wagmi/vue'
 import { erc20Abi, formatUnits, type Address } from 'viem'
 import { logWarn } from '~/utils/errorHandling'
 import type { DisplayStep } from '~/utils/stepDecoding'
@@ -49,7 +48,7 @@ interface UseMultiplyCowSwapOptions {
 }
 
 export const useMultiplyCowSwap = (options: UseMultiplyCowSwapOptions) => {
-  const { address } = useAccount()
+  const { address } = useWagmi()
   const router = useRouter()
   const modal = useModal()
   const { error } = useToast()

--- a/composables/borrow/useMultiplyForm.ts
+++ b/composables/borrow/useMultiplyForm.ts
@@ -1,5 +1,4 @@
 import type { Ref, ComputedRef } from 'vue'
-import { useAccount } from '@wagmi/vue'
 import { formatUnits, maxUint256, zeroAddress, type Address } from 'viem'
 import { logWarn } from '~/utils/errorHandling'
 import { createRaceGuard } from '~/utils/race-guard'
@@ -93,7 +92,7 @@ export const useMultiplyForm = (options: UseMultiplyFormOptions) => {
   const modal = useModal()
   const { error } = useToast()
   const { buildMultiplyPlan, executeTxPlan } = useEulerOperations()
-  const { isConnected, address } = useAccount()
+  const { isConnected, address } = useWagmi()
   const { depositPositions, refreshAllPositions } = useEulerAccount()
   const { eulerLensAddresses, chainId } = useEulerAddresses()
   const { fetchSingleBalance } = useWallets()

--- a/composables/position/useCollateralForm.ts
+++ b/composables/position/useCollateralForm.ts
@@ -1,5 +1,4 @@
 import type { ComputedRef } from 'vue'
-import { useAccount } from '@wagmi/vue'
 import { formatUnits, type Address, type Abi, zeroAddress } from 'viem'
 import { logWarn } from '~/utils/errorHandling'
 import { createRaceGuard } from '~/utils/race-guard'
@@ -114,7 +113,7 @@ export const useCollateralForm = (options: UseCollateralFormOptions) => {
   const { error } = useToast()
   const submitLabel = options.reviewLabel
   const { executeTxPlan } = useEulerOperations()
-  const { isConnected, address } = useAccount()
+  const { isConnected, address } = useWagmi()
   const { isSpyMode } = useSpyMode()
   const { finalizeTxAndRedirect } = useTxFinalization()
   const positionIndex = usePositionIndex()

--- a/composables/repay/useCollateralSwapRepay.ts
+++ b/composables/repay/useCollateralSwapRepay.ts
@@ -1,5 +1,4 @@
 import type { Ref, ComputedRef } from 'vue'
-import { useAccount } from '@wagmi/vue'
 import { formatUnits, zeroAddress, type Address, type Abi } from 'viem'
 import { logWarn } from '~/utils/errorHandling'
 import type { DisplayStep } from '~/utils/stepDecoding'
@@ -64,7 +63,7 @@ export const useCollateralSwapRepay = (options: UseCollateralSwapRepayOptions) =
   const router = useRouter()
   const modal = useModal()
   const { error } = useToast()
-  const { isConnected, address } = useAccount()
+  const { isConnected, address } = useWagmi()
   const { buildSwapPlan, buildSameAssetRepayPlan, buildSameAssetFullRepayPlan, buildSwapFullRepayPlan, executeTxPlan } = useEulerOperations()
   const { eulerLensAddresses, isReady: isEulerAddressesReady, loadEulerConfig } = useEulerAddresses()
   const { finalizeTxAndRedirect } = useTxFinalization()

--- a/composables/repay/useRepaySwapCore.ts
+++ b/composables/repay/useRepaySwapCore.ts
@@ -1,5 +1,4 @@
 import type { Ref, ComputedRef } from 'vue'
-import { useAccount } from '@wagmi/vue'
 import { formatUnits, zeroAddress, type Address } from 'viem'
 import { previewWithdraw, type Vault, type SecuritizeVault } from '~/entities/vault'
 import { getAssetUsdValue } from '~/services/pricing/priceProvider'
@@ -52,7 +51,7 @@ export const useRepaySwapCore = (options: UseRepaySwapCoreOptions) => {
     getQuoteAccounts,
     onQuoteReceived,
   } = options
-  const { address } = useAccount()
+  const { address } = useWagmi()
   const { chainId } = useEulerAddresses()
 
   // --- State ---

--- a/composables/repay/useSavingsRepay.ts
+++ b/composables/repay/useSavingsRepay.ts
@@ -1,5 +1,4 @@
 import type { Ref, ComputedRef } from 'vue'
-import { useAccount } from '@wagmi/vue'
 import { zeroAddress, type Address } from 'viem'
 import { logWarn } from '~/utils/errorHandling'
 import { useModal } from '~/components/ui/composables/useModal'
@@ -61,7 +60,7 @@ export const useSavingsRepay = (options: UseSavingsRepayOptions) => {
 
   const modal = useModal()
   const { error } = useToast()
-  const { isConnected, address } = useAccount()
+  const { isConnected, address } = useWagmi()
   const { buildSwapPlan, buildSavingsRepayPlan, buildSavingsFullRepayPlan, buildSwapFullRepayPlan, executeTxPlan } = useEulerOperations()
   const { getVault: registryGetVault } = useVaultRegistry()
   const { finalizeTxAndRedirect } = useTxFinalization()

--- a/composables/repay/useWalletRepay.ts
+++ b/composables/repay/useWalletRepay.ts
@@ -1,5 +1,4 @@
 import type { Ref, ComputedRef } from 'vue'
-import { useAccount } from '@wagmi/vue'
 import { formatUnits } from 'viem'
 import { FixedPoint } from '~/utils/fixed-point'
 import { logWarn } from '~/utils/errorHandling'
@@ -61,7 +60,7 @@ export const useWalletRepay = (options: UseWalletRepayOptions) => {
   const modal = useModal()
   const { error } = useToast()
   const { buildRepayPlan, buildFullRepayPlan, executeTxPlan } = useEulerOperations()
-  const { isConnected } = useAccount()
+  const { isConnected } = useWagmi()
   const { finalizeTxAndRedirect } = useTxFinalization()
 
   const amount = ref('')

--- a/composables/repay/useWalletSwapRepay.ts
+++ b/composables/repay/useWalletSwapRepay.ts
@@ -1,5 +1,4 @@
 import type { Ref, ComputedRef } from 'vue'
-import { useAccount } from '@wagmi/vue'
 import { formatUnits, getAddress, zeroAddress, type Address } from 'viem'
 import { isNativeCurrencyAddress, resolveWrappedNativeAddress, resolveWrappedNativeAsset } from '~/utils/native-currency'
 import { FixedPoint } from '~/utils/fixed-point'
@@ -68,7 +67,7 @@ export const useWalletSwapRepay = (options: UseWalletSwapRepayOptions) => {
   const { error } = useToast()
   const { buildSwapAndRepayPlan, executeTxPlan } = useEulerOperations()
   const { chainId } = useEulerAddresses()
-  const { isConnected, address } = useAccount()
+  const { isConnected, address } = useWagmi()
   const { fetchSingleBalance } = useWallets()
   const { finalizeTxAndRedirect } = useTxFinalization()
   const { getVault: registryGetVault } = useVaultRegistry()

--- a/composables/useAddressScreen.ts
+++ b/composables/useAddressScreen.ts
@@ -6,6 +6,13 @@ import { resetCountryCache } from '~/services/country'
 import { screenAddress } from '~/services/trm'
 import { getDefaultPageRoute } from '~/entities/menu'
 
+const blockedAddress = ref<string | null>(null)
+const isScreening = ref(false)
+const screenedAddress = ref<string | null>(null)
+let screeningGeneration = 0
+
+const normalizeAddress = (address?: string | null) => address?.toLowerCase() ?? ''
+
 export const useAddressScreen = () => {
   const modal = useModal()
   const { disconnect } = useDisconnect()
@@ -13,9 +20,6 @@ export const useAddressScreen = () => {
 
   const { enableEarnPage, enableLendPage, enableExplorePage } = useDeployConfig()
   const defaultPageRoute = getDefaultPageRoute(enableEarnPage, enableLendPage, enableExplorePage)
-  const blockedAddress = ref<string | null>(null)
-  const isScreening = ref(false)
-  let screeningGeneration = 0
 
   const showBlockedModal = (address: string) => {
     blockedAddress.value = address
@@ -37,6 +41,7 @@ export const useAddressScreen = () => {
     }
 
     const gen = ++screeningGeneration
+    screenedAddress.value = null
     isScreening.value = true
     try {
       const vpnIsUsed = await detectVpn()
@@ -50,6 +55,7 @@ export const useAddressScreen = () => {
         showBlockedModal(address)
         return true
       }
+      screenedAddress.value = address
       return false
     }
     finally {
@@ -59,7 +65,13 @@ export const useAddressScreen = () => {
     }
   }
 
+  const isAddressScreened = (address?: string | null) =>
+    Boolean(address && normalizeAddress(screenedAddress.value) === normalizeAddress(address))
+
   const resetScreeningCache = () => {
+    screeningGeneration++
+    screenedAddress.value = null
+    isScreening.value = false
     resetVpnCache()
     resetCountryCache()
   }
@@ -67,6 +79,8 @@ export const useAddressScreen = () => {
   return {
     isScreening,
     blockedAddress,
+    screenedAddress,
+    isAddressScreened,
     screenConnectedAddress,
     resetScreeningCache,
   }

--- a/composables/useAddressScreen.ts
+++ b/composables/useAddressScreen.ts
@@ -52,6 +52,7 @@ export const useAddressScreen = () => {
 
       if (isRestricted) {
         await disconnect()
+        if (gen !== screeningGeneration) return false
         showBlockedModal(address)
         return true
       }

--- a/composables/useBrevis.ts
+++ b/composables/useBrevis.ts
@@ -1,4 +1,4 @@
-import { useAccount, useSwitchChain, useWriteContract } from '@wagmi/vue'
+import { useSwitchChain, useWriteContract } from '@wagmi/vue'
 import type { Address } from 'viem'
 import axios from 'axios'
 
@@ -100,7 +100,7 @@ const getBrevisCampaignsForVault = (vaultAddress: string): RewardCampaign[] => {
 }
 
 export const useBrevis = () => {
-  const { isConnected, address: wagmiAddress, chain: wagmiChain } = useAccount()
+  const { isConnected, address: wagmiAddress, chain: wagmiChain } = useWagmi()
   const { switchChain } = useSwitchChain()
   const { writeContractAsync } = useWriteContract()
   const { BREVIS_API_URL, BREVIS_MERKLE_PROOF_URL } = useEulerConfig()

--- a/composables/useEulerAccount.ts
+++ b/composables/useEulerAccount.ts
@@ -1,7 +1,6 @@
 import { getAddress } from 'viem'
 import { watch, computed } from 'vue'
 import { useDebounceFn } from '@vueuse/core'
-import { useAccount } from '@wagmi/vue'
 import { useAccountPositions } from './useAccountPositions'
 import { useAccountValues } from './useAccountValues'
 import { useAccountPortfolioMetrics } from './useAccountPortfolioMetrics'
@@ -45,7 +44,7 @@ const {
 export const useEulerAccount = () => {
   const { isLoaded: isBalancesLoaded } = useWallets()
   const { eulerLensAddresses, isReady: isEulerLensAddressesReady, chainId } = useEulerAddresses()
-  const { address } = useAccount()
+  const { address } = useWagmi()
   const { spyAddress } = useSpyMode()
   const portfolioAddress = computed(() => normalizeAddressOrEmpty(spyAddress.value) || normalizeAddressOrEmpty(address.value))
 

--- a/composables/useFuul.ts
+++ b/composables/useFuul.ts
@@ -1,4 +1,4 @@
-import { useAccount, useSwitchChain, useWriteContract } from '@wagmi/vue'
+import { useSwitchChain, useWriteContract } from '@wagmi/vue'
 import type { Address } from 'viem'
 import axios from 'axios'
 
@@ -51,7 +51,7 @@ const fetchFuulProxy = (chainId: number): Promise<FuulProxyResponse> =>
     $fetch<FuulProxyResponse>('/api/rewards/fuul', { query: { chainId } }))
 
 export const useFuul = () => {
-  const { address: wagmiAddress, chain: wagmiChain } = useAccount()
+  const { address: wagmiAddress, chain: wagmiChain } = useWagmi()
   const { switchChain } = useSwitchChain()
   const { writeContractAsync } = useWriteContract()
   const { FUUL_API_BASE_URL, FUUL_MANAGER_ADDRESS, FUUL_FACTORY_ADDRESS } = useEulerConfig()

--- a/composables/useKeyring/index.ts
+++ b/composables/useKeyring/index.ts
@@ -1,5 +1,5 @@
 import { type Ref, ref, watch, onUnmounted } from 'vue'
-import { useAccount, useChainId } from '@wagmi/vue'
+import { useChainId } from '@wagmi/vue'
 import { zeroAddress, type Address } from 'viem'
 import {
   KeyringConnect,
@@ -44,7 +44,7 @@ const readHookTargetField = async <T>(
 
 export const useKeyring = (vaultAddress: string | Ref<string>) => {
   const addressRef = typeof vaultAddress === 'string' ? ref(vaultAddress) : vaultAddress
-  const { address: userAddress } = useAccount()
+  const { address: userAddress } = useWagmi()
   const chainId = useChainId()
   const { getVault } = useVaultRegistry()
   const { rpcUrl } = useRpcClient()

--- a/composables/useMerkl.ts
+++ b/composables/useMerkl.ts
@@ -1,4 +1,4 @@
-import { useAccount, useSwitchChain, useWriteContract } from '@wagmi/vue'
+import { useSwitchChain, useWriteContract } from '@wagmi/vue'
 import type { Address } from 'viem'
 import axios from 'axios'
 
@@ -434,7 +434,7 @@ const getMerklCampaignsForVault = (vaultAddress: string): RewardCampaign[] => {
 }
 
 export const useMerkl = () => {
-  const { isConnected, address: wagmiAddress, chain: wagmiChain } = useAccount()
+  const { isConnected, address: wagmiAddress, chain: wagmiChain } = useWagmi()
   const { switchChain } = useSwitchChain()
   const { MERKL_ADDRESS } = useEulerConfig()
   const { client: rpcClient } = useRpcClient()

--- a/composables/useOperationGuard.ts
+++ b/composables/useOperationGuard.ts
@@ -1,5 +1,5 @@
 import { computed, isRef, watch, onUnmounted, provide, reactive, type Ref } from 'vue'
-import { useAccount, useChainId } from '@wagmi/vue'
+import { useChainId } from '@wagmi/vue'
 import type { Address } from 'viem'
 import { useKeyring, KeyringFlowState } from '~/composables/useKeyring'
 import { useTosGuard } from '~/composables/guards/useTosGuard'
@@ -9,7 +9,7 @@ import { injectKeyringCredential } from '~/utils/keyring-injection'
 import { isVaultKeyring } from '~/utils/eulerLabelsUtils'
 
 export const useOperationGuard = (vaultAddresses: Ref<(string | undefined)[]> | (string | undefined)[]) => {
-  const { address: userAddress } = useAccount()
+  const { address: userAddress } = useWagmi()
   const chainId = useChainId()
 
   const addresses = computed((): string[] => {

--- a/composables/useREULLocks.ts
+++ b/composables/useREULLocks.ts
@@ -1,4 +1,4 @@
-import { useAccount, useWriteContract } from '@wagmi/vue'
+import { useWriteContract } from '@wagmi/vue'
 import type { Address, Abi } from 'viem'
 import { reulLockAbi, reulWithdrawABI } from '~/abis/reul'
 import type { REULLock } from '~/entities/reul'
@@ -13,7 +13,7 @@ const locks: Ref<REULLock[]> = ref([])
 let interval: NodeJS.Timeout | null = null
 
 export const useREULLocks = () => {
-  const { isConnected, address: wagmiAddress, chainId } = useAccount()
+  const { isConnected, address: wagmiAddress, chainId } = useWagmi()
   const { writeContractAsync } = useWriteContract()
   const { eulerTokenAddresses } = useEulerAddresses()
   const { client: rpcClient } = useRpcClient()

--- a/composables/useRewardsApy.ts
+++ b/composables/useRewardsApy.ts
@@ -1,4 +1,3 @@
-import { useAccount } from '@wagmi/vue'
 import { isCampaignEligibleForAddress, type RewardCampaign } from '~/entities/reward-campaign'
 
 export const useRewardsApy = () => {
@@ -7,7 +6,7 @@ export const useRewardsApy = () => {
   const { merklCampaigns, getMerklCampaignsForVault } = useMerkl()
   const { brevisCampaigns, getBrevisCampaignsForVault } = useBrevis()
   const { fuulCampaigns, getFuulCampaignsForVault } = useFuul()
-  const { address: connectedAddress } = useAccount()
+  const { address: connectedAddress } = useWagmi()
   const { spyAddress } = useSpyMode()
 
   const isEnabled = computed(() => settings.value.enableRewardsApy)

--- a/composables/useShowAllHint.ts
+++ b/composables/useShowAllHint.ts
@@ -1,4 +1,3 @@
-import { useAccount } from '@wagmi/vue'
 import { SHOW_ALL_HINT_DISMISSED_KEY } from '~/entities/constants'
 
 const dismissed = useLocalStorage<boolean>(SHOW_ALL_HINT_DISMISSED_KEY, false)
@@ -14,7 +13,7 @@ export const useShowAllHint = () => {
   } = useEulerAccount()
 
   const { isSpyMode } = useSpyMode()
-  const { isConnected } = useAccount()
+  const { isConnected } = useWagmi()
 
   const hasHiddenPositions = computed(() =>
     hiddenBorrowCount.value > 0 || hiddenDepositCount.value > 0,

--- a/composables/useSwapPageLogic.ts
+++ b/composables/useSwapPageLogic.ts
@@ -1,5 +1,4 @@
 import { getAddress, formatUnits } from 'viem'
-import { useAccount } from '@wagmi/vue'
 import { logWarn } from '~/utils/errorHandling'
 import { OperationReviewModal, SlippageSettingsModal } from '#components'
 import { usePriceImpactGate } from '~/composables/usePriceImpactGate'
@@ -95,7 +94,7 @@ export const useSwapPageLogic = (options: UseSwapPageLogicOptions) => {
 
   const router = useRouter()
   const route = useRoute()
-  const { isConnected } = useAccount()
+  const { isConnected } = useWagmi()
   const { executeTxPlan } = useEulerOperations()
   const modal = useModal()
   const { error: showError } = useToast()

--- a/composables/useWagmi.ts
+++ b/composables/useWagmi.ts
@@ -27,13 +27,16 @@ function initializeWagmi() {
   const { screenConnectedAddress, resetScreeningCache, isAddressScreened } = useAddressScreen()
 
   const chainId = computed(() => wagmiChain.value?.id)
+  const screenedWagmiAddress: ComputedRef<Address | undefined> = computed(() =>
+    isAddressScreened(wagmiAddress.value) ? (wagmiAddress.value || undefined) : undefined,
+  )
 
   const { data: ensName } = useEnsName({
-    address: wagmiAddress,
+    address: screenedWagmiAddress,
     chainId: chainId.value,
   })
   const { data: balanceData, isLoading: isLoadingBalance, refetch: refetchBalance } = useBalance({
-    address: wagmiAddress,
+    address: screenedWagmiAddress,
   })
 
   // AppKit may be deferred-initialized (see plugins/00.wagmi.ts). Route

--- a/composables/useWagmi.ts
+++ b/composables/useWagmi.ts
@@ -24,7 +24,7 @@ function initializeWagmi() {
   const { disconnect: wagmiDisconnect } = useDisconnect()
   const { switchChain } = useSwitchChain()
   const config = useConfig()
-  const { screenConnectedAddress, resetScreeningCache } = useAddressScreen()
+  const { screenConnectedAddress, resetScreeningCache, isAddressScreened } = useAddressScreen()
 
   const chainId = computed(() => wagmiChain.value?.id)
 
@@ -65,7 +65,7 @@ function initializeWagmi() {
 
   watch(wagmiAddress, (address, oldAddress) => {
     if (address && address !== oldAddress) {
-      screenConnectedAddress(address)
+      void screenConnectedAddress(address).catch(err => logWarn('useWagmi/screenConnectedAddress', err))
     }
     if (!address && oldAddress) {
       resetScreeningCache()
@@ -86,6 +86,7 @@ function initializeWagmi() {
     refetchBalance,
     modal,
     connectBaseAppInjectedWallet,
+    isAddressScreened,
   }
 }
 
@@ -111,9 +112,12 @@ export const useWagmi = () => {
     refetchBalance,
     modal,
     connectBaseAppInjectedWallet,
+    isAddressScreened,
   } = cachedWagmiData
-  const address: ComputedRef<Address | undefined> = computed(() => wagmiAddress.value || undefined)
-  const isConnected = computed(() => Boolean(wagmiIsConnected.value))
+  const address: ComputedRef<Address | undefined> = computed(() =>
+    isAddressScreened(wagmiAddress.value) ? (wagmiAddress.value || undefined) : undefined,
+  )
+  const isConnected = computed(() => Boolean(wagmiIsConnected.value && isAddressScreened(wagmiAddress.value)))
   const chain = computed(() => wagmiChain.value)
   const chainId = computed(() => wagmiChain.value?.id)
 

--- a/entities/tuning-constants.ts
+++ b/entities/tuning-constants.ts
@@ -18,6 +18,9 @@ export const BATCH_DELAY_COLLECT_MS = 100
 /** Subgraph query timeout (client-side). Longer than server-side subgraph
  * calls because client traffic tolerates higher variance. */
 export const SUBGRAPH_TIMEOUT_MS = 30_000
+/** Wallet screening must resolve promptly so the app can fail closed instead
+ * of leaving a connected wallet in an indeterminate state. */
+export const WALLET_SCREENING_TIMEOUT_MS = 10_000
 
 // ── Debounce ──────────────────────────────────────────────
 /** Price-fetch watchEffects on list pages. Collapses bursts of registry

--- a/pages/borrow/[collateral]/[borrow]/index.vue
+++ b/pages/borrow/[collateral]/[borrow]/index.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { useAccount } from '@wagmi/vue'
 import { getAddress } from 'viem'
 import { useModal } from '~/components/ui/composables/useModal'
 import { VaultUnverifiedDisclaimerModal, SlippageSettingsModal } from '#components'
@@ -22,7 +21,7 @@ const modal = useModal()
 const reviewBorrowLabel = 'Review Borrow'
 const reviewMultiplyLabel = 'Review Multiply'
 const { getBorrowVaultPair, updateVault } = useVaults()
-const { address, isConnected } = useAccount()
+const { address, isConnected } = useWagmi()
 const { chainId } = useEulerAddresses()
 const shareLinkQuery = computed(() => {
   const network = route.query.network

--- a/pages/earn/[vault]/[subAccount]/withdraw.vue
+++ b/pages/earn/[vault]/[subAccount]/withdraw.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { useAccount } from '@wagmi/vue'
 import { FixedPoint } from '~/utils/fixed-point'
 import { useModal } from '~/components/ui/composables/useModal'
 import { OperationReviewModal } from '#components'
@@ -24,7 +23,7 @@ const modal = useModal()
 const { error } = useToast()
 const { buildWithdrawPlan, buildRedeemPlan, executeTxPlan } = useEulerOperations()
 const { getEarnVault } = useVaults()
-const { isConnected, address } = useAccount()
+const { isConnected, address } = useWagmi()
 const { isSpyMode, spyAddress } = useSpyMode()
 const effectiveAddress = computed(() => isSpyMode.value ? spyAddress.value : address.value)
 const { fetchVaultShareBalance } = useWallets()

--- a/pages/earn/[vault]/index.vue
+++ b/pages/earn/[vault]/index.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { useAccount } from '@wagmi/vue'
 import { useModal } from '~/components/ui/composables/useModal'
 import { OperationReviewModal, VaultSupplyApyModal, VaultUnverifiedDisclaimerModal } from '#components'
 import { useToast } from '~/components/ui/composables/useToast'
@@ -28,7 +27,7 @@ const shareLinkQuery = computed(() => {
   }
 })
 const { isReady: isLabelsReady } = useEulerLabels()
-const { isConnected, address } = useAccount()
+const { isConnected, address } = useWagmi()
 const { fetchSingleBalance } = useWallets()
 const { runSimulation, simulationError, clearSimulationError } = useTxPlanSimulation()
 const vaultAddress = route.params.vault as string

--- a/pages/lend/[vault]/[subAccount]/swap.vue
+++ b/pages/lend/[vault]/[subAccount]/swap.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { useAccount } from '@wagmi/vue'
 import { isAddress, getAddress, zeroAddress, type Address } from 'viem'
 import { getCashLimitedWithdrawAmount, type Vault, type SecuritizeVault, fetchSecuritizeVault } from '~/entities/vault'
 import { isSecuritizeVault } from '~/entities/vault/factory'
@@ -17,7 +16,7 @@ import type { DisabledReasonInfo } from '~/components/entities/vault/form/types'
 
 const route = useRoute()
 const { getVault } = useVaults()
-const { address } = useAccount()
+const { address } = useWagmi()
 const { isSpyMode, spyAddress } = useSpyMode()
 const effectiveAddress = computed(() => isSpyMode.value ? spyAddress.value : address.value)
 const { depositPositions } = useEulerAccount()

--- a/pages/lend/[vault]/[subAccount]/withdraw.vue
+++ b/pages/lend/[vault]/[subAccount]/withdraw.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { useAccount } from '@wagmi/vue'
 import { getAddress, formatUnits, type Address, zeroAddress } from 'viem'
 import { FixedPoint } from '~/utils/fixed-point'
 import { useModal } from '~/components/ui/composables/useModal'
@@ -39,7 +38,7 @@ const { error } = useToast()
 useFullBalances()
 const { buildWithdrawPlan, buildRedeemPlan, buildWithdrawAndSwapPlan, buildRedeemAndSwapPlan, executeTxPlan } = useEulerOperations()
 const { getVault, getSecuritizeVault: _getSecuritizeVault, getEscrowVault: _getEscrowVault } = useVaults()
-const { isConnected, address } = useAccount()
+const { isConnected, address } = useWagmi()
 const { isSpyMode, spyAddress } = useSpyMode()
 const effectiveAddress = computed(() => isSpyMode.value ? spyAddress.value : address.value)
 const { fetchVaultShareBalance } = useWallets()

--- a/pages/lend/[vault]/index.vue
+++ b/pages/lend/[vault]/index.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { useAccount } from '@wagmi/vue'
 import { getAddress, formatUnits, type Address, zeroAddress } from 'viem'
 import { isNativeCurrencyAddress, isNativeOfWrapped, resolveWrappedNativeAddress, resolveWrappedNativeAsset } from '~/utils/native-currency'
 import { useModal } from '~/components/ui/composables/useModal'
@@ -70,7 +69,7 @@ const { buildSupplyPlan, buildSwapAndSupplyPlan, executeTxPlan } = useEulerOpera
 const { getVault, getSecuritizeVault, getEscrowVault, updateVault, isEscrowLoadedOnce } = useVaults()
 const { isReady: isLabelsReady } = useEulerLabels()
 const { get: registryGet, getVault: _registryGetVault, isKnownEscrowAddress } = useVaultRegistry()
-const { isConnected, address } = useAccount()
+const { isConnected, address } = useWagmi()
 const { chainId } = useEulerAddresses()
 const shareLinkQuery = computed(() => {
   const network = route.query.network

--- a/pages/onboarding.vue
+++ b/pages/onboarding.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
-import { useAccount } from '@wagmi/vue'
 import { getDefaultPageRoute } from '~/entities/menu'
 
-const { isConnected } = useAccount()
+const { isConnected } = useWagmi()
 
 const { connect } = useWagmi()
 const {

--- a/pages/portfolio.vue
+++ b/pages/portfolio.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { useAccount } from '@wagmi/vue'
 import { formatNumber, formatCompactUsdValue } from '~/utils/string-utils'
 import { POLL_INTERVAL_60S_MS } from '~/entities/tuning-constants'
 
@@ -22,7 +21,7 @@ const {
 } = useEulerAccount()
 const { rewards } = useMerkl()
 const { locks } = useREULLocks()
-const { isConnected, address } = useAccount()
+const { isConnected, address } = useWagmi()
 const { isLoaded: isBalancesLoaded, updateBalances } = useWallets()
 const { eulerLensAddresses } = useEulerAddresses()
 const { portfolioRefreshCounter } = usePortfolioRefresh()

--- a/pages/portfolio/index.vue
+++ b/pages/portfolio/index.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
-import { useAccount } from '@wagmi/vue'
 import { getSubAccountIndex } from '~/entities/account'
 
-const { isConnected, address } = useAccount()
+const { isConnected, address } = useWagmi()
 const { isSpyMode } = useSpyMode()
 const { borrowPositions, isPositionsLoaded, portfolioAddress } = useEulerAccount()
 const { isReady } = useVaults()

--- a/pages/portfolio/rewards.vue
+++ b/pages/portfolio/rewards.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
-import { useAccount } from '@wagmi/vue'
 import { nanoToValue } from '~/utils/crypto-utils'
 
-const { isConnected } = useAccount()
+const { isConnected } = useWagmi()
 const { isSpyMode } = useSpyMode()
 const { enableMerkl, enableIncentra, enableFuul } = useDeployConfig()
 const { rewards, isRewardsLoading } = useMerkl()

--- a/pages/portfolio/saving.vue
+++ b/pages/portfolio/saving.vue
@@ -1,9 +1,8 @@
 <script setup lang="ts">
-import { useAccount } from '@wagmi/vue'
 import type { AccountDepositPosition } from '~/entities/account'
 import { getAssetUsdValueOrZero } from '~/services/pricing/priceProvider'
 
-const { isConnected } = useAccount()
+const { isConnected } = useWagmi()
 const { depositPositions, isDepositsLoaded } = useEulerAccount()
 const { isReady } = useVaults()
 const { isEarnVault } = useVaultRegistry()

--- a/pages/position/[number]/borrow/index.vue
+++ b/pages/position/[number]/borrow/index.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { useAccount } from '@wagmi/vue'
 import { FixedPoint } from '~/utils/fixed-point'
 import { useModal } from '~/components/ui/composables/useModal'
 import { OperationReviewModal } from '#components'
@@ -26,7 +25,7 @@ const modal = useModal()
 const { error } = useToast()
 const { buildBorrowPlan, executeTxPlan } = useEulerOperations()
 const { getBorrowVaultPair } = useVaults()
-const { isConnected, address } = useAccount()
+const { isConnected, address } = useWagmi()
 const { isSpyMode } = useSpyMode()
 const { isPositionsLoading, isPositionsLoaded, getPositionBySubAccountIndex } = useEulerAccount()
 const positionIndex = usePositionIndex()

--- a/pages/position/[number]/borrow/swap.vue
+++ b/pages/position/[number]/borrow/swap.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { useAccount } from '@wagmi/vue'
 import { formatUnits, zeroAddress, type Address } from 'viem'
 import type { AccountBorrowPosition } from '~/entities/account'
 import type { Vault, VaultAsset } from '~/entities/vault'
@@ -15,7 +14,7 @@ import { useSwapPageLogic } from '~/composables/useSwapPageLogic'
 import type { DisabledReasonInfo } from '~/components/entities/vault/form/types'
 
 const route = useRoute()
-const { isConnected, address } = useAccount()
+const { isConnected, address } = useWagmi()
 const { isSpyMode } = useSpyMode()
 const { isPositionsLoaded, isPositionsLoading, getPositionBySubAccountIndex } = useEulerAccount()
 const { buildSwapPlan, buildSameAssetDebtSwapPlan } = useEulerOperations()

--- a/pages/position/[number]/collateral/swap.vue
+++ b/pages/position/[number]/collateral/swap.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { useAccount } from '@wagmi/vue'
 import { erc20Abi, formatUnits, getAddress, maxUint256, zeroAddress, type Address, type Abi } from 'viem'
 import type { AccountBorrowPosition } from '~/entities/account'
 import { eulerAccountLensABI } from '~/entities/euler/abis'
@@ -28,7 +27,7 @@ import { COWSWAP_ORDER_DEADLINE_SECONDS, COWSWAP_PROVIDER_EXTRA_DATA, buildColla
 import { useCowSwapCollateralSwapExecution, useCowSwapOrderStatus, openCowSwapReviewModal, buildApprovalSignSteps } from '~/composables/cowswap'
 
 const route = useRoute()
-const { isConnected, address } = useAccount()
+const { isConnected, address } = useWagmi()
 const { isSpyMode } = useSpyMode()
 const { isPositionsLoaded, isPositionsLoading, getPositionBySubAccountIndex } = useEulerAccount()
 const { buildSwapPlan, buildSameAssetSwapPlan } = useEulerOperations()

--- a/pages/position/[number]/index.vue
+++ b/pages/position/[number]/index.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { useAccount } from '@wagmi/vue'
 import { getAddress, type Address, type Abi } from 'viem'
 import { eulerAccountLensABI } from '~/entities/euler/abis'
 import {
@@ -34,7 +33,7 @@ const _route = useRoute()
 const router = useRouter()
 const modal = useModal()
 const { error } = useToast()
-const { isConnected, address } = useAccount()
+const { isConnected, address } = useWagmi()
 const { isSpyMode } = useSpyMode()
 const { isPositionsLoaded, isPositionsLoading, getPositionBySubAccountIndex } = useEulerAccount()
 const { withIntrinsicBorrowApy, withIntrinsicSupplyApy, getIntrinsicApy, getIntrinsicApyInfo } = useIntrinsicApy()

--- a/pages/position/[number]/multiply.vue
+++ b/pages/position/[number]/multiply.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { useAccount } from '@wagmi/vue'
 import { formatUnits, type Address } from 'viem'
 import { normalizeAddressOrEmpty } from '~/utils/accountPositionHelpers'
 import { OperationReviewModal, SlippageSettingsModal } from '#components'
@@ -28,7 +27,7 @@ const route = useRoute()
 const router = useRouter()
 const modal = useModal()
 const { error } = useToast()
-const { address, isConnected } = useAccount()
+const { address, isConnected } = useWagmi()
 const { isSpyMode } = useSpyMode()
 const { isPositionsLoading, isPositionsLoaded, refreshAllPositions, getPositionBySubAccountIndex } = useEulerAccount()
 const { buildMultiplyPlan, executeTxPlan } = useEulerOperations()

--- a/pages/position/[number]/repay.vue
+++ b/pages/position/[number]/repay.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { useAccount } from '@wagmi/vue'
 import { type Vault, type VaultAsset, getNetAPY } from '~/entities/vault'
 import { getAssetUsdValueOrZero, getCollateralOraclePrice, getAssetOraclePrice, conservativePriceRatioNumber } from '~/services/pricing/priceProvider'
 import { type AccountBorrowPosition, isPositionEligibleForLiquidation } from '~/entities/account'
@@ -23,7 +22,7 @@ import type { DisabledReasonInfo } from '~/components/entities/vault/form/types'
 const _route = useRoute()
 const _router = useRouter()
 const modal = useModal()
-const { isConnected, address } = useAccount()
+const { isConnected, address } = useWagmi()
 const { isSpyMode } = useSpyMode()
 // Page uses SwapTokenSelector — opt into full wallet-token balance fetch while mounted.
 useFullBalances()

--- a/pages/position/[number]/supply.vue
+++ b/pages/position/[number]/supply.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { useAccount } from '@wagmi/vue'
 import { getAddress, type Address, zeroAddress } from 'viem'
 import { isNativeCurrencyAddress, isNativeOfWrapped, resolveWrappedNativeAddress, resolveWrappedNativeAsset } from '~/utils/native-currency'
 import { FixedPoint } from '~/utils/fixed-point'
@@ -17,7 +16,7 @@ import { useCollateralForm } from '~/composables/position/useCollateralForm'
 import type { DisabledReasonInfo } from '~/components/entities/vault/form/types'
 
 const positionIndex = usePositionIndex()
-const { isConnected, address } = useAccount()
+const { isConnected, address } = useWagmi()
 const { isSpyMode } = useSpyMode()
 const { fetchSingleBalance } = useWallets()
 const { buildSupplyPlan, buildSwapAndSupplyPlan } = useEulerOperations()

--- a/pages/position/[number]/withdraw.vue
+++ b/pages/position/[number]/withdraw.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { useAccount } from '@wagmi/vue'
 import { getAddress, type Address, zeroAddress } from 'viem'
 import { FixedPoint } from '~/utils/fixed-point'
 import { getCashLimitedWithdrawAmount, type Vault, type VaultAsset } from '~/entities/vault'
@@ -19,7 +18,7 @@ import { useCollateralForm } from '~/composables/position/useCollateralForm'
 import type { DisabledReasonInfo } from '~/components/entities/vault/form/types'
 
 const positionIndex = usePositionIndex()
-const { address } = useAccount()
+const { address } = useWagmi()
 const { buildWithdrawPlan, buildWithdrawAndSwapPlan } = useEulerOperations()
 const { refreshAllPositions } = useEulerAccount()
 const { eulerLensAddresses } = useEulerAddresses()

--- a/server/api/screen-address.post.ts
+++ b/server/api/screen-address.post.ts
@@ -14,6 +14,11 @@ function isValidAddress(value: unknown): value is string {
   return typeof value === 'string' && /^0x[0-9a-fA-F]{40}$/.test(value)
 }
 
+function isTruthyHeader(value: string | string[] | undefined): boolean {
+  const header = Array.isArray(value) ? value[0] : value
+  return header === 'true'
+}
+
 export default defineEventHandler(async (event) => {
   rateLimiter.consume(event)
 
@@ -24,7 +29,10 @@ export default defineEventHandler(async (event) => {
   }
 
   const address = body.address
-  const vpnIsUsed = String(body.vpnIsUsed ?? false)
+  const vpnIsUsed = String(
+    isTruthyHeader(event.node.req.headers['x-is-vpn'])
+    || isTruthyHeader(event.node.req.headers['x-is-proxy-or-vpn']),
+  )
 
   const screeningUri = process.env.WALLET_SCREENING_URI
 
@@ -50,10 +58,10 @@ export default defineEventHandler(async (event) => {
     }
 
     const data = await resp.json()
-    const isSuspicious = Boolean(data?.addressIsSuspicious)
+    const isSuspicious = data?.addressIsSuspicious !== false
 
     if (isSuspicious) {
-      logger.warn({ ctx: 'screen-address', address }, 'flagged address')
+      logger.warn({ ctx: 'screen-address', address }, 'flagged, malformed, or ambiguous TRM response — failing closed')
     }
 
     return { addressIsSuspicious: isSuspicious }

--- a/server/api/screen-address.post.ts
+++ b/server/api/screen-address.post.ts
@@ -15,8 +15,11 @@ function isValidAddress(value: unknown): value is string {
 }
 
 function isTruthyHeader(value: string | string[] | undefined): boolean {
-  const header = Array.isArray(value) ? value[0] : value
-  return header === 'true'
+  const headers = Array.isArray(value) ? value : [value]
+  return headers
+    .filter((header): header is string => typeof header === 'string')
+    .flatMap(header => header.split(','))
+    .some(token => token.trim().toLowerCase() === 'true')
 }
 
 export default defineEventHandler(async (event) => {

--- a/services/trm.ts
+++ b/services/trm.ts
@@ -17,8 +17,12 @@ export async function screenAddress(
       signal: controller.signal,
     })
 
+    if (!resp.ok) {
+      return true
+    }
+
     const data = await resp.json()
-    return Boolean(data?.addressIsSuspicious)
+    return data?.addressIsSuspicious !== false
   }
   catch {
     return true

--- a/services/trm.ts
+++ b/services/trm.ts
@@ -1,14 +1,20 @@
+import { WALLET_SCREENING_TIMEOUT_MS } from '~/entities/tuning-constants'
+
 export async function screenAddress(
   address: string,
   vpnIsUsed: boolean,
 ): Promise<boolean> {
   if (!address) return false
 
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), WALLET_SCREENING_TIMEOUT_MS)
+
   try {
     const resp = await fetch('/api/screen-address', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ address, vpnIsUsed }),
+      signal: controller.signal,
     })
 
     const data = await resp.json()
@@ -16,5 +22,8 @@ export async function screenAddress(
   }
   catch {
     return true
+  }
+  finally {
+    clearTimeout(timeout)
   }
 }

--- a/services/vpn.ts
+++ b/services/vpn.ts
@@ -1,4 +1,4 @@
-import { CACHE_TTL_5MIN_MS } from '~/entities/tuning-constants'
+import { CACHE_TTL_5MIN_MS, WALLET_SCREENING_TIMEOUT_MS } from '~/entities/tuning-constants'
 
 let cached: { value: boolean, timestamp: number } | null = null
 
@@ -7,13 +7,19 @@ export async function detectVpn(): Promise<boolean> {
     return cached.value
   }
 
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), WALLET_SCREENING_TIMEOUT_MS)
+
   try {
-    const resp = await fetch(window.location.origin, { method: 'HEAD' })
+    const resp = await fetch(window.location.origin, { method: 'HEAD', signal: controller.signal })
     const header = resp.headers.get('x-is-vpn')
     cached = { value: header === 'true', timestamp: Date.now() }
   }
   catch {
     cached = { value: false, timestamp: Date.now() }
+  }
+  finally {
+    clearTimeout(timeout)
   }
 
   return cached.value

--- a/tests/composables/useAddressScreen.test.ts
+++ b/tests/composables/useAddressScreen.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useAddressScreen } from '~/composables/useAddressScreen'
+
+const { USER, mocks } = vi.hoisted(() => ({
+  USER: '0x0000000000000000000000000000000000000001',
+  mocks: {
+    detectVpn: vi.fn(),
+    disconnect: vi.fn(),
+    modalClose: vi.fn(),
+    modalOpen: vi.fn(),
+    resetCountryCache: vi.fn(),
+    resetVpnCache: vi.fn(),
+    routerPush: vi.fn(),
+    screenAddress: vi.fn(),
+  },
+}))
+
+vi.mock('@wagmi/vue', () => ({
+  useDisconnect: () => ({ disconnect: mocks.disconnect }),
+}))
+
+vi.mock('#components', () => ({
+  BlockedAddressModal: {},
+}))
+
+vi.mock('~/components/ui/composables/useModal', () => ({
+  useModal: () => ({
+    close: mocks.modalClose,
+    open: mocks.modalOpen,
+  }),
+}))
+
+vi.mock('~/services/country', () => ({
+  resetCountryCache: mocks.resetCountryCache,
+}))
+
+vi.mock('~/services/vpn', () => ({
+  detectVpn: mocks.detectVpn,
+  resetVpnCache: mocks.resetVpnCache,
+}))
+
+vi.mock('~/services/trm', () => ({
+  screenAddress: mocks.screenAddress,
+}))
+
+describe('useAddressScreen', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubGlobal('useRouter', () => ({ push: mocks.routerPush }))
+    vi.stubGlobal('useDeployConfig', () => ({
+      enableEarnPage: true,
+      enableExplorePage: true,
+      enableLendPage: true,
+    }))
+
+    useAddressScreen().resetScreeningCache()
+    vi.clearAllMocks()
+  })
+
+  it('keeps an address unscreened while the verdict is pending', async () => {
+    let resolveScreening: (value: boolean) => void = () => {}
+    mocks.detectVpn.mockResolvedValue(false)
+    mocks.screenAddress.mockImplementation(() => new Promise<boolean>((resolve) => {
+      resolveScreening = resolve
+    }))
+
+    const screening = useAddressScreen()
+    const promise = screening.screenConnectedAddress(USER)
+
+    expect(screening.isScreening.value).toBe(true)
+    expect(screening.isAddressScreened(USER)).toBe(false)
+
+    await Promise.resolve()
+    expect(screening.isAddressScreened(USER)).toBe(false)
+
+    resolveScreening(false)
+    await promise
+
+    expect(screening.isScreening.value).toBe(false)
+    expect(screening.isAddressScreened(USER)).toBe(true)
+  })
+
+  it('disconnects restricted addresses without marking them screened', async () => {
+    mocks.detectVpn.mockResolvedValue(false)
+    mocks.screenAddress.mockResolvedValue(true)
+
+    const screening = useAddressScreen()
+    await screening.screenConnectedAddress(USER)
+
+    expect(mocks.disconnect).toHaveBeenCalledTimes(1)
+    expect(mocks.modalOpen).toHaveBeenCalledTimes(1)
+    expect(screening.isAddressScreened(USER)).toBe(false)
+  })
+
+  it('invalidates a pending verdict when screening state is reset', async () => {
+    let resolveScreening: (value: boolean) => void = () => {}
+    mocks.detectVpn.mockResolvedValue(false)
+    mocks.screenAddress.mockImplementation(() => new Promise<boolean>((resolve) => {
+      resolveScreening = resolve
+    }))
+
+    const screening = useAddressScreen()
+    const promise = screening.screenConnectedAddress(USER)
+
+    await Promise.resolve()
+    screening.resetScreeningCache()
+    resolveScreening(false)
+    await promise
+
+    expect(screening.isScreening.value).toBe(false)
+    expect(screening.isAddressScreened(USER)).toBe(false)
+  })
+})

--- a/tests/composables/useAddressScreen.test.ts
+++ b/tests/composables/useAddressScreen.test.ts
@@ -110,4 +110,19 @@ describe('useAddressScreen', () => {
     expect(screening.isScreening.value).toBe(false)
     expect(screening.isAddressScreened(USER)).toBe(false)
   })
+
+  it('does not show a stale blocked modal if disconnect resets screening state', async () => {
+    mocks.detectVpn.mockResolvedValue(false)
+    mocks.screenAddress.mockResolvedValue(true)
+    mocks.disconnect.mockImplementation(async () => {
+      useAddressScreen().resetScreeningCache()
+    })
+
+    const screening = useAddressScreen()
+    await screening.screenConnectedAddress(USER)
+
+    expect(mocks.disconnect).toHaveBeenCalledTimes(1)
+    expect(mocks.modalOpen).not.toHaveBeenCalled()
+    expect(screening.isAddressScreened(USER)).toBe(false)
+  })
 })

--- a/tests/composables/useSavingsRepay.test.ts
+++ b/tests/composables/useSavingsRepay.test.ts
@@ -161,6 +161,7 @@ describe('useSavingsRepay', () => {
     vi.stubGlobal('useRpcClient', () => ({ client: ref(null) }))
     vi.stubGlobal('useWagmi', () => ({
       address: ref(USER),
+      isConnected: ref(true),
       chain: ref({ nativeCurrency: { decimals: 18 } }),
     }))
   })

--- a/tests/server/screen-address.test.ts
+++ b/tests/server/screen-address.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { H3Event } from 'h3'
+
+const mocks = vi.hoisted(() => ({
+  consume: vi.fn(),
+}))
+
+vi.mock('h3', () => ({
+  createError: (error: unknown) => error,
+  readBody: (event: { context?: { body?: unknown } }) => event.context?.body,
+}))
+
+vi.mock('~/server/utils/rate-limit', () => ({
+  createRateLimiter: () => ({ consume: mocks.consume }),
+}))
+
+vi.mock('~/server/utils/logger', () => ({
+  logger: {
+    warn: vi.fn(),
+  },
+}))
+
+const handler = (await import('~/server/api/screen-address.post')).default
+
+const USER = '0x0000000000000000000000000000000000000001'
+const SCREENING_URI = 'https://trm.example/screen'
+
+function makeEvent(body: unknown, headers: Record<string, string | undefined> = {}): H3Event {
+  return {
+    context: { body },
+    node: {
+      req: {
+        headers: {
+          'cf-connecting-ip': '127.0.0.1',
+          ...headers,
+        },
+      },
+      res: {},
+    },
+  } as unknown as H3Event
+}
+
+describe('POST /api/screen-address', () => {
+  afterEach(() => {
+    delete process.env.WALLET_SCREENING_URI
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('allows only an explicit false upstream verdict', async () => {
+    process.env.WALLET_SCREENING_URI = SCREENING_URI
+    vi.stubGlobal('fetch', vi.fn(async () =>
+      new Response(JSON.stringify({ addressIsSuspicious: false }), { status: 200 }),
+    ))
+
+    await expect(handler(makeEvent({ address: USER }))).resolves.toEqual({ addressIsSuspicious: false })
+  })
+
+  it('fails closed for malformed successful upstream verdicts', async () => {
+    process.env.WALLET_SCREENING_URI = SCREENING_URI
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({}), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ addressIsSuspicious: null }), { status: 200 }))
+
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(handler(makeEvent({ address: USER }))).resolves.toEqual({ addressIsSuspicious: true })
+    await expect(handler(makeEvent({ address: USER }))).resolves.toEqual({ addressIsSuspicious: true })
+  })
+
+  it('derives vpnIsUsed from trusted request headers', async () => {
+    process.env.WALLET_SCREENING_URI = SCREENING_URI
+    const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) =>
+      new Response(JSON.stringify({ addressIsSuspicious: false }), { status: 200 }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await handler(makeEvent(
+      { address: USER, vpnIsUsed: false },
+      { 'x-is-vpn': 'true' },
+    ))
+    await handler(makeEvent(
+      { address: USER, vpnIsUsed: false },
+      { 'x-is-proxy-or-vpn': 'true' },
+    ))
+    await handler(makeEvent(
+      { address: USER, vpnIsUsed: true },
+      {},
+    ))
+
+    const bodies = fetchMock.mock.calls.map((call) => {
+      const init = call[1]
+      return JSON.parse(String(init?.body)) as { vpnIsUsed: string }
+    })
+    expect(bodies.map(body => body.vpnIsUsed)).toEqual(['true', 'true', 'false'])
+  })
+})

--- a/tests/server/screen-address.test.ts
+++ b/tests/server/screen-address.test.ts
@@ -25,7 +25,7 @@ const handler = (await import('~/server/api/screen-address.post')).default
 const USER = '0x0000000000000000000000000000000000000001'
 const SCREENING_URI = 'https://trm.example/screen'
 
-function makeEvent(body: unknown, headers: Record<string, string | undefined> = {}): H3Event {
+function makeEvent(body: unknown, headers: Record<string, string | string[] | undefined> = {}): H3Event {
   return {
     context: { body },
     node: {
@@ -84,6 +84,14 @@ describe('POST /api/screen-address', () => {
       { 'x-is-proxy-or-vpn': 'true' },
     ))
     await handler(makeEvent(
+      { address: USER, vpnIsUsed: false },
+      { 'x-is-vpn': 'false, TRUE' },
+    ))
+    await handler(makeEvent(
+      { address: USER, vpnIsUsed: false },
+      { 'x-is-proxy-or-vpn': ['false', ' true '] },
+    ))
+    await handler(makeEvent(
       { address: USER, vpnIsUsed: true },
       {},
     ))
@@ -92,6 +100,6 @@ describe('POST /api/screen-address', () => {
       const init = call[1]
       return JSON.parse(String(init?.body)) as { vpnIsUsed: string }
     })
-    expect(bodies.map(body => body.vpnIsUsed)).toEqual(['true', 'true', 'false'])
+    expect(bodies.map(body => body.vpnIsUsed)).toEqual(['true', 'true', 'true', 'true', 'false'])
   })
 })

--- a/tests/services/trm.test.ts
+++ b/tests/services/trm.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { WALLET_SCREENING_TIMEOUT_MS } from '~/entities/tuning-constants'
+import { screenAddress } from '~/services/trm'
+
+const USER = '0x0000000000000000000000000000000000000001'
+
+describe('screenAddress', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('allows only an explicit false suspicious verdict', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({ addressIsSuspicious: false }), { status: 200 })))
+
+    await expect(screenAddress(USER, false)).resolves.toBe(false)
+  })
+
+  it('fails closed for non-ok responses and malformed success bodies', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response('nope', { status: 500 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({}), { status: 200 }))
+
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(screenAddress(USER, false)).resolves.toBe(true)
+    await expect(screenAddress(USER, false)).resolves.toBe(true)
+  })
+
+  it('fails closed when the screening request stalls', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('fetch', vi.fn((_url: string, init?: RequestInit) =>
+      new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')))
+      }),
+    ))
+
+    const promise = screenAddress(USER, false)
+
+    await vi.advanceTimersByTimeAsync(WALLET_SCREENING_TIMEOUT_MS)
+
+    await expect(promise).resolves.toBe(true)
+  })
+})

--- a/tests/services/vpn.test.ts
+++ b/tests/services/vpn.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { WALLET_SCREENING_TIMEOUT_MS } from '~/entities/tuning-constants'
+import { detectVpn, resetVpnCache } from '~/services/vpn'
+
+describe('detectVpn', () => {
+  afterEach(() => {
+    resetVpnCache()
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('reads the VPN edge header', async () => {
+    vi.stubGlobal('window', { location: { origin: 'http://localhost:3000' } })
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(null, {
+      headers: { 'x-is-vpn': 'true' },
+      status: 200,
+    })))
+
+    await expect(detectVpn()).resolves.toBe(true)
+  })
+
+  it('returns false when VPN detection stalls', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('window', { location: { origin: 'http://localhost:3000' } })
+    vi.stubGlobal('fetch', vi.fn((_url: string, init?: RequestInit) =>
+      new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')))
+      }),
+    ))
+
+    const promise = detectVpn()
+
+    await vi.advanceTimersByTimeAsync(WALLET_SCREENING_TIMEOUT_MS)
+
+    await expect(promise).resolves.toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- Fixes the wallet-screening race by keeping app-level wallet state disconnected until the current address has a completed non-restricted screening verdict.
- Routes wallet-gated UI and composables through the screened `useWagmi()` state instead of raw Wagmi account state.

## Changes
- Tracks the screened address centrally in `useAddressScreen()` and invalidates stale pending verdicts on reset/address changes.
- Exposes `isConnected` and `address` from `useWagmi()` only after the raw wallet address matches the latest passed screening verdict.
- Keeps ENS and balance queries on the screened wallet address instead of the raw Wagmi address.
- Adds client-side timeouts around VPN detection and `/api/screen-address` so stalled screening inputs do not hang indefinitely.
- Fails closed unless both the server proxy and client receive an explicit `addressIsSuspicious: false` verdict.
- Derives VPN/proxy status for the TRM proxy from trusted request headers instead of client-supplied request body data.
- Adds focused tests for pending, restricted, reset, malformed response, stalled request, and trusted VPN header behavior.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test:run`
- [x] Local smoke test with allowed TRM fixture
- [x] Local smoke test with suspicious TRM fixture
- [x] Local smoke test with stalled TRM fixture timing out fail-closed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wallet address screening: suspicious/restricted wallets are blocked and trigger automatic disconnect plus blocked modal.

* **Improvements**
  * Screening timeout added to keep wallet connect responsive.
  * App shows connection as disconnected for unscreened addresses; ENS and balance lookups respect screening.
  * Wallet connection state unified across the app for more consistent behavior.

* **Tests**
  * Added coverage for screening, VPN detection and timeout behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/euler-xyz/euler-lite/pull/467?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->