### PR TITLE
fix: validate swapper quote contracts

### DIFF
--- a/composables/useEulerAddresses.ts
+++ b/composables/useEulerAddresses.ts
@@ -48,6 +48,10 @@ interface EulerChainConfig {
       eUSD?: string
       seUSD?: string
     }
+    eulerSwapAddrs?: {
+      eulerSwapV1Periphery?: string
+      eulerSwapV2Periphery?: string
+    }
     peripheryAddrs: {
       adaptiveCurveIRMFactory: string
       capRiskStewardFactory?: string
@@ -215,6 +219,8 @@ export const useEulerAddresses = () => {
       securitizeFactory: config.addresses.peripheryAddrs.securitizeFactory,
       swapVerifier: config.addresses.peripheryAddrs.swapVerifier,
       swapper: config.addresses.peripheryAddrs.swapper,
+      eulerSwapV1Periphery: config.addresses.eulerSwapAddrs?.eulerSwapV1Periphery,
+      eulerSwapV2Periphery: config.addresses.eulerSwapAddrs?.eulerSwapV2Periphery,
       termsOfUseSigner: config.addresses.peripheryAddrs.termsOfUseSigner,
     }
   })

--- a/composables/useEulerOperations/swaps/cross-asset.ts
+++ b/composables/useEulerOperations/swaps/cross-asset.ts
@@ -9,7 +9,7 @@ import { swapperAbi } from '~/entities/euler/abis'
 import type { EVCCall } from '~/utils/evc-converter'
 import { sumCallValues } from '~/utils/pyth'
 import { logWarn } from '~/utils/errorHandling'
-import { assertSwapperVerifierAllowed } from '~/utils/swap-validation'
+import { assertSwapQuoteContractsAllowed } from '~/utils/swap-validation'
 import type { TxPlan } from '~/entities/txPlan'
 import { type SwapApiQuote, SwapperMode, SwapVerificationType } from '~/entities/swap'
 
@@ -49,7 +49,10 @@ export const createCrossAssetSwapBuilders = (
     const userAddr = ctx.address.value as Address
     const evcAddress = ctx.eulerCoreAddresses.value.evc as Address
 
-    assertSwapperVerifierAllowed(quote.verify.verifierAddress, ctx.eulerPeripheryAddresses.value.swapVerifier)
+    assertSwapQuoteContractsAllowed({
+      swapperAddress: quote.swap.swapperAddress,
+      verifierAddress: quote.verify.verifierAddress,
+    }, ctx.eulerPeripheryAddresses.value)
 
     if (isRepay && quote.verify.type !== SwapVerificationType.DebtMax) {
       throw new Error('Swap verifier type mismatch')

--- a/composables/useEulerOperations/swaps/supply-borrow.ts
+++ b/composables/useEulerOperations/swaps/supply-borrow.ts
@@ -12,7 +12,7 @@ import { buildCollateralCleanupCalls } from '~/utils/collateral-cleanup'
 import type { TxPlan } from '~/entities/txPlan'
 import { type SwapApiQuote, SwapperMode, SwapVerificationType } from '~/entities/swap'
 import { logWarn } from '~/utils/errorHandling'
-import { assertSwapperVerifierAllowed } from '~/utils/swap-validation'
+import { assertSwapQuoteContractsAllowed } from '~/utils/swap-validation'
 
 export const createSupplyBorrowSwapBuilders = (
   ctx: OperationsContext,
@@ -43,7 +43,10 @@ export const createSupplyBorrowSwapBuilders = (
     const userAddr = ctx.address.value as Address
     const swapVerifierAddress = ctx.eulerPeripheryAddresses.value.swapVerifier as Address
 
-    assertSwapperVerifierAllowed(quote.verify.verifierAddress, ctx.eulerPeripheryAddresses.value.swapVerifier)
+    assertSwapQuoteContractsAllowed({
+      swapperAddress: quote.swap.swapperAddress,
+      verifierAddress: quote.verify.verifierAddress,
+    }, ctx.eulerPeripheryAddresses.value)
 
     const { steps, permitCall, usesPermit2 } = await helpers.prepareTokenApproval({
       assetAddr: inputTokenAddress,
@@ -155,7 +158,10 @@ export const createSupplyBorrowSwapBuilders = (
     const evcAddress = ctx.eulerCoreAddresses.value.evc as Address
     const swapVerifierAddress = ctx.eulerPeripheryAddresses.value.swapVerifier as Address
 
-    assertSwapperVerifierAllowed(swapQuote.verify.verifierAddress, ctx.eulerPeripheryAddresses.value.swapVerifier)
+    assertSwapQuoteContractsAllowed({
+      swapperAddress: swapQuote.swap.swapperAddress,
+      verifierAddress: swapQuote.verify.verifierAddress,
+    }, ctx.eulerPeripheryAddresses.value)
 
     const subAccountAddr = (subAccount || await getNewSubAccount(ctx.address.value)) as Address
 
@@ -303,7 +309,10 @@ export const createSupplyBorrowSwapBuilders = (
     const withdrawFromAddr = subAccount ? (subAccount as Address) : userAddr
     const swapperAddress = quote.swap.swapperAddress as Address
 
-    assertSwapperVerifierAllowed(quote.verify.verifierAddress, ctx.eulerPeripheryAddresses.value.swapVerifier)
+    assertSwapQuoteContractsAllowed({
+      swapperAddress: quote.swap.swapperAddress,
+      verifierAddress: quote.verify.verifierAddress,
+    }, ctx.eulerPeripheryAddresses.value)
 
     const hooks = new SaHooksBuilder()
     hooks.addContractInterface(vaultAddr, vaultWithdrawAbi)
@@ -393,7 +402,10 @@ export const createSupplyBorrowSwapBuilders = (
     const redeemFromAddr = subAccount ? (subAccount as Address) : userAddr
     const swapperAddress = quote.swap.swapperAddress as Address
 
-    assertSwapperVerifierAllowed(quote.verify.verifierAddress, ctx.eulerPeripheryAddresses.value.swapVerifier)
+    assertSwapQuoteContractsAllowed({
+      swapperAddress: quote.swap.swapperAddress,
+      verifierAddress: quote.verify.verifierAddress,
+    }, ctx.eulerPeripheryAddresses.value)
 
     const hooks = new SaHooksBuilder()
     hooks.addContractInterface(vaultAddr, vaultRedeemAbi)
@@ -499,7 +511,10 @@ export const createSupplyBorrowSwapBuilders = (
     const swapVerifierAddress = ctx.eulerPeripheryAddresses.value.swapVerifier as Address
     const borrowVaultAddr = borrowVaultAddress
 
-    assertSwapperVerifierAllowed(quote.verify.verifierAddress, ctx.eulerPeripheryAddresses.value.swapVerifier)
+    assertSwapQuoteContractsAllowed({
+      swapperAddress: quote.swap.swapperAddress,
+      verifierAddress: quote.verify.verifierAddress,
+    }, ctx.eulerPeripheryAddresses.value)
 
     if (quote.verify.type !== SwapVerificationType.DebtMax) {
       throw new Error('Swap verifier type mismatch')

--- a/composables/useEulerOperations/vault.ts
+++ b/composables/useEulerOperations/vault.ts
@@ -14,7 +14,7 @@ import type { TxPlan, TxStep } from '~/entities/txPlan'
 import type { SwapApiQuote } from '~/entities/swap'
 import { SwapperMode, SwapVerificationType } from '~/entities/swap'
 import { logWarn } from '~/utils/errorHandling'
-import { assertSwapperVerifierAllowed } from '~/utils/swap-validation'
+import { assertSwapQuoteContractsAllowed } from '~/utils/swap-validation'
 
 const isAlreadyEnabled = (list: string[] | undefined, address: string): boolean =>
   !!list?.some(c => c.toLowerCase() === address.toLowerCase())
@@ -577,7 +577,10 @@ export const createVaultBuilders = (
     }
 
     if (swapInfo) {
-      assertSwapperVerifierAllowed(swapInfo.quote.verify.verifierAddress, ctx.eulerPeripheryAddresses.value!.swapVerifier)
+      assertSwapQuoteContractsAllowed({
+        swapperAddress: swapInfo.quote.swap.swapperAddress,
+        verifierAddress: swapInfo.quote.verify.verifierAddress,
+      }, ctx.eulerPeripheryAddresses.value)
     }
 
     const borrowRecipient = swapInfo ? swapInfo.quote.swap.swapperAddress : userAddr

--- a/tests/utils/swap-validation.test.ts
+++ b/tests/utils/swap-validation.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import {
+  assertSwapQuoteContractsAllowed,
+  assertSwapperAllowed,
+  getAllowedSwapperAddresses,
+} from '~/utils/swap-validation'
+
+const SWAPPER = '0x0000000000000000000000000000000000000001'
+const EULER_SWAP_V1_PERIPHERY = '0x0000000000000000000000000000000000000002'
+const EULER_SWAP_V2_PERIPHERY = '0x0000000000000000000000000000000000000003'
+const SWAP_VERIFIER = '0x0000000000000000000000000000000000000004'
+const ATTACKER = '0x0000000000000000000000000000000000000005'
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
+
+const knownAddresses = {
+  swapper: SWAPPER,
+  eulerSwapV1Periphery: EULER_SWAP_V1_PERIPHERY,
+  eulerSwapV2Periphery: EULER_SWAP_V2_PERIPHERY,
+  swapVerifier: SWAP_VERIFIER,
+}
+
+describe('swap validation', () => {
+  it('allowlists canonical swapper contracts from Euler chain config', () => {
+    expect(getAllowedSwapperAddresses({
+      swapper: SWAPPER,
+      eulerSwapV1Periphery: EULER_SWAP_V1_PERIPHERY,
+      eulerSwapV2Periphery: EULER_SWAP_V2_PERIPHERY,
+      eulerSwapPeriphery: ZERO_ADDRESS,
+    })).toEqual([
+      SWAPPER,
+      EULER_SWAP_V1_PERIPHERY,
+      EULER_SWAP_V2_PERIPHERY,
+    ])
+  })
+
+  it('accepts quote swappers that match canonical deployments', () => {
+    expect(() => assertSwapperAllowed(EULER_SWAP_V2_PERIPHERY, knownAddresses)).not.toThrow()
+  })
+
+  it('rejects quote swappers outside canonical deployments', () => {
+    expect(() => assertSwapperAllowed(ATTACKER, knownAddresses)).toThrow(
+      `Unknown swapper address: ${ATTACKER}`,
+    )
+  })
+
+  it('validates swapper and verifier before a quote can build EVC calls', () => {
+    expect(() => assertSwapQuoteContractsAllowed({
+      swapperAddress: EULER_SWAP_V1_PERIPHERY,
+      verifierAddress: SWAP_VERIFIER,
+    }, knownAddresses)).not.toThrow()
+
+    expect(() => assertSwapQuoteContractsAllowed({
+      swapperAddress: ATTACKER,
+      verifierAddress: SWAP_VERIFIER,
+    }, knownAddresses)).toThrow(`Unknown swapper address: ${ATTACKER}`)
+  })
+
+  it('fails closed when no canonical swapper is configured', () => {
+    expect(() => assertSwapperAllowed(SWAPPER, { swapVerifier: SWAP_VERIFIER })).toThrow(
+      'Known swapper address not configured',
+    )
+  })
+})

--- a/utils/swap-validation.ts
+++ b/utils/swap-validation.ts
@@ -1,3 +1,51 @@
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
+
+export type KnownSwapAddresses = Record<string, string | undefined> | null | undefined
+
+const SWAPPER_ALLOWLIST_KEYS = [
+  'swapper',
+  'eulerSwapPeriphery',
+  'eulerSwapV1Periphery',
+  'eulerSwapV2Periphery',
+] as const
+
+const normalizeAddress = (address: string | undefined): string | undefined => {
+  if (!address) return undefined
+
+  const normalized = address.toLowerCase()
+  return normalized === ZERO_ADDRESS ? undefined : normalized
+}
+
+export function getAllowedSwapperAddresses(knownAddresses: KnownSwapAddresses): string[] {
+  const allowed = new Set<string>()
+
+  for (const key of SWAPPER_ALLOWLIST_KEYS) {
+    const normalized = normalizeAddress(knownAddresses?.[key])
+    if (normalized) {
+      allowed.add(normalized)
+    }
+  }
+
+  return [...allowed]
+}
+
+export function assertSwapperAllowed(
+  swapperAddress: string,
+  knownAddresses: KnownSwapAddresses,
+): void {
+  const allowedSwappers = getAllowedSwapperAddresses(knownAddresses)
+
+  if (!allowedSwappers.length) {
+    throw new Error('Known swapper address not configured')
+  }
+
+  if (!allowedSwappers.includes(swapperAddress.toLowerCase())) {
+    throw new Error(
+      `Unknown swapper address: ${swapperAddress}. Expected one of: ${allowedSwappers.join(', ')}`,
+    )
+  }
+}
+
 export function assertSwapperVerifierAllowed(
   swapVerifierAddress: string,
   knownSwapVerifier: string | undefined,
@@ -10,4 +58,12 @@ export function assertSwapperVerifierAllowed(
       `Unknown swap verifier address: ${swapVerifierAddress}. Expected: ${knownSwapVerifier}`,
     )
   }
+}
+
+export function assertSwapQuoteContractsAllowed(
+  quoteContracts: { swapperAddress: string, verifierAddress: string },
+  knownAddresses: KnownSwapAddresses,
+): void {
+  assertSwapperVerifierAllowed(quoteContracts.verifierAddress, knownAddresses?.swapVerifier)
+  assertSwapperAllowed(quoteContracts.swapperAddress, knownAddresses)
 }


### PR DESCRIPTION
## Summary
- Reject swap API quotes that point to non-canonical swapper contracts before building EVC swap batches.
- Keep the existing verifier allowlist behavior, but extend the same trust boundary to the contract that receives funds and executes swap calldata.

## Changes
- Expose EulerSwap V1/V2 periphery addresses from the Euler chain config alongside the existing periphery swapper address.
- Add shared swap quote contract validation that checks both verifier and swapper addresses and fails closed when no canonical swapper is configured.
- Apply the validation across wallet swap, cross-asset swap, withdraw/redeem swap, repay swap, and multiply swap builders.
- Add focused regression coverage for allowed canonical swappers and rejected quote-owned attacker swappers.

## Test plan
- [x] npm run test:run -- tests/utils/swap-validation.test.ts
- [x] npm run typecheck
- [x] npx eslint utils/swap-validation.ts composables/useEulerAddresses.ts composables/useEulerOperations/swaps/supply-borrow.ts composables/useEulerOperations/swaps/cross-asset.ts composables/useEulerOperations/vault.ts tests/utils/swap-validation.test.ts
- [x] Smoke test local Nuxt app and /api/euler-chains response

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for additional Euler Swap periphery addresses in chain configuration.
  * Enhanced swap validation to verify both swapper and verifier contract addresses.

* **Tests**
  * Added comprehensive test suite for swap contract validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/euler-xyz/euler-lite/pull/468?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->