### PR TITLE
fix: use Gregorian year for APY display math

### DIFF
--- a/components/entities/vault/overview/VaultOverviewBlockIRM.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockIRM.vue
@@ -21,6 +21,7 @@ import {
   KINK_IRM_COMPONENTS,
   ADAPTIVE_CURVE_IRM_COMPONENTS,
   KINKY_IRM_COMPONENTS,
+  SECONDS_IN_YEAR,
 } from '~/entities/constants'
 import {
   type Vault,
@@ -76,7 +77,6 @@ const hasValidIRM = computed(() => {
     && vault.interestRateModelAddress !== zeroAddress
 })
 
-const SECONDS_PER_YEAR = 31_557_600 // 365.25 days
 const MAX_UINT32 = 4_294_967_295
 
 // Key borrow APY values derived from the chart data (populated in renderChart)
@@ -180,7 +180,7 @@ const irmParamsDisplay = computed<Array<{ label: string, value: string }>>(() =>
       { label: 'Min rate at kink', value: fmtRate(adaptiveMinRateAPY.value) },
       { label: 'Max rate at kink', value: fmtRate(adaptiveMaxRateAPY.value) },
       { label: 'Kink', value: formatWadPercent(decoded.targetUtilization) },
-      { label: 'Adjustment speed', value: `${(Number(formatUnits(decoded.adjustmentSpeed, 18)) * SECONDS_PER_YEAR).toFixed(1)}x/yr` },
+      { label: 'Adjustment speed', value: `${(Number(formatUnits(decoded.adjustmentSpeed, 18)) * SECONDS_IN_YEAR).toFixed(1)}x/yr` },
     ]
   }
   if (decoded.type === 'kinky') {

--- a/entities/constants.ts
+++ b/entities/constants.ts
@@ -168,7 +168,9 @@ export const PYTH_ORACLE_COMPONENTS = [
   { name: 'maxConfWidth', type: 'uint256' },
 ] as const
 
-export const SECONDS_IN_YEAR = 31_536_000
+// Gregorian year (365.2425 * 86400). Matches EVK/Lens SECONDS_PER_YEAR used by
+// on-chain APY math, so display values round-trip exactly with contract output.
+export const SECONDS_IN_YEAR = 31_556_952
 export const TARGET_TIME_AGO = 3600
 
 export const PERMIT2_TYPES = {


### PR DESCRIPTION
## Summary

- IRM APY display values were drifting by a small but visible amount (e.g. 49.96% instead of 50%, 2.37% instead of 2.38%) because the UI used a flat 365 days = `31_536_000s` for spy→apy conversion, while EVK and Lens contracts compute APYs against `SECONDS_PER_YEAR = 365.2425 * 86400 = 31_556_952` (Gregorian year).
- Updated the shared `SECONDS_IN_YEAR` constant to `31_556_952` so display values now round-trip exactly with on-chain math. The fix flows through:
  - Cyclical IRM "Fixed APY" / "Repayment APY" (the originally-reported rendering bug).
  - Earn-vault APY computed from `convertToAssets` rate change in `entities/vault/apy.ts`.
- Reused the same constant for the adaptive-IRM "Adjustment speed x/yr" label, removing a local `SECONDS_PER_YEAR = 31_557_600` (Julian year, also inconsistent with EVK).

## Verification

Spot-checked the spy→apy formula against the contract-encoded rates:

| Input | Old display | New display |
| --- | --- | --- |
| `secondaryRate = ln(1.5) * 1e27 / 31_556_952` | 49.9596% | **50.0000%** |
| `primaryRate ≈ 2.38% APY` | 2.3784% | **2.3800%** |

## Test plan

- [ ] Cyclical-IRM vault overview shows fixed / repayment APYs matching the values the curator configured.
- [ ] Adaptive-IRM vault overview shows the expected `Adjustment speed x/yr` value (e.g. a vault deployed with adjustment speed targeting `50x/yr` no longer displays `50.03x/yr`).
- [ ] Earn-vault APY chips still render and look reasonable (the 0.07% relative shift is imperceptible at 2-dp display precision).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of APY calculations and displays in vault overview screens to ensure consistent rounding with on-chain mathematics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/euler-xyz/euler-lite/pull/469?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->