### PR TITLE
feat: surface vault type badges on pair details page

### DIFF
--- a/components/entities/vault/CyclicalNoteBadge.vue
+++ b/components/entities/vault/CyclicalNoteBadge.vue
@@ -2,10 +2,11 @@
 import { useModal } from '~/components/ui/composables/useModal'
 import { CyclicalNoteInfoModal } from '#components'
 
-const { size = 'small', block = false, as = 'span' } = defineProps<{
+const { size = 'small', block = false, as = 'span', nudge = false } = defineProps<{
   size?: 'small' | 'large'
   block?: boolean
   as?: 'button' | 'span'
+  nudge?: boolean
 }>()
 
 const modal = useModal()
@@ -25,6 +26,7 @@ const openInfoModal = (event: MouseEvent | KeyboardEvent) => {
     tone="accent"
     :size="size"
     :block="block"
+    :nudge="nudge"
     title="Fixed-rate vault with recurring cycles"
     @click="openInfoModal"
   />

--- a/components/entities/vault/CyclicalNoteBadge.vue
+++ b/components/entities/vault/CyclicalNoteBadge.vue
@@ -2,13 +2,15 @@
 import { useModal } from '~/components/ui/composables/useModal'
 import { CyclicalNoteInfoModal } from '#components'
 
-const { size = 'small' } = defineProps<{
+const { size = 'small', block = false, as = 'span' } = defineProps<{
   size?: 'small' | 'large'
+  block?: boolean
+  as?: 'button' | 'span'
 }>()
 
 const modal = useModal()
 
-const openInfoModal = (event: MouseEvent) => {
+const openInfoModal = (event: MouseEvent | KeyboardEvent) => {
   event.preventDefault()
   event.stopPropagation()
   modal.open(CyclicalNoteInfoModal)
@@ -16,32 +18,14 @@ const openInfoModal = (event: MouseEvent) => {
 </script>
 
 <template>
-  <button
-    type="button"
-    class="cyclical-note-badge inline-flex items-center cursor-pointer"
-    :class="size === 'large'
-      ? 'gap-8 py-8 px-12 rounded-8'
-      : 'gap-4 py-2 px-8 rounded-8 text-p5'"
+  <VaultMetadataTag
+    :as="as"
+    icon="refresh"
+    label="Cyclical note"
+    tone="accent"
+    :size="size"
+    :block="block"
     title="Fixed-rate vault with recurring cycles"
     @click="openInfoModal"
-  >
-    <SvgIcon
-      name="refresh"
-      :class="size === 'large' ? '!w-20 !h-20 mr-2' : '!w-14 !h-14'"
-    />
-    Cyclical note
-  </button>
+  />
 </template>
-
-<style scoped lang="scss">
-.cyclical-note-badge {
-  border: 0;
-  background-color: rgba(var(--accent-rgb), 0.15);
-  color: var(--accent-600);
-
-  [data-theme="dark"] & {
-    background-color: rgba(var(--accent-rgb), 0.2);
-    color: var(--accent-500);
-  }
-}
-</style>

--- a/components/entities/vault/GovernanceLimitedBadge.vue
+++ b/components/entities/vault/GovernanceLimitedBadge.vue
@@ -2,10 +2,11 @@
 import { useModal } from '~/components/ui/composables/useModal'
 import { GovernanceLimitedInfoModal } from '#components'
 
-const { size = 'small', block = false, as = 'span' } = defineProps<{
+const { size = 'small', block = false, as = 'span', nudge = false } = defineProps<{
   size?: 'small' | 'large'
   block?: boolean
   as?: 'button' | 'span'
+  nudge?: boolean
 }>()
 
 const modal = useModal()
@@ -22,9 +23,10 @@ const openInfoModal = (event: MouseEvent | KeyboardEvent) => {
     :as="as"
     icon="pulse"
     label="Limited"
-    tone="neutral"
+    tone="accent"
     :size="size"
     :block="block"
+    :nudge="nudge"
     title="This vault has limited risk management"
     @click="openInfoModal"
   />

--- a/components/entities/vault/GovernanceLimitedBadge.vue
+++ b/components/entities/vault/GovernanceLimitedBadge.vue
@@ -2,13 +2,15 @@
 import { useModal } from '~/components/ui/composables/useModal'
 import { GovernanceLimitedInfoModal } from '#components'
 
-const { size = 'small' } = defineProps<{
+const { size = 'small', block = false, as = 'span' } = defineProps<{
   size?: 'small' | 'large'
+  block?: boolean
+  as?: 'button' | 'span'
 }>()
 
 const modal = useModal()
 
-const openInfoModal = (event: MouseEvent) => {
+const openInfoModal = (event: MouseEvent | KeyboardEvent) => {
   event.preventDefault()
   event.stopPropagation()
   modal.open(GovernanceLimitedInfoModal)
@@ -16,30 +18,14 @@ const openInfoModal = (event: MouseEvent) => {
 </script>
 
 <template>
-  <span
-    class="governance-limited-badge inline-flex items-center cursor-pointer"
-    :class="size === 'large'
-      ? 'gap-8 py-8 px-12 rounded-8'
-      : 'gap-4 py-2 px-8 rounded-8 text-p5'"
+  <VaultMetadataTag
+    :as="as"
+    icon="pulse"
+    label="Limited"
+    tone="neutral"
+    :size="size"
+    :block="block"
     title="This vault has limited risk management"
     @click="openInfoModal"
-  >
-    <SvgIcon
-      name="pulse"
-      :class="size === 'large' ? '!w-20 !h-20 mr-2' : '!w-14 !h-14'"
-    />
-    Limited
-  </span>
+  />
 </template>
-
-<style scoped lang="scss">
-.governance-limited-badge {
-  background-color: rgba(var(--accent-rgb), 0.15);
-  color: var(--accent-600);
-
-  [data-theme="dark"] & {
-    background-color: rgba(var(--accent-rgb), 0.2);
-    color: var(--accent-500);
-  }
-}
-</style>

--- a/components/entities/vault/VaultMetadataTag.vue
+++ b/components/entities/vault/VaultMetadataTag.vue
@@ -72,7 +72,7 @@ const onKeydown = (event: KeyboardEvent) => {
 
   &--small {
     padding: 8px 12px;
-    font-size: 14px;
+    font-size: 16px;
 
     .vault-metadata-tag__icon {
       width: 20px;
@@ -195,6 +195,37 @@ const onKeydown = (event: KeyboardEvent) => {
 
   .vault-metadata-tag__info {
     display: block;
+  }
+}
+
+.vault-metadata-tag--small:not(.vault-metadata-tag--block) {
+  gap: 8px;
+  padding: 0;
+  background-color: transparent;
+  border-color: transparent;
+  border-radius: 0;
+
+  .vault-metadata-tag__icon {
+    width: 24px;
+    height: 24px;
+  }
+
+  &:hover {
+    background-color: transparent;
+    border-color: transparent;
+  }
+}
+
+.vault-metadata-tag--small.vault-metadata-tag--governance:not(.vault-metadata-tag--block) {
+  padding: 4px 10px;
+  border-radius: 10px;
+  background-color: rgba(136, 166, 204, 0.1);
+  border-color: rgba(136, 166, 204, 0.3);
+  transform: translateY(-4px);
+
+  &:hover {
+    background-color: rgba(136, 166, 204, 0.14);
+    border-color: rgba(136, 166, 204, 0.4);
   }
 }
 

--- a/components/entities/vault/VaultMetadataTag.vue
+++ b/components/entities/vault/VaultMetadataTag.vue
@@ -6,6 +6,7 @@ const {
   tone = 'neutral',
   size = 'small',
   block = false,
+  nudge = false,
   title,
 } = defineProps<{
   as?: 'button' | 'span'
@@ -14,6 +15,7 @@ const {
   tone?: 'neutral' | 'governance' | 'accent' | 'warn' | 'danger'
   size?: 'small' | 'large'
   block?: boolean
+  nudge?: boolean
   title?: string
 }>()
 
@@ -37,7 +39,10 @@ const onKeydown = (event: KeyboardEvent) => {
     :class="[
       `vault-metadata-tag--${tone}`,
       `vault-metadata-tag--${size}`,
-      { 'vault-metadata-tag--block': block },
+      {
+        'vault-metadata-tag--block': block,
+        'vault-metadata-tag--nudge': nudge,
+      },
     ]"
     :title="title"
     @click="$emit('click', $event)"
@@ -71,12 +76,14 @@ const onKeydown = (event: KeyboardEvent) => {
   transition: background-color 120ms ease, border-color 120ms ease;
 
   &--small {
-    padding: 8px 12px;
-    font-size: 16px;
+    gap: 4px;
+    padding: 2px 8px;
+    border-radius: 8px;
+    font-size: 14px;
 
     .vault-metadata-tag__icon {
-      width: 20px;
-      height: 20px;
+      width: 14px;
+      height: 14px;
     }
 
     .vault-metadata-tag__info {
@@ -198,34 +205,16 @@ const onKeydown = (event: KeyboardEvent) => {
   }
 }
 
-.vault-metadata-tag--small:not(.vault-metadata-tag--block) {
+.vault-metadata-tag--small.vault-metadata-tag--nudge:not(.vault-metadata-tag--block) {
   gap: 8px;
-  padding: 0;
-  background-color: transparent;
-  border-color: transparent;
-  border-radius: 0;
+  padding: 4px 10px;
+  border-radius: 10px;
+  font-size: 16px;
+  transform: translateY(-4px);
 
   .vault-metadata-tag__icon {
     width: 24px;
     height: 24px;
-  }
-
-  &:hover {
-    background-color: transparent;
-    border-color: transparent;
-  }
-}
-
-.vault-metadata-tag--small.vault-metadata-tag--governance:not(.vault-metadata-tag--block) {
-  padding: 4px 10px;
-  border-radius: 10px;
-  background-color: rgba(136, 166, 204, 0.1);
-  border-color: rgba(136, 166, 204, 0.3);
-  transform: translateY(-4px);
-
-  &:hover {
-    background-color: rgba(136, 166, 204, 0.14);
-    border-color: rgba(136, 166, 204, 0.4);
   }
 }
 

--- a/components/entities/vault/VaultMetadataTag.vue
+++ b/components/entities/vault/VaultMetadataTag.vue
@@ -1,0 +1,204 @@
+<script setup lang="ts">
+const {
+  as = 'span',
+  icon,
+  label,
+  tone = 'neutral',
+  size = 'small',
+  block = false,
+  title,
+} = defineProps<{
+  as?: 'button' | 'span'
+  icon: string
+  label: string
+  tone?: 'neutral' | 'governance' | 'accent' | 'warn' | 'danger'
+  size?: 'small' | 'large'
+  block?: boolean
+  title?: string
+}>()
+
+const emit = defineEmits<{ click: [event: MouseEvent | KeyboardEvent] }>()
+
+const onKeydown = (event: KeyboardEvent) => {
+  if (as === 'button') return
+  if (event.key !== 'Enter' && event.key !== ' ') return
+  event.preventDefault()
+  emit('click', event)
+}
+</script>
+
+<template>
+  <component
+    :is="as"
+    :type="as === 'button' ? 'button' : undefined"
+    :role="as === 'span' ? 'button' : undefined"
+    :tabindex="as === 'span' ? 0 : undefined"
+    class="vault-metadata-tag"
+    :class="[
+      `vault-metadata-tag--${tone}`,
+      `vault-metadata-tag--${size}`,
+      { 'vault-metadata-tag--block': block },
+    ]"
+    :title="title"
+    @click="$emit('click', $event)"
+    @keydown="onKeydown"
+  >
+    <SvgIcon
+      :name="icon"
+      class="vault-metadata-tag__icon"
+    />
+    <span class="vault-metadata-tag__label">{{ label }}</span>
+    <span class="vault-metadata-tag__spacer" />
+    <SvgIcon
+      name="info-circle"
+      class="vault-metadata-tag__info"
+    />
+  </component>
+</template>
+
+<style scoped lang="scss">
+.vault-metadata-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid;
+  border-radius: 10px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 500;
+  line-height: 1.2;
+  text-align: left;
+  transition: background-color 120ms ease, border-color 120ms ease;
+
+  &--small {
+    padding: 8px 12px;
+    font-size: 14px;
+
+    .vault-metadata-tag__icon {
+      width: 20px;
+      height: 20px;
+    }
+
+    .vault-metadata-tag__info {
+      display: none;
+      width: 11px;
+      height: 11px;
+    }
+  }
+
+  &--large {
+    gap: 10px;
+    padding: 12px 15px;
+    font-size: 14.5px;
+
+    .vault-metadata-tag__icon {
+      width: 16px;
+      height: 16px;
+    }
+
+    .vault-metadata-tag__info {
+      width: 12.5px;
+      height: 12.5px;
+    }
+  }
+
+  &--block {
+    width: 100%;
+  }
+
+  &--neutral {
+    background-color: transparent;
+    border-color: var(--border-subtle);
+    color: var(--content-primary);
+
+    &:hover {
+      background-color: var(--bg-card-hover);
+      border-color: var(--border-emphasis);
+    }
+
+    [data-theme="dark"] & {
+      border-color: rgba(255, 255, 255, 0.1);
+
+      &:hover {
+        background-color: rgba(255, 255, 255, 0.04);
+        border-color: rgba(255, 255, 255, 0.18);
+      }
+    }
+  }
+
+  &--accent {
+    background-color: rgba(34, 211, 160, 0.08);
+    border-color: rgba(34, 211, 160, 0.28);
+    color: #22d3a0;
+
+    &:hover {
+      background-color: rgba(34, 211, 160, 0.12);
+      border-color: rgba(34, 211, 160, 0.38);
+    }
+  }
+
+  &--governance {
+    background-color: rgba(136, 166, 204, 0.1);
+    border-color: rgba(136, 166, 204, 0.3);
+    color: #88a6cc;
+
+    &:hover {
+      background-color: rgba(136, 166, 204, 0.14);
+      border-color: rgba(136, 166, 204, 0.4);
+    }
+  }
+
+  &--warn {
+    background-color: rgba(242, 177, 68, 0.13);
+    border-color: rgba(242, 177, 68, 0.32);
+    color: #f2b144;
+
+    &:hover {
+      background-color: rgba(242, 177, 68, 0.17);
+      border-color: rgba(242, 177, 68, 0.42);
+    }
+  }
+
+  &--danger {
+    background-color: rgba(var(--error-rgb), 0.14);
+    border-color: rgba(var(--error-rgb), 0.42);
+    color: var(--error-500);
+
+    &:hover {
+      background-color: rgba(var(--error-rgb), 0.18);
+      border-color: rgba(var(--error-rgb), 0.52);
+    }
+  }
+}
+
+.vault-metadata-tag__icon,
+.vault-metadata-tag__info {
+  flex-shrink: 0;
+}
+
+.vault-metadata-tag__label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.vault-metadata-tag__spacer {
+  display: none;
+}
+
+.vault-metadata-tag--block {
+  .vault-metadata-tag__spacer {
+    display: block;
+    flex: 1 1 auto;
+  }
+
+  .vault-metadata-tag__info {
+    display: block;
+  }
+}
+
+.vault-metadata-tag__info {
+  opacity: 0.55;
+}
+</style>

--- a/components/entities/vault/VaultTypeBadges.vue
+++ b/components/entities/vault/VaultTypeBadges.vue
@@ -6,10 +6,11 @@ import { isCyclicalNoteVault } from '~/entities/vault'
 import { isVaultKeyring, getEntitiesByVault, getEntitiesByEarnVault } from '~/utils/eulerLabelsUtils'
 import { useEulerProductOfVault } from '~/composables/useEulerLabels'
 
-const { vault, layout = 'inline', size = 'small' } = defineProps<{
+const { vault, layout = 'inline', size = 'small', nudge = false } = defineProps<{
   vault: AnyVault
   layout?: 'inline' | 'stacked'
   size?: 'small' | 'large'
+  nudge?: boolean
 }>()
 
 const { isVaultGovernorVerified, isEarnVaultOwnerVerified } = useVaults()
@@ -76,6 +77,7 @@ const tagElement = computed(() => isStacked.value ? 'button' : 'span')
       :size="size"
       :block="isStacked"
       :as="tagElement"
+      :nudge="nudge"
     />
     <VaultTypeChip
       v-if="extraType && isVerified"
@@ -84,24 +86,28 @@ const tagElement = computed(() => isStacked.value ? 'button' : 'span')
       :size="size"
       :block="isStacked"
       :as="tagElement"
+      :nudge="nudge"
     />
     <KeyringBadge
       v-if="isKeyring && isVerified"
       :size="size"
       :block="isStacked"
       :as="tagElement"
+      :nudge="nudge"
     />
     <GovernanceLimitedBadge
       v-if="isGovernanceLimited"
       :size="size"
       :block="isStacked"
       :as="tagElement"
+      :nudge="nudge"
     />
     <CyclicalNoteBadge
       v-if="isCyclicalNote && isVerified"
       :size="size"
       :block="isStacked"
       :as="tagElement"
+      :nudge="nudge"
     />
   </div>
 </template>

--- a/components/entities/vault/VaultTypeBadges.vue
+++ b/components/entities/vault/VaultTypeBadges.vue
@@ -6,8 +6,10 @@ import { isCyclicalNoteVault } from '~/entities/vault'
 import { isVaultKeyring, getEntitiesByVault, getEntitiesByEarnVault } from '~/utils/eulerLabelsUtils'
 import { useEulerProductOfVault } from '~/composables/useEulerLabels'
 
-const { vault } = defineProps<{
+const { vault, layout = 'inline', size = 'small' } = defineProps<{
   vault: AnyVault
+  layout?: 'inline' | 'stacked'
+  size?: 'small' | 'large'
 }>()
 
 const { isVaultGovernorVerified, isEarnVaultOwnerVerified } = useVaults()
@@ -58,30 +60,48 @@ const isCyclicalNote = computed(() => {
   if (isEarn.value || isSecuritize.value) return false
   return isCyclicalNoteVault(vault as Vault)
 })
+
+const isStacked = computed(() => layout === 'stacked')
+const tagElement = computed(() => isStacked.value ? 'button' : 'span')
 </script>
 
 <template>
-  <div class="flex items-center gap-8 flex-wrap">
+  <div
+    class="flex gap-8"
+    :class="isStacked ? 'flex-col items-stretch' : 'items-center flex-wrap'"
+  >
     <VaultTypeChip
       :vault="vault"
       :type="governanceType"
+      :size="size"
+      :block="isStacked"
+      :as="tagElement"
     />
     <VaultTypeChip
       v-if="extraType && isVerified"
       :vault="vault"
       :type="extraType"
+      :size="size"
+      :block="isStacked"
+      :as="tagElement"
     />
     <KeyringBadge
       v-if="isKeyring && isVerified"
-      size="large"
+      :size="size"
+      :block="isStacked"
+      :as="tagElement"
     />
     <GovernanceLimitedBadge
       v-if="isGovernanceLimited"
-      size="large"
+      :size="size"
+      :block="isStacked"
+      :as="tagElement"
     />
     <CyclicalNoteBadge
       v-if="isCyclicalNote && isVerified"
-      size="large"
+      :size="size"
+      :block="isStacked"
+      :as="tagElement"
     />
   </div>
 </template>

--- a/components/entities/vault/VaultTypeChip.vue
+++ b/components/entities/vault/VaultTypeChip.vue
@@ -4,9 +4,12 @@ import { getVaultTypeLabel, getVaultTypeDescription } from '~/entities/vault/des
 import { useModal } from '~/components/ui/composables/useModal'
 import { VaultTypeInfoModal } from '#components'
 
-const { type, vault } = defineProps<{
+const { type, vault, size = 'small', block = false, as = 'span' } = defineProps<{
   type: string
   vault: Vault | EarnVault | SecuritizeVault
+  size?: 'small' | 'large'
+  block?: boolean
+  as?: 'button' | 'span'
 }>()
 
 const modal = useModal()
@@ -35,7 +38,7 @@ const icon = computed(() => {
   switch (type) {
     case 'governed':
     case 'managed':
-      return 'bank'
+      return 'governed'
     case 'escrow':
     case 'securitize':
       return 'shield'
@@ -52,6 +55,12 @@ const label = computed(() => {
 
 const effectiveType = computed(() => isVerified.value ? type : 'unknown')
 
+const tone = computed(() => {
+  if (isWarning.value) return 'danger'
+  if (type === 'governed' || type === 'ungoverned' || type === 'managed' || type === 'edge') return 'governance'
+  return 'neutral'
+})
+
 const openModal = () => {
   modal.open(VaultTypeInfoModal, {
     props: {
@@ -63,37 +72,13 @@ const openModal = () => {
 </script>
 
 <template>
-  <div
-    class="vault-type-chip flex gap-8 items-center py-8 px-12 rounded-8 cursor-pointer"
-    :class="{ 'vault-type-chip--warning': isWarning }"
+  <VaultMetadataTag
+    :as="as"
+    :icon="icon"
+    :label="label"
+    :tone="tone"
+    :size="size"
+    :block="block"
     @click="openModal"
-  >
-    <UiIcon
-      class="mr-2 !w-20 !h-20"
-      :name="icon"
-    />
-    {{ label }}
-  </div>
+  />
 </template>
-
-<style scoped lang="scss">
-.vault-type-chip {
-  background-color: rgba(var(--accent-rgb), 0.15);
-  color: var(--accent-600);
-
-  [data-theme="dark"] & {
-    background-color: rgba(var(--accent-rgb), 0.2);
-    color: var(--accent-500);
-  }
-
-  &--warning {
-    background-color: rgba(var(--error-rgb), 0.1);
-    color: var(--error-500);
-
-    [data-theme="dark"] & {
-      background-color: rgba(var(--error-rgb), 0.1);
-      color: var(--error-500);
-    }
-  }
-}
-</style>

--- a/components/entities/vault/VaultTypeChip.vue
+++ b/components/entities/vault/VaultTypeChip.vue
@@ -4,12 +4,13 @@ import { getVaultTypeLabel, getVaultTypeDescription } from '~/entities/vault/des
 import { useModal } from '~/components/ui/composables/useModal'
 import { VaultTypeInfoModal } from '#components'
 
-const { type, vault, size = 'small', block = false, as = 'span' } = defineProps<{
+const { type, vault, size = 'small', block = false, as = 'span', nudge = false } = defineProps<{
   type: string
   vault: Vault | EarnVault | SecuritizeVault
   size?: 'small' | 'large'
   block?: boolean
   as?: 'button' | 'span'
+  nudge?: boolean
 }>()
 
 const modal = useModal()
@@ -79,6 +80,7 @@ const openModal = () => {
     :tone="tone"
     :size="size"
     :block="block"
+    :nudge="nudge"
     @click="openModal"
   />
 </template>

--- a/components/entities/vault/VaultTypeChip.vue
+++ b/components/entities/vault/VaultTypeChip.vue
@@ -57,7 +57,7 @@ const effectiveType = computed(() => isVerified.value ? type : 'unknown')
 
 const tone = computed(() => {
   if (isWarning.value) return 'danger'
-  if (type === 'governed' || type === 'ungoverned' || type === 'managed' || type === 'edge') return 'governance'
+  if (type === 'governed' || type === 'ungoverned' || type === 'managed') return 'governance'
   return 'neutral'
 })
 

--- a/components/entities/vault/overview/SecuritizeVaultOverview.vue
+++ b/components/entities/vault/overview/SecuritizeVaultOverview.vue
@@ -250,7 +250,10 @@ const supplyCapPercentageDisplay = computed(() => {
           v-if="enableVaultTypeDisplay"
           label="Vault type"
         >
-          <VaultTypeBadges :vault="vault" />
+          <VaultTypeBadges
+            :vault="vault"
+            nudge
+          />
         </VaultOverviewLabelValue>
         <VaultOverviewLabelValue label="Can be borrowed">
           <div class="flex items-center gap-8">

--- a/components/entities/vault/overview/SecuritizeVaultOverview.vue
+++ b/components/entities/vault/overview/SecuritizeVaultOverview.vue
@@ -241,6 +241,7 @@ const supplyCapPercentageDisplay = computed(() => {
             v-else-if="!isGovernorVerified"
             :vault="vault"
             type="unknown"
+            nudge
           />
           <div v-else>
             -

--- a/components/entities/vault/overview/SecuritizeVaultOverview.vue
+++ b/components/entities/vault/overview/SecuritizeVaultOverview.vue
@@ -227,6 +227,7 @@ const supplyCapPercentageDisplay = computed(() => {
               <BaseAvatar
                 :label="entity.name"
                 :src="getEulerLabelEntityLogo(entity.logo)"
+                class="!w-28 !h-28"
               />
               <a
                 :href="entity.url"

--- a/components/entities/vault/overview/VaultOverviewBlockGeneral.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockGeneral.vue
@@ -113,6 +113,7 @@ watchEffect(async () => {
             v-if="!isGovernorVerified"
             :vault="vault"
             type="unknown"
+            nudge
             class="w-fit"
           />
           <div

--- a/components/entities/vault/overview/VaultOverviewBlockGeneral.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockGeneral.vue
@@ -128,6 +128,7 @@ watchEffect(async () => {
               <BaseAvatar
                 :label="entity.name"
                 :src="getEulerLabelEntityLogo(entity.logo)"
+                class="!w-28 !h-28"
               />
               <a
                 v-if="entity.url"

--- a/components/entities/vault/overview/VaultOverviewBlockGeneral.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockGeneral.vue
@@ -151,7 +151,10 @@ watchEffect(async () => {
           v-if="enableVaultTypeDisplay"
           label="Vault type"
         >
-          <VaultTypeBadges :vault="vault" />
+          <VaultTypeBadges
+            :vault="vault"
+            nudge
+          />
         </VaultOverviewLabelValue>
         <VaultOverviewLabelValue label="Can be borrowed">
           <div class="flex items-center gap-8">

--- a/components/entities/vault/overview/VaultOverviewPair.vue
+++ b/components/entities/vault/overview/VaultOverviewPair.vue
@@ -13,6 +13,9 @@ defineProps<{ pair: AnyBorrowVaultPair | AccountBorrowPosition, desktopOverview?
     <VaultOverviewPairBlockGeneral
       :pair="pair"
     />
+    <VaultOverviewPairBlockTypes
+      :pair="pair"
+    />
     <!-- Oracle adapters should always come from the liability (borrow) vault -->
     <VaultOverviewBlockOracleAdapters
       :vault="pair.borrow"

--- a/components/entities/vault/overview/VaultOverviewPairBlockTypes.vue
+++ b/components/entities/vault/overview/VaultOverviewPairBlockTypes.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+import type { AnyBorrowVaultPair } from '~/entities/vault'
+import type { AccountBorrowPosition } from '~/entities/account'
+
+defineProps<{ pair: AnyBorrowVaultPair | AccountBorrowPosition }>()
+</script>
+
+<template>
+  <div class="bg-surface-secondary rounded-xl flex flex-col gap-24 p-24 shadow-card">
+    <p class="text-h3 text-content-primary">
+      Vault types
+    </p>
+    <div class="flex flex-col gap-12">
+      <div class="w-full rounded-xl bg-surface p-16 flex flex-col gap-12 border border-line-subtle">
+        <div class="flex items-center justify-between gap-8">
+          <div class="flex items-center gap-8 min-w-0">
+            <AssetAvatar
+              :asset="pair.collateral.asset"
+              size="20"
+            />
+            <span class="text-p2 font-semibold text-content-primary truncate">
+              {{ pair.collateral.asset.symbol }}
+            </span>
+          </div>
+          <span class="text-p4 text-content-tertiary uppercase tracking-wide flex-shrink-0">
+            Collateral
+          </span>
+        </div>
+        <VaultTypeBadges :vault="pair.collateral" />
+      </div>
+
+      <div class="w-full rounded-xl bg-surface p-16 flex flex-col gap-12 border border-line-subtle">
+        <div class="flex items-center justify-between gap-8">
+          <div class="flex items-center gap-8 min-w-0">
+            <AssetAvatar
+              :asset="pair.borrow.asset"
+              size="20"
+            />
+            <span class="text-p2 font-semibold text-content-primary truncate">
+              {{ pair.borrow.asset.symbol }}
+            </span>
+          </div>
+          <span class="text-p4 text-content-tertiary uppercase tracking-wide flex-shrink-0">
+            Borrow
+          </span>
+        </div>
+        <VaultTypeBadges :vault="pair.borrow" />
+      </div>
+    </div>
+  </div>
+</template>

--- a/components/entities/vault/overview/VaultOverviewPairBlockTypes.vue
+++ b/components/entities/vault/overview/VaultOverviewPairBlockTypes.vue
@@ -12,10 +12,7 @@ defineProps<{ pair: AnyBorrowVaultPair | AccountBorrowPosition }>()
     </p>
     <div class="grid grid-cols-[1fr_1px_1fr] gap-20 items-stretch">
       <div class="min-w-0 flex flex-col gap-12">
-        <div class="flex items-center gap-8 min-w-0">
-          <span class="text-[10px] tracking-[0.08em] uppercase text-content-tertiary font-semibold shrink-0">
-            Collateral
-          </span>
+        <div class="flex items-center gap-8 min-w-0 pl-2">
           <AssetAvatar
             :asset="pair.collateral.asset"
             size="20"
@@ -34,10 +31,7 @@ defineProps<{ pair: AnyBorrowVaultPair | AccountBorrowPosition }>()
       <div class="vault-types-divider w-[1px]" />
 
       <div class="min-w-0 flex flex-col gap-12">
-        <div class="flex items-center gap-8 min-w-0">
-          <span class="text-[10px] tracking-[0.08em] uppercase text-content-tertiary font-semibold shrink-0">
-            Debt
-          </span>
+        <div class="flex items-center gap-8 min-w-0 pl-2">
           <AssetAvatar
             :asset="pair.borrow.asset"
             size="20"

--- a/components/entities/vault/overview/VaultOverviewPairBlockTypes.vue
+++ b/components/entities/vault/overview/VaultOverviewPairBlockTypes.vue
@@ -10,32 +10,58 @@ defineProps<{ pair: AnyBorrowVaultPair | AccountBorrowPosition }>()
     <p class="text-h3 text-content-primary">
       Vault types
     </p>
-    <div class="flex flex-col gap-12">
-      <div class="w-full rounded-xl bg-surface p-16 flex flex-col gap-12 border border-line-subtle">
+    <div class="grid grid-cols-[1fr_1px_1fr] gap-20 items-stretch">
+      <div class="min-w-0 flex flex-col gap-12">
         <div class="flex items-center gap-8 min-w-0">
+          <span class="text-[10px] tracking-[0.08em] uppercase text-content-tertiary font-semibold shrink-0">
+            Collateral
+          </span>
           <AssetAvatar
             :asset="pair.collateral.asset"
             size="20"
           />
-          <span class="text-p2 font-semibold text-content-primary truncate">
+          <span class="text-[14px] leading-none font-semibold text-content-primary truncate">
             {{ pair.collateral.asset.symbol }}
           </span>
         </div>
-        <VaultTypeBadges :vault="pair.collateral" />
+        <VaultTypeBadges
+          :vault="pair.collateral"
+          layout="stacked"
+          size="large"
+        />
       </div>
 
-      <div class="w-full rounded-xl bg-surface p-16 flex flex-col gap-12 border border-line-subtle">
+      <div class="vault-types-divider w-[1px]" />
+
+      <div class="min-w-0 flex flex-col gap-12">
         <div class="flex items-center gap-8 min-w-0">
+          <span class="text-[10px] tracking-[0.08em] uppercase text-content-tertiary font-semibold shrink-0">
+            Debt
+          </span>
           <AssetAvatar
             :asset="pair.borrow.asset"
             size="20"
           />
-          <span class="text-p2 font-semibold text-content-primary truncate">
+          <span class="text-[14px] leading-none font-semibold text-content-primary truncate">
             {{ pair.borrow.asset.symbol }}
           </span>
         </div>
-        <VaultTypeBadges :vault="pair.borrow" />
+        <VaultTypeBadges
+          :vault="pair.borrow"
+          layout="stacked"
+          size="large"
+        />
       </div>
     </div>
   </div>
 </template>
+
+<style scoped lang="scss">
+.vault-types-divider {
+  background-color: rgba(0, 0, 0, 0.04);
+
+  [data-theme="dark"] & {
+    background-color: rgba(255, 255, 255, 0.04);
+  }
+}
+</style>

--- a/components/entities/vault/overview/VaultOverviewPairBlockTypes.vue
+++ b/components/entities/vault/overview/VaultOverviewPairBlockTypes.vue
@@ -12,36 +12,26 @@ defineProps<{ pair: AnyBorrowVaultPair | AccountBorrowPosition }>()
     </p>
     <div class="flex flex-col gap-12">
       <div class="w-full rounded-xl bg-surface p-16 flex flex-col gap-12 border border-line-subtle">
-        <div class="flex items-center justify-between gap-8">
-          <div class="flex items-center gap-8 min-w-0">
-            <AssetAvatar
-              :asset="pair.collateral.asset"
-              size="20"
-            />
-            <span class="text-p2 font-semibold text-content-primary truncate">
-              {{ pair.collateral.asset.symbol }}
-            </span>
-          </div>
-          <span class="text-p4 text-content-tertiary uppercase tracking-wide flex-shrink-0">
-            Collateral
+        <div class="flex items-center gap-8 min-w-0">
+          <AssetAvatar
+            :asset="pair.collateral.asset"
+            size="20"
+          />
+          <span class="text-p2 font-semibold text-content-primary truncate">
+            {{ pair.collateral.asset.symbol }}
           </span>
         </div>
         <VaultTypeBadges :vault="pair.collateral" />
       </div>
 
       <div class="w-full rounded-xl bg-surface p-16 flex flex-col gap-12 border border-line-subtle">
-        <div class="flex items-center justify-between gap-8">
-          <div class="flex items-center gap-8 min-w-0">
-            <AssetAvatar
-              :asset="pair.borrow.asset"
-              size="20"
-            />
-            <span class="text-p2 font-semibold text-content-primary truncate">
-              {{ pair.borrow.asset.symbol }}
-            </span>
-          </div>
-          <span class="text-p4 text-content-tertiary uppercase tracking-wide flex-shrink-0">
-            Borrow
+        <div class="flex items-center gap-8 min-w-0">
+          <AssetAvatar
+            :asset="pair.borrow.asset"
+            size="20"
+          />
+          <span class="text-p2 font-semibold text-content-primary truncate">
+            {{ pair.borrow.asset.symbol }}
           </span>
         </div>
         <VaultTypeBadges :vault="pair.borrow" />

--- a/components/entities/vault/overview/earn/VaultOverviewEarnBlockGeneral.vue
+++ b/components/entities/vault/overview/earn/VaultOverviewEarnBlockGeneral.vue
@@ -126,7 +126,10 @@ const feeDisplay = computed(() => {
           v-if="enableVaultTypeDisplay"
           label="Vault type"
         >
-          <VaultTypeBadges :vault="vault" />
+          <VaultTypeBadges
+            :vault="vault"
+            nudge
+          />
         </VaultOverviewLabelValue>
       </div>
     </div>

--- a/components/entities/vault/overview/earn/VaultOverviewEarnBlockGeneral.vue
+++ b/components/entities/vault/overview/earn/VaultOverviewEarnBlockGeneral.vue
@@ -119,6 +119,7 @@ const feeDisplay = computed(() => {
             v-else
             :vault="vault"
             type="unknown"
+            nudge
             class="w-fit"
           />
         </VaultOverviewLabelValue>

--- a/components/keyring/KeyringBadge.vue
+++ b/components/keyring/KeyringBadge.vue
@@ -2,10 +2,11 @@
 import { useModal } from '~/components/ui/composables/useModal'
 import { KeyringInfoModal } from '#components'
 
-const { size = 'small', block = false, as = 'span' } = defineProps<{
+const { size = 'small', block = false, as = 'span', nudge = false } = defineProps<{
   size?: 'small' | 'large'
   block?: boolean
   as?: 'button' | 'span'
+  nudge?: boolean
 }>()
 
 const modal = useModal()
@@ -25,6 +26,7 @@ const openKeyringInfoModal = (event: MouseEvent | KeyboardEvent) => {
     tone="accent"
     :size="size"
     :block="block"
+    :nudge="nudge"
     title="This vault requires identity verification"
     @click="openKeyringInfoModal"
   />

--- a/components/keyring/KeyringBadge.vue
+++ b/components/keyring/KeyringBadge.vue
@@ -2,13 +2,15 @@
 import { useModal } from '~/components/ui/composables/useModal'
 import { KeyringInfoModal } from '#components'
 
-const { size = 'small' } = defineProps<{
+const { size = 'small', block = false, as = 'span' } = defineProps<{
   size?: 'small' | 'large'
+  block?: boolean
+  as?: 'button' | 'span'
 }>()
 
 const modal = useModal()
 
-const openKeyringInfoModal = (event: MouseEvent) => {
+const openKeyringInfoModal = (event: MouseEvent | KeyboardEvent) => {
   event.preventDefault()
   event.stopPropagation()
   modal.open(KeyringInfoModal)
@@ -16,30 +18,14 @@ const openKeyringInfoModal = (event: MouseEvent) => {
 </script>
 
 <template>
-  <span
-    class="keyring-badge inline-flex items-center cursor-pointer"
-    :class="size === 'large'
-      ? 'gap-8 py-8 px-12 rounded-8'
-      : 'gap-4 py-2 px-8 rounded-8 text-p5'"
+  <VaultMetadataTag
+    :as="as"
+    icon="shield"
+    label="Private"
+    tone="accent"
+    :size="size"
+    :block="block"
     title="This vault requires identity verification"
     @click="openKeyringInfoModal"
-  >
-    <SvgIcon
-      name="shield"
-      :class="size === 'large' ? '!w-20 !h-20 mr-2' : '!w-14 !h-14'"
-    />
-    Private
-  </span>
+  />
 </template>
-
-<style scoped lang="scss">
-.keyring-badge {
-  background-color: rgba(var(--accent-rgb), 0.15);
-  color: var(--accent-600);
-
-  [data-theme="dark"] & {
-    background-color: rgba(var(--accent-rgb), 0.2);
-    color: var(--accent-500);
-  }
-}
-</style>

--- a/composables/useEulerAddresses.ts
+++ b/composables/useEulerAddresses.ts
@@ -51,8 +51,6 @@ interface EulerChainConfig {
     peripheryAddrs: {
       adaptiveCurveIRMFactory: string
       capRiskStewardFactory?: string
-      edgeFactory: string
-      edgeFactoryPerspective: string
       escrowedCollateralPerspective: string
       eulerEarnFactoryPerspective: string
       eulerEarnGovernedPerspective: string
@@ -195,8 +193,6 @@ export const useEulerAddresses = () => {
     return {
       adaptiveCurveIRMFactory: config.addresses.peripheryAddrs.adaptiveCurveIRMFactory,
       capRiskStewardFactory: config.addresses.peripheryAddrs.capRiskStewardFactory,
-      edgeFactory: config.addresses.peripheryAddrs.edgeFactory,
-      edgeFactoryPerspective: config.addresses.peripheryAddrs.edgeFactoryPerspective,
       escrowedCollateralPerspective: config.addresses.peripheryAddrs.escrowedCollateralPerspective,
       eulerEarnFactoryPerspective: config.addresses.peripheryAddrs.eulerEarnFactoryPerspective,
       eulerEarnGovernedPerspective: config.addresses.peripheryAddrs.eulerEarnGovernedPerspective,


### PR DESCRIPTION
## Summary
- Adds a **Vault types** card between Overview and Oracles on the borrow pair details view, showing the collateral and borrow vaults side by side with their governance chip and trait badges (private/keyring, cyclical note, governance-limited, securitize).
- Previously, users had to switch to the per-vault tab to discover special vault traits — now they're visible at the pair level.
- Reuses the existing `VaultTypeBadges` component; no new badge logic was introduced.

## Test plan
- [ ] Open a pair where one or both vaults are private (Keyring) — confirm the "Private" badge shows on the correct side
- [ ] Open a pair involving a cyclical-note vault (e.g. fixed-rate) — confirm the cyclical note badge shows on the correct side
- [ ] Open a pair with a governance-limited or securitize vault — confirm corresponding badges render
- [ ] Open a plain pair (e.g. wstETH/WETH) — confirm only the governance chip shows per vault and layout looks fine
- [ ] Switch through Pair details → collateral → borrow tabs; ensure no regressions
- [ ] Open an existing borrow position (AccountBorrowPosition path) and confirm the new card still renders correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Vault overview adds a "Vault types" block showing collateral and borrow asset types with badges.

* **UI Improvements**
  * Introduced a reusable metadata tag for badges with size, layout (inline/stacked), block, and nudge options; type chips, keyring and governance badges unified for consistent look.
  * Avatar sizing tightened in several vault overview cards.

* **Accessibility**
  * Metadata tags and badges support keyboard activation alongside mouse clicks.

* **Chores**
  * Removed unused periphery address fields (non-user-facing).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/euler-xyz/euler-lite/pull/470?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->