### PR TITLE
fix: simplify toast styling

### DIFF
--- a/components/ui/UiToast.vue
+++ b/components/ui/UiToast.vue
@@ -25,8 +25,8 @@ const hasAction = computed(() => !!props.actionText)
 const iconName = computed(() => {
   const iconMap: Record<ToastVariant, string> = {
     info: 'info-circle',
-    success: 'check-circle',
-    warning: 'info-circle',
+    success: 'check',
+    warning: 'warning',
     error: 'warning-circle',
     neutral: 'info-circle',
   }
@@ -79,7 +79,9 @@ if (!props.persistent && props.duration > 0) {
         </div>
         <button
           v-if="!persistent"
+          type="button"
           class="ui-toast__close"
+          aria-label="Close notification"
           @click="$emit('close')"
         >
           <UiIcon
@@ -93,6 +95,7 @@ if (!props.persistent && props.duration > 0) {
         class="ui-toast__action"
       >
         <button
+          type="button"
           class="ui-toast__action-button"
           @click="$emit('action')"
         >
@@ -111,49 +114,51 @@ if (!props.persistent && props.duration > 0) {
 .ui-toast {
   display: flex;
   flex-direction: column;
+  align-items: stretch;
   width: 100%;
-  border-radius: var(--radius-xl);
-  border: 1px solid;
-  box-shadow: var(--shadow-lg);
-  backdrop-filter: blur(20px);
+  min-width: min(220px, 100%);
+  max-width: 320px;
+  color: var(--ui-toast-neutral-text-color);
+  background-color: var(--ui-toast-background-color);
+  border: 1px solid var(--ui-toast-neutral-border-color);
+  border-radius: var(--radius-md);
+  box-shadow: var(--ui-toast-box-shadow);
   overflow: hidden;
 
-  // Variant colors
   &--info {
-    border-color: var(--ui-toast-info-border-color);
-    background: var(--ui-toast-info-background-color);
-    color: var(--ui-toast-info-text-color);
+    .ui-toast__icon {
+      color: var(--ui-toast-info-text-color);
+    }
   }
 
   &--success {
-    border-color: var(--ui-toast-success-border-color);
-    background: var(--ui-toast-success-background-color);
-    color: var(--ui-toast-success-text-color);
+    .ui-toast__icon {
+      color: var(--ui-toast-success-text-color);
+    }
   }
 
   &--warning {
-    border-color: var(--ui-toast-warning-border-color);
-    background: var(--ui-toast-warning-background-color);
-    color: var(--ui-toast-warning-text-color);
+    .ui-toast__icon {
+      color: var(--ui-toast-warning-text-color);
+    }
   }
 
   &--error {
-    border-color: var(--ui-toast-error-border-color);
-    background: var(--ui-toast-error-background-color);
-    color: var(--ui-toast-error-text-color);
+    .ui-toast__icon {
+      color: var(--ui-toast-error-text-color);
+    }
   }
 
   &--neutral {
-    border-color: var(--ui-toast-neutral-border-color);
-    background: var(--ui-toast-neutral-background-color);
-    color: var(--ui-toast-neutral-text-color);
+    .ui-toast__icon {
+      color: var(--text-tertiary);
+    }
   }
 
-  // Size variants
   &--normal {
     .ui-toast__body {
-      padding: 16px;
-      gap: 12px;
+      padding: 12px 14px;
+      gap: 10px;
     }
 
     .ui-toast__title {
@@ -163,24 +168,29 @@ if (!props.persistent && props.duration > 0) {
     }
 
     .ui-toast__description {
-      font-size: 14px;
-      line-height: 20px;
+      font-size: 13px;
+      line-height: 18px;
     }
 
     .ui-toast__icon {
-      width: 20px;
-      height: 20px;
+      width: 18px;
+      height: 18px;
     }
 
     .ui-toast__action {
-      padding: 12px 16px;
+      padding: 0 14px 12px 42px;
+    }
+
+    .ui-toast__action-button {
+      font-size: 13px;
+      line-height: 18px;
     }
   }
 
   &--compact {
     .ui-toast__body {
-      padding: 12px;
-      gap: 8px;
+      padding: 12px 14px;
+      gap: 10px;
     }
 
     .ui-toast__content {
@@ -204,7 +214,12 @@ if (!props.persistent && props.duration > 0) {
     }
 
     .ui-toast__action {
-      padding: 8px 12px;
+      padding: 0 14px 12px 40px;
+    }
+
+    .ui-toast__action-button {
+      font-size: 12px;
+      line-height: 16px;
     }
 
     .ui-toast__action-icon {
@@ -213,10 +228,10 @@ if (!props.persistent && props.duration > 0) {
     }
   }
 
-  // Structure
   &__body {
     display: flex;
     align-items: center;
+    width: 100%;
   }
 
   &__icon {
@@ -228,6 +243,8 @@ if (!props.persistent && props.duration > 0) {
     flex-direction: column;
     flex: 1;
     min-width: 0;
+    align-self: center;
+    gap: 2px;
   }
 
   &__title,
@@ -236,8 +253,12 @@ if (!props.persistent && props.duration > 0) {
     text-align: left;
   }
 
+  &__title {
+    color: var(--text-primary);
+  }
+
   &__description {
-    opacity: 0.8;
+    color: var(--text-secondary);
   }
 
   &__close {
@@ -245,33 +266,35 @@ if (!props.persistent && props.duration > 0) {
     align-items: center;
     justify-content: center;
     flex-shrink: 0;
-    width: 24px;
-    height: 24px;
+    width: 20px;
+    height: 20px;
     padding: 0;
-    background: none;
+    background: transparent;
     border: none;
     border-radius: var(--radius-sm);
     cursor: pointer;
-    color: currentColor;
-    opacity: 0.5;
-    transition: opacity var(--duration-fast) var(--ease-default);
+    color: var(--text-tertiary);
+    transition: background-color var(--trs-fast), color var(--trs-fast);
 
     &:hover {
-      opacity: 1;
+      color: var(--text-primary);
+      background-color: var(--ui-button-secondary-ghost-hover-background-color);
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--focus-ring);
+      outline-offset: 2px;
     }
   }
 
   &__close-icon {
-    width: 14px;
-    height: 14px;
+    width: 16px;
+    height: 16px;
   }
 
   &__action {
     display: flex;
     align-items: center;
-    border-top: 1px solid currentColor;
-    border-top-color: inherit;
-    opacity: 0.8;
   }
 
   &__action-button {
@@ -280,15 +303,22 @@ if (!props.persistent && props.duration > 0) {
     gap: 6px;
     background: none;
     border: none;
+    border-radius: var(--radius-sm);
     cursor: pointer;
     padding: 0;
-    color: currentColor;
+    color: var(--text-accent);
     font-size: inherit;
     font-weight: 600;
-    transition: opacity var(--duration-fast) var(--ease-default);
+    line-height: inherit;
+    transition: background-color var(--trs-fast), color var(--trs-fast);
 
     &:hover {
-      opacity: 0.7;
+      color: var(--text-primary);
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--focus-ring);
+      outline-offset: 2px;
     }
   }
 

--- a/components/ui/styles/main.scss
+++ b/components/ui/styles/main.scss
@@ -148,7 +148,7 @@
 
   // Toast
   --ui-toast-background-color: #ffffff;
-  --ui-toast-box-shadow: var(--shadow-lg);
+  --ui-toast-box-shadow: var(--shadow-md);
 
   --ui-toast-info-border-color: rgba(var(--accent-rgb), 0.3);
   --ui-toast-info-background-color: rgba(var(--accent-rgb), 0.1);

--- a/pages/ui.vue
+++ b/pages/ui.vue
@@ -2,6 +2,7 @@
 import AssetInput from '~/components/entities/asset/AssetInput.vue'
 import type { VaultAsset } from '~/entities/vault'
 import { useModal } from '~/components/ui/composables/useModal'
+import type { ToastVariant } from '~/components/ui/toast.types'
 import { AcknowledgeTermsModal } from '#components'
 
 const radioModel = ref('radio-test-1')
@@ -11,6 +12,7 @@ const switchModel = ref(false)
 const inputModel = ref('')
 const inputWithValueModel = ref('Example value')
 const inputErrorModel = ref('Error value')
+const toastVariants: ToastVariant[] = ['success', 'info', 'warning', 'error', 'neutral']
 const asset: VaultAsset = {
   name: 'Mock TON',
   decimals: 18n,
@@ -28,6 +30,37 @@ const openLegalModal = () => {
   <section>
     <div>
       <div class="p-16">
+        <h3 class="text-h3 mb-16">
+          Toast Variations
+        </h3>
+
+        <div class="grid grid-cols-2 gap-12 mb-32 mobile:grid-cols-1">
+          <div
+            v-for="variant in toastVariants"
+            :key="`normal-${variant}`"
+            class="flex flex-col gap-8"
+          >
+            <UiToast
+              :variant="variant"
+              title="Link copied"
+              description="The share URL is ready to paste."
+              :persistent="false"
+            />
+            <UiToast
+              :variant="variant"
+              title="Compact toast"
+              size="compact"
+            />
+            <UiToast
+              :variant="variant"
+              title="Action available"
+              description="Review the transaction details before continuing."
+              action-text="Review"
+              :persistent="false"
+            />
+          </div>
+        </div>
+
         <h3 class="text-h3 mb-16">
           Input Components
         </h3>


### PR DESCRIPTION
## Summary
- Simplifies toast presentation so transient messages feel lighter and closer to the app design system.
- Replaces the oversized success badge with a plain check icon and tighter spacing.

## Changes
- Uses a neutral toast surface with the shared border radius, shadow token, and text colors.
- Keeps variant color on the status icon only, reducing the heavy full-alert treatment.
- Adds explicit button types and an accessible close label for toast controls.

## Test plan
- [x] npm run lint
- [x] Manually trigger a success toast and confirm it renders as a compact single-row notification.
- [x] Manually check error/warning/info toasts in light and dark themes.


<img width="534" height="416" alt="image" src="https://github.com/user-attachments/assets/1f017882-626c-4dbb-9e84-2bf669981005" />

<img width="591" height="344" alt="image" src="https://github.com/user-attachments/assets/fb3c975d-e1ab-4ff4-97ae-3cbce2737302" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Refined toast component styling with updated icon mappings and improved visual presentation
  * Adjusted shadow styling for better visual depth
  * Enhanced spacing and typography for toast variants (normal and compact)

* **Documentation**
  * Added toast variations showcase displaying all available toast types and configurations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/euler-xyz/euler-lite/pull/471?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->