### PR TITLE
Show collateral points on borrow pairs

### DIFF
--- a/components/entities/vault/VaultBorrowItem.vue
+++ b/components/entities/vault/VaultBorrowItem.vue
@@ -460,6 +460,10 @@ const linkPath = computed(() => ({
           </UiModalPreviewTrigger>
         </div>
         <div class="text-p2 text-content-primary flex items-center justify-center">
+          <VaultPoints
+            class="mr-4"
+            :vault="pair.collateral"
+          />
           <UiModalPreviewTrigger
             v-if="hasSupplyRewards(pair.collateral.address)"
             :component="VaultSupplyApyModal"
@@ -597,6 +601,7 @@ const linkPath = computed(() => ({
           </div>
         </div>
         <div class="flex gap-8 justify-end items-center text-right flex-1">
+          <VaultPoints :vault="pair.collateral" />
           <UiModalPreviewTrigger
             v-if="hasSupplyRewards(pair.collateral.address)"
             :component="VaultSupplyApyModal"

--- a/components/entities/vault/VaultPoints.vue
+++ b/components/entities/vault/VaultPoints.vue
@@ -34,6 +34,7 @@ const onPointClick = (
 
 <template>
   <div
+    v-if="points.length"
     class="text-p1 flex items-center gap-0 hover:gap-8 transition-[gap] duration-300 ease-in-out"
   >
     <img

--- a/components/entities/vault/overview/VaultOverviewPairBlockGeneral.vue
+++ b/components/entities/vault/overview/VaultOverviewPairBlockGeneral.vue
@@ -225,6 +225,7 @@ const rampDownModalData = computed(() => ({
             </span>
           </template>
           <span class="flex items-center gap-4">
+            <VaultPoints :vault="pair.collateral" />
             <UiModalPreviewTrigger
               v-if="hasSupplyRewards(pair.collateral.address)"
               :component="VaultSupplyApyModal"


### PR DESCRIPTION
## Summary
- Show collateral vault point badges on borrow pair overview cards so labels-backed points are visible on pair pages.
- Keep points tied to the supply/collateral side of the pair, matching the labels data shape and existing vault badge behavior.

## Changes
- Renders the existing VaultPoints component next to the Supply APY value for the collateral vault.
- Leaves APY calculation and the Supply APY modal unchanged; points remain informational badges, not APY components.

## Test plan
- [x] Run npm run lint -- components/entities/vault/overview/VaultOverviewPairBlockGeneral.vue
- [x] Open a borrow pair whose collateral vault has labels points and confirm the badge appears beside Supply APY.
- [x] Open a borrow pair without collateral points and confirm no extra badge is shown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Vault points are now shown in the Supply APY area across vault overview and borrow item views (desktop and mobile), adding collateral metrics to APY displays.

* **Bug Fixes**
  * Vault points section is now hidden when no points exist, preventing empty UI elements from appearing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/euler-xyz/euler-lite/pull/472?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->