### PR TITLE
fix: handle Securitize points and VPN stalls

### DIFF
--- a/components/entities/vault/VaultMetadataTag.vue
+++ b/components/entities/vault/VaultMetadataTag.vue
@@ -116,7 +116,7 @@ const onKeydown = (event: KeyboardEvent) => {
   &--neutral {
     background-color: transparent;
     border-color: var(--border-subtle);
-    color: var(--content-primary);
+    color: var(--text-primary);
 
     &:hover {
       background-color: var(--bg-card-hover);

--- a/components/entities/vault/VaultPoints.vue
+++ b/components/entities/vault/VaultPoints.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
-import type { EarnVault, Vault } from '~/entities/vault'
+import type { EarnVault, SecuritizeVault, Vault } from '~/entities/vault'
 import { getEulerLabelEntityLogo } from '~/entities/euler/labels'
 import { useModal } from '~/components/ui/composables/useModal'
 import { VaultPointsModal } from '#components'
 
-const { vault } = defineProps<{ vault: Vault | EarnVault }>()
+const { vault } = defineProps<{ vault: Vault | EarnVault | SecuritizeVault }>()
 
 const points = useEulerPointsOfVault(vault.address)
 const modal = useModal()

--- a/services/vpn.ts
+++ b/services/vpn.ts
@@ -16,7 +16,7 @@ export async function detectVpn(): Promise<boolean> {
     cached = { value: header === 'true', timestamp: Date.now() }
   }
   catch {
-    cached = { value: false, timestamp: Date.now() }
+    cached = { value: true, timestamp: Date.now() }
   }
   finally {
     clearTimeout(timeout)

--- a/tests/services/vpn.test.ts
+++ b/tests/services/vpn.test.ts
@@ -19,7 +19,7 @@ describe('detectVpn', () => {
     await expect(detectVpn()).resolves.toBe(true)
   })
 
-  it('returns false when VPN detection stalls', async () => {
+  it('fails closed when VPN detection stalls', async () => {
     vi.useFakeTimers()
     vi.stubGlobal('window', { location: { origin: 'http://localhost:3000' } })
     vi.stubGlobal('fetch', vi.fn((_url: string, init?: RequestInit) =>
@@ -32,6 +32,6 @@ describe('detectVpn', () => {
 
     await vi.advanceTimersByTimeAsync(WALLET_SCREENING_TIMEOUT_MS)
 
-    await expect(promise).resolves.toBe(false)
+    await expect(promise).resolves.toBe(true)
   })
 })


### PR DESCRIPTION
## Summary
- Fix the borrow-pair point badge type error by allowing VaultPoints to accept Securitize collateral vaults.
- Align VPN header detection with fail-closed screening semantics when the probe stalls or errors.
- Use the defined text-primary token for neutral vault metadata tags instead of an undefined content-primary variable.

## Changes
- Widen VaultPoints props to accept Vault, EarnVault, or SecuritizeVault; the component only needs the vault address for point lookup.
- Cache VPN detection failures as true so downstream screening treats unknown VPN status as blocking-risk instead of not-VPN.
- Replace the neutral VaultMetadataTag color token with the repo-defined CSS variable.
- Update the stalled VPN detection test to assert fail-closed behavior.

## Test plan
- [x] npm run typecheck
- [x] npm run test:run -- tests/services/vpn.test.ts tests/composables/useAddressScreen.test.ts tests/server/screen-address.test.ts
- [x] npm run test:run
- [x] npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * VPN detection now treats stalled/failed checks as VPN present, improving wallet screening reliability.

* **Improvements**
  * Vault display component now supports an additional vault type for broader compatibility.

* **Style**
  * Neutral tag text color adjusted for improved visual consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/euler-xyz/euler-lite/pull/474?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->