### PR TITLE
fix: filter wallet swap repay sweeps

### DIFF
--- a/composables/repay/useWalletSwapRepay.ts
+++ b/composables/repay/useWalletSwapRepay.ts
@@ -7,7 +7,7 @@ import { getTotalCollateralValue } from '~/utils/position-estimates'
 import { useModal } from '~/components/ui/composables/useModal'
 import { OperationReviewModal } from '#components'
 import { useToast } from '~/components/ui/composables/useToast'
-import { getNetAPY, getProjectedRates, type Vault, type VaultAsset } from '~/entities/vault'
+import { getNetAPY, getProjectedRates, isEVKVault, type SecuritizeVault, type Vault, type VaultAsset } from '~/entities/vault'
 import { getAssetUsdValue, getAssetUsdValueOrZero, getTokenUsdValue } from '~/services/pricing/priceProvider'
 import type { AccountBorrowPosition } from '~/entities/account'
 import type { TxPlan } from '~/entities/txPlan'
@@ -277,8 +277,8 @@ export const useWalletSwapRepay = (options: UseWalletSwapRepayOptions) => {
     if (isFullRepay.value) {
       const collAddrs = position.value?.collaterals ?? (collateralVault.value ? [collateralVault.value.address] : [])
       for (const addr of collAddrs) {
-        const v = registryGetVault(addr) as Vault | undefined
-        if (v) steps.push({ vault: v, op: OP_TRANSFER })
+        const v = registryGetVault(addr) as Vault | SecuritizeVault | undefined
+        if (v && isEVKVault(v)) steps.push({ vault: v, op: OP_TRANSFER })
       }
     }
     return steps

--- a/composables/useEulerOperations/swaps/supply-borrow.ts
+++ b/composables/useEulerOperations/swaps/supply-borrow.ts
@@ -13,11 +13,17 @@ import type { TxPlan } from '~/entities/txPlan'
 import { type SwapApiQuote, SwapperMode, SwapVerificationType } from '~/entities/swap'
 import { logWarn } from '~/utils/errorHandling'
 import { assertSwapQuoteContractsAllowed } from '~/utils/swap-validation'
+import { isEVKVault, type SecuritizeVault, type Vault } from '~/entities/vault'
 
 export const createSupplyBorrowSwapBuilders = (
   ctx: OperationsContext,
   helpers: OperationHelpers,
 ) => {
+  const isSweepable = (addr: string): boolean => {
+    const v = ctx.registryGetVault(addr as Address) as Vault | SecuritizeVault | undefined
+    return !!v && isEVKVault(v)
+  }
+
   /**
    * Swap an arbitrary token from the user's wallet and deposit the output into a vault.
    */
@@ -543,7 +549,9 @@ export const createSupplyBorrowSwapBuilders = (
       hooks.addContractInterface(evcAddress, evcDisableCollateralAbi)
       const collateralAddresses = enabledCollaterals || []
       for (const collateralAddr of collateralAddresses) {
-        hooks.addContractInterface(collateralAddr as Address, vaultTransferFromMaxAbi)
+        if (isSweepable(collateralAddr)) {
+          hooks.addContractInterface(collateralAddr as Address, vaultTransferFromMaxAbi)
+        }
       }
     }
 
@@ -614,6 +622,7 @@ export const createSupplyBorrowSwapBuilders = (
       const isMainAccount = subAccount.toLowerCase() === userAddr.toLowerCase()
       if (!isMainAccount) {
         for (const collateralAddr of collateralAddresses) {
+          if (!isSweepable(collateralAddr)) continue
           evcCalls.push({
             targetContract: collateralAddr as Address,
             onBehalfOfAccount: subAccount,

--- a/tests/composables/useEulerOperations-wallet-swap-repay.test.ts
+++ b/tests/composables/useEulerOperations-wallet-swap-repay.test.ts
@@ -1,0 +1,181 @@
+import type { Abi, Address, Hex } from 'viem'
+import { decodeFunctionData } from 'viem'
+import { computed, ref } from 'vue'
+import { describe, expect, it, vi } from 'vitest'
+import { evcDisableCollateralAbi, evcDisableControllerAbi } from '~/abis/evc'
+import { vaultTransferFromMaxAbi } from '~/abis/vault'
+import { swapperAbi, swapVerifierAbi, transferFromSenderAbi } from '~/entities/euler/abis'
+import { type SwapApiQuote, SwapperMode, SwapVerificationType } from '~/entities/swap'
+import type { SecuritizeVault, Vault } from '~/entities/vault'
+import type { TxPlan } from '~/entities/txPlan'
+import { createSupplyBorrowSwapBuilders } from '~/composables/useEulerOperations/swaps/supply-borrow'
+import { buildSwapVerifierData } from '~/composables/useEulerOperations/swaps/verify'
+import type { OperationHelpers, OperationsContext } from '~/composables/useEulerOperations/types'
+import type { EVCCall } from '~/utils/evc-converter'
+
+const USER = '0x0000000000000000000000000000000000000001' as Address
+const SUB_ACCOUNT = '0x0000000000000000000000000000000000000002' as Address
+const EVC = '0x0000000000000000000000000000000000000003' as Address
+const SWAP_VERIFIER = '0x0000000000000000000000000000000000000004' as Address
+const SWAPPER = '0x0000000000000000000000000000000000000005' as Address
+const INPUT_TOKEN = '0x0000000000000000000000000000000000000006' as Address
+const BORROW_VAULT = '0x0000000000000000000000000000000000000007' as Address
+const EVK_COLLATERAL = '0x0000000000000000000000000000000000000008' as Address
+const SECURITIZE_COLLATERAL = '0x0000000000000000000000000000000000000009' as Address
+
+const decodeAbi = [
+  ...transferFromSenderAbi,
+  ...swapperAbi,
+  ...swapVerifierAbi,
+  ...evcDisableControllerAbi,
+  ...evcDisableCollateralAbi,
+  ...vaultTransferFromMaxAbi,
+] as Abi
+
+const makeVault = (address: Address): Vault => ({
+  address,
+} as unknown as Vault)
+
+const makeSecuritizeVault = (address: Address): SecuritizeVault => ({
+  address,
+  type: 'securitize',
+} as unknown as SecuritizeVault)
+
+const createContext = (): OperationsContext => ({
+  address: ref(USER),
+  chainId: ref(1),
+  writeContractAsync: vi.fn(),
+  signTypedDataAsync: vi.fn(),
+  config: {} as OperationsContext['config'],
+  eulerCoreAddresses: computed(() => ({ evc: EVC })),
+  eulerPeripheryAddresses: computed(() => ({
+    swapVerifier: SWAP_VERIFIER,
+    swapper: SWAPPER,
+  })),
+  eulerLensAddresses: computed(() => ({})),
+  rpcUrl: '',
+  PYTH_HERMES_URL: '',
+  SUBGRAPH_URL: '',
+  registryGet: vi.fn(),
+  registryGetVault: vi.fn((addr: Address) => {
+    if (addr.toLowerCase() === EVK_COLLATERAL.toLowerCase()) return makeVault(addr)
+    if (addr.toLowerCase() === SECURITIZE_COLLATERAL.toLowerCase()) return makeSecuritizeVault(addr)
+    return undefined
+  }),
+  permit2Enabled: ref(false),
+  rpcProvider: {} as OperationsContext['rpcProvider'],
+})
+
+const helpers: OperationHelpers = {
+  prepareTokenApproval: vi.fn(async () => ({ steps: [], permitCall: undefined, usesPermit2: false })),
+  injectPythHealthCheckUpdates: vi.fn(async () => undefined),
+  buildEvcBatchStep: ({ evcCalls, label }) => ({
+    type: 'evc-batch',
+    label,
+    to: EVC,
+    abi: [],
+    functionName: 'batch',
+    args: [evcCalls],
+  }),
+  buildNativeWrapCalls: vi.fn(() => []),
+  resolveEffectiveCollaterals: vi.fn(),
+  adjustForInterest: (amount: bigint) => amount,
+  preparePythUpdates: vi.fn(),
+  preparePythUpdatesForHealthCheck: vi.fn(),
+}
+
+const makeQuote = (): SwapApiQuote => {
+  const quote = {
+    amountIn: '100',
+    amountInMax: '100',
+    amountOut: '100',
+    amountOutMin: '100',
+    accountIn: USER,
+    accountOut: SUB_ACCOUNT,
+    vaultIn: BORROW_VAULT,
+    receiver: BORROW_VAULT,
+    tokenIn: {
+      address: INPUT_TOKEN,
+      chainId: 1,
+      decimals: 18,
+      logoURI: '',
+      name: 'Input',
+      symbol: 'IN',
+    },
+    tokenOut: {
+      address: INPUT_TOKEN,
+      chainId: 1,
+      decimals: 18,
+      logoURI: '',
+      name: 'Borrow',
+      symbol: 'BRW',
+    },
+    slippage: 0,
+    swap: {
+      swapperAddress: SWAPPER,
+      swapperData: '0x' as Hex,
+      multicallItems: [],
+    },
+    verify: {
+      verifierAddress: SWAP_VERIFIER,
+      verifierData: '0x' as Hex,
+      type: SwapVerificationType.DebtMax,
+      vault: BORROW_VAULT,
+      account: SUB_ACCOUNT,
+      amount: '100',
+      deadline: 0,
+    },
+    route: [{ providerName: 'test' }],
+  } as SwapApiQuote
+
+  quote.verify.verifierData = buildSwapVerifierData({
+    quote,
+    swapperMode: SwapperMode.EXACT_IN,
+    isRepay: true,
+    requestedSlippage: 0,
+    currentDebt: 100n,
+  })
+
+  return quote
+}
+
+const planCalls = (plan: TxPlan): EVCCall[] => plan.steps[0]?.args[0] as EVCCall[]
+
+const decodedCalls = (plan: TxPlan) => planCalls(plan).map(call => ({
+  target: call.targetContract,
+  ...decodeFunctionData({ abi: decodeAbi, data: call.data }),
+}))
+
+describe('wallet swap full repay cleanup', () => {
+  it('sweeps only EVK collaterals while disabling every collateral', async () => {
+    const builders = createSupplyBorrowSwapBuilders(createContext(), helpers)
+
+    const plan = await builders.buildSwapAndRepayPlan({
+      inputTokenAddress: INPUT_TOKEN,
+      inputAmount: 100n,
+      quote: makeQuote(),
+      requestedSlippage: 0,
+      borrowVaultAddress: BORROW_VAULT,
+      subAccount: SUB_ACCOUNT,
+      enabledCollaterals: [EVK_COLLATERAL, SECURITIZE_COLLATERAL],
+      isFullRepay: true,
+      swapperMode: SwapperMode.EXACT_IN,
+      currentDebt: 100n,
+    })
+
+    const calls = decodedCalls(plan)
+    const transferFromMaxCalls = calls.filter(call => call.functionName === 'transferFromMax')
+    const disableCollateralCalls = calls.filter(call => call.functionName === 'disableCollateral')
+
+    expect(transferFromMaxCalls).toEqual([
+      expect.objectContaining({
+        target: EVK_COLLATERAL,
+        args: [SUB_ACCOUNT, USER],
+      }),
+    ])
+    expect(disableCollateralCalls).toEqual([
+      expect.objectContaining({ args: [SUB_ACCOUNT, EVK_COLLATERAL] }),
+      expect.objectContaining({ args: [SUB_ACCOUNT, SECURITIZE_COLLATERAL] }),
+    ])
+  })
+})


### PR DESCRIPTION
## Summary
- Fix wallet swap full-repay cleanup so non-EVK and Securitize collaterals are not swept with transferFromMax.
- Align the planned operation warning path with the transaction builder so only sweepable EVK collaterals are classified as OP_TRANSFER.

## Changes
- Add an isSweepable guard to the wallet swap repay builder for transferFromMax ABI registration and call emission.
- Preserve disableCollateral calls for every enabled collateral during full-repay cleanup.
- Add a regression test covering mixed EVK and Securitize collateral cleanup.

## Test plan
- [x] npm run test:run -- tests/composables/useEulerOperations-wallet-swap-repay.test.ts
- [x] npm run test:run
- [x] npm run build
- [x] npm run lint
- [x] npm run typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced full-debt repay operation flow to correctly execute collateral transfer operations based on vault configuration types, improving accuracy and reliability of repayment processes.

* **Tests**
  * Added comprehensive test coverage for wallet swap repay cleanup flows, including validation of collateral transfer execution and operation sequencing across repayment scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/euler-xyz/euler-lite/pull/476?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->