### PR TITLE
fix: filter disable collateral sweeps

### DIFF
--- a/composables/useEulerOperations/repay.ts
+++ b/composables/useEulerOperations/repay.ts
@@ -179,7 +179,9 @@ export const createRepayBuilders = (
     const evcAddress = ctx.eulerCoreAddresses.value.evc as Address
 
     const hooks = new SaHooksBuilder()
-    hooks.addContractInterface(vaultAddr, vaultTransferFromMaxAbi)
+    if (isSweepable(vaultAddr)) {
+      hooks.addContractInterface(vaultAddr, vaultTransferFromMaxAbi)
+    }
     hooks.addContractInterface(evcAddress, evcDisableCollateralAbi)
 
     const evcCalls: EVCCall[] = []
@@ -193,7 +195,7 @@ export const createRepayBuilders = (
       userAddr,
     })
 
-    if (subAccountAddr.toLowerCase() !== userAddr.toLowerCase()) {
+    if (subAccountAddr.toLowerCase() !== userAddr.toLowerCase() && isSweepable(vaultAddr)) {
       const transferCall: EVCCall = {
         targetContract: vaultAddr,
         onBehalfOfAccount: subAccountAddr,

--- a/tests/composables/useEulerOperations-disable-collateral.test.ts
+++ b/tests/composables/useEulerOperations-disable-collateral.test.ts
@@ -1,0 +1,124 @@
+import type { Abi, Address } from 'viem'
+import { decodeFunctionData } from 'viem'
+import { computed, ref } from 'vue'
+import { describe, expect, it, vi } from 'vitest'
+import { evcDisableCollateralAbi } from '~/abis/evc'
+import { vaultTransferFromMaxAbi } from '~/abis/vault'
+import type { SecuritizeVault, Vault } from '~/entities/vault'
+import type { TxPlan } from '~/entities/txPlan'
+import { createRepayBuilders } from '~/composables/useEulerOperations/repay'
+import type { OperationHelpers, OperationsContext } from '~/composables/useEulerOperations/types'
+import type { EVCCall } from '~/utils/evc-converter'
+
+const USER = '0x0000000000000000000000000000000000000001' as Address
+const SUB_ACCOUNT = '0x0000000000000000000000000000000000000002' as Address
+const EVC = '0x0000000000000000000000000000000000000003' as Address
+const BORROW_VAULT = '0x0000000000000000000000000000000000000004' as Address
+const EVK_COLLATERAL = '0x0000000000000000000000000000000000000005' as Address
+const SECURITIZE_COLLATERAL = '0x0000000000000000000000000000000000000006' as Address
+
+const decodeAbi = [
+  ...evcDisableCollateralAbi,
+  ...vaultTransferFromMaxAbi,
+] as Abi
+
+const makeVault = (address: Address): Vault => ({
+  address,
+} as unknown as Vault)
+
+const makeSecuritizeVault = (address: Address): SecuritizeVault => ({
+  address,
+  type: 'securitize',
+} as unknown as SecuritizeVault)
+
+const createContext = (): OperationsContext => ({
+  address: ref(USER),
+  chainId: ref(1),
+  writeContractAsync: vi.fn(),
+  signTypedDataAsync: vi.fn(),
+  config: {} as OperationsContext['config'],
+  eulerCoreAddresses: computed(() => ({ evc: EVC })),
+  eulerPeripheryAddresses: computed(() => ({})),
+  eulerLensAddresses: computed(() => ({})),
+  rpcUrl: '',
+  PYTH_HERMES_URL: '',
+  SUBGRAPH_URL: '',
+  registryGet: vi.fn(),
+  registryGetVault: vi.fn((addr: Address) => {
+    if (addr.toLowerCase() === EVK_COLLATERAL.toLowerCase()) return makeVault(addr)
+    if (addr.toLowerCase() === SECURITIZE_COLLATERAL.toLowerCase()) return makeSecuritizeVault(addr)
+    return undefined
+  }),
+  permit2Enabled: ref(false),
+  rpcProvider: {} as OperationsContext['rpcProvider'],
+})
+
+const helpers: OperationHelpers = {
+  prepareTokenApproval: vi.fn(),
+  injectPythHealthCheckUpdates: vi.fn(async () => undefined),
+  buildEvcBatchStep: ({ evcCalls, label }) => ({
+    type: 'evc-batch',
+    label,
+    to: EVC,
+    abi: [],
+    functionName: 'batch',
+    args: [evcCalls],
+  }),
+  buildNativeWrapCalls: vi.fn(),
+  resolveEffectiveCollaterals: vi.fn(),
+  adjustForInterest: (amount: bigint) => amount,
+  preparePythUpdates: vi.fn(),
+  preparePythUpdatesForHealthCheck: vi.fn(),
+}
+
+const planCalls = (plan: TxPlan): EVCCall[] => plan.steps[0]?.args[0] as EVCCall[]
+
+const decodedCalls = (plan: TxPlan) => planCalls(plan).map(call => ({
+  target: call.targetContract,
+  ...decodeFunctionData({ abi: decodeAbi, data: call.data }),
+}))
+
+describe('disable collateral cleanup', () => {
+  it('sweeps EVK collateral from subaccounts before disabling it', async () => {
+    const builders = createRepayBuilders(createContext(), helpers)
+
+    const plan = await builders.buildDisableCollateralPlan(
+      SUB_ACCOUNT,
+      EVK_COLLATERAL,
+      BORROW_VAULT,
+      [EVK_COLLATERAL],
+    )
+
+    expect(decodedCalls(plan)).toEqual([
+      expect.objectContaining({
+        target: EVK_COLLATERAL,
+        functionName: 'transferFromMax',
+        args: [SUB_ACCOUNT, USER],
+      }),
+      expect.objectContaining({
+        target: EVC,
+        functionName: 'disableCollateral',
+        args: [SUB_ACCOUNT, EVK_COLLATERAL],
+      }),
+    ])
+  })
+
+  it('does not sweep Securitize collateral when disabling it from a subaccount', async () => {
+    const builders = createRepayBuilders(createContext(), helpers)
+
+    const plan = await builders.buildDisableCollateralPlan(
+      SUB_ACCOUNT,
+      SECURITIZE_COLLATERAL,
+      BORROW_VAULT,
+      [SECURITIZE_COLLATERAL],
+    )
+
+    expect(decodedCalls(plan)).toEqual([
+      expect.objectContaining({
+        target: EVC,
+        functionName: 'disableCollateral',
+        args: [SUB_ACCOUNT, SECURITIZE_COLLATERAL],
+      }),
+    ])
+  })
+})


### PR DESCRIPTION
## Summary
- Follow-up fix for the manual disable-collateral path; this is intentionally not intended for the current release.
- Prevent non-EVK and Securitize collateral disables from trying to sweep subaccount shares through transferFromMax.

## Changes
- Guard transferFromMax ABI registration and call emission in buildDisableCollateralPlan with the existing isSweepable check.
- Preserve the EVC disableCollateral call for all vault types.
- Add regression coverage for EVK and Securitize collateral disable cleanup from subaccounts.

## Test plan
- [x] npm run test:run -- tests/composables/useEulerOperations-disable-collateral.test.ts
- [x] npm run test:run
- [x] npm run build
- [x] npm run lint
- [x] npm run typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed collateral cleanup logic to properly evaluate when vault sweeps should be performed, preventing unnecessary transfers in certain configurations.

* **Tests**
  * Added comprehensive test coverage for collateral disabling behavior across different vault types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/euler-xyz/euler-lite/pull/478?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->