### PR TITLE
fix: correct earn vault 1h supply APY algorithm

### DIFF
--- a/entities/vault/apy.ts
+++ b/entities/vault/apy.ts
@@ -1,4 +1,4 @@
-import { parseUnits, type Address } from 'viem'
+import type { Address } from 'viem'
 import { logger } from '~/utils/logger'
 import { SECONDS_IN_YEAR, TARGET_TIME_AGO } from '~/entities/constants'
 import { eulerUtilsLensABI, eulerVaultLensABI } from '~/entities/euler/abis'
@@ -104,43 +104,109 @@ export const getRoe = (
 }
 
 interface BlockDataCache {
-  oneHourAgoBlock: number
-  timeElapsedSeconds: number
+  measurementBlock: number
+  measurementTimestamp: bigint
+  priorBlock: number
+  priorTimestamp: bigint
 }
 
 const SAMPLE_DISTANCE = 10_000
 
+// Blocks to step back from the latest head when picking the "current" sample
+// point. Load-balanced JSON-RPC fleets can serve subsequent eth_calls from
+// nodes whose heads lag the node that answered `getBlockNumber()` by 1–2
+// blocks; pinning convertToAssets to `latest.number` would then fail on lagging
+// nodes. Backing off by a few blocks puts the measurement at a height that
+// every plausibly-synced backend has seen, while the resulting staleness
+// (~60s on Ethereum, sub-second on most L2s) is negligible against the 3600s
+// measurement window.
+const MEASUREMENT_BLOCK_BACKOFF = 5
+
+// Extra digits of precision added on top of share decimals when probing the
+// vault exchange rate. The probe is linear in `convertToAssets`, so scaling it
+// up costs nothing other than headroom against uint256 overflow. With 1e12 on
+// top of asset decimals, even low-decimal assets (USDC/cbBTC) keep tens of
+// significant digits of resolution in the 1h rate change.
+const PROBE_PRECISION_BOOST = 12n
+
+// Compound a measured rate change observed over `elapsedSeconds` into an APY,
+// using continuous-per-second compounding to match the EVK/Lens convention.
+// Equivalent to `(1 + spy) ** SECONDS_IN_YEAR - 1` where `spy = rateChange / elapsedSeconds`.
+// Exported for unit testing.
+export const computeApyFromRateChange = (
+  currentRate: bigint,
+  priorRate: bigint,
+  elapsedSeconds: number,
+): number => {
+  if (priorRate === 0n || elapsedSeconds <= 0) {
+    return 0
+  }
+  const rateChange = Number(currentRate - priorRate) / Number(priorRate)
+  const spy = rateChange / elapsedSeconds
+  const apy = (Math.pow(1 + spy, SECONDS_IN_YEAR) - 1) * 100
+  return Number.isFinite(apy) ? apy : 0
+}
+
 export const fetchBlockDataForAPY = async (rpcUrl: string, chainId: number): Promise<BlockDataCache | null> => {
   try {
     const client = getPublicClient(rpcUrl)
-    const currentBlock = Math.max(0, Number(await client.getBlockNumber()) - 1)
-    const sampleDistance = Math.min(SAMPLE_DISTANCE, currentBlock)
 
+    // Pick a recent block from any node, then back off so the result is one
+    // that every plausibly-synced backend has seen. Both the rate and the
+    // timestamp will be pinned to this height, so atomicity is preserved by
+    // historical-block determinism rather than by bundling reads.
+    const latestBlockNumber = Number(await client.getBlockNumber())
+    const measurementBlock = latestBlockNumber - MEASUREMENT_BLOCK_BACKOFF
+    if (measurementBlock < 1) {
+      return null
+    }
+
+    const sampleDistance = Math.min(SAMPLE_DISTANCE, measurementBlock)
     if (sampleDistance === 0) {
       return null
     }
 
-    const [currentBlockData, sampleBlockData] = await Promise.all([
-      client.getBlock({ blockNumber: BigInt(currentBlock) }),
-      client.getBlock({ blockNumber: BigInt(currentBlock - sampleDistance) }),
+    // Fetch the measurement block (gives currentTimestamp + acts as the upper
+    // sample point) and the older sample block in parallel.
+    const [measurementBlockData, sampleBlockData] = await Promise.all([
+      client.getBlock({ blockNumber: BigInt(measurementBlock) }),
+      client.getBlock({ blockNumber: BigInt(measurementBlock - sampleDistance) }),
     ])
 
-    if (!currentBlockData || !sampleBlockData) {
+    if (!measurementBlockData || !sampleBlockData) {
       return null
     }
 
-    const timeDiff = Number(currentBlockData.timestamp - sampleBlockData.timestamp)
-    const avgBlockTime = timeDiff / sampleDistance
-
+    const avgBlockTime = Number(measurementBlockData.timestamp - sampleBlockData.timestamp) / sampleDistance
     if (avgBlockTime <= 0) {
       return null
     }
 
     const blocksPerHour = Math.round(TARGET_TIME_AGO / avgBlockTime)
-    const oneHourAgoBlock = Math.max(0, currentBlock - blocksPerHour)
-    const timeElapsedSeconds = blocksPerHour * avgBlockTime
+    const priorBlock = measurementBlock - blocksPerHour
 
-    return { oneHourAgoBlock, timeElapsedSeconds }
+    // Bail if the chain has less than ~1h of history rather than silently
+    // clamping to genesis — the latter would normalise the rate change against
+    // a too-short window and explode the displayed APY.
+    if (priorBlock < 1) {
+      return null
+    }
+
+    // Read the actual timestamp at the prior block instead of trusting the
+    // 10K-block average. Block-rate variance over the last hour (sequencer
+    // hiccups, MEV bursts, late-block stretches) would otherwise scale the
+    // displayed APY by the inverse of the rate skew.
+    const priorBlockData = await client.getBlock({ blockNumber: BigInt(priorBlock) })
+    if (!priorBlockData) {
+      return null
+    }
+
+    return {
+      measurementBlock,
+      measurementTimestamp: measurementBlockData.timestamp,
+      priorBlock,
+      priorTimestamp: priorBlockData.timestamp,
+    }
   }
   catch (e) {
     logConciseFetchError('apy/fetchBlockData', chainId, 'block data', e)
@@ -158,32 +224,30 @@ export const calculateEarnVaultAPYWithCache = async (
   try {
     const client = getPublicClient(rpcUrl)
 
-    const oneShare = parseUnits('1', Number(decimals))
+    const probeShares = 10n ** (decimals + PROBE_PRECISION_BOOST)
 
-    const [currentRate, oneHourAgoRate] = await Promise.all([
+    // Both reads target fixed historical blocks, so any synced node returns
+    // the same data and the two reads pair correctly with the cache's
+    // pre-fetched timestamps even when served by different RPC backends.
+    const [currentRate, priorRate] = await Promise.all([
       client.readContract({
         address: vaultAddress as Address,
         abi: vaultConvertToAssetsAbi,
         functionName: 'convertToAssets',
-        args: [oneShare],
+        args: [probeShares],
+        blockNumber: BigInt(blockCache.measurementBlock),
       }) as Promise<bigint>,
       client.readContract({
         address: vaultAddress as Address,
         abi: vaultConvertToAssetsAbi,
         functionName: 'convertToAssets',
-        args: [oneShare],
-        blockNumber: BigInt(blockCache.oneHourAgoBlock),
+        args: [probeShares],
+        blockNumber: BigInt(blockCache.priorBlock),
       }) as Promise<bigint>,
     ])
 
-    if (oneHourAgoRate === 0n || blockCache.timeElapsedSeconds <= 0) {
-      return 0
-    }
-
-    const rateChange = Number(currentRate - oneHourAgoRate) / Number(oneHourAgoRate)
-    const apy = ((rateChange * SECONDS_IN_YEAR) / blockCache.timeElapsedSeconds) * 100
-
-    return Number.isFinite(apy) ? apy : 0
+    const timeElapsedSeconds = Number(blockCache.measurementTimestamp - blockCache.priorTimestamp)
+    return computeApyFromRateChange(currentRate, priorRate, timeElapsedSeconds)
   }
   catch (e) {
     logger.error({ ctx: 'apy/calculate', chainId, vault: vaultAddress, err: e }, 'failed to calculate APY')

--- a/tests/entities/vault/apy.test.ts
+++ b/tests/entities/vault/apy.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
-import { getNetAPY, getRoe } from '~/entities/vault/apy'
+import { computeApyFromRateChange, getNetAPY, getRoe } from '~/entities/vault/apy'
+import { SECONDS_IN_YEAR } from '~/entities/constants'
 
 describe('getNetAPY', () => {
   it('returns 0 when supplyUSD is 0', () => {
@@ -74,5 +75,73 @@ describe('getRoe', () => {
   it('handles supply-only position', () => {
     // supply=100 at 5%, borrow=0 → equity=100, roe = 100*0.05/100 = 0.05
     expect(getRoe(100, 0.05, 0, 0)).toBeCloseTo(0.05, 6)
+  })
+})
+
+describe('computeApyFromRateChange', () => {
+  // 1e15 keeps Number(priorRate) inside Number.MAX_SAFE_INTEGER so the
+  // bigint → Number conversion in the helper preserves precision.
+  const PROBE = 10n ** 15n
+  const ONE_HOUR = 3600
+
+  // Convert a target APY (decimal, e.g. 0.05 = 5%) into the bigint delta the
+  // helper would observe over `elapsedSeconds`, given priorRate = PROBE.
+  const deltaForApy = (apy: number, elapsedSeconds: number): bigint => {
+    const spy = Math.pow(1 + apy, 1 / SECONDS_IN_YEAR) - 1
+    const rateChange = Math.pow(1 + spy, elapsedSeconds) - 1
+    return BigInt(Math.round(Number(PROBE) * rateChange))
+  }
+
+  it('returns 0 when prior rate is zero', () => {
+    expect(computeApyFromRateChange(100n, 0n, ONE_HOUR)).toBe(0)
+  })
+
+  it('returns 0 when elapsed seconds is zero or negative', () => {
+    expect(computeApyFromRateChange(PROBE + 1000n, PROBE, 0)).toBe(0)
+    expect(computeApyFromRateChange(PROBE + 1000n, PROBE, -1)).toBe(0)
+  })
+
+  it('returns 0 when both rates are identical', () => {
+    expect(computeApyFromRateChange(PROBE, PROBE, ONE_HOUR)).toBe(0)
+  })
+
+  it.each([
+    { apy: 0.01 },
+    { apy: 0.05 },
+    { apy: 0.10 },
+    { apy: 0.25 },
+    { apy: 0.50 },
+    { apy: 1.00 },
+  ])('round-trips compound APY = $apy from a 1h rate change', ({ apy }) => {
+    const delta = deltaForApy(apy, ONE_HOUR)
+    const result = computeApyFromRateChange(PROBE + delta, PROBE, ONE_HOUR)
+    // 0.5pp tolerance covers integer-rounding of delta at this probe size.
+    expect(result).toBeCloseTo(apy * 100, 0)
+  })
+
+  it('round-trips a target APY across non-3600s windows', () => {
+    // 47 minutes — what a real measurement would look like when the actual
+    // timestamp delta differs from the nominal 1h target.
+    const elapsed = 47 * 60
+    const delta = deltaForApy(0.08, elapsed)
+    const result = computeApyFromRateChange(PROBE + delta, PROBE, elapsed)
+    expect(result).toBeCloseTo(8, 1)
+  })
+
+  it('produces a higher APY than the old linear formula at high yields', () => {
+    // Sanity check that we are compounding, not just annualising linearly.
+    // 50% APY over 1h: spy ≈ 1.286e-8, 1h rateChange ≈ 4.629e-5.
+    // Linear: 4.629e-5 / 3600 * SECONDS_IN_YEAR * 100 ≈ 40.58
+    // Compound: ~50.00
+    const delta = deltaForApy(0.50, ONE_HOUR)
+    const result = computeApyFromRateChange(PROBE + delta, PROBE, ONE_HOUR)
+    expect(result).toBeGreaterThan(45)
+    expect(result).toBeLessThan(55)
+  })
+
+  it('handles negative rate change (vault lost value)', () => {
+    const result = computeApyFromRateChange(PROBE - 1_000_000n, PROBE, ONE_HOUR)
+    expect(result).toBeLessThan(0)
+    expect(Number.isFinite(result)).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary

The Earn vault 1h supply APY displayed in the lend UI was visibly off in several distinct ways. This PR rewrites the algorithm in `entities/vault/apy.ts` to fix three root causes and pins reads to historical blocks for atomicity across load-balanced RPC fleets.

### Issues fixed

1. **`timeElapsedSeconds` was estimated, not measured.** The previous code set the denominator to `blocksPerHour * avgBlockTime` (always ≈ 3600 by construction). The numerator (rate change) reflected the *actual* elapsed time between the sampled blocks. Block-rate variance over the last hour (L2 sequencer hiccups, MEV bursts, late-block stretches) therefore scaled the displayed APY by the inverse of the skew. Now both reads are pinned to fixed historical blocks and `elapsed = measurementTimestamp − priorTimestamp` is read directly from chain data.

2. **APR was being labeled as APY.** `rateChange / dt * SECONDS_IN_YEAR` is a simple linear annualisation, but the rest of the UI (cyclical-IRM display, Lens `computeAPYs`) uses compound `(1 + spy)^SECONDS_PER_YEAR − 1`. The mismatch was sub-visible below ~10% APY but reached ~19% relative error at 50% APY. Now the helper compounds.

3. **Precision floor on low-decimal assets.** The probe was `parseUnits('1', decimals)`, i.e. exactly one share. For a USDC-backed Earn vault that's `1e6` units, and a 1h change at 5% APY produces only ~5 wei of delta — integer rounding inside `convertToAssets` dominated and the displayed value snapped to discrete steps. The probe is now `10^(decimals + 12)`; since `convertToAssets` is linear in input, this costs nothing other than uint256 headroom.

### Architecture

- **Shared cache (`fetchBlockDataForAPY`)** picks `measurementBlock = latestBlockNumber − 5` (back-off ensures every plausibly-synced backend has it), then derives `priorBlock` from a 10K-block sample, and pre-fetches the timestamp at each of those two blocks.
- **Per-vault (`calculateEarnVaultAPYWithCache`)** issues two `convertToAssets` reads pinned by explicit `blockNumber` to `measurementBlock` and `priorBlock`. Both target fixed historical blocks, so any synced node returns the same data and the reads pair correctly with the cache's pre-fetched timestamps even when served by different RPC backends.
- **Atomicity** comes from historical-block determinism, not from a multicall primitive. No Multicall3, no convention break.
- The previous code's back-off-by-1 was an incomplete version of this same idea — it backed off the timestamp read but still queried `convertToAssets` at implicit `'latest'`, leaving the rate-vs-timestamp window misaligned on load-balanced fleets.

### Test plan

- [x] `computeApyFromRateChange` extracted as a pure helper and unit-tested across target APYs (1%, 5%, 10%, 25%, 50%, 100%), non-3600s windows, negative rate changes, and zero/edge inputs (8 new test cases).
- [x] Full test suite passes (24/24 in `apy.test.ts`).
- [x] `vue-tsc --noEmit` clean.
- [x] Manual: load lend page on Ethereum and at least one L2 — verify Earn vault APYs no longer drift between refreshes and are within shouting distance of the underlying strategy APYs.
- [x] Manual: USDC-backed Earn vault APY no longer "stair-steps" between refreshes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced vault APY calculation accuracy with improved handling of historical block data and refined mathematical methods for yield computations.
  * Strengthened precision in APY rate calculations through updated data structures and enhanced computational approaches.

* **Tests**
  * Expanded test suite with comprehensive coverage of APY calculation scenarios, including edge case handling and round-trip rate change verification across various time windows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/euler-xyz/euler-lite/pull/480?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->