### PR TITLE
fix: gate swap submission when price impact cannot be computed

### DIFF
--- a/components/entities/operation/HighPriceImpactModal.vue
+++ b/components/entities/operation/HighPriceImpactModal.vue
@@ -2,8 +2,9 @@
 import { formatNumber } from '~/utils/string-utils'
 
 const props = defineProps<{
-  directPriceImpact: number
+  directPriceImpact: number | null
   multipliedPriceImpact?: number | null
+  unknown?: boolean
   onConfirm: () => void | Promise<void>
 }>()
 const emits = defineEmits(['close'])
@@ -11,6 +12,13 @@ const emits = defineEmits(['close'])
 const confirmText = ref('')
 const isSubmitting = ref(false)
 const isConfirmed = computed(() => confirmText.value.trim().toLowerCase() === 'i understand')
+
+const title = computed(() => props.unknown ? 'Price Impact Unavailable' : 'High Price Impact')
+const description = computed(() =>
+  props.unknown
+    ? 'We could not fetch a USD value for one or both sides of this swap, so the price impact cannot be calculated. Please double-check the swap in/out amounts before continuing.'
+    : 'This transaction has a very high price impact. You may receive significantly less value than expected.',
+)
 
 const onCancel = () => {
   emits('close')
@@ -31,18 +39,21 @@ const onSubmit = async () => {
 <template>
   <BaseModalWrapper
     warning
-    title="High Price Impact"
+    :title="title"
     @close="onCancel"
   >
     <div class="flex flex-col gap-24 flex-grow">
       <div class="text-p3 text-content-secondary">
-        This transaction has a very high price impact. You may receive significantly less value than expected.
+        {{ description }}
       </div>
 
-      <div class="bg-surface-secondary rounded-12 p-16 flex flex-col gap-8">
+      <div
+        v-if="!unknown"
+        class="bg-surface-secondary rounded-12 p-16 flex flex-col gap-8"
+      >
         <div class="flex justify-between">
           <span class="text-p3 text-content-tertiary">Price impact</span>
-          <span class="text-p2 text-error-500">{{ formatNumber(directPriceImpact, 2, 2) }}%</span>
+          <span class="text-p2 text-error-500">{{ directPriceImpact !== null ? `${formatNumber(directPriceImpact, 2, 2)}%` : 'Unknown' }}</span>
         </div>
         <div
           v-if="multipliedPriceImpact !== undefined && multipliedPriceImpact !== null"

--- a/components/entities/operation/HighPriceImpactModal.vue
+++ b/components/entities/operation/HighPriceImpactModal.vue
@@ -16,7 +16,7 @@ const isConfirmed = computed(() => confirmText.value.trim().toLowerCase() === 'i
 const title = computed(() => props.unknown ? 'Price Impact Unavailable' : 'High Price Impact')
 const description = computed(() =>
   props.unknown
-    ? 'We could not fetch a USD value for one or both sides of this swap, so the price impact cannot be calculated. Please double-check the swap in/out amounts before continuing.'
+    ? 'We could not fetch the market price of one or both sides of this swap, so the price impact cannot be calculated. Please double-check the swap in/out amounts before continuing.'
     : 'This transaction has a very high price impact. You may receive significantly less value than expected.',
 )
 

--- a/components/entities/operation/OperationReviewModal.vue
+++ b/components/entities/operation/OperationReviewModal.vue
@@ -12,6 +12,7 @@ import { useVaultRegistry } from '~/composables/useVaultRegistry'
 import { logWarn } from '~/utils/errorHandling'
 import { formatNumber } from '~/utils/string-utils'
 import { getAssetLogoUrl } from '~/composables/useTokenList'
+import { useAllowanceSlotResolution } from '~/composables/useEulerOperations/allowance'
 
 const emits = defineEmits(['close', 'confirm'])
 
@@ -54,6 +55,7 @@ const { address: walletAddress, chainId: currentChainId } = useWagmi()
 const { isSpyMode } = useSpyMode()
 const { getVault } = useVaultRegistry()
 const { buildSimulationStateOverride } = useEulerOperations()
+const { isResolvingAllowanceSlotIndex } = useAllowanceSlotResolution()
 const { eulerCoreAddresses } = useEulerAddresses()
 const {
   isSimulating: isTenderlySimulating,
@@ -134,9 +136,15 @@ const handleTenderlySimulate = async () => {
 }
 
 const internalSubmitting = ref(false)
+const isReviewActionBlocked = computed(() =>
+  internalSubmitting.value || isResolvingAllowanceSlotIndex.value,
+)
+const isTenderlyPreparing = computed(() =>
+  isTenderlySimulating.value || isResolvingAllowanceSlotIndex.value,
+)
 
 const handleConfirm = async () => {
-  if (internalSubmitting.value) return
+  if (isReviewActionBlocked.value) return
   const result = onConfirm()
   // If onConfirm returns a promise, keep the modal open with a loading state
   // and let the caller close it via modal.close(). Otherwise close immediately
@@ -305,13 +313,13 @@ const permit2DisclaimerText = 'You are granting the Permit2 contract an unlimite
           v-else-if="tenderlyEnabled"
           type="button"
           class="flex items-center gap-6 text-p3 text-content-primary hover:text-content-primary transition-colors"
-          :disabled="isTenderlySimulating"
+          :disabled="isTenderlyPreparing"
           @click="handleTenderlySimulate"
         >
           <SvgIcon
-            :name="isTenderlySimulating ? 'loading' : 'arrow-top-right'"
+            :name="isTenderlyPreparing ? 'loading' : 'arrow-top-right'"
             class="!w-16 !h-16"
-            :class="{ 'animate-spin': isTenderlySimulating }"
+            :class="{ 'animate-spin': isTenderlyPreparing }"
           />
           Simulate on Tenderly
         </button>
@@ -378,8 +386,8 @@ const permit2DisclaimerText = 'You are granting the Permit2 contract an unlimite
         variant="primary"
         size="xlarge"
         rounded
-        :disabled="isSpyMode || internalSubmitting"
-        :loading="internalSubmitting"
+        :disabled="isSpyMode || isReviewActionBlocked"
+        :loading="isReviewActionBlocked"
         @click="handleConfirm"
       >
         {{ isSpyMode ? 'Spy mode (read-only)' : (internalSubmitting && submittingLabel ? submittingLabel : btnLabel) }}

--- a/components/entities/swap/SwapDetailsSummary.vue
+++ b/components/entities/swap/SwapDetailsSummary.vue
@@ -66,6 +66,17 @@ const emit = defineEmits<{
     </p>
   </SummaryRow>
   <SummaryRow
+    v-else-if="(inputDisplay || outputDisplay) && (multipliedPriceImpact === null || multipliedPriceImpact === undefined)"
+    label="Price impact"
+  >
+    <p
+      class="text-p2 text-error-500"
+      title="USD price unavailable for one of the assets. Double-check the swap in/out amounts before continuing."
+    >
+      Unavailable
+    </p>
+  </SummaryRow>
+  <SummaryRow
     v-if="multipliedPriceImpact !== null && multipliedPriceImpact !== undefined"
     label="Multiplied price impact"
   >

--- a/components/entities/vault/form/VaultFormSubmit.vue
+++ b/components/entities/vault/form/VaultFormSubmit.vue
@@ -10,6 +10,7 @@ import { AcknowledgeTermsModal, VaultUnverifiedDisclaimerModal } from '#componen
 import type { KeyringFlowState, CredentialData } from '~/composables/useKeyring'
 import type { TosGuardState } from '~/composables/guards/useTosGuard'
 import type { UnverifiedVaultGuardState } from '~/composables/guards/useUnverifiedVaultGuard'
+import { useAllowanceSlotResolution } from '~/composables/useEulerOperations/allowance'
 
 interface KeyringGuardState {
   needsVerification: boolean
@@ -26,6 +27,7 @@ const { isConnected } = useAccount()
 const { isSpyMode } = useSpyMode()
 const { chainId: _chainId } = useEulerAddresses()
 const { chainId, switchChain, connect } = useWagmi()
+const { isResolvingAllowanceSlotIndex } = useAllowanceSlotResolution()
 const modal = useModal()
 
 const keyringGuard = inject<KeyringGuardState | null>('keyring-guard', null)
@@ -51,15 +53,17 @@ const needToSwitchChain = computed(() => {
 const hasActiveSession = computed(() => isConnected.value || isSpyMode.value)
 const _disabled = computed(() => {
   if (isOperationBlocked.value) return true
+  if (isResolvingAllowanceSlotIndex.value) return true
   return props.disabled && !needToSwitchChain.value
 })
+const isLoading = computed(() => props.loading || isResolvingAllowanceSlotIndex.value)
 
 const GENERIC_DISABLED_REASON = 'Complete the form fields above to continue.'
 
 const effectiveDisabledReason = computed(() => {
   if (operationBlockReason.value) return operationBlockReason.value
   if (props.disabledReason) return props.disabledReason
-  if (_disabled.value && !props.loading) return GENERIC_DISABLED_REASON
+  if (_disabled.value && !isLoading.value) return GENERIC_DISABLED_REASON
   return undefined
 })
 
@@ -72,7 +76,7 @@ const tooltipVariantClass = computed(() => {
 })
 
 const showTooltip = () => {
-  if (_disabled.value && !props.loading) {
+  if (_disabled.value && !isLoading.value) {
     isTooltipVisible.value = true
     // Defer update until after v-if mounts the floating element,
     // otherwise the first paint lands at the wrapper's origin.
@@ -183,7 +187,7 @@ const openTermsModal = () => {
         size="large"
         type="submit"
         :variant="needToSwitchChain ? 'red' : 'primary'"
-        :loading="loading"
+        :loading="isLoading"
         :disabled="_disabled"
         @click="onClick"
       >
@@ -196,7 +200,7 @@ const openTermsModal = () => {
         </template>
       </UiButton>
       <div
-        v-if="isTooltipVisible && _disabled && !loading"
+        v-if="isTooltipVisible && _disabled && !isLoading"
         ref="floating"
         :style="floatingStyles"
         :class="['vault-form-submit__tooltip', tooltipVariantClass]"

--- a/composables/borrow/useMultiplyForm.ts
+++ b/composables/borrow/useMultiplyForm.ts
@@ -1162,6 +1162,7 @@ export const useMultiplyForm = (options: UseMultiplyFormOptions) => {
     multiplySwapReady,
     multiplySlippage,
     multiplySelectedProvider,
+    multiplyEffectiveQuote,
     multiplyQuoteCardsSorted,
     isMultiplyQuoteLoading,
     multiplyQuoteError,

--- a/composables/position/useCollateralForm.ts
+++ b/composables/position/useCollateralForm.ts
@@ -350,8 +350,14 @@ export const useCollateralForm = (options: UseCollateralFormOptions) => {
     toVault: computed(() => options.mode === 'supply' ? collateralVault.value : null),
   })
 
+  const shouldGateUnknownPriceImpact = computed(() =>
+    options.needsSwap.value
+    && swapEffectiveQuote.value !== null
+    && swapPriceImpact.value === null,
+  )
   const { guardWithPriceImpact } = usePriceImpactGate({
     directPriceImpact: swapPriceImpact,
+    shouldGateUnknown: shouldGateUnknownPriceImpact,
   })
 
   const swapRouteItems = computed(() => {

--- a/composables/useEulerOperations/allowance.ts
+++ b/composables/useEulerOperations/allowance.ts
@@ -10,6 +10,15 @@ import { logWarn } from '~/utils/errorHandling'
 
 const allowanceSlotIndexCache = new Map<string, bigint>()
 const maxUint256Hex = toHex(maxUint256, { size: 32 })
+const pendingAllowanceSlotResolutions = ref(0)
+
+export const useAllowanceSlotResolution = () => {
+  const isResolvingAllowanceSlotIndex = computed(() => pendingAllowanceSlotResolutions.value > 0)
+
+  return {
+    isResolvingAllowanceSlotIndex,
+  }
+}
 
 export const createAllowanceHelpers = (ctx: OperationsContext, permit2: Permit2Helpers): AllowanceHelpers => {
   const checkAllowance = async (assetAddress: Address, spenderAddress: Address, userAddress: Address): Promise<bigint> => {
@@ -75,15 +84,21 @@ export const createAllowanceHelpers = (ctx: OperationsContext, permit2: Permit2H
       return false
     }
 
-    for (let i = 0; i <= ALLOWANCE_MAX_SEQUENTIAL_SLOT; i++) {
-      if (await trySlot(BigInt(i))) return BigInt(i)
-    }
-    for (const slotIndex of ALLOWANCE_EXTRA_SLOT_CANDIDATES) {
-      if (await trySlot(slotIndex)) return slotIndex
-    }
+    pendingAllowanceSlotResolutions.value += 1
+    try {
+      for (let i = 0; i <= ALLOWANCE_MAX_SEQUENTIAL_SLOT; i++) {
+        if (await trySlot(BigInt(i))) return BigInt(i)
+      }
+      for (const slotIndex of ALLOWANCE_EXTRA_SLOT_CANDIDATES) {
+        if (await trySlot(slotIndex)) return slotIndex
+      }
 
-    logWarn('resolveAllowanceSlotIndex', 'no slot found for token', { data: { token: tokenKey, owner, spender } })
-    return undefined
+      logWarn('resolveAllowanceSlotIndex', 'no slot found for token', { data: { token: tokenKey, owner, spender } })
+      return undefined
+    }
+    finally {
+      pendingAllowanceSlotResolutions.value = Math.max(0, pendingAllowanceSlotResolutions.value - 1)
+    }
   }
 
   const buildErc20AllowanceOverrides = async (

--- a/composables/usePriceImpactGate.ts
+++ b/composables/usePriceImpactGate.ts
@@ -7,13 +7,20 @@ import { isPriceImpactDanger } from '~/utils/priceImpact'
 export const usePriceImpactGate = (options: {
   directPriceImpact: Ref<number | null> | ComputedRef<number | null>
   multipliedPriceImpact?: Ref<number | null> | ComputedRef<number | null>
+  shouldGateUnknown?: Ref<boolean> | ComputedRef<boolean>
 }) => {
   const modal = useModal()
 
-  const needsConfirmation = computed(() =>
+  const isDanger = computed(() =>
     isPriceImpactDanger(unref(options.directPriceImpact))
     || isPriceImpactDanger(unref(options.multipliedPriceImpact) ?? null),
   )
+
+  const isUnknown = computed(() =>
+    Boolean(options.shouldGateUnknown && unref(options.shouldGateUnknown)),
+  )
+
+  const needsConfirmation = computed(() => isDanger.value || isUnknown.value)
 
   const guardWithPriceImpact = async (onProceed: () => void | Promise<void>) => {
     if (!needsConfirmation.value) {
@@ -22,8 +29,9 @@ export const usePriceImpactGate = (options: {
     }
     modal.open(HighPriceImpactModal, {
       props: {
-        directPriceImpact: unref(options.directPriceImpact) ?? 0,
+        directPriceImpact: unref(options.directPriceImpact),
         multipliedPriceImpact: unref(options.multipliedPriceImpact) ?? null,
+        unknown: isUnknown.value && !isDanger.value,
         onConfirm: async () => {
           modal.close()
           await onProceed()

--- a/composables/useSwapPageLogic.ts
+++ b/composables/useSwapPageLogic.ts
@@ -395,7 +395,13 @@ export const useSwapPageLogic = (options: UseSwapPageLogicOptions) => {
 
   // ── Price impact ───────────────────────────────────────────────────────
   const priceImpact = ref<number | null>(null)
-  const { guardWithPriceImpact } = usePriceImpactGate({ directPriceImpact: priceImpact })
+  const shouldGateUnknownPriceImpact = computed(() =>
+    !isSameAsset.value && quote.value !== null && priceImpact.value === null,
+  )
+  const { guardWithPriceImpact } = usePriceImpactGate({
+    directPriceImpact: priceImpact,
+    shouldGateUnknown: shouldGateUnknownPriceImpact,
+  })
 
   watchEffect(async () => {
     if (!quote.value || !fromVault.value || !toVault.value) {

--- a/pages/borrow/[collateral]/[borrow]/index.vue
+++ b/pages/borrow/[collateral]/[borrow]/index.vue
@@ -163,10 +163,20 @@ const multiply = useMultiplyForm({
 const { guardWithPriceImpact: guardWithMultiplyPriceImpact } = usePriceImpactGate({
   directPriceImpact: multiply.multiplyPriceImpact,
   multipliedPriceImpact: multiply.multipliedPriceImpact,
+  shouldGateUnknown: computed(() =>
+    !multiply.multiplyIsSameAsset.value
+    && multiply.multiplyEffectiveQuote.value !== null
+    && multiply.multiplyPriceImpact.value === null,
+  ),
 })
 
 const { guardWithPriceImpact: guardWithBorrowSwapPriceImpact } = usePriceImpactGate({
   directPriceImpact: borrow.borrowSwapPriceImpact,
+  shouldGateUnknown: computed(() =>
+    borrow.borrowNeedsSwap.value
+    && borrow.borrowSwapEffectiveQuote.value !== null
+    && borrow.borrowSwapPriceImpact.value === null,
+  ),
 })
 
 // --- Submit disabled ---

--- a/pages/lend/[vault]/[subAccount]/withdraw.vue
+++ b/pages/lend/[vault]/[subAccount]/withdraw.vue
@@ -231,8 +231,12 @@ const { priceImpact: swapPriceImpact } = useSwapPriceImpact({
   fromVault: vault,
 })
 
+const shouldGateUnknownPriceImpact = computed(() =>
+  swapEffectiveQuote.value !== null && swapPriceImpact.value === null,
+)
 const { guardWithPriceImpact } = usePriceImpactGate({
   directPriceImpact: swapPriceImpact,
+  shouldGateUnknown: shouldGateUnknownPriceImpact,
 })
 
 const swapRouteItems = computed(() => {

--- a/pages/lend/[vault]/index.vue
+++ b/pages/lend/[vault]/index.vue
@@ -625,8 +625,14 @@ const { priceImpact: swapPriceImpact } = useSwapPriceImpact({
   toVault: evkVault,
 })
 
+const shouldGateUnknownPriceImpact = computed(() =>
+  needsSwap.value
+  && swapEffectiveQuote.value !== null
+  && swapPriceImpact.value === null,
+)
 const { guardWithPriceImpact } = usePriceImpactGate({
   directPriceImpact: swapPriceImpact,
+  shouldGateUnknown: shouldGateUnknownPriceImpact,
 })
 
 const swapRouteItems = computed(() => {

--- a/pages/position/[number]/multiply.vue
+++ b/pages/position/[number]/multiply.vue
@@ -476,6 +476,11 @@ const multipliedPriceImpact = computed(() =>
 const { guardWithPriceImpact } = usePriceImpactGate({
   directPriceImpact: multiplyPriceImpact,
   multipliedPriceImpact,
+  shouldGateUnknown: computed(() =>
+    !multiplyIsSameAsset.value
+    && multiplyEffectiveQuote.value !== null
+    && multiplyPriceImpact.value === null,
+  ),
 })
 const multiplyRoutedVia = computed(() => {
   if (!multiplySelectedProvider.value) return isMultiplyQuoteLoading.value ? null : 'Not selected'

--- a/pages/position/[number]/repay.vue
+++ b/pages/position/[number]/repay.vue
@@ -160,6 +160,11 @@ const walletSwap = useWalletSwapRepay({
 
 const { guardWithPriceImpact: guardWithWalletSwapPriceImpact } = usePriceImpactGate({
   directPriceImpact: walletSwap.swapPriceImpact,
+  shouldGateUnknown: computed(() =>
+    walletSwap.needsSwap.value
+    && walletSwap.quotes.selectedQuote.value !== null
+    && walletSwap.swapPriceImpact.value === null,
+  ),
 })
 
 const isWalletSwapRestricted = computed(() =>
@@ -211,9 +216,19 @@ const savings = useSavingsRepay({
 
 const { guardWithPriceImpact: guardWithCollateralPriceImpact } = usePriceImpactGate({
   directPriceImpact: collateral.priceImpact,
+  shouldGateUnknown: computed(() =>
+    !collateral.isSameAsset.value
+    && collateral.quotes.selectedQuote.value !== null
+    && collateral.priceImpact.value === null,
+  ),
 })
 const { guardWithPriceImpact: guardWithSavingsPriceImpact } = usePriceImpactGate({
   directPriceImpact: savings.priceImpact,
+  shouldGateUnknown: computed(() =>
+    !savings.isSameAsset.value
+    && savings.quotes.selectedQuote.value !== null
+    && savings.priceImpact.value === null,
+  ),
 })
 
 // --- Form tabs ---


### PR DESCRIPTION
## Summary

- Block swap-based operation submission when the app cannot compute price impact, so users must explicitly acknowledge unknown pricing before continuing.
- Keep operation review, Tenderly simulation, and form submit controls blocked while allowance slot resolution is still in flight, avoiding review or execution from partial approval simulation state.

## Changes

- `usePriceImpactGate` accepts an optional `shouldGateUnknown` signal and reuses the high-price-impact acknowledgement flow for swaps whose `directPriceImpact` is `null`.
- `HighPriceImpactModal` adds a "Price Impact Unavailable" variant with copy that asks the user to double-check swap in/out amounts instead of implying a directional loss the app cannot calculate.
- `SwapDetailsSummary` renders a red `Unavailable` price-impact row when an active quote exists but pricing cannot be computed, rather than hiding the row.
- The unknown-impact gate is wired through swap, borrow-with-swap, lend deposit/withdraw swap, position collateral swap, repay wallet/collateral/savings flows, and multiply flows.
- Allowance slot resolution now exposes a shared pending state; submit/review/Tenderly actions show loading and stay disabled while ERC-20 allowance override slots are being resolved.

## Test plan

- [ ] Lend supply to a vault using a "Pay with" asset that has no USD price in the app. Confirm the `Unavailable` row is visible and the modal blocks submit until `I understand` is typed.
- [ ] Lend withdraw and swap to an asset with no USD price. Confirm the gate fires.
- [ ] Repay from wallet using a pay-with asset with no USD price. Confirm the gate fires.
- [ ] Repay from savings/collateral where one side has no USD price. Confirm the gate fires.
- [ ] Borrow with swap into a collateral asset with no USD price. Confirm the gate fires.
- [ ] Multiply from both `/borrow` and `/position/[n]/multiply` where one leg has no USD price. Confirm the gate fires.
- [ ] Verify a normal swap with full pricing data still proceeds without the modal.
- [ ] Verify same-asset transfers still proceed without the modal.
- [ ] Trigger a flow that resolves allowance storage slots and confirm submit/review/Tenderly controls remain loading/disabled until slot resolution finishes.
