### PR TITLE
Add Yuzu intrinsic APY

### DIFF
--- a/entities/custom.ts
+++ b/entities/custom.ts
@@ -20,6 +20,7 @@ export type IntrinsicApySourceConfig
     | { provider: 'infinifi', address: string, chainId: number, infinifiVariant: 'locked' | 'staked', infinifiLockedKey?: string }
     | { provider: 'accountable', address: string, chainId: number, loanAddress: string }
     | { provider: 'coinshift', address: string, chainId: number, period: '7d' | '30d' | '90d' }
+    | { provider: 'yuzu-dashboard', address: string, chainId: number, yuzuApyField: 'yzprime_apy_1d' | 'yzprime_apy_7d' | 'yzprime_apy_30d' }
 
 export const intrinsicApySources: readonly IntrinsicApySourceConfig[] = [
   // DefiLlama pools — Ethereum (1)
@@ -92,6 +93,9 @@ export const intrinsicApySources: readonly IntrinsicApySourceConfig[] = [
   // Accountable loans — Monad (143)
   { provider: 'accountable', chainId: 143, address: '0x8d3F9f9Eb2f5E8B48EFBB4074440D1E2A34Bc365', loanAddress: '0x8dCE15fc6a98484C995Fc702cBfBdA14A30454af' },
   { provider: 'accountable', chainId: 143, address: '0xC6De1DC0B59682bE906E5BcA14E385E74EE88168', loanAddress: '0x2653137fd4118AD25BCEFb31Ca748957b8528B01' },
+
+  // Yuzu — yzPrime
+  { provider: 'yuzu-dashboard', chainId: 143, address: '0xc9ea90692757831d98Ac629F2A0140E02b80A7DA', yuzuApyField: 'yzprime_apy_7d' },
 
   // DefiLlama pools — Sonic (146)
   { provider: 'defillama', chainId: 146, address: '0x16af6b1315471Dc306D47e9CcEfEd6e5996285B6', poolId: '24b3096a-488d-4a61-afa6-e5e9be2ce4bf' },

--- a/server/utils/intrinsic-apy.ts
+++ b/server/utils/intrinsic-apy.ts
@@ -40,6 +40,7 @@ const UPSTREAM_URLS = {
   infinifi: 'https://eth-api.infinifi.xyz/api/protocol/data',
   accountable: 'https://yield.accountable.capital/api/loan/address',
   coinshift: 'https://uspc-nav.coinshift.xyz/api/nav/returns',
+  yuzuDashboard: 'https://yuzu-accountable.yuzu.money/v1/dashboard',
 } as const
 
 const PENDLE_API_BASE = 'https://api-v2.pendle.finance/core/v2'
@@ -372,6 +373,70 @@ async function extractCoinshift(sources: CoinshiftSource[]): Promise<Array<[stri
   return out
 }
 
+type YuzuDashboardSource = Extract<IntrinsicApySourceConfig, { provider: 'yuzu-dashboard' }>
+type YuzuDashboardTimelineRow = {
+  date?: string
+  ts?: string | number
+} & Partial<Record<YuzuDashboardSource['yuzuApyField'], string | number | null>>
+type YuzuDashboardResponse = {
+  data?: {
+    reserves?: {
+      timeline?: YuzuDashboardTimelineRow[]
+    }
+  }
+}
+
+const yuzuDateValue = (date?: string): number => {
+  if (!date) return Number.NEGATIVE_INFINITY
+  const parsed = Date.parse(`${date}T00:00:00Z`)
+  return Number.isFinite(parsed) ? parsed : Number.NEGATIVE_INFINITY
+}
+
+const yuzuTimestampValue = (ts?: string | number): number => {
+  const parsed = Number(ts)
+  return Number.isFinite(parsed) ? parsed : Number.NEGATIVE_INFINITY
+}
+
+export function extractLatestYuzuApy(
+  rows: readonly YuzuDashboardTimelineRow[] | undefined,
+  field: YuzuDashboardSource['yuzuApyField'],
+): number | null {
+  let latest: YuzuDashboardTimelineRow | undefined
+  for (const row of rows ?? []) {
+    if (!row) continue
+    if (!latest) {
+      latest = row
+      continue
+    }
+    const rowDate = yuzuDateValue(row.date)
+    const latestDate = yuzuDateValue(latest.date)
+    if (
+      rowDate > latestDate
+      || (rowDate === latestDate && yuzuTimestampValue(row.ts) > yuzuTimestampValue(latest.ts))
+    ) {
+      latest = row
+    }
+  }
+
+  const apy = Number(latest?.[field])
+  return Number.isFinite(apy) ? apy : null
+}
+
+async function extractYuzuDashboard(sources: YuzuDashboardSource[]): Promise<Array<[string, IntrinsicApyInfo]>> {
+  const data = await fetchUpstream<YuzuDashboardResponse>('yuzu-dashboard', UPSTREAM_URLS.yuzuDashboard)
+  const out: Array<[string, IntrinsicApyInfo]> = []
+  for (const s of sources) {
+    const apy = extractLatestYuzuApy(data?.data?.reserves?.timeline, s.yuzuApyField)
+    if (apy === null) continue
+    out.push([normalize(s.address), {
+      apy,
+      provider: 'Yuzu',
+      source: UPSTREAM_URLS.yuzuDashboard,
+    }])
+  }
+  return out
+}
+
 type YoSource = Extract<IntrinsicApySourceConfig, { provider: 'yo' }>
 
 async function extractYo(sources: YoSource[]): Promise<Array<[string, IntrinsicApyInfo]>> {
@@ -426,7 +491,7 @@ async function extractSimple<S extends IntrinsicApySourceConfig, T>(
 }
 
 // Providers with dedicated extractors in the switch below.
-type ExplicitProvider = 'defillama' | 'pendle' | 'securitize' | 'stablewatch' | 'renzo' | 'midas' | 'yo' | 'infinifi' | 'accountable' | 'coinshift'
+type ExplicitProvider = 'defillama' | 'pendle' | 'securitize' | 'stablewatch' | 'renzo' | 'midas' | 'yo' | 'infinifi' | 'accountable' | 'coinshift' | 'yuzu-dashboard'
 // Every remaining provider must have an entry in SIMPLE_SPECS — enforced at the type level.
 type SimpleProvider = Exclude<IntrinsicApySourceConfig['provider'], ExplicitProvider>
 
@@ -494,6 +559,7 @@ async function extractForProvider(
     case 'infinifi': return extractInfinifi(sources as InfinifiSource[])
     case 'accountable': return extractAccountable(sources as AccountableSource[])
     case 'coinshift': return extractCoinshift(sources as CoinshiftSource[])
+    case 'yuzu-dashboard': return extractYuzuDashboard(sources as YuzuDashboardSource[])
     default: {
       const simpleProvider: SimpleProvider = provider
       const spec = SIMPLE_SPECS[simpleProvider]

--- a/tests/server/intrinsic-apy.test.ts
+++ b/tests/server/intrinsic-apy.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { extractLatestYuzuApy } from '~/server/utils/intrinsic-apy'
+
+describe('extractLatestYuzuApy', () => {
+  it('uses the configured APY field from the latest date', () => {
+    const rows = [
+      { date: '2026-05-18', ts: '1779065174400', yzprime_apy_7d: 5.9, yzprime_apy_30d: 5.8 },
+      { date: '2026-05-19', ts: '1779151572900', yzprime_apy_7d: 6.0, yzprime_apy_30d: 6.0 },
+      { date: '2026-05-20', ts: '1779241574271', yzprime_apy_7d: 6.1, yzprime_apy_30d: 6.0 },
+    ]
+
+    expect(extractLatestYuzuApy(rows, 'yzprime_apy_7d')).toBe(6.1)
+  })
+
+  it('uses the highest timestamp when multiple rows share the latest date', () => {
+    const rows = [
+      { date: '2026-05-20', ts: '1779241574271', yzprime_apy_7d: 6.1 },
+      { date: '2026-05-20', ts: '1779287476493', yzprime_apy_7d: 6.2 },
+      { date: '2026-05-19', ts: '1779151572900', yzprime_apy_7d: 7.0 },
+    ]
+
+    expect(extractLatestYuzuApy(rows, 'yzprime_apy_7d')).toBe(6.2)
+  })
+
+  it('returns null when the latest row lacks the configured APY field', () => {
+    const rows = [
+      { date: '2026-05-19', ts: '1779151572900', yzprime_apy_7d: 6.0 },
+      { date: '2026-05-20', ts: '1779287476493', yzprime_apy_30d: 6.1 },
+    ]
+
+    expect(extractLatestYuzuApy(rows, 'yzprime_apy_7d')).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
- Add Yuzu dashboard as an intrinsic APY source so yzPrime lending markets include the asset-native yield.
- Map Monad yzPrime to the 7d Yuzu APY from the latest dashboard timeline entry.

## Changes
- Adds a typed yuzu-dashboard intrinsic APY source config.
- Fetches the Yuzu dashboard through the existing intrinsic APY upstream cache.
- Selects the latest timeline row by date and timestamp, then reads yzprime_apy_7d for yzPrime.
- Covers latest-row selection and missing-field behavior with server tests.

## Test plan
- [x] npm run test:run -- tests/server/intrinsic-apy.test.ts
- [x] npm run typecheck
- [x] npm run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Integrated Yuzu dashboard as a new APY data provider for accessing yield data.
  * Supports multiple time-period APY variants (1-day, 7-day, and 30-day options) for flexible sourcing.

* **Tests**
  * Added test coverage for APY extraction logic and edge case handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/euler-xyz/euler-lite/pull/482?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->