### PR TITLE
fix wallet screening VPN fail-closed path

### DIFF
--- a/composables/useAddressScreen.ts
+++ b/composables/useAddressScreen.ts
@@ -47,9 +47,10 @@ export const useAddressScreen = () => {
       const vpnIsUsed = await detectVpn()
       if (gen !== screeningGeneration) return false
 
-      const isRestricted = await screenAddress(address, vpnIsUsed)
+      const addressIsRestricted = await screenAddress(address, vpnIsUsed)
       if (gen !== screeningGeneration) return false
 
+      const isRestricted = vpnIsUsed || addressIsRestricted
       if (isRestricted) {
         await disconnect()
         if (gen !== screeningGeneration) return false

--- a/server/api/screen-address.post.ts
+++ b/server/api/screen-address.post.ts
@@ -34,7 +34,8 @@ export default defineEventHandler(async (event) => {
   const address = body.address
   const vpnIsUsed = String(
     isTruthyHeader(event.node.req.headers['x-is-vpn'])
-    || isTruthyHeader(event.node.req.headers['x-is-proxy-or-vpn']),
+    || isTruthyHeader(event.node.req.headers['x-is-proxy-or-vpn'])
+    || body.vpnIsUsed === true,
   )
 
   const screeningUri = process.env.WALLET_SCREENING_URI

--- a/tests/composables/useAddressScreen.test.ts
+++ b/tests/composables/useAddressScreen.test.ts
@@ -92,6 +92,19 @@ describe('useAddressScreen', () => {
     expect(screening.isAddressScreened(USER)).toBe(false)
   })
 
+  it('disconnects fail-closed VPN detections without marking them screened', async () => {
+    mocks.detectVpn.mockResolvedValue(true)
+    mocks.screenAddress.mockResolvedValue(false)
+
+    const screening = useAddressScreen()
+    await screening.screenConnectedAddress(USER)
+
+    expect(mocks.screenAddress).toHaveBeenCalledWith(USER, true)
+    expect(mocks.disconnect).toHaveBeenCalledTimes(1)
+    expect(mocks.modalOpen).toHaveBeenCalledTimes(1)
+    expect(screening.isAddressScreened(USER)).toBe(false)
+  })
+
   it('invalidates a pending verdict when screening state is reset', async () => {
     let resolveScreening: (value: boolean) => void = () => {}
     mocks.detectVpn.mockResolvedValue(false)

--- a/tests/server/screen-address.test.ts
+++ b/tests/server/screen-address.test.ts
@@ -68,7 +68,7 @@ describe('POST /api/screen-address', () => {
     await expect(handler(makeEvent({ address: USER }))).resolves.toEqual({ addressIsSuspicious: true })
   })
 
-  it('derives vpnIsUsed from trusted request headers', async () => {
+  it('derives vpnIsUsed from trusted request headers or a positive client signal', async () => {
     process.env.WALLET_SCREENING_URI = SCREENING_URI
     const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) =>
       new Response(JSON.stringify({ addressIsSuspicious: false }), { status: 200 }),
@@ -100,6 +100,6 @@ describe('POST /api/screen-address', () => {
       const init = call[1]
       return JSON.parse(String(init?.body)) as { vpnIsUsed: string }
     })
-    expect(bodies.map(body => body.vpnIsUsed)).toEqual(['true', 'true', 'true', 'true', 'false'])
+    expect(bodies.map(body => body.vpnIsUsed)).toEqual(['true', 'true', 'true', 'true', 'true'])
   })
 })


### PR DESCRIPTION
## Summary
- Ensure a positive or fail-closed VPN detection cannot become an allowed wallet state when address screening returns an allow verdict.
- Forward client-positive VPN detection to the server-side TRM request while preserving trusted edge headers as restrictive.

## Changes
- Combines the client VPN result with the wallet screening verdict before marking an address screened.
- Treats `vpnIsUsed: true` in the POST body as restrictive when building the upstream screening payload, without allowing body values to override restrictive headers.
- Adds regression coverage for VPN-positive detection plus permissive screening and updates server VPN derivation expectations.

## Test plan
- [x] npm test -- --run tests/services/trm.test.ts tests/services/vpn.test.ts tests/server/screen-address.test.ts tests/composables/useAddressScreen.test.ts tests/utils/swap-validation.test.ts tests/composables/useEulerOperations-wallet-swap-repay.test.ts tests/composables/useEulerOperations-disable-collateral.test.ts
- [x] npm run typecheck
- [x] npm run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced VPN detection to consider request headers and explicit client signals for more accurate identification.
  * Improved address screening logic to properly combine VPN detection results with address restriction status.

* **Tests**
  * Expanded test coverage for VPN detection and address screening scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/euler-xyz/euler-lite/pull/483?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->