### PR TITLE
fix

### DIFF
--- a/composables/useMerkl.ts
+++ b/composables/useMerkl.ts
@@ -404,6 +404,7 @@ const loadRewards = async (chainId: number, isInitialLoading = true, forceRefres
     const res = await axios.get(userRewardsEndpoint(address.value), {
       params: {
         chainId,
+        type: 'TOKEN',
       },
     })
 


### PR DESCRIPTION
## Summary
- Hide Merkl point campaigns from the claimable portfolio rewards panel by requesting token rewards only.
- Keep Merkl points available for separate points surfaces instead of mixing them with claimable token rewards.

## Changes
- Adds the Merkl user rewards query parameter `type=TOKEN` when loading portfolio rewards.
- Leaves public Merkl campaign/APY loading unchanged.

## Test
- npm run typecheck
- Verified live Merkl API behavior: `type=TOKEN` returns token rewards only, while `type=POINT` returns point campaigns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the rewards retrieval request to include additional filtering parameters for more accurate reward data retrieval.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/euler-xyz/euler-lite/pull/486?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->