### PR TITLE
refactor: summarize vault type badges

### DIFF
--- a/components/entities/vault/VaultTypeBadges.vue
+++ b/components/entities/vault/VaultTypeBadges.vue
@@ -1,69 +1,23 @@
 <script setup lang="ts">
-import { zeroAddress } from 'viem'
 import type { AnyVault } from '~/composables/useVaultRegistry'
-import type { Vault, EarnVault, SecuritizeVault } from '~/entities/vault'
-import { isCyclicalNoteVault } from '~/entities/vault'
-import { isVaultKeyring, getEntitiesByVault, getEntitiesByEarnVault } from '~/utils/eulerLabelsUtils'
-import { useEulerProductOfVault } from '~/composables/useEulerLabels'
+import type { VaultTypeBadge } from '~/composables/useVaultTypeBadges'
 
-const { vault, layout = 'inline', size = 'small', nudge = false } = defineProps<{
+const { vault, layout = 'inline', size = 'small', nudge = false, summaryOnly = false } = defineProps<{
   vault: AnyVault
   layout?: 'inline' | 'stacked'
   size?: 'small' | 'large'
   nudge?: boolean
+  summaryOnly?: boolean
 }>()
 
-const { isVaultGovernorVerified, isEarnVaultOwnerVerified } = useVaults()
-
-const addressRef = computed(() => vault.address)
-const product = useEulerProductOfVault(addressRef)
-
-const isEarn = computed(() => 'type' in vault && vault.type === 'earn')
-const isSecuritize = computed(() => 'type' in vault && vault.type === 'securitize')
-
-const entities = computed(() => {
-  if (isEarn.value) return getEntitiesByEarnVault(vault as EarnVault)
-  return getEntitiesByVault(vault as Vault | SecuritizeVault)
-})
-
-const isVerified = computed(() => {
-  if (isEarn.value) return isEarnVaultOwnerVerified(vault as EarnVault)
-  return isVaultGovernorVerified(vault as Vault)
-})
-
-const isGovernanceLimited = computed(() =>
-  product.isGovernanceLimited && isVerified.value,
-)
-
-const governanceType = computed(() => {
-  if (isEarn.value) {
-    return entities.value.length ? 'managed' : 'unknown'
-  }
-
-  const v = vault as Vault | SecuritizeVault
-  if ('vaultCategory' in v && v.vaultCategory === 'escrow') return 'escrow'
-  if (!v.governorAdmin) return 'unknown'
-  if (v.governorAdmin === zeroAddress) return 'ungoverned'
-  if (entities.value.length) {
-    return 'governed'
-  }
-  return 'unknown'
-})
-
-const extraType = computed(() => {
-  if (isSecuritize.value) return 'securitize'
-  return undefined
-})
-
-const isKeyring = computed(() => isVaultKeyring(vault.address))
-
-const isCyclicalNote = computed(() => {
-  if (isEarn.value || isSecuritize.value) return false
-  return isCyclicalNoteVault(vault as Vault)
-})
+const vaultRef = computed(() => vault)
+const { badges, governanceType, summaryBadges } = useVaultTypeBadges(vaultRef)
 
 const isStacked = computed(() => layout === 'stacked')
 const tagElement = computed(() => isStacked.value ? 'button' : 'span')
+const visibleBadges = computed(() => summaryOnly ? summaryBadges.value : badges.value)
+const hasVisibleBadge = (badge: VaultTypeBadge): boolean => visibleBadges.value.includes(badge)
+const showGovernanceType = computed(() => hasVisibleBadge(governanceType.value))
 </script>
 
 <template>
@@ -72,6 +26,7 @@ const tagElement = computed(() => isStacked.value ? 'button' : 'span')
     :class="isStacked ? 'flex-col items-stretch' : 'items-center flex-wrap'"
   >
     <VaultTypeChip
+      v-if="showGovernanceType"
       :vault="vault"
       :type="governanceType"
       :size="size"
@@ -80,30 +35,30 @@ const tagElement = computed(() => isStacked.value ? 'button' : 'span')
       :nudge="nudge"
     />
     <VaultTypeChip
-      v-if="extraType && isVerified"
+      v-if="hasVisibleBadge('securitize')"
       :vault="vault"
-      :type="extraType"
+      type="securitize"
       :size="size"
       :block="isStacked"
       :as="tagElement"
       :nudge="nudge"
     />
     <KeyringBadge
-      v-if="isKeyring && isVerified"
+      v-if="hasVisibleBadge('private')"
       :size="size"
       :block="isStacked"
       :as="tagElement"
       :nudge="nudge"
     />
     <GovernanceLimitedBadge
-      v-if="isGovernanceLimited"
+      v-if="hasVisibleBadge('governanceLimited')"
       :size="size"
       :block="isStacked"
       :as="tagElement"
       :nudge="nudge"
     />
     <CyclicalNoteBadge
-      v-if="isCyclicalNote && isVerified"
+      v-if="hasVisibleBadge('cyclicalNote')"
       :size="size"
       :block="isStacked"
       :as="tagElement"

--- a/components/entities/vault/VaultTypeBadges.vue
+++ b/components/entities/vault/VaultTypeBadges.vue
@@ -11,13 +11,14 @@ const { vault, layout = 'inline', size = 'small', nudge = false, summaryOnly = f
 }>()
 
 const vaultRef = computed(() => vault)
-const { badges, governanceType, summaryBadges } = useVaultTypeBadges(vaultRef)
+const { badges, governanceType, summaryBadges, summaryGovernanceType } = useVaultTypeBadges(vaultRef)
 
 const isStacked = computed(() => layout === 'stacked')
 const tagElement = computed(() => isStacked.value ? 'button' : 'span')
 const visibleBadges = computed(() => summaryOnly ? summaryBadges.value : badges.value)
+const visibleGovernanceType = computed(() => summaryOnly ? summaryGovernanceType.value : governanceType.value)
 const hasVisibleBadge = (badge: VaultTypeBadge): boolean => visibleBadges.value.includes(badge)
-const showGovernanceType = computed(() => hasVisibleBadge(governanceType.value))
+const showGovernanceType = computed(() => hasVisibleBadge(visibleGovernanceType.value))
 </script>
 
 <template>
@@ -28,7 +29,7 @@ const showGovernanceType = computed(() => hasVisibleBadge(governanceType.value))
     <VaultTypeChip
       v-if="showGovernanceType"
       :vault="vault"
-      :type="governanceType"
+      :type="visibleGovernanceType"
       :size="size"
       :block="isStacked"
       :as="tagElement"

--- a/components/entities/vault/overview/VaultOverviewPairBlockTypes.vue
+++ b/components/entities/vault/overview/VaultOverviewPairBlockTypes.vue
@@ -2,11 +2,23 @@
 import type { AnyBorrowVaultPair } from '~/entities/vault'
 import type { AccountBorrowPosition } from '~/entities/account'
 
-defineProps<{ pair: AnyBorrowVaultPair | AccountBorrowPosition }>()
+const { pair } = defineProps<{ pair: AnyBorrowVaultPair | AccountBorrowPosition }>()
+
+const collateral = computed(() => pair.collateral)
+const borrow = computed(() => pair.borrow)
+const collateralBadges = useVaultTypeBadges(collateral)
+const borrowBadges = useVaultTypeBadges(borrow)
+
+const showVaultTypesSummary = computed(() =>
+  collateralBadges.hasSummaryBadges.value || borrowBadges.hasSummaryBadges.value,
+)
 </script>
 
 <template>
-  <div class="bg-surface-secondary rounded-xl flex flex-col gap-24 p-24 shadow-card">
+  <div
+    v-if="showVaultTypesSummary"
+    class="bg-surface-secondary rounded-xl flex flex-col gap-24 p-24 shadow-card"
+  >
     <p class="text-h3 text-content-primary">
       Vault types
     </p>
@@ -25,6 +37,7 @@ defineProps<{ pair: AnyBorrowVaultPair | AccountBorrowPosition }>()
           :vault="pair.collateral"
           layout="stacked"
           size="large"
+          summary-only
         />
       </div>
 
@@ -44,6 +57,7 @@ defineProps<{ pair: AnyBorrowVaultPair | AccountBorrowPosition }>()
           :vault="pair.borrow"
           layout="stacked"
           size="large"
+          summary-only
         />
       </div>
     </div>

--- a/composables/useVaultTypeBadges.ts
+++ b/composables/useVaultTypeBadges.ts
@@ -73,6 +73,9 @@ export const useVaultTypeBadges = (vault: Ref<VaultTypeBadgeVault>) => {
   })
 
   const hasSummaryBadges = computed(() => summaryBadges.value.length > 0)
+  const summaryGovernanceType = computed<VaultGovernanceBadge>(() =>
+    summaryBadges.value.includes('unknown') ? 'unknown' : governanceType.value,
+  )
 
   return {
     badges,
@@ -80,5 +83,6 @@ export const useVaultTypeBadges = (vault: Ref<VaultTypeBadgeVault>) => {
     hasSummaryBadges,
     isVerified,
     summaryBadges,
+    summaryGovernanceType,
   }
 }

--- a/composables/useVaultTypeBadges.ts
+++ b/composables/useVaultTypeBadges.ts
@@ -1,0 +1,84 @@
+import { zeroAddress } from 'viem'
+import type { Ref } from 'vue'
+import type { EarnVault, SecuritizeVault, Vault } from '~/entities/vault'
+import { isCyclicalNoteVault } from '~/entities/vault'
+import { useEulerProductOfVault } from '~/composables/useEulerLabels'
+import { getEntitiesByEarnVault, getEntitiesByVault, isVaultKeyring } from '~/utils/eulerLabelsUtils'
+
+type VaultTypeBadgeVault = EarnVault | SecuritizeVault | Vault
+
+export type VaultGovernanceBadge = 'governed' | 'managed' | 'escrow' | 'ungoverned' | 'unknown'
+export type VaultTypeBadge = VaultGovernanceBadge | 'securitize' | 'private' | 'governanceLimited' | 'cyclicalNote'
+export type VaultTypeSummaryBadge = Extract<VaultTypeBadge, 'cyclicalNote' | 'private' | 'unknown'>
+
+export const useVaultTypeBadges = (vault: Ref<VaultTypeBadgeVault>) => {
+  const { isVaultGovernorVerified, isEarnVaultOwnerVerified } = useVaults()
+
+  const addressRef = computed(() => vault.value.address)
+  const product = useEulerProductOfVault(addressRef)
+
+  const isEarn = computed(() => 'type' in vault.value && vault.value.type === 'earn')
+  const isSecuritize = computed(() => 'type' in vault.value && vault.value.type === 'securitize')
+
+  const entities = computed(() => {
+    if (isEarn.value) return getEntitiesByEarnVault(vault.value as EarnVault)
+    return getEntitiesByVault(vault.value as Vault | SecuritizeVault)
+  })
+
+  const isVerified = computed(() => {
+    if (isEarn.value) return isEarnVaultOwnerVerified(vault.value as EarnVault)
+    return isVaultGovernorVerified(vault.value as Vault | SecuritizeVault)
+  })
+
+  const governanceType = computed<VaultGovernanceBadge>(() => {
+    if (isEarn.value) {
+      return entities.value.length ? 'managed' : 'unknown'
+    }
+
+    const v = vault.value as Vault | SecuritizeVault
+    if ('vaultCategory' in v && v.vaultCategory === 'escrow') return 'escrow'
+    if (!v.governorAdmin) return 'unknown'
+    if (v.governorAdmin.toLowerCase() === zeroAddress) return 'ungoverned'
+    return entities.value.length ? 'governed' : 'unknown'
+  })
+
+  const isGovernanceLimited = computed(() =>
+    product.isGovernanceLimited && isVerified.value,
+  )
+
+  const isCyclicalNote = computed(() => {
+    if (isEarn.value || isSecuritize.value) return false
+    return isCyclicalNoteVault(vault.value as Vault)
+  })
+
+  const badges = computed<VaultTypeBadge[]>(() => {
+    const result: VaultTypeBadge[] = [governanceType.value]
+
+    if (isVerified.value && isSecuritize.value) result.push('securitize')
+    if (isVerified.value && isVaultKeyring(vault.value.address)) result.push('private')
+    if (isGovernanceLimited.value) result.push('governanceLimited')
+    if (isVerified.value && isCyclicalNote.value) result.push('cyclicalNote')
+
+    return result
+  })
+
+  const summaryBadges = computed<VaultTypeSummaryBadge[]>(() => {
+    const result: VaultTypeSummaryBadge[] = []
+
+    if (!isVerified.value || governanceType.value === 'unknown') result.push('unknown')
+    if (badges.value.includes('private')) result.push('private')
+    if (badges.value.includes('cyclicalNote')) result.push('cyclicalNote')
+
+    return result
+  })
+
+  const hasSummaryBadges = computed(() => summaryBadges.value.length > 0)
+
+  return {
+    badges,
+    governanceType,
+    hasSummaryBadges,
+    isVerified,
+    summaryBadges,
+  }
+}

--- a/tests/composables/useVaultTypeBadges.test.ts
+++ b/tests/composables/useVaultTypeBadges.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import { zeroAddress } from 'viem'
+import { INTEREST_RATE_MODEL_TYPE } from '~/entities/constants'
+import type { Vault } from '~/entities/vault'
+import { useVaultTypeBadges } from '~/composables/useVaultTypeBadges'
+
+const state = vi.hoisted(() => ({
+  earnOwners: new Set<string>(),
+  entityGovernors: new Set<string>(),
+  governanceLimitedVaults: new Set<string>(),
+  keyringVaults: new Set<string>(),
+  verifiedEarnVaults: new Set<string>(),
+  verifiedVaults: new Set<string>(),
+}))
+
+vi.mock('~/composables/useEulerLabels', () => ({
+  useEulerProductOfVault: (addressRef: { value?: string } | string) => ({
+    get isGovernanceLimited() {
+      const address = typeof addressRef === 'string' ? addressRef : addressRef.value
+      return !!address && state.governanceLimitedVaults.has(address.toLowerCase())
+    },
+  }),
+}))
+
+vi.mock('~/utils/eulerLabelsUtils', () => ({
+  getEntitiesByEarnVault: (vault: { owner?: string }) =>
+    vault.owner && state.earnOwners.has(vault.owner.toLowerCase()) ? [{}] : [],
+  getEntitiesByVault: (vault: { governorAdmin?: string }) =>
+    vault.governorAdmin && state.entityGovernors.has(vault.governorAdmin.toLowerCase()) ? [{}] : [],
+  isVaultKeyring: (address: string) => state.keyringVaults.has(address.toLowerCase()),
+}))
+
+const verifiedGovernor = '0x1000000000000000000000000000000000000001'
+
+const makeVault = (overrides: Partial<Vault> = {}): Vault => ({
+  address: '0x2000000000000000000000000000000000000002',
+  asset: {
+    address: '0x3000000000000000000000000000000000000003',
+    decimals: 18n,
+    name: 'Wrapped Ether',
+    symbol: 'WETH',
+  },
+  governorAdmin: verifiedGovernor,
+  irmInfo: {
+    interestRateModelInfo: {
+      interestRateModelType: INTEREST_RATE_MODEL_TYPE.KINK,
+    },
+  },
+  verified: true,
+  ...overrides,
+} as Vault)
+
+const setupVaultsMock = () => {
+  ;(globalThis as unknown as { useVaults: unknown }).useVaults = () => ({
+    isEarnVaultOwnerVerified: (vault: { address: string }) =>
+      state.verifiedEarnVaults.has(vault.address.toLowerCase()),
+    isVaultGovernorVerified: (vault: { address: string }) =>
+      state.verifiedVaults.has(vault.address.toLowerCase()),
+  })
+}
+
+const verify = (vault: Vault) => {
+  state.verifiedVaults.add(vault.address.toLowerCase())
+  if (vault.governorAdmin) state.entityGovernors.add(vault.governorAdmin.toLowerCase())
+}
+
+describe('useVaultTypeBadges', () => {
+  beforeEach(() => {
+    state.earnOwners.clear()
+    state.entityGovernors.clear()
+    state.governanceLimitedVaults.clear()
+    state.keyringVaults.clear()
+    state.verifiedEarnVaults.clear()
+    state.verifiedVaults.clear()
+    setupVaultsMock()
+  })
+
+  it('does not include ordinary governance badges in the summary', () => {
+    const vault = makeVault()
+    verify(vault)
+
+    const { badges, governanceType, hasSummaryBadges, summaryBadges } = useVaultTypeBadges(ref(vault))
+
+    expect(governanceType.value).toBe('governed')
+    expect(badges.value).toEqual(['governed'])
+    expect(summaryBadges.value).toEqual([])
+    expect(hasSummaryBadges.value).toBe(false)
+  })
+
+  it('summarizes verified keyring vaults as private', () => {
+    const vault = makeVault()
+    verify(vault)
+    state.keyringVaults.add(vault.address.toLowerCase())
+
+    const { badges, hasSummaryBadges, summaryBadges } = useVaultTypeBadges(ref(vault))
+
+    expect(badges.value).toEqual(['governed', 'private'])
+    expect(summaryBadges.value).toEqual(['private'])
+    expect(hasSummaryBadges.value).toBe(true)
+  })
+
+  it.each([
+    INTEREST_RATE_MODEL_TYPE.FIXED_CYCLICAL_BINARY,
+    INTEREST_RATE_MODEL_TYPE.FIXED_CYCLICAL_BINARY_MONTHLY,
+  ])('summarizes verified cyclical IRM type %s as cyclical note', (interestRateModelType) => {
+    const vault = makeVault({
+      irmInfo: {
+        interestRateModelInfo: { interestRateModelType },
+      },
+    })
+    verify(vault)
+
+    const { badges, summaryBadges } = useVaultTypeBadges(ref(vault))
+
+    expect(badges.value).toEqual(['governed', 'cyclicalNote'])
+    expect(summaryBadges.value).toEqual(['cyclicalNote'])
+  })
+
+  it('does not treat KINKY IRM as cyclical note', () => {
+    const vault = makeVault({
+      irmInfo: {
+        interestRateModelInfo: { interestRateModelType: INTEREST_RATE_MODEL_TYPE.KINKY },
+      },
+    })
+    verify(vault)
+
+    const { badges, summaryBadges } = useVaultTypeBadges(ref(vault))
+
+    expect(badges.value).toEqual(['governed'])
+    expect(summaryBadges.value).toEqual([])
+  })
+
+  it('summarizes unverified or unrecognized vaults as unknown only', () => {
+    const vault = makeVault({
+      irmInfo: {
+        interestRateModelInfo: {
+          interestRateModelType: INTEREST_RATE_MODEL_TYPE.FIXED_CYCLICAL_BINARY,
+        },
+      },
+      verified: false,
+    })
+
+    const { badges, governanceType, summaryBadges } = useVaultTypeBadges(ref(vault))
+
+    expect(governanceType.value).toBe('unknown')
+    expect(badges.value).toEqual(['unknown'])
+    expect(summaryBadges.value).toEqual(['unknown'])
+  })
+
+  it('keeps ungoverned and governance-limited badges out of the pair summary', () => {
+    const vault = makeVault({
+      address: '0x4000000000000000000000000000000000000004',
+      governorAdmin: zeroAddress,
+    })
+    state.verifiedVaults.add(vault.address.toLowerCase())
+    state.governanceLimitedVaults.add(vault.address.toLowerCase())
+
+    const { badges, governanceType, hasSummaryBadges, summaryBadges } = useVaultTypeBadges(ref(vault))
+
+    expect(governanceType.value).toBe('ungoverned')
+    expect(badges.value).toEqual(['ungoverned', 'governanceLimited'])
+    expect(summaryBadges.value).toEqual([])
+    expect(hasSummaryBadges.value).toBe(false)
+  })
+})

--- a/tests/composables/useVaultTypeBadges.test.ts
+++ b/tests/composables/useVaultTypeBadges.test.ts
@@ -148,6 +148,25 @@ describe('useVaultTypeBadges', () => {
     expect(summaryBadges.value).toEqual(['unknown'])
   })
 
+  it('renders failed verification as unknown even when the governor has a label entity', () => {
+    const vault = makeVault({
+      irmInfo: {
+        interestRateModelInfo: {
+          interestRateModelType: INTEREST_RATE_MODEL_TYPE.FIXED_CYCLICAL_BINARY,
+        },
+      },
+      verified: false,
+    })
+    state.entityGovernors.add(vault.governorAdmin.toLowerCase())
+
+    const { badges, governanceType, summaryBadges, summaryGovernanceType } = useVaultTypeBadges(ref(vault))
+
+    expect(governanceType.value).toBe('governed')
+    expect(badges.value).toEqual(['governed'])
+    expect(summaryBadges.value).toEqual(['unknown'])
+    expect(summaryGovernanceType.value).toBe('unknown')
+  })
+
   it('keeps ungoverned and governance-limited badges out of the pair summary', () => {
     const vault = makeVault({
       address: '0x4000000000000000000000000000000000000004',


### PR DESCRIPTION
## Summary
- Pair information shows vault type summaries only when a side has a private, cyclical note, or unknown badge.
- Shared vault type badge derivation lives in one composable so full badge rendering and summary rendering stay aligned.

## Changes
- Added `useVaultTypeBadges` to derive governance, private, governance-limited, securitize, and cyclical badges from the same source.
- Added `summaryOnly` rendering to `VaultTypeBadges` for pair summaries.
- Updated `VaultOverviewPairBlockTypes` to hide the section when neither side has summary badges.
- Added focused tests for private, unknown, cyclical IRM types 4/5, KINKY IRM type 3, and hidden normal/governance-limited cases.

## Test plan
- [x] `npm run test:run -- tests/composables/useVaultTypeBadges.test.ts tests/entities/vault/utils.test.ts`
- [x] `npm run typecheck`
- [x] `npx eslint composables/useVaultTypeBadges.ts components/entities/vault/VaultTypeBadges.vue components/entities/vault/overview/VaultOverviewPairBlockTypes.vue tests/composables/useVaultTypeBadges.test.ts`
- [x] Manually checked a private pair renders `Private` in pair information.
- [x] Manually checked a normal governed pair hides the vault types section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a compact badge summary mode to show only key vault indicators (cyclical note, private, unknown) where appropriate; overview displays now opt into this summary mode.

* **Refactor**
  * Centralized badge and governance-type logic into a shared utility for consistent badge visibility and simpler templates.

* **Tests**
  * Added tests covering badge combinations, verification, governance states, and summary behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/euler-xyz/euler-lite/pull/488?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->