### PR TITLE
fix: keep ungoverned vaults out of summaries

### DIFF
--- a/composables/useVaultTypeBadges.ts
+++ b/composables/useVaultTypeBadges.ts
@@ -51,6 +51,11 @@ export const useVaultTypeBadges = (vault: Ref<VaultTypeBadgeVault>) => {
     return isCyclicalNoteVault(vault.value as Vault)
   })
 
+  const shouldSummarizeAsUnknown = computed(() =>
+    governanceType.value === 'unknown'
+    || (!isVerified.value && !['escrow', 'ungoverned'].includes(governanceType.value)),
+  )
+
   const badges = computed<VaultTypeBadge[]>(() => {
     const result: VaultTypeBadge[] = [governanceType.value]
 
@@ -65,7 +70,7 @@ export const useVaultTypeBadges = (vault: Ref<VaultTypeBadgeVault>) => {
   const summaryBadges = computed<VaultTypeSummaryBadge[]>(() => {
     const result: VaultTypeSummaryBadge[] = []
 
-    if (!isVerified.value || governanceType.value === 'unknown') result.push('unknown')
+    if (shouldSummarizeAsUnknown.value) result.push('unknown')
     if (badges.value.includes('private')) result.push('private')
     if (badges.value.includes('cyclicalNote')) result.push('cyclicalNote')
 

--- a/tests/composables/useVaultTypeBadges.test.ts
+++ b/tests/composables/useVaultTypeBadges.test.ts
@@ -167,18 +167,33 @@ describe('useVaultTypeBadges', () => {
     expect(summaryGovernanceType.value).toBe('unknown')
   })
 
-  it('keeps ungoverned and governance-limited badges out of the pair summary', () => {
+  it('keeps unverified ungoverned vaults out of the pair summary', () => {
     const vault = makeVault({
       address: '0x4000000000000000000000000000000000000004',
       governorAdmin: zeroAddress,
     })
+
+    const { badges, governanceType, hasSummaryBadges, isVerified, summaryBadges } = useVaultTypeBadges(ref(vault))
+
+    expect(governanceType.value).toBe('ungoverned')
+    expect(isVerified.value).toBe(false)
+    expect(badges.value).toEqual(['ungoverned'])
+    expect(summaryBadges.value).toEqual([])
+    expect(hasSummaryBadges.value).toBe(false)
+  })
+
+  it('keeps governance-limited badges out of the pair summary', () => {
+    const vault = makeVault({
+      address: '0x4000000000000000000000000000000000000004',
+    })
     state.verifiedVaults.add(vault.address.toLowerCase())
     state.governanceLimitedVaults.add(vault.address.toLowerCase())
+    state.entityGovernors.add(vault.governorAdmin.toLowerCase())
 
     const { badges, governanceType, hasSummaryBadges, summaryBadges } = useVaultTypeBadges(ref(vault))
 
-    expect(governanceType.value).toBe('ungoverned')
-    expect(badges.value).toEqual(['ungoverned', 'governanceLimited'])
+    expect(governanceType.value).toBe('governed')
+    expect(badges.value).toEqual(['governed', 'governanceLimited'])
     expect(summaryBadges.value).toEqual([])
     expect(hasSummaryBadges.value).toBe(false)
   })


### PR DESCRIPTION
## Summary
- Keep pair-level vault type summaries focused on actionable summary badges.
- Prevent unverified zero-governor vaults from surfacing as `Unknown` in the pair summary.

## Changes
- Add an explicit summary guard so `Unknown` appears for unrecognized vaults and failed verification on governed or managed vaults.
- Keep `escrow` and `ungoverned` out of the summary-only `Unknown` path.
- Split the regression coverage for unverified ungoverned vaults and governance-limited vaults.

## Test plan
- [x] `npm run test:run -- tests/composables/useVaultTypeBadges.test.ts tests/entities/vault/utils.test.ts`
- [x] `npm run typecheck`
- [x] `npx eslint composables/useVaultTypeBadges.ts tests/composables/useVaultTypeBadges.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined vault status badge display logic for improved accuracy when determining the "unknown" status for unverified and ungoverned vaults.

* **Tests**
  * Enhanced test coverage with separate test cases for distinct vault governance and verification scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/euler-xyz/euler-lite/pull/490?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->