### PR TITLE
fix: tint securitize vault badge

### DIFF
--- a/components/entities/vault/VaultTypeChip.vue
+++ b/components/entities/vault/VaultTypeChip.vue
@@ -58,6 +58,7 @@ const effectiveType = computed(() => isVerified.value ? type : 'unknown')
 
 const tone = computed(() => {
   if (isWarning.value) return 'danger'
+  if (type === 'securitize') return 'accent'
   if (type === 'governed' || type === 'ungoverned' || type === 'managed') return 'governance'
   return 'neutral'
 })


### PR DESCRIPTION
## Summary
- Make the Securitize vault type badge use the existing green accent styling so its shield icon matches similar green metadata badges.

## Changes
- Updated verified Securitize vault chips to use the shared accent tone while preserving danger styling for unverified or unknown states.

## Test plan
- [x] npm run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated visual appearance of Securitize vault type display.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/euler-xyz/euler-lite/pull/492?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->