### PR TITLE
chore: source yzPrime intrinsic APY from DefiLlama

### DIFF
--- a/entities/custom.ts
+++ b/entities/custom.ts
@@ -20,7 +20,6 @@ export type IntrinsicApySourceConfig
     | { provider: 'infinifi', address: string, chainId: number, infinifiVariant: 'locked' | 'staked', infinifiLockedKey?: string }
     | { provider: 'accountable', address: string, chainId: number, loanAddress: string }
     | { provider: 'coinshift', address: string, chainId: number, period: '7d' | '30d' | '90d' }
-    | { provider: 'yuzu-dashboard', address: string, chainId: number, yuzuApyField: 'yzprime_apy_1d' | 'yzprime_apy_7d' | 'yzprime_apy_30d' }
     | { provider: 'hyperbeat' | 'kinetiq' | 'lhype' | 'lsthype' | 'noon' | 'valantis', address: string, chainId: number }
 
 export const intrinsicApySources: readonly IntrinsicApySourceConfig[] = [
@@ -103,13 +102,11 @@ export const intrinsicApySources: readonly IntrinsicApySourceConfig[] = [
   // DefiLlama pools — Monad (143)
   { provider: 'defillama', chainId: 143, address: '0x10Aeaf63194db8d453d4D85a06E5eFE1dd0b5417', poolId: '747c1d2a-c668-4682-b9f9-296708a3dd90' },
   { provider: 'defillama', chainId: 143, address: '0x1b68626dca36c7fe922fd2d55e4f631d962de19c', poolId: 'ee40513c-9356-4c53-9f26-446b484a8ae2' },
+  { provider: 'defillama', chainId: 143, address: '0xc9ea90692757831d98Ac629F2A0140E02b80A7DA', poolId: '18147bfe-ee41-4762-9a95-c0ff28215798', useSpotApy: true }, // yzPrime
 
   // Accountable loans — Monad (143)
   { provider: 'accountable', chainId: 143, address: '0x8d3F9f9Eb2f5E8B48EFBB4074440D1E2A34Bc365', loanAddress: '0x8dCE15fc6a98484C995Fc702cBfBdA14A30454af' },
   { provider: 'accountable', chainId: 143, address: '0xC6De1DC0B59682bE906E5BcA14E385E74EE88168', loanAddress: '0x2653137fd4118AD25BCEFb31Ca748957b8528B01' },
-
-  // Yuzu — yzPrime
-  { provider: 'yuzu-dashboard', chainId: 143, address: '0xc9ea90692757831d98Ac629F2A0140E02b80A7DA', yuzuApyField: 'yzprime_apy_7d' },
 
   // DefiLlama pools — Sonic (146)
   { provider: 'defillama', chainId: 146, address: '0x16af6b1315471Dc306D47e9CcEfEd6e5996285B6', poolId: '24b3096a-488d-4a61-afa6-e5e9be2ce4bf' },

--- a/server/utils/intrinsic-apy.ts
+++ b/server/utils/intrinsic-apy.ts
@@ -40,7 +40,6 @@ const UPSTREAM_URLS = {
   infinifi: 'https://eth-api.infinifi.xyz/api/protocol/data',
   accountable: 'https://yield.accountable.capital/api/loan/address',
   coinshift: 'https://uspc-nav.coinshift.xyz/api/nav/returns',
-  yuzuDashboard: 'https://yuzu-accountable.yuzu.money/v1/dashboard',
   hyperbeat: 'https://api.hyperbeat.org/api/v1/staking?address=0xCeaD893b162D38e714D82d06a7fe0b0dc3c38E0b',
   kinetiq: 'https://api-v2.pendle.finance/core/v2/999/markets/0x31104779b2a07a273d6c662419377773083d0b2e/data',
   lhype: 'https://app.loopingcollective.org/api/external/asset/lhype',
@@ -412,70 +411,6 @@ async function extractCoinshift(sources: CoinshiftSource[]): Promise<Array<[stri
   return out
 }
 
-type YuzuDashboardSource = Extract<IntrinsicApySourceConfig, { provider: 'yuzu-dashboard' }>
-type YuzuDashboardTimelineRow = {
-  date?: string
-  ts?: string | number
-} & Partial<Record<YuzuDashboardSource['yuzuApyField'], string | number | null>>
-type YuzuDashboardResponse = {
-  data?: {
-    reserves?: {
-      timeline?: YuzuDashboardTimelineRow[]
-    }
-  }
-}
-
-const yuzuDateValue = (date?: string): number => {
-  if (!date) return Number.NEGATIVE_INFINITY
-  const parsed = Date.parse(`${date}T00:00:00Z`)
-  return Number.isFinite(parsed) ? parsed : Number.NEGATIVE_INFINITY
-}
-
-const yuzuTimestampValue = (ts?: string | number): number => {
-  const parsed = Number(ts)
-  return Number.isFinite(parsed) ? parsed : Number.NEGATIVE_INFINITY
-}
-
-export function extractLatestYuzuApy(
-  rows: readonly YuzuDashboardTimelineRow[] | undefined,
-  field: YuzuDashboardSource['yuzuApyField'],
-): number | null {
-  let latest: YuzuDashboardTimelineRow | undefined
-  for (const row of rows ?? []) {
-    if (!row) continue
-    if (!latest) {
-      latest = row
-      continue
-    }
-    const rowDate = yuzuDateValue(row.date)
-    const latestDate = yuzuDateValue(latest.date)
-    if (
-      rowDate > latestDate
-      || (rowDate === latestDate && yuzuTimestampValue(row.ts) > yuzuTimestampValue(latest.ts))
-    ) {
-      latest = row
-    }
-  }
-
-  const apy = Number(latest?.[field])
-  return Number.isFinite(apy) ? apy : null
-}
-
-async function extractYuzuDashboard(sources: YuzuDashboardSource[]): Promise<Array<[string, IntrinsicApyInfo]>> {
-  const data = await fetchUpstream<YuzuDashboardResponse>('yuzu-dashboard', UPSTREAM_URLS.yuzuDashboard)
-  const out: Array<[string, IntrinsicApyInfo]> = []
-  for (const s of sources) {
-    const apy = extractLatestYuzuApy(data?.data?.reserves?.timeline, s.yuzuApyField)
-    if (apy === null) continue
-    out.push([normalize(s.address), {
-      apy,
-      provider: 'Yuzu',
-      source: UPSTREAM_URLS.yuzuDashboard,
-    }])
-  }
-  return out
-}
-
 type YoSource = Extract<IntrinsicApySourceConfig, { provider: 'yo' }>
 
 async function extractYo(sources: YoSource[]): Promise<Array<[string, IntrinsicApyInfo]>> {
@@ -579,7 +514,7 @@ async function extractSimple<S extends IntrinsicApySourceConfig, T>(
 }
 
 // Providers with dedicated extractors in the switch below.
-type ExplicitProvider = 'defillama' | 'pendle' | 'securitize' | 'stablewatch' | 'renzo' | 'midas' | 'yo' | 'infinifi' | 'accountable' | 'coinshift' | 'yuzu-dashboard' | 'valantis'
+type ExplicitProvider = 'defillama' | 'pendle' | 'securitize' | 'stablewatch' | 'renzo' | 'midas' | 'yo' | 'infinifi' | 'accountable' | 'coinshift' | 'valantis'
 // Every remaining provider must have an entry in SIMPLE_SPECS — enforced at the type level.
 type SimpleProvider = Exclude<IntrinsicApySourceConfig['provider'], ExplicitProvider>
 
@@ -679,7 +614,6 @@ async function extractForProvider(
     case 'infinifi': return extractInfinifi(sources as InfinifiSource[])
     case 'accountable': return extractAccountable(sources as AccountableSource[])
     case 'coinshift': return extractCoinshift(sources as CoinshiftSource[])
-    case 'yuzu-dashboard': return extractYuzuDashboard(sources as YuzuDashboardSource[])
     case 'valantis': return extractValantis(sources as ValantisSource[])
     default: {
       const simpleProvider: SimpleProvider = provider

--- a/tests/server/intrinsic-apy.test.ts
+++ b/tests/server/intrinsic-apy.test.ts
@@ -1,40 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import {
   extractHyperbeatWeightedApr,
-  extractLatestYuzuApy,
   extractValantisApy,
 } from '~/server/utils/intrinsic-apy'
-
-describe('extractLatestYuzuApy', () => {
-  it('uses the configured APY field from the latest date', () => {
-    const rows = [
-      { date: '2026-05-18', ts: '1779065174400', yzprime_apy_7d: 5.9, yzprime_apy_30d: 5.8 },
-      { date: '2026-05-19', ts: '1779151572900', yzprime_apy_7d: 6.0, yzprime_apy_30d: 6.0 },
-      { date: '2026-05-20', ts: '1779241574271', yzprime_apy_7d: 6.1, yzprime_apy_30d: 6.0 },
-    ]
-
-    expect(extractLatestYuzuApy(rows, 'yzprime_apy_7d')).toBe(6.1)
-  })
-
-  it('uses the highest timestamp when multiple rows share the latest date', () => {
-    const rows = [
-      { date: '2026-05-20', ts: '1779241574271', yzprime_apy_7d: 6.1 },
-      { date: '2026-05-20', ts: '1779287476493', yzprime_apy_7d: 6.2 },
-      { date: '2026-05-19', ts: '1779151572900', yzprime_apy_7d: 7.0 },
-    ]
-
-    expect(extractLatestYuzuApy(rows, 'yzprime_apy_7d')).toBe(6.2)
-  })
-
-  it('returns null when the latest row lacks the configured APY field', () => {
-    const rows = [
-      { date: '2026-05-19', ts: '1779151572900', yzprime_apy_7d: 6.0 },
-      { date: '2026-05-20', ts: '1779287476493', yzprime_apy_30d: 6.1 },
-    ]
-
-    expect(extractLatestYuzuApy(rows, 'yzprime_apy_7d')).toBeNull()
-  })
-})
 
 describe('HyperEVM intrinsic APY helpers', () => {
   it('uses only active Hyperbeat delegations when computing weighted APR', () => {


### PR DESCRIPTION
## Summary

Switches the Monad **yzPrime** intrinsic APY from the Yuzu dashboard scraper to its DefiLlama yields pool, and removes the now-unused `yuzu-dashboard` provider entirely.

The DefiLlama pool [`18147bfe-ee41-4762-9a95-c0ff28215798`](https://defillama.com/yields/pool/18147bfe-ee41-4762-9a95-c0ff28215798) resolves to `YZPRIME` / `yuzu-money` on Monad — the same token previously sourced via the scraper. Using DefiLlama matches how every other Monad/Yuzu entry (e.g. `syzUSD`) is wired and removes a bespoke first-party scraper.

## Changes

- **`entities/custom.ts`**: Replace the `yuzu-dashboard` entry for yzPrime (`0xc9ea…7DA`) with a `defillama` entry (`useSpotApy: true`, consistent with the sibling `syzUSD` config). Drop the `yuzu-dashboard` member from the `IntrinsicApySourceConfig` union.
- **`server/utils/intrinsic-apy.ts`**: Remove the orphaned `yuzu-dashboard` upstream URL, types, `extractLatestYuzuApy`/`extractYuzuDashboard` handlers, dispatch case, and `ExplicitProvider` member.
- **`tests/server/intrinsic-apy.test.ts`**: Remove the now-dead `extractLatestYuzuApy` test block.

## Notes

- `useSpotApy: true` reads DefiLlama's spot `apy` (noisier than the previous `yzprime_apy_7d` smoothing). DefiLlama has no 7d window; dropping the flag would use the 30d mean instead if smoothing is preferred.

## Test plan

- [x] `npx vitest run tests/server/intrinsic-apy.test.ts` — passing
- [x] `npm run typecheck` — passing (exit 0)
- [x] No remaining references to the `yuzu-dashboard` provider