### PR TITLE
fix: rename 'Fixed period' to 'Fixed rate period' in cyclical IRM overview

### DIFF
--- a/components/entities/vault/overview/VaultOverviewBlockCyclicalIRM.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockCyclicalIRM.vue
@@ -324,7 +324,7 @@ const formatDuration = (seconds: bigint): string => {
     >
       <div>
         <p class="mb-10 text-p2 text-content-tertiary">
-          Fixed period
+          Fixed rate period
         </p>
         <dl class="flex flex-col">
           <div class="cyclical-irm-row">


### PR DESCRIPTION
## Summary
Renames the visible label **"Fixed period" → "Fixed rate period"** in the cyclical-note IRM overview block, for consistency with the surrounding "Fixed rate start / end" terminology.

## Changes
- `components/entities/vault/overview/VaultOverviewBlockCyclicalIRM.vue` — single label string change.

## Test plan
- [ ] Open a cyclical-note vault overview and confirm the left column header reads "Fixed rate period".