### PR TITLE
fix: keep borrow-side UI and totals for vaults with residual debt

### DIFF
--- a/components/entities/vault/VaultItem.vue
+++ b/components/entities/vault/VaultItem.vue
@@ -12,7 +12,7 @@ import BaseLoadableContent from '~/components/base/BaseLoadableContent.vue'
 import { useModal } from '~/components/ui/composables/useModal'
 import { useVaultRegistry } from '~/composables/useVaultRegistry'
 import { VaultSupplyApyModal, VaultCollateralExposureModal, UiModalPreviewTrigger } from '#components'
-import { isCyclicalNoteVault } from '~/utils/vault/classification'
+import { isCyclicalNoteVault, isVaultBorrowable } from '~/utils/vault/classification'
 import { getAddress } from 'viem'
 
 const { isConnected } = useWagmi()
@@ -37,7 +37,7 @@ const entityLogos = computed(() => {
   return entities.map(e => getEulerLabelEntityLogo(e.logo))
 })
 const isEscrow = computed(() => getVaultCategory(vault.address) === 'escrow')
-const isBorrowable = computed(() => !isEscrow.value && vault.collaterals.some(ltv => ltv.borrowLTV > 0))
+const isBorrowable = computed(() => isVaultBorrowable(vault))
 const displayName = computed(() => {
   if (isEscrow.value) return 'Escrowed collateral'
   return product.name || vault.shares.name

--- a/components/entities/vault/overview/VaultOverviewBlockAddresses.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockAddresses.vue
@@ -3,12 +3,15 @@ import type { EVault } from '@eulerxyz/euler-v2-sdk'
 import { getExplorerLink } from '~/utils/block-explorer'
 import { getSpecialAddressLabel } from '~/utils/special-addresses'
 import { getVaultHookTarget } from '~/utils/vault-hooks'
+import { isVaultBorrowable } from '~/utils/vault/classification'
 
 const { vault } = defineProps<{ vault: EVault }>()
 
 const { chainId } = useEulerAddresses()
 
-const isBorrowable = computed(() => vault.isBorrowable)
+// Surface borrow-side addresses while debt is being wound down, not only while
+// new borrows are allowed (see isVaultBorrowable).
+const isBorrowable = computed(() => isVaultBorrowable(vault))
 
 const interestRateModelAddress = computed(() =>
   vault.interestRateModel.address,

--- a/components/entities/vault/overview/VaultOverviewBlockRiskParameters.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockRiskParameters.vue
@@ -8,6 +8,7 @@ import { nanoToValue } from '~/utils/crypto-utils'
 import { formatAssetValue } from '~/utils/sdk-prices'
 import { formatHookedOpsSummary, getHookedOperationMetas, getVaultHookedOperations, hasAnyHookedOperation, isHookDisabling, isVaultEffectivelyPaused } from '~/utils/vault-hooks'
 import { useModal } from '~/components/ui/composables/useModal'
+import { isVaultBorrowable } from '~/utils/vault/classification'
 import { VaultHooksInfoModal } from '#components'
 
 const { vault } = defineProps<{ vault: EVault }>()
@@ -19,7 +20,9 @@ const { getVaultCategory } = useVaultRegistry()
 
 const shareTokenExchangeRate: Ref<bigint | undefined> = ref()
 
-const isBorrowable = computed(() => vault.isBorrowable)
+// Borrow-side risk params stay visible while debt is being wound down — not
+// just while new borrows are allowed (see isVaultBorrowable).
+const isBorrowable = computed(() => isVaultBorrowable(vault))
 
 const supplyCapPercentageDisplay = computed(() => vault.caps.supplyCapUtilization)
 const borrowCapPercentageDisplay = computed(() => vault.caps.borrowCapUtilization)

--- a/components/entities/vault/overview/VaultOverviewBlockStats.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockStats.vue
@@ -5,13 +5,14 @@ import { formatAssetValue } from '~/utils/sdk-prices'
 import { formatNumber, compactNumber, formatCompactUsdValue } from '~/utils/string-utils'
 import { VaultSupplyApyModal, VaultBorrowApyModal, UiModalPreviewTrigger } from '#components'
 import { withVaultIntrinsicApy, getVaultIntrinsicApy, getVaultIntrinsicApyInfo } from '~/utils/vault-intrinsic-apy'
+import { isVaultBorrowable } from '~/utils/vault/classification'
 
 const { vault } = defineProps<{ vault: EVault }>()
 
 const { settings } = useUserSettings()
 const enableIntrinsicApy = computed(() => settings.value.enableIntrinsicApy)
 const { getSupplyRewardApy, getBorrowRewardApy, getSupplyRewardCampaigns, getBorrowRewardCampaigns, hasSupplyRewards, hasBorrowRewards } = useRewardsApy()
-const isBorrowable = computed(() => vault.collaterals.some(ltv => ltv.borrowLTV > 0))
+const isBorrowable = computed(() => isVaultBorrowable(vault))
 
 const supplyApyWithRewards = computed(() => withVaultIntrinsicApy(
   getVaultSupplyApy(vault),

--- a/composables/useMarketGroups.ts
+++ b/composables/useMarketGroups.ts
@@ -7,6 +7,7 @@ import type { AnyVault } from '~/composables/useVaultRegistry'
 import { getAssetUsdValueOrZero } from '~/utils/sdk-prices'
 import { isVaultNotExplorable, isVaultFeatured, isVaultRecentlyAdded, isVaultDeprecated, getProductKeyByVault } from '~/utils/eulerLabelsUtils'
 import { isLiveCollateralEdge } from '~/utils/vault/ltv'
+import { isVaultBorrowable } from '~/utils/vault/classification'
 import { liteVaultFetchOptions } from '~/utils/sdk-fetch-options'
 
 // -- Helpers --
@@ -14,12 +15,8 @@ import { liteVaultFetchOptions } from '~/utils/sdk-fetch-options'
 const hasGovernorAdmin = (vault: AnyVault): vault is EVault =>
   isEVault(vault) && 'governorAdmin' in vault
 
-const isBorrowableVault = (vault: AnyVault): boolean => {
-  if (!isEVault(vault)) return false
-  const { getVaultCategory } = useVaultRegistry()
-  if (getVaultCategory(vault.address) === 'escrow') return false
-  return vault.collaterals.some(ltv => ltv.borrowLTV > 0)
-}
+const isBorrowableVault = (vault: AnyVault): boolean =>
+  isEVault(vault) && isVaultBorrowable(vault)
 
 const getCollateralAddresses = (vault: AnyVault): string[] => {
   if (!isEVault(vault)) return []

--- a/tests/utils/vault/classification.test.ts
+++ b/tests/utils/vault/classification.test.ts
@@ -1,7 +1,27 @@
 import { describe, it, expect } from 'vitest'
 import type { EVault, SecuritizeCollateralVault } from '@eulerxyz/euler-v2-sdk'
 import { INTEREST_RATE_MODEL_TYPE } from '~/entities/constants'
-import { isCyclicalNoteVault } from '~/utils/vault/classification'
+import { isCyclicalNoteVault, isVaultBorrowable } from '~/utils/vault/classification'
+
+const makeBorrowableInput = (
+  isBorrowable: boolean,
+  totalBorrowed: bigint,
+): Pick<EVault, 'isBorrowable' | 'totalBorrowed'> =>
+  ({ isBorrowable, totalBorrowed } as Pick<EVault, 'isBorrowable' | 'totalBorrowed'>)
+
+describe('isVaultBorrowable', () => {
+  it('is true when the SDK reports the vault as borrowable', () => {
+    expect(isVaultBorrowable(makeBorrowableInput(true, 0n))).toBe(true)
+  })
+
+  it('is true on residual debt even when the SDK reports not borrowable', () => {
+    expect(isVaultBorrowable(makeBorrowableInput(false, 1n))).toBe(true)
+  })
+
+  it('is false when not borrowable and there is no outstanding debt', () => {
+    expect(isVaultBorrowable(makeBorrowableInput(false, 0n))).toBe(false)
+  })
+})
 
 describe('isCyclicalNoteVault', () => {
   it('returns true for EVaults using the fixed cyclical IRM', () => {

--- a/utils/vault/classification.ts
+++ b/utils/vault/classification.ts
@@ -1,6 +1,24 @@
 import type { EVault, SecuritizeCollateralVault } from '@eulerxyz/euler-v2-sdk'
 import { INTEREST_RATE_MODEL_TYPE } from '~/entities/constants'
 
+/**
+ * Should borrow-side UI / aggregation treat this vault as borrowable?
+ *
+ * `EVault.isBorrowable` is config-derived (some collateral has an active borrow
+ * or liquidation LTV, including active ramp-down) and answers "can a *new*
+ * borrow be opened". This predicate additionally returns true when there is
+ * residual outstanding debt (`totalBorrowed > 0`) — e.g. a vault whose LTVs
+ * have fully ramped to zero but whose existing borrows are still being repaid.
+ * Use it to gate borrow-side display (overview blocks) and discovery
+ * aggregates so residual exposure stays visible and counted.
+ *
+ * Escrow / non-borrowable vault types report `isBorrowable === false` and carry
+ * no debt, so they remain non-borrowable here.
+ */
+export const isVaultBorrowable = (
+  vault: Pick<EVault, 'isBorrowable' | 'totalBorrowed'>,
+): boolean => vault.isBorrowable || vault.totalBorrowed > 0n
+
 export const isCyclicalNoteVault = (
   vault: EVault | SecuritizeCollateralVault | null | undefined,
 ): boolean => {


### PR DESCRIPTION
## Summary

Vaults whose collateral LTVs have **fully ramped to zero** while borrows are still being repaid were treated as non-borrowable. As a result:
- their borrow-side overview blocks (Stats, Risk parameters, Addresses) were hidden, and
- their outstanding debt was dropped from the explore-page **Total borrowed** / **Available liquidity** aggregates.

The root cause: `EVault.isBorrowable` (and the local LTV checks scattered across the borrow gates) are **config-derived** — they answer "can a *new* borrow be opened" (`hasActiveBorrowableLtv`: some collateral has an active borrow/liquidation LTV, including active ramp-down). They never look at outstanding debt, so a fully-wound-down vault with residual `totalBorrowed > 0` reads as non-borrowable.

## Change

Add an app-level predicate in `utils/vault/classification.ts`:

```ts
export const isVaultBorrowable = (
  vault: Pick<EVault, 'isBorrowable' | 'totalBorrowed'>,
): boolean => vault.isBorrowable || vault.totalBorrowed > 0n
```

and route the **vault-level** borrow gates + the market-group aggregation through it:

- `composables/useMarketGroups.ts` — `isBorrowableVault` now `isEVault(vault) && isVaultBorrowable(vault)`. Since the explore aggregation already gates `totalBorrowed` / `availableLiquidity` on this predicate, residual debt is now counted. (Escrow vaults report `isBorrowable === false` and carry no debt, so the previous explicit escrow guard is now redundant.)
- `VaultItem.vue`, `VaultOverviewBlockStats.vue`, `VaultOverviewBlockRiskParameters.vue`, `VaultOverviewBlockAddresses.vue` — borrow-side content stays visible while debt is wound down.

`EVault.isBorrowable` keeps meaning "new borrows allowed"; residual outstanding debt is handled separately for display/aggregation, rather than overloading the SDK property.

### Scope notes
- The **per-pair** collateral-exposure card (`VaultOverviewPairBlockGeneral`, the "Collateral exposure" block) is intentionally left strictly LTV-driven — it can't attribute residual debt to a specific collateral.
- This also **unifies** two previously inconsistent gates: `VaultItem` / `Stats` used the narrow `collaterals.some(borrowLTV > 0)`, while `RiskParameters` / `Addresses` used the broader SDK `isBorrowable` (which also counts liquidation-LTV / ramp-down). All vault-level gates now share one definition, so ramp-down vaults are treated consistently across the list, stats, and explore aggregates.

## Test plan

- [x] `vitest run tests/utils/vault/classification.test.ts` — added 3 `isVaultBorrowable` cases (borrowable, residual-debt-only, neither); passing.
- [x] ESLint clean on changed files.
- [ ] **`nuxt typecheck` / full suite must run in CI** — the local environment is offline and the dev-only `@eulerxyz/euler-v2-sdk` isn't installable here, so type checking against `EVault` could not be run locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved borrowability detection across vault overview displays to correctly show borrow-related information, including risk parameters, addresses, and statistics. Vaults now properly display borrowing-related details when carrying outstanding debt, particularly during debt reduction phases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/euler-xyz/euler-lite/pull/503?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->