### PR TITLE
refactor: read keyring classification from labels 'tags' field

### DIFF
--- a/entities/euler/labels.ts
+++ b/entities/euler/labels.ts
@@ -21,7 +21,6 @@ export type EulerLabelVaultOverride = {
   restricted?: string[]
   notExplorableLend?: boolean
   notExplorableBorrow?: boolean
-  keyring?: boolean
 }
 
 export type EulerLabelProduct = {
@@ -38,7 +37,10 @@ export type EulerLabelProduct = {
   block?: string[]
   recentlyAddedVaults?: string[]
   vaultOverrides?: Record<string, EulerLabelVaultOverride>
-  keyring?: boolean
+  // Freeform classification tags, e.g. 'keyring' or 'access control'. Replaces
+  // the former `keyring` boolean. Only product-level tags are read today; the
+  // labels SDK does not yet surface override-level tags (tracked as follow-up).
+  tags?: string[]
 }
 
 export type EulerLabelEarnVaultEntry = {

--- a/utils/eulerLabelsUtils.ts
+++ b/utils/eulerLabelsUtils.ts
@@ -18,10 +18,8 @@ import {
   getEulerLabelVaultRestricted,
   isEulerLabelEarnVaultDeprecated,
   isEulerLabelEarnVaultNotExplorable,
-  isEulerLabelProductKeyring,
   isEulerLabelVaultDeprecated,
   isEulerLabelVaultFeatured,
-  isEulerLabelVaultKeyring,
   isEulerLabelVaultNotExplorable,
   isEulerLabelVaultNotExplorableBorrow,
   isEulerLabelVaultNotExplorableLend,
@@ -162,11 +160,14 @@ export const isVaultNotExplorableLend = (vaultAddress: string): boolean =>
 export const isVaultNotExplorableBorrow = (vaultAddress: string): boolean =>
   isEulerLabelVaultNotExplorableBorrow(labels(), vaultAddress)
 
+const productHasTag = (product: EulerLabelProduct, tag: string): boolean =>
+  product.tags?.includes(tag) ?? false
+
 export const isVaultKeyring = (vaultAddress: string): boolean =>
-  isEulerLabelVaultKeyring(labels(), vaultAddress)
+  productHasTag(getProductByVault(vaultAddress), 'keyring')
 
 export const isProductKeyring = (productKey: string): boolean =>
-  isEulerLabelProductKeyring(labels(), productKey)
+  productHasTag((labels().products[productKey] as EulerLabelProduct | undefined) ?? eulerLabelProductEmpty, 'keyring')
 
 export const getEntitiesByVault = (vault: { governorAdmin?: string, governor?: string }): EulerLabelEntity[] =>
   getEulerLabelEntitiesByVault(labels(), vault) as EulerLabelEntity[]


### PR DESCRIPTION
## Summary
Follows euler-xyz/euler-labels#623, which replaces the product `keyring` boolean with a freeform `tags` string array. This switches euler-lite to recognize keyring vaults via `tags.includes('keyring')`.

## Changes
- **`entities/euler/labels.ts`** — drop `keyring?: boolean` from `EulerLabelProduct` and `EulerLabelVaultOverride`; add `tags?: string[]` to `EulerLabelProduct`.
- **`utils/eulerLabelsUtils.ts`** — `isVaultKeyring` / `isProductKeyring` now read product-level `tags` instead of delegating to the SDK's `isEulerLabelVaultKeyring` / `isEulerLabelProductKeyring` (keyring-boolean) helpers. Adds a small `productHasTag` helper.

The `isVaultKeyring` / `isProductKeyring` signatures are unchanged, so all consumers (badges, operation guard, hook modal, discovery graph, item rows) are untouched.

## Why a shim, not an SDK change
The labels parsing/detection now lives in the published `@eulerxyz/euler-v2-sdk`. Its product normalization preserves unknown **product-level** fields (so `tags` survive), but its `vaultOverrides` parser allowlists keys and **drops** unknown override fields. Reading product-level tags here unblocks the migration without an SDK release. Current keyring data is product-level only, so behavior is preserved.

## Follow-up
- Update `@eulerxyz/euler-v2-sdk` to parse `tags` natively (incl. override-level tags) and expose tag helpers; then this shim can delegate to the SDK again.

## Deploy ordering
⚠️ Depends on the euler-labels `tags` data (euler-xyz/euler-labels#623) being live in the served labels before this deploys, otherwise keyring vaults temporarily lose their "Private" classification.

## Verification
- `npm run typecheck` passes.
- `vitest run` for `useVaultTypeBadges` / `useBorrowForm` passes (10 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced freeform tags system for product labeling, replacing legacy boolean-based approach.

* **Refactor**
  * Updated vault and product metadata structure to support enhanced tagging and explorability controls.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/euler-xyz/euler-lite/pull/504?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->