### PR TITLE
refactor: read keyring classification from labels 'tags' field (master)

### DIFF
--- a/components/entities/vault/AccessControlBadge.vue
+++ b/components/entities/vault/AccessControlBadge.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import { useModal } from '~/components/ui/composables/useModal'
+import { AccessControlInfoModal } from '#components'
+
+const { size = 'small', block = false, as = 'span', nudge = false } = defineProps<{
+  size?: 'small' | 'large'
+  block?: boolean
+  as?: 'button' | 'span'
+  nudge?: boolean
+}>()
+
+const modal = useModal()
+
+const openInfoModal = (event: MouseEvent | KeyboardEvent) => {
+  event.preventDefault()
+  event.stopPropagation()
+  modal.open(AccessControlInfoModal)
+}
+</script>
+
+<template>
+  <VaultMetadataTag
+    :as="as"
+    icon="search-user"
+    label="Access control"
+    tone="accent"
+    :size="size"
+    :block="block"
+    :nudge="nudge"
+    title="This vault restricts operations to allowlisted addresses"
+    @click="openInfoModal"
+  />
+</template>

--- a/components/entities/vault/AccessControlInfoModal.vue
+++ b/components/entities/vault/AccessControlInfoModal.vue
@@ -1,0 +1,68 @@
+<script setup lang="ts">
+defineEmits(['close'])
+</script>
+
+<template>
+  <BaseModalWrapper
+    title="Access-controlled Vault"
+    @close="$emit('close')"
+  >
+    <div class="flex flex-col gap-16 pt-8">
+      <div class="flex items-center justify-center">
+        <div class="flex items-center justify-center w-48 h-48 rounded-12 bg-accent-100">
+          <SvgIcon
+            name="search-user"
+            class="!w-24 !h-24 text-accent-600"
+          />
+        </div>
+      </div>
+
+      <div class="flex flex-col gap-8">
+        <p class="text-p2 text-content-primary text-center font-medium">
+          Permissioned Operations
+        </p>
+        <p class="text-p3 text-content-secondary text-center">
+          This vault routes operations through an access-control hook. Only addresses on an on-chain allowlist can perform the gated operations.
+        </p>
+      </div>
+
+      <div class="flex flex-col gap-8 p-12 rounded-12 bg-surface-secondary">
+        <div class="flex items-start gap-8">
+          <SvgIcon
+            name="check-circle"
+            class="!w-16 !h-16 text-accent-600 mt-2 shrink-0"
+          />
+          <p class="text-p3 text-content-secondary">
+            Access is granted by the vault manager — there is no self-service verification
+          </p>
+        </div>
+        <div class="flex items-start gap-8">
+          <SvgIcon
+            name="check-circle"
+            class="!w-16 !h-16 text-accent-600 mt-2 shrink-0"
+          />
+          <p class="text-p3 text-content-secondary">
+            If your address is not whitelisted, the gated operations will revert
+          </p>
+        </div>
+        <div class="flex items-start gap-8">
+          <SvgIcon
+            name="check-circle"
+            class="!w-16 !h-16 text-accent-600 mt-2 shrink-0"
+          />
+          <p class="text-p3 text-content-secondary">
+            Which operations are gated depends on the vault's hook configuration
+          </p>
+        </div>
+      </div>
+
+      <UiButton
+        variant="primary"
+        size="large"
+        @click="$emit('close')"
+      >
+        Got it
+      </UiButton>
+    </div>
+  </BaseModalWrapper>
+</template>

--- a/components/entities/vault/VaultHooksInfoModal.vue
+++ b/components/entities/vault/VaultHooksInfoModal.vue
@@ -9,7 +9,7 @@ import {
 } from '~/utils/vault-hooks'
 import { getExplorerLink } from '~/utils/block-explorer'
 import { getSpecialAddressLabel } from '~/utils/special-addresses'
-import { isVaultKeyring } from '~/utils/eulerLabelsUtils'
+import { isVaultAccessControlled, isVaultKeyring } from '~/utils/eulerLabelsUtils'
 import { truncate } from '~/utils/string-utils'
 
 const emits = defineEmits<{ close: [] }>()
@@ -57,8 +57,17 @@ const hookTargetLink = computed(() => getExplorerLink(vault.hookTarget, chainId.
 
 const hookTargetLabel = computed(() => {
   if (isVaultKeyring(vault.address)) return 'Keyring (identity verification)'
+  if (isVaultAccessControlled(vault.address)) return 'Access control (allowlist)'
   return 'Third-party hook contract'
 })
+
+// Extra explanation shown for permissioned vaults that gate operations behind
+// an on-chain allowlist (access-control hook target).
+const hookTargetNote = computed(() =>
+  isVaultAccessControlled(vault.address)
+    ? 'This vault is permissioned: the operations below can only be performed by addresses that the vault manager has added to an on-chain allowlist. If your address is not whitelisted, those operations will revert. Access is granted by the manager — there is no self-service verification.'
+    : '',
+)
 
 const onCopyClick = (address: string) => {
   copyToClipboard(address).catch(() => {})
@@ -106,6 +115,12 @@ const handleClose = () => {
           />
         </button>
       </div>
+      <p
+        v-if="hookTargetNote"
+        class="text-p3 text-content-tertiary"
+      >
+        {{ hookTargetNote }}
+      </p>
     </div>
 
     <div

--- a/components/entities/vault/VaultTypeBadges.vue
+++ b/components/entities/vault/VaultTypeBadges.vue
@@ -51,6 +51,13 @@ const showGovernanceType = computed(() => hasVisibleBadge(visibleGovernanceType.
       :as="tagElement"
       :nudge="nudge"
     />
+    <AccessControlBadge
+      v-if="hasVisibleBadge('accessControl')"
+      :size="size"
+      :block="isStacked"
+      :as="tagElement"
+      :nudge="nudge"
+    />
     <GovernanceLimitedBadge
       v-if="hasVisibleBadge('governanceLimited')"
       :size="size"

--- a/composables/useVaultTypeBadges.ts
+++ b/composables/useVaultTypeBadges.ts
@@ -3,13 +3,13 @@ import type { Ref } from 'vue'
 import type { EarnVault, SecuritizeVault, Vault } from '~/entities/vault'
 import { isCyclicalNoteVault } from '~/entities/vault'
 import { useEulerProductOfVault } from '~/composables/useEulerLabels'
-import { getEntitiesByEarnVault, getEntitiesByVault, isVaultKeyring } from '~/utils/eulerLabelsUtils'
+import { getEntitiesByEarnVault, getEntitiesByVault, isVaultAccessControlled, isVaultKeyring } from '~/utils/eulerLabelsUtils'
 
 type VaultTypeBadgeVault = EarnVault | SecuritizeVault | Vault
 
 export type VaultGovernanceBadge = 'governed' | 'managed' | 'escrow' | 'ungoverned' | 'unknown'
-export type VaultTypeBadge = VaultGovernanceBadge | 'securitize' | 'private' | 'governanceLimited' | 'cyclicalNote'
-export type VaultTypeSummaryBadge = Extract<VaultTypeBadge, 'cyclicalNote' | 'private' | 'unknown'>
+export type VaultTypeBadge = VaultGovernanceBadge | 'securitize' | 'private' | 'accessControl' | 'governanceLimited' | 'cyclicalNote'
+export type VaultTypeSummaryBadge = Extract<VaultTypeBadge, 'cyclicalNote' | 'private' | 'accessControl' | 'unknown'>
 
 export const useVaultTypeBadges = (vault: Ref<VaultTypeBadgeVault>) => {
   const { isVaultGovernorVerified, isEarnVaultOwnerVerified } = useVaults()
@@ -56,6 +56,7 @@ export const useVaultTypeBadges = (vault: Ref<VaultTypeBadgeVault>) => {
 
     if (isVerified.value && isSecuritize.value) result.push('securitize')
     if (isVerified.value && isVaultKeyring(vault.value.address)) result.push('private')
+    if (isVerified.value && isVaultAccessControlled(vault.value.address)) result.push('accessControl')
     if (isGovernanceLimited.value) result.push('governanceLimited')
     if (isVerified.value && isCyclicalNote.value) result.push('cyclicalNote')
 
@@ -67,6 +68,7 @@ export const useVaultTypeBadges = (vault: Ref<VaultTypeBadgeVault>) => {
 
     if (!isVerified.value || governanceType.value === 'unknown') result.push('unknown')
     if (badges.value.includes('private')) result.push('private')
+    if (badges.value.includes('accessControl')) result.push('accessControl')
     if (badges.value.includes('cyclicalNote')) result.push('cyclicalNote')
 
     return result

--- a/entities/euler/labels.ts
+++ b/entities/euler/labels.ts
@@ -21,7 +21,7 @@ export type EulerLabelVaultOverride = {
   restricted?: string[]
   notExplorableLend?: boolean
   notExplorableBorrow?: boolean
-  keyring?: boolean
+  tags?: string[]
 }
 
 export type EulerLabelProduct = {
@@ -38,7 +38,9 @@ export type EulerLabelProduct = {
   block?: string[]
   recentlyAddedVaults?: string[]
   vaultOverrides?: Record<string, EulerLabelVaultOverride>
-  keyring?: boolean
+  // Freeform classification tags, e.g. 'keyring' or 'access control'. Replaces
+  // the former `keyring` boolean.
+  tags?: string[]
 }
 
 export type EulerLabelEarnVaultEntry = {

--- a/tests/composables/useVaultTypeBadges.test.ts
+++ b/tests/composables/useVaultTypeBadges.test.ts
@@ -6,6 +6,7 @@ import type { Vault } from '~/entities/vault'
 import { useVaultTypeBadges } from '~/composables/useVaultTypeBadges'
 
 const state = vi.hoisted(() => ({
+  accessControlVaults: new Set<string>(),
   earnOwners: new Set<string>(),
   entityGovernors: new Set<string>(),
   governanceLimitedVaults: new Set<string>(),
@@ -29,6 +30,7 @@ vi.mock('~/utils/eulerLabelsUtils', () => ({
   getEntitiesByVault: (vault: { governorAdmin?: string }) =>
     vault.governorAdmin && state.entityGovernors.has(vault.governorAdmin.toLowerCase()) ? [{}] : [],
   isVaultKeyring: (address: string) => state.keyringVaults.has(address.toLowerCase()),
+  isVaultAccessControlled: (address: string) => state.accessControlVaults.has(address.toLowerCase()),
 }))
 
 const verifiedGovernor = '0x1000000000000000000000000000000000000001'
@@ -67,6 +69,7 @@ const verify = (vault: Vault) => {
 
 describe('useVaultTypeBadges', () => {
   beforeEach(() => {
+    state.accessControlVaults.clear()
     state.earnOwners.clear()
     state.entityGovernors.clear()
     state.governanceLimitedVaults.clear()
@@ -97,6 +100,18 @@ describe('useVaultTypeBadges', () => {
 
     expect(badges.value).toEqual(['governed', 'private'])
     expect(summaryBadges.value).toEqual(['private'])
+    expect(hasSummaryBadges.value).toBe(true)
+  })
+
+  it('summarizes verified access-controlled vaults as accessControl', () => {
+    const vault = makeVault()
+    verify(vault)
+    state.accessControlVaults.add(vault.address.toLowerCase())
+
+    const { badges, hasSummaryBadges, summaryBadges } = useVaultTypeBadges(ref(vault))
+
+    expect(badges.value).toEqual(['governed', 'accessControl'])
+    expect(summaryBadges.value).toEqual(['accessControl'])
     expect(hasSummaryBadges.value).toBe(true)
   })
 

--- a/utils/eulerLabelsUtils.ts
+++ b/utils/eulerLabelsUtils.ts
@@ -344,6 +344,11 @@ export const isVaultKeyring = (vaultAddress: string): boolean => {
 export const isProductKeyring = (productKey: string): boolean =>
   productHasTag(products[productKey], 'keyring')
 
+export const isVaultAccessControlled = (vaultAddress: string): boolean => {
+  const product = getProductByVault(vaultAddress)
+  return productHasTag(product, 'access control') || vaultOverrideHasTag(product, vaultAddress, 'access control')
+}
+
 // Widened to Vault | SecuritizeVault — both expose governorAdmin: string and
 // the helper only reads that one field. Callers from the discovery matrix
 // pass either type without casting.

--- a/utils/eulerLabelsUtils.ts
+++ b/utils/eulerLabelsUtils.ts
@@ -105,7 +105,7 @@ export const extractVaultOverrides = (raw: Record<string, unknown>): Record<stri
     if (Array.isArray(entry.restricted)) override.restricted = entry.restricted.filter((v): v is string => typeof v === 'string')
     if (typeof entry.notExplorableLend === 'boolean') override.notExplorableLend = entry.notExplorableLend
     if (typeof entry.notExplorableBorrow === 'boolean') override.notExplorableBorrow = entry.notExplorableBorrow
-    if (typeof entry.keyring === 'boolean') override.keyring = entry.keyring
+    if (Array.isArray(entry.tags)) override.tags = entry.tags.filter((v): v is string => typeof v === 'string')
     if (Object.keys(override).length > 0) {
       overrides[normalizeAddress(key)] = override
     }
@@ -330,16 +330,19 @@ export const isVaultNotExplorableBorrow = (vaultAddress: string): boolean => {
   return override?.notExplorableBorrow === true
 }
 
+const productHasTag = (product: EulerLabelProduct | undefined, tag: string): boolean =>
+  product?.tags?.includes(tag) ?? false
+
+const vaultOverrideHasTag = (product: EulerLabelProduct | undefined, vaultAddress: string, tag: string): boolean =>
+  product?.vaultOverrides?.[normalizeAddress(vaultAddress)]?.tags?.includes(tag) ?? false
+
 export const isVaultKeyring = (vaultAddress: string): boolean => {
   const product = getProductByVault(vaultAddress)
-  if (product.keyring === true) return true
-  const override = product.vaultOverrides?.[normalizeAddress(vaultAddress)]
-  return override?.keyring === true
+  return productHasTag(product, 'keyring') || vaultOverrideHasTag(product, vaultAddress, 'keyring')
 }
 
-export const isProductKeyring = (productKey: string): boolean => {
-  return products[productKey]?.keyring === true
-}
+export const isProductKeyring = (productKey: string): boolean =>
+  productHasTag(products[productKey], 'keyring')
 
 // Widened to Vault | SecuritizeVault — both expose governorAdmin: string and
 // the helper only reads that one field. Callers from the discovery matrix


### PR DESCRIPTION
## Summary
Production-bound (`master`) variant of #504. Follows euler-xyz/euler-labels#623, which replaces the product `keyring` boolean with a freeform `tags` string array (also valid on vault overrides). Switches euler-lite to recognize keyring vaults via `tags.includes('keyring')`.

This is the master-targeted version: the SDK refactor that gutted `eulerLabelsUtils.ts` is on `development` but hasn't landed on `master` yet, so the parser is still local here. That means **override-level tags work natively** — no SDK shim required, no follow-up.

## Why a separate PR from #504
`utils/eulerLabelsUtils.ts` is ~435 LOC on `master` vs ~170 LOC on `development` (the SDK absorbed most of it on development). The two branches' diffs against the keyring-boolean migration are structurally different and can't share commits.

## Changes
- **`entities/euler/labels.ts`** — drop `keyring?: boolean` from `EulerLabelProduct` and `EulerLabelVaultOverride`; add `tags?: string[]` to both.
- **`utils/eulerLabelsUtils.ts`** — `extractVaultOverrides` now reads `entry.tags` (string-filtered) instead of `entry.keyring`. `isVaultKeyring` / `isProductKeyring` read tags via small `productHasTag` / `vaultOverrideHasTag` helpers. Supports product-level **and** override-level tags.

The `isVaultKeyring` / `isProductKeyring` signatures are unchanged, so all consumers (badges, operation guard, hook modal, discovery graph, item rows) are untouched.

## Deploy ordering
⚠️ Depends on the euler-labels `tags` data (euler-xyz/euler-labels#623) being live in the served labels before this deploys, otherwise keyring vaults temporarily lose their "Private" classification.

## Verification
- `npm run typecheck` passes.
- `vitest run useVaultTypeBadges` passes (8 tests).

## Companion
- #505 (the access-control chip) has a master-targeted variant stacked on this PR — see the next PR in this branch.