### PR TITLE
feat: recognize access-control hook vaults with a distinct chip (master)

### DIFF
--- a/components/entities/vault/AccessControlBadge.vue
+++ b/components/entities/vault/AccessControlBadge.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import { useModal } from '~/components/ui/composables/useModal'
+import { AccessControlInfoModal } from '#components'
+
+const { size = 'small', block = false, as = 'span', nudge = false } = defineProps<{
+  size?: 'small' | 'large'
+  block?: boolean
+  as?: 'button' | 'span'
+  nudge?: boolean
+}>()
+
+const modal = useModal()
+
+const openInfoModal = (event: MouseEvent | KeyboardEvent) => {
+  event.preventDefault()
+  event.stopPropagation()
+  modal.open(AccessControlInfoModal)
+}
+</script>
+
+<template>
+  <VaultMetadataTag
+    :as="as"
+    icon="search-user"
+    label="Access control"
+    tone="accent"
+    :size="size"
+    :block="block"
+    :nudge="nudge"
+    title="This vault restricts operations to allowlisted addresses"
+    @click="openInfoModal"
+  />
+</template>

--- a/components/entities/vault/AccessControlInfoModal.vue
+++ b/components/entities/vault/AccessControlInfoModal.vue
@@ -1,0 +1,68 @@
+<script setup lang="ts">
+defineEmits(['close'])
+</script>
+
+<template>
+  <BaseModalWrapper
+    title="Access-controlled Vault"
+    @close="$emit('close')"
+  >
+    <div class="flex flex-col gap-16 pt-8">
+      <div class="flex items-center justify-center">
+        <div class="flex items-center justify-center w-48 h-48 rounded-12 bg-accent-100">
+          <SvgIcon
+            name="search-user"
+            class="!w-24 !h-24 text-accent-600"
+          />
+        </div>
+      </div>
+
+      <div class="flex flex-col gap-8">
+        <p class="text-p2 text-content-primary text-center font-medium">
+          Permissioned Operations
+        </p>
+        <p class="text-p3 text-content-secondary text-center">
+          This vault routes operations through an access-control hook. Only addresses on an on-chain allowlist can perform the gated operations.
+        </p>
+      </div>
+
+      <div class="flex flex-col gap-8 p-12 rounded-12 bg-surface-secondary">
+        <div class="flex items-start gap-8">
+          <SvgIcon
+            name="check-circle"
+            class="!w-16 !h-16 text-accent-600 mt-2 shrink-0"
+          />
+          <p class="text-p3 text-content-secondary">
+            Access is granted by the vault manager — there is no self-service verification
+          </p>
+        </div>
+        <div class="flex items-start gap-8">
+          <SvgIcon
+            name="check-circle"
+            class="!w-16 !h-16 text-accent-600 mt-2 shrink-0"
+          />
+          <p class="text-p3 text-content-secondary">
+            If your address is not whitelisted, the gated operations will revert
+          </p>
+        </div>
+        <div class="flex items-start gap-8">
+          <SvgIcon
+            name="check-circle"
+            class="!w-16 !h-16 text-accent-600 mt-2 shrink-0"
+          />
+          <p class="text-p3 text-content-secondary">
+            Which operations are gated depends on the vault's hook configuration
+          </p>
+        </div>
+      </div>
+
+      <UiButton
+        variant="primary"
+        size="large"
+        @click="$emit('close')"
+      >
+        Got it
+      </UiButton>
+    </div>
+  </BaseModalWrapper>
+</template>

--- a/components/entities/vault/VaultHooksInfoModal.vue
+++ b/components/entities/vault/VaultHooksInfoModal.vue
@@ -9,7 +9,7 @@ import {
 } from '~/utils/vault-hooks'
 import { getExplorerLink } from '~/utils/block-explorer'
 import { getSpecialAddressLabel } from '~/utils/special-addresses'
-import { isVaultKeyring } from '~/utils/eulerLabelsUtils'
+import { isVaultAccessControlled, isVaultKeyring } from '~/utils/eulerLabelsUtils'
 import { truncate } from '~/utils/string-utils'
 
 const emits = defineEmits<{ close: [] }>()
@@ -57,8 +57,17 @@ const hookTargetLink = computed(() => getExplorerLink(vault.hookTarget, chainId.
 
 const hookTargetLabel = computed(() => {
   if (isVaultKeyring(vault.address)) return 'Keyring (identity verification)'
+  if (isVaultAccessControlled(vault.address)) return 'Access control (allowlist)'
   return 'Third-party hook contract'
 })
+
+// Extra explanation shown for permissioned vaults that gate operations behind
+// an on-chain allowlist (access-control hook target).
+const hookTargetNote = computed(() =>
+  isVaultAccessControlled(vault.address)
+    ? 'This vault is permissioned: the operations below can only be performed by addresses that the vault manager has added to an on-chain allowlist. If your address is not whitelisted, those operations will revert. Access is granted by the manager — there is no self-service verification.'
+    : '',
+)
 
 const onCopyClick = (address: string) => {
   copyToClipboard(address).catch(() => {})
@@ -106,6 +115,12 @@ const handleClose = () => {
           />
         </button>
       </div>
+      <p
+        v-if="hookTargetNote"
+        class="text-p3 text-content-tertiary"
+      >
+        {{ hookTargetNote }}
+      </p>
     </div>
 
     <div

--- a/components/entities/vault/VaultTypeBadges.vue
+++ b/components/entities/vault/VaultTypeBadges.vue
@@ -51,6 +51,13 @@ const showGovernanceType = computed(() => hasVisibleBadge(visibleGovernanceType.
       :as="tagElement"
       :nudge="nudge"
     />
+    <AccessControlBadge
+      v-if="hasVisibleBadge('accessControl')"
+      :size="size"
+      :block="isStacked"
+      :as="tagElement"
+      :nudge="nudge"
+    />
     <GovernanceLimitedBadge
       v-if="hasVisibleBadge('governanceLimited')"
       :size="size"

--- a/composables/useVaultTypeBadges.ts
+++ b/composables/useVaultTypeBadges.ts
@@ -3,13 +3,13 @@ import type { Ref } from 'vue'
 import type { EarnVault, SecuritizeVault, Vault } from '~/entities/vault'
 import { isCyclicalNoteVault } from '~/entities/vault'
 import { useEulerProductOfVault } from '~/composables/useEulerLabels'
-import { getEntitiesByEarnVault, getEntitiesByVault, isVaultKeyring } from '~/utils/eulerLabelsUtils'
+import { getEntitiesByEarnVault, getEntitiesByVault, isVaultAccessControlled, isVaultKeyring } from '~/utils/eulerLabelsUtils'
 
 type VaultTypeBadgeVault = EarnVault | SecuritizeVault | Vault
 
 export type VaultGovernanceBadge = 'governed' | 'managed' | 'escrow' | 'ungoverned' | 'unknown'
-export type VaultTypeBadge = VaultGovernanceBadge | 'securitize' | 'private' | 'governanceLimited' | 'cyclicalNote'
-export type VaultTypeSummaryBadge = Extract<VaultTypeBadge, 'cyclicalNote' | 'private' | 'unknown'>
+export type VaultTypeBadge = VaultGovernanceBadge | 'securitize' | 'private' | 'accessControl' | 'governanceLimited' | 'cyclicalNote'
+export type VaultTypeSummaryBadge = Extract<VaultTypeBadge, 'cyclicalNote' | 'private' | 'accessControl' | 'unknown'>
 
 export const useVaultTypeBadges = (vault: Ref<VaultTypeBadgeVault>) => {
   const { isVaultGovernorVerified, isEarnVaultOwnerVerified } = useVaults()
@@ -56,6 +56,7 @@ export const useVaultTypeBadges = (vault: Ref<VaultTypeBadgeVault>) => {
 
     if (isVerified.value && isSecuritize.value) result.push('securitize')
     if (isVerified.value && isVaultKeyring(vault.value.address)) result.push('private')
+    if (isVerified.value && isVaultAccessControlled(vault.value.address)) result.push('accessControl')
     if (isGovernanceLimited.value) result.push('governanceLimited')
     if (isVerified.value && isCyclicalNote.value) result.push('cyclicalNote')
 
@@ -67,6 +68,7 @@ export const useVaultTypeBadges = (vault: Ref<VaultTypeBadgeVault>) => {
 
     if (!isVerified.value || governanceType.value === 'unknown') result.push('unknown')
     if (badges.value.includes('private')) result.push('private')
+    if (badges.value.includes('accessControl')) result.push('accessControl')
     if (badges.value.includes('cyclicalNote')) result.push('cyclicalNote')
 
     return result

--- a/tests/composables/useVaultTypeBadges.test.ts
+++ b/tests/composables/useVaultTypeBadges.test.ts
@@ -6,6 +6,7 @@ import type { Vault } from '~/entities/vault'
 import { useVaultTypeBadges } from '~/composables/useVaultTypeBadges'
 
 const state = vi.hoisted(() => ({
+  accessControlVaults: new Set<string>(),
   earnOwners: new Set<string>(),
   entityGovernors: new Set<string>(),
   governanceLimitedVaults: new Set<string>(),
@@ -29,6 +30,7 @@ vi.mock('~/utils/eulerLabelsUtils', () => ({
   getEntitiesByVault: (vault: { governorAdmin?: string }) =>
     vault.governorAdmin && state.entityGovernors.has(vault.governorAdmin.toLowerCase()) ? [{}] : [],
   isVaultKeyring: (address: string) => state.keyringVaults.has(address.toLowerCase()),
+  isVaultAccessControlled: (address: string) => state.accessControlVaults.has(address.toLowerCase()),
 }))
 
 const verifiedGovernor = '0x1000000000000000000000000000000000000001'
@@ -67,6 +69,7 @@ const verify = (vault: Vault) => {
 
 describe('useVaultTypeBadges', () => {
   beforeEach(() => {
+    state.accessControlVaults.clear()
     state.earnOwners.clear()
     state.entityGovernors.clear()
     state.governanceLimitedVaults.clear()
@@ -97,6 +100,18 @@ describe('useVaultTypeBadges', () => {
 
     expect(badges.value).toEqual(['governed', 'private'])
     expect(summaryBadges.value).toEqual(['private'])
+    expect(hasSummaryBadges.value).toBe(true)
+  })
+
+  it('summarizes verified access-controlled vaults as accessControl', () => {
+    const vault = makeVault()
+    verify(vault)
+    state.accessControlVaults.add(vault.address.toLowerCase())
+
+    const { badges, hasSummaryBadges, summaryBadges } = useVaultTypeBadges(ref(vault))
+
+    expect(badges.value).toEqual(['governed', 'accessControl'])
+    expect(summaryBadges.value).toEqual(['accessControl'])
     expect(hasSummaryBadges.value).toBe(true)
   })
 

--- a/utils/eulerLabelsUtils.ts
+++ b/utils/eulerLabelsUtils.ts
@@ -344,6 +344,11 @@ export const isVaultKeyring = (vaultAddress: string): boolean => {
 export const isProductKeyring = (productKey: string): boolean =>
   productHasTag(products[productKey], 'keyring')
 
+export const isVaultAccessControlled = (vaultAddress: string): boolean => {
+  const product = getProductByVault(vaultAddress)
+  return productHasTag(product, 'access control') || vaultOverrideHasTag(product, vaultAddress, 'access control')
+}
+
 // Widened to Vault | SecuritizeVault — both expose governorAdmin: string and
 // the helper only reads that one field. Callers from the discovery matrix
 // pass either type without casting.


### PR DESCRIPTION
## Summary
Production-bound (`master`) variant of #505. Adds first-class recognition of **access-control hook** vaults (e.g. `HookTargetAccessControl` allowlists), handled like the existing keyring/"Private" chip. Driven by the labels `tags` field — a product (or vault override) tagged `access control` surfaces a distinct chip and explanatory copy.

> **Stacked on #506** (base = `refactor/labels-tags-keyring-master`). Review/merge #506 first; GitHub will retarget this to `master` once #506 merges. The diff here is PR-only.

## Changes
- **`utils/eulerLabelsUtils.ts`** — `isVaultAccessControlled()` (tag check for `'access control'`, checks product- and override-level), reusing the helpers from #506.
- **`composables/useVaultTypeBadges.ts`** — new `'accessControl'` badge in `VaultTypeBadge` and the summary union; pushed for verified access-controlled vaults.
- **`components/entities/vault/AccessControlBadge.vue`** + **`AccessControlInfoModal.vue`** — new chip + info modal mirroring `KeyringBadge`/`KeyringInfoModal` (icon `search-user`, tone `accent`).
- **`VaultTypeBadges.vue`** — renders the chip alongside the others.
- **`VaultHooksInfoModal.vue`** — labels the hook target as **"Access control (allowlist)"** and adds a note explaining that gated operations require an on-chain allowlist (access granted by the manager; no self-service verification).
- **tests** — `useVaultTypeBadges` test for the `accessControl` summary badge.

## Deferred (follow-up)
The hook target is `AccessControlEnumerable`, so we can RPC `getRoleMemberCount`/`getRoleMember` per hooked-operation selector (and `WILD_CARD`) to show *which* addresses are whitelisted for each operation. Intentionally left out of this PR.

## Verification
- `npm run typecheck` passes.
- `vitest run useVaultTypeBadges` passes (9 tests, incl. the new access-control case).
- `eslint` clean on all changed files.