### PR TITLE
feat: show private/cyclical/unknown chips on exposure cards

### DIFF
--- a/components/entities/vault/VaultCollateralExposureModal.vue
+++ b/components/entities/vault/VaultCollateralExposureModal.vue
@@ -83,7 +83,14 @@ const onCollateralClick = (address: string) => {
           <VaultLabelsAndAssets
             :vault="pair.collateral"
             :assets="[pair.collateral.asset]"
-          />
+          >
+            <span @click.stop.prevent>
+              <VaultTypeBadges
+                :vault="pair.collateral"
+                summary-only
+              />
+            </span>
+          </VaultLabelsAndAssets>
         </div>
         <div class="flex flex-col gap-12 px-16 pt-12 pb-16">
           <VaultOverviewLabelValue

--- a/components/entities/vault/VaultTypeBadges.vue
+++ b/components/entities/vault/VaultTypeBadges.vue
@@ -19,10 +19,12 @@ const visibleBadges = computed(() => summaryOnly ? summaryBadges.value : badges.
 const visibleGovernanceType = computed(() => summaryOnly ? summaryGovernanceType.value : governanceType.value)
 const hasVisibleBadge = (badge: VaultTypeBadge): boolean => visibleBadges.value.includes(badge)
 const showGovernanceType = computed(() => hasVisibleBadge(visibleGovernanceType.value))
+const hasAnyBadge = computed(() => visibleBadges.value.length > 0)
 </script>
 
 <template>
   <div
+    v-if="hasAnyBadge"
     class="flex gap-8"
     :class="isStacked ? 'flex-col items-stretch' : 'items-center flex-wrap'"
   >

--- a/components/entities/vault/overview/earn/VaultOverviewEarnBlockExposure.vue
+++ b/components/entities/vault/overview/earn/VaultOverviewEarnBlockExposure.vue
@@ -199,6 +199,12 @@ load()
               >
                 <VaultWarningIcon :warning="row.hookWarning" />
               </span>
+              <span @click.stop.prevent>
+                <VaultTypeBadges
+                  :vault="row.vault"
+                  summary-only
+                />
+              </span>
             </VaultLabelsAndAssets>
           </template>
           <template v-else>


### PR DESCRIPTION
## Summary
- Adds summary-only `VaultTypeBadges` to the collateral exposure modal cards (in `VaultCollateralExposureModal`) and to the EulerEarn exposure cards (in `VaultOverviewEarnBlockExposure`)
- Surfaces the same private / access-control / cyclical-note / unknown signals already shown in vault headers so users can spot them without drilling into each market
- `VaultTypeBadges` now hides its wrapper when no badges are visible, so cards without any of those traits don't pick up an empty layout gap

## Test plan
- [ ] Open a vault that has collateral exposures including private / access-control / cyclical-note collaterals — chips show next to the collateral name in the exposure modal
- [ ] Open a vault whose collaterals are all standard governed — no extra chips and no layout shift
- [ ] Open an EulerEarn vault whose strategies include private / access-control / cyclical-note / unknown — chips show next to each strategy
- [ ] Click a chip — it opens the info modal and does NOT navigate to the collateral / strategy market
- [ ] Click outside a chip on the card — still navigates as before