### PR TITLE
fix: improve exposure card layout

### DIFF
--- a/components/entities/vault/VaultCollateralExposureModal.vue
+++ b/components/entities/vault/VaultCollateralExposureModal.vue
@@ -80,17 +80,19 @@ const onCollateralClick = (address: string) => {
         @click="onCollateralClick(pair.collateral.address)"
       >
         <div class="px-16 pt-16 pb-12 border-b border-line-subtle">
-          <VaultLabelsAndAssets
-            :vault="pair.collateral"
-            :assets="[pair.collateral.asset]"
-          >
-            <span @click.stop.prevent>
-              <VaultTypeBadges
-                :vault="pair.collateral"
-                summary-only
-              />
-            </span>
-          </VaultLabelsAndAssets>
+          <div class="min-w-0">
+            <VaultLabelsAndAssets
+              class="min-w-0"
+              :vault="pair.collateral"
+              :assets="[pair.collateral.asset]"
+            />
+            <VaultTypeBadges
+              class="mt-8 w-full justify-end"
+              :vault="pair.collateral"
+              summary-only
+              @click.stop.prevent
+            />
+          </div>
         </div>
         <div class="flex flex-col gap-12 px-16 pt-12 pb-16">
           <VaultOverviewLabelValue

--- a/components/entities/vault/VaultEarnItem.vue
+++ b/components/entities/vault/VaultEarnItem.vue
@@ -89,12 +89,12 @@ const supplyApyModalData = computed(() => ({
     :class="isGeoBlocked ? 'opacity-50' : ''"
     :to="{ path: `/earn/${vault.address}`, query: { network: $route.query.network } }"
   >
-    <div class="flex py-16 px-16 pb-12 border-b border-line-subtle">
+    <div class="flex items-start gap-12 py-16 px-16 pb-12 border-b border-line-subtle">
       <AssetAvatar
         :asset="vault.asset"
         size="40"
       />
-      <div class="flex-grow ml-12">
+      <div class="min-w-0 flex-1">
         <div class="text-content-tertiary text-p3 mb-4 flex items-center gap-8">
           <VaultDisplayName
             :name="displayName"
@@ -118,13 +118,13 @@ const supplyApyModalData = computed(() => ({
         </div>
         <div
           v-if="description"
-          class="text-p3 text-content-tertiary mt-4 line-clamp-1"
+          class="text-p3 text-content-tertiary mt-4 max-w-[85%] line-clamp-1 mobile:max-w-full"
         >
           {{ description }}
         </div>
       </div>
-      <div class="flex flex-col items-end">
-        <div class="text-content-tertiary text-p3 mb-4 text-right flex items-center gap-4">
+      <div class="flex flex-col items-end shrink-0 ml-16">
+        <div class="text-content-tertiary text-p3 mb-4 text-right flex items-center justify-end gap-4 whitespace-nowrap">
           Supply APY
           <span class="inline-flex items-center rounded-8 px-8 py-2 bg-accent-100 text-accent-600 text-p5">
             1h

--- a/components/entities/vault/overview/earn/VaultOverviewEarnBlockExposure.vue
+++ b/components/entities/vault/overview/earn/VaultOverviewEarnBlockExposure.vue
@@ -181,79 +181,85 @@ load()
         @click="onExposureClick(row.exposure.info.vault)"
       >
         <div
-          class="px-16 pt-16 pb-12 border-b border-line-subtle flex items-center justify-between"
+          class="px-16 pt-16 pb-12 border-b border-line-subtle"
         >
-          <template v-if="row.vault">
-            <VaultLabelsAndAssets
-              :vault="row.vault"
-              :assets="[{
-                address: row.exposure.info.asset,
-                decimals: row.exposure.info.assetDecimals,
-                name: row.exposure.info.assetName,
-                symbol: row.exposure.info.assetSymbol,
-              }]"
-            >
-              <span
-                v-if="row.hookWarning"
-                @click.stop.prevent
-              >
-                <VaultWarningIcon :warning="row.hookWarning" />
-              </span>
-              <span @click.stop.prevent>
-                <VaultTypeBadges
+          <div class="grid grid-cols-[minmax(0,1fr)_auto] gap-x-16 gap-y-8">
+            <template v-if="row.vault">
+              <div class="min-w-0 self-center row-span-2">
+                <VaultLabelsAndAssets
+                  class="min-w-0"
                   :vault="row.vault"
-                  summary-only
+                  :assets="[{
+                    address: row.exposure.info.asset,
+                    decimals: row.exposure.info.assetDecimals,
+                    name: row.exposure.info.assetName,
+                    symbol: row.exposure.info.assetSymbol,
+                  }]"
+                >
+                  <span
+                    v-if="row.hookWarning"
+                    @click.stop.prevent
+                  >
+                    <VaultWarningIcon :warning="row.hookWarning" />
+                  </span>
+                </VaultLabelsAndAssets>
+              </div>
+            </template>
+            <template v-else>
+              <div class="flex items-center gap-12 self-center">
+                <AssetAvatar
+                  :asset="{ address: row.exposure.info.asset, symbol: row.exposure.info.assetSymbol }"
+                  size="40"
                 />
-              </span>
-            </VaultLabelsAndAssets>
-          </template>
-          <template v-else>
-            <div class="flex items-center gap-12">
-              <AssetAvatar
-                :asset="{ address: row.exposure.info.asset, symbol: row.exposure.info.assetSymbol }"
-                size="40"
-              />
-              <div>
-                <div class="text-content-tertiary text-p3">
-                  {{ row.exposure.info.vaultName }}
-                </div>
-                <div class="text-h5 text-content-primary">
-                  {{ row.exposure.info.assetSymbol }}
+                <div>
+                  <div class="text-content-tertiary text-p3">
+                    {{ row.exposure.info.vaultName }}
+                  </div>
+                  <div class="text-h5 text-content-primary">
+                    {{ row.exposure.info.assetSymbol }}
+                  </div>
                 </div>
               </div>
+            </template>
+            <div
+              v-if="row.vault"
+              class="flex flex-col items-end shrink-0 justify-self-end"
+            >
+              <div class="text-content-tertiary text-p3 mb-4 flex items-center gap-4">
+                Supply APY
+                <UiModalPreviewTrigger
+                  :component="VaultSupplyApyModal"
+                  :modal-data="() => getStrategySupplyApyModalData(row.vault)"
+                  aria-label="Show supply APY breakdown"
+                >
+                  <SvgIcon
+                    class="!w-16 !h-16 shrink-0 text-content-muted hover:text-content-secondary transition-colors cursor-pointer"
+                    name="info-circle"
+                  />
+                </UiModalPreviewTrigger>
+              </div>
+              <div class="text-p2 flex items-center text-accent-600 font-semibold">
+                <UiModalPreviewTrigger
+                  v-if="hasSupplyRewards(row.vault.address)"
+                  :component="VaultSupplyApyModal"
+                  :modal-data="() => getStrategySupplyApyModalData(row.vault)"
+                  aria-label="Show supply APY rewards breakdown"
+                >
+                  <SvgIcon
+                    class="!w-20 !h-20 text-accent-500 mr-4 cursor-pointer"
+                    name="sparks"
+                  />
+                </UiModalPreviewTrigger>
+                {{ formatNumber(getStrategySupplyApy(row.vault)) }}%
+              </div>
             </div>
-          </template>
-          <div
-            v-if="row.vault"
-            class="flex flex-col items-end shrink-0"
-          >
-            <div class="text-content-tertiary text-p3 mb-4 flex items-center gap-4">
-              Supply APY
-              <UiModalPreviewTrigger
-                :component="VaultSupplyApyModal"
-                :modal-data="() => getStrategySupplyApyModalData(row.vault)"
-                aria-label="Show supply APY breakdown"
-              >
-                <SvgIcon
-                  class="!w-16 !h-16 shrink-0 text-content-muted hover:text-content-secondary transition-colors cursor-pointer"
-                  name="info-circle"
-                />
-              </UiModalPreviewTrigger>
-            </div>
-            <div class="text-p2 flex items-center text-accent-600 font-semibold">
-              <UiModalPreviewTrigger
-                v-if="hasSupplyRewards(row.vault.address)"
-                :component="VaultSupplyApyModal"
-                :modal-data="() => getStrategySupplyApyModalData(row.vault)"
-                aria-label="Show supply APY rewards breakdown"
-              >
-                <SvgIcon
-                  class="!w-20 !h-20 text-accent-500 mr-4 cursor-pointer"
-                  name="sparks"
-                />
-              </UiModalPreviewTrigger>
-              {{ formatNumber(getStrategySupplyApy(row.vault)) }}%
-            </div>
+            <VaultTypeBadges
+              v-if="row.vault"
+              class="justify-end justify-self-end"
+              :vault="row.vault"
+              summary-only
+              @click.stop.prevent
+            />
           </div>
         </div>
         <div class="flex flex-col gap-12 px-16 pt-12 pb-16">


### PR DESCRIPTION
## Summary
- Improve exposure card badge placement so summary chips no longer crowd vault names or APY values.
- Keep Earn list descriptions from forcing the APY rail to wrap on wide cards.

## Changes
- Reworked Earn exposure card headers into a two-column grid with the vault identity vertically centered across the APY and badge rows.
- Right-align summary badges in their own row for Earn exposure cards and collateral exposure modal rows.
- Constrained Earn list descriptions to preserve space for the APY column while keeping mobile layout full width.

## Test plan
- [x] Verified KPK ETH Yield Term exposure cards on /earn/0xB6D6D89ad4b4D61C15a293e28b74f77F6817fF48?network=1 at desktop and mobile-sized viewports.
- [x] Verified KPK ETH Yield Term Earn list card on /earn?network=1&search=KPK+ETH+Yield+Term.
- [x] Ran npm run lint.