### PR TITLE
fix: improve vault badge UX

### DIFF
--- a/components/entities/vault/RecentlyAddedBadge.vue
+++ b/components/entities/vault/RecentlyAddedBadge.vue
@@ -1,0 +1,76 @@
+<script setup lang="ts">
+const isTooltipEnabled = ref(false)
+const showTooltip = ref(false)
+let tooltipTimeout: ReturnType<typeof setTimeout> | undefined
+let mobileQuery: MediaQueryList | undefined
+
+const updateTooltipAvailability = () => {
+  isTooltipEnabled.value = Boolean(mobileQuery?.matches)
+  if (!isTooltipEnabled.value) showTooltip.value = false
+}
+
+const toggleTooltip = () => {
+  showTooltip.value = !showTooltip.value
+  if (tooltipTimeout) clearTimeout(tooltipTimeout)
+  if (showTooltip.value) {
+    tooltipTimeout = setTimeout(() => {
+      showTooltip.value = false
+    }, 1800)
+  }
+}
+
+const onActivate = (event: MouseEvent | KeyboardEvent) => {
+  if (!isTooltipEnabled.value) return
+  event.preventDefault()
+  event.stopPropagation()
+  toggleTooltip()
+}
+
+onMounted(() => {
+  mobileQuery = window.matchMedia('(max-width: 900px)')
+  updateTooltipAvailability()
+  mobileQuery.addEventListener('change', updateTooltipAvailability)
+})
+
+onBeforeUnmount(() => {
+  if (tooltipTimeout) clearTimeout(tooltipTimeout)
+  mobileQuery?.removeEventListener('change', updateTooltipAvailability)
+})
+</script>
+
+<template>
+  <span
+    class="recently-added-badge relative inline-flex items-center gap-4 rounded-8 px-8 py-2 text-p5 mobile:gap-0 mobile:rounded-full mobile:w-26 mobile:h-26 mobile:p-0 mobile:justify-center"
+    :role="isTooltipEnabled ? 'button' : undefined"
+    :tabindex="isTooltipEnabled ? 0 : undefined"
+    title="Recently added vault"
+    @click="onActivate"
+    @keydown.enter="onActivate"
+    @keydown.space="onActivate"
+  >
+    <SvgIcon
+      name="star"
+      class="!w-14 !h-14"
+    />
+    <span class="mobile:hidden">Recently added</span>
+    <span
+      v-if="showTooltip"
+      class="hidden mobile:block absolute left-1/2 bottom-full mb-8 -translate-x-1/2 whitespace-nowrap rounded-8 bg-surface-secondary border border-line-default px-8 py-4 text-p5 text-content-primary shadow-card z-10"
+    >
+      Recently added
+    </span>
+  </span>
+</template>
+
+<style scoped lang="scss">
+.recently-added-badge {
+  border: 1px solid rgba(34, 211, 160, 0.28);
+  color: #22d3a0;
+  background-color: rgba(34, 211, 160, 0.08);
+  transition: background-color 120ms ease, border-color 120ms ease;
+
+  @media (max-width: 900px) {
+    cursor: pointer;
+  }
+}
+</style>

--- a/components/entities/vault/VaultBorrowItem.vue
+++ b/components/entities/vault/VaultBorrowItem.vue
@@ -260,21 +260,16 @@ const linkPath = computed(() => ({
         />
         <div class="flex-grow ml-12">
           <div class="text-content-tertiary text-p3 mb-4 flex items-center gap-8">
-            <VaultDisplayName
-              :name="pairName"
-              :is-unverified="isAnyUnverified"
-            />
-            <span
-              v-if="isRecentlyAdded"
-              class="inline-flex items-center gap-4 rounded-8 px-8 py-2 bg-accent-100 text-accent-600 text-p5"
-              title="Recently added vault"
-            >
-              <SvgIcon
-                name="star"
-                class="!w-14 !h-14"
+            <span class="min-w-0">
+              <VaultDisplayName
+                :name="pairName"
+                :is-unverified="isAnyUnverified"
               />
-              Recently added
             </span>
+            <RecentlyAddedBadge
+              v-if="isRecentlyAdded"
+              class="mobile:hidden"
+            />
             <KeyringBadge v-if="isKeyring && !isAnyGovernorUnverified" />
             <GovernanceLimitedBadge v-if="isAnyGovernanceLimited" />
             <CyclicalNoteBadge v-if="isCyclicalNote && !isAnyGovernorUnverified" />
@@ -297,10 +292,16 @@ const linkPath = computed(() => ({
               Deprecated
             </span>
           </div>
-          <div class="text-h5 text-content-primary">
-            {{
-              [pair.collateral.asset.symbol, pair.borrow.asset.symbol].join("/")
-            }}
+          <div class="text-h5 text-content-primary flex items-center gap-8">
+            <span>
+              {{
+                [pair.collateral.asset.symbol, pair.borrow.asset.symbol].join("/")
+              }}
+            </span>
+            <RecentlyAddedBadge
+              v-if="isRecentlyAdded"
+              class="hidden mobile:inline-flex shrink-0"
+            />
           </div>
         </div>
       </div>

--- a/components/entities/vault/VaultEarnItem.vue
+++ b/components/entities/vault/VaultEarnItem.vue
@@ -100,17 +100,9 @@ const supplyApyModalData = computed(() => ({
             :name="displayName"
             :is-unverified="isUnverified"
           />
-          <span
+          <RecentlyAddedBadge
             v-if="isRecentlyAdded"
-            class="inline-flex items-center gap-4 rounded-8 px-8 py-2 bg-accent-100 text-accent-600 text-p5"
-            title="Recently added vault"
-          >
-            <SvgIcon
-              name="star"
-              class="!w-14 !h-14"
-            />
-            Recently added
-          </span>
+          />
           <RestrictedBadge v-if="isGeoBlocked" />
         </div>
         <div class="text-h5 text-content-primary">

--- a/components/entities/vault/VaultItem.vue
+++ b/components/entities/vault/VaultItem.vue
@@ -163,17 +163,9 @@ watchEffect(async () => {
             :name="displayName"
             :is-unverified="isUnverified"
           />
-          <span
+          <RecentlyAddedBadge
             v-if="isRecentlyAdded"
-            class="inline-flex items-center gap-4 rounded-8 px-8 py-2 bg-accent-100 text-accent-600 text-p5"
-            title="Recently added vault"
-          >
-            <SvgIcon
-              name="star"
-              class="!w-14 !h-14"
-            />
-            Recently added
-          </span>
+          />
           <KeyringBadge v-if="isKeyring && isGovernorVerified" />
           <GovernanceLimitedBadge v-if="isGovernanceLimited" />
           <CyclicalNoteBadge v-if="isCyclicalNote && isGovernorVerified" />

--- a/components/entities/vault/discovery/DiscoveryMarketCard.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketCard.vue
@@ -143,17 +143,9 @@ const getMaxRoeModalData = (result: BestMaxRoeResult) => ({
             <template v-else>
               Ungrouped
             </template>
-            <span
+            <RecentlyAddedBadge
               v-if="market.metrics.hasRecentlyAdded"
-              class="inline-flex items-center gap-4 rounded-8 px-8 py-2 bg-accent-100 text-accent-600 text-p5"
-              title="Recently added vault"
-            >
-              <SvgIcon
-                name="star"
-                class="!w-14 !h-14"
-              />
-              Recently added
-            </span>
+            />
             <GovernanceLimitedBadge v-if="isGovernanceLimited" />
           </div>
           <div class="text-h5 text-content-primary">

--- a/components/entities/vault/overview/VaultOverviewPairBlockTypes.vue
+++ b/components/entities/vault/overview/VaultOverviewPairBlockTypes.vue
@@ -8,9 +8,11 @@ const collateral = computed(() => pair.collateral)
 const borrow = computed(() => pair.borrow)
 const collateralBadges = useVaultTypeBadges(collateral)
 const borrowBadges = useVaultTypeBadges(borrow)
+const hasCollateralSummaryBadges = computed(() => collateralBadges.hasSummaryBadges.value)
+const hasBorrowSummaryBadges = computed(() => borrowBadges.hasSummaryBadges.value)
 
 const showVaultTypesSummary = computed(() =>
-  collateralBadges.hasSummaryBadges.value || borrowBadges.hasSummaryBadges.value,
+  hasCollateralSummaryBadges.value || hasBorrowSummaryBadges.value,
 )
 </script>
 
@@ -34,11 +36,22 @@ const showVaultTypesSummary = computed(() =>
           </span>
         </div>
         <VaultTypeBadges
+          v-if="hasCollateralSummaryBadges"
           :vault="pair.collateral"
           layout="stacked"
           size="large"
           summary-only
         />
+        <div
+          v-else
+          class="vault-types-empty"
+        >
+          <SvgIcon
+            name="check-circle"
+            class="vault-types-empty__icon"
+          />
+          <span>Standard vault</span>
+        </div>
       </div>
 
       <div class="vault-types-divider w-[1px]" />
@@ -54,17 +67,55 @@ const showVaultTypesSummary = computed(() =>
           </span>
         </div>
         <VaultTypeBadges
+          v-if="hasBorrowSummaryBadges"
           :vault="pair.borrow"
           layout="stacked"
           size="large"
           summary-only
         />
+        <div
+          v-else
+          class="vault-types-empty"
+        >
+          <SvgIcon
+            name="check-circle"
+            class="vault-types-empty__icon"
+          />
+          <span>Standard vault</span>
+        </div>
       </div>
     </div>
   </div>
 </template>
 
 <style scoped lang="scss">
+.vault-types-empty {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  max-width: 100%;
+  min-height: 48px;
+  padding: 12px 15px;
+  border: 1px solid var(--border-default);
+  border-radius: 10px;
+  color: var(--text-secondary);
+  font-size: 14.5px;
+  font-weight: 500;
+  line-height: 1.2;
+  background-color: rgba(255, 255, 255, 0.035);
+
+  [data-theme="light"] & {
+    background-color: rgba(0, 0, 0, 0.025);
+  }
+}
+
+.vault-types-empty__icon {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+}
+
 .vault-types-divider {
   background-color: rgba(0, 0, 0, 0.04);
 

--- a/pages/borrow/index.vue
+++ b/pages/borrow/index.vue
@@ -11,6 +11,7 @@ import { useVaultSearch } from '~/composables/useVaultSearch'
 import { isOpDisabled, OP_BORROW, OP_DEPOSIT, OP_TRANSFER } from '~/utils/vault-hooks'
 import { buildTvlSortedOptions } from '~/utils/buildTvlSortedOptions'
 import { DEBOUNCE_LIST_PRICE_FETCH_MS } from '~/entities/tuning-constants'
+import { compareRecentlyAddedBoost } from '~/utils/recentlyAddedSort'
 
 const { withIntrinsicBorrowApy, withIntrinsicSupplyApy } = useIntrinsicApy()
 const { getSupplyRewardApy, getBorrowRewardApy, getLoopingRewardApy } = useRewardsApy()
@@ -312,9 +313,12 @@ const isPairRecentlyAdded = (pair: AnyBorrowVaultPair) =>
 
 const applyRecentlyAddedPairSort = (sorted: AnyBorrowVaultPair[]): AnyBorrowVaultPair[] => {
   return [...sorted].sort((a, b) => {
-    const af = isPairRecentlyAdded(a) ? 1 : 0
-    const bf = isPairRecentlyAdded(b) ? 1 : 0
-    return bf - af
+    return compareRecentlyAddedBoost(
+      isPairRecentlyAdded(a),
+      pairLiquidityUsd.value.get(getPairKey(a)) ?? 0,
+      isPairRecentlyAdded(b),
+      pairLiquidityUsd.value.get(getPairKey(b)) ?? 0,
+    )
   })
 }
 

--- a/pages/earn/index.vue
+++ b/pages/earn/index.vue
@@ -11,6 +11,7 @@ import { useCustomFilters } from '~/composables/useCustomFilters'
 import { useVaultSearch } from '~/composables/useVaultSearch'
 import { buildTvlSortedOptions } from '~/utils/buildTvlSortedOptions'
 import { DEBOUNCE_LIST_PRICE_FETCH_MS } from '~/entities/tuning-constants'
+import { compareRecentlyAddedBoost } from '~/utils/recentlyAddedSort'
 
 defineOptions({
   name: 'EarnPage',
@@ -162,9 +163,12 @@ const filteredList = computed(() => {
 
 const applyRecentlyAddedSort = <T extends { address: string }>(sorted: T[]): T[] => {
   return [...sorted].sort((a, b) => {
-    const af = isVaultRecentlyAdded(a.address) ? 1 : 0
-    const bf = isVaultRecentlyAdded(b.address) ? 1 : 0
-    return bf - af
+    return compareRecentlyAddedBoost(
+      isVaultRecentlyAdded(a.address),
+      vaultLiquidityUsd.value.get(a.address) ?? 0,
+      isVaultRecentlyAdded(b.address),
+      vaultLiquidityUsd.value.get(b.address) ?? 0,
+    )
   })
 }
 

--- a/pages/explore/index.vue
+++ b/pages/explore/index.vue
@@ -12,6 +12,7 @@ import type { Vault } from '~/entities/vault'
 import { isVaultType, getVaultAddress, getVaultAssetSymbol, getVaultAssetAddress } from '~/utils/discoveryCalculations'
 import { buildTvlSortedOptions } from '~/utils/buildTvlSortedOptions'
 import type { FilterOptionEntry } from '~/utils/buildTvlSortedOptions'
+import { compareRecentlyAddedBoost } from '~/utils/recentlyAddedSort'
 
 defineOptions({
   name: 'ExplorePage',
@@ -182,9 +183,12 @@ const filteredMarkets = computed(() => {
 
 const applyRecentlyAddedSort = (sorted: MarketGroup[]): MarketGroup[] => {
   return [...sorted].sort((a, b) => {
-    const af = a.metrics.hasRecentlyAdded ? 1 : 0
-    const bf = b.metrics.hasRecentlyAdded ? 1 : 0
-    return bf - af
+    return compareRecentlyAddedBoost(
+      a.metrics.hasRecentlyAdded,
+      a.metrics.totalAvailableLiquidity,
+      b.metrics.hasRecentlyAdded,
+      b.metrics.totalAvailableLiquidity,
+    )
   })
 }
 

--- a/pages/lend/index.vue
+++ b/pages/lend/index.vue
@@ -14,6 +14,7 @@ import { nanoToValue } from '~/utils/crypto-utils'
 import { isOpDisabled, OP_DEPOSIT } from '~/utils/vault-hooks'
 import { buildTvlSortedOptions } from '~/utils/buildTvlSortedOptions'
 import { DEBOUNCE_LIST_PRICE_FETCH_MS } from '~/entities/tuning-constants'
+import { compareRecentlyAddedBoost } from '~/utils/recentlyAddedSort'
 
 defineOptions({
   name: 'LendPage',
@@ -224,9 +225,12 @@ const filteredList = computed(() => {
 
 const applyRecentlyAddedSort = <T extends { address: string }>(sorted: T[]): T[] => {
   return [...sorted].sort((a, b) => {
-    const af = isVaultRecentlyAdded(a.address) ? 1 : 0
-    const bf = isVaultRecentlyAdded(b.address) ? 1 : 0
-    return bf - af
+    return compareRecentlyAddedBoost(
+      isVaultRecentlyAdded(a.address),
+      vaultLiquidityUsd.value.get(a.address) ?? 0,
+      isVaultRecentlyAdded(b.address),
+      vaultLiquidityUsd.value.get(b.address) ?? 0,
+    )
   })
 }
 

--- a/utils/recentlyAddedSort.ts
+++ b/utils/recentlyAddedSort.ts
@@ -1,0 +1,12 @@
+export const RECENTLY_ADDED_SORT_MIN_USD = 1_000
+
+export const compareRecentlyAddedBoost = (
+  aRecentlyAdded: boolean,
+  aLiquidityUsd: number,
+  bRecentlyAdded: boolean,
+  bLiquidityUsd: number,
+) => {
+  const aBoost = aRecentlyAdded && aLiquidityUsd >= RECENTLY_ADDED_SORT_MIN_USD ? 1 : 0
+  const bBoost = bRecentlyAdded && bLiquidityUsd >= RECENTLY_ADDED_SORT_MIN_USD ? 1 : 0
+  return bBoost - aBoost
+}


### PR DESCRIPTION
## Summary
- Align recently-added badges across list cards and make the mobile state compact without losing tooltip context.
- Keep recently-added markets discoverable without letting empty or near-empty launches dominate default sorting.
- Make the Vault types comparison show an explicit standard-vault state when only one side has summary badges.

## Changes
- Added a shared RecentlyAddedBadge component used by lend, earn, borrow, and explore cards.
- Collapsed the recently-added badge to a 26px star-only chip on mobile, with tap/keyboard tooltip behavior only where the label is hidden.
- Added a shared recently-added sort helper with a $1k liquidity threshold across lend, earn, borrow, and explore.
- The recently-added badge still renders regardless of liquidity; only the sort boost is gated. Vaults/pairs/groups below $1k liquidity keep their normal sorted position, while newly added markets at or above the threshold can still be promoted.
- The threshold uses the available liquidity source already available on each page: vault liquidity for lend/earn, pair liquidity for borrow, and group total available liquidity for explore.
- Added a neutral Standard vault state with an icon in pair Vault types comparisons so empty sides no longer look broken.

<img width="533" height="187" alt="image" src="https://github.com/user-attachments/assets/c2bb5c73-a9a5-4ec6-9ca7-d98efb062660" />

<img width="978" height="354" alt="image" src="https://github.com/user-attachments/assets/facf4e2d-bfea-4e7e-8bf4-55c6a2588764" />

<img width="396" height="222" alt="image" src="https://github.com/user-attachments/assets/fa17772f-9cbf-42df-8f1b-7ad3d835e886" />

## Test plan
- [x] npm run lint
- [x] npm run typecheck
- [x] Verified mobile recently-added tooltip behavior on lend and borrow list cards.
- [x] Verified the Vault types comparison renders Standard vault alongside access-control/cyclical-note badges.