### PR TITLE
fix: accept non-canonical address checksums in vault route guard

### DIFF
--- a/server/middleware/ensure-vault.ts
+++ b/server/middleware/ensure-vault.ts
@@ -1,5 +1,5 @@
 import { getRequestURL, sendRedirect } from 'h3'
-import { isAddress } from 'viem'
+import { getAddress, isAddress } from 'viem'
 import { getVaultCategory } from '../utils/vault-categories-store'
 
 /**
@@ -43,11 +43,18 @@ export default defineEventHandler(async (event) => {
   const query = url.searchParams.toString()
   const redirectUrl = `/${section}${query ? `?${query}` : ''}`
 
-  // Validate addresses are well-formed
+  // Validate addresses are well-formed and normalize them. Use the non-strict
+  // check so addresses with non-canonical EIP-55 checksum casing (e.g. a
+  // hand-edited or lowercased URL) are still accepted — strict mode would
+  // reject a valid vault address purely on checksum casing and bounce the user
+  // to the section list. getAddress() canonicalizes the casing for the
+  // downstream category lookup (which itself validates strictly).
+  const normalized: string[] = []
   for (const addr of addresses) {
-    if (!isAddress(addr)) {
+    if (!isAddress(addr, { strict: false })) {
       return sendRedirect(event, redirectUrl, 302)
     }
+    normalized.push(getAddress(addr))
   }
 
   // Resolve chain from ?network= query param
@@ -58,7 +65,7 @@ export default defineEventHandler(async (event) => {
   }
 
   // Check each vault address exists in the factory
-  for (const addr of addresses) {
+  for (const addr of normalized) {
     const category = await getVaultCategory(chainId, addr)
     if (!category) {
       return sendRedirect(event, redirectUrl, 302)


### PR DESCRIPTION
## Problem

Navigating directly to a vault page with a URL whose address has a **non-canonical EIP-55 checksum** (e.g. a hand-edited or lowercased-then-recased link) instantly bounces the user to the section list (`/lend`, `/earn`, `/borrow`) — with no toast and no modal. The vault is never shown.

Example URLs that reproduced it (both are real, in-subgraph EVK vaults, just unverified):
- `/lend/0xe4266Ed0eD99cB8e24CD3bAe221A336e09F0Ce75?network=1`
- `/lend/0xb101113CFc272367a33A4b3B725766aC1075C548?network=1`

## Root cause

The redirect is a **server-side 302** from `server/middleware/ensure-vault.ts`, not the client middleware or the unverified-vault modal. The middleware validated the address with viem's `isAddress(addr)`, which **defaults to strict mode and enforces the EIP-55 checksum**. A valid address with the wrong checksum casing fails the check and is redirected before the page or any client code runs.

A second strict gate exists downstream: `getVaultCategory()` also begins with `if (!isAddress(address)) return undefined`, so even relaxing only the first check would still bounce via the `!category` branch.

Verified at the HTTP layer:

| URL casing | Before | After |
|---|---|---|
| bad checksum (reported URLs) | 302 → /lend | 200 (loads) |
| lowercase | 200 | 200 |
| correct checksum | 200 | 200 |
| valid hex but not a real vault | 302 | 302 (unchanged) |
| malformed (`0xZZZZ`) | 302 | 302 (unchanged) |

## Fix

In `server/middleware/ensure-vault.ts`:
- Validate with `isAddress(addr, { strict: false })` so a valid address isn't rejected purely on checksum casing.
- Normalize each address with `getAddress(addr)` before the category lookup so the strict re-validation inside `getVaultCategory()` passes.

This mirrors the client middleware, which already normalizes leniently via `getAddress()`. Applies to all guarded routes (`/lend`, `/earn`, `/borrow/{a}/{b}`). Genuinely unknown or malformed addresses still redirect — only checksum casing is no longer a reason to bounce.

## Testing

- HTTP-level checks against a local dev server for every casing (table above).
- End-to-end in a headless browser: the reported bad-checksum URL now stays on the vault page and shows the expected "unverified vault" disclaimer modal (these vaults are not in the verified labels), instead of bouncing to `/lend`.