### PR TITLE
fix: align position APY breakdowns

### DIFF
--- a/components/entities/portfolio/PortfolioBorrowItem.vue
+++ b/components/entities/portfolio/PortfolioBorrowItem.vue
@@ -39,7 +39,7 @@ const modal = useModal()
 const { settings } = useUserSettings()
 const enableIntrinsicApy = computed(() => settings.value.enableIntrinsicApy)
 const { getSupplyRewardApy, getBorrowRewardApy, getEligibleLoopingRewardApy, getSupplyRewardCampaigns, getBorrowRewardCampaigns, getLoopingRewardCampaigns, hasSupplyRewards, hasBorrowRewards, isLoopingEligible } = useRewardsApy()
-const { viewer, visibleTotal } = useApyVisibility()
+const { viewer, visibleBreakdown, visibleTotal } = useApyVisibility()
 
 const borrowVault = computed(() => position.borrowVault as EVault)
 const collateralVault = computed(() => position.collateralVault as EVault | SecuritizeCollateralVault)
@@ -230,6 +230,8 @@ const netAssetValueDisplay = computed(() => {
 
 const apyBreakdown = computed(() => position.getApyBreakdown({ viewer: viewer.value }))
 const roeBreakdown = computed(() => position.getRoeBreakdown({ viewer: viewer.value }))
+const netApyBreakdown = computed(() => visibleBreakdown(apyBreakdown.value))
+const visibleRoeBreakdown = computed(() => visibleBreakdown(roeBreakdown.value))
 const netAPY = computed(() => visibleTotal(apyBreakdown.value))
 const roe = computed(() => visibleTotal(roeBreakdown.value))
 
@@ -248,6 +250,7 @@ const actualMultiplier = computed(() => position.multiplier ?? 0)
 
 const netApyModalData = computed(() => ({
   props: {
+    apyBreakdown: netApyBreakdown.value,
     supplyUSD: collateralValue.value.usd,
     borrowUSD: borrowedValue.value.usd,
     baseSupplyAPY: baseSupplyApy.value,
@@ -267,6 +270,7 @@ const netApyModalData = computed(() => ({
 
 const roeModalData = computed(() => ({
   props: {
+    roeBreakdown: visibleRoeBreakdown.value,
     roe: roe.value ?? 0,
     multiplier: Number.isFinite(actualMultiplier.value) ? actualMultiplier.value : 0,
     supplyAPY: collateralSupplyApy.value,

--- a/components/entities/vault/PortfolioRoeModal.vue
+++ b/components/entities/vault/PortfolioRoeModal.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
+import type { YieldApyBreakdown } from '@eulerxyz/euler-v2-sdk'
 import { formatNumber } from '~/utils/string-utils'
 import type { RewardCampaign } from '~/entities/reward-campaign'
 import { PROVIDER_LABELS, PROVIDER_LOGOS, rewardCampaignDisplays } from '~/entities/reward-campaign'
 
 const emits = defineEmits(['close'])
 const {
+  roeBreakdown,
   roe,
   multiplier,
   supplyAPY,
@@ -20,6 +22,7 @@ const {
   inline = false,
   close = true,
 } = defineProps<{
+  roeBreakdown?: YieldApyBreakdown
   roe: number
   multiplier: number
   supplyAPY: number
@@ -48,6 +51,16 @@ const mapCampaigns = (campaigns: RewardCampaign[] | undefined, side: string) => 
 const supplyRewardsInfo = computed(() => mapCampaigns(supplyCampaigns, 'supply'))
 const borrowRewardsInfo = computed(() => mapCampaigns(borrowCampaigns, 'borrow'))
 const loopingRewardsInfo = computed(() => mapCampaigns(loopingCampaigns, 'looping'))
+const allRewardsInfo = computed(() => [
+  ...supplyRewardsInfo.value,
+  ...borrowRewardsInfo.value,
+  ...(loopingEligible === false ? [] : loopingRewardsInfo.value),
+])
+
+const displayRoe = computed(() => roeBreakdown?.total ?? roe)
+const hasIntrinsicContribution = computed(() => Math.abs(roeBreakdown?.intrinsicApy ?? 0) > 0)
+const hasRewardContribution = computed(() => Math.abs(roeBreakdown?.rewards ?? 0) > 0)
+const signedPrefix = (value: number) => value < 0 ? '- ' : '+ '
 
 const handleClose = () => {
   emits('close')
@@ -64,7 +77,161 @@ const handleClose = () => {
     <p class="text-content-primary text-p3 mb-16">
       ROE (Return on Equity) estimates the annualized return on your own capital in this leveraged position based on your actual LTV and multiplier.
     </p>
-    <div class="mb-24">
+    <div
+      v-if="roeBreakdown"
+      class="mb-24"
+    >
+      <div class="pb-16 mb-16 border-b border-line-default">
+        <div class="flex justify-between items-center mb-16">
+          <div>
+            <p class="mb-4">
+              Your LTV
+            </p>
+            <p class="text-content-primary">
+              Current loan-to-value ratio
+            </p>
+          </div>
+          <div class="text-h5">
+            {{ formatNumber(userLTV, 2) }}%
+          </div>
+        </div>
+        <div class="flex justify-between items-center mb-16">
+          <div>
+            <p class="mb-4">
+              Multiplier
+            </p>
+            <p class="text-content-primary">
+              Effective multiplier at your LTV
+            </p>
+          </div>
+          <div class="text-h5">
+            {{ formatNumber(multiplier, 2, 2) }}x
+          </div>
+        </div>
+        <div class="flex justify-between items-center">
+          <div>
+            <p class="mb-4 flex items-center gap-4">
+              Supply ROE
+              <UiFootnote
+                title="Supply ROE"
+                text="Supply ROE is the leveraged supply-yield contribution shown relative to your net asset value."
+                tooltip-placement="top-start"
+                class="[--ui-footnote-icon-color:var(--c-content-tertiary)]"
+              />
+            </p>
+          </div>
+          <div class="text-h5">
+            {{ signedPrefix(roeBreakdown.lending) }}{{ formatNumber(Math.abs(roeBreakdown.lending)) }}%
+          </div>
+        </div>
+        <div
+          v-if="hasRewardContribution"
+          class="flex justify-between items-center mt-16"
+        >
+          <div>
+            <p class="mb-4 flex items-center gap-4">
+              <SvgIcon
+                class="!w-20 !h-20 text-accent-500"
+                name="sparks"
+              />
+              <span>Rewards ROE</span>
+              <UiFootnote
+                title="Rewards ROE"
+                text="Rewards ROE is the weighted contribution from active eligible reward campaigns for this position."
+                tooltip-placement="top-start"
+                class="[--ui-footnote-icon-color:var(--c-content-tertiary)]"
+              />
+            </p>
+          </div>
+          <div class="text-h5">
+            {{ signedPrefix(roeBreakdown.rewards) }}{{ formatNumber(Math.abs(roeBreakdown.rewards)) }}%
+          </div>
+        </div>
+        <div
+          v-for="reward in allRewardsInfo"
+          :key="reward.id"
+          class="flex justify-between items-center mt-12"
+        >
+          <div class="flex">
+            <img
+              v-if="reward.rewardToken.icon"
+              class="w-20 h-20 rounded-full"
+              :src="reward.rewardToken.icon"
+              alt="Reward token logo"
+            >
+            <p :class="reward.rewardToken.icon ? 'ml-12' : ''">
+              {{ reward.rewardToken.symbol }}
+            </p>
+            <p class="ml-4 text-content-primary">
+              (<a
+                v-if="reward.sourceUrl"
+                :href="reward.sourceUrl"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="underline"
+                @click.stop
+              ><img
+                v-if="PROVIDER_LOGOS[reward.source]"
+                :src="PROVIDER_LOGOS[reward.source]"
+                class="w-14 h-14 inline-block align-middle mr-2 bg-white rounded-sm p-1"
+                :alt="PROVIDER_LABELS[reward.source]"
+              >{{ PROVIDER_LABELS[reward.source] || reward.source }}</a><template v-else>
+                <img
+                  v-if="PROVIDER_LOGOS[reward.source]"
+                  :src="PROVIDER_LOGOS[reward.source]"
+                  class="w-14 h-14 inline-block align-middle mr-2 bg-white rounded-sm p-1"
+                  :alt="PROVIDER_LABELS[reward.source]"
+                >{{ PROVIDER_LABELS[reward.source] || reward.source }}
+              </template>{{ reward.endDate ? `, ends ${reward.endDate.toFormat('MMMM dd, yyyy')}` : '' }})
+            </p>
+          </div>
+          <div class="text-p2">
+            {{ formatNumber(reward.apr) }}%
+          </div>
+        </div>
+        <div
+          v-if="hasIntrinsicContribution"
+          class="flex justify-between items-center mt-16"
+        >
+          <div>
+            <p class="mb-4 flex items-center gap-4">
+              Intrinsic ROE
+              <UiFootnote
+                title="Intrinsic ROE"
+                text="Intrinsic ROE is the leveraged contribution from asset-native yield, when intrinsic APY is enabled."
+                tooltip-placement="top-start"
+                class="[--ui-footnote-icon-color:var(--c-content-tertiary)]"
+              />
+            </p>
+          </div>
+          <div class="text-h5">
+            {{ signedPrefix(roeBreakdown.intrinsicApy) }}{{ formatNumber(Math.abs(roeBreakdown.intrinsicApy)) }}%
+          </div>
+        </div>
+      </div>
+      <div class="pb-16 mb-16 border-b border-line-default">
+        <div class="flex justify-between items-center">
+          <div>
+            <p class="mb-4 flex items-center gap-4">
+              Borrow cost ROE
+              <UiFootnote
+                title="Borrow cost ROE"
+                text="Borrow cost ROE is weighted by your debt relative to net asset value, so it reflects the leveraged cost of this position."
+                tooltip-placement="top-start"
+                class="[--ui-footnote-icon-color:var(--c-content-tertiary)]"
+              />
+            </p>
+          </div>
+          <div class="text-h5">
+            {{ signedPrefix(roeBreakdown.borrowing) }}{{ formatNumber(Math.abs(roeBreakdown.borrowing)) }}%
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      v-else
+      class="mb-24"
+    >
       <div class="pb-16 mb-16 border-b border-line-default">
         <div class="flex justify-between items-center mb-16">
           <div>
@@ -349,9 +516,9 @@ const handleClose = () => {
       </div>
       <p
         class="text-h4"
-        :class="[roe >= 0 ? 'text-accent-600' : 'text-error-500']"
+        :class="[displayRoe >= 0 ? 'text-accent-600' : 'text-error-500']"
       >
-        = {{ formatNumber(roe) }}%
+        = {{ formatNumber(displayRoe) }}%
       </p>
     </div>
   </BaseModalWrapper>

--- a/components/entities/vault/VaultNetApyModal.vue
+++ b/components/entities/vault/VaultNetApyModal.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
+import type { YieldApyBreakdown } from '@eulerxyz/euler-v2-sdk'
 import { formatNumber } from '~/utils/string-utils'
 import type { RewardCampaign } from '~/entities/reward-campaign'
 import { PROVIDER_LABELS, PROVIDER_LOGOS, rewardCampaignDisplays } from '~/entities/reward-campaign'
 
 const emits = defineEmits(['close'])
 const {
+  apyBreakdown,
   baseSupplyAPY,
   baseBorrowAPY,
   intrinsicSupplyAPY,
@@ -20,6 +22,7 @@ const {
   inline = false,
   close = true,
 } = defineProps<{
+  apyBreakdown?: YieldApyBreakdown
   supplyUSD: number
   borrowUSD: number
   baseSupplyAPY: number
@@ -51,6 +54,16 @@ const mapCampaigns = (campaigns: RewardCampaign[] | undefined, side: string) => 
 const supplyRewardsInfo = computed(() => mapCampaigns(supplyCampaigns, 'supply'))
 const borrowRewardsInfo = computed(() => mapCampaigns(borrowCampaigns, 'borrow'))
 const loopingRewardsInfo = computed(() => mapCampaigns(loopingCampaigns, 'looping'))
+const allRewardsInfo = computed(() => [
+  ...supplyRewardsInfo.value,
+  ...borrowRewardsInfo.value,
+  ...(loopingEligible === false ? [] : loopingRewardsInfo.value),
+])
+
+const displayNetApy = computed(() => apyBreakdown?.total ?? netAPY)
+const hasIntrinsicContribution = computed(() => Math.abs(apyBreakdown?.intrinsicApy ?? 0) > 0)
+const hasRewardContribution = computed(() => Math.abs(apyBreakdown?.rewards ?? 0) > 0)
+const signedPrefix = (value: number) => value < 0 ? '- ' : '+ '
 
 const handleClose = () => {
   emits('close')
@@ -67,7 +80,135 @@ const handleClose = () => {
     <p class="text-content-primary text-p3 mb-16">
       Net APY estimates the annualized return on your supplied collateral after accounting for borrowing costs and any reward incentives. A positive net APY means the combined yield exceeds the cost of borrowing. A negative net APY means borrowing costs outweigh the yield.
     </p>
-    <div class="mb-24">
+    <div
+      v-if="apyBreakdown"
+      class="mb-24"
+    >
+      <div class="pb-16 mb-16 border-b border-line-default">
+        <div class="flex justify-between items-center">
+          <div>
+            <p class="mb-4 flex items-center gap-4">
+              Supply APY
+              <UiFootnote
+                title="Supply APY"
+                text="Supply APY is the yield contribution from supplied collateral, shown relative to total supplied value."
+                tooltip-placement="top-start"
+                class="[--ui-footnote-icon-color:var(--c-content-tertiary)]"
+              />
+            </p>
+          </div>
+          <div class="text-h5">
+            {{ signedPrefix(apyBreakdown.lending) }}{{ formatNumber(Math.abs(apyBreakdown.lending)) }}%
+          </div>
+        </div>
+        <div
+          v-if="hasRewardContribution"
+          class="flex justify-between items-center mt-16"
+        >
+          <div>
+            <p class="mb-4 flex items-center gap-4">
+              <SvgIcon
+                class="!w-20 !h-20 text-accent-500"
+                name="sparks"
+              />
+              <span>Rewards APY</span>
+              <UiFootnote
+                title="Rewards APY"
+                text="Rewards APY is the weighted contribution from active eligible reward campaigns for this position."
+                tooltip-placement="top-start"
+                class="[--ui-footnote-icon-color:var(--c-content-tertiary)]"
+              />
+            </p>
+          </div>
+          <div class="text-h5">
+            {{ signedPrefix(apyBreakdown.rewards) }}{{ formatNumber(Math.abs(apyBreakdown.rewards)) }}%
+          </div>
+        </div>
+        <div
+          v-for="reward in allRewardsInfo"
+          :key="reward.id"
+          class="flex justify-between items-center mt-12"
+        >
+          <div class="flex">
+            <img
+              v-if="reward.rewardToken.icon"
+              class="w-20 h-20 rounded-full"
+              :src="reward.rewardToken.icon"
+              alt="Reward token logo"
+            >
+            <p :class="reward.rewardToken.icon ? 'ml-12' : ''">
+              {{ reward.rewardToken.symbol }}
+            </p>
+            <p class="ml-4 text-content-primary">
+              (<a
+                v-if="reward.sourceUrl"
+                :href="reward.sourceUrl"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="underline"
+                @click.stop
+              ><img
+                v-if="PROVIDER_LOGOS[reward.source]"
+                :src="PROVIDER_LOGOS[reward.source]"
+                class="w-14 h-14 inline-block align-middle mr-2 bg-white rounded-sm p-1"
+                :alt="PROVIDER_LABELS[reward.source]"
+              >{{ PROVIDER_LABELS[reward.source] || reward.source }}</a><template v-else>
+                <img
+                  v-if="PROVIDER_LOGOS[reward.source]"
+                  :src="PROVIDER_LOGOS[reward.source]"
+                  class="w-14 h-14 inline-block align-middle mr-2 bg-white rounded-sm p-1"
+                  :alt="PROVIDER_LABELS[reward.source]"
+                >{{ PROVIDER_LABELS[reward.source] || reward.source }}
+              </template>{{ reward.endDate ? `, ends ${reward.endDate.toFormat('MMMM dd, yyyy')}` : '' }})
+            </p>
+          </div>
+          <div class="text-p2">
+            {{ formatNumber(reward.apr) }}%
+          </div>
+        </div>
+        <div
+          v-if="hasIntrinsicContribution"
+          class="flex justify-between items-center mt-16"
+        >
+          <div>
+            <p class="mb-4 flex items-center gap-4">
+              Intrinsic APY
+              <UiFootnote
+                title="Intrinsic APY"
+                text="Intrinsic APY is the weighted contribution from asset-native yield, when intrinsic APY is enabled."
+                tooltip-placement="top-start"
+                class="[--ui-footnote-icon-color:var(--c-content-tertiary)]"
+              />
+            </p>
+          </div>
+          <div class="text-h5">
+            {{ signedPrefix(apyBreakdown.intrinsicApy) }}{{ formatNumber(Math.abs(apyBreakdown.intrinsicApy)) }}%
+          </div>
+        </div>
+      </div>
+      <div class="pb-16 mb-16 border-b border-line-default">
+        <div class="flex justify-between items-center">
+          <div>
+            <p class="mb-4 flex items-center gap-4">
+              Borrow cost APY
+              <UiFootnote
+                title="Borrow cost APY"
+                text="Borrow cost APY is weighted by your borrowed value relative to supplied collateral, so it can be lower than the market Borrow APY."
+                tooltip-placement="top-start"
+                class="[--ui-footnote-icon-color:var(--c-content-tertiary)]"
+              />
+            </p>
+          </div>
+          <div class="text-h5">
+            {{ signedPrefix(apyBreakdown.borrowing) }}{{ formatNumber(Math.abs(apyBreakdown.borrowing)) }}%
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      v-else
+      class="mb-24"
+    >
       <div class="pb-16 mb-16 border-b border-line-default">
         <div class="flex justify-between items-center">
           <div>
@@ -348,9 +489,9 @@ const handleClose = () => {
       </div>
       <p
         class="text-h4"
-        :class="[netAPY >= 0 ? 'text-accent-600' : 'text-error-500']"
+        :class="[displayNetApy >= 0 ? 'text-accent-600' : 'text-error-500']"
       >
-        = {{ formatNumber(netAPY) }}%
+        = {{ formatNumber(displayNetApy) }}%
       </p>
     </div>
   </BaseModalWrapper>

--- a/components/ui/UiFootnote.vue
+++ b/components/ui/UiFootnote.vue
@@ -161,7 +161,7 @@ onClickOutside(reference, () => {
     line-height: 20px;
     word-wrap: break-word;
     overflow-wrap: break-word;
-    hyphens: auto;
+    hyphens: none;
   }
 
   &__floating-divider {

--- a/pages/position/[number]/index.vue
+++ b/pages/position/[number]/index.vue
@@ -24,6 +24,7 @@ const { error } = useToast()
 const { isConnected, address } = useWagmi()
 const { isSpyMode } = useSpyMode()
 const { isPositionsLoaded, isPositionsLoading, getPositionBySubAccountIndex } = useEulerAccount()
+const { viewer, visibleBreakdown } = useApyVisibility()
 const { settings } = useUserSettings()
 const enableIntrinsicApy = computed(() => settings.value.enableIntrinsicApy)
 const { getSupplyRewardApy, getBorrowRewardApy, hasSupplyRewards, hasBorrowRewards, getSupplyRewardCampaigns, getBorrowRewardCampaigns } = useRewardsApy()
@@ -339,8 +340,13 @@ const timeToLiquidationDisplay = computed(() => {
   const result = formatTtl(getBorrowPositionTimeToLiquidation(position.value))
   return result?.display || '-'
 })
-// Net APY: sync computed so it tracks collateralValue, borrowMarketValue, and APY values
-const netAPY = computed(() => {
+const apyBreakdown = computed(() => position.value?.getApyBreakdown({ viewer: viewer.value }))
+const netApyBreakdown = computed(() => visibleBreakdown(apyBreakdown.value))
+const sdkRoeBreakdown = computed(() => position.value?.getRoeBreakdown({ viewer: viewer.value }))
+const visibleRoeBreakdown = computed(() => visibleBreakdown(sdkRoeBreakdown.value))
+
+// Local fallback for positions where the SDK breakdown is unavailable.
+const fallbackNetAPY = computed(() => {
   if (!position.value || !borrowVault.value) return 0
   return getNetAPY(
     collateralValue.value.usd,
@@ -351,8 +357,9 @@ const netAPY = computed(() => {
     borrowRewardAPY.value || null,
   )
 })
+const netAPY = computed(() => netApyBreakdown.value?.total ?? fallbackNetAPY.value)
 
-const roe = computed(() => {
+const fallbackRoe = computed(() => {
   if (!position.value || !borrowVault.value) return 0
   return getRoe(
     collateralValue.value.usd,
@@ -363,6 +370,7 @@ const roe = computed(() => {
     borrowRewardAPY.value || null,
   )
 })
+const roe = computed(() => visibleRoeBreakdown.value?.total ?? fallbackRoe.value)
 
 const supplyCampaignsForModal = computed(() => getSupplyRewardCampaigns(collateralVault.value?.address || ''))
 const borrowCampaignsForModal = computed(() => getBorrowRewardCampaigns(borrowVault.value?.address || '', collateralVault.value?.address || ''))
@@ -375,6 +383,7 @@ const positionMultiplier = computed(() => {
 
 const netApyModalData = computed(() => ({
   props: {
+    apyBreakdown: netApyBreakdown.value,
     supplyUSD: collateralValue.value.usd,
     borrowUSD: borrowMarketValue.value.usd,
     baseSupplyAPY: baseSupplyAPY.value,
@@ -391,6 +400,7 @@ const netApyModalData = computed(() => ({
 
 const roeModalData = computed(() => ({
   props: {
+    roeBreakdown: visibleRoeBreakdown.value,
     roe: roe.value,
     multiplier: Number.isFinite(positionMultiplier.value) ? positionMultiplier.value : 0,
     supplyAPY: collateralSupplyApy.value,


### PR DESCRIPTION
## Summary
- Align actual-position Net APY and ROE modal rows with the SDK contribution breakdowns that drive the displayed totals.
- Clarify weighted borrow cost, rewards, supply, and intrinsic contributions with compact footnotes instead of inline explanatory copy.
- Keep raw-rate fallback layouts for non-position contexts while preventing tooltip word hyphenation.

## Changes
- Pass visible SDK APY/ROE breakdowns into position and portfolio borrow modals.
- Render contribution-mode rows for actual-position Net APY and ROE, including eligible campaign details.
- Filter ineligible looping campaign detail rows from contribution-mode reward displays.
- Preserve existing raw APY/ROE formula layouts when no SDK breakdown is available.

## Test plan
- [x] npm run typecheck
- [x] npm run lint
- [x] git diff --check
- [x] Smoke-tested position 1 on Base spy mode at localhost:3000 for Net APY and ROE modal values.
- [x] Cross-checked live position inputs, vault scope, campaign scope, and denominators for the Clearstar USDC/deSPXA example.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * APY and ROE modals now display detailed component-level breakdowns, including Supply APY/ROE, Rewards APY/ROE, Intrinsic APY/ROE, and Borrow cost information.
  * Modals show LTV and multiplier context alongside breakdown details.

* **Style**
  * Updated word hyphenation behavior in footnote text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->