### PR TITLE
fix: preserve recently added labels

### DIFF
--- a/composables/useEulerLabels.ts
+++ b/composables/useEulerLabels.ts
@@ -21,6 +21,15 @@ import { erc4626AssetAbi } from '~/abis/erc4626'
 import { buildBatchItem, evcBatchCall } from '~/utils/multicall'
 import { normalizeAddress } from '~/utils/normalizeAddress'
 
+type EulerLabelProductCompat = EulerLabelProduct & {
+  recentlyAddedVaults?: string[]
+}
+
+type EulerLabelsDataCompat = Omit<EulerLabelsData, 'products'> & {
+  products: Record<string, EulerLabelProductCompat>
+  recentlyAddedEarnVaults?: Set<string>
+}
+
 const LABEL_QUERY_NAMES = [
   'queryEulerLabelsEntities',
   'queryEulerLabelsProducts',
@@ -38,6 +47,7 @@ const createEmptyEulerLabelsData = (): EulerLabelsData => ({
   earnVaultEntries: {},
   earnVaultBlocks: {},
   earnVaultRestrictions: {},
+  recentlyAddedEarnVaults: new Set(),
   deprecatedEarnVaults: {},
   earnVaultDescriptions: {},
   earnVaultNotices: {},
@@ -68,13 +78,14 @@ export const getEulerLabelsVersion = (): number => labelsVersion.value
 
 export const getEulerLabelWrapPairs = (): Record<string, string> => wrapPairs
 
-export const __setEulerLabelsDataForTest = (data: Partial<EulerLabelsData> = {}) => {
+export const __setEulerLabelsDataForTest = (data: Partial<EulerLabelsDataCompat> = {}) => {
   setLabelsData({
     ...createEmptyEulerLabelsData(),
     ...data,
+    recentlyAddedEarnVaults: data.recentlyAddedEarnVaults ?? new Set(),
     notExplorableEarnVaults: data.notExplorableEarnVaults ?? new Set(),
     assetPatternRules: data.assetPatternRules ?? [],
-  }, null)
+  } as unknown as EulerLabelsData, null)
   isReady.value = true
   isLoading.value = false
 }

--- a/composables/useEulerLabels.ts
+++ b/composables/useEulerLabels.ts
@@ -38,7 +38,6 @@ const createEmptyEulerLabelsData = (): EulerLabelsData => ({
   earnVaultEntries: {},
   earnVaultBlocks: {},
   earnVaultRestrictions: {},
-  featuredEarnVaults: new Set(),
   deprecatedEarnVaults: {},
   earnVaultDescriptions: {},
   earnVaultNotices: {},
@@ -46,7 +45,7 @@ const createEmptyEulerLabelsData = (): EulerLabelsData => ({
   assetBlocks: {},
   assetRestrictions: {},
   assetPatternRules: [],
-})
+} as unknown as EulerLabelsData)
 
 const labelsData = shallowRef<EulerLabelsData>(createEmptyEulerLabelsData())
 const labelsChainId = ref<number | null>(null)
@@ -73,7 +72,6 @@ export const __setEulerLabelsDataForTest = (data: Partial<EulerLabelsData> = {})
   setLabelsData({
     ...createEmptyEulerLabelsData(),
     ...data,
-    featuredEarnVaults: data.featuredEarnVaults ?? new Set(),
     notExplorableEarnVaults: data.notExplorableEarnVaults ?? new Set(),
     assetPatternRules: data.assetPatternRules ?? [],
   }, null)

--- a/tests/utils/euler-labels-utils.test.ts
+++ b/tests/utils/euler-labels-utils.test.ts
@@ -66,12 +66,13 @@ describe('isVaultRecentlyAdded', () => {
   })
 
   it('checks SDK Earn recently-added vaults', () => {
-    const address = '0x0000000000000000000000000000000000000202'
+    const lowerAddress = '0x8d3f9f9eb2f5e8b48efbb4074440d1e2a34bc365'
+    const checksummedAddress = normalizeAddress(lowerAddress)
 
     __setEulerLabelsDataForTest({
-      recentlyAddedEarnVaults: new Set([normalizeAddress(address)]),
+      recentlyAddedEarnVaults: new Set([lowerAddress]),
     })
 
-    expect(isVaultRecentlyAdded(address.toLowerCase())).toBe(true)
+    expect(isVaultRecentlyAdded(checksummedAddress)).toBe(true)
   })
 })

--- a/tests/utils/euler-labels-utils.test.ts
+++ b/tests/utils/euler-labels-utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { __setEulerLabelsDataForTest } from '~/composables/useEulerLabels'
-import { getActiveProductVaultAddresses, normalizeProducts } from '~/utils/eulerLabelsUtils'
+import { getActiveProductVaultAddresses, isVaultRecentlyAdded, normalizeProducts } from '~/utils/eulerLabelsUtils'
 import { normalizeAddress } from '~/utils/normalizeAddress'
 
 describe('normalizeProducts', () => {
@@ -42,5 +42,36 @@ describe('getActiveProductVaultAddresses', () => {
     })
 
     expect(getActiveProductVaultAddresses()).toEqual([normalizeAddress(active)])
+  })
+})
+
+describe('isVaultRecentlyAdded', () => {
+  it('checks product recently-added vaults', () => {
+    const address = '0x0000000000000000000000000000000000000201'
+
+    __setEulerLabelsDataForTest({
+      products: {
+        test: {
+          name: 'Test',
+          description: '',
+          entity: [],
+          url: '',
+          vaults: [normalizeAddress(address)],
+          recentlyAddedVaults: [normalizeAddress(address)],
+        },
+      },
+    })
+
+    expect(isVaultRecentlyAdded(address)).toBe(true)
+  })
+
+  it('checks SDK Earn recently-added vaults', () => {
+    const address = '0x0000000000000000000000000000000000000202'
+
+    __setEulerLabelsDataForTest({
+      recentlyAddedEarnVaults: new Set([normalizeAddress(address)]),
+    })
+
+    expect(isVaultRecentlyAdded(address.toLowerCase())).toBe(true)
   })
 })

--- a/utils/eulerLabelsUtils.ts
+++ b/utils/eulerLabelsUtils.ts
@@ -35,6 +35,10 @@ import { normalizeAddress } from '~/utils/normalizeAddress'
 
 const labels = () => getCurrentEulerLabelsData()
 
+type EulerLabelsWithRecentlyAdded = ReturnType<typeof getCurrentEulerLabelsData> & {
+  recentlyAddedEarnVaults?: Set<string>
+}
+
 const MAX_REGEX_INPUT_LEN = 128
 
 export const patternRuleMatches = (
@@ -96,9 +100,14 @@ export const getAssetPatternRules = (): EulerLabelAssetPatternRule[] =>
 
 export const isVaultRecentlyAdded = (vaultAddress: string): boolean => {
   const normalized = normalizeAddress(vaultAddress)
-  return Object.values(labels().products).some(product =>
+  const currentLabels = labels() as EulerLabelsWithRecentlyAdded
+  const productRecentlyAdded = Object.values(currentLabels.products).some(product =>
     ((product as EulerLabelProduct).recentlyAddedVaults ?? []).some(address => normalizeAddress(address) === normalized),
   )
+  if (productRecentlyAdded) return true
+
+  const earnRecentlyAdded = currentLabels.recentlyAddedEarnVaults
+  return earnRecentlyAdded?.has(normalized) || earnRecentlyAdded?.has(normalized.toLowerCase()) || false
 }
 
 export const normalizeProducts = (data: Record<string, EulerLabelProduct>): { products: Record<string, EulerLabelProduct>, vaultAddresses: string[] } => {


### PR DESCRIPTION
## Summary
- Preserve SDK-backed recently-added labels for both product vaults and Earn vault entries.
- Remove the stale featuredEarnVaults empty-label shape from Lite.
- Keep the empty labels helper compatible with the currently installed SDK type while the SDK label cleanup lands.

## Related PRs
- SDK recently-added support: https://github.com/euler-xyz/euler-sdks/pull/49
- SDK featured cleanup: https://github.com/euler-xyz/euler-sdks/pull/50

## Changes
- Add cross-version label data compatibility for recentlyAddedVaults and recentlyAddedEarnVaults.
- Initialize recentlyAddedEarnVaults in the empty label data helper and test setter.
- Update isVaultRecentlyAdded to check product recentlyAddedVaults first, then SDK-backed Earn recentlyAddedEarnVaults.
- Stop initializing/injecting featuredEarnVaults.
- Add regression coverage for product and Earn recently-added membership.

## Test plan
- [x] rg "\bfeatured\b|featuredVaults|featuredEarnVaults|isEulerLabelVaultFeatured" /Users/seranged/Documents/GitHub/euler-lite -n
- [x] npm run test:run -- tests/utils/euler-labels-utils.test.ts
- [x] npm run typecheck
- [x] npx eslint composables/useEulerLabels.ts utils/eulerLabelsUtils.ts tests/utils/euler-labels-utils.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved earn-vault data initialization to better handle deprecated vaults, descriptions/notices, non-explorable vaults, and asset-related defaults.

* **Bug Fixes**
  * Improved "recently added" detection so earn vaults are recognized consistently (including case-insensitive addresses) and across earn-vault sources.

* **Tests**
  * Added tests covering expanded recently-added behavior and updated test fixtures to match the new data shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->