### PR TITLE
fix: restore invalid vault route fallback

### DIFF
--- a/pages/borrow/[collateral]/[borrow]/index.vue
+++ b/pages/borrow/[collateral]/[borrow]/index.vue
@@ -67,6 +67,7 @@ getBorrowVaultPair(collateralAddress, borrowAddress).then((p) => {
   pair.value = p
 }).catch((e) => {
   logWarn('[borrow] failed to load vault pair', e)
+  void router.replace({ path: '/borrow', query: route.query })
 })
 
 const borrowVault = computed(() => pair.value?.borrow)

--- a/server/middleware/ensure-vault.ts
+++ b/server/middleware/ensure-vault.ts
@@ -1,5 +1,12 @@
 import { getRequestURL, sendRedirect } from 'h3'
-import { isAddress } from 'viem'
+import { getAddress, isAddress } from 'viem'
+import { withWallClock } from '../utils/fetchWithTimeout'
+import {
+  refreshChainVaults,
+  vaultsCache,
+  type SerialisedSnapshot,
+  type SerialisedVault,
+} from '../utils/vaults-cache'
 
 /**
  * Vault route patterns:
@@ -9,6 +16,40 @@ import { isAddress } from 'viem'
  */
 const LEND_EARN_RE = /^\/(lend|earn)\/([^/?#]+)/
 const BORROW_RE = /^\/borrow\/([^/?#]+)\/([^/?#]+)/
+const VAULT_ROUTE_VALIDATION_BUDGET_MS = 8_000
+
+const getSnapshot = async (chainId: number): Promise<SerialisedSnapshot | undefined> => {
+  const cacheKey = String(chainId)
+  const cached = vaultsCache.get(cacheKey) ?? vaultsCache.getStale(cacheKey)
+  if (cached) return cached
+
+  try {
+    return await withWallClock(
+      () => refreshChainVaults(chainId),
+      VAULT_ROUTE_VALIDATION_BUDGET_MS,
+      'vault route validation',
+    )
+  }
+  catch (err) {
+    console.warn('[ensure-vault] failed to validate vault route', err)
+    return undefined
+  }
+}
+
+const getVaultAddress = (vault: SerialisedVault): string | undefined => {
+  const data = vault.data as { address?: unknown }
+  return typeof data.address === 'string' ? data.address : undefined
+}
+
+const snapshotHasVault = (snapshot: SerialisedSnapshot, address: string): boolean => {
+  const normalized = address.toLowerCase()
+  return [
+    ...snapshot.evkVaults,
+    ...snapshot.earnVaults,
+    ...snapshot.securitizeVaults,
+    ...snapshot.escrowVaults,
+  ].some(vault => getVaultAddress(vault)?.toLowerCase() === normalized)
+}
 
 export default defineEventHandler(async (event) => {
   const url = getRequestURL(event)
@@ -42,15 +83,33 @@ export default defineEventHandler(async (event) => {
   const query = url.searchParams.toString()
   const redirectUrl = `/${section}${query ? `?${query}` : ''}`
 
-  // Validate addresses are well-formed. Use the non-strict check so valid
-  // addresses with non-canonical checksum casing do not get bounced.
+  // Validate addresses are well-formed and normalize them. Use the non-strict
+  // check so valid addresses with non-canonical checksum casing do not get
+  // bounced; getAddress() canonicalizes casing for snapshot membership checks.
+  const normalized: string[] = []
   for (const addr of addresses) {
     if (!isAddress(addr, { strict: false })) {
       return sendRedirect(event, redirectUrl, 302)
     }
+    normalized.push(getAddress(addr))
   }
 
-  // Existence/type validation is SDK-backed on the client. Server middleware
-  // only rejects malformed route addresses so direct navigation does not keep
-  // a duplicate vault-classification fetch path alive.
+  // Resolve chain from ?network= query param. If it is absent, keep the route
+  // client-backed because we cannot pick the right chain snapshot safely.
+  const networkParam = url.searchParams.get('network')
+  const chainId = networkParam ? parseInt(networkParam, 10) : NaN
+  if (!chainId || isNaN(chainId)) {
+    return
+  }
+
+  const snapshot = await getSnapshot(chainId)
+  if (!snapshot) {
+    return
+  }
+
+  for (const addr of normalized) {
+    if (!snapshotHasVault(snapshot, addr)) {
+      return sendRedirect(event, redirectUrl, 302)
+    }
+  }
 })


### PR DESCRIPTION
## Summary
- Validate direct vault detail routes against the server-side vault snapshot before rendering.
- Redirect stale or typoed vault URLs back to the relevant list page instead of leaving the client on a loader.
- Keep a small borrow-page client fallback for unresolved pairs when route validation is unavailable.

## Notes
This keeps validation SDK-backed through the current server vault snapshot cache instead of restoring the deleted legacy vault-categories helper. If the snapshot cannot be loaded within the route-validation budget, the middleware fails open to the existing client path.

## Test plan
- npx eslint server/middleware/ensure-vault.ts 'pages/borrow/[collateral]/[borrow]/index.vue'
- npm run typecheck
- curl -I http://localhost:3001/lend/0x000000000000000000000000000000000000dEaD?network=1 -> 302 /lend?network=1
- curl -I http://localhost:3001/borrow/0x000000000000000000000000000000000000dEaD/0x000000000000000000000000000000000000dEaD?network=1 -> 302 /borrow?network=1
- curl -I http://localhost:3001/earn/0x000000000000000000000000000000000000dEaD?network=1 -> 302 /earn?network=1
- Browser smoke against localhost:3001 confirmed invalid lend and borrow detail URLs land on the list pages with no loader.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved borrow vault access—users are now automatically redirected to the borrow page when requesting an invalid vault instead of encountering errors.
* Added server-side validation for vault routes to prevent access to non-existent or malformed vault addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->