### PR TITLE
fix(vaults): format liquidation bonus range

### DIFF
--- a/components/entities/vault/overview/VaultOverviewBlockRiskParameters.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockRiskParameters.vue
@@ -8,6 +8,7 @@ import { nanoToValue } from '~/utils/crypto-utils'
 import { formatAssetValue } from '~/utils/sdk-prices'
 import { formatHookedOpsSummary, getHookedOperationMetas, getVaultHookedOperations, hasAnyHookedOperation, isHookDisabling, isVaultEffectivelyPaused } from '~/utils/vault-hooks'
 import { isVaultBorrowable } from '~/utils/vault/classification'
+import { formatLiquidationBonusRange } from '~/utils/vault/liquidation'
 import { VaultHooksInfoModal } from '#components'
 
 const { vault } = defineProps<{ vault: EVault }>()
@@ -24,9 +25,7 @@ const isBorrowable = computed(() => isVaultBorrowable(vault))
 const supplyCapPercentageDisplay = computed(() => vault.caps.supplyCapUtilization)
 const borrowCapPercentageDisplay = computed(() => vault.caps.borrowCapUtilization)
 const hookedOperations = computed(() => getVaultHookedOperations(vault))
-const maxLiquidationDiscountPercent = computed(() => {
-  return vault.liquidation.maxLiquidationDiscount * 100
-})
+const liquidationBonusRange = computed(() => formatLiquidationBonusRange(vault))
 const showShareTokenExchangeRate = computed(() =>
   getVaultCategory(vault.address) !== 'escrow'
   && (vault.caps.borrowCap !== 0n || vault.totalBorrowed > 0n),
@@ -102,7 +101,7 @@ const hooksModalData = computed(() => ({
     <div class="flex flex-col items-start gap-24">
       <VaultOverviewLabelValue
         v-if="isBorrowable"
-        :value="`0-${maxLiquidationDiscountPercent}%`"
+        :value="liquidationBonusRange"
         orientation="horizontal"
       >
         <template #label>

--- a/tests/utils/vault/liquidation.test.ts
+++ b/tests/utils/vault/liquidation.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import type { EVault } from '@eulerxyz/euler-v2-sdk'
+import {
+  formatLiquidationBonusRange,
+  getMaxLiquidationDiscountDisplayPercent,
+} from '~/utils/vault/liquidation'
+
+const makeVault = (maxLiquidationDiscount: number): Pick<EVault, 'liquidation'> => ({
+  liquidation: {
+    maxLiquidationDiscount,
+    liquidationCoolOffTime: 0,
+    socializeDebt: false,
+  },
+})
+
+describe('liquidation display helpers', () => {
+  it('formats fractional max liquidation discounts without float noise', () => {
+    const vault = makeVault(0.035)
+
+    expect(getMaxLiquidationDiscountDisplayPercent(vault)).toBeCloseTo(3.5)
+    expect(formatLiquidationBonusRange(vault)).toBe('0-3.5%')
+  })
+
+  it('preserves whole-percent discounts', () => {
+    expect(formatLiquidationBonusRange(makeVault(0.15))).toBe('0-15%')
+  })
+
+  it('preserves half-percent discounts', () => {
+    expect(formatLiquidationBonusRange(makeVault(0.105))).toBe('0-10.5%')
+  })
+})

--- a/utils/discoveryCalculations.ts
+++ b/utils/discoveryCalculations.ts
@@ -12,6 +12,7 @@ import { formatHookedOpsSummary, getHookedOperationMetas, getVaultHookedOperatio
 import { INTEREST_RATE_MODEL_TYPE } from '~/entities/constants'
 import { getVaultBorrowApy, getVaultSupplyApy } from '~/utils/vault-display'
 import { computeSupplyApy, computeBorrowApy, type ApyVisibilitySettings } from '~/utils/collateralOptions'
+import { getMaxLiquidationDiscountDisplayPercent } from '~/utils/vault/liquidation'
 
 // ============================================================
 // Types & Constants
@@ -811,8 +812,8 @@ export const CONFIG_ROWS: AttributeRow[] = [
     label: 'Max liquidation discount',
     getValue: (vault) => {
       if (!isEVault(vault) || isEscrow(vault)) return NA_CELL
-      const pct = vault.liquidation.maxLiquidationDiscount * 100
-      return { display: `${pct}%`, kind: 'text' }
+      const pct = getMaxLiquidationDiscountDisplayPercent(vault)
+      return { display: `${formatNumber(pct, 2, 0)}%`, kind: 'text' }
     },
   },
   {

--- a/utils/vault/liquidation.ts
+++ b/utils/vault/liquidation.ts
@@ -1,0 +1,14 @@
+import type { EVault } from '@eulerxyz/euler-v2-sdk'
+import { formatNumber } from '~/utils/string-utils'
+
+export const getMaxLiquidationDiscountDisplayPercent = (
+  vault: Pick<EVault, 'liquidation'>,
+): number => {
+  const discount = vault.liquidation.maxLiquidationDiscount
+  if (!Number.isFinite(discount) || discount <= 0) return 0
+  return discount * 100
+}
+
+export const formatLiquidationBonusRange = (
+  vault: Pick<EVault, 'liquidation'>,
+): string => `0-${formatNumber(getMaxLiquidationDiscountDisplayPercent(vault), 2, 0)}%`


### PR DESCRIPTION
  ## Summary
  - Fix liquidation bonus display so fractional max liquidation discounts render
  correctly.
  - Prevent raw floating-point output like `3.5000000000000004%` in the lend overview
  and discovery config row.

  ## Changes
  - Add a shared liquidation display helper that converts the SDK fractional discount
  to a formatted percent.
  - Use the helper in `VaultOverviewBlockRiskParameters` and discovery calculations.
  - Add focused tests for whole-percent and half-percent liquidation discount display.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved liquidation bonus and max liquidation discount percentage formatting to correctly display fractional values without floating-point errors.

* **Tests**
  * Added test coverage for liquidation display formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->