### PR TITLE
Fix startup redirect blocking

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -110,8 +110,8 @@ const checkMigrationAnnouncement = () => {
   })
 }
 
-await loadEulerConfig()
 checkOnboarding()
+void loadEulerConfig()
 // onMounted (not synchronous like checkOnboarding) because the modal system requires the DOM
 onMounted(checkMigrationAnnouncement)
 

--- a/composables/useEulerAddresses.ts
+++ b/composables/useEulerAddresses.ts
@@ -24,6 +24,7 @@ const chainId = ref<number>(0)
 const error = ref<string | null>(null)
 
 let initialized = false
+let pendingEulerConfigLoad: Promise<void> | undefined
 
 const initAllowedChainIds = () => {
   if (initialized) return
@@ -48,30 +49,41 @@ export const useEulerAddresses = () => {
 
   const loadEulerConfig = async () => {
     if (eulerChainsConfig.value.length > 0) return
+    if (pendingEulerConfigLoad) return pendingEulerConfigLoad
 
-    isLoading.value = true
-    error.value = null
+    const promise = (async () => {
+      isLoading.value = true
+      error.value = null
 
-    try {
-      const { getEulerSdk } = await import('~/composables/useEulerSdk')
-      const sdk = await getEulerSdk()
-      const data = sdk.deploymentService
-        .getDeploymentChainIds()
-        .map(chainId => sdk.deploymentService.getDeployment(chainId))
-      const filteredData = data.filter(chain => allowedChainIds.value.includes(chain.chainId))
+      try {
+        const { getEulerSdk } = await import('~/composables/useEulerSdk')
+        const sdk = await getEulerSdk()
+        const data = sdk.deploymentService
+          .getDeploymentChainIds()
+          .map(chainId => sdk.deploymentService.getDeployment(chainId))
+        const filteredData = data.filter(chain => allowedChainIds.value.includes(chain.chainId))
 
-      if (!filteredData.length) {
-        logWarn('useEulerAddresses', 'enabledChainIds did not match any remote chains, using full list')
+        if (!filteredData.length) {
+          logWarn('useEulerAddresses', 'enabledChainIds did not match any remote chains, using full list')
+        }
+
+        eulerChainsConfig.value = filteredData.length ? filteredData : data
       }
+      catch (err) {
+        error.value = err instanceof Error ? err.message : 'Unknown error'
+        logWarn('useEulerAddresses', err, { severity: 'error' })
+      }
+      finally {
+        isLoading.value = false
+      }
+    })()
 
-      eulerChainsConfig.value = filteredData.length ? filteredData : data
-    }
-    catch (err) {
-      error.value = err instanceof Error ? err.message : 'Unknown error'
-      logWarn('useEulerAddresses', err, { severity: 'error' })
+    pendingEulerConfigLoad = promise
+    try {
+      await promise
     }
     finally {
-      isLoading.value = false
+      if (pendingEulerConfigLoad === promise) pendingEulerConfigLoad = undefined
     }
   }
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -5,9 +5,14 @@ const { enableEarnPage, enableLendPage, enableExplorePage } = useDeployConfig()
 const defaultPageRoute = getDefaultPageRoute(enableEarnPage, enableLendPage, enableExplorePage)
 
 const route = useRoute()
+const isOnboardingCompleted = useLocalStorage('is-onboarding-completed', false)
 // Non-blocking to avoid Suspense + pageTransition crash on direct navigation
 navigateTo(
-  { name: defaultPageRoute, query: route.query, hash: route.hash },
+  {
+    name: isOnboardingCompleted.value ? defaultPageRoute : 'onboarding',
+    query: route.query,
+    hash: route.hash,
+  },
   { replace: true },
 )
 </script>


### PR DESCRIPTION
## Summary
- Let the root route decide onboarding vs default navigation before SDK deployment config finishes loading.
- Prevent duplicate deployment-config loads during startup so cold SDK initialization does not block routing.

## Changes
- Move the root app deployment-config load off the startup navigation critical path.
- Add pending-promise deduplication to `loadEulerConfig()`.
- Preserve first-run onboarding by making `pages/index.vue` redirect to onboarding when the completion flag is absent.

## Test plan
- [x] `npm exec -- eslint app.vue composables/useEulerAddresses.ts pages/index.vue`
- [x] `npm run typecheck`
- [x] Local browser smoke: cleared storage lands on `/onboarding?network=1`, Connect later reaches `/explore?network=1`, completed onboarding root load reaches `/explore?network=1`