### PR TITLE
fix: use earn exposure allocation values

### DIFF
--- a/components/entities/vault/overview/earn/VaultOverviewEarnBlockExposure.vue
+++ b/components/entities/vault/overview/earn/VaultOverviewEarnBlockExposure.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { isEVault, type EVault, type EulerEarnStrategyInfo, type EulerEarn } from '@eulerxyz/euler-v2-sdk'
-import { getAssetUsdValueOrZero } from '~/utils/sdk-prices'
+import { getAssetUsdValue } from '~/utils/sdk-prices'
 import { useVaultRegistry } from '~/composables/useVaultRegistry'
 import { formatNumber, compactNumber, formatCompactUsdValue, formatExactAmount } from '~/utils/string-utils'
 import { nanoToValue, roundAndCompactTokens } from '~/utils/crypto-utils'
@@ -77,13 +77,11 @@ const load = async () => {
 
 const loadExposureUsdPrices = async () => {
   const pricePromises = exposureList.value.map(async (exposure) => {
-    const exposureVault = getExposureVaultByAddress(exposure.address)
-    if (!exposureVault) return { key: exposure.address, allocationUsd: 0, capUsd: 0 }
     const [allocationUsd, capUsd] = await Promise.all([
-      getAssetUsdValueOrZero(exposure.allocatedAssets, exposureVault, 'off-chain'),
+      getAssetUsdValue(exposure.allocatedAssets, vault, 'off-chain'),
       isUnlimitedCap(exposure)
-        ? Promise.resolve(0)
-        : getAssetUsdValueOrZero(exposure.allocationCap.current, exposureVault, 'off-chain'),
+        ? Promise.resolve(undefined)
+        : getAssetUsdValue(exposure.allocationCap.current, vault, 'off-chain'),
     ])
     return { key: exposure.address, allocationUsd, capUsd }
   })
@@ -92,8 +90,8 @@ const loadExposureUsdPrices = async () => {
   const newPrices = new Map<string, number>()
   const newCapPrices = new Map<string, number>()
   results.forEach(({ key, allocationUsd, capUsd }) => {
-    newPrices.set(key, allocationUsd)
-    newCapPrices.set(key, capUsd)
+    if (allocationUsd !== undefined) newPrices.set(key, allocationUsd)
+    if (capUsd !== undefined) newCapPrices.set(key, capUsd)
   })
   exposureUsdPrices.value = newPrices
   exposureCapUsdPrices.value = newCapPrices
@@ -147,8 +145,7 @@ const getExposureUsdPrice = (exposure: typeof exposureList.value[0]) => {
 }
 
 const getExposureAssetAmount = (exposure: typeof exposureList.value[0]) => {
-  const strategyVault = exposure.vault as EVault | undefined ?? getExposureVaultByAddress(exposure.address)
-  return `${roundAndCompactTokens(exposure.allocatedAssets, strategyVault?.asset.decimals ?? 18)} ${strategyVault?.asset.symbol ?? ''}`
+  return `${roundAndCompactTokens(exposure.allocatedAssets, vault.asset.decimals)} ${vault.asset.symbol}`
 }
 
 load()
@@ -271,7 +268,7 @@ load()
               <span class="text-content-secondary">({{ compactNumber(getAllocationPercentage(row.exposure), 2) }}%)</span>
             </template>
             <template v-else>
-              <UiExactAmount :exact="formatExactAmount(row.exposure.allocatedAssets, row.vault?.asset.decimals ?? 18, row.vault?.asset.symbol)">
+              <UiExactAmount :exact="formatExactAmount(row.exposure.allocatedAssets, vault.asset.decimals, vault.asset.symbol)">
                 {{ getExposureAssetAmount(row.exposure) }}
               </UiExactAmount>
               <span class="text-content-secondary">({{ compactNumber(getAllocationPercentage(row.exposure), 2) }}%)</span>
@@ -314,8 +311,8 @@ load()
                 {{ formatCompactUsdValue(exposureCapUsdPrices.get(row.exposure.address) || 0) }}
               </template>
               <template v-else>
-                <UiExactAmount :exact="formatExactAmount(row.exposure.allocationCap.current, row.vault?.asset.decimals ?? 18, row.vault?.asset.symbol)">
-                  {{ roundAndCompactTokens(row.exposure.allocationCap.current, row.vault?.asset.decimals ?? 18) }} {{ row.vault?.asset.symbol }}
+                <UiExactAmount :exact="formatExactAmount(row.exposure.allocationCap.current, vault.asset.decimals, vault.asset.symbol)">
+                  {{ roundAndCompactTokens(row.exposure.allocationCap.current, vault.asset.decimals) }} {{ vault.asset.symbol }}
                 </UiExactAmount>
               </template>
             </span>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@eulerxyz/euler-v2-sdk": "1.0.1",
+        "@eulerxyz/euler-v2-sdk": "1.0.2",
         "@floating-ui/vue": "1.1.11",
         "@gvade/nuxt3-svg-sprite": "1.0.3",
         "@keyringnetwork/keyring-connect-sdk": "3.2.0",
@@ -1444,9 +1444,8 @@
       }
     },
     "node_modules/@eulerxyz/euler-v2-sdk": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@eulerxyz/euler-v2-sdk/-/euler-v2-sdk-1.0.1.tgz",
-      "integrity": "sha512-iCjzquYZMiurWJKDmPaPtKOadDT8Ccm+MjpZ2f49IhHx5xKZPcrs0xnu6PLUnCUGLWQbv3C+JPNzTPiQV/jevg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@eulerxyz/euler-v2-sdk/-/euler-v2-sdk-1.0.2.tgz",
       "license": "MIT",
       "dependencies": {
         "viem": "2.48.8"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     ]
   },
   "dependencies": {
-    "@eulerxyz/euler-v2-sdk": "1.0.1",
+    "@eulerxyz/euler-v2-sdk": "1.0.2",
     "@floating-ui/vue": "1.1.11",
     "@gvade/nuxt3-svg-sprite": "1.0.3",
     "@keyringnetwork/keyring-connect-sdk": "3.2.0",


### PR DESCRIPTION
## Summary
- Price Earn exposure current allocation and allocation cap from Earn strategy allocation fields using the parent Earn vault asset.
- Keep strategy EVK vault data for labels, APY, access-control badges, and notes.
- Bump @eulerxyz/euler-v2-sdk to 1.0.2.

## Testing
- npm run typecheck
- Local localhost:3000 smoke with the packed SDK fix showed all four Exposure rows for KPK ETH Yield Term and removed the bad $0 (100%) allocation display.

## Local tarball confirmation
- Installed the packed SDK changes into the local euler-lite app and verified the affected route on localhost:3000:
  /earn/0xB6D6D89ad4b4D61C15a293e28b74f77F6817fF48?network=1
- Confirmed Exposure renders 4 rows: K3 Capital Prime Market, KPK tETH Term Borrow, Escrowed collateral, and KPK wstETH Term Borrow.
- Confirmed the previously missing K3 / eWETH-2 strategy is present with allocation around 269.89 WETH (100%).
- Confirmed current allocation and allocation cap display use Earn strategy allocation fields, while strategy vault metadata supplies APY, labels, access-control badges, and notes.
- Confirmed Earn allocation cap semantics: K3/tETH/wstETH rows use the Earn strategy cap of 5,000 WETH; Escrowed collateral renders unlimited.

## Dependency order
This PR depends on publishing @eulerxyz/euler-v2-sdk@1.0.2 from the SDK PR first. The package-lock entry points at the expected 1.0.2 registry tarball, but does not include a future registry integrity hash; refresh it with npm install after the SDK package is published.