### PR TITLE
fix: refresh USD values after hydration

### DIFF
--- a/components/entities/vault/discovery/DiscoveryMarketAccordion.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketAccordion.vue
@@ -31,6 +31,7 @@ const props = defineProps<{
   initialExpanded?: string[]
 }>()
 
+const { isMarketDataResolved } = useVaults()
 const route = useRoute()
 const { chainId } = useEulerAddresses()
 const shareLinkQuery = computed(() => {
@@ -106,14 +107,14 @@ const vaultUsdCache = ref<Map<string, VaultUsdCacheEntry>>(new Map())
 const formatUsdOrDisplay = (p: { hasPrice: boolean, usdValue: number, display: string }) =>
   p.hasPrice ? formatCompactUsdValue(p.usdValue) : p.display
 
-const loadVaultUsdValues = async (market: MarketGroup) => {
+const loadVaultUsdValues = async (market: MarketGroup, { force = false }: { force?: boolean } = {}) => {
   const newEntries = new Map(vaultUsdCache.value)
   const allVaults = [...market.vaults, ...market.externalCollateral].filter(isMatrixCompatibleVault)
 
   await Promise.all(
     allVaults.map(async (vault) => {
       const addr = getVaultAddress(vault).toLowerCase()
-      if (!addr || newEntries.has(addr)) return
+      if (!addr || (!force && newEntries.has(addr))) return
       const totalAssets = 'totalAssets' in vault ? vault.totalAssets as bigint : 0n
       const borrow = 'totalBorrowed' in vault ? vault.totalBorrowed as bigint : 0n
       const supplyCapRaw = 'caps' in vault ? vault.caps.supplyCap : ('supplyCap' in vault ? vault.supplyCap as bigint : maxUint256)
@@ -149,11 +150,21 @@ const loadVaultUsdValues = async (market: MarketGroup) => {
   vaultUsdCache.value = newEntries
 }
 
+const loadExpandedVaultUsdValues = async () => {
+  const expanded = props.markets.filter(market => isExpanded(market.id))
+  if (!expanded.length) return
+  await Promise.all(expanded.map(market => loadVaultUsdValues(market, { force: true })))
+}
+
 const onToggle = (market: MarketGroup) => {
   const wasExpanded = isExpanded(market.id)
   toggleExpand(market.id)
   if (!wasExpanded) loadVaultUsdValues(market)
 }
+
+watch([() => props.markets, isMarketDataResolved], () => {
+  void loadExpandedVaultUsdValues()
+})
 
 // -- Matrix view selector (single dropdown spans Stats, Configuration,
 // Oracles, and the four numeric pair metrics) --

--- a/pages/earn/[vault]/[subAccount]/withdraw.vue
+++ b/pages/earn/[vault]/[subAccount]/withdraw.vue
@@ -13,6 +13,7 @@ import { getAddress } from 'viem'
 import { OperationReviewModal } from '#components'
 import { FixedPoint } from '~/utils/fixed-point'
 import { getCashLimitedWithdrawAmount } from '~/utils/vault/withdraw'
+import { createRaceGuard } from '~/utils/race-guard'
 
 const router = useRouter()
 const route = useRoute()
@@ -20,7 +21,7 @@ const modal = useModal()
 const { error } = useToast()
 const { planWithdrawOrRedeem, executePlan } = useEulerTx()
 const { account: planAccount } = usePlanAccount()
-const { getEarnVault } = useVaults()
+const { getEarnVault, isMarketDataResolved } = useVaults()
 const { isConnected, address } = useWagmi()
 const { isSpyMode, spyAddress } = useSpyMode()
 const effectiveAddress = computed(() => isSpyMode.value ? spyAddress.value : address.value)
@@ -54,6 +55,7 @@ const estimatesError = ref('')
 const assetsBalanceUsd = ref(0)
 const withdrawableAssetsUsd = ref(0)
 const deltaUsd = ref(0)
+const usdPriceGuard = createRaceGuard()
 
 const rewardApy = computed(() => getSupplyRewardApy(vault.value?.address || ''))
 const amountFixed = computed(() => {
@@ -227,15 +229,23 @@ load()
 
 // Update USD prices when vault or amounts change
 watchEffect(async () => {
+  const gen = usdPriceGuard.next()
+  void isMarketDataResolved.value
   if (!vault.value) {
     assetsBalanceUsd.value = 0
     withdrawableAssetsUsd.value = 0
     deltaUsd.value = 0
     return
   }
-  assetsBalanceUsd.value = await getAssetUsdValueOrZero(assetsBalance.value, vault.value, 'off-chain')
-  withdrawableAssetsUsd.value = await getAssetUsdValueOrZero(withdrawableAssets.value, vault.value, 'off-chain')
-  deltaUsd.value = await getAssetUsdValueOrZero(delta.value, vault.value, 'off-chain')
+  const [nextAssetsBalanceUsd, nextWithdrawableAssetsUsd, nextDeltaUsd] = await Promise.all([
+    getAssetUsdValueOrZero(assetsBalance.value, vault.value, 'off-chain'),
+    getAssetUsdValueOrZero(withdrawableAssets.value, vault.value, 'off-chain'),
+    getAssetUsdValueOrZero(delta.value, vault.value, 'off-chain'),
+  ])
+  if (usdPriceGuard.isStale(gen)) return
+  assetsBalanceUsd.value = nextAssetsBalanceUsd
+  withdrawableAssetsUsd.value = nextWithdrawableAssetsUsd
+  deltaUsd.value = nextDeltaUsd
 })
 
 watch([isConnected, effectiveAddress], async () => {

--- a/pages/earn/index.vue
+++ b/pages/earn/index.vue
@@ -19,7 +19,7 @@ defineOptions({
   name: 'EarnPage',
 })
 
-const { isEarnUpdating } = useVaults()
+const { isEarnUpdating, isMarketDataResolved } = useVaults()
 const isPricesReady = ref(false)
 const { isReady: labelsReady } = useEulerLabels()
 const isLoading = computed(() => isEarnUpdating.value || !labelsReady.value || !isPricesReady.value)
@@ -66,10 +66,12 @@ useUrlQuerySync([
 // Cache for USD values used in sorting (keyed by vault address)
 const vaultTotalSupplyUsd = ref<Map<string, number>>(new Map())
 const vaultLiquidityUsd = ref<Map<string, number>>(new Map())
+let priceLoadId = 0
 
 // Fetch USD values for all earn vaults. Debounced to collapse the bursts
 // of registry updates streamed during loadVaults's RPC refresh.
 const fetchEarnPrices = useDebounceFn(async () => {
+  const loadId = ++priceLoadId
   const vaults = list.value
   if (!vaults.length) {
     isPricesReady.value = true
@@ -89,11 +91,14 @@ const fetchEarnPrices = useDebounceFn(async () => {
         liquidityValues.set(vault.address, liquidity)
       }),
     )
+    if (loadId !== priceLoadId) return
     vaultTotalSupplyUsd.value = totalSupplyValues
     vaultLiquidityUsd.value = liquidityValues
   }
   finally {
-    isPricesReady.value = true
+    if (loadId === priceLoadId) {
+      isPricesReady.value = true
+    }
   }
 }, DEBOUNCE_LIST_PRICE_FETCH_MS)
 
@@ -109,6 +114,7 @@ onDeactivated(() => {
 
 watchEffect(() => {
   void list.value
+  void isMarketDataResolved.value
   if (!isActive.value) return
   fetchEarnPrices()
 })

--- a/pages/lend/[vault]/[subAccount]/withdraw.vue
+++ b/pages/lend/[vault]/[subAccount]/withdraw.vue
@@ -25,6 +25,7 @@ import { SwapTokenSelector, SlippageSettingsModal, OperationReviewModal } from '
 import { FixedPoint } from '~/utils/fixed-point'
 import { getCashLimitedWithdrawAmount } from '~/utils/vault/withdraw'
 import { invalidateSdkQueries } from '~/utils/sdk-query-cache'
+import { createRaceGuard } from '~/utils/race-guard'
 
 const router = useRouter()
 const route = useRoute()
@@ -34,7 +35,7 @@ const { error } = useToast()
 useFullBalances()
 const { planWithdrawOrRedeem, prepareTransactionPlan, executePreparedPlan, prefetchPluginData } = useEulerTx()
 const { account: cachedAccount } = useFreshAccount()
-const { getVault, getSecuritizeVault: _getSecuritizeVault, getEscrowVault: _getEscrowVault } = useVaults()
+const { getVault, getSecuritizeVault: _getSecuritizeVault, getEscrowVault: _getEscrowVault, isMarketDataResolved } = useVaults()
 const { isConnected, address } = useWagmi()
 const { isSpyMode, spyAddress } = useSpyMode()
 const effectiveAddress = computed(() => isSpyMode.value ? spyAddress.value : address.value)
@@ -174,18 +175,27 @@ const estimateSupplyAPYDisplay = computed(() => {
 const assetsBalanceUsd = ref(0)
 const withdrawableAssetsUsd = ref(0)
 const deltaUsd = ref(0)
+const usdPriceGuard = createRaceGuard()
 
 // Update USD prices when vault or amounts change
 watchEffect(async () => {
+  const gen = usdPriceGuard.next()
+  void isMarketDataResolved.value
   if (!vault.value || isSecuritizeVaultType.value) {
     assetsBalanceUsd.value = 0
     withdrawableAssetsUsd.value = 0
     deltaUsd.value = 0
     return
   }
-  assetsBalanceUsd.value = await getAssetUsdValueOrZero(assetsBalance.value, vault.value as EVault, 'off-chain')
-  withdrawableAssetsUsd.value = await getAssetUsdValueOrZero(withdrawableAssets.value, vault.value as EVault, 'off-chain')
-  deltaUsd.value = await getAssetUsdValueOrZero(delta.value, vault.value as EVault, 'off-chain')
+  const [nextAssetsBalanceUsd, nextWithdrawableAssetsUsd, nextDeltaUsd] = await Promise.all([
+    getAssetUsdValueOrZero(assetsBalance.value, vault.value as EVault, 'off-chain'),
+    getAssetUsdValueOrZero(withdrawableAssets.value, vault.value as EVault, 'off-chain'),
+    getAssetUsdValueOrZero(delta.value, vault.value as EVault, 'off-chain'),
+  ])
+  if (usdPriceGuard.isStale(gen)) return
+  assetsBalanceUsd.value = nextAssetsBalanceUsd
+  withdrawableAssetsUsd.value = nextWithdrawableAssetsUsd
+  deltaUsd.value = nextDeltaUsd
 })
 
 // Swap quote helpers

--- a/pages/lend/index.vue
+++ b/pages/lend/index.vue
@@ -20,7 +20,7 @@ defineOptions({
   name: 'LendPage',
 })
 
-const { borrowList, isEVaultUpdating } = useVaults()
+const { borrowList, isEVaultUpdating, isMarketDataResolved } = useVaults()
 const { getVerifiedEVaults } = useVaultRegistry()
 const { chainId } = useEulerAddresses()
 const showAllLabelEntries = useShowAllLabelEntries()
@@ -68,6 +68,7 @@ useUrlQuerySync([
 const vaultUsdValues = ref<Map<string, number>>(new Map())
 const vaultLiquidityUsd = ref<Map<string, number>>(new Map())
 const vaultWalletUsd = ref<Map<string, number>>(new Map())
+let priceLoadId = 0
 
 const getDisplayedVaultSupplyApy = (vault: EVault): number => {
   const baseApy = getVaultSupplyApy(vault)
@@ -126,6 +127,7 @@ const borrowableVaults = computed(() => {
 // price-fetch cycle. Reading rewardsVersion.value establishes a reactive
 // dependency so this also re-runs when reward data loads asynchronously.
 const fetchLendPrices = useDebounceFn(async () => {
+  const loadId = ++priceLoadId
   const vaults = borrowableVaults.value
   if (!vaults.length) {
     isPricesReady.value = true
@@ -152,12 +154,15 @@ const fetchLendPrices = useDebounceFn(async () => {
       }),
     )
 
+    if (loadId !== priceLoadId) return
     vaultUsdValues.value = supplyValues
     vaultLiquidityUsd.value = liquidityValues
     vaultWalletUsd.value = walletValues
   }
   finally {
-    isPricesReady.value = true
+    if (loadId === priceLoadId) {
+      isPricesReady.value = true
+    }
   }
 }, DEBOUNCE_LIST_PRICE_FETCH_MS)
 
@@ -177,6 +182,7 @@ watchEffect(() => {
   // debounced fetcher. Values are re-read inside fetchLendPrices at execution
   // time to avoid closing over stale references.
   void rewardsVersion.value
+  void isMarketDataResolved.value
   void borrowableVaults.value
   if (!isActive.value) return
   fetchLendPrices()


### PR DESCRIPTION
## Summary
- Refresh USD-derived list, withdraw, and Discovery expanded values when market data hydration finishes.
- Prevent older async price fetches from overwriting newer hydrated values on Earn/Lend list views and withdraw pages.

## Changes
- Re-run Earn and Lend list price maps when market data resolves, with stale-request guards for overlapping debounced fetches.
- Re-run Earn and Lend withdraw USD summaries after market-data hydration using race guards.
- Refresh expanded Discovery market USD cache after hydration so Graph/Matrix values do not stay on fallback values.

## Test plan
- [x] npm run typecheck
- [x] npx eslint components/entities/vault/discovery/DiscoveryMarketAccordion.vue pages/earn/[vault]/[subAccount]/withdraw.vue pages/earn/index.vue pages/lend/[vault]/[subAccount]/withdraw.vue pages/lend/index.vue
- [x] Before/after mobile smoke with delayed hydration on development and this branch for Earn, Lend, Earn withdraw, and Explore.
- [x] Local smoke: http://localhost:3000/earn?network=1
- [x] Local smoke: http://localhost:3000/lend?network=1
- [x] Local smoke: http://localhost:3000/earn/0xB6D6D89ad4b4D61C15a293e28b74f77F6817fF48/0/withdraw?network=1
- [x] Local smoke: http://localhost:3000/lend/0xD8b27CF359b7D15710a5BE299AF6e7Bf904984C2/0/withdraw?network=1
- [x] Local smoke: http://localhost:3000/explore?network=1, including expanded Graph and Matrix views
- [x] Local smoke: http://localhost:3000/explore/kpk-securitize?network=1
- [ ] After deploy, validate: https://app.euler.finance/earn?network=1
- [ ] After deploy, validate: https://app.euler.finance/lend?network=1
- [ ] After deploy, validate: https://app.euler.finance/earn/0xB6D6D89ad4b4D61C15a293e28b74f77F6817fF48/0/withdraw?network=1
- [ ] After deploy, validate: https://app.euler.finance/lend/0xD8b27CF359b7D15710a5BE299AF6e7Bf904984C2/0/withdraw?network=1
- [ ] After deploy, validate: https://app.euler.finance/explore?network=1
- [ ] After deploy, validate: https://app.euler.finance/explore/kpk-securitize?network=1

Note: withdraw pages were route-smoked locally without a connected or spied account that has a real balance position.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced accuracy of vault USD valuations and displayed balances by implementing safeguards to prevent stale async price data from overwriting recent market updates across earn, lend, and discovery pages.
  * Improved handling of concurrent price calculations to ensure the latest market rates and vault data are consistently synchronized and reflected in balance displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->