### PR TITLE
fix: address borrow overview review findings

### DIFF
--- a/components/entities/vault/discovery/DiscoveryMarketAccordion.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketAccordion.vue
@@ -108,13 +108,14 @@ const formatUsdOrDisplay = (p: { hasPrice: boolean, usdValue: number, display: s
   p.hasPrice ? formatCompactUsdValue(p.usdValue) : p.display
 
 const loadVaultUsdValues = async (market: MarketGroup, { force = false }: { force?: boolean } = {}) => {
-  const newEntries = new Map(vaultUsdCache.value)
+  const existingEntries = vaultUsdCache.value
+  const marketEntries = new Map<string, VaultUsdCacheEntry>()
   const allVaults = [...market.vaults, ...market.externalCollateral].filter(isMatrixCompatibleVault)
 
   await Promise.all(
     allVaults.map(async (vault) => {
       const addr = getVaultAddress(vault).toLowerCase()
-      if (!addr || (!force && newEntries.has(addr))) return
+      if (!addr || (!force && existingEntries.has(addr))) return
       const totalAssets = 'totalAssets' in vault ? vault.totalAssets as bigint : 0n
       const borrow = 'totalBorrowed' in vault ? vault.totalBorrowed as bigint : 0n
       const supplyCapRaw = 'caps' in vault ? vault.caps.supplyCap : ('supplyCap' in vault ? vault.supplyCap as bigint : maxUint256)
@@ -132,7 +133,7 @@ const loadVaultUsdValues = async (market: MarketGroup, { force = false }: { forc
         borrowCapHasPrice ? formatAssetValue(borrowCapRaw, vault, 'off-chain') : null,
       ])
 
-      newEntries.set(addr, {
+      marketEntries.set(addr, {
         supply: formatUsdOrDisplay(supplyPrice),
         supplyUsd: supplyPrice.hasPrice ? supplyPrice.usdValue : 0,
         borrow: formatUsdOrDisplay(borrowPrice),
@@ -147,7 +148,7 @@ const loadVaultUsdValues = async (market: MarketGroup, { force = false }: { forc
     }),
   )
 
-  vaultUsdCache.value = newEntries
+  vaultUsdCache.value = new Map([...vaultUsdCache.value, ...marketEntries])
 }
 
 const loadExpandedVaultUsdValues = async () => {

--- a/components/entities/vault/overview/VaultOverviewPairBlockGeneral.vue
+++ b/components/entities/vault/overview/VaultOverviewPairBlockGeneral.vue
@@ -63,6 +63,8 @@ const netApy = computed(() => supplyApyWithRewards.value - borrowApyWithRewards.
 const maxRoe = computed(() =>
   getMaxRoe(maxMultiplier.value, supplyApyWithRewards.value, borrowApyWithRewards.value, loopingRewardAPY.value),
 )
+const netApyClass = computed(() => netApy.value >= 0 ? 'text-accent-600' : 'text-error-500')
+const maxRoeClass = computed(() => maxRoe.value >= 0 ? 'text-accent-600' : 'text-error-500')
 
 const baseSupplyApy = computed(() => getVaultSupplyApy(collateralVault.value))
 const baseBorrowApy = computed(() => getVaultBorrowApy(borrowVault.value))
@@ -401,7 +403,10 @@ const rampDownModalData = computed(() => ({
                     </UiModalPreviewTrigger>
                   </span>
                 </template>
-                <span class="flex items-center gap-4 text-accent-600 font-semibold">
+                <span
+                  class="flex items-center gap-4 font-semibold"
+                  :class="netApyClass"
+                >
                   <UiModalPreviewTrigger
                     v-if="hasSupplyRewards(collateralVault.address) || hasBorrowRewards(borrowVault.address, collateralVault.address) || hasLoopingRewards(borrowVault.address, collateralVault.address)"
                     :component="VaultNetApyPairModal"
@@ -449,7 +454,10 @@ const rampDownModalData = computed(() => ({
                     </UiModalPreviewTrigger>
                   </span>
                 </template>
-                <span class="flex items-center gap-4 text-accent-600 font-semibold">
+                <span
+                  class="flex items-center gap-4 font-semibold"
+                  :class="maxRoeClass"
+                >
                   <UiModalPreviewTrigger
                     v-if="hasSupplyRewards(collateralVault.address) || hasBorrowRewards(borrowVault.address, collateralVault.address) || hasLoopingRewards(borrowVault.address, collateralVault.address)"
                     :component="VaultMaxRoeModal"


### PR DESCRIPTION
## Summary
- Merge refreshed Explore-market USD cache entries into the latest cache state to avoid concurrent expanded-market refreshes overwriting one another.
- Color borrow-pair overview Net APY and Max ROE by sign so negative values render with error styling.

## Test plan
- npx eslint components/entities/vault/discovery/DiscoveryMarketAccordion.vue components/entities/vault/overview/VaultOverviewPairBlockGeneral.vue
- npm run typecheck

Refs #544 review comments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Net APY and Max ROE values now display in green for positive values and red for negative values for improved visual clarity.

* **Refactor**
  * Improved vault USD value caching efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->