### PR TITLE
fix: allow unverified vault deep links

### DIFF
--- a/server/middleware/ensure-vault.ts
+++ b/server/middleware/ensure-vault.ts
@@ -1,12 +1,8 @@
 import { getRequestURL, sendRedirect } from 'h3'
-import { getAddress, isAddress } from 'viem'
+import { VaultType } from '@eulerxyz/euler-v2-sdk'
+import { getAddress, isAddress, type Address } from 'viem'
 import { withWallClock } from '../utils/fetchWithTimeout'
-import {
-  refreshChainVaults,
-  vaultsCache,
-  type SerialisedSnapshot,
-  type SerialisedVault,
-} from '../utils/vaults-cache'
+import { getServerSdk } from '../utils/sdk-server'
 
 /**
  * Vault route patterns:
@@ -18,14 +14,13 @@ const LEND_EARN_RE = /^\/(lend|earn)\/([^/?#]+)/
 const BORROW_RE = /^\/borrow\/([^/?#]+)\/([^/?#]+)/
 const VAULT_ROUTE_VALIDATION_BUDGET_MS = 8_000
 
-const getSnapshot = async (chainId: number): Promise<SerialisedSnapshot | undefined> => {
-  const cacheKey = String(chainId)
-  const cached = vaultsCache.get(cacheKey) ?? vaultsCache.getStale(cacheKey)
-  if (cached) return cached
-
+const resolveVaultTypes = async (
+  chainId: number,
+  addresses: Address[],
+): Promise<Partial<Record<Address, string>> | undefined> => {
   try {
     return await withWallClock(
-      () => refreshChainVaults(chainId),
+      async () => (await getServerSdk(chainId)).vaultMetaService.fetchVaultTypes(chainId, addresses),
       VAULT_ROUTE_VALIDATION_BUDGET_MS,
       'vault route validation',
     )
@@ -34,21 +29,6 @@ const getSnapshot = async (chainId: number): Promise<SerialisedSnapshot | undefi
     console.warn('[ensure-vault] failed to validate vault route', err)
     return undefined
   }
-}
-
-const getVaultAddress = (vault: SerialisedVault): string | undefined => {
-  const data = vault.data as { address?: unknown }
-  return typeof data.address === 'string' ? data.address : undefined
-}
-
-const snapshotHasVault = (snapshot: SerialisedSnapshot, address: string): boolean => {
-  const normalized = address.toLowerCase()
-  return [
-    ...snapshot.evkVaults,
-    ...snapshot.earnVaults,
-    ...snapshot.securitizeVaults,
-    ...snapshot.escrowVaults,
-  ].some(vault => getVaultAddress(vault)?.toLowerCase() === normalized)
 }
 
 export default defineEventHandler(async (event) => {
@@ -83,10 +63,10 @@ export default defineEventHandler(async (event) => {
   const query = url.searchParams.toString()
   const redirectUrl = `/${section}${query ? `?${query}` : ''}`
 
-  // Validate addresses are well-formed and normalize them. Use the non-strict
-  // check so valid addresses with non-canonical checksum casing do not get
-  // bounced; getAddress() canonicalizes casing for snapshot membership checks.
-  const normalized: string[] = []
+  // Validate route address segments before resolving vault types. Snapshot
+  // membership is not exhaustive: unverified EVK vaults can still be valid
+  // direct links when the SDK resolver recognizes them.
+  const normalized: Address[] = []
   for (const addr of addresses) {
     if (!isAddress(addr, { strict: false })) {
       return sendRedirect(event, redirectUrl, 302)
@@ -95,20 +75,21 @@ export default defineEventHandler(async (event) => {
   }
 
   // Resolve chain from ?network= query param. If it is absent, keep the route
-  // client-backed because we cannot pick the right chain snapshot safely.
+  // client-backed because we cannot pick the right chain resolver safely.
   const networkParam = url.searchParams.get('network')
   const chainId = networkParam ? parseInt(networkParam, 10) : NaN
   if (!chainId || isNaN(chainId)) {
     return
   }
 
-  const snapshot = await getSnapshot(chainId)
-  if (!snapshot) {
+  const types = await resolveVaultTypes(chainId, normalized)
+  if (!types) {
     return
   }
 
   for (const addr of normalized) {
-    if (!snapshotHasVault(snapshot, addr)) {
+    const type = types[addr] ?? types[addr.toLowerCase() as Address]
+    if (!type || type === VaultType.Unknown) {
       return sendRedirect(event, redirectUrl, 302)
     }
   }


### PR DESCRIPTION
## Summary
- Allow direct vault URLs for valid but unverified EVK vaults to load instead of redirecting just because they are absent from the curated snapshot.
- Keep malformed, stale, and syntactically valid non-vault route params redirecting to their parent list pages.

## Changes
- Replace server-side snapshot membership validation with SDK vault type resolution.
- Preserve syntax validation for lend, earn, and borrow route address params before resolving vault types.
- Fail open if the route validator cannot resolve upstream data, matching the previous middleware behavior during validation failures.

## Test plan
- [x] npm run typecheck
- [x] npx eslint server/middleware/ensure-vault.ts
- [x] curl -sSI 'http://localhost:3000/lend/0x0120c2748545a4D9C875CDdFB439f786d6f1B460?network=1' returns 200
- [x] curl -sSI 'http://localhost:3000/lend/not-an-address?network=1' redirects to /lend?network=1
- [x] curl -sSI 'http://localhost:3000/lend/0x000000000000000000000000000000000000dEaD?network=1' redirects to /lend?network=1
- [x] curl -sSI 'http://[::1]:3000/borrow/0x056f3a2E41d2778D3a0c0714439c53af2987718E/0xD8b27CF359b7D15710a5BE299AF6e7Bf904984C2?network=1' returns 200
- [x] curl -sSI 'http://[::1]:3000/borrow/0x056f3a2E41d2778D3a0c0714439c53af2987718E/0x000000000000000000000000000000000000dEaD?network=1' redirects to /borrow?network=1
- [x] Headless Chrome keeps the unverified lend URL after hydration
- [x] Headless Chrome keeps the configured borrow pair URL after hydration