### PR TITLE
feat: consume label classification tags

### DIFF
--- a/components/entities/vault/SecuritizeVaultItem.vue
+++ b/components/entities/vault/SecuritizeVaultItem.vue
@@ -3,6 +3,7 @@ import type { SecuritizeCollateralVault, EVault } from '@eulerxyz/euler-v2-sdk'
 import { formatAssetValue } from '~/utils/sdk-prices'
 import { isVaultBlockedByCountry } from '~/composables/useGeoBlock'
 import { useEulerProductOfVault, useEulerEntitiesOfVault } from '~/composables/useEulerLabels'
+import { isVaultGovernanceLimited } from '~/utils/eulerLabelsUtils'
 import { getEulerLabelEntityLogo } from '~/entities/euler/labels'
 import { withVaultIntrinsicApy, getVaultIntrinsicApy, getVaultIntrinsicApyInfo } from '~/utils/vault-intrinsic-apy'
 import { formatNumber, formatCompactUsdValue } from '~/utils/string-utils'
@@ -22,7 +23,7 @@ const entities = useEulerEntitiesOfVault(vault as unknown as EVault)
 
 const isUnverified = computed(() => !isVerifiedVault(vault.address))
 const isGovernorVerified = computed(() => isVaultGovernorVerified(vault as unknown as EVault))
-const isGovernanceLimited = computed(() => product.isGovernanceLimited && isGovernorVerified.value)
+const isGovernanceLimited = computed(() => isVaultGovernanceLimited(vault.address) && isGovernorVerified.value)
 const entityName = computed(() => {
   if (!isGovernorVerified.value || entities.length === 0) return ''
   if (entities.length === 1) return entities[0].name

--- a/components/entities/vault/VaultBorrowItem.vue
+++ b/components/entities/vault/VaultBorrowItem.vue
@@ -1,13 +1,12 @@
 <script setup lang="ts">
 import type { EVault } from '@eulerxyz/euler-v2-sdk'
-import { isCyclicalNoteVault } from '~/utils/vault/classification'
 import { getUtilisationWarning, getBorrowCapWarning, getCollateralSupplyCapWarning } from '~/composables/useVaultWarnings'
 import { formatAssetValue } from '~/utils/sdk-prices'
 import { getMaxMultiplier, getMaxRoe } from '~/utils/leverage'
 import { withVaultIntrinsicApy, getVaultIntrinsicApy, getVaultIntrinsicApyInfo } from '~/utils/vault-intrinsic-apy'
 import { getVaultAvailableLiquidity, getVaultUtilization } from '~/utils/vault-display'
 import { useEulerProductOfVault } from '~/composables/useEulerLabels'
-import { isVaultGovernanceLimited, isVaultRecentlyAdded, isVaultKeyring, getUniqueEntitiesByVaults } from '~/utils/eulerLabelsUtils'
+import { isVaultGovernanceLimited, isVaultRecentlyAdded, isVaultKeyring, isVaultCyclicalNote, getUniqueEntitiesByVaults } from '~/utils/eulerLabelsUtils'
 import { getEulerLabelEntityLogo } from '~/entities/euler/labels'
 import { isAnyVaultBlockedByCountry, isVaultRestrictedByCountry } from '~/composables/useGeoBlock'
 import { VaultBorrowApyModal, VaultMaxRoeModal, VaultNetApyPairModal, VaultSupplyApyModal, UiModalPreviewTrigger } from '#components'
@@ -82,7 +81,7 @@ const isPairEffectivelyBlocked = computed(() => {
 
 const isRecentlyAdded = computed(() => isVaultRecentlyAdded(pair.collateral.address) || isVaultRecentlyAdded(pair.borrow.address))
 const isKeyring = computed(() => isVaultKeyring(pair.collateral.address) || isVaultKeyring(pair.borrow.address))
-const isCyclicalNote = computed(() => isCyclicalNoteVault(pair.borrow))
+const isCyclicalNote = computed(() => isVaultCyclicalNote(pair.borrow.address))
 
 const isAnyDeprecated = computed(() => {
   const collateralAddr = getAddress(pair.collateral.address)

--- a/components/entities/vault/VaultBorrowItem.vue
+++ b/components/entities/vault/VaultBorrowItem.vue
@@ -7,7 +7,7 @@ import { getMaxMultiplier, getMaxRoe } from '~/utils/leverage'
 import { withVaultIntrinsicApy, getVaultIntrinsicApy, getVaultIntrinsicApyInfo } from '~/utils/vault-intrinsic-apy'
 import { getVaultAvailableLiquidity, getVaultUtilization } from '~/utils/vault-display'
 import { useEulerProductOfVault } from '~/composables/useEulerLabels'
-import { isVaultRecentlyAdded, isVaultKeyring, getUniqueEntitiesByVaults } from '~/utils/eulerLabelsUtils'
+import { isVaultGovernanceLimited, isVaultRecentlyAdded, isVaultKeyring, getUniqueEntitiesByVaults } from '~/utils/eulerLabelsUtils'
 import { getEulerLabelEntityLogo } from '~/entities/euler/labels'
 import { isAnyVaultBlockedByCountry, isVaultRestrictedByCountry } from '~/composables/useGeoBlock'
 import { VaultBorrowApyModal, VaultMaxRoeModal, VaultNetApyPairModal, VaultSupplyApyModal, UiModalPreviewTrigger } from '#components'
@@ -46,7 +46,6 @@ const entityDisplay = computed(() => {
 const { settings } = useUserSettings()
 const enableIntrinsicApy = computed(() => settings.value.enableIntrinsicApy)
 const { getBorrowRewardApy, getSupplyRewardApy, getLoopingRewardApy, hasSupplyRewards, hasBorrowRewards, hasLoopingRewards, getBorrowRewardCampaigns, getSupplyRewardCampaigns, getLoopingRewardCampaigns } = useRewardsApy()
-
 const collateralProduct = useEulerProductOfVault(
   computed(() => pair.collateral.address),
 )
@@ -55,7 +54,7 @@ const borrowProduct = useEulerProductOfVault(
 )
 
 const isAnyGovernanceLimited = computed(() =>
-  (collateralProduct.isGovernanceLimited || borrowProduct.isGovernanceLimited) && !isAnyGovernorUnverified.value,
+  (isVaultGovernanceLimited(pair.collateral.address) || isVaultGovernanceLimited(pair.borrow.address)) && !isAnyGovernorUnverified.value,
 )
 
 const isEscrowCollateral = computed(

--- a/components/entities/vault/VaultItem.vue
+++ b/components/entities/vault/VaultItem.vue
@@ -3,7 +3,7 @@ import type { EVault } from '@eulerxyz/euler-v2-sdk'
 import { getUtilisationWarning, getSupplyCapWarning } from '~/composables/useVaultWarnings'
 import { formatAssetValue } from '~/utils/sdk-prices'
 import { useEulerProductOfVault, useEulerEntitiesOfVault } from '~/composables/useEulerLabels'
-import { isVaultGovernanceLimited, isVaultRecentlyAdded, isVaultKeyring } from '~/utils/eulerLabelsUtils'
+import { isVaultGovernanceLimited, isVaultRecentlyAdded, isVaultKeyring, isVaultCyclicalNote } from '~/utils/eulerLabelsUtils'
 import { withVaultIntrinsicApy, getVaultIntrinsicApy, getVaultIntrinsicApyInfo } from '~/utils/vault-intrinsic-apy'
 import { getEulerLabelEntityLogo } from '~/entities/euler/labels'
 import { isVaultBlockedByCountry } from '~/composables/useGeoBlock'
@@ -12,7 +12,7 @@ import BaseLoadableContent from '~/components/base/BaseLoadableContent.vue'
 import { useModal } from '~/components/ui/composables/useModal'
 import { useVaultRegistry } from '~/composables/useVaultRegistry'
 import { VaultSupplyApyModal, VaultCollateralExposureModal, UiModalPreviewTrigger } from '#components'
-import { isCyclicalNoteVault, isVaultBorrowable } from '~/utils/vault/classification'
+import { isVaultBorrowable } from '~/utils/vault/classification'
 import { getAddress } from 'viem'
 
 const { isConnected } = useWagmi()
@@ -114,7 +114,7 @@ const utilizationDisplay = computed(() => compactNumber(utilization.value, 2, 2)
 const isGeoBlocked = computed(() => isVaultBlockedByCountry(vault.address))
 const isRecentlyAdded = computed(() => isVaultRecentlyAdded(vault.address))
 const isKeyring = computed(() => isVaultKeyring(vault.address))
-const isCyclicalNote = computed(() => isCyclicalNoteVault(vault))
+const isCyclicalNote = computed(() => isVaultCyclicalNote(vault.address))
 const utilisationWarning = computed(() => getUtilisationWarning(vault, 'lend'))
 const supplyCapWarning = computed(() => getSupplyCapWarning(vault))
 const statsGridCols = computed(() => {

--- a/components/entities/vault/VaultItem.vue
+++ b/components/entities/vault/VaultItem.vue
@@ -3,7 +3,7 @@ import type { EVault } from '@eulerxyz/euler-v2-sdk'
 import { getUtilisationWarning, getSupplyCapWarning } from '~/composables/useVaultWarnings'
 import { formatAssetValue } from '~/utils/sdk-prices'
 import { useEulerProductOfVault, useEulerEntitiesOfVault } from '~/composables/useEulerLabels'
-import { isVaultRecentlyAdded, isVaultKeyring } from '~/utils/eulerLabelsUtils'
+import { isVaultGovernanceLimited, isVaultRecentlyAdded, isVaultKeyring } from '~/utils/eulerLabelsUtils'
 import { withVaultIntrinsicApy, getVaultIntrinsicApy, getVaultIntrinsicApyInfo } from '~/utils/vault-intrinsic-apy'
 import { getEulerLabelEntityLogo } from '~/entities/euler/labels'
 import { isVaultBlockedByCountry } from '~/composables/useGeoBlock'
@@ -25,7 +25,7 @@ const entities = useEulerEntitiesOfVault(vault)
 const { getVaultCategory, isVerifiedVault, get: registryGet } = useVaultRegistry()
 const isUnverified = computed(() => !isVerifiedVault(vault.address))
 const isGovernorVerified = computed(() => isVaultGovernorVerified(vault))
-const isGovernanceLimited = computed(() => product.isGovernanceLimited && isGovernorVerified.value)
+const isGovernanceLimited = computed(() => isVaultGovernanceLimited(vault.address) && isGovernorVerified.value)
 const entityName = computed(() => {
   if (!isGovernorVerified.value || entities.length === 0) return ''
   if (entities.length === 1) return entities[0].name

--- a/components/entities/vault/discovery/DiscoveryMarketCard.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketCard.vue
@@ -30,7 +30,7 @@ const { getBorrowRewardApy, getSupplyRewardApy, getLoopingRewardApy } = useRewar
 const { products } = useEulerLabels()
 
 const isGovernanceLimited = computed(() =>
-  props.market.source === 'product' && !!products[props.market.id]?.isGovernanceLimited,
+  props.market.source === 'product' && (products[props.market.id]?.tags?.includes('governance limited') ?? false),
 )
 
 const getProductDescription = (market: MarketGroup): string => {

--- a/components/entities/vault/discovery/DiscoveryMarketGraph.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketGraph.vue
@@ -1,10 +1,9 @@
 <script setup lang="ts">
 import type { MarketGroup, MiniDiagramData } from '~/entities/lend-discovery'
-import { isCyclicalNoteVault } from '~/utils/vault/classification'
 import { getAssetLogoUrl } from '~/composables/useTokenList'
-import { isVaultDeprecated, isVaultKeyring } from '~/utils/eulerLabelsUtils'
+import { isVaultDeprecated, isVaultKeyring, isVaultCyclicalNote } from '~/utils/eulerLabelsUtils'
 import { stringToColor } from '~/utils/string-utils'
-import { getEnlargedDiagram, getArrow, getLabelPosition, getGraphConnectedAddresses, isNodeRampingDown, isExternalCollateral, findVault } from '~/utils/discoveryCalculations'
+import { getEnlargedDiagram, getArrow, getLabelPosition, getGraphConnectedAddresses, isNodeRampingDown, isExternalCollateral } from '~/utils/discoveryCalculations'
 
 const props = defineProps<{
   market: MarketGroup
@@ -35,7 +34,7 @@ const isGraphEdgeHighlighted = (fromAddr: string, toAddr: string): boolean => {
 }
 
 const isNodeCyclicalNote = (address: string): boolean => {
-  return isCyclicalNoteVault(findVault(props.market, address))
+  return isVaultCyclicalNote(address)
 }
 </script>
 

--- a/components/entities/vault/overview/SecuritizeVaultOverview.vue
+++ b/components/entities/vault/overview/SecuritizeVaultOverview.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { EVault, EVaultCollateral, SecuritizeCollateralVault } from '@eulerxyz/euler-v2-sdk'
 import { useEulerEntitiesOfVault } from '~/composables/useEulerLabels'
-import { getProductByVault, getProductKeyByVault } from '~/utils/eulerLabelsUtils'
+import { getProductByVault, getProductKeyByVault, isVaultGovernanceLimited } from '~/utils/eulerLabelsUtils'
 import { useVaultRegistry } from '~/composables/useVaultRegistry'
 import { getEulerLabelEntityLogo } from '~/entities/euler/labels'
 import { isVaultBlockedByCountry } from '~/composables/useGeoBlock'
@@ -35,7 +35,7 @@ const description = computed(() => {
 })
 const entities = useEulerEntitiesOfVault(vault as unknown as EVault)
 const isGovernorVerified = computed(() => isVaultGovernorVerified(vault as unknown as EVault))
-const isGovernanceLimited = computed(() => product.isGovernanceLimited && isGovernorVerified.value)
+const isGovernanceLimited = computed(() => isVaultGovernanceLimited(vault.address) && isGovernorVerified.value)
 const marketProductKey = computed(() => getProductKeyByVault(vault.address))
 const marketProductName = computed(() => getProductByVault(vault.address).name)
 

--- a/components/entities/vault/overview/VaultOverview.vue
+++ b/components/entities/vault/overview/VaultOverview.vue
@@ -1,13 +1,13 @@
 <script setup lang="ts">
 import type { EVault } from '@eulerxyz/euler-v2-sdk'
-import { isCyclicalNoteVault } from '~/utils/vault/classification'
+import { isVaultCyclicalNote } from '~/utils/eulerLabelsUtils'
 
 const emits = defineEmits<{
   'vault-click': [address: string]
 }>()
 const { vault } = defineProps<{ vault: EVault, desktopOverview?: boolean }>()
 
-const isCyclicalIRM = computed(() => isCyclicalNoteVault(vault))
+const isCyclicalIRM = computed(() => isVaultCyclicalNote(vault.address))
 </script>
 
 <template>

--- a/components/entities/vault/overview/VaultOverviewBlockGeneral.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockGeneral.vue
@@ -5,7 +5,7 @@ import type { Component } from 'vue'
 
 import { formatAssetValue } from '~/utils/sdk-prices'
 import { useEulerEntitiesOfVault, useEulerProductOfVault } from '~/composables/useEulerLabels'
-import { getProductByVault, getProductKeyByVault } from '~/utils/eulerLabelsUtils'
+import { getProductByVault, getProductKeyByVault, isVaultGovernanceLimited } from '~/utils/eulerLabelsUtils'
 import { getEulerLabelEntityLogo } from '~/entities/euler/labels'
 import { isVaultBlockedByCountry } from '~/composables/useGeoBlock'
 import { autoLink } from '~/utils/autoLink'
@@ -39,7 +39,7 @@ const isDeprecated = computed(() => {
 const deprecationReason = computed(() => isDeprecated.value ? product.deprecationReason || '' : '')
 const isRestricted = computed(() => isVaultBlockedByCountry(vault.address))
 const isGovernorVerified = computed(() => isVaultGovernorVerified(vault))
-const isGovernanceLimited = computed(() => product.isGovernanceLimited && isGovernorVerified.value)
+const isGovernanceLimited = computed(() => isVaultGovernanceLimited(vault.address) && isGovernorVerified.value)
 
 // Count how many EVaults reference this vault as a borrowable collateral.
 // Use the registry directly, matching the baseline app. `borrowList` is

--- a/components/entities/vault/overview/VaultOverviewBlockIRM.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockIRM.vue
@@ -94,7 +94,6 @@ const irmTypeLabel = computed(() => {
   if (type === INTEREST_RATE_MODEL_TYPE.KINK) return 'Kink'
   if (type === INTEREST_RATE_MODEL_TYPE.ADAPTIVE_CURVE) return 'Adaptive'
   if (type === INTEREST_RATE_MODEL_TYPE.KINKY) return 'Kinky'
-  if (type === INTEREST_RATE_MODEL_TYPE.FIXED_CYCLICAL_BINARY) return 'Cyclical note'
   return 'Interest Rate Model'
 })
 

--- a/composables/useEulerLabels.ts
+++ b/composables/useEulerLabels.ts
@@ -21,15 +21,6 @@ import { erc4626AssetAbi } from '~/abis/erc4626'
 import { buildBatchItem, evcBatchCall } from '~/utils/multicall'
 import { normalizeAddress } from '~/utils/normalizeAddress'
 
-type EulerLabelProductCompat = EulerLabelProduct & {
-  recentlyAddedVaults?: string[]
-}
-
-type EulerLabelsDataCompat = Omit<EulerLabelsData, 'products'> & {
-  products: Record<string, EulerLabelProductCompat>
-  recentlyAddedEarnVaults?: Set<string>
-}
-
 const LABEL_QUERY_NAMES = [
   'queryEulerLabelsEntities',
   'queryEulerLabelsProducts',
@@ -47,7 +38,6 @@ const createEmptyEulerLabelsData = (): EulerLabelsData => ({
   earnVaultEntries: {},
   earnVaultBlocks: {},
   earnVaultRestrictions: {},
-  recentlyAddedEarnVaults: new Set(),
   deprecatedEarnVaults: {},
   earnVaultDescriptions: {},
   earnVaultNotices: {},
@@ -78,11 +68,10 @@ export const getEulerLabelsVersion = (): number => labelsVersion.value
 
 export const getEulerLabelWrapPairs = (): Record<string, string> => wrapPairs
 
-export const __setEulerLabelsDataForTest = (data: Partial<EulerLabelsDataCompat> = {}) => {
+export const __setEulerLabelsDataForTest = (data: Partial<EulerLabelsData> = {}) => {
   setLabelsData({
     ...createEmptyEulerLabelsData(),
     ...data,
-    recentlyAddedEarnVaults: data.recentlyAddedEarnVaults ?? new Set(),
     notExplorableEarnVaults: data.notExplorableEarnVaults ?? new Set(),
     assetPatternRules: data.assetPatternRules ?? [],
   } as unknown as EulerLabelsData, null)

--- a/composables/useVaultTypeBadges.ts
+++ b/composables/useVaultTypeBadges.ts
@@ -2,8 +2,7 @@ import { zeroAddress } from 'viem'
 import { isEVault, type EulerEarn, type EVault, type SecuritizeCollateralVault } from '@eulerxyz/euler-v2-sdk'
 import type { Ref } from 'vue'
 import { isCyclicalNoteVault } from '~/utils/vault/classification'
-import { useEulerProductOfVault } from '~/composables/useEulerLabels'
-import { getEntitiesByEarnVault, getEntitiesByVault, isVaultAccessControlled, isVaultKeyring } from '~/utils/eulerLabelsUtils'
+import { getEntitiesByEarnVault, getEntitiesByVault, isVaultAccessControlled, isVaultGovernanceLimited, isVaultKeyring } from '~/utils/eulerLabelsUtils'
 import { useVaultRegistry } from '~/composables/useVaultRegistry'
 
 type VaultTypeBadgeVault = EVault | EulerEarn | SecuritizeCollateralVault
@@ -17,7 +16,6 @@ export const useVaultTypeBadges = (vault: Ref<VaultTypeBadgeVault>) => {
   const { getVaultCategory } = useVaultRegistry()
 
   const addressRef = computed(() => vault.value.address)
-  const product = useEulerProductOfVault(addressRef)
 
   const isEarn = computed(() => vault.value.type === 'EulerEarn')
   const isSecuritize = computed(() => vault.value.type === 'SecuritizeCollateral')
@@ -48,7 +46,7 @@ export const useVaultTypeBadges = (vault: Ref<VaultTypeBadgeVault>) => {
   })
 
   const isGovernanceLimited = computed(() =>
-    product.isGovernanceLimited && isVerified.value,
+    isVaultGovernanceLimited(addressRef.value) && isVerified.value,
   )
 
   const isCyclicalNote = computed(() => {

--- a/composables/useVaultTypeBadges.ts
+++ b/composables/useVaultTypeBadges.ts
@@ -1,8 +1,7 @@
 import { zeroAddress } from 'viem'
 import { isEVault, type EulerEarn, type EVault, type SecuritizeCollateralVault } from '@eulerxyz/euler-v2-sdk'
 import type { Ref } from 'vue'
-import { isCyclicalNoteVault } from '~/utils/vault/classification'
-import { getEntitiesByEarnVault, getEntitiesByVault, isVaultAccessControlled, isVaultGovernanceLimited, isVaultKeyring } from '~/utils/eulerLabelsUtils'
+import { getEntitiesByEarnVault, getEntitiesByVault, isVaultAccessControlled, isVaultCyclicalNote, isVaultGovernanceLimited, isVaultKeyring } from '~/utils/eulerLabelsUtils'
 import { useVaultRegistry } from '~/composables/useVaultRegistry'
 
 type VaultTypeBadgeVault = EVault | EulerEarn | SecuritizeCollateralVault
@@ -51,7 +50,7 @@ export const useVaultTypeBadges = (vault: Ref<VaultTypeBadgeVault>) => {
 
   const isCyclicalNote = computed(() => {
     if (!isEVault(vault.value)) return false
-    return isCyclicalNoteVault(vault.value)
+    return isVaultCyclicalNote(vault.value.address)
   })
 
   const badges = computed<VaultTypeBadge[]>(() => {

--- a/composables/useVaultWarnings.ts
+++ b/composables/useVaultWarnings.ts
@@ -1,6 +1,7 @@
 import { isSecuritizeCollateralVault, type EVault, type SecuritizeCollateralVault } from '@eulerxyz/euler-v2-sdk'
 import { isCyclicalNoteVault } from '~/utils/vault/classification'
 import { getVaultUtilization } from '~/utils/vault-display'
+import { isVaultHighUtilisationWarningSuppressed } from '~/utils/eulerLabelsUtils'
 import {
   findBlockingDisabledOp,
   getOpMeta,
@@ -103,6 +104,8 @@ export const getUtilisationWarning = (
   const utilisation = getVaultUtilization(vault)
   const level = getUtilisationLevel(utilisation)
   if (!level) return null
+
+  if (level === 'high' && isVaultHighUtilisationWarningSuppressed(vault.address)) return null
 
   if (context !== 'repay' && isCyclicalNoteVault(vault)) {
     return { level: 'info', tone: 'success', ...targetUtilisationMessage }

--- a/composables/useVaultWarnings.ts
+++ b/composables/useVaultWarnings.ts
@@ -1,6 +1,6 @@
 import { isSecuritizeCollateralVault, type EVault, type SecuritizeCollateralVault } from '@eulerxyz/euler-v2-sdk'
-import { isCyclicalNoteVault } from '~/utils/vault/classification'
 import { getVaultUtilization } from '~/utils/vault-display'
+import { isVaultCyclicalNote } from '~/utils/eulerLabelsUtils'
 import {
   findBlockingDisabledOp,
   getOpMeta,
@@ -104,7 +104,7 @@ export const getUtilisationWarning = (
   const level = getUtilisationLevel(utilisation)
   if (!level) return null
 
-  if (context !== 'repay' && isCyclicalNoteVault(vault)) {
+  if (context !== 'repay' && isVaultCyclicalNote(vault.address)) {
     return { level: 'info', tone: 'success', ...targetUtilisationMessage }
   }
 

--- a/composables/useVaultWarnings.ts
+++ b/composables/useVaultWarnings.ts
@@ -104,11 +104,11 @@ export const getUtilisationWarning = (
   const level = getUtilisationLevel(utilisation)
   if (!level) return null
 
-  if (level === 'high' && isVaultHighUtilisationWarningSuppressed(vault.address)) return null
-
   if (context !== 'repay' && isVaultCyclicalNote(vault.address)) {
     return { level: 'info', tone: 'success', ...targetUtilisationMessage }
   }
+
+  if (level === 'high' && isVaultHighUtilisationWarningSuppressed(vault.address)) return null
 
   const { title, message } = utilisationMessages[context][level]
   return { level, title, message }

--- a/docs/keyring-hooks.md
+++ b/docs/keyring-hooks.md
@@ -16,11 +16,11 @@ Keyring vaults are flagged via the labels system (`products.json`):
 {
   "private-market": {
     "name": "Private Market",
-    "keyring": true,           // All vaults in this product require keyring
+    "tags": ["keyring"],       // All vaults in this product require keyring
     "vaults": ["0x1234..."],
     "vaultOverrides": {
       "0x5678...": {
-        "keyring": true        // Per-vault override (if product-level is false)
+        "tags": ["keyring"]    // Per-vault classification
       }
     }
   }
@@ -28,8 +28,8 @@ Keyring vaults are flagged via the labels system (`products.json`):
 ```
 
 Utility functions in `utils/eulerLabelsUtils.ts`:
-- `isVaultKeyring(vaultAddress)` — checks product-level or vault-override `keyring` flag
-- `isProductKeyring(productKey)` — checks product-level flag (for explore page)
+- `isVaultKeyring(vaultAddress)` — checks product-level or vault-override `keyring` tag
+- `isProductKeyring(productKey)` — checks the product-level `keyring` tag
 
 ### On-chain reads (zero hardcoded addresses)
 

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -163,7 +163,7 @@ interface VaultMetadata {
   portfolioNotice: string | null
   deprecationReason: string | null
   deprecated: boolean                        // true if listed under any product's deprecatedVaults or earn entry has deprecated: true
-  governanceLimited: boolean                 // true when the owning product has isGovernanceLimited: true (governor exists but no active risk management). False for vaults without a product.
+  governanceLimited: boolean                 // true when the owning product has the "governance limited" tag. False for vaults without a product.
   productId: string | null                   // product slug from products.json that owns this vault; null for escrow and for vaults with no product entry
   asset: {
     address: string                          // checksummed

--- a/docs/vault-labels-and-verification.md
+++ b/docs/vault-labels-and-verification.md
@@ -52,11 +52,9 @@ Structure: `Record<string, Product>` — keys are product identifiers (e.g. `"eu
     // Optional fields
     "deprecatedVaults": ["0xold1..."],           // Phased-out vault addresses (still verified, shown as deprecated)
     "deprecationReason": "Migrated to v2",       // Why deprecated — shown in warning banner. Supports URLs.
-    "isGovernanceLimited": true,                 // If true, shows "Limited risk management" in UI
+    "tags": ["keyring", "governance limited"],   // Product classification tags
     "notExplorable": true,                       // If true, hides ALL product vaults from lend/borrow/explore pages
     "block": ["US", "EU"],                       // Country codes/groups to hard-block (see geo-blocking.md)
-    "keyring": true,                               // All vaults require Keyring verification (see keyring-hooks.md)
-    "recentlyAddedVaults": ["0x1234...abcd"],    // Vault addresses to sort to top in discovery tables
     "vaultOverrides": {                          // Per-vault customizations (see below)
       "0x5678...ef01": {
         "description": "Custom description for this vault",
@@ -65,7 +63,8 @@ Structure: `Record<string, Product>` — keys are product identifiers (e.g. `"eu
         "block": ["US", "EU", "CH"],
         "restricted": ["JP"],
         "notExplorableLend": true,
-        "notExplorableBorrow": true
+        "notExplorableBorrow": true,
+        "tags": ["recently added"]
       }
     }
   }
@@ -84,12 +83,12 @@ Structure: `Record<string, Product>` — keys are product identifiers (e.g. `"eu
 | `vaults` | `string[]` | Yes | Active vault addresses (checksummed). These become "verified" vaults in the app. |
 | `deprecatedVaults` | `string[]` | No | Phased-out vault addresses. Still verified and viewable in portfolio, but hidden from discovery tables and shown with a deprecation warning. |
 | `deprecationReason` | `string` | No | Explanation for deprecation. Shown in a warning banner on vault overview. URLs are auto-linked. Also accepts legacy key `deprecateReason`. |
-| `isGovernanceLimited` | `boolean` | No | If `true`, shows "Limited risk management" text under the Risk Manager section on vault overview. The risk manager entity display is also faded to 20% opacity across all UI components (browse lists, vault overview, explore market cards) to visually convey limited active risk management. |
+| `tags` | `string[]` | No | Product classification tags. `keyring` marks all product vaults as requiring Keyring identity verification; `access control` marks vaults gated by an allowlist hook; `governance limited` shows "Limited risk management" and fades the risk manager entity display. |
 | `notExplorable` | `boolean` | No | If `true`, hides **all** vaults in this product from lend, borrow, and explore discovery pages. Takes precedence over per-vault `notExplorableLend`/`notExplorableBorrow`. Vaults remain accessible via direct URL. |
 | `block` | `string[]` | No | Country codes or group aliases (`EU`, `EEA`, `EFTA`) for hard geo-blocking. See [geo-blocking.md](./geo-blocking.md). |
-| `recentlyAddedVaults` | `string[]` | No | Subset of `vaults` to sort to the top in discovery tables. |
-| `keyring` | `boolean` | No | If `true`, all vaults in this product require Keyring identity verification. See [keyring-hooks.md](./keyring-hooks.md). |
 | `vaultOverrides` | `Record<string, VaultOverride>` | No | Per-vault customizations keyed by checksummed address. See next section. |
+
+Classification markers use a clean-cut tags schema. Product `isGovernanceLimited`, product `recentlyAddedVaults`, and earn-vault `recentlyAdded` are not supported by the current labels contract.
 
 #### Vault Override Fields
 
@@ -104,7 +103,7 @@ Per-vault overrides allow customizing behavior for individual vaults within a pr
 | `restricted` | `string[]` | Soft geo-restriction for this vault only. No product-level fallback. See [geo-blocking.md](./geo-blocking.md). |
 | `notExplorableLend` | `boolean` | If `true`, hides this vault from the **lend** discovery page. Product-level `notExplorable` takes precedence. |
 | `notExplorableBorrow` | `boolean` | If `true`, hides this vault from the **borrow** discovery page — both as a borrow vault and as collateral. Product-level `notExplorable` takes precedence. |
-| `keyring` | `boolean` | If `true`, this specific vault requires Keyring identity verification (overrides product-level). See [keyring-hooks.md](./keyring-hooks.md). |
+| `tags` | `string[]` | Vault classification tags. `keyring`, `access control`, and `recently added` apply to this specific vault. See [keyring-hooks.md](./keyring-hooks.md). |
 
 **Precedence rules**:
 - `block`: vault override replaces product-level (not additive)
@@ -195,7 +194,7 @@ Structure: `Array<string | EarnVaultEntry>` — each entry is either a plain add
     "address": "0xDetailedEarnVault...",          // Vault address (required)
     "block": ["US", "EU"],                        // Hard geo-blocking (country codes/groups)
     "restricted": ["JP"],                         // Soft geo-restriction
-    "recentlyAdded": true,                        // Sort to top in earn discovery table
+    "tags": ["recently added"],                   // Sort to top in earn discovery table
     "deprecated": true,                           // Mark as deprecated
     "deprecationReason": "Migrated to new vault", // Deprecation explanation
     "description": "Custom description",          // Vault description
@@ -211,11 +210,13 @@ Structure: `Array<string | EarnVaultEntry>` — each entry is either a plain add
 | `address` | `string` | Yes | Checksummed vault address |
 | `block` | `string[]` | No | Country codes/groups for hard geo-blocking (same syntax as products.json `block`) |
 | `restricted` | `string[]` | No | Country codes/groups for soft geo-restriction |
-| `recentlyAdded` | `boolean` | No | If `true`, sorts vault to top in earn discovery table |
+| `tags` | `string[]` | No | Earn-vault classification tags. `recently added` sorts the vault to the top in earn discovery. |
 | `deprecated` | `boolean` | No | If `true`, marks vault as deprecated (hidden from discovery, warning banner shown) |
 | `deprecationReason` | `string` | No | Explanation shown in deprecation warning banner |
 | `description` | `string` | No | Custom description displayed on earn vault items and overview pages |
 | `portfolioNotice` | `string` | No | Operational notice shown on portfolio position cards. Supports auto-linked URLs and **bold** formatting. |
+
+Classification markers use a clean-cut tags schema. Earn-vault `recentlyAdded` is not supported by the current labels contract.
 
 ---
 
@@ -319,7 +320,7 @@ Labels control which vaults appear on each discovery page:
 | Override `notExplorableLend: true` | Hidden | Visible | Visible |
 | Override `notExplorableBorrow: true` | Visible | Hidden (both sides) | Visible |
 | `deprecatedVaults` | Hidden | Hidden | Visible (dimmed) |
-| `recentlyAddedVaults` / `recentlyAdded` | Sorted to top | Sorted to top | Sorted to top |
+| `recently added` tag | Sorted to top | Sorted to top | Sorted to top |
 
 Product-level `notExplorable` always takes precedence over per-vault overrides. Vaults hidden from discovery are still accessible via direct URL and remain visible in the user's portfolio.
 
@@ -358,7 +359,7 @@ Entities are matched to vaults through two mechanisms:
 1. **Labels**: `product.entity` names the owning entity key(s), which are looked up in `entities.json`
 2. **Governor admin**: `vault.governorAdmin` is compared against entity `addresses` keys to identify the governing entity
 
-The governor admin must match an address in one of the product's declared entities for the vault to be considered "governor verified". If `isGovernanceLimited` is set, the vault shows "Limited risk management" text and the entity display is faded to 20% opacity across all UI surfaces (list items, overview pages, explore cards).
+The governor admin must match an address in one of the product's declared entities for the vault to be considered "governor verified". If the product has the `governance limited` tag, the vault shows "Limited risk management" text and the entity display is faded to 20% opacity across all UI surfaces (list items, overview pages, explore cards).
 
 ## Sentinel Address Labels
 

--- a/docs/vault-labels-and-verification.md
+++ b/docs/vault-labels-and-verification.md
@@ -83,7 +83,7 @@ Structure: `Record<string, Product>` — keys are product identifiers (e.g. `"eu
 | `vaults` | `string[]` | Yes | Active vault addresses (checksummed). These become "verified" vaults in the app. |
 | `deprecatedVaults` | `string[]` | No | Phased-out vault addresses. Still verified and viewable in portfolio, but hidden from discovery tables and shown with a deprecation warning. |
 | `deprecationReason` | `string` | No | Explanation for deprecation. Shown in a warning banner on vault overview. URLs are auto-linked. Also accepts legacy key `deprecateReason`. |
-| `tags` | `string[]` | No | Product classification tags. `keyring` marks all product vaults as requiring Keyring identity verification; `access control` marks vaults gated by an allowlist hook; `governance limited` shows "Limited risk management" and fades the risk manager entity display. |
+| `tags` | `string[]` | No | Product classification tags. `keyring` marks all product vaults as requiring Keyring identity verification; `access control` marks vaults gated by an allowlist hook; `governance limited` shows "Limited risk management" and fades the risk manager entity display; `suppress high utilisation warning` hides the high-utilisation warning while leaving critical utilisation warnings visible. |
 | `notExplorable` | `boolean` | No | If `true`, hides **all** vaults in this product from lend, borrow, and explore discovery pages. Takes precedence over per-vault `notExplorableLend`/`notExplorableBorrow`. Vaults remain accessible via direct URL. |
 | `block` | `string[]` | No | Country codes or group aliases (`EU`, `EEA`, `EFTA`) for hard geo-blocking. See [geo-blocking.md](./geo-blocking.md). |
 | `vaultOverrides` | `Record<string, VaultOverride>` | No | Per-vault customizations keyed by checksummed address. See next section. |
@@ -103,7 +103,7 @@ Per-vault overrides allow customizing behavior for individual vaults within a pr
 | `restricted` | `string[]` | Soft geo-restriction for this vault only. No product-level fallback. See [geo-blocking.md](./geo-blocking.md). |
 | `notExplorableLend` | `boolean` | If `true`, hides this vault from the **lend** discovery page. Product-level `notExplorable` takes precedence. |
 | `notExplorableBorrow` | `boolean` | If `true`, hides this vault from the **borrow** discovery page — both as a borrow vault and as collateral. Product-level `notExplorable` takes precedence. |
-| `tags` | `string[]` | Vault classification tags. `keyring`, `access control`, and `recently added` apply to this specific vault. See [keyring-hooks.md](./keyring-hooks.md). |
+| `tags` | `string[]` | Vault classification tags. `keyring`, `access control`, `recently added`, and `suppress high utilisation warning` apply to this specific vault. See [keyring-hooks.md](./keyring-hooks.md). |
 
 **Precedence rules**:
 - `block`: vault override replaces product-level (not additive)

--- a/docs/vault-labels-and-verification.md
+++ b/docs/vault-labels-and-verification.md
@@ -83,7 +83,7 @@ Structure: `Record<string, Product>` — keys are product identifiers (e.g. `"eu
 | `vaults` | `string[]` | Yes | Active vault addresses (checksummed). These become "verified" vaults in the app. |
 | `deprecatedVaults` | `string[]` | No | Phased-out vault addresses. Still verified and viewable in portfolio, but hidden from discovery tables and shown with a deprecation warning. |
 | `deprecationReason` | `string` | No | Explanation for deprecation. Shown in a warning banner on vault overview. URLs are auto-linked. Also accepts legacy key `deprecateReason`. |
-| `tags` | `string[]` | No | Product classification tags. `keyring` marks all product vaults as requiring Keyring identity verification; `access control` marks vaults gated by an allowlist hook; `governance limited` shows "Limited risk management" and fades the risk manager entity display. |
+| `tags` | `string[]` | No | Product classification tags. `keyring` marks all product vaults as requiring Keyring identity verification; `access control` marks vaults gated by an allowlist hook; `governance limited` shows "Limited risk management" and fades the risk manager entity display; `cyclical note` shows cyclical-note badges, target-utilisation copy, and the cyclical IRM overview. |
 | `notExplorable` | `boolean` | No | If `true`, hides **all** vaults in this product from lend, borrow, and explore discovery pages. Takes precedence over per-vault `notExplorableLend`/`notExplorableBorrow`. Vaults remain accessible via direct URL. |
 | `block` | `string[]` | No | Country codes or group aliases (`EU`, `EEA`, `EFTA`) for hard geo-blocking. See [geo-blocking.md](./geo-blocking.md). |
 | `vaultOverrides` | `Record<string, VaultOverride>` | No | Per-vault customizations keyed by checksummed address. See next section. |
@@ -103,7 +103,7 @@ Per-vault overrides allow customizing behavior for individual vaults within a pr
 | `restricted` | `string[]` | Soft geo-restriction for this vault only. No product-level fallback. See [geo-blocking.md](./geo-blocking.md). |
 | `notExplorableLend` | `boolean` | If `true`, hides this vault from the **lend** discovery page. Product-level `notExplorable` takes precedence. |
 | `notExplorableBorrow` | `boolean` | If `true`, hides this vault from the **borrow** discovery page — both as a borrow vault and as collateral. Product-level `notExplorable` takes precedence. |
-| `tags` | `string[]` | Vault classification tags. `keyring`, `access control`, and `recently added` apply to this specific vault. See [keyring-hooks.md](./keyring-hooks.md). |
+| `tags` | `string[]` | Vault classification tags. `keyring`, `access control`, `recently added`, and `cyclical note` apply to this specific vault. See [keyring-hooks.md](./keyring-hooks.md). |
 
 **Precedence rules**:
 - `block`: vault override replaces product-level (not additive)

--- a/entities/euler/labels.ts
+++ b/entities/euler/labels.ts
@@ -33,13 +33,11 @@ export type EulerLabelProduct = {
   vaults: string[]
   deprecatedVaults?: string[]
   deprecationReason?: string
-  isGovernanceLimited?: boolean
   notExplorable?: boolean
   block?: string[]
-  recentlyAddedVaults?: string[]
   vaultOverrides?: Record<string, EulerLabelVaultOverride>
-  // Freeform classification tags, e.g. 'keyring' or 'access control'. Replaces
-  // the former `keyring` boolean.
+  // Freeform classification tags, e.g. 'keyring', 'access control', or
+  // 'governance limited'. Replaces the former bespoke classification booleans.
   tags?: string[]
 }
 
@@ -47,7 +45,7 @@ export type EulerLabelEarnVaultEntry = {
   address: string
   block?: string[]
   restricted?: string[]
-  recentlyAdded?: boolean
+  tags?: string[]
   deprecated?: boolean
   deprecationReason?: string
   description?: string

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@eulerxyz/euler-v2-sdk": "1.0.1",
+        "@eulerxyz/euler-v2-sdk": "1.0.2",
         "@floating-ui/vue": "1.1.11",
         "@gvade/nuxt3-svg-sprite": "1.0.3",
         "@keyringnetwork/keyring-connect-sdk": "3.2.0",
@@ -1444,9 +1444,9 @@
       }
     },
     "node_modules/@eulerxyz/euler-v2-sdk": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@eulerxyz/euler-v2-sdk/-/euler-v2-sdk-1.0.1.tgz",
-      "integrity": "sha512-iCjzquYZMiurWJKDmPaPtKOadDT8Ccm+MjpZ2f49IhHx5xKZPcrs0xnu6PLUnCUGLWQbv3C+JPNzTPiQV/jevg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@eulerxyz/euler-v2-sdk/-/euler-v2-sdk-1.0.2.tgz",
+      "integrity": "sha512-8Dy+QrJWC2o9DCwFazpiejhLVJKME6zejJaQhn7SpvPdiAmzCCKIiAcb5KyQFDSoaf2tHRFLOe39hKv5xB8NpQ==",
       "license": "MIT",
       "dependencies": {
         "viem": "2.48.8"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     ]
   },
   "dependencies": {
-    "@eulerxyz/euler-v2-sdk": "1.0.1",
+    "@eulerxyz/euler-v2-sdk": "1.0.2",
     "@floating-ui/vue": "1.1.11",
     "@gvade/nuxt3-svg-sprite": "1.0.3",
     "@keyringnetwork/keyring-connect-sdk": "3.2.0",

--- a/server/api/labels/[file].get.ts
+++ b/server/api/labels/[file].get.ts
@@ -3,6 +3,7 @@ import { createRateLimiter } from '~/server/utils/rate-limit'
 import { createTtlCache } from '~/server/utils/cache'
 import { fetchWithTimeout } from '~/server/utils/fetchWithTimeout'
 import { createInFlightDedup } from '~/server/utils/in-flight'
+import { resolveLabelsFileUrl } from '~/server/utils/labels-base-url'
 import { reportStatus } from '~/server/utils/log'
 
 const CACHE_TTL_MS = 300_000
@@ -122,14 +123,7 @@ export function validateNode(node: unknown, path: string): void {
 }
 
 function getUpstreamUrl(scope: LabelScope, file: string): string {
-  const baseUrl = (process.env.NUXT_PUBLIC_CONFIG_LABELS_BASE_URL || '').trim().replace(/\/+$/, '')
-  if (baseUrl) {
-    return `${baseUrl}/${scope}/${file}`
-  }
-
-  const repo = process.env.NUXT_PUBLIC_CONFIG_LABELS_REPO || 'euler-xyz/euler-labels'
-  const branch = process.env.NUXT_PUBLIC_CONFIG_LABELS_REPO_BRANCH || 'master'
-  return `https://raw.githubusercontent.com/${repo}/refs/heads/${branch}/${scope}/${file}`
+  return resolveLabelsFileUrl(scope, file)
 }
 
 /**

--- a/server/utils/labels-base-url.ts
+++ b/server/utils/labels-base-url.ts
@@ -1,0 +1,11 @@
+export function resolveLabelsBaseUrl(): string {
+  const explicit = (process.env.NUXT_PUBLIC_CONFIG_LABELS_BASE_URL || '').trim().replace(/\/+$/, '')
+  if (explicit) return explicit
+  const repo = process.env.NUXT_PUBLIC_CONFIG_LABELS_REPO || 'euler-xyz/euler-labels'
+  const branch = process.env.NUXT_PUBLIC_CONFIG_LABELS_REPO_BRANCH || 'master'
+  return `https://raw.githubusercontent.com/${repo}/refs/heads/${branch}`
+}
+
+export function resolveLabelsFileUrl(scope: number | 'all', file: string): string {
+  return `${resolveLabelsBaseUrl()}/${scope}/${file}`
+}

--- a/server/utils/labels-view.ts
+++ b/server/utils/labels-view.ts
@@ -36,6 +36,7 @@ export interface VaultOverride {
   description?: unknown
   portfolioNotice?: unknown
   deprecationReason?: unknown
+  tags?: unknown
 }
 
 export interface EntityEntryFull extends EulerLabelEntity {
@@ -117,6 +118,14 @@ function hasTag(tags: unknown, tag: string): boolean {
   return Array.isArray(tags) && tags.includes(tag)
 }
 
+function overrideHasTag(
+  overrides: Record<string, VaultOverride>,
+  address: Address,
+  tag: string,
+): boolean {
+  return hasTag(overrides[address]?.tags, tag)
+}
+
 // SDK builder shared with vaults-cache via server/utils/sdk-server.ts.
 const getSdk = (chainId: number): Promise<EulerSDK> => getServerSdk(chainId)
 
@@ -125,7 +134,7 @@ async function fetchTokenList(chainId: number): Promise<TokenListEntry[]> {
   return Array.isArray(data?.tokens) ? data.tokens : []
 }
 
-function buildProductDescriptors(products: Record<string, ProductEntryFull>): {
+export function buildProductDescriptors(products: Record<string, ProductEntryFull>): {
   productByVault: Map<Address, ProductDescriptor>
   deprecatedSet: Set<Address>
 } {
@@ -152,14 +161,18 @@ function buildProductDescriptors(products: Record<string, ProductEntryFull>): {
       entityKeys: declaredKeysOf(product.entity),
       vaultOverrides: overrides,
     }
+    const descriptorForVault = (addr: Address): ProductDescriptor => ({
+      ...desc,
+      governanceLimited: desc.governanceLimited || overrideHasTag(overrides, addr, 'governance limited'),
+    })
     for (const v of product.vaults ?? []) {
       const addr = tryChecksum(v)
-      if (addr) productByVault.set(addr, desc)
+      if (addr) productByVault.set(addr, descriptorForVault(addr))
     }
     for (const v of product.deprecatedVaults ?? []) {
       const addr = tryChecksum(v)
       if (addr) {
-        productByVault.set(addr, desc)
+        productByVault.set(addr, descriptorForVault(addr))
         deprecatedSet.add(addr)
       }
     }

--- a/server/utils/labels-view.ts
+++ b/server/utils/labels-view.ts
@@ -29,9 +29,7 @@ export interface ChainVaultsSnapshot {
   escrowVaults: EVault[]
 }
 
-export interface ProductEntryFull extends EulerLabelProduct {
-  isGovernanceLimited?: unknown
-}
+export type ProductEntryFull = EulerLabelProduct
 
 export interface VaultOverride {
   name?: unknown
@@ -66,7 +64,7 @@ export interface ProductDescriptor {
   description: string | null
   portfolioNotice: string | null
   deprecationReason: string | null
-  isGovernanceLimited: boolean
+  governanceLimited: boolean
   forceUnverified: boolean
   entityKeys: string[]
   vaultOverrides: Record<string, VaultOverride>
@@ -115,6 +113,10 @@ function uniqueAddresses(addresses: Iterable<string>): Address[] {
   return [...result.values()]
 }
 
+function hasTag(tags: unknown, tag: string): boolean {
+  return Array.isArray(tags) && tags.includes(tag)
+}
+
 // SDK builder shared with vaults-cache via server/utils/sdk-server.ts.
 const getSdk = (chainId: number): Promise<EulerSDK> => getServerSdk(chainId)
 
@@ -145,7 +147,7 @@ function buildProductDescriptors(products: Record<string, ProductEntryFull>): {
       description: strOrNull(product.description),
       portfolioNotice: strOrNull(product.portfolioNotice),
       deprecationReason: strOrNull(product.deprecationReason),
-      isGovernanceLimited: product.isGovernanceLimited === true,
+      governanceLimited: hasTag(product.tags, 'governance limited'),
       forceUnverified: strOrNull(product.deprecationReason)?.toLowerCase().includes('unrecognized entity') === true,
       entityKeys: declaredKeysOf(product.entity),
       vaultOverrides: overrides,

--- a/server/utils/sdk-server.ts
+++ b/server/utils/sdk-server.ts
@@ -30,6 +30,7 @@ import {
   type VaultDataSource,
 } from '~/utils/api-url-env'
 import { resolveRpcUrl } from './rpc'
+import { resolveLabelsBaseUrl } from './labels-base-url'
 
 const sdkByChain = new Map<number, Promise<EulerSDK>>()
 
@@ -60,14 +61,6 @@ const adapterConfigForSource = (source: VaultDataSource): Partial<EulerSDKConfig
     case 'v3': return v3AdapterConfig
     default: return fallbackAdapterConfig
   }
-}
-
-function resolveLabelsBaseUrl(): string {
-  const explicit = (process.env.NUXT_PUBLIC_CONFIG_LABELS_BASE_URL || '').trim().replace(/\/+$/, '')
-  if (explicit) return explicit
-  const repo = process.env.NUXT_PUBLIC_CONFIG_LABELS_REPO || 'euler-xyz/euler-labels'
-  const branch = process.env.NUXT_PUBLIC_CONFIG_LABELS_REPO_BRANCH || 'master'
-  return `https://raw.githubusercontent.com/${repo}/refs/heads/${branch}`
 }
 
 const buildServerSdkConfig = (chainId: number): EulerSDKConfig => {

--- a/server/utils/sdk-server.ts
+++ b/server/utils/sdk-server.ts
@@ -62,6 +62,14 @@ const adapterConfigForSource = (source: VaultDataSource): Partial<EulerSDKConfig
   }
 }
 
+function resolveLabelsBaseUrl(): string {
+  const explicit = (process.env.NUXT_PUBLIC_CONFIG_LABELS_BASE_URL || '').trim().replace(/\/+$/, '')
+  if (explicit) return explicit
+  const repo = process.env.NUXT_PUBLIC_CONFIG_LABELS_REPO || 'euler-xyz/euler-labels'
+  const branch = process.env.NUXT_PUBLIC_CONFIG_LABELS_REPO_BRANCH || 'master'
+  return `https://raw.githubusercontent.com/${repo}/refs/heads/${branch}`
+}
+
 const buildServerSdkConfig = (chainId: number): EulerSDKConfig => {
   const rpcUrl = resolveRpcUrl(chainId)
   if (!rpcUrl) throw new Error(`No RPC URL configured for chain ${chainId}`)
@@ -74,6 +82,7 @@ const buildServerSdkConfig = (chainId: number): EulerSDKConfig => {
   return {
     rpcUrls: { [chainId]: rpcUrl },
     v3ApiUrl,
+    eulerLabelsBaseUrl: resolveLabelsBaseUrl(),
     tokenlistApiBaseUrl: v3ApiUrl,
     ...(v3ApiKey ? { v3ApiKey } : {}),
     ...adapterConfigForSource(source),

--- a/server/utils/vault-metadata.ts
+++ b/server/utils/vault-metadata.ts
@@ -1,6 +1,7 @@
 import type { Address } from 'viem'
 import { createTtlCache } from './cache'
 import { tryChecksum } from './labels-helpers'
+import { resolveLabelsBaseUrl } from './labels-base-url'
 import {
   buildLabelsView,
   type EntityEntryFull,
@@ -74,14 +75,6 @@ function strOrNull(value: unknown): string | null {
 
 function strOrEmpty(value: unknown): string {
   return typeof value === 'string' ? value : ''
-}
-
-function resolveLabelsBaseUrl(): string {
-  const explicit = (process.env.NUXT_PUBLIC_CONFIG_LABELS_BASE_URL || '').trim().replace(/\/+$/, '')
-  if (explicit) return explicit
-  const repo = process.env.NUXT_PUBLIC_CONFIG_LABELS_REPO || 'euler-xyz/euler-labels'
-  const branch = process.env.NUXT_PUBLIC_CONFIG_LABELS_REPO_BRANCH || 'master'
-  return `https://raw.githubusercontent.com/${repo}/refs/heads/${branch}`
 }
 
 function entityLogoUrl(fileName: string): string {

--- a/server/utils/vault-metadata.ts
+++ b/server/utils/vault-metadata.ts
@@ -49,7 +49,7 @@ export interface VaultMetadata {
   deprecationReason: string | null
   /** True if the vault is listed under any product's `deprecatedVaults` (or earn-vaults `deprecated: true`). */
   deprecated: boolean
-  /** True when the owning product has `isGovernanceLimited: true` (governor exists but no active risk management). False for vaults without a product. */
+  /** True when the owning product has the `governance limited` tag. False for vaults without a product. */
   governanceLimited: boolean
   /** The owning product slug from products.json (e.g. "euler-prime"), or null for vaults outside any product (escrow, earn-only entries, governor mismatch with no product). */
   productId: string | null
@@ -166,7 +166,7 @@ function buildEvkMetadata(
     portfolioNotice,
     deprecationReason,
     deprecated,
-    governanceLimited: product?.isGovernanceLimited === true,
+    governanceLimited: product?.governanceLimited === true,
     productId: product?.slug ?? null,
     asset: buildAsset(vault.asset, ctx.view.tokenLogos),
     entities,
@@ -203,7 +203,7 @@ function buildEarnMetadata(vault: EulerEarn, ctx: BuildContext): VaultMetadata |
     portfolioNotice,
     deprecationReason,
     deprecated,
-    governanceLimited: product?.isGovernanceLimited === true,
+    governanceLimited: product?.governanceLimited === true,
     productId: product?.slug ?? null,
     asset: buildAsset(vault.asset, ctx.view.tokenLogos),
     entities,

--- a/tests/composables/useVaultTypeBadges.test.ts
+++ b/tests/composables/useVaultTypeBadges.test.ts
@@ -15,15 +15,6 @@ const state = vi.hoisted(() => ({
   verifiedVaults: new Set<string>(),
 }))
 
-vi.mock('~/composables/useEulerLabels', () => ({
-  useEulerProductOfVault: (addressRef: { value?: string } | string) => ({
-    get isGovernanceLimited() {
-      const address = typeof addressRef === 'string' ? addressRef : addressRef.value
-      return !!address && state.governanceLimitedVaults.has(address.toLowerCase())
-    },
-  }),
-}))
-
 vi.mock('~/utils/eulerLabelsUtils', () => ({
   getEntitiesByEarnVault: (vault: { owner?: string }) =>
     vault.owner && state.earnOwners.has(vault.owner.toLowerCase()) ? [{}] : [],
@@ -31,6 +22,7 @@ vi.mock('~/utils/eulerLabelsUtils', () => ({
     vault.governorAdmin && state.entityGovernors.has(vault.governorAdmin.toLowerCase()) ? [{}] : [],
   isVaultKeyring: (address: string) => state.keyringVaults.has(address.toLowerCase()),
   isVaultAccessControlled: (address: string) => state.accessControlVaults.has(address.toLowerCase()),
+  isVaultGovernanceLimited: (address: string) => state.governanceLimitedVaults.has(address.toLowerCase()),
 }))
 
 vi.mock('~/composables/useVaultRegistry', () => ({

--- a/tests/composables/useVaultTypeBadges.test.ts
+++ b/tests/composables/useVaultTypeBadges.test.ts
@@ -11,6 +11,7 @@ const state = vi.hoisted(() => ({
   entityGovernors: new Set<string>(),
   governanceLimitedVaults: new Set<string>(),
   keyringVaults: new Set<string>(),
+  cyclicalNoteVaults: new Set<string>(),
   verifiedEarnVaults: new Set<string>(),
   verifiedVaults: new Set<string>(),
 }))
@@ -23,6 +24,7 @@ vi.mock('~/utils/eulerLabelsUtils', () => ({
   isVaultKeyring: (address: string) => state.keyringVaults.has(address.toLowerCase()),
   isVaultAccessControlled: (address: string) => state.accessControlVaults.has(address.toLowerCase()),
   isVaultGovernanceLimited: (address: string) => state.governanceLimitedVaults.has(address.toLowerCase()),
+  isVaultCyclicalNote: (address: string) => state.cyclicalNoteVaults.has(address.toLowerCase()),
 }))
 
 vi.mock('~/composables/useVaultRegistry', () => ({
@@ -77,6 +79,7 @@ describe('useVaultTypeBadges', () => {
     state.entityGovernors.clear()
     state.governanceLimitedVaults.clear()
     state.keyringVaults.clear()
+    state.cyclicalNoteVaults.clear()
     state.verifiedEarnVaults.clear()
     state.verifiedVaults.clear()
     setupVaultsMock()
@@ -118,14 +121,10 @@ describe('useVaultTypeBadges', () => {
     expect(hasSummaryBadges.value).toBe(true)
   })
 
-  it.each([
-    INTEREST_RATE_MODEL_TYPE.FIXED_CYCLICAL_BINARY,
-    INTEREST_RATE_MODEL_TYPE.FIXED_CYCLICAL_BINARY_MONTHLY,
-  ])('summarizes verified cyclical IRM type %s as cyclical note', (interestRateModelType) => {
-    const vault = makeVault({
-      interestRateModel: makeInterestRateModel(interestRateModelType),
-    })
+  it('summarizes verified cyclical-note-tagged vaults as cyclical note', () => {
+    const vault = makeVault()
     verify(vault)
+    state.cyclicalNoteVaults.add(vault.address.toLowerCase())
 
     const { badges, summaryBadges } = useVaultTypeBadges(shallowRef(vault))
 
@@ -133,9 +132,9 @@ describe('useVaultTypeBadges', () => {
     expect(summaryBadges.value).toEqual(['cyclicalNote'])
   })
 
-  it('does not treat KINKY IRM as cyclical note', () => {
+  it('does not treat cyclical IRM type as cyclical note without a label tag', () => {
     const vault = makeVault({
-      interestRateModel: makeInterestRateModel(INTEREST_RATE_MODEL_TYPE.KINKY),
+      interestRateModel: makeInterestRateModel(INTEREST_RATE_MODEL_TYPE.FIXED_CYCLICAL_BINARY),
     })
     verify(vault)
 

--- a/tests/composables/useVaultWarnings.test.ts
+++ b/tests/composables/useVaultWarnings.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 import type { EVault, SecuritizeCollateralVault } from '@eulerxyz/euler-v2-sdk'
 import { getCollateralSupplyCapWarning, getUtilisationWarning } from '~/composables/useVaultWarnings'
+import { __setEulerLabelsDataForTest } from '~/composables/useEulerLabels'
 import { INTEREST_RATE_MODEL_TYPE } from '~/entities/constants'
+import { normalizeAddress } from '~/utils/normalizeAddress'
 
 const makeVault = (supplyCapUtilization: number): EVault =>
   ({
@@ -14,14 +16,20 @@ const makeUtilisedVault = (
   totalAssets: bigint,
   borrow: bigint,
   interestRateModelType: number = INTEREST_RATE_MODEL_TYPE.KINK,
+  address = '0x0000000000000000000000000000000000000001',
 ): EVault =>
   ({
+    address: normalizeAddress(address),
     totalAssets,
     borrow,
     interestRateModel: { type: interestRateModelType },
   }) as unknown as EVault
 
 describe('getUtilisationWarning', () => {
+  beforeEach(() => {
+    __setEulerLabelsDataForTest()
+  })
+
   it('returns the standard high utilisation warning for non-cyclical borrow markets', () => {
     const warning = getUtilisationWarning(makeUtilisedVault(100n, 95n), 'borrow')
 
@@ -69,6 +77,62 @@ describe('getUtilisationWarning', () => {
     )
 
     expect(warning).toBeNull()
+  })
+
+  it('suppresses high utilisation warnings for tagged vaults', () => {
+    const address = normalizeAddress('0x0000000000000000000000000000000000000501')
+
+    __setEulerLabelsDataForTest({
+      products: {
+        test: {
+          name: 'Test',
+          description: '',
+          entity: [],
+          url: '',
+          vaults: [address],
+          vaultOverrides: {
+            [address]: {
+              tags: ['suppress high utilisation warning'],
+            },
+          },
+        },
+      },
+    })
+
+    const warning = getUtilisationWarning(
+      makeUtilisedVault(100n, 95n, INTEREST_RATE_MODEL_TYPE.KINK, address),
+      'borrow',
+    )
+
+    expect(warning).toBeNull()
+  })
+
+  it('keeps critical utilisation warnings for tagged vaults', () => {
+    const address = normalizeAddress('0x0000000000000000000000000000000000000502')
+
+    __setEulerLabelsDataForTest({
+      products: {
+        test: {
+          name: 'Test',
+          description: '',
+          entity: [],
+          url: '',
+          vaults: [address],
+          tags: ['suppress high utilisation warning'],
+        },
+      },
+    })
+
+    const warning = getUtilisationWarning(
+      makeUtilisedVault(100n, 99n, INTEREST_RATE_MODEL_TYPE.KINK, address),
+      'borrow',
+    )
+
+    expect(warning).toEqual({
+      level: 'critical',
+      title: 'Critical utilisation',
+      message: 'Utilisation is critically high. Interest rates are very elevated. Available liquidity is near zero.',
+    })
   })
 })
 

--- a/tests/composables/useVaultWarnings.test.ts
+++ b/tests/composables/useVaultWarnings.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 import type { EVault, SecuritizeCollateralVault } from '@eulerxyz/euler-v2-sdk'
 import { getCollateralSupplyCapWarning, getUtilisationWarning } from '~/composables/useVaultWarnings'
+import { __setEulerLabelsDataForTest } from '~/composables/useEulerLabels'
 import { INTEREST_RATE_MODEL_TYPE } from '~/entities/constants'
+import { normalizeAddress } from '~/utils/normalizeAddress'
 
 const makeVault = (supplyCapUtilization: number): EVault =>
   ({
@@ -14,14 +16,20 @@ const makeUtilisedVault = (
   totalAssets: bigint,
   borrow: bigint,
   interestRateModelType: number = INTEREST_RATE_MODEL_TYPE.KINK,
+  address = '0x0000000000000000000000000000000000000001',
 ): EVault =>
   ({
+    address: normalizeAddress(address),
     totalAssets,
     borrow,
     interestRateModel: { type: interestRateModelType },
   }) as unknown as EVault
 
 describe('getUtilisationWarning', () => {
+  beforeEach(() => {
+    __setEulerLabelsDataForTest()
+  })
+
   it('returns the standard high utilisation warning for non-cyclical borrow markets', () => {
     const warning = getUtilisationWarning(makeUtilisedVault(100n, 95n), 'borrow')
 
@@ -33,10 +41,24 @@ describe('getUtilisationWarning', () => {
   })
 
   it.each(['borrow', 'lend', 'general'] as const)(
-    'returns target utilisation info for highly utilised cyclical note markets in %s context',
+    'returns target utilisation info for highly utilised cyclical-note-tagged markets in %s context',
     (context) => {
+      const address = normalizeAddress('0x0000000000000000000000000000000000000501')
+      __setEulerLabelsDataForTest({
+        products: {
+          test: {
+            name: 'Test',
+            description: '',
+            entity: [],
+            url: '',
+            vaults: [address],
+            tags: ['cyclical note'],
+          },
+        },
+      })
+
       const warning = getUtilisationWarning(
-        makeUtilisedVault(100n, 99n, INTEREST_RATE_MODEL_TYPE.FIXED_CYCLICAL_BINARY),
+        makeUtilisedVault(100n, 99n, INTEREST_RATE_MODEL_TYPE.KINK, address),
         context,
       )
 
@@ -50,8 +72,22 @@ describe('getUtilisationWarning', () => {
   )
 
   it('keeps liquidity constraint copy for highly utilised cyclical repay sources', () => {
+    const address = normalizeAddress('0x0000000000000000000000000000000000000502')
+    __setEulerLabelsDataForTest({
+      products: {
+        test: {
+          name: 'Test',
+          description: '',
+          entity: [],
+          url: '',
+          vaults: [address],
+          tags: ['cyclical note'],
+        },
+      },
+    })
+
     const warning = getUtilisationWarning(
-      makeUtilisedVault(100n, 99n, INTEREST_RATE_MODEL_TYPE.FIXED_CYCLICAL_BINARY),
+      makeUtilisedVault(100n, 99n, INTEREST_RATE_MODEL_TYPE.KINK, address),
       'repay',
     )
 
@@ -63,12 +99,39 @@ describe('getUtilisationWarning', () => {
   })
 
   it('does not show target utilisation info below the shared utilisation threshold', () => {
+    const address = normalizeAddress('0x0000000000000000000000000000000000000503')
+    __setEulerLabelsDataForTest({
+      products: {
+        test: {
+          name: 'Test',
+          description: '',
+          entity: [],
+          url: '',
+          vaults: [address],
+          tags: ['cyclical note'],
+        },
+      },
+    })
+
     const warning = getUtilisationWarning(
-      makeUtilisedVault(100n, 94n, INTEREST_RATE_MODEL_TYPE.FIXED_CYCLICAL_BINARY),
+      makeUtilisedVault(100n, 94n, INTEREST_RATE_MODEL_TYPE.KINK, address),
       'borrow',
     )
 
     expect(warning).toBeNull()
+  })
+
+  it('does not use cyclical IRM type as the target-utilisation classifier', () => {
+    const warning = getUtilisationWarning(
+      makeUtilisedVault(100n, 99n, INTEREST_RATE_MODEL_TYPE.FIXED_CYCLICAL_BINARY),
+      'borrow',
+    )
+
+    expect(warning).toEqual({
+      level: 'critical',
+      title: 'Critical utilisation',
+      message: 'Utilisation is critically high. Interest rates are very elevated. Available liquidity is near zero.',
+    })
   })
 })
 

--- a/tests/composables/useVaultWarnings.test.ts
+++ b/tests/composables/useVaultWarnings.test.ts
@@ -149,6 +149,35 @@ describe('getUtilisationWarning', () => {
     expect(warning).toBeNull()
   })
 
+  it('keeps target utilisation info when cyclical-note vaults also suppress high utilisation warnings', () => {
+    const address = normalizeAddress('0x0000000000000000000000000000000000000504')
+
+    __setEulerLabelsDataForTest({
+      products: {
+        test: {
+          name: 'Test',
+          description: '',
+          entity: [],
+          url: '',
+          vaults: [address],
+          tags: ['cyclical note', 'suppress high utilisation warning'],
+        },
+      },
+    })
+
+    const warning = getUtilisationWarning(
+      makeUtilisedVault(100n, 95n, INTEREST_RATE_MODEL_TYPE.KINK, address),
+      'borrow',
+    )
+
+    expect(warning).toEqual({
+      level: 'info',
+      tone: 'success',
+      title: 'Target utilisation',
+      message: 'Cyclical Note markets are designed to run near full utilization. Withdrawal liquidity opens up at the end of each cycle, when borrowers are pushed to repay.',
+    })
+  })
+
   it('keeps critical utilisation warnings for tagged vaults', () => {
     const address = normalizeAddress('0x0000000000000000000000000000000000000502')
 

--- a/tests/server/labels-view.test.ts
+++ b/tests/server/labels-view.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { buildTokenLogoMap } from '~/server/utils/labels-view'
+import { buildProductDescriptors, buildTokenLogoMap } from '~/server/utils/labels-view'
 
 describe('buildTokenLogoMap', () => {
   it('keeps only http(s) logo URLs', () => {
@@ -18,5 +18,30 @@ describe('buildTokenLogoMap', () => {
     expect(map.has('0x4444444444444444444444444444444444444444')).toBe(false)
     expect(map.has('0x5555555555555555555555555555555555555555')).toBe(false)
     expect(map.has('0x6666666666666666666666666666666666666666')).toBe(false)
+  })
+})
+
+describe('buildProductDescriptors', () => {
+  it('applies governance-limited vault override tags per vault', () => {
+    const limitedVault = '0x0000000000000000000000000000000000000701'
+    const standardVault = '0x0000000000000000000000000000000000000702'
+
+    const { productByVault } = buildProductDescriptors({
+      test: {
+        name: 'Test',
+        description: '',
+        entity: [],
+        url: '',
+        vaults: [limitedVault, standardVault],
+        vaultOverrides: {
+          [limitedVault]: {
+            tags: ['governance limited'],
+          },
+        },
+      },
+    })
+
+    expect(productByVault.get(limitedVault)?.governanceLimited).toBe(true)
+    expect(productByVault.get(standardVault)?.governanceLimited).toBe(false)
   })
 })

--- a/tests/utils/discovery-calculations.test.ts
+++ b/tests/utils/discovery-calculations.test.ts
@@ -26,6 +26,7 @@ vi.mock('~/utils/eulerLabelsUtils', () => ({
     if (vault.address === '0xSecuritize') return [{ name: 'Securitize', logo: 'securitize.png' }]
     return []
   },
+  isVaultCyclicalNote: () => false,
   isVaultDeprecated: () => false,
 }))
 

--- a/tests/utils/euler-labels-utils.test.ts
+++ b/tests/utils/euler-labels-utils.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import { __setEulerLabelsDataForTest } from '~/composables/useEulerLabels'
-import { getActiveProductVaultAddresses, getUniqueEntitiesByVaults, isVaultRecentlyAdded, normalizeProducts } from '~/utils/eulerLabelsUtils'
+import { getActiveProductVaultAddresses, getUniqueEntitiesByVaults, isVaultGovernanceLimited, isVaultRecentlyAdded, normalizeProducts } from '~/utils/eulerLabelsUtils'
 import { normalizeAddress } from '~/utils/normalizeAddress'
 
 describe('normalizeProducts', () => {
-  it('normalizes recently added vault addresses for membership checks', () => {
+  it('normalizes active and deprecated vault addresses', () => {
     const lowerAddress = '0x8d3f9f9eb2f5e8b48efbb4074440d1e2a34bc365'
+    const deprecatedAddress = '0x0000000000000000000000000000000000000102'
 
     const { products } = normalizeProducts({
       test: {
@@ -14,11 +15,12 @@ describe('normalizeProducts', () => {
         entity: [],
         url: '',
         vaults: [lowerAddress],
-        recentlyAddedVaults: [lowerAddress],
+        deprecatedVaults: [deprecatedAddress],
       },
     })
 
-    expect(products.test.recentlyAddedVaults).toEqual([normalizeAddress(lowerAddress)])
+    expect(products.test.vaults).toEqual([normalizeAddress(lowerAddress)])
+    expect(products.test.deprecatedVaults).toEqual([normalizeAddress(deprecatedAddress)])
   })
 })
 
@@ -102,7 +104,7 @@ describe('getUniqueEntitiesByVaults', () => {
 })
 
 describe('isVaultRecentlyAdded', () => {
-  it('checks product recently-added vaults', () => {
+  it('checks product recently-added tags', () => {
     const address = '0x0000000000000000000000000000000000000201'
 
     __setEulerLabelsDataForTest({
@@ -113,7 +115,7 @@ describe('isVaultRecentlyAdded', () => {
           entity: [],
           url: '',
           vaults: [normalizeAddress(address)],
-          recentlyAddedVaults: [normalizeAddress(address)],
+          tags: ['recently added'],
         },
       },
     })
@@ -121,14 +123,63 @@ describe('isVaultRecentlyAdded', () => {
     expect(isVaultRecentlyAdded(address)).toBe(true)
   })
 
-  it('checks SDK Earn recently-added vaults', () => {
+  it('checks vault override recently-added tags', () => {
+    const address = '0x0000000000000000000000000000000000000202'
+
+    __setEulerLabelsDataForTest({
+      products: {
+        test: {
+          name: 'Test',
+          description: '',
+          entity: [],
+          url: '',
+          vaults: [normalizeAddress(address)],
+          vaultOverrides: {
+            [normalizeAddress(address)]: {
+              tags: ['recently added'],
+            },
+          },
+        },
+      },
+    })
+
+    expect(isVaultRecentlyAdded(address)).toBe(true)
+  })
+
+  it('checks Earn recently-added tags', () => {
     const lowerAddress = '0x8d3f9f9eb2f5e8b48efbb4074440d1e2a34bc365'
     const checksummedAddress = normalizeAddress(lowerAddress)
 
     __setEulerLabelsDataForTest({
-      recentlyAddedEarnVaults: new Set([lowerAddress]),
+      earnVaultEntries: {
+        [lowerAddress]: {
+          address: checksummedAddress,
+          tags: ['recently added'],
+        },
+      },
     })
 
     expect(isVaultRecentlyAdded(checksummedAddress)).toBe(true)
+  })
+})
+
+describe('isVaultGovernanceLimited', () => {
+  it('checks governance-limited product tags', () => {
+    const address = '0x0000000000000000000000000000000000000301'
+
+    __setEulerLabelsDataForTest({
+      products: {
+        test: {
+          name: 'Test',
+          description: '',
+          entity: [],
+          url: '',
+          vaults: [normalizeAddress(address)],
+          tags: ['governance limited'],
+        },
+      },
+    })
+
+    expect(isVaultGovernanceLimited(address)).toBe(true)
   })
 })

--- a/tests/utils/euler-labels-utils.test.ts
+++ b/tests/utils/euler-labels-utils.test.ts
@@ -190,6 +190,29 @@ describe('isVaultGovernanceLimited', () => {
 
     expect(isVaultGovernanceLimited(address)).toBe(true)
   })
+
+  it('checks governance-limited vault override tags', () => {
+    const address = '0x0000000000000000000000000000000000000302'
+
+    __setEulerLabelsDataForTest({
+      products: {
+        test: {
+          name: 'Test',
+          description: '',
+          entity: [],
+          url: '',
+          vaults: [normalizeAddress(address)],
+          vaultOverrides: {
+            [normalizeAddress(address)]: {
+              tags: ['governance limited'],
+            },
+          },
+        },
+      },
+    })
+
+    expect(isVaultGovernanceLimited(address)).toBe(true)
+  })
 })
 
 describe('isVaultHighUtilisationWarningSuppressed', () => {

--- a/tests/utils/euler-labels-utils.test.ts
+++ b/tests/utils/euler-labels-utils.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'vitest'
 import { __setEulerLabelsDataForTest } from '~/composables/useEulerLabels'
-import { getActiveProductVaultAddresses, getUniqueEntitiesByVaults, isVaultGovernanceLimited, isVaultRecentlyAdded, normalizeProducts } from '~/utils/eulerLabelsUtils'
+import {
+  getActiveProductVaultAddresses,
+  getUniqueEntitiesByVaults,
+  isVaultCyclicalNote,
+  isVaultGovernanceLimited,
+  isVaultRecentlyAdded,
+  normalizeProducts,
+} from '~/utils/eulerLabelsUtils'
 import { normalizeAddress } from '~/utils/normalizeAddress'
 
 describe('normalizeProducts', () => {
@@ -181,5 +188,49 @@ describe('isVaultGovernanceLimited', () => {
     })
 
     expect(isVaultGovernanceLimited(address)).toBe(true)
+  })
+})
+
+describe('isVaultCyclicalNote', () => {
+  it('checks cyclical-note product tags', () => {
+    const address = '0x0000000000000000000000000000000000000401'
+
+    __setEulerLabelsDataForTest({
+      products: {
+        test: {
+          name: 'Test',
+          description: '',
+          entity: [],
+          url: '',
+          vaults: [normalizeAddress(address)],
+          tags: ['cyclical note'],
+        },
+      },
+    })
+
+    expect(isVaultCyclicalNote(address)).toBe(true)
+  })
+
+  it('checks cyclical-note vault override tags', () => {
+    const address = '0x0000000000000000000000000000000000000402'
+
+    __setEulerLabelsDataForTest({
+      products: {
+        test: {
+          name: 'Test',
+          description: '',
+          entity: [],
+          url: '',
+          vaults: [normalizeAddress(address)],
+          vaultOverrides: {
+            [normalizeAddress(address)]: {
+              tags: ['cyclical note'],
+            },
+          },
+        },
+      },
+    })
+
+    expect(isVaultCyclicalNote(address)).toBe(true)
   })
 })

--- a/tests/utils/euler-labels-utils.test.ts
+++ b/tests/utils/euler-labels-utils.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'vitest'
 import { __setEulerLabelsDataForTest } from '~/composables/useEulerLabels'
-import { getActiveProductVaultAddresses, getUniqueEntitiesByVaults, isVaultGovernanceLimited, isVaultRecentlyAdded, normalizeProducts } from '~/utils/eulerLabelsUtils'
+import {
+  getActiveProductVaultAddresses,
+  getUniqueEntitiesByVaults,
+  isVaultGovernanceLimited,
+  isVaultHighUtilisationWarningSuppressed,
+  isVaultRecentlyAdded,
+  normalizeProducts,
+} from '~/utils/eulerLabelsUtils'
 import { normalizeAddress } from '~/utils/normalizeAddress'
 
 describe('normalizeProducts', () => {
@@ -181,5 +188,49 @@ describe('isVaultGovernanceLimited', () => {
     })
 
     expect(isVaultGovernanceLimited(address)).toBe(true)
+  })
+})
+
+describe('isVaultHighUtilisationWarningSuppressed', () => {
+  it('checks high-utilisation warning suppression product tags', () => {
+    const address = '0x0000000000000000000000000000000000000401'
+
+    __setEulerLabelsDataForTest({
+      products: {
+        test: {
+          name: 'Test',
+          description: '',
+          entity: [],
+          url: '',
+          vaults: [normalizeAddress(address)],
+          tags: ['suppress high utilisation warning'],
+        },
+      },
+    })
+
+    expect(isVaultHighUtilisationWarningSuppressed(address)).toBe(true)
+  })
+
+  it('checks high-utilisation warning suppression vault override tags', () => {
+    const address = '0x0000000000000000000000000000000000000402'
+
+    __setEulerLabelsDataForTest({
+      products: {
+        test: {
+          name: 'Test',
+          description: '',
+          entity: [],
+          url: '',
+          vaults: [normalizeAddress(address)],
+          vaultOverrides: {
+            [normalizeAddress(address)]: {
+              tags: ['suppress high utilisation warning'],
+            },
+          },
+        },
+      },
+    })
+
+    expect(isVaultHighUtilisationWarningSuppressed(address)).toBe(true)
   })
 })

--- a/utils/discoveryCalculations.ts
+++ b/utils/discoveryCalculations.ts
@@ -6,7 +6,7 @@ import { maxUint256 } from 'viem'
 import type { AnyVault } from '~/composables/useVaultRegistry'
 
 import { getEulerLabelEntityLogo } from '~/entities/euler/labels'
-import { getEntitiesByVault, isVaultDeprecated } from '~/utils/eulerLabelsUtils'
+import { getEntitiesByVault, isVaultCyclicalNote, isVaultDeprecated } from '~/utils/eulerLabelsUtils'
 import { formatNumber, compactNumber, truncate } from '~/utils/string-utils'
 import { formatHookedOpsSummary, getHookedOperationMetas, getVaultHookedOperations, hasAnyHookedOperation, isVaultEffectivelyPaused } from '~/utils/vault-hooks'
 import { INTEREST_RATE_MODEL_TYPE } from '~/entities/constants'
@@ -741,8 +741,6 @@ const getIrmTypeLabel = (t: number | undefined): string => {
   if (t === INTEREST_RATE_MODEL_TYPE.KINK) return 'Kink'
   if (t === INTEREST_RATE_MODEL_TYPE.ADAPTIVE_CURVE) return 'Adaptive'
   if (t === INTEREST_RATE_MODEL_TYPE.KINKY) return 'Kinky'
-  if (t === INTEREST_RATE_MODEL_TYPE.FIXED_CYCLICAL_BINARY) return 'Cyclical note'
-  if (t === INTEREST_RATE_MODEL_TYPE.FIXED_CYCLICAL_BINARY_MONTHLY) return 'Cyclical note'
   return '—'
 }
 
@@ -793,7 +791,9 @@ export const CONFIG_ROWS: AttributeRow[] = [
     getValue: (vault) => {
       if (!isEVault(vault) || isEscrow(vault)) return NA_CELL
       const t = vault.interestRateModel.type
-      const label = getIrmTypeLabel(typeof t === 'number' ? t : undefined)
+      const label = isVaultCyclicalNote(vault.address)
+        ? 'Cyclical note'
+        : getIrmTypeLabel(typeof t === 'number' ? t : undefined)
       return { display: label, kind: 'text', hint: vault.interestRateModel.address }
     },
   },

--- a/utils/eulerLabelsUtils.ts
+++ b/utils/eulerLabelsUtils.ts
@@ -191,6 +191,15 @@ export const isVaultGovernanceLimited = (vaultAddress: string): boolean => {
   return productHasTag(product, 'governance limited')
 }
 
+export const isVaultCyclicalNote = (vaultAddress: string): boolean => {
+  const normalized = normalizeAddress(vaultAddress)
+  const product = getEulerLabelProductByVault(labels(), normalized) as EulerLabelProduct | undefined
+  return (
+    productHasTag(product, 'cyclical note')
+    || vaultOverrideHasTag(product, normalized, 'cyclical note')
+  )
+}
+
 export type EulerLabelEntityVaultLike = {
   address?: string
   governorAdmin?: string

--- a/utils/eulerLabelsUtils.ts
+++ b/utils/eulerLabelsUtils.ts
@@ -191,6 +191,15 @@ export const isVaultGovernanceLimited = (vaultAddress: string): boolean => {
   return productHasTag(product, 'governance limited')
 }
 
+export const isVaultHighUtilisationWarningSuppressed = (vaultAddress: string): boolean => {
+  const normalized = normalizeAddress(vaultAddress)
+  const product = getEulerLabelProductByVault(labels(), normalized) as EulerLabelProduct | undefined
+  return (
+    productHasTag(product, 'suppress high utilisation warning')
+    || vaultOverrideHasTag(product, normalized, 'suppress high utilisation warning')
+  )
+}
+
 export type EulerLabelEntityVaultLike = {
   address?: string
   governorAdmin?: string

--- a/utils/eulerLabelsUtils.ts
+++ b/utils/eulerLabelsUtils.ts
@@ -29,15 +29,11 @@ import {
   type EulerLabelAssetPatternRule,
   type EulerEarn,
 } from '@eulerxyz/euler-v2-sdk'
-import { eulerLabelProductEmpty, type EulerLabelProduct, type EulerLabelEntity, type EulerLabelPointReward } from '~/entities/euler/labels'
+import { eulerLabelProductEmpty, type EulerLabelEarnVaultEntry, type EulerLabelProduct, type EulerLabelEntity, type EulerLabelPointReward } from '~/entities/euler/labels'
 import { getCurrentEulerLabelsData, getEulerLabelWrapPairs } from '~/composables/useEulerLabels'
 import { normalizeAddress } from '~/utils/normalizeAddress'
 
 const labels = () => getCurrentEulerLabelsData()
-
-type EulerLabelsWithRecentlyAdded = ReturnType<typeof getCurrentEulerLabelsData> & {
-  recentlyAddedEarnVaults?: Set<string>
-}
 
 const MAX_REGEX_INPUT_LEN = 128
 
@@ -98,16 +94,30 @@ export const getAssetRestricted = (assetAddress: string): string[] | undefined =
 export const getAssetPatternRules = (): EulerLabelAssetPatternRule[] =>
   labels().assetPatternRules
 
+const productHasTag = (product: EulerLabelProduct | undefined, tag: string): boolean =>
+  product?.tags?.includes(tag) ?? false
+
+const vaultOverrideHasTag = (
+  product: EulerLabelProduct | undefined,
+  normalizedVaultAddress: string,
+  tag: string,
+): boolean =>
+  product?.vaultOverrides?.[normalizedVaultAddress]?.tags?.includes(tag) ?? false
+
+const earnEntryHasTag = (entry: EulerLabelEarnVaultEntry | undefined, tag: string): boolean =>
+  entry?.tags?.includes(tag) ?? false
+
+const getEarnEntryByVault = (normalizedVaultAddress: string): EulerLabelEarnVaultEntry | undefined =>
+  labels().earnVaultEntries[normalizedVaultAddress.toLowerCase()] as EulerLabelEarnVaultEntry | undefined
+
 export const isVaultRecentlyAdded = (vaultAddress: string): boolean => {
   const normalized = normalizeAddress(vaultAddress)
-  const currentLabels = labels() as EulerLabelsWithRecentlyAdded
-  const productRecentlyAdded = Object.values(currentLabels.products).some(product =>
-    ((product as EulerLabelProduct).recentlyAddedVaults ?? []).some(address => normalizeAddress(address) === normalized),
+  const product = getEulerLabelProductByVault(labels(), normalized) as EulerLabelProduct | undefined
+  return (
+    productHasTag(product, 'recently added')
+    || vaultOverrideHasTag(product, normalized, 'recently added')
+    || earnEntryHasTag(getEarnEntryByVault(normalized), 'recently added')
   )
-  if (productRecentlyAdded) return true
-
-  const earnRecentlyAdded = currentLabels.recentlyAddedEarnVaults
-  return earnRecentlyAdded?.has(normalized) || earnRecentlyAdded?.has(normalized.toLowerCase()) || false
 }
 
 export const normalizeProducts = (data: Record<string, EulerLabelProduct>): { products: Record<string, EulerLabelProduct>, vaultAddresses: string[] } => {
@@ -117,14 +127,12 @@ export const normalizeProducts = (data: Record<string, EulerLabelProduct>): { pr
   Object.entries(data).forEach(([key, product]) => {
     const normalizedVaults = product.vaults.map(normalizeAddress)
     const normalizedDeprecated = (product.deprecatedVaults || []).map(normalizeAddress)
-    const normalizedRecentlyAdded = (product.recentlyAddedVaults || []).map(normalizeAddress)
     const fallbackReason = (product as EulerLabelProduct & { deprecateReason?: string }).deprecateReason
 
     normalized[key] = {
       ...product,
       vaults: normalizedVaults,
       deprecatedVaults: normalizedDeprecated,
-      recentlyAddedVaults: normalizedRecentlyAdded,
       deprecationReason: product.deprecationReason || fallbackReason,
     }
 
@@ -176,6 +184,12 @@ export const isProductKeyring = (productKey: string): boolean =>
 
 export const isVaultAccessControlled = (vaultAddress: string): boolean =>
   isEulerLabelVaultAccessControlled(labels(), vaultAddress)
+
+export const isVaultGovernanceLimited = (vaultAddress: string): boolean => {
+  const normalized = normalizeAddress(vaultAddress)
+  const product = getEulerLabelProductByVault(labels(), normalized) as EulerLabelProduct | undefined
+  return productHasTag(product, 'governance limited')
+}
 
 export type EulerLabelEntityVaultLike = {
   address?: string

--- a/utils/eulerLabelsUtils.ts
+++ b/utils/eulerLabelsUtils.ts
@@ -188,7 +188,10 @@ export const isVaultAccessControlled = (vaultAddress: string): boolean =>
 export const isVaultGovernanceLimited = (vaultAddress: string): boolean => {
   const normalized = normalizeAddress(vaultAddress)
   const product = getEulerLabelProductByVault(labels(), normalized) as EulerLabelProduct | undefined
-  return productHasTag(product, 'governance limited')
+  return (
+    productHasTag(product, 'governance limited')
+    || vaultOverrideHasTag(product, normalized, 'governance limited')
+  )
 }
 
 export const isVaultHighUtilisationWarningSuppressed = (vaultAddress: string): boolean => {


### PR DESCRIPTION
## Summary
- Updates Lite to consume label classifications from `tags`.
- Includes recently-added, governance-limited, high-utilisation warning suppression, and cyclical-note UI support in the combined Lite migration branch.

## Changes
- Reads `recently added` from product tags, vault override tags, and Earn entry tags.
- Reads governance-limited, warning-suppression, and cyclical-note classifications through shared label helpers.
- Suppresses tagged high-utilisation warnings while keeping critical utilisation warnings visible.
- Renders cyclical-note badges, IRM labels, and target-utilisation copy from labels tags rather than IRM type.
- Points server-side SDK labels loading at Lite configured labels base so public metadata uses the same label source.
- Updates docs and focused tests for the tag schema.

## Stack
- Canonical merge and publish order: https://github.com/euler-xyz/euler-sdks/pull/55
- This PR is the combined Lite migration branch and should be updated to the published SDK version with a refreshed lockfile before merge.

## Companion PRs
- SDK migration: https://github.com/euler-xyz/euler-sdks/pull/55
- Labels migration: https://github.com/euler-xyz/euler-labels/pull/641

## Folded-in follow-ups
- Vault warning tags: https://github.com/euler-xyz/euler-lite/pull/550
- Cyclical-note labels: https://github.com/euler-xyz/euler-lite/pull/551

## Test plan
- [x] `npm run test:run`
- [x] `npm run build`
- [x] `npm run typecheck` after SDK publish/version bump/lockfile update

Current typecheck blocker before the SDK update: installed SDK types do not yet include migrated Earn label `tags`; local installed SDK types also require `turtle` in `RewardSource` maps.

## Follow-up before merge
- [x] Publish SDK package from the combined SDK migration stack.
- [x] Bump Lite to the published SDK version and commit the lockfile update.
- [x] Rerun `npm run typecheck` with the published SDK version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Vault classification switched to a tag-based system, updating badges, labels, discovery displays, warnings, and IRM label behavior across the UI and metadata.

* **Documentation**
  * Docs updated to describe the new tags schema and label semantics.

* **Tests**
  * Tests revised to validate tag-driven classification, badge/warning behavior, and discovery labeling.

* **Chores**
  * Dependency bump for the SDK.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->