### PR TITLE
feat: support vault warning tags

### DIFF
--- a/composables/useVaultWarnings.ts
+++ b/composables/useVaultWarnings.ts
@@ -1,6 +1,7 @@
 import { isSecuritizeCollateralVault, type EVault, type SecuritizeCollateralVault } from '@eulerxyz/euler-v2-sdk'
 import { isCyclicalNoteVault } from '~/utils/vault/classification'
 import { getVaultUtilization } from '~/utils/vault-display'
+import { isVaultHighUtilisationWarningSuppressed } from '~/utils/eulerLabelsUtils'
 import {
   findBlockingDisabledOp,
   getOpMeta,
@@ -103,6 +104,8 @@ export const getUtilisationWarning = (
   const utilisation = getVaultUtilization(vault)
   const level = getUtilisationLevel(utilisation)
   if (!level) return null
+
+  if (level === 'high' && isVaultHighUtilisationWarningSuppressed(vault.address)) return null
 
   if (context !== 'repay' && isCyclicalNoteVault(vault)) {
     return { level: 'info', tone: 'success', ...targetUtilisationMessage }

--- a/docs/vault-labels-and-verification.md
+++ b/docs/vault-labels-and-verification.md
@@ -83,7 +83,7 @@ Structure: `Record<string, Product>` — keys are product identifiers (e.g. `"eu
 | `vaults` | `string[]` | Yes | Active vault addresses (checksummed). These become "verified" vaults in the app. |
 | `deprecatedVaults` | `string[]` | No | Phased-out vault addresses. Still verified and viewable in portfolio, but hidden from discovery tables and shown with a deprecation warning. |
 | `deprecationReason` | `string` | No | Explanation for deprecation. Shown in a warning banner on vault overview. URLs are auto-linked. Also accepts legacy key `deprecateReason`. |
-| `tags` | `string[]` | No | Product classification tags. `keyring` marks all product vaults as requiring Keyring identity verification; `access control` marks vaults gated by an allowlist hook; `governance limited` shows "Limited risk management" and fades the risk manager entity display. |
+| `tags` | `string[]` | No | Product classification tags. `keyring` marks all product vaults as requiring Keyring identity verification; `access control` marks vaults gated by an allowlist hook; `governance limited` shows "Limited risk management" and fades the risk manager entity display; `suppress high utilisation warning` hides the high-utilisation warning while leaving critical utilisation warnings visible. |
 | `notExplorable` | `boolean` | No | If `true`, hides **all** vaults in this product from lend, borrow, and explore discovery pages. Takes precedence over per-vault `notExplorableLend`/`notExplorableBorrow`. Vaults remain accessible via direct URL. |
 | `block` | `string[]` | No | Country codes or group aliases (`EU`, `EEA`, `EFTA`) for hard geo-blocking. See [geo-blocking.md](./geo-blocking.md). |
 | `vaultOverrides` | `Record<string, VaultOverride>` | No | Per-vault customizations keyed by checksummed address. See next section. |
@@ -103,7 +103,7 @@ Per-vault overrides allow customizing behavior for individual vaults within a pr
 | `restricted` | `string[]` | Soft geo-restriction for this vault only. No product-level fallback. See [geo-blocking.md](./geo-blocking.md). |
 | `notExplorableLend` | `boolean` | If `true`, hides this vault from the **lend** discovery page. Product-level `notExplorable` takes precedence. |
 | `notExplorableBorrow` | `boolean` | If `true`, hides this vault from the **borrow** discovery page — both as a borrow vault and as collateral. Product-level `notExplorable` takes precedence. |
-| `tags` | `string[]` | Vault classification tags. `keyring`, `access control`, and `recently added` apply to this specific vault. See [keyring-hooks.md](./keyring-hooks.md). |
+| `tags` | `string[]` | Vault classification tags. `keyring`, `access control`, `recently added`, and `suppress high utilisation warning` apply to this specific vault. See [keyring-hooks.md](./keyring-hooks.md). |
 
 **Precedence rules**:
 - `block`: vault override replaces product-level (not additive)

--- a/tests/composables/useVaultWarnings.test.ts
+++ b/tests/composables/useVaultWarnings.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 import type { EVault, SecuritizeCollateralVault } from '@eulerxyz/euler-v2-sdk'
 import { getCollateralSupplyCapWarning, getUtilisationWarning } from '~/composables/useVaultWarnings'
+import { __setEulerLabelsDataForTest } from '~/composables/useEulerLabels'
 import { INTEREST_RATE_MODEL_TYPE } from '~/entities/constants'
+import { normalizeAddress } from '~/utils/normalizeAddress'
 
 const makeVault = (supplyCapUtilization: number): EVault =>
   ({
@@ -14,14 +16,20 @@ const makeUtilisedVault = (
   totalAssets: bigint,
   borrow: bigint,
   interestRateModelType: number = INTEREST_RATE_MODEL_TYPE.KINK,
+  address = '0x0000000000000000000000000000000000000001',
 ): EVault =>
   ({
+    address: normalizeAddress(address),
     totalAssets,
     borrow,
     interestRateModel: { type: interestRateModelType },
   }) as unknown as EVault
 
 describe('getUtilisationWarning', () => {
+  beforeEach(() => {
+    __setEulerLabelsDataForTest()
+  })
+
   it('returns the standard high utilisation warning for non-cyclical borrow markets', () => {
     const warning = getUtilisationWarning(makeUtilisedVault(100n, 95n), 'borrow')
 
@@ -69,6 +77,62 @@ describe('getUtilisationWarning', () => {
     )
 
     expect(warning).toBeNull()
+  })
+
+  it('suppresses high utilisation warnings for tagged vaults', () => {
+    const address = normalizeAddress('0x0000000000000000000000000000000000000501')
+
+    __setEulerLabelsDataForTest({
+      products: {
+        test: {
+          name: 'Test',
+          description: '',
+          entity: [],
+          url: '',
+          vaults: [address],
+          vaultOverrides: {
+            [address]: {
+              tags: ['suppress high utilisation warning'],
+            },
+          },
+        },
+      },
+    })
+
+    const warning = getUtilisationWarning(
+      makeUtilisedVault(100n, 95n, INTEREST_RATE_MODEL_TYPE.KINK, address),
+      'borrow',
+    )
+
+    expect(warning).toBeNull()
+  })
+
+  it('keeps critical utilisation warnings for tagged vaults', () => {
+    const address = normalizeAddress('0x0000000000000000000000000000000000000502')
+
+    __setEulerLabelsDataForTest({
+      products: {
+        test: {
+          name: 'Test',
+          description: '',
+          entity: [],
+          url: '',
+          vaults: [address],
+          tags: ['suppress high utilisation warning'],
+        },
+      },
+    })
+
+    const warning = getUtilisationWarning(
+      makeUtilisedVault(100n, 99n, INTEREST_RATE_MODEL_TYPE.KINK, address),
+      'borrow',
+    )
+
+    expect(warning).toEqual({
+      level: 'critical',
+      title: 'Critical utilisation',
+      message: 'Utilisation is critically high. Interest rates are very elevated. Available liquidity is near zero.',
+    })
   })
 })
 

--- a/tests/utils/euler-labels-utils.test.ts
+++ b/tests/utils/euler-labels-utils.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'vitest'
 import { __setEulerLabelsDataForTest } from '~/composables/useEulerLabels'
-import { getActiveProductVaultAddresses, getUniqueEntitiesByVaults, isVaultGovernanceLimited, isVaultRecentlyAdded, normalizeProducts } from '~/utils/eulerLabelsUtils'
+import {
+  getActiveProductVaultAddresses,
+  getUniqueEntitiesByVaults,
+  isVaultGovernanceLimited,
+  isVaultHighUtilisationWarningSuppressed,
+  isVaultRecentlyAdded,
+  normalizeProducts,
+} from '~/utils/eulerLabelsUtils'
 import { normalizeAddress } from '~/utils/normalizeAddress'
 
 describe('normalizeProducts', () => {
@@ -181,5 +188,49 @@ describe('isVaultGovernanceLimited', () => {
     })
 
     expect(isVaultGovernanceLimited(address)).toBe(true)
+  })
+})
+
+describe('isVaultHighUtilisationWarningSuppressed', () => {
+  it('checks high-utilisation warning suppression product tags', () => {
+    const address = '0x0000000000000000000000000000000000000401'
+
+    __setEulerLabelsDataForTest({
+      products: {
+        test: {
+          name: 'Test',
+          description: '',
+          entity: [],
+          url: '',
+          vaults: [normalizeAddress(address)],
+          tags: ['suppress high utilisation warning'],
+        },
+      },
+    })
+
+    expect(isVaultHighUtilisationWarningSuppressed(address)).toBe(true)
+  })
+
+  it('checks high-utilisation warning suppression vault override tags', () => {
+    const address = '0x0000000000000000000000000000000000000402'
+
+    __setEulerLabelsDataForTest({
+      products: {
+        test: {
+          name: 'Test',
+          description: '',
+          entity: [],
+          url: '',
+          vaults: [normalizeAddress(address)],
+          vaultOverrides: {
+            [normalizeAddress(address)]: {
+              tags: ['suppress high utilisation warning'],
+            },
+          },
+        },
+      },
+    })
+
+    expect(isVaultHighUtilisationWarningSuppressed(address)).toBe(true)
   })
 })

--- a/utils/eulerLabelsUtils.ts
+++ b/utils/eulerLabelsUtils.ts
@@ -191,6 +191,15 @@ export const isVaultGovernanceLimited = (vaultAddress: string): boolean => {
   return productHasTag(product, 'governance limited')
 }
 
+export const isVaultHighUtilisationWarningSuppressed = (vaultAddress: string): boolean => {
+  const normalized = normalizeAddress(vaultAddress)
+  const product = getEulerLabelProductByVault(labels(), normalized) as EulerLabelProduct | undefined
+  return (
+    productHasTag(product, 'suppress high utilisation warning')
+    || vaultOverrideHasTag(product, normalized, 'suppress high utilisation warning')
+  )
+}
+
 export type EulerLabelEntityVaultLike = {
   address?: string
   governorAdmin?: string


### PR DESCRIPTION
## Summary
- Read the `suppress high utilisation warning` label tag in Lite.
- Suppress only the high-utilisation warning for tagged vaults.
- Keep critical utilisation warnings visible.
- Add warning and label utility regressions.

## Stack
- Canonical merge and publish order: https://github.com/euler-xyz/euler-sdks/pull/55
- This PR targets `migration/labels-classification-tags` and merges into the Lite migration branch when included.

## Companion PRs
- SDK: https://github.com/euler-xyz/euler-sdks/pull/56
- Labels: https://github.com/euler-xyz/euler-labels/pull/642

## Test
- `npm run test:run -- tests/utils/euler-labels-utils.test.ts tests/composables/useVaultWarnings.test.ts`
- `npm run typecheck`
- `NUXT_IGNORE_LOCK=1 npm run build`
- Headless Chrome smoke on VBILL borrow route: VBILL names rendered, `High utilisation` absent, `Critical utilisation` absent