### PR TITLE
feat: read cyclical notes from labels

### DIFF
--- a/components/entities/vault/VaultBorrowItem.vue
+++ b/components/entities/vault/VaultBorrowItem.vue
@@ -1,13 +1,12 @@
 <script setup lang="ts">
 import type { EVault } from '@eulerxyz/euler-v2-sdk'
-import { isCyclicalNoteVault } from '~/utils/vault/classification'
 import { getUtilisationWarning, getBorrowCapWarning, getCollateralSupplyCapWarning } from '~/composables/useVaultWarnings'
 import { formatAssetValue } from '~/utils/sdk-prices'
 import { getMaxMultiplier, getMaxRoe } from '~/utils/leverage'
 import { withVaultIntrinsicApy, getVaultIntrinsicApy, getVaultIntrinsicApyInfo } from '~/utils/vault-intrinsic-apy'
 import { getVaultAvailableLiquidity, getVaultUtilization } from '~/utils/vault-display'
 import { useEulerProductOfVault } from '~/composables/useEulerLabels'
-import { isVaultGovernanceLimited, isVaultRecentlyAdded, isVaultKeyring, getUniqueEntitiesByVaults } from '~/utils/eulerLabelsUtils'
+import { isVaultGovernanceLimited, isVaultRecentlyAdded, isVaultKeyring, isVaultCyclicalNote, getUniqueEntitiesByVaults } from '~/utils/eulerLabelsUtils'
 import { getEulerLabelEntityLogo } from '~/entities/euler/labels'
 import { isAnyVaultBlockedByCountry, isVaultRestrictedByCountry } from '~/composables/useGeoBlock'
 import { VaultBorrowApyModal, VaultMaxRoeModal, VaultNetApyPairModal, VaultSupplyApyModal, UiModalPreviewTrigger } from '#components'
@@ -82,7 +81,7 @@ const isPairEffectivelyBlocked = computed(() => {
 
 const isRecentlyAdded = computed(() => isVaultRecentlyAdded(pair.collateral.address) || isVaultRecentlyAdded(pair.borrow.address))
 const isKeyring = computed(() => isVaultKeyring(pair.collateral.address) || isVaultKeyring(pair.borrow.address))
-const isCyclicalNote = computed(() => isCyclicalNoteVault(pair.borrow))
+const isCyclicalNote = computed(() => isVaultCyclicalNote(pair.borrow.address))
 
 const isAnyDeprecated = computed(() => {
   const collateralAddr = getAddress(pair.collateral.address)

--- a/components/entities/vault/VaultItem.vue
+++ b/components/entities/vault/VaultItem.vue
@@ -3,7 +3,7 @@ import type { EVault } from '@eulerxyz/euler-v2-sdk'
 import { getUtilisationWarning, getSupplyCapWarning } from '~/composables/useVaultWarnings'
 import { formatAssetValue } from '~/utils/sdk-prices'
 import { useEulerProductOfVault, useEulerEntitiesOfVault } from '~/composables/useEulerLabels'
-import { isVaultGovernanceLimited, isVaultRecentlyAdded, isVaultKeyring } from '~/utils/eulerLabelsUtils'
+import { isVaultGovernanceLimited, isVaultRecentlyAdded, isVaultKeyring, isVaultCyclicalNote } from '~/utils/eulerLabelsUtils'
 import { withVaultIntrinsicApy, getVaultIntrinsicApy, getVaultIntrinsicApyInfo } from '~/utils/vault-intrinsic-apy'
 import { getEulerLabelEntityLogo } from '~/entities/euler/labels'
 import { isVaultBlockedByCountry } from '~/composables/useGeoBlock'
@@ -12,7 +12,7 @@ import BaseLoadableContent from '~/components/base/BaseLoadableContent.vue'
 import { useModal } from '~/components/ui/composables/useModal'
 import { useVaultRegistry } from '~/composables/useVaultRegistry'
 import { VaultSupplyApyModal, VaultCollateralExposureModal, UiModalPreviewTrigger } from '#components'
-import { isCyclicalNoteVault, isVaultBorrowable } from '~/utils/vault/classification'
+import { isVaultBorrowable } from '~/utils/vault/classification'
 import { getAddress } from 'viem'
 
 const { isConnected } = useWagmi()
@@ -114,7 +114,7 @@ const utilizationDisplay = computed(() => compactNumber(utilization.value, 2, 2)
 const isGeoBlocked = computed(() => isVaultBlockedByCountry(vault.address))
 const isRecentlyAdded = computed(() => isVaultRecentlyAdded(vault.address))
 const isKeyring = computed(() => isVaultKeyring(vault.address))
-const isCyclicalNote = computed(() => isCyclicalNoteVault(vault))
+const isCyclicalNote = computed(() => isVaultCyclicalNote(vault.address))
 const utilisationWarning = computed(() => getUtilisationWarning(vault, 'lend'))
 const supplyCapWarning = computed(() => getSupplyCapWarning(vault))
 const statsGridCols = computed(() => {

--- a/components/entities/vault/discovery/DiscoveryMarketGraph.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketGraph.vue
@@ -1,10 +1,9 @@
 <script setup lang="ts">
 import type { MarketGroup, MiniDiagramData } from '~/entities/lend-discovery'
-import { isCyclicalNoteVault } from '~/utils/vault/classification'
 import { getAssetLogoUrl } from '~/composables/useTokenList'
-import { isVaultDeprecated, isVaultKeyring } from '~/utils/eulerLabelsUtils'
+import { isVaultDeprecated, isVaultKeyring, isVaultCyclicalNote } from '~/utils/eulerLabelsUtils'
 import { stringToColor } from '~/utils/string-utils'
-import { getEnlargedDiagram, getArrow, getLabelPosition, getGraphConnectedAddresses, isNodeRampingDown, isExternalCollateral, findVault } from '~/utils/discoveryCalculations'
+import { getEnlargedDiagram, getArrow, getLabelPosition, getGraphConnectedAddresses, isNodeRampingDown, isExternalCollateral } from '~/utils/discoveryCalculations'
 
 const props = defineProps<{
   market: MarketGroup
@@ -35,7 +34,7 @@ const isGraphEdgeHighlighted = (fromAddr: string, toAddr: string): boolean => {
 }
 
 const isNodeCyclicalNote = (address: string): boolean => {
-  return isCyclicalNoteVault(findVault(props.market, address))
+  return isVaultCyclicalNote(address)
 }
 </script>
 

--- a/components/entities/vault/overview/VaultOverview.vue
+++ b/components/entities/vault/overview/VaultOverview.vue
@@ -1,13 +1,13 @@
 <script setup lang="ts">
 import type { EVault } from '@eulerxyz/euler-v2-sdk'
-import { isCyclicalNoteVault } from '~/utils/vault/classification'
+import { isVaultCyclicalNote } from '~/utils/eulerLabelsUtils'
 
 const emits = defineEmits<{
   'vault-click': [address: string]
 }>()
 const { vault } = defineProps<{ vault: EVault, desktopOverview?: boolean }>()
 
-const isCyclicalIRM = computed(() => isCyclicalNoteVault(vault))
+const isCyclicalIRM = computed(() => isVaultCyclicalNote(vault.address))
 </script>
 
 <template>

--- a/components/entities/vault/overview/VaultOverviewBlockIRM.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockIRM.vue
@@ -94,7 +94,6 @@ const irmTypeLabel = computed(() => {
   if (type === INTEREST_RATE_MODEL_TYPE.KINK) return 'Kink'
   if (type === INTEREST_RATE_MODEL_TYPE.ADAPTIVE_CURVE) return 'Adaptive'
   if (type === INTEREST_RATE_MODEL_TYPE.KINKY) return 'Kinky'
-  if (type === INTEREST_RATE_MODEL_TYPE.FIXED_CYCLICAL_BINARY) return 'Cyclical note'
   return 'Interest Rate Model'
 })
 

--- a/composables/useVaultTypeBadges.ts
+++ b/composables/useVaultTypeBadges.ts
@@ -1,8 +1,7 @@
 import { zeroAddress } from 'viem'
 import { isEVault, type EulerEarn, type EVault, type SecuritizeCollateralVault } from '@eulerxyz/euler-v2-sdk'
 import type { Ref } from 'vue'
-import { isCyclicalNoteVault } from '~/utils/vault/classification'
-import { getEntitiesByEarnVault, getEntitiesByVault, isVaultAccessControlled, isVaultGovernanceLimited, isVaultKeyring } from '~/utils/eulerLabelsUtils'
+import { getEntitiesByEarnVault, getEntitiesByVault, isVaultAccessControlled, isVaultCyclicalNote, isVaultGovernanceLimited, isVaultKeyring } from '~/utils/eulerLabelsUtils'
 import { useVaultRegistry } from '~/composables/useVaultRegistry'
 
 type VaultTypeBadgeVault = EVault | EulerEarn | SecuritizeCollateralVault
@@ -51,7 +50,7 @@ export const useVaultTypeBadges = (vault: Ref<VaultTypeBadgeVault>) => {
 
   const isCyclicalNote = computed(() => {
     if (!isEVault(vault.value)) return false
-    return isCyclicalNoteVault(vault.value)
+    return isVaultCyclicalNote(vault.value.address)
   })
 
   const badges = computed<VaultTypeBadge[]>(() => {

--- a/composables/useVaultWarnings.ts
+++ b/composables/useVaultWarnings.ts
@@ -1,6 +1,6 @@
 import { isSecuritizeCollateralVault, type EVault, type SecuritizeCollateralVault } from '@eulerxyz/euler-v2-sdk'
-import { isCyclicalNoteVault } from '~/utils/vault/classification'
 import { getVaultUtilization } from '~/utils/vault-display'
+import { isVaultCyclicalNote } from '~/utils/eulerLabelsUtils'
 import {
   findBlockingDisabledOp,
   getOpMeta,
@@ -104,7 +104,7 @@ export const getUtilisationWarning = (
   const level = getUtilisationLevel(utilisation)
   if (!level) return null
 
-  if (context !== 'repay' && isCyclicalNoteVault(vault)) {
+  if (context !== 'repay' && isVaultCyclicalNote(vault.address)) {
     return { level: 'info', tone: 'success', ...targetUtilisationMessage }
   }
 

--- a/docs/vault-labels-and-verification.md
+++ b/docs/vault-labels-and-verification.md
@@ -83,7 +83,7 @@ Structure: `Record<string, Product>` — keys are product identifiers (e.g. `"eu
 | `vaults` | `string[]` | Yes | Active vault addresses (checksummed). These become "verified" vaults in the app. |
 | `deprecatedVaults` | `string[]` | No | Phased-out vault addresses. Still verified and viewable in portfolio, but hidden from discovery tables and shown with a deprecation warning. |
 | `deprecationReason` | `string` | No | Explanation for deprecation. Shown in a warning banner on vault overview. URLs are auto-linked. Also accepts legacy key `deprecateReason`. |
-| `tags` | `string[]` | No | Product classification tags. `keyring` marks all product vaults as requiring Keyring identity verification; `access control` marks vaults gated by an allowlist hook; `governance limited` shows "Limited risk management" and fades the risk manager entity display. |
+| `tags` | `string[]` | No | Product classification tags. `keyring` marks all product vaults as requiring Keyring identity verification; `access control` marks vaults gated by an allowlist hook; `governance limited` shows "Limited risk management" and fades the risk manager entity display; `cyclical note` shows cyclical-note badges, target-utilisation copy, and the cyclical IRM overview. |
 | `notExplorable` | `boolean` | No | If `true`, hides **all** vaults in this product from lend, borrow, and explore discovery pages. Takes precedence over per-vault `notExplorableLend`/`notExplorableBorrow`. Vaults remain accessible via direct URL. |
 | `block` | `string[]` | No | Country codes or group aliases (`EU`, `EEA`, `EFTA`) for hard geo-blocking. See [geo-blocking.md](./geo-blocking.md). |
 | `vaultOverrides` | `Record<string, VaultOverride>` | No | Per-vault customizations keyed by checksummed address. See next section. |
@@ -103,7 +103,7 @@ Per-vault overrides allow customizing behavior for individual vaults within a pr
 | `restricted` | `string[]` | Soft geo-restriction for this vault only. No product-level fallback. See [geo-blocking.md](./geo-blocking.md). |
 | `notExplorableLend` | `boolean` | If `true`, hides this vault from the **lend** discovery page. Product-level `notExplorable` takes precedence. |
 | `notExplorableBorrow` | `boolean` | If `true`, hides this vault from the **borrow** discovery page — both as a borrow vault and as collateral. Product-level `notExplorable` takes precedence. |
-| `tags` | `string[]` | Vault classification tags. `keyring`, `access control`, and `recently added` apply to this specific vault. See [keyring-hooks.md](./keyring-hooks.md). |
+| `tags` | `string[]` | Vault classification tags. `keyring`, `access control`, `recently added`, and `cyclical note` apply to this specific vault. See [keyring-hooks.md](./keyring-hooks.md). |
 
 **Precedence rules**:
 - `block`: vault override replaces product-level (not additive)

--- a/tests/composables/useVaultTypeBadges.test.ts
+++ b/tests/composables/useVaultTypeBadges.test.ts
@@ -11,6 +11,7 @@ const state = vi.hoisted(() => ({
   entityGovernors: new Set<string>(),
   governanceLimitedVaults: new Set<string>(),
   keyringVaults: new Set<string>(),
+  cyclicalNoteVaults: new Set<string>(),
   verifiedEarnVaults: new Set<string>(),
   verifiedVaults: new Set<string>(),
 }))
@@ -23,6 +24,7 @@ vi.mock('~/utils/eulerLabelsUtils', () => ({
   isVaultKeyring: (address: string) => state.keyringVaults.has(address.toLowerCase()),
   isVaultAccessControlled: (address: string) => state.accessControlVaults.has(address.toLowerCase()),
   isVaultGovernanceLimited: (address: string) => state.governanceLimitedVaults.has(address.toLowerCase()),
+  isVaultCyclicalNote: (address: string) => state.cyclicalNoteVaults.has(address.toLowerCase()),
 }))
 
 vi.mock('~/composables/useVaultRegistry', () => ({
@@ -77,6 +79,7 @@ describe('useVaultTypeBadges', () => {
     state.entityGovernors.clear()
     state.governanceLimitedVaults.clear()
     state.keyringVaults.clear()
+    state.cyclicalNoteVaults.clear()
     state.verifiedEarnVaults.clear()
     state.verifiedVaults.clear()
     setupVaultsMock()
@@ -118,14 +121,10 @@ describe('useVaultTypeBadges', () => {
     expect(hasSummaryBadges.value).toBe(true)
   })
 
-  it.each([
-    INTEREST_RATE_MODEL_TYPE.FIXED_CYCLICAL_BINARY,
-    INTEREST_RATE_MODEL_TYPE.FIXED_CYCLICAL_BINARY_MONTHLY,
-  ])('summarizes verified cyclical IRM type %s as cyclical note', (interestRateModelType) => {
-    const vault = makeVault({
-      interestRateModel: makeInterestRateModel(interestRateModelType),
-    })
+  it('summarizes verified cyclical-note-tagged vaults as cyclical note', () => {
+    const vault = makeVault()
     verify(vault)
+    state.cyclicalNoteVaults.add(vault.address.toLowerCase())
 
     const { badges, summaryBadges } = useVaultTypeBadges(shallowRef(vault))
 
@@ -133,9 +132,9 @@ describe('useVaultTypeBadges', () => {
     expect(summaryBadges.value).toEqual(['cyclicalNote'])
   })
 
-  it('does not treat KINKY IRM as cyclical note', () => {
+  it('does not treat cyclical IRM type as cyclical note without a label tag', () => {
     const vault = makeVault({
-      interestRateModel: makeInterestRateModel(INTEREST_RATE_MODEL_TYPE.KINKY),
+      interestRateModel: makeInterestRateModel(INTEREST_RATE_MODEL_TYPE.FIXED_CYCLICAL_BINARY),
     })
     verify(vault)
 

--- a/tests/composables/useVaultWarnings.test.ts
+++ b/tests/composables/useVaultWarnings.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 import type { EVault, SecuritizeCollateralVault } from '@eulerxyz/euler-v2-sdk'
 import { getCollateralSupplyCapWarning, getUtilisationWarning } from '~/composables/useVaultWarnings'
+import { __setEulerLabelsDataForTest } from '~/composables/useEulerLabels'
 import { INTEREST_RATE_MODEL_TYPE } from '~/entities/constants'
+import { normalizeAddress } from '~/utils/normalizeAddress'
 
 const makeVault = (supplyCapUtilization: number): EVault =>
   ({
@@ -14,14 +16,20 @@ const makeUtilisedVault = (
   totalAssets: bigint,
   borrow: bigint,
   interestRateModelType: number = INTEREST_RATE_MODEL_TYPE.KINK,
+  address = '0x0000000000000000000000000000000000000001',
 ): EVault =>
   ({
+    address: normalizeAddress(address),
     totalAssets,
     borrow,
     interestRateModel: { type: interestRateModelType },
   }) as unknown as EVault
 
 describe('getUtilisationWarning', () => {
+  beforeEach(() => {
+    __setEulerLabelsDataForTest()
+  })
+
   it('returns the standard high utilisation warning for non-cyclical borrow markets', () => {
     const warning = getUtilisationWarning(makeUtilisedVault(100n, 95n), 'borrow')
 
@@ -33,10 +41,24 @@ describe('getUtilisationWarning', () => {
   })
 
   it.each(['borrow', 'lend', 'general'] as const)(
-    'returns target utilisation info for highly utilised cyclical note markets in %s context',
+    'returns target utilisation info for highly utilised cyclical-note-tagged markets in %s context',
     (context) => {
+      const address = normalizeAddress('0x0000000000000000000000000000000000000501')
+      __setEulerLabelsDataForTest({
+        products: {
+          test: {
+            name: 'Test',
+            description: '',
+            entity: [],
+            url: '',
+            vaults: [address],
+            tags: ['cyclical note'],
+          },
+        },
+      })
+
       const warning = getUtilisationWarning(
-        makeUtilisedVault(100n, 99n, INTEREST_RATE_MODEL_TYPE.FIXED_CYCLICAL_BINARY),
+        makeUtilisedVault(100n, 99n, INTEREST_RATE_MODEL_TYPE.KINK, address),
         context,
       )
 
@@ -50,8 +72,22 @@ describe('getUtilisationWarning', () => {
   )
 
   it('keeps liquidity constraint copy for highly utilised cyclical repay sources', () => {
+    const address = normalizeAddress('0x0000000000000000000000000000000000000502')
+    __setEulerLabelsDataForTest({
+      products: {
+        test: {
+          name: 'Test',
+          description: '',
+          entity: [],
+          url: '',
+          vaults: [address],
+          tags: ['cyclical note'],
+        },
+      },
+    })
+
     const warning = getUtilisationWarning(
-      makeUtilisedVault(100n, 99n, INTEREST_RATE_MODEL_TYPE.FIXED_CYCLICAL_BINARY),
+      makeUtilisedVault(100n, 99n, INTEREST_RATE_MODEL_TYPE.KINK, address),
       'repay',
     )
 
@@ -63,12 +99,39 @@ describe('getUtilisationWarning', () => {
   })
 
   it('does not show target utilisation info below the shared utilisation threshold', () => {
+    const address = normalizeAddress('0x0000000000000000000000000000000000000503')
+    __setEulerLabelsDataForTest({
+      products: {
+        test: {
+          name: 'Test',
+          description: '',
+          entity: [],
+          url: '',
+          vaults: [address],
+          tags: ['cyclical note'],
+        },
+      },
+    })
+
     const warning = getUtilisationWarning(
-      makeUtilisedVault(100n, 94n, INTEREST_RATE_MODEL_TYPE.FIXED_CYCLICAL_BINARY),
+      makeUtilisedVault(100n, 94n, INTEREST_RATE_MODEL_TYPE.KINK, address),
       'borrow',
     )
 
     expect(warning).toBeNull()
+  })
+
+  it('does not use cyclical IRM type as the target-utilisation classifier', () => {
+    const warning = getUtilisationWarning(
+      makeUtilisedVault(100n, 99n, INTEREST_RATE_MODEL_TYPE.FIXED_CYCLICAL_BINARY),
+      'borrow',
+    )
+
+    expect(warning).toEqual({
+      level: 'critical',
+      title: 'Critical utilisation',
+      message: 'Utilisation is critically high. Interest rates are very elevated. Available liquidity is near zero.',
+    })
   })
 })
 

--- a/tests/utils/euler-labels-utils.test.ts
+++ b/tests/utils/euler-labels-utils.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'vitest'
 import { __setEulerLabelsDataForTest } from '~/composables/useEulerLabels'
-import { getActiveProductVaultAddresses, getUniqueEntitiesByVaults, isVaultGovernanceLimited, isVaultRecentlyAdded, normalizeProducts } from '~/utils/eulerLabelsUtils'
+import {
+  getActiveProductVaultAddresses,
+  getUniqueEntitiesByVaults,
+  isVaultCyclicalNote,
+  isVaultGovernanceLimited,
+  isVaultRecentlyAdded,
+  normalizeProducts,
+} from '~/utils/eulerLabelsUtils'
 import { normalizeAddress } from '~/utils/normalizeAddress'
 
 describe('normalizeProducts', () => {
@@ -181,5 +188,49 @@ describe('isVaultGovernanceLimited', () => {
     })
 
     expect(isVaultGovernanceLimited(address)).toBe(true)
+  })
+})
+
+describe('isVaultCyclicalNote', () => {
+  it('checks cyclical-note product tags', () => {
+    const address = '0x0000000000000000000000000000000000000401'
+
+    __setEulerLabelsDataForTest({
+      products: {
+        test: {
+          name: 'Test',
+          description: '',
+          entity: [],
+          url: '',
+          vaults: [normalizeAddress(address)],
+          tags: ['cyclical note'],
+        },
+      },
+    })
+
+    expect(isVaultCyclicalNote(address)).toBe(true)
+  })
+
+  it('checks cyclical-note vault override tags', () => {
+    const address = '0x0000000000000000000000000000000000000402'
+
+    __setEulerLabelsDataForTest({
+      products: {
+        test: {
+          name: 'Test',
+          description: '',
+          entity: [],
+          url: '',
+          vaults: [normalizeAddress(address)],
+          vaultOverrides: {
+            [normalizeAddress(address)]: {
+              tags: ['cyclical note'],
+            },
+          },
+        },
+      },
+    })
+
+    expect(isVaultCyclicalNote(address)).toBe(true)
   })
 })

--- a/utils/discoveryCalculations.ts
+++ b/utils/discoveryCalculations.ts
@@ -6,7 +6,7 @@ import { maxUint256 } from 'viem'
 import type { AnyVault } from '~/composables/useVaultRegistry'
 
 import { getEulerLabelEntityLogo } from '~/entities/euler/labels'
-import { getEntitiesByVault, isVaultDeprecated } from '~/utils/eulerLabelsUtils'
+import { getEntitiesByVault, isVaultCyclicalNote, isVaultDeprecated } from '~/utils/eulerLabelsUtils'
 import { formatNumber, compactNumber, truncate } from '~/utils/string-utils'
 import { formatHookedOpsSummary, getHookedOperationMetas, getVaultHookedOperations, hasAnyHookedOperation, isVaultEffectivelyPaused } from '~/utils/vault-hooks'
 import { INTEREST_RATE_MODEL_TYPE } from '~/entities/constants'
@@ -741,8 +741,6 @@ const getIrmTypeLabel = (t: number | undefined): string => {
   if (t === INTEREST_RATE_MODEL_TYPE.KINK) return 'Kink'
   if (t === INTEREST_RATE_MODEL_TYPE.ADAPTIVE_CURVE) return 'Adaptive'
   if (t === INTEREST_RATE_MODEL_TYPE.KINKY) return 'Kinky'
-  if (t === INTEREST_RATE_MODEL_TYPE.FIXED_CYCLICAL_BINARY) return 'Cyclical note'
-  if (t === INTEREST_RATE_MODEL_TYPE.FIXED_CYCLICAL_BINARY_MONTHLY) return 'Cyclical note'
   return '—'
 }
 
@@ -793,7 +791,9 @@ export const CONFIG_ROWS: AttributeRow[] = [
     getValue: (vault) => {
       if (!isEVault(vault) || isEscrow(vault)) return NA_CELL
       const t = vault.interestRateModel.type
-      const label = getIrmTypeLabel(typeof t === 'number' ? t : undefined)
+      const label = isVaultCyclicalNote(vault.address)
+        ? 'Cyclical note'
+        : getIrmTypeLabel(typeof t === 'number' ? t : undefined)
       return { display: label, kind: 'text', hint: vault.interestRateModel.address }
     },
   },

--- a/utils/eulerLabelsUtils.ts
+++ b/utils/eulerLabelsUtils.ts
@@ -191,6 +191,15 @@ export const isVaultGovernanceLimited = (vaultAddress: string): boolean => {
   return productHasTag(product, 'governance limited')
 }
 
+export const isVaultCyclicalNote = (vaultAddress: string): boolean => {
+  const normalized = normalizeAddress(vaultAddress)
+  const product = getEulerLabelProductByVault(labels(), normalized) as EulerLabelProduct | undefined
+  return (
+    productHasTag(product, 'cyclical note')
+    || vaultOverrideHasTag(product, normalized, 'cyclical note')
+  )
+}
+
 export type EulerLabelEntityVaultLike = {
   address?: string
   governorAdmin?: string


### PR DESCRIPTION
## Summary
- Move cyclical-note UI classification from raw IRM type to Euler label tags.
- Keep the cyclical IRM component using IRM data for fixed-rate and repayment-window rendering.
- Update warnings, badges, discovery labels, docs, and regression tests around the tag-based classifier.

## Stack
- Canonical merge and publish order: https://github.com/euler-xyz/euler-sdks/pull/55
- This PR targets `migration/labels-classification-tags` and merges into the Lite migration branch when included.

## Companion PRs
- SDK: https://github.com/euler-xyz/euler-sdks/pull/57
- Labels: https://github.com/euler-xyz/euler-labels/pull/643

## Tests
- `npm run test:run -- tests/utils/euler-labels-utils.test.ts tests/composables/useVaultWarnings.test.ts tests/composables/useVaultTypeBadges.test.ts tests/utils/vault/classification.test.ts`
- `npm run typecheck`
- `NUXT_IGNORE_LOCK=1 npm run build`
- Headless Chrome smoke on both KPK ETH Yield Term vault pages with `NUXT_PUBLIC_CONFIG_LABELS_BASE_URL=http://127.0.0.1:4317`
- `git diff --check`