### PR TITLE
Fix approval-only simulation gating

### DIFF
--- a/composables/useTransactionPlanSimulation.ts
+++ b/composables/useTransactionPlanSimulation.ts
@@ -1,5 +1,10 @@
 import type { SimulationStateOverrideOptions, TransactionPlan, TransactionPlanPrepared } from '@eulerxyz/euler-v2-sdk'
-import { formatSimulationFailure, getTxErrorMessage } from '~/utils/tx-errors'
+import {
+  formatSimulationFailure,
+  getTxErrorMessage,
+  isNonBlockingApprovalSimulationError,
+  isNonBlockingApprovalSimulationFailure,
+} from '~/utils/tx-errors'
 
 export const useTransactionPlanSimulation = () => {
   const { simulatePlan, simulatePreparedPlan } = useEulerTx()
@@ -10,7 +15,10 @@ export const useTransactionPlanSimulation = () => {
     simulationError.value = ''
   }
 
-  const handleResult = (result: Awaited<ReturnType<typeof simulatePlan>>) => {
+  const handleResult = (
+    plan: TransactionPlan | TransactionPlanPrepared,
+    result: Awaited<ReturnType<typeof simulatePlan>>,
+  ) => {
     // canExecute is false when EITHER the simulated batch reverted OR the
     // user is just missing approvals/balances (diagnostics). We only want to
     // block Review on real reverts — the modal handles approval prompts and
@@ -22,6 +30,7 @@ export const useTransactionPlanSimulation = () => {
         || !!result.vaultStatusErrors?.length
         || !!result.simulationError
     if (hasHardFailure) {
+      if (isNonBlockingApprovalSimulationFailure(plan, result)) return true
       simulationError.value = formatSimulationFailure(result)
       return false
     }
@@ -32,9 +41,10 @@ export const useTransactionPlanSimulation = () => {
     clearSimulationError()
     isSimulating.value = true
     try {
-      return handleResult(await simulatePlan(plan, stateOverrideOptions))
+      return handleResult(plan, await simulatePlan(plan, stateOverrideOptions))
     }
     catch (e) {
+      if (await isNonBlockingApprovalSimulationError(plan, e)) return true
       // Transport / wagmi / SDK-side errors (RPC down, signTypedData rejected, etc.)
       simulationError.value = await getTxErrorMessage(e)
       return false
@@ -48,9 +58,10 @@ export const useTransactionPlanSimulation = () => {
     clearSimulationError()
     isSimulating.value = true
     try {
-      return handleResult(await simulatePreparedPlan(prepared, stateOverrideOptions))
+      return handleResult(prepared, await simulatePreparedPlan(prepared, stateOverrideOptions))
     }
     catch (e) {
+      if (await isNonBlockingApprovalSimulationError(prepared, e)) return true
       simulationError.value = await getTxErrorMessage(e)
       return false
     }

--- a/tests/composables/useBorrowForm.test.ts
+++ b/tests/composables/useBorrowForm.test.ts
@@ -42,6 +42,7 @@ const { USER, SUB_ACCOUNT_A, SUB_ACCOUNT_B, VAULT, vault, planAccount, mocks } =
       preloadSubAccountSnapshot: vi.fn(),
       fetchSingleBalance: vi.fn(async () => 0n),
       runSimulation: vi.fn(),
+      modalOpen: vi.fn(),
     },
   }
 })
@@ -53,7 +54,7 @@ vi.mock('#components', () => ({
 
 vi.mock('~/components/ui/composables/useModal', () => ({
   useModal: () => ({
-    open: vi.fn(),
+    open: mocks.modalOpen,
     close: vi.fn(),
   }),
 }))
@@ -288,5 +289,19 @@ describe('useBorrowForm savings collateral', () => {
     expect(form.borrowActiveBalance.value).toBe(0n)
     expect(form.errorText.value).toBe('Savings position not found')
     expect(form.isSubmitDisabled.value).toBe(true)
+  })
+
+  it('opens the review modal after a non-blocking borrow simulation', async () => {
+    const positions = shallowRef<PortfolioSavingsPosition<VaultEntity>[]>([])
+    const form = makeForm(positions)
+    mocks.planBorrow.mockResolvedValue([{ type: 'requiredApproval' }, { type: 'evcBatch' }])
+    mocks.runSimulation.mockResolvedValue(true)
+
+    form.collateralAmount.value = '1'
+    form.borrowAmount.value = '1'
+    await form.submit()
+
+    expect(mocks.runSimulation).toHaveBeenCalled()
+    expect(mocks.modalOpen).toHaveBeenCalled()
   })
 })

--- a/tests/utils/tx-errors.test.ts
+++ b/tests/utils/tx-errors.test.ts
@@ -1,6 +1,13 @@
 import { afterEach, describe, it, expect } from 'vitest'
 import { ContractFunctionRevertedError, encodeAbiParameters, type Hex } from 'viem'
-import { formatSimulationFailure, getTxErrorCode, getTxErrorMessage, shouldDiscardQuoteOnEstimateGasError } from '~/utils/tx-errors'
+import {
+  formatSimulationFailure,
+  getTxErrorCode,
+  getTxErrorMessage,
+  isNonBlockingApprovalSimulationError,
+  isNonBlockingApprovalSimulationFailure,
+  shouldDiscardQuoteOnEstimateGasError,
+} from '~/utils/tx-errors'
 import { clearOperationMeta, setOperationMeta } from '~/utils/operationGuardRegistry'
 
 const buildRevertError = (raw: Hex) =>
@@ -102,6 +109,156 @@ describe('formatSimulationFailure: friendly message mapping', () => {
       }],
     } as never
     expect(formatSimulationFailure(result)).toContain('E_SomethingUnmapped()')
+  })
+})
+
+describe('isNonBlockingApprovalSimulationFailure', () => {
+  const decodedEntry = (signature: string) => ({ signature, params: [] })
+  const requiredApprovalPlan = [{
+    type: 'requiredApproval',
+    token: '0x1111111111111111111111111111111111111111',
+    owner: '0x2222222222222222222222222222222222222222',
+    spender: '0x3333333333333333333333333333333333333333',
+    amount: 1n,
+  }] as never
+  const batchOnlyPlan = [{ type: 'evcBatch', items: [] }] as never
+
+  it('does not block approval-like failed batch items when the plan has approvals', () => {
+    const result = {
+      failedBatchItems: [{
+        index: 0,
+        error: '0x',
+        decodedError: [decodedEntry('E_TransferFromFailed()')],
+      }],
+    } as never
+
+    expect(isNonBlockingApprovalSimulationFailure(requiredApprovalPlan, result)).toBe(true)
+  })
+
+  it('does not block approval-like simulation errors for prepared plans', () => {
+    const prepared = {
+      __prepared: true,
+      plan: requiredApprovalPlan,
+      chainId: 1,
+      account: '0x2222222222222222222222222222222222222222',
+      usePermit2: true,
+      unlimitedApproval: false,
+    } as never
+    const result = {
+      simulationError: {
+        error: new Error('reverted'),
+        decoded: [decodedEntry('ERC20InsufficientAllowance(address,address,uint256,uint256)')],
+      },
+    } as never
+
+    expect(isNonBlockingApprovalSimulationFailure(prepared, result)).toBe(true)
+  })
+
+  it('requires approval or insufficiency context', () => {
+    const result = {
+      failedBatchItems: [{
+        index: 0,
+        error: '0x',
+        decodedError: [decodedEntry('E_TransferFromFailed()')],
+      }],
+    } as never
+
+    expect(isNonBlockingApprovalSimulationFailure(batchOnlyPlan, result)).toBe(false)
+  })
+
+  it('uses insufficiency diagnostics as context for approval-like failures', () => {
+    const result = {
+      failedBatchItems: [{
+        index: 0,
+        error: '0x',
+        decodedError: [decodedEntry('SAFE_TRANSFER_FROM_FAILED()')],
+      }],
+      insufficientDirectAllowances: [{
+        token: '0x1111111111111111111111111111111111111111',
+        amount: 1n,
+      }],
+    } as never
+
+    expect(isNonBlockingApprovalSimulationFailure(batchOnlyPlan, result)).toBe(true)
+  })
+
+  it('does not let derived account status failures block approval-like failed batch items', () => {
+    const result = {
+      failedBatchItems: [{
+        index: 0,
+        error: '0x9773bb71',
+        decodedError: [
+          decodedEntry('E_TransferFromFailed(bytes,bytes)'),
+          decodedEntry('AllowanceExpired(uint256)'),
+          decodedEntry('Expired()'),
+          decodedEntry('ERC20InsufficientAllowance(address,uint256,uint256)'),
+        ],
+      }],
+      accountStatusErrors: [{
+        account: '0x2222222222222222222222222222222222222222',
+        decoded: [decodedEntry('E_AccountLiquidity()')],
+      }],
+      insufficientPermit2Allowances: [{
+        token: '0x1111111111111111111111111111111111111111',
+        amount: 1n,
+      }],
+      insufficientDirectAllowances: [{
+        token: '0x1111111111111111111111111111111111111111',
+        amount: 1n,
+      }],
+    } as never
+
+    expect(isNonBlockingApprovalSimulationFailure(requiredApprovalPlan, result)).toBe(true)
+  })
+
+  it('keeps account status failures blocking when there is no approval-like primary failure', () => {
+    const result = {
+      accountStatusErrors: [{
+        account: '0x2222222222222222222222222222222222222222',
+        decoded: [decodedEntry('E_AccountLiquidity()')],
+      }],
+    } as never
+
+    expect(isNonBlockingApprovalSimulationFailure(requiredApprovalPlan, result)).toBe(false)
+  })
+
+  it('keeps non-approval protocol errors blocking', () => {
+    const result = {
+      failedBatchItems: [{
+        index: 0,
+        error: '0x',
+        decodedError: [decodedEntry('E_AccountLiquidity()')],
+      }],
+    } as never
+
+    expect(isNonBlockingApprovalSimulationFailure(requiredApprovalPlan, result)).toBe(false)
+  })
+
+  it('does not block thrown approval-like simulation errors when the plan has approvals', async () => {
+    expect(
+      await isNonBlockingApprovalSimulationError(
+        requiredApprovalPlan,
+        new Error('execution reverted: E_TransferFromFailed'),
+      ),
+    ).toBe(true)
+  })
+
+  it('requires approval context for thrown approval-like simulation errors', async () => {
+    expect(
+      await isNonBlockingApprovalSimulationError(
+        batchOnlyPlan,
+        new Error('execution reverted: E_TransferFromFailed'),
+      ),
+    ).toBe(false)
+  })
+
+  it('keeps thrown non-approval protocol errors blocking', async () => {
+    expect(
+      await isNonBlockingApprovalSimulationError(
+        requiredApprovalPlan,
+        new Error('execution reverted: E_AccountLiquidity'),
+      ),
+    ).toBe(false)
   })
 })
 

--- a/utils/tx-errors.ts
+++ b/utils/tx-errors.ts
@@ -1,6 +1,13 @@
 import { BaseError, ContractFunctionRevertedError, decodeAbiParameters, formatUnits, type Hex } from 'viem'
 import { decodeSmartContractErrors } from '@eulerxyz/euler-v2-sdk'
-import type { DecodedSmartContractError, SimulateBatchResult, SimulationInsufficientRequirement, VaultEntity } from '@eulerxyz/euler-v2-sdk'
+import type {
+  DecodedSmartContractError,
+  SimulateBatchResult,
+  SimulationInsufficientRequirement,
+  TransactionPlan,
+  TransactionPlanPrepared,
+  VaultEntity,
+} from '@eulerxyz/euler-v2-sdk'
 import { ERROR_MESSAGE_MAP, ERROR_SIGNATURE_MAP } from '~/entities/constants'
 import { getOperationMeta } from '~/utils/operationGuardRegistry'
 import { getChainById } from '~/entities/chainRegistry'
@@ -161,6 +168,116 @@ const formatDecodedError = (decoded: DecodedSmartContractError): string => {
   const name = decoded.signature.split('(')[0] ?? decoded.signature
   if (!decoded.params.length) return `${name}()`
   return `${name}(${decoded.params.map(formatDecodedParam).join(', ')})`
+}
+
+const NON_BLOCKING_APPROVAL_SIMULATION_ERRORS = new Set([
+  '0x9773bb71',
+  'e_transferfromfailed',
+  'insufficient_allowance',
+  'e_insufficientallowance',
+  'erc20insufficientallowance',
+  'transferfromfailed',
+  'transfer_from_failed',
+  'transferfailed',
+  'transfer_failed',
+  'safetransferfailed',
+  'safe_transfer_failed',
+  'safetransferfromfailed',
+  'safe_transfer_from_failed',
+  'insufficient_balance',
+  'e_insufficientbalance',
+  'erc20insufficientbalance',
+])
+
+const BLOCKING_SIMULATION_ERROR_PREFIXES = [
+  'swapper_',
+  'swapverifier_',
+  'erc4626exceeded',
+]
+
+const BLOCKING_SIMULATION_ERRORS = new Set([
+  'e_accountliquidity',
+  'e_insufficientcash',
+  'e_notenoughliquidity',
+  'notenoughliquidity',
+  'slippageexceeded',
+])
+
+const decodedErrorName = (decoded: DecodedSmartContractError): string =>
+  (decoded.signature.split('(')[0] || decoded.signature).toLowerCase()
+
+const isBlockingSimulationErrorName = (name: string) =>
+  BLOCKING_SIMULATION_ERRORS.has(name)
+  || BLOCKING_SIMULATION_ERROR_PREFIXES.some(prefix => name.startsWith(prefix))
+
+const isApprovalLikeSimulationErrorName = (name: string) =>
+  NON_BLOCKING_APPROVAL_SIMULATION_ERRORS.has(name)
+  || name.includes('allowance')
+  || name.includes('transferfrom')
+
+const isNonBlockingApprovalErrorChain = (chain: readonly DecodedSmartContractError[]): boolean => {
+  if (!chain.length) return false
+  const names = chain.map(decodedErrorName)
+  return names.some(isApprovalLikeSimulationErrorName)
+    && !names.some(isBlockingSimulationErrorName)
+}
+
+const hasSimulationInsufficiencyDiagnostics = <T extends VaultEntity>(result: SimulateBatchResult<T>) =>
+  !!result.insufficientWalletAssets?.length
+  || !!result.insufficientPermit2Allowances?.length
+  || !!result.insufficientDirectAllowances?.length
+
+const planItems = (plan: TransactionPlan | TransactionPlanPrepared): TransactionPlan =>
+  Array.isArray(plan) ? plan : plan.plan
+
+const planHasRequiredApproval = (plan: TransactionPlan | TransactionPlanPrepared) =>
+  planItems(plan).some(item => item.type === 'requiredApproval')
+
+const errorSelector = (error: Hex | undefined): string | undefined =>
+  error?.slice(0, 10).toLowerCase()
+
+export const isNonBlockingApprovalSimulationFailure = <T extends VaultEntity>(
+  plan: TransactionPlan | TransactionPlanPrepared,
+  result: SimulateBatchResult<T>,
+): boolean => {
+  const failedBatchItems = result.failedBatchItems ?? []
+  const hasSimulationFailure = !!failedBatchItems.length || !!result.simulationError
+  if (!hasSimulationFailure) return false
+
+  const hasApprovalOrBalanceContext = planHasRequiredApproval(plan) || hasSimulationInsufficiencyDiagnostics(result)
+  if (!hasApprovalOrBalanceContext) return false
+
+  const failedItemsAreNonBlocking = failedBatchItems.every((item) => {
+    const selector = errorSelector(item.error)
+    return (selector !== undefined && NON_BLOCKING_APPROVAL_SIMULATION_ERRORS.has(selector))
+      || isNonBlockingApprovalErrorChain(item.decodedError)
+  })
+  const simulationErrorIsNonBlocking = result.simulationError
+    ? isNonBlockingApprovalErrorChain(result.simulationError.decoded)
+    : true
+
+  return failedItemsAreNonBlocking && simulationErrorIsNonBlocking
+}
+
+export const isNonBlockingApprovalSimulationError = async (
+  plan: TransactionPlan | TransactionPlanPrepared,
+  error: unknown,
+): Promise<boolean> => {
+  if (!planHasRequiredApproval(plan)) return false
+
+  const localCode = extractErrorCode(error)
+  if (localCode) {
+    const name = localCode.toLowerCase()
+    return isApprovalLikeSimulationErrorName(name) && !isBlockingSimulationErrorName(name)
+  }
+
+  try {
+    const decoded = await decodeSmartContractErrors(error)
+    return isNonBlockingApprovalErrorChain(decoded)
+  }
+  catch {
+    return false
+  }
 }
 
 // The SDK returns the decoded chain in nesting order (outer wrapper first,


### PR DESCRIPTION
## Summary
- Allow borrow/deposit review flows to continue when SDK state-override simulation hits approval-only token transfer failures.
- Preserve hard blocking for real protocol failures while matching the backup behavior for missing allowance override slots.

## Changes
- Classifies SDK `SimulateBatchResult` failures with approval-like failed batch items as non-blocking, including the TAC shape where the failed deposit also produces a derived account liquidity check.
- Applies the same policy to thrown simulation errors before surfacing user-facing transaction errors.
- Adds coverage for structured SDK results, thrown errors, and borrow form modal opening after a non-blocking simulation.

## Test plan
- [x] `npm run test:run -- tests/utils/tx-errors.test.ts tests/composables/useBorrowForm.test.ts`
- [x] `npx eslint utils/tx-errors.ts composables/useTransactionPlanSimulation.ts tests/utils/tx-errors.test.ts tests/composables/useBorrowForm.test.ts`
- [x] `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Transactions with non-blocking approval simulation failures now advance to review instead of blocking.
  * Improved error handling for approval-required transaction workflows to better distinguish between critical and non-critical failures.
  * Enhanced transaction simulation logic to support smoother approval flows across borrow and other transaction types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->