### PR TITLE
fix: wait for borrow pair market data

### DIFF
--- a/composables/useVaults.ts
+++ b/composables/useVaults.ts
@@ -974,9 +974,11 @@ const getBorrowVaultPair = async (
   const collateralAddr = getAddress(collateralAddress)
   const borrowAddr = getAddress(borrowAddress)
 
-  // Wait for escrow vaults to load before checking registry
-  if (!isEscrowLoadedOnce.value) {
-    await until(isEscrowLoadedOnce).toBe(true)
+  // Wait for snapshot enrichment / RPC refresh before resolving a one-time
+  // direct-route pair; otherwise the page can capture vault instances before
+  // rewards and market data have been populated.
+  if (!isMarketDataResolved.value) {
+    await until(isMarketDataResolved).toBe(true)
   }
 
   const borrowType = getType(borrowAddr)


### PR DESCRIPTION
## Summary
- Fix direct borrow deeplinks rendering reward-derived rates before vault market data finishes hydrating.
- Ensure one-time borrow pair resolution waits for the existing market-data-ready signal so the overview uses settled APY and ROE values.

## Changes
- Replace the escrow-only wait in getBorrowVaultPair with the stricter isMarketDataResolved gate.
- Preserve the existing fallback/fetch behavior after market data has settled.

## Test plan
- [x] npm run typecheck
- [x] npx eslint composables/useVaults.ts
- [x] Local browser: direct-load /borrow/0xCf4846E0d8A8667c516B844EB72A4d6e7430101D/0x2Ff596321782FE034102f55af5ad707A4Ce0d6a7?network=1 and verify Supply APY 3.44%, Net APY 0.34%, Max ROE 6.47%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where vault pair data could be displayed before market data and rewards information were fully loaded, ensuring all related fields are properly populated before rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->