### PR TITLE
docs: update SDK env docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,7 @@ DEV_GEO_COUNTRY=GB
 # Reown (AppKit) configuration
 # The NUXT_PUBLIC_ prefix is required so Nuxt can expose these to the client
 # as a build-time fallback. The server plugin also accepts the short names
-# (APPKIT_PROJECT_ID, APP_URL) for Doppler overrides at runtime.
+# (APPKIT_PROJECT_ID) for Doppler overrides at runtime.
 NUXT_PUBLIC_APP_KIT_PROJECT_ID=
 NUXT_PUBLIC_APP_URL=
 
@@ -44,7 +44,9 @@ TENDERLY_PROJECT_SLUG=
 
 # Chain configuration
 # Enabled chains are derived from RPC_URL_<chainId> env vars.
-# Each RPC URL also needs a matching NUXT_PUBLIC_SUBGRAPH_URI_<chainId>.
+# Each RPC URL also needs a matching SUBGRAPH_URL_<chainId> or
+# NUXT_PUBLIC_SUBGRAPH_URI_<chainId>. SUBGRAPH_URL_* is server-only and
+# preferred; NUXT_PUBLIC_SUBGRAPH_URI_* remains supported for existing deploys.
 # Any chain ID supported by @reown/appkit/networks works — no code changes needed.
 #
 # Deprecated chains (comma-separated chain IDs, e.g. "1,56,236")
@@ -125,19 +127,21 @@ NUXT_PUBLIC_CONFIG_ENABLE_FUUL="true"
 NUXT_PUBLIC_CONFIG_UNISWAP_TOKEN_LIST_URL="https://tokens.uniswap.org"
 NUXT_PUBLIC_CONFIG_DEFILLAMA_TOKEN_LIST_URL="https://d3g10bzo9rdluh.cloudfront.net"
 
-# Subgraph URIs per chain
-NUXT_PUBLIC_SUBGRAPH_URI_1="https://api.goldsky.com/api/public/project_cm4iagnemt1wp01xn4gh1agft/subgraphs/euler-simple-mainnet/latest/gn"
-NUXT_PUBLIC_SUBGRAPH_URI_130="https://api.goldsky.com/api/public/project_cm4iagnemt1wp01xn4gh1agft/subgraphs/euler-simple-unichain/latest/gn"
-NUXT_PUBLIC_SUBGRAPH_URI_143="https://api.goldsky.com/api/public/project_cm4iagnemt1wp01xn4gh1agft/subgraphs/euler-simple-monad/latest/gn"
-NUXT_PUBLIC_SUBGRAPH_URI_146="https://api.goldsky.com/api/public/project_cm4iagnemt1wp01xn4gh1agft/subgraphs/euler-simple-sonic/latest/gn"
-NUXT_PUBLIC_SUBGRAPH_URI_1923="https://api.goldsky.com/api/public/project_cm4iagnemt1wp01xn4gh1agft/subgraphs/euler-simple-swell/latest/gn"
-NUXT_PUBLIC_SUBGRAPH_URI_239="https://api.goldsky.com/api/public/project_cm4iagnemt1wp01xn4gh1agft/subgraphs/euler-simple-tac/latest/gn"
-NUXT_PUBLIC_SUBGRAPH_URI_42161="https://api.goldsky.com/api/public/project_cm4iagnemt1wp01xn4gh1agft/subgraphs/euler-simple-arbitrum/latest/gn"
-NUXT_PUBLIC_SUBGRAPH_URI_43114="https://api.goldsky.com/api/public/project_cm4iagnemt1wp01xn4gh1agft/subgraphs/euler-simple-avalanche/latest/gn"
-NUXT_PUBLIC_SUBGRAPH_URI_56="https://api.goldsky.com/api/public/project_cm4iagnemt1wp01xn4gh1agft/subgraphs/euler-simple-bsc/latest/gn"
-NUXT_PUBLIC_SUBGRAPH_URI_59144="https://api.goldsky.com/api/public/project_cm4iagnemt1wp01xn4gh1agft/subgraphs/euler-simple-linea/latest/gn"
-NUXT_PUBLIC_SUBGRAPH_URI_60808="https://api.goldsky.com/api/public/project_cm4iagnemt1wp01xn4gh1agft/subgraphs/euler-simple-bob/latest/gn"
-NUXT_PUBLIC_SUBGRAPH_URI_80094="https://api.goldsky.com/api/public/project_cm4iagnemt1wp01xn4gh1agft/subgraphs/euler-simple-berachain/latest/gn"
-NUXT_PUBLIC_SUBGRAPH_URI_8453="https://api.goldsky.com/api/public/project_cm4iagnemt1wp01xn4gh1agft/subgraphs/euler-simple-base/latest/gn"
-NUXT_PUBLIC_SUBGRAPH_URI_9745="https://api.goldsky.com/api/public/project_cm4iagnemt1wp01xn4gh1agft/subgraphs/euler-simple-plasma/latest/gn"
-NUXT_PUBLIC_SUBGRAPH_URI_999=https://api.goldsky.com/api/public/project_cm4iagnemt1wp01xn4gh1agft/subgraphs/euler-simple-hyperevm/1.0.2/gn
+# Subgraph URIs per chain. Existing deployments can keep using
+# NUXT_PUBLIC_SUBGRAPH_URI_<chainId>; new deployments should use
+# SUBGRAPH_URL_<chainId>.
+SUBGRAPH_URL_1="https://api.goldsky.com/api/public/project_cm4iagnemt1wp01xn4gh1agft/subgraphs/euler-simple-mainnet/latest/gn"
+SUBGRAPH_URL_130="https://api.goldsky.com/api/public/project_cm4iagnemt1wp01xn4gh1agft/subgraphs/euler-simple-unichain/latest/gn"
+SUBGRAPH_URL_143="https://api.goldsky.com/api/public/project_cm4iagnemt1wp01xn4gh1agft/subgraphs/euler-simple-monad/latest/gn"
+SUBGRAPH_URL_146="https://api.goldsky.com/api/public/project_cm4iagnemt1wp01xn4gh1agft/subgraphs/euler-simple-sonic/latest/gn"
+SUBGRAPH_URL_1923="https://api.goldsky.com/api/public/project_cm4iagnemt1wp01xn4gh1agft/subgraphs/euler-simple-swell/latest/gn"
+SUBGRAPH_URL_239="https://api.goldsky.com/api/public/project_cm4iagnemt1wp01xn4gh1agft/subgraphs/euler-simple-tac/latest/gn"
+SUBGRAPH_URL_42161="https://api.goldsky.com/api/public/project_cm4iagnemt1wp01xn4gh1agft/subgraphs/euler-simple-arbitrum/latest/gn"
+SUBGRAPH_URL_43114="https://api.goldsky.com/api/public/project_cm4iagnemt1wp01xn4gh1agft/subgraphs/euler-simple-avalanche/latest/gn"
+SUBGRAPH_URL_56="https://api.goldsky.com/api/public/project_cm4iagnemt1wp01xn4gh1agft/subgraphs/euler-simple-bsc/latest/gn"
+SUBGRAPH_URL_59144="https://api.goldsky.com/api/public/project_cm4iagnemt1wp01xn4gh1agft/subgraphs/euler-simple-linea/latest/gn"
+SUBGRAPH_URL_60808="https://api.goldsky.com/api/public/project_cm4iagnemt1wp01xn4gh1agft/subgraphs/euler-simple-bob/latest/gn"
+SUBGRAPH_URL_80094="https://api.goldsky.com/api/public/project_cm4iagnemt1wp01xn4gh1agft/subgraphs/euler-simple-berachain/latest/gn"
+SUBGRAPH_URL_8453="https://api.goldsky.com/api/public/project_cm4iagnemt1wp01xn4gh1agft/subgraphs/euler-simple-base/latest/gn"
+SUBGRAPH_URL_9745="https://api.goldsky.com/api/public/project_cm4iagnemt1wp01xn4gh1agft/subgraphs/euler-simple-plasma/latest/gn"
+SUBGRAPH_URL_999=https://api.goldsky.com/api/public/project_cm4iagnemt1wp01xn4gh1agft/subgraphs/euler-simple-hyperevm/1.0.2/gn

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ cp .env.example .env
 | `APPKIT_PROJECT_ID` or `NUXT_PUBLIC_APP_KIT_PROJECT_ID` | Reown (WalletConnect) project ID                |
 | `NUXT_PUBLIC_APP_URL`                | Your app's public URL                                       |
 | `RPC_URL_<chainId>`                  | RPC endpoint per chain (e.g. `RPC_URL_1` for Ethereum)      |
-| `NUXT_PUBLIC_SUBGRAPH_URI_<chainId>` | Subgraph URI per chain                                      |
+| `SUBGRAPH_URL_<chainId>` or `NUXT_PUBLIC_SUBGRAPH_URI_<chainId>` | Subgraph URI per chain. `SUBGRAPH_URL_*` is server-only and preferred; `NUXT_PUBLIC_SUBGRAPH_URI_*` remains supported for existing deployments. |
 
 #### API URLs
 
@@ -52,7 +52,34 @@ cp .env.example .env
 | `SWAP_API_URL` or `NUXT_PUBLIC_SWAP_API_URL` | —           | Euler swap API                        |
 | `PYTH_HERMES_URL` or `NUXT_PUBLIC_PYTH_HERMES_URL` | `https://hermes.pyth.network` | Pyth oracle endpoint (proxied via `/api/pyth/updates`) |
 
-> **Doppler compatibility:** If your secret manager injects `NUXT_PUBLIC_*` prefixed URL names (e.g. `NUXT_PUBLIC_V3_API_URL`), the server accepts those forms automatically. V3 API keys should use server-side names such as `EULER_SDK_V3_API_KEY`.
+> **Doppler compatibility:** If your secret manager injects prefixed URL names, the server also accepts `EULER_SDK_V3_API_URL` and `NUXT_PUBLIC_V3_API_URL`. V3 API keys should use server-side names such as `EULER_SDK_V3_API_KEY`.
+
+#### SDK Data Source Controls
+
+Euler Lite uses the [Euler V2 SDK](https://github.com/euler-xyz/euler-sdks) for vault reads, portfolio data, prices, rewards, and transaction plans. These controls select which SDK adapter path is used for cached browsing reads and the server-side vault snapshot:
+
+| Variable | Default | Description |
+| -------- | ------- | ----------- |
+| `SERVER_VAULT_CACHE_SOURCE` | `fallback` | Server snapshot builder adapter chain: `fallback`, `onchain`, or `v3`. |
+| `NUXT_PUBLIC_BROWSER_VAULT_SOURCE` | `fallback` | Browser "fast" SDK adapter chain: `fallback`, `onchain`, or `v3`. The plan-time SDK is always on-chain. |
+| `DISABLE_SERVER_VAULT_CACHE` | `false` | Set to `true` to disable `/api/vaults` snapshots and let the browser fall through to the normal RPC pipeline. |
+| `DEPRECATED_CHAINS` | — | Comma-separated chain IDs shown collapsed in the chain selector and skipped by startup warm-cache cycles. |
+
+`fallback` uses V3 first and on-chain reads second. If no V3 URL is configured, Lite passes `disableV3: true` to the SDK so fallback reads go straight on-chain.
+
+#### Optional Server Controls
+
+| Variable | Description |
+| -------- | ----------- |
+| `CORS_ALLOWED_ORIGINS` | Comma-separated allowlist for `/api/*`; falls back to `NUXT_PUBLIC_APP_URL`. |
+| `CSP_EXTRA_CONNECT_SRC` | Extra `connect-src` origins for development or staging endpoints. |
+| `DEV_GEO_COUNTRY` | Local/preview country fallback when Cloudflare geo headers are absent. Do not set in production behind Cloudflare. |
+| `WALLET_SCREENING_URI` | Optional server-side wallet screening endpoint proxied by `/api/screen-address`. |
+| `STABLEWATCH_API_KEY` | Optional server-side Stablewatch key for intrinsic APY data. |
+| `TENDERLY_ACCESS_KEY`, `TENDERLY_ACCOUNT_SLUG`, `TENDERLY_PROJECT_SLUG` | Optional Tenderly simulation configuration. |
+| `FUUL_API_URL` or `NUXT_PUBLIC_FUUL_API_URL` | Optional Fuul API upstream override. |
+| `INCENTRA_API_URL` or `NUXT_PUBLIC_INCENTRA_API_URL` | Optional Incentra/Brevis API upstream override. |
+| `SENTRY_AUTH_TOKEN` | Build-time sourcemap upload token; do not set at runtime. |
 
 #### Branding & Feature Flags
 
@@ -100,14 +127,14 @@ Chains are configured dynamically at runtime. Each chain requires two env vars:
 ```bash
 # Ethereum Mainnet
 RPC_URL_1=https://your-rpc-endpoint.com
-NUXT_PUBLIC_SUBGRAPH_URI_1=https://api.goldsky.com/.../euler-simple-mainnet/latest/gn
+SUBGRAPH_URL_1=https://api.goldsky.com/.../euler-simple-mainnet/latest/gn
 
 # Arbitrum
 RPC_URL_42161=https://your-arbitrum-rpc.com
-NUXT_PUBLIC_SUBGRAPH_URI_42161=https://api.goldsky.com/.../euler-simple-arbitrum/latest/gn
+SUBGRAPH_URL_42161=https://api.goldsky.com/.../euler-simple-arbitrum/latest/gn
 ```
 
-The app scans for `RPC_URL_<chainId>` env vars at server startup and automatically enables those chains. No code changes needed to add or remove chains.
+The app scans for `RPC_URL_<chainId>` env vars at server startup and automatically enables those chains. The SDK subgraph adapters call the same-origin `/api/proxy/subgraph/<chainId>` route, which resolves `SUBGRAPH_URL_<chainId>` first and `NUXT_PUBLIC_SUBGRAPH_URI_<chainId>` second. No code changes needed to add or remove chains.
 
 #### Base App In-App Browser
 
@@ -117,7 +144,7 @@ To make Base mainnet available in that environment, configure the same runtime c
 
 ```bash
 RPC_URL_8453=https://your-base-rpc.com
-NUXT_PUBLIC_SUBGRAPH_URI_8453=https://api.goldsky.com/.../euler-simple-base/latest/gn
+SUBGRAPH_URL_8453=https://api.goldsky.com/.../euler-simple-base/latest/gn
 ```
 
 ### 3. Customize Your Instance
@@ -245,7 +272,7 @@ docker run -p 3000:3000 \
   -e SWAP_API_URL=https://swap.euler.finance \
   -e APPKIT_PROJECT_ID=your-project-id \
   -e RPC_URL_1=https://your-rpc.com \
-  -e NUXT_PUBLIC_SUBGRAPH_URI_1=https://your-subgraph.com \
+  -e SUBGRAPH_URL_1=https://your-subgraph.com \
   euler-lite node .output/server/index.mjs
 ```
 
@@ -305,7 +332,7 @@ Before deploying:
 - [ ] Copied `.env.example` to `.env` and filled in values
 - [ ] Set `APPKIT_PROJECT_ID` and `NUXT_PUBLIC_APP_URL`
 - [ ] Set `V3_API_URL`, optional `EULER_SDK_V3_API_KEY`, and `SWAP_API_URL`
-- [ ] Added at least one `RPC_URL_<chainId>` with matching `NUXT_PUBLIC_SUBGRAPH_URI_<chainId>`
+- [ ] Added at least one `RPC_URL_<chainId>` with matching `SUBGRAPH_URL_<chainId>` or `NUXT_PUBLIC_SUBGRAPH_URI_<chainId>`
 - [ ] Configured branding via `NUXT_PUBLIC_CONFIG_*` env vars (title, description, logo, social links, social share image)
 - [ ] Customized theme colors in `assets/styles/variables.scss` (THEME CONFIGURATION section)
 - [ ] Replaced favicon files in `public/favicons/`
@@ -332,7 +359,7 @@ Before deploying:
 ### No Chains Available
 
 - Ensure at least one `RPC_URL_<chainId>` env var is set
-- Each chain needs a matching `NUXT_PUBLIC_SUBGRAPH_URI_<chainId>`
+- Each chain needs a matching `SUBGRAPH_URL_<chainId>` or `NUXT_PUBLIC_SUBGRAPH_URI_<chainId>`
 
 ## Additional Resources
 

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -132,7 +132,7 @@ The `/api/pyth/updates` endpoint proxies Pyth Hermes price update requests throu
 ## Troubleshooting
 
 - If the app fails to start, ensure Node 24+ and reinstall deps.
-- If blockchain calls fail, verify `RPC_URL_<chainId>` env vars and check that matching `NUXT_PUBLIC_SUBGRAPH_URI_<chainId>` is set.
+- If blockchain calls fail, verify `RPC_URL_<chainId>` env vars and check that matching `SUBGRAPH_URL_<chainId>` or `NUXT_PUBLIC_SUBGRAPH_URI_<chainId>` is set.
 - If token logos don't load, verify `V3_API_URL` (or `EULER_SDK_V3_API_URL` / `NUXT_PUBLIC_V3_API_URL`) and, when required by the upstream, `EULER_SDK_V3_API_KEY`. Token data is fetched server-side via `/api/token-list` which aggregates Euler V3, Uniswap, DefiLlama, and Merkl sources with fallback.
 
 ---

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -100,7 +100,7 @@ SWAP_API_URL=https://swap.euler.finance
 
 # Chain RPC endpoints (one per chain you want to enable)
 RPC_URL_1=https://your-ethereum-rpc.com
-NUXT_PUBLIC_SUBGRAPH_URI_1=https://your-subgraph.com
+SUBGRAPH_URL_1=https://your-subgraph.com
 ```
 
 ## Key External Services
@@ -127,7 +127,7 @@ NUXT_PUBLIC_SUBGRAPH_URI_1=https://your-subgraph.com
 
 - **Purpose**: Incentive campaign distribution
 - **Integration**: API for incentive campaigns
-- **Data Source**: Campaign APR data (claiming not yet available)
+- **Data Source**: Campaign APR data and claimable rewards
 
 ## 🆘 Common Issues
 
@@ -140,7 +140,7 @@ NUXT_PUBLIC_SUBGRAPH_URI_1=https://your-subgraph.com
 ### Blockchain Connection Issues
 
 - Verify `RPC_URL_<chainId>` env vars are set correctly
-- Ensure matching `NUXT_PUBLIC_SUBGRAPH_URI_<chainId>` exists for each chain
+- Ensure matching `SUBGRAPH_URL_<chainId>` or `NUXT_PUBLIC_SUBGRAPH_URI_<chainId>` exists for each chain
 - Ensure RPC endpoints are accessible
 
 ### Wallet Connection Problems


### PR DESCRIPTION
## Summary
- Refresh the SDK and environment documentation so operators see the current Lite runtime contract.
- Point readers to the Euler V2 SDK repo from the SDK data source section.
- Remove stale Fuul claiming wording and prefer server-only subgraph env names while preserving compatibility notes.

## Changes
- Document SDK data source controls for server snapshots and the browser fast SDK.
- Update README, getting started, and development troubleshooting examples to use SUBGRAPH_URL_<chainId> with NUXT_PUBLIC_SUBGRAPH_URI_<chainId> as a supported fallback.
- Refresh .env.example comments and subgraph sample keys to match the server-side proxy resolution order.

## Test plan
- [x] git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration guidance for blockchain subgraph endpoints, prioritizing server-side setup for new deployments.
  * Enhanced blockchain connection troubleshooting and setup documentation.
  * Clarified reward data availability descriptions across deployment guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->