### PR TITLE
Fix CoW swap quote ordering

### DIFF
--- a/components/entities/swap/SwapRouteSelector.vue
+++ b/components/entities/swap/SwapRouteSelector.vue
@@ -1,23 +1,10 @@
 <script setup lang="ts">
-type SwapRouteBadgeTone = 'best' | 'worse'
-
-type SwapRouteItem = {
-  provider: string
-  amount: string
-  symbol: string
-  gasCostLabel?: string
-  netUsdLabel?: string
-  routeLabel?: string
-  isGasless?: boolean
-  badge?: {
-    label: string
-    tone: SwapRouteBadgeTone
-  }
-}
-
-const VISIBLE_COUNT = 3
-
-const isGaslessItem = (item: SwapRouteItem) => !!item.isGasless
+import type { SwapRouteItem } from '~/utils/swapRouteItems'
+import {
+  getVisibleSwapRouteItems,
+  isGaslessSwapRouteItem as isGaslessItem,
+  SWAP_ROUTE_VISIBLE_COUNT,
+} from '~/utils/swapRouteVisibility'
 
 const props = withDefaults(defineProps<{
   title?: string
@@ -41,23 +28,12 @@ const emit = defineEmits<{
 
 const expanded = ref(false)
 
-const hasMore = computed(() => props.items.length > VISIBLE_COUNT)
-const visibleItems = computed(() => {
-  if (expanded.value) return props.items
-
-  const top = props.items.slice(0, VISIBLE_COUNT)
-  // If a gasless (CoW) route exists but is below the visible cutoff, always
-  // surface it in the collapsed view so users see the gasless option without
-  // expanding the list.
-  if (top.some(isGaslessItem)) return top
-
-  const cow = props.items.find(isGaslessItem)
-  if (!cow) return top
-
-  return top.length >= VISIBLE_COUNT
-    ? [...top.slice(0, VISIBLE_COUNT - 1), cow]
-    : [...top, cow]
-})
+const hasMore = computed(() => props.items.length > SWAP_ROUTE_VISIBLE_COUNT)
+const visibleItems = computed(() => getVisibleSwapRouteItems(props.items, {
+  expanded: expanded.value,
+  promoteGasless: true,
+  visibleCount: SWAP_ROUTE_VISIBLE_COUNT,
+}))
 
 const onSelect = (provider: string) => {
   emit('select', provider)

--- a/composables/useSwapQuotesParallel.ts
+++ b/composables/useSwapQuotesParallel.ts
@@ -282,20 +282,21 @@ export const useSwapQuotesParallel = (options: SwapQuotesParallelOptions) => {
     client: PublicClient | null,
     gasPricePromise: Promise<bigint | undefined>,
   ): Promise<SwapQuoteCard | null> => {
+    const amountUsdPromise = getAmountUsd(quote).catch(() => undefined)
+
     // CoW intents settle off-chain — gas cost is genuinely zero from the
     // user's perspective. Mark the card so the route selector renders
-    // "Gasless". Do not block route visibility on auxiliary USD pricing.
+    // "Gasless".
     if (isCowProviderOrQuote(provider, quote)) {
       return {
         provider,
         quote,
+        amountUsd: await amountUsdPromise,
         gasCostNative: 0n,
         gasCostUsd: 0,
         isGasless: true,
       }
     }
-
-    const amountUsdPromise = getAmountUsd(quote).catch(() => undefined)
 
     if (!client || !options.buildTxPlanForQuote) {
       return { provider, quote, amountUsd: await amountUsdPromise }

--- a/tests/composables/useSwapQuotesParallel.test.ts
+++ b/tests/composables/useSwapQuotesParallel.test.ts
@@ -3,8 +3,26 @@ import { computed, nextTick, ref, watch } from 'vue'
 import { SwapperMode, type SwapQuote } from '@eulerxyz/euler-v2-sdk'
 import { useSwapQuotesParallel } from '~/composables/useSwapQuotesParallel'
 
+const { getTokenUsdValueMock } = vi.hoisted(() => ({
+  getTokenUsdValueMock: vi.fn(),
+}))
+
+vi.mock('~/utils/sdk-prices', () => ({
+  getTokenUsdValue: getTokenUsdValueMock,
+}))
+
 const makeQuote = (amountIn: string, amountOut: string): SwapQuote =>
   ({ amountIn, amountOut }) as SwapQuote
+
+const makeUsdcOutQuote = (amountOut: string): SwapQuote =>
+  ({
+    amountIn: '100',
+    amountOut,
+    tokenOut: {
+      address: '0x0000000000000000000000000000000000000002',
+      decimals: 6,
+    },
+  }) as unknown as SwapQuote
 
 const requestParams = {
   tokenIn: '0x0000000000000000000000000000000000000001',
@@ -30,6 +48,10 @@ describe('useSwapQuotesParallel', () => {
   beforeEach(() => {
     getSwapProviders = vi.fn()
     getSwapQuotes = vi.fn()
+    getTokenUsdValueMock.mockReset()
+    getTokenUsdValueMock.mockImplementation(async (amount: bigint, decimals: number) =>
+      Number(amount) / 10 ** decimals,
+    )
 
     vi.stubGlobal('ref', ref)
     vi.stubGlobal('computed', computed)
@@ -134,6 +156,28 @@ describe('useSwapQuotesParallel', () => {
       accountOut: requestParams.accountOut,
     })
     expect(otherCall.providerExtraData).toBeUndefined()
+  })
+
+  it('scores CoW quotes with zero gas instead of pushing them behind priced routes', async () => {
+    const cowQuote = makeUsdcOutQuote('213000000000')
+    const otherQuote = makeUsdcOutQuote('212900000000')
+    getSwapProviders.mockResolvedValue(['other', 'cow'])
+    getSwapQuotes.mockImplementation(({ provider }: { provider: string }) =>
+      Promise.resolve([provider === 'cow' ? cowQuote : otherQuote]),
+    )
+
+    const quotes = useSwapQuotesParallel({ amountField: 'amountOut', compare: 'max', includeCowSwap: true })
+    await quotes.requestQuotes(requestParams)
+    await flushPromises()
+    await nextTick()
+
+    expect(quotes.sortedQuoteCards.value[0]).toMatchObject({
+      provider: 'cow',
+      amountUsd: 213000,
+      gasCostUsd: 0,
+      isGasless: true,
+    })
+    expect(quotes.sortedQuoteCards.value[1].provider).toBe('other')
   })
 
   it('evaluates callable includeCowSwap for each quote request', async () => {

--- a/tests/utils/swap-route-visibility.test.ts
+++ b/tests/utils/swap-route-visibility.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { getVisibleSwapRouteItems } from '~/utils/swapRouteVisibility'
+import type { SwapRouteItem } from '~/utils/swapRouteItems'
+
+const makeItem = (provider: string, isGasless = false): SwapRouteItem => ({
+  provider,
+  amount: '1',
+  symbol: 'ETH',
+  isGasless,
+})
+
+const providers = (items: SwapRouteItem[]) => items.map(item => item.provider)
+
+describe('getVisibleSwapRouteItems', () => {
+  const items = [
+    makeItem('best'),
+    makeItem('second'),
+    makeItem('third'),
+    makeItem('cow', true),
+    makeItem('fifth'),
+  ]
+
+  it('keeps sorted collapsed order when gasless promotion is disabled', () => {
+    expect(providers(getVisibleSwapRouteItems(items, {
+      expanded: false,
+      promoteGasless: false,
+    }))).toEqual(['best', 'second', 'third'])
+  })
+
+  it('promotes a below-cutoff gasless route to the third collapsed slot when enabled', () => {
+    expect(providers(getVisibleSwapRouteItems(items, {
+      expanded: false,
+      promoteGasless: true,
+    }))).toEqual(['best', 'second', 'cow'])
+  })
+
+  it('keeps a gasless route in its sorted position when it is already visible', () => {
+    const alreadyVisible = [
+      makeItem('best'),
+      makeItem('cow', true),
+      makeItem('third'),
+      makeItem('fourth'),
+    ]
+
+    expect(providers(getVisibleSwapRouteItems(alreadyVisible, {
+      expanded: false,
+      promoteGasless: true,
+    }))).toEqual(['best', 'cow', 'third'])
+  })
+
+  it('keeps full sorted order when expanded', () => {
+    expect(providers(getVisibleSwapRouteItems(items, {
+      expanded: true,
+      promoteGasless: true,
+    }))).toEqual(['best', 'second', 'third', 'cow', 'fifth'])
+  })
+})

--- a/utils/swapRouteVisibility.ts
+++ b/utils/swapRouteVisibility.ts
@@ -1,0 +1,27 @@
+import type { SwapRouteItem } from '~/utils/swapRouteItems'
+
+export const SWAP_ROUTE_VISIBLE_COUNT = 3
+
+export const isGaslessSwapRouteItem = (item: Pick<SwapRouteItem, 'isGasless'>) => !!item.isGasless
+
+export const getVisibleSwapRouteItems = (
+  items: SwapRouteItem[],
+  options: {
+    expanded: boolean
+    promoteGasless: boolean
+    visibleCount?: number
+  },
+) => {
+  const visibleCount = options.visibleCount ?? SWAP_ROUTE_VISIBLE_COUNT
+  if (options.expanded) return items
+
+  const top = items.slice(0, visibleCount)
+  if (!options.promoteGasless || top.some(isGaslessSwapRouteItem)) return top
+
+  const gasless = items.find(isGaslessSwapRouteItem)
+  if (!gasless) return top
+
+  return top.length >= visibleCount
+    ? [...top.slice(0, visibleCount - 1), gasless]
+    : [...top, gasless]
+}


### PR DESCRIPTION
## Summary
- Score CoW quotes with zero gas so they sort by net USD alongside other routes.
- Keep CoW visible in the collapsed three-route list while preserving score-sorted order in the expanded list.

## Changes
- Compute `amountUsd` for CoW quote cards before returning the gasless card with `gasCostUsd: 0`.
- Move collapsed route visibility into a pure helper so collapsed and expanded behavior are explicit.
- Add coverage for CoW quote scoring and route visibility ordering.

## Test plan
- [x] `npm run test:run -- tests/composables/useSwapQuotesParallel.test.ts tests/utils/swap-route-visibility.test.ts tests/utils/swap-quotes.test.ts`
- [x] `npx eslint components/entities/swap/SwapRouteSelector.vue composables/useSwapQuotesParallel.ts utils/swapRouteVisibility.ts tests/composables/useSwapQuotesParallel.test.ts tests/utils/swap-route-visibility.test.ts`
- [x] Manual localhost check on the reported borrow/multiply route with 100000 USDC supply and 3.13x multiplier: collapsed list shows CoW in slot 3; expanded list keeps CoW in score-sorted order.
- [ ] `npm run typecheck` is currently blocked by existing unrelated errors in `tests/utils/euler-labels-utils.test.ts:165` and `utils/sdk-query-policy.ts:76`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Gas-free swap options now display complete pricing information including USD amounts previously missing from quotes.

* **Improvements**
  * Enhanced swap route visibility logic to better promote and prioritize gas-free options in collapsed swap route lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->