### PR TITLE
feat: gate Max ROE by token category

### DIFF
--- a/components/entities/portfolio/PortfolioBorrowItem.vue
+++ b/components/entities/portfolio/PortfolioBorrowItem.vue
@@ -24,6 +24,7 @@ import { nanoToValue, roundAndCompactTokens } from '~/utils/crypto-utils'
 import { useEulerProductOfVault } from '~/composables/useEulerLabels'
 import { withVaultIntrinsicApy, getVaultIntrinsicApy } from '~/utils/vault-intrinsic-apy'
 import { getBorrowPositionEffectiveLiquidationLTV, getBorrowPositionUserLTVPercent } from '~/utils/ltv'
+import { areTokenAddressesCorrelatedByTags } from '~/utils/token-categories'
 
 const { position } = defineProps<{ position: PortfolioBorrowPosition<VaultEntity> }>()
 const { getVaultCategory, isVerifiedVault } = useVaultRegistry()
@@ -41,6 +42,7 @@ const { settings } = useUserSettings()
 const enableIntrinsicApy = computed(() => settings.value.enableIntrinsicApy)
 const { getSupplyRewardApy, getBorrowRewardApy, getEligibleLoopingRewardApy, getSupplyRewardCampaigns, getBorrowRewardCampaigns, getLoopingRewardCampaigns, hasSupplyRewards, hasBorrowRewards, isLoopingEligible } = useRewardsApy()
 const { viewer, visibleBreakdown, visibleTotal } = useApyVisibility()
+const { getTokenCategoryTags } = useTokenList()
 
 const borrowVault = computed(() => position.borrowVault as EVault)
 const collateralVault = computed(() => position.collateralVault as EVault | SecuritizeCollateralVault)
@@ -179,6 +181,17 @@ const hasRewards = computed(() =>
   || hasBorrowRewards(borrowVault.value.address || '', collateralVault.value.address || '')
   || loopingEligible.value,
 )
+const isRoeApplicable = computed(() => {
+  const collaterals = collateralItems.value.map(item => item.vault)
+  if (!collaterals.length || !borrowVault.value) return false
+  return collaterals.every(collateral =>
+    areTokenAddressesCorrelatedByTags(
+      collateral.asset.address,
+      borrowVault.value.asset.address,
+      getTokenCategoryTags,
+    ),
+  )
+})
 const collateralSupplyApy = computed(() => {
   return withVaultIntrinsicApy(
     getVaultSupplyApy(collateralVault.value),
@@ -415,7 +428,10 @@ const openPositionInformationModal = () => {
                 {{ netAPY !== undefined && Number.isFinite(netAPY) ? `${formatNumber(netAPY)}%` : '-' }}
               </div>
             </div>
-            <div class="flex flex-col items-end">
+            <div
+              v-if="isRoeApplicable"
+              class="flex flex-col items-end"
+            >
               <div class="text-content-tertiary text-p3 mb-4 flex items-center gap-4">
                 ROE
                 <UiModalPreviewTrigger

--- a/components/entities/portfolio/PortfolioBorrowItem.vue
+++ b/components/entities/portfolio/PortfolioBorrowItem.vue
@@ -24,7 +24,7 @@ import { nanoToValue, roundAndCompactTokens } from '~/utils/crypto-utils'
 import { useEulerProductOfVault } from '~/composables/useEulerLabels'
 import { withVaultIntrinsicApy, getVaultIntrinsicApy } from '~/utils/vault-intrinsic-apy'
 import { getBorrowPositionEffectiveLiquidationLTV, getBorrowPositionUserLTVPercent } from '~/utils/ltv'
-import { areTokenAddressesCorrelatedByTags } from '~/utils/token-categories'
+import { areRoeCollateralVaultsCorrelatedWithBorrow } from '~/utils/position-roe'
 
 const { position } = defineProps<{ position: PortfolioBorrowPosition<VaultEntity> }>()
 const { getVaultCategory, isVerifiedVault } = useVaultRegistry()
@@ -184,13 +184,8 @@ const hasRewards = computed(() =>
 const isRoeApplicable = computed(() => {
   const collaterals = collateralItems.value.map(item => item.vault)
   if (!collaterals.length || !borrowVault.value) return false
-  return collaterals.every(collateral =>
-    areTokenAddressesCorrelatedByTags(
-      collateral.asset.address,
-      borrowVault.value.asset.address,
-      getTokenCategoryTags,
-    ),
-  )
+  if (collateralAddresses.value.length > collaterals.length) return false
+  return areRoeCollateralVaultsCorrelatedWithBorrow(collaterals, borrowVault.value, getTokenCategoryTags)
 })
 const collateralSupplyApy = computed(() => {
   return withVaultIntrinsicApy(
@@ -391,12 +386,19 @@ const openPositionInformationModal = () => {
               :data-value="pairSymbols"
             >
               <span class="truncate">{{ pairSymbols }}</span>
-              <CorrelatedPairBadge
-                v-if="isRoeApplicable"
-                compact
-                :label="actualMultiplierDisplay"
-                title="Correlated position. Effective multiplier at your LTV."
-              />
+              <span class="inline-flex items-center gap-4">
+                <CorrelatedPairBadge
+                  v-if="isRoeApplicable"
+                  compact
+                  title="Correlated position."
+                />
+                <CorrelatedPairBadge
+                  v-if="isRoeApplicable && actualMultiplierDisplay !== '-'"
+                  compact
+                  :label="actualMultiplierDisplay"
+                  title="Effective multiplier at your LTV."
+                />
+              </span>
             </div>
           </div>
           <div class="flex gap-16 items-start shrink-0">

--- a/components/entities/portfolio/PortfolioBorrowItem.vue
+++ b/components/entities/portfolio/PortfolioBorrowItem.vue
@@ -25,6 +25,7 @@ import { useEulerProductOfVault } from '~/composables/useEulerLabels'
 import { withVaultIntrinsicApy, getVaultIntrinsicApy } from '~/utils/vault-intrinsic-apy'
 import { getBorrowPositionEffectiveLiquidationLTV, getBorrowPositionUserLTVPercent } from '~/utils/ltv'
 import { areRoeCollateralVaultsCorrelatedWithBorrow } from '~/utils/position-roe'
+import { getTokenAddressesCorrelationCategoryLabel } from '~/utils/token-categories'
 
 const { position } = defineProps<{ position: PortfolioBorrowPosition<VaultEntity> }>()
 const { getVaultCategory, isVerifiedVault } = useVaultRegistry()
@@ -191,6 +192,16 @@ const isRoeApplicable = computed(() => {
   if (!collaterals.length || !borrowVault.value) return false
   if (collateralAddresses.value.length > collaterals.length) return false
   return areRoeCollateralVaultsCorrelatedWithBorrow(collaterals, borrowVault.value, getTokenCategoryTags)
+})
+const correlatedBadgeTitle = computed(() => {
+  const category = getTokenAddressesCorrelationCategoryLabel(
+    [
+      ...collateralItems.value.map(item => item.vault.asset.address),
+      borrowVault.value.asset.address,
+    ],
+    getTokenCategoryTags,
+  )
+  return category ? `Correlated category: ${category}` : undefined
 })
 const collateralSupplyApy = computed(() => {
   return withVaultIntrinsicApy(
@@ -394,7 +405,7 @@ const openPositionInformationModal = () => {
                 <CorrelatedPairBadge
                   v-if="isRoeApplicable"
                   compact
-                  title="Correlated position."
+                  :title="correlatedBadgeTitle"
                 />
                 <CorrelatedPairBadge
                   v-if="isRoeApplicable && actualMultiplierDisplay !== '-'"

--- a/components/entities/portfolio/PortfolioBorrowItem.vue
+++ b/components/entities/portfolio/PortfolioBorrowItem.vue
@@ -265,6 +265,9 @@ const userLTVDisplay = computed(() => {
   return Number.isFinite(userLTV.value) ? formatNumber(userLTV.value, 2) : '∞'
 })
 const actualMultiplier = computed(() => position.multiplier ?? 0)
+const actualMultiplierDisplay = computed(() =>
+  Number.isFinite(actualMultiplier.value) ? `${formatNumber(actualMultiplier.value, 2, 2)}x` : '-',
+)
 
 const netApyModalData = computed(() => ({
   props: {
@@ -391,7 +394,8 @@ const openPositionInformationModal = () => {
               <CorrelatedPairBadge
                 v-if="isRoeApplicable"
                 compact
-                title="All collateral assets in this position share a trusted price-correlation category with the borrow asset, so ROE is shown."
+                :label="actualMultiplierDisplay"
+                title="Correlated position. Effective multiplier at your LTV."
               />
             </div>
           </div>

--- a/components/entities/portfolio/PortfolioBorrowItem.vue
+++ b/components/entities/portfolio/PortfolioBorrowItem.vue
@@ -325,6 +325,7 @@ const openPositionInformationModal = () => {
     :data-sub-account="position.subAccount.toLowerCase()"
     :data-collateral-address="primaryCollateralAddress.toLowerCase()"
     :data-borrow-address="borrowAddress.toLowerCase()"
+    :data-correlated="isRoeApplicable"
   >
     <div class="flex py-16 px-16 pb-12 border-b border-line-default">
       <div
@@ -380,13 +381,18 @@ const openPositionInformationModal = () => {
               </span>
             </div>
             <div
-              class="text-h5 text-content-primary truncate"
+              class="text-h5 text-content-primary flex items-center gap-8 min-w-0"
               data-id="data-point"
               :data-key="positionKey"
               data-field="asset-symbols"
               :data-value="pairSymbols"
             >
-              {{ pairSymbols }}
+              <span class="truncate">{{ pairSymbols }}</span>
+              <CorrelatedPairBadge
+                v-if="isRoeApplicable"
+                compact
+                title="All collateral assets in this position share a trusted price-correlation category with the borrow asset, so ROE is shown."
+              />
             </div>
           </div>
           <div class="flex gap-16 items-start shrink-0">

--- a/components/entities/portfolio/PortfolioBorrowItem.vue
+++ b/components/entities/portfolio/PortfolioBorrowItem.vue
@@ -170,11 +170,16 @@ const pairName = computed(() => {
 })
 const supplyRewardAPY = computed(() => getSupplyRewardApy(collateralVault.value.address || ''))
 const borrowRewardAPY = computed(() => getBorrowRewardApy(borrowVault.value.address || '', collateralVault.value.address || ''))
+const actualMultiplier = computed(() => {
+  const multiplier = position.multiplier
+  return multiplier !== undefined && Number.isFinite(multiplier) ? multiplier : null
+})
+const rewardMultiplier = computed(() => actualMultiplier.value ?? 0)
 const loopingRewardAPY = computed(() =>
-  getEligibleLoopingRewardApy(borrowVault.value.address || '', collateralVault.value.address || '', actualMultiplier.value),
+  getEligibleLoopingRewardApy(borrowVault.value.address || '', collateralVault.value.address || '', rewardMultiplier.value),
 )
 const loopingEligible = computed(() =>
-  isLoopingEligible(borrowVault.value.address || '', collateralVault.value.address || '', actualMultiplier.value),
+  isLoopingEligible(borrowVault.value.address || '', collateralVault.value.address || '', rewardMultiplier.value),
 )
 const hasRewards = computed(() =>
   hasSupplyRewards(collateralVault.value.address || '')
@@ -259,9 +264,8 @@ const userLTVDisplay = computed(() => {
   if (userLTV.value === null) return ''
   return Number.isFinite(userLTV.value) ? formatNumber(userLTV.value, 2) : '∞'
 })
-const actualMultiplier = computed(() => position.multiplier ?? 0)
 const actualMultiplierDisplay = computed(() =>
-  Number.isFinite(actualMultiplier.value) ? `${formatNumber(actualMultiplier.value, 2, 2)}x` : '-',
+  actualMultiplier.value !== null ? `${formatNumber(actualMultiplier.value, 2, 2)}x` : '-',
 )
 
 const netApyModalData = computed(() => ({
@@ -288,7 +292,7 @@ const roeModalData = computed(() => ({
   props: {
     roeBreakdown: visibleRoeBreakdown.value,
     roe: roe.value ?? 0,
-    multiplier: Number.isFinite(actualMultiplier.value) ? actualMultiplier.value : 0,
+    multiplier: actualMultiplier.value,
     supplyAPY: collateralSupplyApy.value,
     borrowAPY: borrowApy.value,
     supplyRewardAPY: supplyRewardAPY.value || null,

--- a/components/entities/vault/CorrelatedPairBadge.vue
+++ b/components/entities/vault/CorrelatedPairBadge.vue
@@ -6,7 +6,6 @@ const props = withDefaults(defineProps<{
 }>(), {
   compact: false,
   label: 'Correlated',
-  title: 'Assets share a trusted price-correlation category.',
 })
 </script>
 
@@ -14,7 +13,7 @@ const props = withDefaults(defineProps<{
   <span
     class="correlated-pair-badge inline-flex items-center rounded-8 whitespace-nowrap"
     :class="props.compact ? 'px-6 py-1' : 'px-8 py-2'"
-    :title="props.title"
+    :title="props.title || undefined"
   >
     {{ props.label }}
   </span>

--- a/components/entities/vault/CorrelatedPairBadge.vue
+++ b/components/entities/vault/CorrelatedPairBadge.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+const props = withDefaults(defineProps<{
+  compact?: boolean
+  label?: string
+  title?: string
+}>(), {
+  compact: false,
+  label: 'Correlated',
+  title: 'Assets share a trusted price-correlation category.',
+})
+</script>
+
+<template>
+  <span
+    class="correlated-pair-badge inline-flex items-center rounded-8 whitespace-nowrap"
+    :class="props.compact ? 'px-6 py-1' : 'px-8 py-2'"
+    :title="props.title"
+  >
+    {{ props.label }}
+  </span>
+</template>
+
+<style scoped lang="scss">
+.correlated-pair-badge {
+  border: 1px solid rgba(136, 166, 204, 0.3);
+  background-color: rgba(136, 166, 204, 0.1);
+  color: #88a6cc;
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 16px;
+}
+</style>

--- a/components/entities/vault/PortfolioRoeModal.vue
+++ b/components/entities/vault/PortfolioRoeModal.vue
@@ -24,7 +24,7 @@ const {
 } = defineProps<{
   roeBreakdown?: YieldApyBreakdown
   roe: number
-  multiplier: number
+  multiplier: number | null
   supplyAPY: number
   borrowAPY: number
   supplyRewardAPY?: number | null
@@ -58,6 +58,9 @@ const allRewardsInfo = computed(() => [
 ])
 
 const displayRoe = computed(() => roeBreakdown?.total ?? roe)
+const multiplierDisplay = computed(() =>
+  multiplier !== null && Number.isFinite(multiplier) ? `${formatNumber(multiplier, 2, 2)}x` : '-',
+)
 const hasIntrinsicContribution = computed(() => Math.abs(roeBreakdown?.intrinsicApy ?? 0) > 0)
 const hasRewardContribution = computed(() => Math.abs(roeBreakdown?.rewards ?? 0) > 0)
 const signedPrefix = (value: number) => value < 0 ? '- ' : '+ '
@@ -105,7 +108,7 @@ const handleClose = () => {
             </p>
           </div>
           <div class="text-h5">
-            {{ formatNumber(multiplier, 2, 2) }}x
+            {{ multiplierDisplay }}
           </div>
         </div>
         <div class="flex justify-between items-center">
@@ -256,7 +259,7 @@ const handleClose = () => {
             </p>
           </div>
           <div class="text-h5">
-            {{ formatNumber(multiplier, 2, 2) }}x
+            {{ multiplierDisplay }}
           </div>
         </div>
         <div class="flex justify-between items-center mb-16">

--- a/components/entities/vault/VaultBorrowItem.vue
+++ b/components/entities/vault/VaultBorrowItem.vue
@@ -246,6 +246,7 @@ const linkPath = computed(() => ({
     :data-key="pairKey"
     :data-collateral-address="pair.collateral.address.toLowerCase()"
     :data-borrow-address="pair.borrow.address.toLowerCase()"
+    :data-correlated="showMaxRoe"
     :class="[
       enableEntityBranding ? '' : 'grid-cols-6',
       (isGeoBlocked || isPairEffectivelyBlocked) ? 'opacity-50' : '',
@@ -255,7 +256,7 @@ const linkPath = computed(() => ({
     <!-- Header: contents on desktop (children become grid items), flex on mobile -->
     <div class="contents mobile:!flex mobile:py-16 mobile:px-16 mobile:pb-12 mobile:border-b mobile:border-line-subtle">
       <div
-        :class="enableEntityBranding ? 'col-span-5' : 'col-span-4'"
+        :class="enableEntityBranding ? 'col-span-4' : 'col-span-3'"
         class="flex pl-16 py-16 pb-12 mobile:!p-0 mobile:flex-1 mobile:min-w-0 mobile:items-center"
       >
         <AssetAvatar
@@ -316,47 +317,68 @@ const linkPath = computed(() => ({
               v-if="isRecentlyAdded"
               class="hidden mobile:inline-flex shrink-0"
             />
+            <CorrelatedPairBadge
+              v-if="showMaxRoe"
+              compact
+              title="This pair shares a trusted price-correlation category, so Max ROE is shown."
+            />
           </div>
         </div>
       </div>
-      <div class="flex flex-col items-center justify-end py-16 pb-12 mobile:!flex mobile:items-end">
-        <div class="text-content-tertiary text-p3 mb-4 text-right flex items-center gap-4">
-          Borrow APY
-          <UiModalPreviewTrigger
-            :component="VaultBorrowApyModal"
-            :modal-data="borrowApyModalData"
-            aria-label="Show borrow APY breakdown"
+      <div class="col-span-3 grid grid-cols-[repeat(3,112px)] justify-end gap-x-24 pr-16 py-16 pb-12 mobile:!flex mobile:flex-col mobile:items-end mobile:gap-8 mobile:!p-0">
+        <div class="flex flex-col items-end">
+          <div class="text-content-tertiary text-p3 mb-4 text-right flex items-center justify-end gap-4">
+            Borrow APY
+            <UiModalPreviewTrigger
+              :component="VaultBorrowApyModal"
+              :modal-data="borrowApyModalData"
+              aria-label="Show borrow APY breakdown"
+            >
+              <SvgIcon
+                class="!w-16 !h-16 shrink-0 text-content-muted hover:text-content-secondary transition-colors cursor-pointer"
+                name="info-circle"
+                data-modal-trigger="borrow-apy"
+              />
+            </UiModalPreviewTrigger>
+          </div>
+          <div
+            class="text-p2 flex items-center justify-end text-accent-600 font-semibold"
+            data-id="data-point"
+            :data-key="pairKey"
+            data-field="borrow-apy"
+            :data-value="borrowApyWithRewards"
           >
-            <SvgIcon
-              class="!w-16 !h-16 shrink-0 text-content-muted hover:text-content-secondary transition-colors cursor-pointer"
-              name="info-circle"
-              data-modal-trigger="borrow-apy"
-            />
-          </UiModalPreviewTrigger>
+            <UiModalPreviewTrigger
+              v-if="hasBorrowApyRewards"
+              :component="VaultBorrowApyModal"
+              :modal-data="borrowApyModalData"
+              aria-label="Show borrow APY rewards breakdown"
+            >
+              <SvgIcon
+                class="!w-20 !h-20 text-accent-500 mr-4 cursor-pointer"
+                name="sparks"
+                data-modal-trigger="borrow-apy"
+              />
+            </UiModalPreviewTrigger>
+            {{ formatNumber(borrowApyWithRewards) }}%
+          </div>
         </div>
-        <div
-          class="text-p2 flex items-center text-accent-600 font-semibold"
-          data-id="data-point"
-          :data-key="pairKey"
-          data-field="borrow-apy"
-          :data-value="borrowApyWithRewards"
-        >
-          <UiModalPreviewTrigger
-            v-if="hasBorrowApyRewards"
-            :component="VaultBorrowApyModal"
-            :modal-data="borrowApyModalData"
-            aria-label="Show borrow APY rewards breakdown"
+        <div class="flex flex-col items-end">
+          <div class="text-content-tertiary text-p3 mb-4 text-right">
+            Max multiplier
+          </div>
+          <div
+            class="text-p2 text-content-primary"
+            data-id="data-point"
+            :data-key="pairKey"
+            data-field="max-multiplier"
+            :data-value="maxMultiplier"
           >
-            <SvgIcon
-              class="!w-20 !h-20 text-accent-500 mr-4 cursor-pointer"
-              name="sparks"
-              data-modal-trigger="borrow-apy"
-            />
-          </UiModalPreviewTrigger>
-          {{ formatNumber(borrowApyWithRewards) }}%
+            {{ formatNumber(maxMultiplier, 2, 2) }}x
+          </div>
         </div>
-        <div class="hidden mobile:!flex mobile:flex-col mobile:items-end mobile:mt-8">
-          <div class="text-content-tertiary text-p3 mb-4 text-right flex items-center gap-4">
+        <div class="flex flex-col items-end">
+          <div class="text-content-tertiary text-p3 mb-4 text-right flex items-center justify-end gap-4">
             {{ headlineMetricLabel }}
             <UiModalPreviewTrigger
               :component="headlineMetricModalComponent"
@@ -371,7 +393,7 @@ const linkPath = computed(() => ({
             </UiModalPreviewTrigger>
           </div>
           <div
-            class="text-p2 text-accent-600 font-semibold flex items-center"
+            class="text-p2 text-accent-600 font-semibold flex items-center justify-end"
             data-id="data-point"
             :data-key="pairKey"
             :data-field="headlineMetricField"
@@ -393,50 +415,13 @@ const linkPath = computed(() => ({
           </div>
         </div>
       </div>
-      <div class="flex flex-col items-end pr-16 py-16 pb-12 mobile:!hidden">
-        <div class="text-content-tertiary text-p3 mb-4 text-right flex items-center gap-4">
-          {{ headlineMetricLabel }}
-          <UiModalPreviewTrigger
-            :component="headlineMetricModalComponent"
-            :modal-data="headlineMetricModalData"
-            :aria-label="headlineMetricAriaLabel"
-          >
-            <SvgIcon
-              class="!w-16 !h-16 shrink-0 text-content-muted hover:text-content-secondary transition-colors cursor-pointer"
-              name="info-circle"
-              :data-modal-trigger="headlineMetricTrigger"
-            />
-          </UiModalPreviewTrigger>
-        </div>
-        <div
-          class="text-p2 text-accent-600 font-semibold flex items-center"
-          data-id="data-point"
-          :data-key="pairKey"
-          :data-field="headlineMetricField"
-          :data-value="headlineMetricValue"
-        >
-          <UiModalPreviewTrigger
-            v-if="hasAnyRewards"
-            :component="headlineMetricModalComponent"
-            :modal-data="headlineMetricModalData"
-            :aria-label="headlineMetricRewardsAriaLabel"
-          >
-            <SvgIcon
-              class="!w-20 !h-20 text-accent-500 mr-4 cursor-pointer"
-              name="sparks"
-              :data-modal-trigger="headlineMetricTrigger"
-            />
-          </UiModalPreviewTrigger>
-          {{ formatNumber(headlineMetricValue, 2, 2) }}%
-        </div>
-      </div>
     </div>
 
     <!-- Border separator (desktop only) -->
     <div class="col-span-full border-b border-line-subtle mobile:!hidden" />
 
     <!-- Body stats: contents on desktop (children become grid items), flex on mobile -->
-    <div class="contents mobile:!flex mobile:py-12 mobile:px-16 mobile:pb-12 mobile:justify-between mobile:border-b mobile:border-line-subtle">
+    <div class="col-span-full flex items-start mobile:!flex mobile:gap-0 mobile:py-12 mobile:px-16 mobile:pb-12 mobile:justify-between mobile:border-b mobile:border-line-subtle">
       <div
         v-if="enableEntityBranding"
         class="pl-16 py-12 pb-12 mobile:!hidden"
@@ -475,147 +460,137 @@ const linkPath = computed(() => ({
           class="text-p2 text-content-primary"
         >-</div>
       </div>
-      <div
-        class="py-12 pb-12 mobile:!p-0"
-        :class="{ 'pl-16': !enableEntityBranding }"
-      >
-        <div class="text-content-tertiary text-p3 mb-4 flex items-center gap-4">
-          Available liquidity
-          <VaultWarningIcon
-            :warning="[borrowCapInfo, supplyCapInfo]"
-            tooltip-placement="top-start"
-          />
-        </div>
+      <div class="ml-auto grid grid-cols-[repeat(5,112px)] justify-end gap-x-24 pr-16 mobile:contents">
         <div
-          class="text-p2 text-content-primary"
-          data-id="data-point"
-          :data-key="pairKey"
-          data-field="available-liquidity"
-          :data-value="liquidityDisplay"
+          class="py-12 pb-12 text-right mobile:!p-0"
+          :class="{ 'pl-16': !enableEntityBranding }"
         >
-          {{ liquidityDisplay }}
-        </div>
-      </div>
-      <div class="py-12 pb-12 text-center mobile:!hidden">
-        <div class="text-content-tertiary text-p3 mb-4 flex items-center justify-center gap-4">
-          Supply APY
-          <UiModalPreviewTrigger
-            :component="VaultSupplyApyModal"
-            :modal-data="supplyApyModalData"
-            aria-label="Show supply APY breakdown"
-          >
-            <SvgIcon
-              class="!w-16 !h-16 shrink-0 text-content-muted hover:text-content-secondary transition-colors cursor-pointer"
-              name="info-circle"
-              data-modal-trigger="supply-apy"
+          <div class="text-content-tertiary text-p3 mb-4 flex items-center justify-end gap-4">
+            Available liquidity
+            <VaultWarningIcon
+              :warning="[borrowCapInfo, supplyCapInfo]"
+              tooltip-placement="top-start"
             />
-          </UiModalPreviewTrigger>
-        </div>
-        <div
-          class="text-p2 text-content-primary flex items-center justify-center"
-          data-id="data-point"
-          :data-key="pairKey"
-          data-field="supply-apy"
-          :data-value="supplyApyWithRewards"
-        >
-          <VaultPoints
-            class="mr-4"
-            :vault="pair.collateral"
-          />
-          <UiModalPreviewTrigger
-            v-if="hasSupplyRewards(pair.collateral.address)"
-            :component="VaultSupplyApyModal"
-            :modal-data="supplyApyModalData"
-            aria-label="Show supply APY rewards breakdown"
-          >
-            <SvgIcon
-              class="!w-20 !h-20 text-accent-500 mr-4 cursor-pointer"
-              name="sparks"
-              data-modal-trigger="supply-apy"
-            />
-          </UiModalPreviewTrigger>
-          {{ formatNumber(supplyApyWithRewards, 2, 2) }}%
-        </div>
-      </div>
-      <div class="py-12 pb-12 text-center mobile:!p-0">
-        <div class="text-content-tertiary text-p3 mb-4 flex items-center justify-center gap-4">
-          Net APY
-          <UiModalPreviewTrigger
-            :component="VaultNetApyPairModal"
-            :modal-data="netApyModalData"
-            aria-label="Show net APY breakdown"
-          >
-            <SvgIcon
-              class="!w-16 !h-16 shrink-0 text-content-muted hover:text-content-secondary transition-colors cursor-pointer"
-              name="info-circle"
-              data-modal-trigger="net-apy"
-            />
-          </UiModalPreviewTrigger>
-        </div>
-        <div
-          class="text-p2 text-content-primary flex items-center justify-center"
-          data-id="data-point"
-          :data-key="pairKey"
-          data-field="net-apy"
-          :data-value="netApy"
-        >
-          <UiModalPreviewTrigger
-            v-if="hasAnyRewards"
-            :component="VaultNetApyPairModal"
-            :modal-data="netApyModalData"
-            aria-label="Show net APY rewards breakdown"
-          >
-            <SvgIcon
-              class="!w-20 !h-20 text-accent-500 mr-4 cursor-pointer"
-              name="sparks"
-              data-modal-trigger="net-apy"
-            />
-          </UiModalPreviewTrigger>
-          {{ formatNumber(netApy, 2, 2) }}%
-        </div>
-      </div>
-      <div class="py-12 pb-12 text-center mobile:!hidden">
-        <div class="text-content-tertiary text-p3 mb-4">Max multiplier</div>
-        <div
-          class="text-p2 text-content-primary"
-          data-id="data-point"
-          :data-key="pairKey"
-          data-field="max-multiplier"
-          :data-value="maxMultiplier"
-        >
-          {{ formatNumber(maxMultiplier, 2, 2) }}x
-        </div>
-      </div>
-      <div class="py-12 pb-12 text-center mobile:!hidden">
-        <div class="text-content-tertiary text-p3 mb-4">Max LTV</div>
-        <div
-          class="text-p2 text-content-primary"
-          data-id="data-point"
-          :data-key="pairKey"
-          data-field="max-ltv"
-          :data-value="maxLTV"
-        >
-          {{ compactNumber(maxLTV, 2, 2) }}%
-        </div>
-      </div>
-      <div class="pr-16 py-12 pb-12 flex flex-col items-end mobile:!hidden">
-        <div class="text-content-tertiary text-p3 mb-4 flex items-center gap-4">
-          Utilization
-          <VaultWarningIcon :warning="utilisationWarning" />
-        </div>
-        <div class="flex gap-8 justify-end items-center text-right">
-          <UiRadialProgress
-            :value="utilization"
-            :max="100"
-          />
+          </div>
           <div
             class="text-p2 text-content-primary"
             data-id="data-point"
             :data-key="pairKey"
-            data-field="utilization"
-            :data-value="utilization"
+            data-field="available-liquidity"
+            :data-value="liquidityDisplay"
           >
-            {{ compactNumber(utilization, 2, 2) }}%
+            {{ liquidityDisplay }}
+          </div>
+        </div>
+        <div class="py-12 pb-12 text-right mobile:!hidden">
+          <div class="text-content-tertiary text-p3 mb-4 flex items-center justify-end gap-4">
+            Supply APY
+            <UiModalPreviewTrigger
+              :component="VaultSupplyApyModal"
+              :modal-data="supplyApyModalData"
+              aria-label="Show supply APY breakdown"
+            >
+              <SvgIcon
+                class="!w-16 !h-16 shrink-0 text-content-muted hover:text-content-secondary transition-colors cursor-pointer"
+                name="info-circle"
+                data-modal-trigger="supply-apy"
+              />
+            </UiModalPreviewTrigger>
+          </div>
+          <div
+            class="text-p2 text-content-primary flex items-center justify-end"
+            data-id="data-point"
+            :data-key="pairKey"
+            data-field="supply-apy"
+            :data-value="supplyApyWithRewards"
+          >
+            <VaultPoints
+              class="mr-4"
+              :vault="pair.collateral"
+            />
+            <UiModalPreviewTrigger
+              v-if="hasSupplyRewards(pair.collateral.address)"
+              :component="VaultSupplyApyModal"
+              :modal-data="supplyApyModalData"
+              aria-label="Show supply APY rewards breakdown"
+            >
+              <SvgIcon
+                class="!w-20 !h-20 text-accent-500 mr-4 cursor-pointer"
+                name="sparks"
+                data-modal-trigger="supply-apy"
+              />
+            </UiModalPreviewTrigger>
+            {{ formatNumber(supplyApyWithRewards, 2, 2) }}%
+          </div>
+        </div>
+        <div class="py-12 pb-12 text-right mobile:!p-0">
+          <div class="text-content-tertiary text-p3 mb-4 flex items-center justify-end gap-4">
+            Net APY
+            <UiModalPreviewTrigger
+              :component="VaultNetApyPairModal"
+              :modal-data="netApyModalData"
+              aria-label="Show net APY breakdown"
+            >
+              <SvgIcon
+                class="!w-16 !h-16 shrink-0 text-content-muted hover:text-content-secondary transition-colors cursor-pointer"
+                name="info-circle"
+                data-modal-trigger="net-apy"
+              />
+            </UiModalPreviewTrigger>
+          </div>
+          <div
+            class="text-p2 text-content-primary flex items-center justify-end"
+            data-id="data-point"
+            :data-key="pairKey"
+            data-field="net-apy"
+            :data-value="netApy"
+          >
+            <UiModalPreviewTrigger
+              v-if="hasAnyRewards"
+              :component="VaultNetApyPairModal"
+              :modal-data="netApyModalData"
+              aria-label="Show net APY rewards breakdown"
+            >
+              <SvgIcon
+                class="!w-20 !h-20 text-accent-500 mr-4 cursor-pointer"
+                name="sparks"
+                data-modal-trigger="net-apy"
+              />
+            </UiModalPreviewTrigger>
+            {{ formatNumber(netApy, 2, 2) }}%
+          </div>
+        </div>
+        <div class="py-12 pb-12 text-right mobile:!hidden">
+          <div class="text-content-tertiary text-p3 mb-4">Max LTV</div>
+          <div
+            class="text-p2 text-content-primary"
+            data-id="data-point"
+            :data-key="pairKey"
+            data-field="max-ltv"
+            :data-value="maxLTV"
+          >
+            {{ compactNumber(maxLTV, 2, 2) }}%
+          </div>
+        </div>
+        <div class="py-12 pb-12 flex flex-col items-end mobile:!hidden">
+          <div class="text-content-tertiary text-p3 mb-4 flex items-center justify-end gap-4">
+            Utilization
+            <VaultWarningIcon :warning="utilisationWarning" />
+          </div>
+          <div class="flex gap-8 justify-end items-center text-right">
+            <UiRadialProgress
+              :value="utilization"
+              :max="100"
+            />
+            <div
+              class="text-p2 text-content-primary"
+              data-id="data-point"
+              :data-key="pairKey"
+              data-field="utilization"
+              :data-value="utilization"
+            >
+              {{ compactNumber(utilization, 2, 2) }}%
+            </div>
           </div>
         </div>
       </div>
@@ -737,16 +712,6 @@ const linkPath = computed(() => ({
           </UiModalPreviewTrigger>
           <div class="text-p2 text-content-primary">
             {{ formatNumber(netApy, 2, 2) }}%
-          </div>
-        </div>
-      </div>
-      <div class="flex w-full justify-between">
-        <div class="flex-1">
-          <div class="text-content-tertiary text-p3">Max multiplier</div>
-        </div>
-        <div class="flex gap-8 justify-end items-center text-right flex-1">
-          <div class="text-p2 text-content-primary">
-            {{ formatNumber(maxMultiplier, 2, 2) }}x
           </div>
         </div>
       </div>

--- a/components/entities/vault/VaultBorrowItem.vue
+++ b/components/entities/vault/VaultBorrowItem.vue
@@ -230,7 +230,10 @@ const route = useRoute()
 
 const linkPath = computed(() => ({
   path: `/borrow/${pair.collateral.address}/${pair.borrow.address}`,
-  query: { network: route.query.network },
+  query: {
+    network: route.query.network,
+    ...(showMaxRoe.value ? { tab: 'multiply' } : {}),
+  },
 }))
 </script>
 

--- a/components/entities/vault/VaultBorrowItem.vue
+++ b/components/entities/vault/VaultBorrowItem.vue
@@ -217,6 +217,15 @@ const maxRoeModalData = computed(() => ({
   },
 }))
 
+const headlineMetricLabel = computed(() => showMaxRoe.value ? 'Max ROE' : 'Net APY')
+const headlineMetricValue = computed(() => showMaxRoe.value ? maxRoe.value : netApy.value)
+const headlineMetricModalComponent = computed(() => showMaxRoe.value ? VaultMaxRoeModal : VaultNetApyPairModal)
+const headlineMetricModalData = computed(() => showMaxRoe.value ? maxRoeModalData.value : netApyModalData.value)
+const headlineMetricField = computed(() => showMaxRoe.value ? 'max-roe' : 'fallback-net-apy')
+const headlineMetricTrigger = computed(() => showMaxRoe.value ? 'max-roe' : 'net-apy')
+const headlineMetricAriaLabel = computed(() => showMaxRoe.value ? 'Show max ROE breakdown' : 'Show net APY breakdown')
+const headlineMetricRewardsAriaLabel = computed(() => showMaxRoe.value ? 'Show max ROE rewards breakdown' : 'Show net APY rewards breakdown')
+
 const route = useRoute()
 
 const linkPath = computed(() => ({
@@ -343,21 +352,18 @@ const linkPath = computed(() => ({
           </UiModalPreviewTrigger>
           {{ formatNumber(borrowApyWithRewards) }}%
         </div>
-        <div
-          v-if="showMaxRoe"
-          class="hidden mobile:!flex mobile:flex-col mobile:items-end mobile:mt-8"
-        >
+        <div class="hidden mobile:!flex mobile:flex-col mobile:items-end mobile:mt-8">
           <div class="text-content-tertiary text-p3 mb-4 text-right flex items-center gap-4">
-            Max ROE
+            {{ headlineMetricLabel }}
             <UiModalPreviewTrigger
-              :component="VaultMaxRoeModal"
-              :modal-data="maxRoeModalData"
-              aria-label="Show max ROE breakdown"
+              :component="headlineMetricModalComponent"
+              :modal-data="headlineMetricModalData"
+              :aria-label="headlineMetricAriaLabel"
             >
               <SvgIcon
                 class="!w-16 !h-16 shrink-0 text-content-muted hover:text-content-secondary transition-colors cursor-pointer"
                 name="info-circle"
-                data-modal-trigger="max-roe"
+                :data-modal-trigger="headlineMetricTrigger"
               />
             </UiModalPreviewTrigger>
           </div>
@@ -365,40 +371,37 @@ const linkPath = computed(() => ({
             class="text-p2 text-accent-600 font-semibold flex items-center"
             data-id="data-point"
             :data-key="pairKey"
-            data-field="max-roe"
-            :data-value="maxRoe"
+            :data-field="headlineMetricField"
+            :data-value="headlineMetricValue"
           >
             <UiModalPreviewTrigger
               v-if="hasAnyRewards"
-              :component="VaultMaxRoeModal"
-              :modal-data="maxRoeModalData"
-              aria-label="Show max ROE rewards breakdown"
+              :component="headlineMetricModalComponent"
+              :modal-data="headlineMetricModalData"
+              :aria-label="headlineMetricRewardsAriaLabel"
             >
               <SvgIcon
                 class="!w-20 !h-20 text-accent-500 mr-4 cursor-pointer"
                 name="sparks"
-                data-modal-trigger="max-roe"
+                :data-modal-trigger="headlineMetricTrigger"
               />
             </UiModalPreviewTrigger>
-            {{ formatNumber(maxRoe, 2, 2) }}%
+            {{ formatNumber(headlineMetricValue, 2, 2) }}%
           </div>
         </div>
       </div>
-      <div
-        v-if="showMaxRoe"
-        class="flex flex-col items-end pr-16 py-16 pb-12 mobile:!hidden"
-      >
+      <div class="flex flex-col items-end pr-16 py-16 pb-12 mobile:!hidden">
         <div class="text-content-tertiary text-p3 mb-4 text-right flex items-center gap-4">
-          Max ROE
+          {{ headlineMetricLabel }}
           <UiModalPreviewTrigger
-            :component="VaultMaxRoeModal"
-            :modal-data="maxRoeModalData"
-            aria-label="Show max ROE breakdown"
+            :component="headlineMetricModalComponent"
+            :modal-data="headlineMetricModalData"
+            :aria-label="headlineMetricAriaLabel"
           >
             <SvgIcon
               class="!w-16 !h-16 shrink-0 text-content-muted hover:text-content-secondary transition-colors cursor-pointer"
               name="info-circle"
-              data-modal-trigger="max-roe"
+              :data-modal-trigger="headlineMetricTrigger"
             />
           </UiModalPreviewTrigger>
         </div>
@@ -406,22 +409,22 @@ const linkPath = computed(() => ({
           class="text-p2 text-accent-600 font-semibold flex items-center"
           data-id="data-point"
           :data-key="pairKey"
-          data-field="max-roe"
-          :data-value="maxRoe"
+          :data-field="headlineMetricField"
+          :data-value="headlineMetricValue"
         >
           <UiModalPreviewTrigger
             v-if="hasAnyRewards"
-            :component="VaultMaxRoeModal"
-            :modal-data="maxRoeModalData"
-            aria-label="Show max ROE rewards breakdown"
+            :component="headlineMetricModalComponent"
+            :modal-data="headlineMetricModalData"
+            :aria-label="headlineMetricRewardsAriaLabel"
           >
             <SvgIcon
               class="!w-20 !h-20 text-accent-500 mr-4 cursor-pointer"
               name="sparks"
-              data-modal-trigger="max-roe"
+              :data-modal-trigger="headlineMetricTrigger"
             />
           </UiModalPreviewTrigger>
-          {{ formatNumber(maxRoe, 2, 2) }}%
+          {{ formatNumber(headlineMetricValue, 2, 2) }}%
         </div>
       </div>
     </div>

--- a/components/entities/vault/VaultBorrowItem.vue
+++ b/components/entities/vault/VaultBorrowItem.vue
@@ -13,7 +13,7 @@ import { VaultBorrowApyModal, VaultMaxRoeModal, VaultNetApyPairModal, VaultSuppl
 import { isSecuritizeBorrowPair, type AnyBorrowVaultPair } from '~/types/borrow-pair'
 import { getAddress } from 'viem'
 import { formatNumber, compactNumber, formatCompactUsdValue } from '~/utils/string-utils'
-import { areTokenAddressesCorrelatedByTags } from '~/utils/token-categories'
+import { areTokenAddressesCorrelatedByTags, getTokenAddressesCorrelationCategoryLabel } from '~/utils/token-categories'
 
 const { pair } = defineProps<{ pair: AnyBorrowVaultPair }>()
 const { enableEntityBranding } = useDeployConfig()
@@ -161,6 +161,13 @@ const showMaxRoe = computed(() =>
     getTokenCategoryTags,
   ),
 )
+const correlatedBadgeTitle = computed(() => {
+  const category = getTokenAddressesCorrelationCategoryLabel(
+    [pair.collateral.asset.address, pair.borrow.asset.address],
+    getTokenCategoryTags,
+  )
+  return category ? `Correlated category: ${category}` : undefined
+})
 const maxLTV = computed(() => formatNumber(ltvToPercent(pair.ltv.borrowLTV), 2))
 const utilization = computed(() => getVaultUtilization(pair.borrow))
 const utilisationWarning = computed(() => getUtilisationWarning(pair.borrow, 'borrow'))
@@ -333,7 +340,7 @@ const linkPath = computed(() => ({
             <CorrelatedPairBadge
               v-if="showMaxRoe"
               compact
-              title="This pair shares a trusted price-correlation category, so Max ROE is shown."
+              :title="correlatedBadgeTitle"
             />
           </div>
         </div>

--- a/components/entities/vault/VaultBorrowItem.vue
+++ b/components/entities/vault/VaultBorrowItem.vue
@@ -19,7 +19,7 @@ const { pair } = defineProps<{ pair: AnyBorrowVaultPair }>()
 const { enableEntityBranding } = useDeployConfig()
 const { isVaultGovernorVerified, isSecuritizeGovernorVerified } = useVaults()
 const { getVaultCategory, isVerifiedVault } = useVaultRegistry()
-const { getTokenCategoryTags } = useTokenList()
+const { getTokenCategoryTags, isLoaded: isTokenListLoaded } = useTokenList()
 const pairKey = computed(() => `${pair.collateral.address.toLowerCase()}:${pair.borrow.address.toLowerCase()}`)
 
 const isAnyGovernorUnverified = computed(() => {
@@ -144,8 +144,18 @@ const netApy = computed(
 const maxRoe = computed(() =>
   getMaxRoe(maxMultiplier.value, supplyApyWithRewards.value, borrowApyWithRewards.value, loopingRewardsAPY.value),
 )
+const isSameAssetPair = computed(() => {
+  try {
+    return getAddress(pair.collateral.asset.address) === getAddress(pair.borrow.asset.address)
+  }
+  catch {
+    return pair.collateral.asset.address.toLowerCase() === pair.borrow.asset.address.toLowerCase()
+  }
+})
+const isCorrelationReady = computed(() => isTokenListLoaded.value || isSameAssetPair.value)
 const showMaxRoe = computed(() =>
-  areTokenAddressesCorrelatedByTags(
+  isCorrelationReady.value
+  && areTokenAddressesCorrelatedByTags(
     pair.collateral.asset.address,
     pair.borrow.asset.address,
     getTokenCategoryTags,
@@ -217,7 +227,10 @@ const maxRoeModalData = computed(() => ({
   },
 }))
 
-const headlineMetricLabel = computed(() => showMaxRoe.value ? 'Max ROE' : 'Net APY')
+const headlineMetricLabel = computed(() => {
+  if (!isCorrelationReady.value) return 'Yield'
+  return showMaxRoe.value ? 'Max ROE' : 'Net APY'
+})
 const headlineMetricValue = computed(() => showMaxRoe.value ? maxRoe.value : netApy.value)
 const headlineMetricModalComponent = computed(() => showMaxRoe.value ? VaultMaxRoeModal : VaultNetApyPairModal)
 const headlineMetricModalData = computed(() => showMaxRoe.value ? maxRoeModalData.value : netApyModalData.value)
@@ -254,16 +267,16 @@ const linkPath = computed(() => ({
     :style="enableEntityBranding ? { gridTemplateColumns: 'repeat(7, 1fr)' } : undefined"
   >
     <!-- Header: contents on desktop (children become grid items), flex on mobile -->
-    <div class="contents mobile:!flex mobile:py-16 mobile:px-16 mobile:pb-12 mobile:border-b mobile:border-line-subtle">
+    <div class="contents mobile:!flex mobile:flex-col mobile:gap-12 mobile:py-16 mobile:px-16 mobile:pb-12 mobile:border-b mobile:border-line-subtle">
       <div
         :class="enableEntityBranding ? 'col-span-4' : 'col-span-3'"
-        class="flex pl-16 py-16 pb-12 mobile:!p-0 mobile:flex-1 mobile:min-w-0 mobile:items-center"
+        class="flex pl-16 py-16 pb-12 mobile:!p-0 mobile:w-full mobile:min-w-0 mobile:items-center"
       >
         <AssetAvatar
           :asset="[pair.collateral.asset, pair.borrow.asset]"
           size="40"
         />
-        <div class="flex-grow ml-12">
+        <div class="flex-grow ml-12 min-w-0">
           <div
             class="text-content-tertiary text-p3 mb-4 flex items-center gap-8"
             data-id="data-point"
@@ -302,13 +315,13 @@ const linkPath = computed(() => ({
             </span>
           </div>
           <div
-            class="text-h5 text-content-primary flex items-center gap-8"
+            class="text-h5 text-content-primary flex flex-wrap items-center gap-8 min-w-0"
             data-id="data-point"
             :data-key="pairKey"
             data-field="asset-symbols"
             :data-value="[pair.collateral.asset.symbol, pair.borrow.asset.symbol].join('/')"
           >
-            <span>
+            <span class="min-w-0 truncate">
               {{
                 [pair.collateral.asset.symbol, pair.borrow.asset.symbol].join("/")
               }}
@@ -325,9 +338,12 @@ const linkPath = computed(() => ({
           </div>
         </div>
       </div>
-      <div class="col-span-3 grid grid-cols-[repeat(3,112px)] justify-end gap-x-24 pr-16 py-16 pb-12 mobile:!flex mobile:flex-col mobile:items-end mobile:gap-8 mobile:!p-0">
-        <div class="flex flex-col items-end">
-          <div class="text-content-tertiary text-p3 mb-4 text-right flex items-center justify-end gap-4">
+      <div
+        class="col-span-3 grid grid-cols-[repeat(3,112px)] justify-end gap-x-24 pr-16 py-16 pb-12 mobile:!grid mobile:w-full mobile:gap-x-12 mobile:border-t mobile:border-line-subtle mobile:pt-12 mobile:!px-0 mobile:!pb-0"
+        :class="showMaxRoe ? 'mobile:grid-cols-3' : 'mobile:grid-cols-2'"
+      >
+        <div class="flex flex-col items-end mobile:items-start mobile:min-w-0">
+          <div class="text-content-tertiary text-p3 mb-4 text-right flex items-center justify-end gap-4 mobile:text-left mobile:justify-start">
             Borrow APY
             <UiModalPreviewTrigger
               :component="VaultBorrowApyModal"
@@ -342,7 +358,7 @@ const linkPath = computed(() => ({
             </UiModalPreviewTrigger>
           </div>
           <div
-            class="text-p2 flex items-center justify-end text-accent-600 font-semibold"
+            class="text-p2 flex items-center justify-end text-accent-600 font-semibold mobile:justify-start"
             data-id="data-point"
             :data-key="pairKey"
             data-field="borrow-apy"
@@ -363,12 +379,15 @@ const linkPath = computed(() => ({
             {{ formatNumber(borrowApyWithRewards) }}%
           </div>
         </div>
-        <div class="flex flex-col items-end">
-          <div class="text-content-tertiary text-p3 mb-4 text-right">
+        <div
+          class="flex flex-col items-end mobile:items-center mobile:min-w-0"
+          :class="{ 'mobile:!hidden': !showMaxRoe }"
+        >
+          <div class="text-content-tertiary text-p3 mb-4 text-right mobile:text-center">
             Max multiplier
           </div>
           <div
-            class="text-p2 text-content-primary"
+            class="text-p2 text-content-primary mobile:text-center"
             data-id="data-point"
             :data-key="pairKey"
             data-field="max-multiplier"
@@ -377,10 +396,11 @@ const linkPath = computed(() => ({
             {{ formatNumber(maxMultiplier, 2, 2) }}x
           </div>
         </div>
-        <div class="flex flex-col items-end">
+        <div class="flex flex-col items-end mobile:min-w-0">
           <div class="text-content-tertiary text-p3 mb-4 text-right flex items-center justify-end gap-4">
             {{ headlineMetricLabel }}
             <UiModalPreviewTrigger
+              v-if="isCorrelationReady"
               :component="headlineMetricModalComponent"
               :modal-data="headlineMetricModalData"
               :aria-label="headlineMetricAriaLabel"
@@ -400,7 +420,7 @@ const linkPath = computed(() => ({
             :data-value="headlineMetricValue"
           >
             <UiModalPreviewTrigger
-              v-if="hasAnyRewards"
+              v-if="isCorrelationReady && hasAnyRewards"
               :component="headlineMetricModalComponent"
               :modal-data="headlineMetricModalData"
               :aria-label="headlineMetricRewardsAriaLabel"
@@ -411,7 +431,7 @@ const linkPath = computed(() => ({
                 :data-modal-trigger="headlineMetricTrigger"
               />
             </UiModalPreviewTrigger>
-            {{ formatNumber(headlineMetricValue, 2, 2) }}%
+            {{ isCorrelationReady ? `${formatNumber(headlineMetricValue, 2, 2)}%` : '-' }}
           </div>
         </div>
       </div>
@@ -421,7 +441,7 @@ const linkPath = computed(() => ({
     <div class="col-span-full border-b border-line-subtle mobile:!hidden" />
 
     <!-- Body stats: contents on desktop (children become grid items), flex on mobile -->
-    <div class="col-span-full flex items-start mobile:!flex mobile:gap-0 mobile:py-12 mobile:px-16 mobile:pb-12 mobile:justify-between mobile:border-b mobile:border-line-subtle">
+    <div class="col-span-full flex items-start mobile:!hidden">
       <div
         v-if="enableEntityBranding"
         class="pl-16 py-12 pb-12 mobile:!hidden"
@@ -528,7 +548,7 @@ const linkPath = computed(() => ({
         </div>
         <div
           v-if="showMaxRoe"
-          class="py-12 pb-12 text-right mobile:!p-0"
+          class="py-12 pb-12 text-right"
         >
           <div class="text-content-tertiary text-p3 mb-4 flex items-center justify-end gap-4">
             Net APY
@@ -604,6 +624,22 @@ const linkPath = computed(() => ({
 
     <!-- Mobile expanded stats -->
     <div class="hidden mobile:flex mobile:flex-col gap-12 py-12 px-16 pb-16">
+      <div class="flex w-full justify-between">
+        <div class="flex-1">
+          <div class="text-content-tertiary text-p3 flex items-center gap-4">
+            Available liquidity
+            <VaultWarningIcon
+              :warning="[borrowCapInfo, supplyCapInfo]"
+              tooltip-placement="top-end"
+            />
+          </div>
+        </div>
+        <div class="flex gap-8 justify-end items-center text-right flex-1">
+          <div class="text-p2 text-content-primary">
+            {{ liquidityDisplay }}
+          </div>
+        </div>
+      </div>
       <div
         v-if="enableEntityBranding"
         class="flex w-full justify-between"
@@ -650,7 +686,48 @@ const linkPath = computed(() => ({
           </div>
         </div>
       </div>
-      <div class="flex w-full justify-between">
+      <div
+        v-if="showMaxRoe"
+        class="flex w-full justify-between"
+      >
+        <div class="flex-1">
+          <div class="text-content-tertiary text-p3 flex items-center gap-4">
+            Net APY
+            <UiModalPreviewTrigger
+              :component="VaultNetApyPairModal"
+              :modal-data="netApyModalData"
+              aria-label="Show net APY breakdown"
+            >
+              <SvgIcon
+                class="!w-16 !h-16 shrink-0 text-content-muted hover:text-content-secondary transition-colors cursor-pointer"
+                name="info-circle"
+                data-modal-trigger="net-apy"
+              />
+            </UiModalPreviewTrigger>
+          </div>
+        </div>
+        <div class="flex gap-8 justify-end items-center text-right flex-1">
+          <UiModalPreviewTrigger
+            v-if="hasAnyRewards"
+            :component="VaultNetApyPairModal"
+            :modal-data="netApyModalData"
+            aria-label="Show net APY rewards breakdown"
+          >
+            <SvgIcon
+              class="!w-20 !h-20 text-accent-500 cursor-pointer"
+              name="sparks"
+              data-modal-trigger="net-apy"
+            />
+          </UiModalPreviewTrigger>
+          <div class="text-p2 text-content-primary">
+            {{ formatNumber(netApy, 2, 2) }}%
+          </div>
+        </div>
+      </div>
+      <div
+        v-if="showMaxRoe"
+        class="flex w-full justify-between"
+      >
         <div class="flex-1">
           <div class="text-content-tertiary text-p3 flex items-center gap-4">
             Supply APY
@@ -683,41 +760,6 @@ const linkPath = computed(() => ({
           </UiModalPreviewTrigger>
           <div class="text-p2 text-content-primary">
             {{ formatNumber(supplyApyWithRewards, 2, 2) }}%
-          </div>
-        </div>
-      </div>
-      <div class="flex w-full justify-between">
-        <div class="flex-1">
-          <div class="text-content-tertiary text-p3 flex items-center gap-4">
-            Net APY
-            <UiModalPreviewTrigger
-              :component="VaultNetApyPairModal"
-              :modal-data="netApyModalData"
-              aria-label="Show net APY breakdown"
-            >
-              <SvgIcon
-                class="!w-16 !h-16 shrink-0 text-content-muted hover:text-content-secondary transition-colors cursor-pointer"
-                name="info-circle"
-                data-modal-trigger="net-apy"
-              />
-            </UiModalPreviewTrigger>
-          </div>
-        </div>
-        <div class="flex gap-8 justify-end items-center text-right flex-1">
-          <UiModalPreviewTrigger
-            v-if="hasAnyRewards"
-            :component="VaultNetApyPairModal"
-            :modal-data="netApyModalData"
-            aria-label="Show net APY rewards breakdown"
-          >
-            <SvgIcon
-              class="!w-20 !h-20 text-accent-500 cursor-pointer"
-              name="sparks"
-              data-modal-trigger="net-apy"
-            />
-          </UiModalPreviewTrigger>
-          <div class="text-p2 text-content-primary">
-            {{ formatNumber(netApy, 2, 2) }}%
           </div>
         </div>
       </div>

--- a/components/entities/vault/VaultBorrowItem.vue
+++ b/components/entities/vault/VaultBorrowItem.vue
@@ -460,7 +460,10 @@ const linkPath = computed(() => ({
           class="text-p2 text-content-primary"
         >-</div>
       </div>
-      <div class="ml-auto grid grid-cols-[140px_repeat(4,112px)] justify-end gap-x-20 pr-16 mobile:contents">
+      <div
+        class="ml-auto grid justify-end gap-x-20 pr-16 mobile:contents"
+        :class="showMaxRoe ? 'grid-cols-[140px_repeat(4,112px)]' : 'grid-cols-[140px_repeat(3,112px)]'"
+      >
         <div
           class="py-12 pb-12 text-right mobile:!p-0"
           :class="{ 'pl-16': !enableEntityBranding }"
@@ -523,7 +526,10 @@ const linkPath = computed(() => ({
             {{ formatNumber(supplyApyWithRewards, 2, 2) }}%
           </div>
         </div>
-        <div class="py-12 pb-12 text-right mobile:!p-0">
+        <div
+          v-if="showMaxRoe"
+          class="py-12 pb-12 text-right mobile:!p-0"
+        >
           <div class="text-content-tertiary text-p3 mb-4 flex items-center justify-end gap-4">
             Net APY
             <UiModalPreviewTrigger

--- a/components/entities/vault/VaultBorrowItem.vue
+++ b/components/entities/vault/VaultBorrowItem.vue
@@ -460,12 +460,12 @@ const linkPath = computed(() => ({
           class="text-p2 text-content-primary"
         >-</div>
       </div>
-      <div class="ml-auto grid grid-cols-[repeat(5,112px)] justify-end gap-x-24 pr-16 mobile:contents">
+      <div class="ml-auto grid grid-cols-[140px_repeat(4,112px)] justify-end gap-x-20 pr-16 mobile:contents">
         <div
           class="py-12 pb-12 text-right mobile:!p-0"
           :class="{ 'pl-16': !enableEntityBranding }"
         >
-          <div class="text-content-tertiary text-p3 mb-4 flex items-center justify-end gap-4">
+          <div class="text-content-tertiary text-p3 mb-4 flex items-center justify-end gap-4 whitespace-nowrap">
             Available liquidity
             <VaultWarningIcon
               :warning="[borrowCapInfo, supplyCapInfo]"

--- a/components/entities/vault/VaultBorrowItem.vue
+++ b/components/entities/vault/VaultBorrowItem.vue
@@ -724,10 +724,7 @@ const linkPath = computed(() => ({
           </div>
         </div>
       </div>
-      <div
-        v-if="showMaxRoe"
-        class="flex w-full justify-between"
-      >
+      <div class="flex w-full justify-between">
         <div class="flex-1">
           <div class="text-content-tertiary text-p3 flex items-center gap-4">
             Supply APY

--- a/components/entities/vault/VaultBorrowItem.vue
+++ b/components/entities/vault/VaultBorrowItem.vue
@@ -469,7 +469,7 @@ const linkPath = computed(() => ({
             Available liquidity
             <VaultWarningIcon
               :warning="[borrowCapInfo, supplyCapInfo]"
-              tooltip-placement="top-start"
+              tooltip-placement="top-end"
             />
           </div>
           <div

--- a/components/entities/vault/VaultBorrowItem.vue
+++ b/components/entities/vault/VaultBorrowItem.vue
@@ -13,11 +13,13 @@ import { VaultBorrowApyModal, VaultMaxRoeModal, VaultNetApyPairModal, VaultSuppl
 import { isSecuritizeBorrowPair, type AnyBorrowVaultPair } from '~/types/borrow-pair'
 import { getAddress } from 'viem'
 import { formatNumber, compactNumber, formatCompactUsdValue } from '~/utils/string-utils'
+import { areTokenAddressesCorrelatedByTags } from '~/utils/token-categories'
 
 const { pair } = defineProps<{ pair: AnyBorrowVaultPair }>()
 const { enableEntityBranding } = useDeployConfig()
 const { isVaultGovernorVerified, isSecuritizeGovernorVerified } = useVaults()
 const { getVaultCategory, isVerifiedVault } = useVaultRegistry()
+const { getTokenCategoryTags } = useTokenList()
 const pairKey = computed(() => `${pair.collateral.address.toLowerCase()}:${pair.borrow.address.toLowerCase()}`)
 
 const isAnyGovernorUnverified = computed(() => {
@@ -141,6 +143,13 @@ const netApy = computed(
 )
 const maxRoe = computed(() =>
   getMaxRoe(maxMultiplier.value, supplyApyWithRewards.value, borrowApyWithRewards.value, loopingRewardsAPY.value),
+)
+const showMaxRoe = computed(() =>
+  areTokenAddressesCorrelatedByTags(
+    pair.collateral.asset.address,
+    pair.borrow.asset.address,
+    getTokenCategoryTags,
+  ),
 )
 const maxLTV = computed(() => formatNumber(ltvToPercent(pair.ltv.borrowLTV), 2))
 const utilization = computed(() => getVaultUtilization(pair.borrow))
@@ -334,7 +343,10 @@ const linkPath = computed(() => ({
           </UiModalPreviewTrigger>
           {{ formatNumber(borrowApyWithRewards) }}%
         </div>
-        <div class="hidden mobile:!flex mobile:flex-col mobile:items-end mobile:mt-8">
+        <div
+          v-if="showMaxRoe"
+          class="hidden mobile:!flex mobile:flex-col mobile:items-end mobile:mt-8"
+        >
           <div class="text-content-tertiary text-p3 mb-4 text-right flex items-center gap-4">
             Max ROE
             <UiModalPreviewTrigger
@@ -372,7 +384,10 @@ const linkPath = computed(() => ({
           </div>
         </div>
       </div>
-      <div class="flex flex-col items-end pr-16 py-16 pb-12 mobile:!hidden">
+      <div
+        v-if="showMaxRoe"
+        class="flex flex-col items-end pr-16 py-16 pb-12 mobile:!hidden"
+      >
         <div class="text-content-tertiary text-p3 mb-4 text-right flex items-center gap-4">
           Max ROE
           <UiModalPreviewTrigger

--- a/components/entities/vault/VaultLabelsAndAssets.vue
+++ b/components/entities/vault/VaultLabelsAndAssets.vue
@@ -92,7 +92,7 @@ const displayAssetsLabel = computed(() => assetsLabel || assets.map(asset => ass
   <div
     v-if="vault"
     :class="[size === 'large' ? 'gap-16' : 'gap-12']"
-    class="flex items-center"
+    class="flex items-center min-w-0"
     data-id="vault-header"
     :data-key="pairVault ? `${vault.address.toLowerCase()}:${pairVault.address.toLowerCase()}` : vault.address.toLowerCase()"
     :data-vault-address="vault.address.toLowerCase()"
@@ -108,10 +108,10 @@ const displayAssetsLabel = computed(() => assetsLabel || assets.map(asset => ass
       :size="size === 'large' ? '46' : '38'"
     />
 
-    <div>
-      <div class="flex items-center gap-8 mb-4">
+    <div class="min-w-0">
+      <div class="flex flex-wrap items-center gap-8 mb-4 min-w-0">
         <span
-          class="text-content-tertiary"
+          class="text-content-tertiary min-w-0"
           data-id="data-point"
           :data-key="pairVault ? `${vault.address.toLowerCase()}:${pairVault.address.toLowerCase()}` : vault.address.toLowerCase()"
           data-field="name"
@@ -147,13 +147,13 @@ const displayAssetsLabel = computed(() => assetsLabel || assets.map(asset => ass
       </div>
 
       <p
-        class="flex items-center gap-8 text-p2 font-semibold text-content-primary"
+        class="flex flex-wrap items-center gap-8 text-p2 font-semibold text-content-primary min-w-0"
         data-id="data-point"
         :data-key="pairVault ? `${vault.address.toLowerCase()}:${pairVault.address.toLowerCase()}` : vault.address.toLowerCase()"
         data-field="asset-symbols"
         :data-value="displayAssetsLabel"
       >
-        <span>{{ displayAssetsLabel }}</span>
+        <span class="min-w-0 truncate">{{ displayAssetsLabel }}</span>
         <slot name="symbol-trailing" />
       </p>
     </div>

--- a/components/entities/vault/VaultLabelsAndAssets.vue
+++ b/components/entities/vault/VaultLabelsAndAssets.vue
@@ -147,13 +147,14 @@ const displayAssetsLabel = computed(() => assetsLabel || assets.map(asset => ass
       </div>
 
       <p
-        class="text-p2 font-semibold text-content-primary"
+        class="flex items-center gap-8 text-p2 font-semibold text-content-primary"
         data-id="data-point"
         :data-key="pairVault ? `${vault.address.toLowerCase()}:${pairVault.address.toLowerCase()}` : vault.address.toLowerCase()"
         data-field="asset-symbols"
         :data-value="displayAssetsLabel"
       >
-        {{ displayAssetsLabel }}
+        <span>{{ displayAssetsLabel }}</span>
+        <slot name="symbol-trailing" />
       </p>
     </div>
   </div>

--- a/components/entities/vault/discovery/DiscoveryMarketCard.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketCard.vue
@@ -22,6 +22,7 @@ defineEmits<{
 }>()
 
 const { products } = useEulerLabels()
+const { getTokenCategoryTags } = useTokenList()
 const bestRoeMarketGroups = computed(() => [props.market])
 const { getBestMaxROE } = useBestMaxROE(bestRoeMarketGroups)
 
@@ -35,6 +36,29 @@ const getProductDescription = (market: MarketGroup): string => {
 }
 
 const getBestMaxRoe = (market: MarketGroup): BestMaxRoeResult => getBestMaxROE(market.id)
+
+const getCorrelatedPairCount = (market: MarketGroup): number => {
+  let count = 0
+  for (const liability of getBorrowableVaults(market)) {
+    for (const ltv of liability.collaterals) {
+      if (ltv.borrowLTV === 0) continue
+      const collateral = findVault(market, ltv.address)
+      if (!collateral) continue
+      if (
+        areTokenAddressesCorrelatedByTags(
+          collateral.asset.address,
+          liability.asset.address,
+          getTokenCategoryTags,
+        )
+      ) {
+        count++
+      }
+    }
+  }
+  return count
+}
+
+const correlatedPairCount = computed(() => getCorrelatedPairCount(props.market))
 
 const getMaxRoeModalData = (result: BestMaxRoeResult) => ({
   props: {
@@ -137,6 +161,17 @@ const getMaxRoeModalData = (result: BestMaxRoeResult) => ({
             data-field="pair-count"
             :data-value="diagram.pairCount"
           >{{ diagram.pairCount }} pairs</span>
+          <span
+            v-if="correlatedPairCount > 0"
+            class="text-accent-500 text-p5 mt-4"
+            data-id="data-point"
+            :data-key="market.id"
+            data-field="correlated-pair-count"
+            :data-value="correlatedPairCount"
+            title="Pairs eligible for Max ROE under the trusted correlation category rule."
+          >
+            {{ correlatedPairCount }} correlated
+          </span>
           <span
             v-if="getDeprecatedVaultCount(market) > 0"
             class="text-warning-500 text-p5 mt-4"

--- a/components/entities/vault/discovery/DiscoveryMarketCard.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketCard.vue
@@ -22,7 +22,6 @@ defineEmits<{
 }>()
 
 const { products } = useEulerLabels()
-const { getTokenCategoryTags } = useTokenList()
 const bestRoeMarketGroups = computed(() => [props.market])
 const { getBestMaxROE } = useBestMaxROE(bestRoeMarketGroups)
 
@@ -36,29 +35,6 @@ const getProductDescription = (market: MarketGroup): string => {
 }
 
 const getBestMaxRoe = (market: MarketGroup): BestMaxRoeResult => getBestMaxROE(market.id)
-
-const getCorrelatedPairCount = (market: MarketGroup): number => {
-  let count = 0
-  for (const liability of getBorrowableVaults(market)) {
-    for (const ltv of liability.collaterals) {
-      if (ltv.borrowLTV === 0) continue
-      const collateral = findVault(market, ltv.address)
-      if (!collateral) continue
-      if (
-        areTokenAddressesCorrelatedByTags(
-          collateral.asset.address,
-          liability.asset.address,
-          getTokenCategoryTags,
-        )
-      ) {
-        count++
-      }
-    }
-  }
-  return count
-}
-
-const correlatedPairCount = computed(() => getCorrelatedPairCount(props.market))
 
 const getMaxRoeModalData = (result: BestMaxRoeResult) => ({
   props: {
@@ -161,17 +137,6 @@ const getMaxRoeModalData = (result: BestMaxRoeResult) => ({
             data-field="pair-count"
             :data-value="diagram.pairCount"
           >{{ diagram.pairCount }} pairs</span>
-          <span
-            v-if="correlatedPairCount > 0"
-            class="text-accent-500 text-p5 mt-4"
-            data-id="data-point"
-            :data-key="market.id"
-            data-field="correlated-pair-count"
-            :data-value="correlatedPairCount"
-            title="Pairs eligible for Max ROE under the trusted correlation category rule."
-          >
-            {{ correlatedPairCount }} correlated
-          </span>
           <span
             v-if="getDeprecatedVaultCount(market) > 0"
             class="text-warning-500 text-p5 mt-4"

--- a/components/entities/vault/discovery/DiscoveryMarketCard.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketCard.vue
@@ -7,13 +7,9 @@ import {
   getDeprecatedVaultCount,
   getUnknownCollateralCount,
   getMiniDiagram,
-  getBorrowableVaults,
-  findVault,
   type BestMaxRoeResult,
 } from '~/utils/discoveryCalculations'
-import { getMaxMultiplier, getMaxRoe } from '~/utils/leverage'
-import { withVaultIntrinsicApy } from '~/utils/vault-intrinsic-apy'
-import { areTokenAddressesCorrelatedByTags } from '~/utils/token-categories'
+import { useBestMaxROE } from '~/composables/useBestMaxROE'
 import { VaultMaxRoeModal, UiModalPreviewTrigger } from '#components'
 
 const props = defineProps<{
@@ -25,11 +21,9 @@ defineEmits<{
   toggle: []
 }>()
 
-const { settings } = useUserSettings()
-const enableIntrinsicApy = computed(() => settings.value.enableIntrinsicApy)
-const { getBorrowRewardApy, getSupplyRewardApy, getLoopingRewardApy } = useRewardsApy()
 const { products } = useEulerLabels()
-const { getTokenCategoryTags } = useTokenList()
+const bestRoeMarketGroups = computed(() => [props.market])
+const { getBestMaxROE } = useBestMaxROE(bestRoeMarketGroups)
 
 const isGovernanceLimited = computed(() =>
   props.market.source === 'product' && (products[props.market.id]?.tags?.includes('governance limited') ?? false),
@@ -40,102 +34,7 @@ const getProductDescription = (market: MarketGroup): string => {
   return products[market.id]?.description ?? ''
 }
 
-const getBestMaxRoe = (market: MarketGroup): BestMaxRoeResult => {
-  const borrowable = getBorrowableVaults(market)
-  let best = -Infinity
-  let bestHasRewards = false
-  let bestPair = ''
-  let bestMultiplier = 1
-  let bestSupplyAPY = 0
-  let bestBorrowAPY = 0
-  let bestBorrowLTV = 0
-  let bestBorrowVaultAddress = ''
-  let bestCollateralAddress = ''
-  let fallback = -Infinity
-  let fallbackHasRewards = false
-  let fallbackPair = ''
-  let fallbackSupplyAPY = 0
-  let fallbackBorrowAPY = 0
-  let fallbackBorrowVaultAddress = ''
-  let fallbackCollateralAddress = ''
-
-  for (const liability of borrowable) {
-    const borrowBase = getVaultBorrowApy(liability)
-    const borrowApy = withVaultIntrinsicApy(borrowBase, liability, enableIntrinsicApy.value)
-
-    for (const ltv of liability.collaterals) {
-      if (ltv.borrowLTV === 0) continue
-      const collateral = findVault(market, ltv.address)
-      if (!collateral) continue
-
-      const supplyBase = getVaultSupplyApy(collateral)
-      const supplyApy = withVaultIntrinsicApy(supplyBase, collateral, enableIntrinsicApy.value)
-      const supplyRewards = getSupplyRewardApy(collateral.address)
-      const borrowRewards = getBorrowRewardApy(liability.address, collateral.address)
-      const loopingRewards = getLoopingRewardApy(liability.address, collateral.address)
-
-      const supplyFinal = supplyApy + supplyRewards
-      const borrowFinal = borrowApy - borrowRewards
-      const multiplier = getMaxMultiplier(ltv.borrowLTV)
-      const roe = getMaxRoe(multiplier, supplyFinal, borrowFinal, loopingRewards)
-      const netApy = supplyFinal - borrowFinal + loopingRewards
-      const hasRewards = supplyRewards > 0 || borrowRewards > 0 || loopingRewards > 0
-
-      if (netApy > fallback) {
-        fallback = netApy
-        fallbackHasRewards = hasRewards
-        fallbackPair = `${collateral.asset.symbol}/${liability.asset.symbol}`
-        fallbackSupplyAPY = supplyFinal
-        fallbackBorrowAPY = borrowFinal
-        fallbackBorrowVaultAddress = liability.address
-        fallbackCollateralAddress = collateral.address
-      }
-
-      if (!areTokenAddressesCorrelatedByTags(collateral.asset.address, liability.asset.address, getTokenCategoryTags)) continue
-
-      if (roe > best) {
-        best = roe
-        bestHasRewards = hasRewards
-        bestPair = `${collateral.asset.symbol}/${liability.asset.symbol}`
-        bestMultiplier = multiplier
-        bestSupplyAPY = supplyFinal
-        bestBorrowAPY = borrowFinal
-        bestBorrowLTV = ltvToPercent(ltv.borrowLTV)
-        bestBorrowVaultAddress = liability.address
-        bestCollateralAddress = collateral.address
-      }
-    }
-  }
-
-  if (!(Number.isFinite(best) && best > -Infinity) && Number.isFinite(fallback) && fallback > -Infinity) {
-    return {
-      value: fallback,
-      metric: 'net-apy',
-      hasRewards: fallbackHasRewards,
-      pair: fallbackPair,
-      maxMultiplier: 1,
-      supplyAPY: fallbackSupplyAPY,
-      borrowAPY: fallbackBorrowAPY,
-      borrowLTV: 0,
-      borrowVaultAddress: fallbackBorrowVaultAddress,
-      collateralAddress: fallbackCollateralAddress,
-    }
-  }
-
-  const value = Number.isFinite(best) && best > -Infinity ? best : 0
-  return {
-    value,
-    metric: 'max-roe',
-    hasRewards: bestHasRewards,
-    pair: bestPair,
-    maxMultiplier: bestMultiplier,
-    supplyAPY: bestSupplyAPY,
-    borrowAPY: bestBorrowAPY,
-    borrowLTV: bestBorrowLTV,
-    borrowVaultAddress: bestBorrowVaultAddress,
-    collateralAddress: bestCollateralAddress,
-  }
-}
+const getBestMaxRoe = (market: MarketGroup): BestMaxRoeResult => getBestMaxROE(market.id)
 
 const getMaxRoeModalData = (result: BestMaxRoeResult) => ({
   props: {

--- a/components/entities/vault/discovery/DiscoveryMarketCard.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketCard.vue
@@ -13,6 +13,7 @@ import {
 } from '~/utils/discoveryCalculations'
 import { getMaxMultiplier, getMaxRoe } from '~/utils/leverage'
 import { withVaultIntrinsicApy } from '~/utils/vault-intrinsic-apy'
+import { areTokenAddressesCorrelatedByTags } from '~/utils/token-categories'
 import { VaultMaxRoeModal, UiModalPreviewTrigger } from '#components'
 
 const props = defineProps<{
@@ -28,6 +29,7 @@ const { settings } = useUserSettings()
 const enableIntrinsicApy = computed(() => settings.value.enableIntrinsicApy)
 const { getBorrowRewardApy, getSupplyRewardApy, getLoopingRewardApy } = useRewardsApy()
 const { products } = useEulerLabels()
+const { getTokenCategoryTags } = useTokenList()
 
 const isGovernanceLimited = computed(() =>
   props.market.source === 'product' && (products[props.market.id]?.tags?.includes('governance limited') ?? false),
@@ -49,6 +51,13 @@ const getBestMaxRoe = (market: MarketGroup): BestMaxRoeResult => {
   let bestBorrowLTV = 0
   let bestBorrowVaultAddress = ''
   let bestCollateralAddress = ''
+  let fallback = -Infinity
+  let fallbackHasRewards = false
+  let fallbackPair = ''
+  let fallbackSupplyAPY = 0
+  let fallbackBorrowAPY = 0
+  let fallbackBorrowVaultAddress = ''
+  let fallbackCollateralAddress = ''
 
   for (const liability of borrowable) {
     const borrowBase = getVaultBorrowApy(liability)
@@ -69,10 +78,24 @@ const getBestMaxRoe = (market: MarketGroup): BestMaxRoeResult => {
       const borrowFinal = borrowApy - borrowRewards
       const multiplier = getMaxMultiplier(ltv.borrowLTV)
       const roe = getMaxRoe(multiplier, supplyFinal, borrowFinal, loopingRewards)
+      const netApy = supplyFinal - borrowFinal + loopingRewards
+      const hasRewards = supplyRewards > 0 || borrowRewards > 0 || loopingRewards > 0
+
+      if (netApy > fallback) {
+        fallback = netApy
+        fallbackHasRewards = hasRewards
+        fallbackPair = `${collateral.asset.symbol}/${liability.asset.symbol}`
+        fallbackSupplyAPY = supplyFinal
+        fallbackBorrowAPY = borrowFinal
+        fallbackBorrowVaultAddress = liability.address
+        fallbackCollateralAddress = collateral.address
+      }
+
+      if (!areTokenAddressesCorrelatedByTags(collateral.asset.address, liability.asset.address, getTokenCategoryTags)) continue
 
       if (roe > best) {
         best = roe
-        bestHasRewards = supplyRewards > 0 || borrowRewards > 0 || loopingRewards > 0
+        bestHasRewards = hasRewards
         bestPair = `${collateral.asset.symbol}/${liability.asset.symbol}`
         bestMultiplier = multiplier
         bestSupplyAPY = supplyFinal
@@ -84,9 +107,25 @@ const getBestMaxRoe = (market: MarketGroup): BestMaxRoeResult => {
     }
   }
 
+  if (!(Number.isFinite(best) && best > -Infinity) && Number.isFinite(fallback) && fallback > -Infinity) {
+    return {
+      value: fallback,
+      metric: 'net-apy',
+      hasRewards: fallbackHasRewards,
+      pair: fallbackPair,
+      maxMultiplier: 1,
+      supplyAPY: fallbackSupplyAPY,
+      borrowAPY: fallbackBorrowAPY,
+      borrowLTV: 0,
+      borrowVaultAddress: fallbackBorrowVaultAddress,
+      collateralAddress: fallbackCollateralAddress,
+    }
+  }
+
   const value = Number.isFinite(best) && best > -Infinity ? best : 0
   return {
     value,
+    metric: 'max-roe',
     hasRewards: bestHasRewards,
     pair: bestPair,
     maxMultiplier: bestMultiplier,
@@ -267,8 +306,9 @@ const getMaxRoeModalData = (result: BestMaxRoeResult) => ({
           <div class="flex-1 min-w-0">
             <template v-if="bestRoe.value > 0">
               <div class="text-content-tertiary text-p3 mb-4 flex items-center gap-4">
-                Max ROE
+                {{ bestRoe.metric === 'max-roe' ? 'Max ROE' : 'Net APY' }}
                 <UiModalPreviewTrigger
+                  v-if="bestRoe.metric === 'max-roe'"
                   :component="VaultMaxRoeModal"
                   :modal-data="getMaxRoeModalData(bestRoe)"
                   aria-label="Show max ROE breakdown"
@@ -283,11 +323,11 @@ const getMaxRoeModalData = (result: BestMaxRoeResult) => ({
                 class="text-p2 text-content-primary flex items-center gap-4 min-w-0"
                 data-id="data-point"
                 :data-key="market.id"
-                data-field="best-max-roe"
+                :data-field="bestRoe.metric === 'max-roe' ? 'best-max-roe' : 'fallback-net-apy'"
                 :data-value="bestRoe.value"
               >
                 <UiModalPreviewTrigger
-                  v-if="bestRoe.hasRewards"
+                  v-if="bestRoe.metric === 'max-roe' && bestRoe.hasRewards"
                   :component="VaultMaxRoeModal"
                   :modal-data="getMaxRoeModalData(bestRoe)"
                   aria-label="Show max ROE rewards breakdown"
@@ -417,8 +457,9 @@ const getMaxRoeModalData = (result: BestMaxRoeResult) => ({
           class="flex w-full justify-between"
         >
           <div class="text-content-tertiary text-p3 flex items-center gap-4 whitespace-nowrap">
-            Max ROE
+            {{ bestRoe.metric === 'max-roe' ? 'Max ROE' : 'Net APY' }}
             <UiModalPreviewTrigger
+              v-if="bestRoe.metric === 'max-roe'"
               :component="VaultMaxRoeModal"
               :modal-data="getMaxRoeModalData(bestRoe)"
               aria-label="Show max ROE breakdown"
@@ -432,7 +473,7 @@ const getMaxRoeModalData = (result: BestMaxRoeResult) => ({
           <div class="text-p2 text-content-primary flex flex-wrap items-center justify-end gap-x-4">
             <span class="flex items-center gap-4 shrink-0">
               <UiModalPreviewTrigger
-                v-if="bestRoe.hasRewards"
+                v-if="bestRoe.metric === 'max-roe' && bestRoe.hasRewards"
                 :component="VaultMaxRoeModal"
                 :modal-data="getMaxRoeModalData(bestRoe)"
                 aria-label="Show max ROE rewards breakdown"

--- a/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
@@ -142,6 +142,14 @@ const getCellMetricValue = (
   }
 }
 
+const isUnavailableRoeCell = (
+  collateralAddr: string,
+  liabilityAddr: string,
+): boolean =>
+  props.dotMetric === 'roe'
+  && !!props.matrix.cells.get(collateralAddr)?.get(liabilityAddr)
+  && !isCorrelatedCell(collateralAddr, liabilityAddr)
+
 const shouldShowSparkles = (
   collateralAddr: string,
   liabilityAddr: string,
@@ -550,6 +558,8 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
               :data-field="dotMetric"
               :data-present="!!matrix.cells.get(row.address)?.get(col.address)"
               :data-correlated="matrix.cells.get(row.address)?.get(col.address) ? isCorrelatedCell(row.address, col.address) : undefined"
+              :title="isUnavailableRoeCell(row.address, col.address) ? 'Max ROE only shown for correlated pairs.' : undefined"
+              :aria-label="isUnavailableRoeCell(row.address, col.address) ? 'Max ROE only shown for correlated pairs' : undefined"
               :data-value="
                 (() => {
                   const cell = matrix.cells.get(row.address)?.get(col.address);
@@ -725,7 +735,13 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
                     class="!w-10 !h-10 text-accent-500 shrink-0"
                   />
                   <span
-                    v-if="
+                    v-if="isUnavailableRoeCell(row.address, col.address)"
+                    class="text-p5 whitespace-nowrap text-content-muted"
+                  >
+                    -
+                  </span>
+                  <span
+                    v-else-if="
                       Number.isFinite(
                         getCellMetricValue(
                           matrix.cells.get(row.address)!.get(col.address)!,

--- a/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
@@ -133,10 +133,9 @@ const getCellMetricValue = (
       return getMaxMultiplier(cell.ltv.borrowLTV)
     case 'net-apy':
       return computeEnhancedApys(cell, collateralAddr, liabilityAddr).netApy
-    case 'roe': {
-      const apys = computeEnhancedApys(cell, collateralAddr, liabilityAddr)
-      return isCorrelatedCell(collateralAddr, liabilityAddr) ? apys.roe : apys.netApy
-    }
+    case 'roe':
+      if (!isCorrelatedCell(collateralAddr, liabilityAddr)) return Number.NaN
+      return computeEnhancedApys(cell, collateralAddr, liabilityAddr).roe
     default:
       return 0
   }
@@ -147,6 +146,7 @@ const shouldShowSparkles = (
   liabilityAddr: string,
 ): boolean => {
   if (props.dotMetric !== 'net-apy' && props.dotMetric !== 'roe') return false
+  if (props.dotMetric === 'roe' && !isCorrelatedCell(collateralAddr, liabilityAddr)) return false
   const collateral = findVault(props.market, collateralAddr)
   const liability = findVault(props.market, liabilityAddr)
   const hasSupplyRewardsForCell = collateral
@@ -698,7 +698,10 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
                 </template>
 
                 <!-- Numeric metrics: original rendering -->
-                <div class="inline-flex items-center justify-center gap-2">
+                <div
+                  v-if="dotMetric !== 'oracle'"
+                  class="inline-flex items-center justify-center gap-2"
+                >
                   <SvgIcon
                     v-if="
                       dotMetric === 'lltv'
@@ -714,6 +717,15 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
                     class="!w-10 !h-10 text-accent-500 shrink-0"
                   />
                   <span
+                    v-if="
+                      Number.isFinite(
+                        getCellMetricValue(
+                          matrix.cells.get(row.address)!.get(col.address)!,
+                          row.address,
+                          col.address,
+                        ),
+                      )
+                    "
                     class="text-p5 whitespace-nowrap transition-all"
                     :class="[
                       selectedCell?.collateralAddr === row.address

--- a/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
@@ -16,6 +16,7 @@ import { getOracleRouteStepKey, useOracleAdapterPrices } from '~/composables/use
 import { getCollateralOracleRouteSteps, getDebtOracleRouteSteps, isOracleAdapterRouteStep } from '~/utils/oracle-route-steps'
 import type { MarketGroup } from '~/entities/lend-discovery'
 import { withVaultIntrinsicApy } from '~/utils/vault-intrinsic-apy'
+import { areTokenAddressesCorrelatedByTags } from '~/utils/token-categories'
 import type { Address } from 'viem'
 import type { CSSProperties } from 'vue'
 
@@ -43,6 +44,7 @@ const {
 } = useRewardsApy()
 const { oracleAdapters, loadAllOracleAdapters } = useEulerLabels()
 const { chainId } = useEulerAddresses()
+const { getTokenCategoryTags } = useTokenList()
 
 const hoveredCell = ref<{
   collateralAddr: string
@@ -103,6 +105,20 @@ const computeEnhancedApys = (
   }
 }
 
+const isCorrelatedCell = (
+  collateralAddr: string,
+  liabilityAddr: string,
+): boolean => {
+  const collateral = findVault(props.market, collateralAddr)
+  const liability = findVault(props.market, liabilityAddr)
+  if (!collateral || !liability) return false
+  return areTokenAddressesCorrelatedByTags(
+    collateral.asset.address,
+    liability.asset.address,
+    getTokenCategoryTags,
+  )
+}
+
 const getCellMetricValue = (
   cell: MatrixCell,
   collateralAddr: string,
@@ -117,8 +133,10 @@ const getCellMetricValue = (
       return getMaxMultiplier(cell.ltv.borrowLTV)
     case 'net-apy':
       return computeEnhancedApys(cell, collateralAddr, liabilityAddr).netApy
-    case 'roe':
-      return computeEnhancedApys(cell, collateralAddr, liabilityAddr).roe
+    case 'roe': {
+      const apys = computeEnhancedApys(cell, collateralAddr, liabilityAddr)
+      return isCorrelatedCell(collateralAddr, liabilityAddr) ? apys.roe : apys.netApy
+    }
     default:
       return 0
   }
@@ -530,7 +548,14 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
               :data-borrow-address="col.address"
               :data-field="dotMetric"
               :data-present="!!matrix.cells.get(row.address)?.get(col.address)"
-              :data-value="matrix.cells.get(row.address)?.get(col.address) ? getCellMetricValue(matrix.cells.get(row.address)!.get(col.address)!, row.address, col.address) : undefined"
+              :data-value="
+                (() => {
+                  const cell = matrix.cells.get(row.address)?.get(col.address);
+                  if (!cell) return undefined;
+                  const value = getCellMetricValue(cell, row.address, col.address);
+                  return Number.isFinite(value) ? value : undefined;
+                })()
+              "
               :class="[
                 selectedCell?.collateralAddr === row.address
                   && selectedCell?.liabilityAddr === col.address
@@ -560,6 +585,7 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
                     row.address,
                     col.address,
                   );
+                  if (!Number.isFinite(val)) return undefined;
                   return {
                     backgroundColor: getCellBgColor(
                       val,
@@ -672,10 +698,7 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
                 </template>
 
                 <!-- Numeric metrics: original rendering -->
-                <div
-                  v-else
-                  class="inline-flex items-center justify-center gap-2"
-                >
+                <div class="inline-flex items-center justify-center gap-2">
                   <SvgIcon
                     v-if="
                       dotMetric === 'lltv'

--- a/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
@@ -133,9 +133,10 @@ const getCellMetricValue = (
       return getMaxMultiplier(cell.ltv.borrowLTV)
     case 'net-apy':
       return computeEnhancedApys(cell, collateralAddr, liabilityAddr).netApy
-    case 'roe':
-      if (!isCorrelatedCell(collateralAddr, liabilityAddr)) return Number.NaN
-      return computeEnhancedApys(cell, collateralAddr, liabilityAddr).roe
+    case 'roe': {
+      const apys = computeEnhancedApys(cell, collateralAddr, liabilityAddr)
+      return isCorrelatedCell(collateralAddr, liabilityAddr) ? apys.roe : Number.NaN
+    }
     default:
       return 0
   }
@@ -548,6 +549,7 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
               :data-borrow-address="col.address"
               :data-field="dotMetric"
               :data-present="!!matrix.cells.get(row.address)?.get(col.address)"
+              :data-correlated="matrix.cells.get(row.address)?.get(col.address) ? isCorrelatedCell(row.address, col.address) : undefined"
               :data-value="
                 (() => {
                   const cell = matrix.cells.get(row.address)?.get(col.address);
@@ -712,6 +714,12 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
                     title="Liquidation LTV ramping down"
                   />
                   <SvgIcon
+                    v-if="dotMetric === 'roe' && isCorrelatedCell(row.address, col.address)"
+                    name="check-circle"
+                    class="!w-10 !h-10 text-success-500 shrink-0"
+                    title="Correlated pair"
+                  />
+                  <SvgIcon
                     v-if="shouldShowSparkles(row.address, col.address)"
                     name="sparks"
                     class="!w-10 !h-10 text-accent-500 shrink-0"
@@ -738,14 +746,20 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
                     ]"
                   >
                     {{
-                      formatMetricValue(
-                        getCellMetricValue(
-                          matrix.cells.get(row.address)!.get(col.address)!,
-                          row.address,
-                          col.address,
-                        ),
-                        dotMetric,
-                      )
+                      Number.isFinite(getCellMetricValue(
+                        matrix.cells.get(row.address)!.get(col.address)!,
+                        row.address,
+                        col.address,
+                      ))
+                        ? formatMetricValue(
+                          getCellMetricValue(
+                            matrix.cells.get(row.address)!.get(col.address)!,
+                            row.address,
+                            col.address,
+                          ),
+                          dotMetric,
+                        )
+                        : 'N/A'
                     }}
                   </span>
                 </div>

--- a/components/entities/vault/overview/SecuritizeVaultOverviewPairBlockGeneral.vue
+++ b/components/entities/vault/overview/SecuritizeVaultOverviewPairBlockGeneral.vue
@@ -7,8 +7,10 @@ import { useModal } from '~/components/ui/composables/useModal'
 import { VaultBorrowApyModal, VaultRampDownModal, VaultSupplyApyModal, UiModalPreviewTrigger } from '#components'
 import type { EVaultCollateral } from '@eulerxyz/euler-v2-sdk'
 import { formatNumber, formatSignificant } from '~/utils/string-utils'
+import { areTokenAddressesCorrelatedByTags } from '~/utils/token-categories'
 
 const { pair } = defineProps<{ pair: SecuritizeBorrowVaultPair }>()
+const { getTokenCategoryTags } = useTokenList()
 
 const currentLiquidationLTV = computed(() => pair.ltv.currentLiquidationLTV)
 const isRamping = computed(() => pair.ltv.isLiquidationLTVRamping)
@@ -41,6 +43,13 @@ const loopingRewardAPY = computed(() => getLoopingRewardApy(pair.borrow.address,
 const maxMultiplier = computed(() => getMaxMultiplier(pair.ltv.borrowLTV))
 const maxRoe = computed(() =>
   getMaxRoe(maxMultiplier.value, supplyApyWithRewards.value, borrowApyWithRewards.value, loopingRewardAPY.value),
+)
+const showMaxRoe = computed(() =>
+  areTokenAddressesCorrelatedByTags(
+    pair.collateral.asset.address,
+    pair.borrow.asset.address,
+    getTokenCategoryTags,
+  ),
 )
 
 const priceInvert = usePriceInvert(
@@ -182,6 +191,7 @@ const onRampDownInfoIconClick = (event: MouseEvent, pair: EVaultCollateral) => {
         </span>
       </VaultOverviewLabelValue>
       <VaultOverviewLabelValue
+        v-if="showMaxRoe"
         label="Max ROE"
         :value="`${formatNumber(maxRoe, 2, 2)}%`"
       />

--- a/components/entities/vault/overview/VaultOverviewPairBlockGeneral.vue
+++ b/components/entities/vault/overview/VaultOverviewPairBlockGeneral.vue
@@ -16,9 +16,11 @@ import {
   getPairRampConfig,
 } from '~/utils/borrow-pair'
 import { getVaultAvailableLiquidity } from '~/utils/vault-display'
+import { areTokenAddressesCorrelatedByTags } from '~/utils/token-categories'
 import { VaultNetApyPairModal, VaultMaxRoeModal, VaultRampDownModal, VaultSupplyApyModal, VaultBorrowApyModal, UiModalPreviewTrigger } from '#components'
 
 const { pair } = defineProps<{ pair: AnyBorrowVaultPair | PortfolioBorrowPosition<VaultEntity> }>()
+const { getTokenCategoryTags } = useTokenList()
 
 const borrowVault = computed(() => getPairBorrowVault(pair))
 const collateralVault = computed(() => getPairCollateralVault(pair))
@@ -62,6 +64,13 @@ const maxMultiplier = computed(() => pairBorrowLTV.value === undefined ? 1 : get
 const netApy = computed(() => supplyApyWithRewards.value - borrowApyWithRewards.value + loopingRewardAPY.value)
 const maxRoe = computed(() =>
   getMaxRoe(maxMultiplier.value, supplyApyWithRewards.value, borrowApyWithRewards.value, loopingRewardAPY.value),
+)
+const showMaxRoe = computed(() =>
+  areTokenAddressesCorrelatedByTags(
+    collateralVault.value.asset.address,
+    borrowVault.value.asset.address,
+    getTokenCategoryTags,
+  ),
 )
 const netApyClass = computed(() => netApy.value >= 0 ? 'text-accent-600' : 'text-error-500')
 const maxRoeClass = computed(() => maxRoe.value >= 0 ? 'text-accent-600' : 'text-error-500')
@@ -437,7 +446,10 @@ const rampDownModalData = computed(() => ({
                 :value="pairBorrowLTVPercent === null ? '-' : `${formatNumber(maxMultiplier, 2, 2)}x`"
               />
 
-              <VaultOverviewLabelValue orientation="horizontal">
+              <VaultOverviewLabelValue
+                v-if="showMaxRoe"
+                orientation="horizontal"
+              >
                 <template #label>
                   <span class="flex items-center gap-4">
                     Max ROE

--- a/components/entities/vault/overview/VaultOverviewPairBlockGeneral.vue
+++ b/components/entities/vault/overview/VaultOverviewPairBlockGeneral.vue
@@ -12,6 +12,7 @@ import {
   getPairBorrowLTV,
   getPairBorrowVault,
   getPairCollateralVault,
+  getPairCollateralVaults,
   getPairCurrentLiquidationLTV,
   getPairRampConfig,
 } from '~/utils/borrow-pair'
@@ -66,10 +67,12 @@ const maxRoe = computed(() =>
   getMaxRoe(maxMultiplier.value, supplyApyWithRewards.value, borrowApyWithRewards.value, loopingRewardAPY.value),
 )
 const showMaxRoe = computed(() =>
-  areTokenAddressesCorrelatedByTags(
-    collateralVault.value.asset.address,
-    borrowVault.value.asset.address,
-    getTokenCategoryTags,
+  getPairCollateralVaults(pair).every(collateral =>
+    areTokenAddressesCorrelatedByTags(
+      collateral.asset.address,
+      borrowVault.value.asset.address,
+      getTokenCategoryTags,
+    ),
   ),
 )
 const netApyClass = computed(() => netApy.value >= 0 ? 'text-accent-600' : 'text-error-500')

--- a/components/entities/vault/overview/VaultOverviewPairBlockGeneral.vue
+++ b/components/entities/vault/overview/VaultOverviewPairBlockGeneral.vue
@@ -12,16 +12,13 @@ import {
   getPairBorrowLTV,
   getPairBorrowVault,
   getPairCollateralVault,
-  getPairCollateralVaults,
   getPairCurrentLiquidationLTV,
   getPairRampConfig,
 } from '~/utils/borrow-pair'
 import { getVaultAvailableLiquidity } from '~/utils/vault-display'
-import { areTokenAddressesCorrelatedByTags } from '~/utils/token-categories'
 import { VaultNetApyPairModal, VaultMaxRoeModal, VaultRampDownModal, VaultSupplyApyModal, VaultBorrowApyModal, UiModalPreviewTrigger } from '#components'
 
 const { pair } = defineProps<{ pair: AnyBorrowVaultPair | PortfolioBorrowPosition<VaultEntity> }>()
-const { getTokenCategoryTags } = useTokenList()
 
 const borrowVault = computed(() => getPairBorrowVault(pair))
 const collateralVault = computed(() => getPairCollateralVault(pair))
@@ -65,15 +62,6 @@ const maxMultiplier = computed(() => pairBorrowLTV.value === undefined ? 1 : get
 const netApy = computed(() => supplyApyWithRewards.value - borrowApyWithRewards.value + loopingRewardAPY.value)
 const maxRoe = computed(() =>
   getMaxRoe(maxMultiplier.value, supplyApyWithRewards.value, borrowApyWithRewards.value, loopingRewardAPY.value),
-)
-const showMaxRoe = computed(() =>
-  getPairCollateralVaults(pair).every(collateral =>
-    areTokenAddressesCorrelatedByTags(
-      collateral.asset.address,
-      borrowVault.value.asset.address,
-      getTokenCategoryTags,
-    ),
-  ),
 )
 const netApyClass = computed(() => netApy.value >= 0 ? 'text-accent-600' : 'text-error-500')
 const maxRoeClass = computed(() => maxRoe.value >= 0 ? 'text-accent-600' : 'text-error-500')
@@ -449,10 +437,7 @@ const rampDownModalData = computed(() => ({
                 :value="pairBorrowLTVPercent === null ? '-' : `${formatNumber(maxMultiplier, 2, 2)}x`"
               />
 
-              <VaultOverviewLabelValue
-                v-if="showMaxRoe"
-                orientation="horizontal"
-              >
+              <VaultOverviewLabelValue orientation="horizontal">
                 <template #label>
                   <span class="flex items-center gap-4">
                     Max ROE

--- a/components/ui/UiFootnote.vue
+++ b/components/ui/UiFootnote.vue
@@ -130,9 +130,10 @@ onClickOutside(reference, () => {
 
   &__floating {
     position: relative;
-    max-width: calc(800px / 2);
+    max-width: 400px;
     min-width: 200px;
     width: max-content;
+    white-space: normal;
     padding: 16px;
     border-radius: 12px;
     background-color: var(--ui-footnote-floating-background-color);
@@ -145,6 +146,7 @@ onClickOutside(reference, () => {
     flex-direction: column;
     gap: 4px;
     width: 100%;
+    text-align: left;
   }
 
   &__floating-title {

--- a/composables/useBestMaxROE.ts
+++ b/composables/useBestMaxROE.ts
@@ -1,7 +1,6 @@
 import type { MarketGroup } from '~/entities/lend-discovery'
-import { isEVault } from '@eulerxyz/euler-v2-sdk'
 import { areTokenAddressesCorrelatedByTags } from '~/utils/token-categories'
-import { type BestMaxRoeResult, getBorrowableVaults } from '~/utils/discoveryCalculations'
+import { type BestMaxRoeResult, getBorrowableVaults, getVaultAddress, getVaultAssetAddress, getVaultAssetSymbol } from '~/utils/discoveryCalculations'
 import { getMaxMultiplier, getMaxRoe } from '~/utils/leverage'
 import {
   computeSupplyApy,
@@ -9,6 +8,19 @@ import {
   sumBorrowRewardApr,
   sumLoopingRewardApr,
 } from '~/utils/collateralOptions'
+
+type LendRewardCampaign = { action?: string, apr?: number }
+type MaybeRewardedVault = {
+  rewards?: {
+    getActiveCampaigns: (params: { viewer: string | undefined }) => LendRewardCampaign[]
+  }
+}
+
+const getLendRewardCampaigns = (vault: unknown, viewer: string | undefined): LendRewardCampaign[] => {
+  if (!vault || typeof vault !== 'object' || !('rewards' in vault)) return []
+  return (vault as MaybeRewardedVault).rewards?.getActiveCampaigns({ viewer }) ?? []
+}
+
 /**
  * Computes the headline metric for each market group by iterating actual
  * collateral/liability pairs with LTV relationships. Correlated pairs use
@@ -29,7 +41,12 @@ export const useBestMaxROE = (marketGroups: Ref<MarketGroup[]>) => {
 
     const allVaults = [...group.vaults, ...group.externalCollateral]
     const knownAddresses = new Set(
-      allVaults.map(v => (isEVault(v) ? v.address : '').toLowerCase()).filter(Boolean),
+      allVaults.map(v => getVaultAddress(v).toLowerCase()).filter(Boolean),
+    )
+    const vaultsByAddress = new Map(
+      allVaults
+        .map(v => [getVaultAddress(v).toLowerCase(), v] as const)
+        .filter(([address]) => Boolean(address)),
     )
 
     const visibilitySettings = {
@@ -60,55 +77,55 @@ export const useBestMaxROE = (marketGroups: Ref<MarketGroup[]>) => {
         const colAddr = ltv.address.toLowerCase()
         if (!knownAddresses.has(colAddr)) continue
 
-        const collateral = allVaults.find(
-          v => isEVault(v) && v.address.toLowerCase() === colAddr,
-        )
-        if (!collateral || !isEVault(collateral)) continue
+        const collateral = vaultsByAddress.get(colAddr)
+        if (!collateral) continue
+        const collateralAddress = getVaultAddress(collateral)
 
         const supplyFinal = computeSupplyApy(collateral, viewer.value, visibilitySettings)
         const borrowFinal = computeBorrowApy(
           liability,
           viewer.value,
           visibilitySettings,
-          collateral.address,
+          collateralAddress,
         )
         const maxMultiplier = getMaxMultiplier(ltv.borrowLTV)
         const loopingRewards = enableRewardsApy.value
-          ? sumLoopingRewardApr(liability, viewer.value, collateral.address, maxMultiplier)
+          ? sumLoopingRewardApr(liability, viewer.value, collateralAddress, maxMultiplier)
           : 0
         const roe = getMaxRoe(maxMultiplier, supplyFinal, borrowFinal, loopingRewards)
+        const collateralLendCampaigns = getLendRewardCampaigns(collateral, viewer.value)
 
         const supplyHasRewards = enableRewardsApy.value
-          && (liability.rewards || collateral.rewards) !== undefined
-          && (sumBorrowRewardApr(liability, viewer.value, collateral.address) > 0
+          && (liability.rewards !== undefined || collateralLendCampaigns.length > 0)
+          && (sumBorrowRewardApr(liability, viewer.value, collateralAddress) > 0
             || loopingRewards > 0
-            || ((collateral.rewards?.getActiveCampaigns({ viewer: viewer.value }) ?? []).some(
+            || collateralLendCampaigns.some(
               c => c.action === 'LEND' && typeof c.apr === 'number' && c.apr > 0,
-            )))
+            ))
 
         const netApy = supplyFinal - borrowFinal + loopingRewards
         if (netApy > fallback) {
           fallback = netApy
           fallbackHasRewards = supplyHasRewards
-          fallbackPair = `${collateral.asset.symbol}/${liability.asset.symbol}`
+          fallbackPair = `${getVaultAssetSymbol(collateral)}/${liability.asset.symbol}`
           fallbackSupplyAPY = supplyFinal
           fallbackBorrowAPY = borrowFinal
           fallbackBorrowVaultAddress = liability.address
-          fallbackCollateralAddress = collateral.address
+          fallbackCollateralAddress = collateralAddress
         }
 
-        if (!areTokenAddressesCorrelatedByTags(collateral.asset.address, liability.asset.address, getTokenCategoryTags)) continue
+        if (!areTokenAddressesCorrelatedByTags(getVaultAssetAddress(collateral), liability.asset.address, getTokenCategoryTags)) continue
 
         if (roe > best) {
           best = roe
           bestHasRewards = supplyHasRewards
-          bestPair = `${collateral.asset.symbol}/${liability.asset.symbol}`
+          bestPair = `${getVaultAssetSymbol(collateral)}/${liability.asset.symbol}`
           bestMultiplier = maxMultiplier
           bestSupplyAPY = supplyFinal
           bestBorrowAPY = borrowFinal
           bestBorrowLTV = ltvToPercent(ltv.borrowLTV)
           bestBorrowVaultAddress = liability.address
-          bestCollateralAddress = collateral.address
+          bestCollateralAddress = collateralAddress
         }
       }
     }

--- a/composables/useBestMaxROE.ts
+++ b/composables/useBestMaxROE.ts
@@ -1,5 +1,6 @@
 import type { MarketGroup } from '~/entities/lend-discovery'
 import { isEVault } from '@eulerxyz/euler-v2-sdk'
+import { areTokenAddressesCorrelatedByTags } from '~/utils/token-categories'
 import { type BestMaxRoeResult, getBorrowableVaults } from '~/utils/discoveryCalculations'
 import { getMaxMultiplier, getMaxRoe } from '~/utils/leverage'
 import {
@@ -8,11 +9,11 @@ import {
   sumBorrowRewardApr,
   sumLoopingRewardApr,
 } from '~/utils/collateralOptions'
-
 /**
- * Computes the best max ROE for each market group by iterating all actual
- * collateral/liability pairs with LTV relationships. Uses leveraged return
- * (max ROE) instead of simple net APY spread.
+ * Computes the headline metric for each market group by iterating actual
+ * collateral/liability pairs with LTV relationships. Correlated pairs use
+ * leveraged return (max ROE); groups without a correlated pair fall back to
+ * the best visible net APY.
  *
  * Returns a reactive map of marketGroupId -> BestMaxRoeResult.
  */
@@ -21,6 +22,7 @@ export const useBestMaxROE = (marketGroups: Ref<MarketGroup[]>) => {
   const enableIntrinsicApy = computed(() => settings.value.enableIntrinsicApy)
   const enableRewardsApy = computed(() => settings.value.enableRewardsApy)
   const { viewer } = useApyVisibility()
+  const { getTokenCategoryTags } = useTokenList()
 
   const computeForGroup = (group: MarketGroup): BestMaxRoeResult => {
     const borrowableVaults = getBorrowableVaults(group)
@@ -44,6 +46,13 @@ export const useBestMaxROE = (marketGroups: Ref<MarketGroup[]>) => {
     let bestBorrowLTV = 0
     let bestBorrowVaultAddress = ''
     let bestCollateralAddress = ''
+    let fallback = -Infinity
+    let fallbackHasRewards = false
+    let fallbackPair = ''
+    let fallbackSupplyAPY = 0
+    let fallbackBorrowAPY = 0
+    let fallbackBorrowVaultAddress = ''
+    let fallbackCollateralAddress = ''
 
     for (const liability of borrowableVaults) {
       for (const ltv of liability.collaterals) {
@@ -77,6 +86,19 @@ export const useBestMaxROE = (marketGroups: Ref<MarketGroup[]>) => {
               c => c.action === 'LEND' && typeof c.apr === 'number' && c.apr > 0,
             )))
 
+        const netApy = supplyFinal - borrowFinal + loopingRewards
+        if (netApy > fallback) {
+          fallback = netApy
+          fallbackHasRewards = supplyHasRewards
+          fallbackPair = `${collateral.asset.symbol}/${liability.asset.symbol}`
+          fallbackSupplyAPY = supplyFinal
+          fallbackBorrowAPY = borrowFinal
+          fallbackBorrowVaultAddress = liability.address
+          fallbackCollateralAddress = collateral.address
+        }
+
+        if (!areTokenAddressesCorrelatedByTags(collateral.asset.address, liability.asset.address, getTokenCategoryTags)) continue
+
         if (roe > best) {
           best = roe
           bestHasRewards = supplyHasRewards
@@ -91,9 +113,25 @@ export const useBestMaxROE = (marketGroups: Ref<MarketGroup[]>) => {
       }
     }
 
+    if (!(Number.isFinite(best) && best > -Infinity) && Number.isFinite(fallback) && fallback > -Infinity) {
+      return {
+        value: fallback,
+        metric: 'net-apy',
+        hasRewards: fallbackHasRewards,
+        pair: fallbackPair,
+        maxMultiplier: 1,
+        supplyAPY: fallbackSupplyAPY,
+        borrowAPY: fallbackBorrowAPY,
+        borrowLTV: 0,
+        borrowVaultAddress: fallbackBorrowVaultAddress,
+        collateralAddress: fallbackCollateralAddress,
+      }
+    }
+
     const value = Number.isFinite(best) && best > -Infinity ? best : 0
     return {
       value,
+      metric: 'max-roe',
       hasRewards: bestHasRewards,
       pair: bestPair,
       maxMultiplier: bestMultiplier,
@@ -119,6 +157,7 @@ export const useBestMaxROE = (marketGroups: Ref<MarketGroup[]>) => {
 
   const defaultResult: BestMaxRoeResult = {
     value: 0,
+    metric: 'max-roe',
     hasRewards: false,
     pair: '',
     maxMultiplier: 1,

--- a/composables/useTokenList.ts
+++ b/composables/useTokenList.ts
@@ -6,14 +6,16 @@ import { logWarn } from '~/utils/errorHandling'
 import { CACHE_TTL_5MIN_MS } from '~/entities/tuning-constants'
 import { getChainById } from '~/entities/chainRegistry'
 import { createRaceGuard } from '~/utils/race-guard'
+import { normalizeTokenCategoryTags } from '~/utils/token-categories'
 
-interface TokenListEntry {
+export interface TokenListEntry {
   chainId: number
   address: string
   name: string
   symbol: string
   decimals: number
   logoURI?: string
+  tags?: string[]
 }
 
 // Singleton state
@@ -35,7 +37,16 @@ const filterByChain = (chainId: number) => {
     try {
       const normalized = getAddress(token.address).toLowerCase()
       if (!filtered.has(normalized)) {
-        filtered.set(normalized, token)
+        const tags = normalizeTokenCategoryTags(token.tags)
+        filtered.set(normalized, {
+          chainId: token.chainId,
+          address: token.address,
+          name: token.name,
+          symbol: token.symbol,
+          decimals: token.decimals,
+          ...(token.logoURI ? { logoURI: token.logoURI } : {}),
+          ...(tags.length ? { tags } : {}),
+        })
       }
     }
     catch {
@@ -47,7 +58,7 @@ const filterByChain = (chainId: number) => {
   const nativeSymbol = chain?.nativeCurrency?.symbol
   const wrappedSymbol = nativeSymbol ? `W${nativeSymbol}`.toUpperCase() : null
   const hasWrappedNative = wrappedSymbol
-    && [...filtered.values()].some(t => t.symbol.toUpperCase() === wrappedSymbol)
+    && [...filtered.values()].find(t => t.symbol.toUpperCase() === wrappedSymbol)
 
   if (hasWrappedNative) {
     if (!filtered.has(zeroAddress)) {
@@ -57,6 +68,7 @@ const filterByChain = (chainId: number) => {
         name: chain!.nativeCurrency.name,
         symbol: chain!.nativeCurrency.symbol,
         decimals: chain!.nativeCurrency.decimals,
+        ...(hasWrappedNative.tags?.length ? { tags: hasWrappedNative.tags } : {}),
       })
     }
   }
@@ -146,6 +158,9 @@ const getTokenByAddress = (address: string): TokenListEntry | undefined => {
   }
 }
 
+const getTokenCategoryTags = (address: string): string[] =>
+  normalizeTokenCategoryTags(getTokenByAddress(address)?.tags)
+
 const getAllTokens = (): TokenListEntry[] => {
   return [...tokenMap.value.values()]
 }
@@ -178,6 +193,7 @@ export const useTokenList = () => {
     hasToken,
     getAllTokens,
     getTokenByAddress,
+    getTokenCategoryTags,
     toVaultAsset,
     isLoading,
     isLoaded,

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@eulerxyz/euler-v2-sdk": "1.0.3-rc.0",
+        "@eulerxyz/euler-v2-sdk": "1.0.3",
         "@floating-ui/vue": "1.1.11",
         "@gvade/nuxt3-svg-sprite": "1.0.3",
         "@keyringnetwork/keyring-connect-sdk": "3.2.0",
@@ -1444,9 +1444,9 @@
       }
     },
     "node_modules/@eulerxyz/euler-v2-sdk": {
-      "version": "1.0.3-rc.0",
-      "resolved": "https://registry.npmjs.org/@eulerxyz/euler-v2-sdk/-/euler-v2-sdk-1.0.3-rc.0.tgz",
-      "integrity": "sha512-ZfmaispiPQ5XJT1uwZcYiPfojn/n6Pr9XIp/nYD9KzVPdes7Mbt94boyTjn10Oob//lLy7oYCzKriBgZ+U1HAQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@eulerxyz/euler-v2-sdk/-/euler-v2-sdk-1.0.3.tgz",
+      "integrity": "sha512-rqR6FtLq4l6+UNIlLakTPhEFZFjXWQfbpFWzTOLuZ/ginnvSAjrtZgxMnhIAHu23gh9C6//T3Zwzi5gtoQ8chg==",
       "license": "MIT",
       "dependencies": {
         "viem": "2.48.8"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@eulerxyz/euler-v2-sdk": "1.0.2",
+        "@eulerxyz/euler-v2-sdk": "1.0.3-rc.0",
         "@floating-ui/vue": "1.1.11",
         "@gvade/nuxt3-svg-sprite": "1.0.3",
         "@keyringnetwork/keyring-connect-sdk": "3.2.0",
@@ -1444,9 +1444,9 @@
       }
     },
     "node_modules/@eulerxyz/euler-v2-sdk": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@eulerxyz/euler-v2-sdk/-/euler-v2-sdk-1.0.2.tgz",
-      "integrity": "sha512-8Dy+QrJWC2o9DCwFazpiejhLVJKME6zejJaQhn7SpvPdiAmzCCKIiAcb5KyQFDSoaf2tHRFLOe39hKv5xB8NpQ==",
+      "version": "1.0.3-rc.0",
+      "resolved": "https://registry.npmjs.org/@eulerxyz/euler-v2-sdk/-/euler-v2-sdk-1.0.3-rc.0.tgz",
+      "integrity": "sha512-ZfmaispiPQ5XJT1uwZcYiPfojn/n6Pr9XIp/nYD9KzVPdes7Mbt94boyTjn10Oob//lLy7oYCzKriBgZ+U1HAQ==",
       "license": "MIT",
       "dependencies": {
         "viem": "2.48.8"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     ]
   },
   "dependencies": {
-    "@eulerxyz/euler-v2-sdk": "1.0.3-rc.0",
+    "@eulerxyz/euler-v2-sdk": "1.0.3",
     "@floating-ui/vue": "1.1.11",
     "@gvade/nuxt3-svg-sprite": "1.0.3",
     "@keyringnetwork/keyring-connect-sdk": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     ]
   },
   "dependencies": {
-    "@eulerxyz/euler-v2-sdk": "1.0.2",
+    "@eulerxyz/euler-v2-sdk": "1.0.3-rc.0",
     "@floating-ui/vue": "1.1.11",
     "@gvade/nuxt3-svg-sprite": "1.0.3",
     "@keyringnetwork/keyring-connect-sdk": "3.2.0",

--- a/pages/borrow/[collateral]/[borrow]/index.vue
+++ b/pages/borrow/[collateral]/[borrow]/index.vue
@@ -20,6 +20,7 @@ import { useModal } from '~/components/ui/composables/useModal'
 import { SlippageSettingsModal, VaultUnverifiedDisclaimerModal } from '#components'
 import { getAddress } from 'viem'
 import { areRoeCollateralVaultsCorrelatedWithBorrow, mergeRoeCollateralVaults } from '~/utils/position-roe'
+import { getTokenAddressesCorrelationCategoryLabel } from '~/utils/token-categories'
 
 const router = useRouter()
 const route = useRoute()
@@ -186,6 +187,19 @@ const showMultiplyRoe = computed(() =>
     getTokenCategoryTags,
   ),
 )
+const correlatedBadgeTitle = computed(() => {
+  const category = getTokenAddressesCorrelationCategoryLabel(
+    [
+      ...mergeRoeCollateralVaults([
+        collateralVault.value,
+        multiply.multiplySupplyVault.value,
+      ]).map(vault => vault.asset.address),
+      borrowVault.value?.asset.address,
+    ],
+    getTokenCategoryTags,
+  )
+  return category ? `Correlated category: ${category}` : undefined
+})
 
 const { guardWithPriceImpact: guardWithMultiplyPriceImpact } = usePriceImpactGate({
   directPriceImpact: multiply.multiplyPriceImpact,
@@ -474,7 +488,7 @@ watch(
             <CorrelatedPairBadge
               v-if="showMultiplyRoe"
               compact
-              title="This pair shares a trusted price-correlation category, so ROE is shown."
+              :title="correlatedBadgeTitle"
             />
           </template>
           <UiShareLinkButton

--- a/pages/borrow/[collateral]/[borrow]/index.vue
+++ b/pages/borrow/[collateral]/[borrow]/index.vue
@@ -19,7 +19,7 @@ import type { DisabledReasonInfo } from '~/components/entities/vault/form/types'
 import { useModal } from '~/components/ui/composables/useModal'
 import { SlippageSettingsModal, VaultUnverifiedDisclaimerModal } from '#components'
 import { getAddress } from 'viem'
-import { areTokenAddressesCorrelatedByTags } from '~/utils/token-categories'
+import { areRoeCollateralVaultsCorrelatedWithBorrow, mergeRoeCollateralVaults } from '~/utils/position-roe'
 
 const router = useRouter()
 const route = useRoute()
@@ -76,14 +76,6 @@ const borrowVault = computed(() => pair.value?.borrow)
 const collateralVault = computed(() => pair.value?.collateral)
 const isSecuritizeCollateral = computed(() => pair.value ? isSecuritizeBorrowPair(pair.value) : false)
 const pairAssets = computed(() => [collateralVault.value?.asset, borrowVault.value?.asset])
-const showMultiplyRoe = computed(() =>
-  areTokenAddressesCorrelatedByTags(
-    collateralVault.value?.asset.address,
-    borrowVault.value?.asset.address,
-    getTokenCategoryTags,
-  ),
-)
-
 // --- Shared functions ---
 const normalizeAddress = (addr?: string) => {
   if (!addr) return ''
@@ -179,6 +171,16 @@ const multiply = useMultiplyForm({
   isGeoBlocked,
   isMultiplyRestricted,
 })
+const showMultiplyRoe = computed(() =>
+  areRoeCollateralVaultsCorrelatedWithBorrow(
+    mergeRoeCollateralVaults([
+      collateralVault.value,
+      multiply.multiplySupplyVault.value,
+    ]),
+    borrowVault.value,
+    getTokenCategoryTags,
+  ),
+)
 
 const { guardWithPriceImpact: guardWithMultiplyPriceImpact } = usePriceImpactGate({
   directPriceImpact: multiply.multiplyPriceImpact,

--- a/pages/borrow/[collateral]/[borrow]/index.vue
+++ b/pages/borrow/[collateral]/[borrow]/index.vue
@@ -54,10 +54,15 @@ const collateralAddress = route.params.collateral as string
 const borrowAddress = route.params.borrow as string
 useOperationGuard([collateralAddress, borrowAddress])
 
+const formTabFromQuery = (value: unknown): 'borrow' | 'multiply' | undefined => {
+  const tabValue = Array.isArray(value) ? value[0] : value
+  return tabValue === 'borrow' || tabValue === 'multiply' ? tabValue : undefined
+}
+
 // --- Shared state ---
 const balance = ref(0n)
 const tab = ref()
-const formTab = ref<'borrow' | 'multiply'>('borrow')
+const formTab = ref<'borrow' | 'multiply'>(formTabFromQuery(route.query.tab) ?? 'borrow')
 const pendingSubAccount = ref<string | null>(null)
 const isPendingSubAccountLoading = ref(false)
 let pendingSubAccountPromise: Promise<string> | null = null
@@ -431,6 +436,13 @@ watch(formTab, () => {
   borrow.resetOnTabSwitch()
   multiply.resetOnTabSwitch()
 })
+
+watch(
+  () => [route.params.collateral, route.params.borrow, route.query.tab],
+  () => {
+    formTab.value = formTabFromQuery(route.query.tab) ?? 'borrow'
+  },
+)
 </script>
 
 <template>

--- a/pages/borrow/[collateral]/[borrow]/index.vue
+++ b/pages/borrow/[collateral]/[borrow]/index.vue
@@ -19,6 +19,7 @@ import type { DisabledReasonInfo } from '~/components/entities/vault/form/types'
 import { useModal } from '~/components/ui/composables/useModal'
 import { SlippageSettingsModal, VaultUnverifiedDisclaimerModal } from '#components'
 import { getAddress } from 'viem'
+import { areTokenAddressesCorrelatedByTags } from '~/utils/token-categories'
 
 const router = useRouter()
 const route = useRoute()
@@ -26,6 +27,7 @@ const modal = useModal()
 const reviewBorrowLabel = 'Review Borrow'
 const reviewMultiplyLabel = 'Review Multiply'
 const { getBorrowVaultPair, updateVault } = useVaults()
+const { getTokenCategoryTags } = useTokenList()
 const { address, isConnected } = useWagmi()
 const { isSpyMode, spyAddress } = useSpyMode()
 const { chainId } = useEulerAddresses()
@@ -74,6 +76,13 @@ const borrowVault = computed(() => pair.value?.borrow)
 const collateralVault = computed(() => pair.value?.collateral)
 const isSecuritizeCollateral = computed(() => pair.value ? isSecuritizeBorrowPair(pair.value) : false)
 const pairAssets = computed(() => [collateralVault.value?.asset, borrowVault.value?.asset])
+const showMultiplyRoe = computed(() =>
+  areTokenAddressesCorrelatedByTags(
+    collateralVault.value?.asset.address,
+    borrowVault.value?.asset.address,
+    getTokenCategoryTags,
+  ),
+)
 
 // --- Shared functions ---
 const normalizeAddress = (addr?: string) => {
@@ -848,7 +857,10 @@ watch(formTab, () => {
                       :loading="multiply.isMultiplyQuoteLoading.value"
                       variant="card"
                     >
-                      <SummaryRow label="ROE">
+                      <SummaryRow
+                        v-if="showMultiplyRoe"
+                        label="ROE"
+                      >
                         <SummaryValue
                           :after="multiply.multiplyRoeAfter.value !== null && multiply.multiplySwapReady.value ? formatNumber(multiply.multiplyRoeAfter.value) : (multiply.multiplyRoeBefore.value !== null ? formatNumber(multiply.multiplyRoeBefore.value) : undefined)"
                           suffix="%"

--- a/pages/borrow/[collateral]/[borrow]/index.vue
+++ b/pages/borrow/[collateral]/[borrow]/index.vue
@@ -878,10 +878,7 @@ watch(
                       :loading="multiply.isMultiplyQuoteLoading.value"
                       variant="card"
                     >
-                      <SummaryRow
-                        v-if="showMultiplyRoe"
-                        label="ROE"
-                      >
+                      <SummaryRow label="ROE">
                         <SummaryValue
                           :after="multiply.multiplyRoeAfter.value !== null && multiply.multiplySwapReady.value ? formatNumber(multiply.multiplyRoeAfter.value) : (multiply.multiplyRoeBefore.value !== null ? formatNumber(multiply.multiplyRoeBefore.value) : undefined)"
                           suffix="%"

--- a/pages/borrow/[collateral]/[borrow]/index.vue
+++ b/pages/borrow/[collateral]/[borrow]/index.vue
@@ -470,6 +470,13 @@ watch(
           :assets="pairAssets as VaultAsset[]"
           size="large"
         >
+          <template #symbol-trailing>
+            <CorrelatedPairBadge
+              v-if="showMultiplyRoe"
+              compact
+              title="This pair shares a trusted price-correlation category, so ROE is shown."
+            />
+          </template>
           <UiShareLinkButton
             class="-ml-4 !w-24 !h-24"
             :path="`/borrow/${collateralVault.address}/${borrowVault.address}`"

--- a/pages/borrow/index.vue
+++ b/pages/borrow/index.vue
@@ -70,6 +70,9 @@ const compareMaxRoeDesc = (a: AnyBorrowVaultPair, b: AnyBorrowVaultPair): number
     const netApyDelta = getNetApy(b) - getNetApy(a)
     if (netApyDelta !== 0) return netApyDelta
 
+    const recentlyAddedDelta = compareRecentlyAddedPairBoost(a, b)
+    if (recentlyAddedDelta !== 0) return recentlyAddedDelta
+
     const liquidityDelta = comparePairLiquidityDesc(a, b)
     if (liquidityDelta !== 0) return liquidityDelta
 
@@ -81,6 +84,9 @@ const compareMaxRoeDesc = (a: AnyBorrowVaultPair, b: AnyBorrowVaultPair): number
 
   const roeDelta = bValue - aValue
   if (roeDelta !== 0) return roeDelta
+
+  const recentlyAddedDelta = compareRecentlyAddedPairBoost(a, b)
+  if (recentlyAddedDelta !== 0) return recentlyAddedDelta
 
   const liquidityDelta = comparePairLiquidityDesc(a, b)
   if (liquidityDelta !== 0) return liquidityDelta
@@ -371,14 +377,17 @@ const isPairRecentlyAdded = (pair: AnyBorrowVaultPair) =>
 
 const applyRecentlyAddedPairSort = (sorted: AnyBorrowVaultPair[]): AnyBorrowVaultPair[] => {
   return [...sorted].sort((a, b) => {
-    return compareRecentlyAddedBoost(
-      isPairRecentlyAdded(a),
-      pairLiquidityUsd.value.get(getPairKey(a)) ?? 0,
-      isPairRecentlyAdded(b),
-      pairLiquidityUsd.value.get(getPairKey(b)) ?? 0,
-    )
+    return compareRecentlyAddedPairBoost(a, b)
   })
 }
+
+const compareRecentlyAddedPairBoost = (a: AnyBorrowVaultPair, b: AnyBorrowVaultPair): number =>
+  compareRecentlyAddedBoost(
+    isPairRecentlyAdded(a),
+    pairLiquidityUsd.value.get(getPairKey(a)) ?? 0,
+    isPairRecentlyAdded(b),
+    pairLiquidityUsd.value.get(getPairKey(b)) ?? 0,
+  )
 
 const applyDeprecatedPairSort = (sorted: AnyBorrowVaultPair[]): AnyBorrowVaultPair[] => {
   return [...sorted].sort((a, b) => {
@@ -416,6 +425,9 @@ const sortedBorrowList = computed(() => {
 
         const scoreDelta = b.compositeScore - a.compositeScore
         if (scoreDelta !== 0) return scoreDelta
+
+        const recentlyAddedDelta = compareRecentlyAddedPairBoost(a.pair, b.pair)
+        if (recentlyAddedDelta !== 0) return recentlyAddedDelta
 
         const liquidityDelta = comparePairLiquidityDesc(a.pair, b.pair)
         if (liquidityDelta !== 0) return liquidityDelta

--- a/pages/borrow/index.vue
+++ b/pages/borrow/index.vue
@@ -15,10 +15,19 @@ import { getAssetLogoUrl } from '~/composables/useTokenList'
 import { getVaultAvailableLiquidity, getVaultUtilization } from '~/utils/vault-display'
 import { withVaultIntrinsicApy } from '~/utils/vault-intrinsic-apy'
 import { compareRecentlyAddedBoost } from '~/utils/recentlyAddedSort'
+import { areTokenAddressesCorrelatedByTags } from '~/utils/token-categories'
 
 const { settings } = useUserSettings()
 const enableIntrinsicApy = computed(() => settings.value.enableIntrinsicApy)
 const { getSupplyRewardApy, getBorrowRewardApy, getLoopingRewardApy } = useRewardsApy()
+const { getTokenCategoryTags } = useTokenList()
+
+const isCorrelatedPair = (pair: AnyBorrowVaultPair) =>
+  areTokenAddressesCorrelatedByTags(
+    pair.collateral.asset.address,
+    pair.borrow.asset.address,
+    getTokenCategoryTags,
+  )
 
 const getNetApy = (pair: AnyBorrowVaultPair) => {
   const baseSupplyApy = getVaultSupplyApy(pair.collateral)
@@ -32,6 +41,8 @@ const getNetApy = (pair: AnyBorrowVaultPair) => {
 }
 
 const getSortMaxRoe = (pair: AnyBorrowVaultPair) => {
+  if (!isCorrelatedPair(pair)) return Number.NEGATIVE_INFINITY
+
   const borrowLTV = ltvToPercent(pair.ltv.borrowLTV)
   const maxMultiplier = Math.max(1, Math.floor(100 / (100 - borrowLTV) * 100) / 100)
   const baseSupplyApy = getVaultSupplyApy(pair.collateral)
@@ -42,6 +53,17 @@ const getSortMaxRoe = (pair: AnyBorrowVaultPair) => {
   const borrowFinal = borrowApy - getBorrowRewardApy(pair.borrow.address, pair.collateral.address)
   const loopingRewards = getLoopingRewardApy(pair.borrow.address, pair.collateral.address)
   return supplyFinal + (maxMultiplier - 1) * (supplyFinal - borrowFinal) + loopingRewards
+}
+
+const compareMaxRoeDesc = (a: AnyBorrowVaultPair, b: AnyBorrowVaultPair): number => {
+  const aValue = getSortMaxRoe(a)
+  const bValue = getSortMaxRoe(b)
+  const aFinite = Number.isFinite(aValue)
+  const bFinite = Number.isFinite(bValue)
+  if (!aFinite && !bFinite) return 0
+  if (!aFinite) return 1
+  if (!bFinite) return -1
+  return bValue - aValue
 }
 
 defineOptions({
@@ -394,7 +416,7 @@ const sortedBorrowList = computed(() => {
       break
     case 'Max ROE':
       sorted = applyRecentlyAddedPairSort([...filteredBorrowList.value].sort((a: AnyBorrowVaultPair, b: AnyBorrowVaultPair) => {
-        return getSortMaxRoe(b) - getSortMaxRoe(a)
+        return compareMaxRoeDesc(a, b)
       }))
       break
     case 'Net APY':

--- a/pages/borrow/index.vue
+++ b/pages/borrow/index.vue
@@ -367,6 +367,14 @@ const filteredBorrowList = computed(() => {
     .filter(matchesCustomFilters)
 })
 
+const correlatedFilteredCount = computed(() =>
+  filteredBorrowList.value.filter(isCorrelatedPair).length,
+)
+
+const correlatedFilteredCountLabel = computed(() =>
+  `${correlatedFilteredCount.value} correlated pair${correlatedFilteredCount.value === 1 ? '' : 's'}`,
+)
+
 const isPairRecentlyAdded = (pair: AnyBorrowVaultPair) =>
   isVaultRecentlyAdded(pair.collateral.address) || isVaultRecentlyAdded(pair.borrow.address)
 
@@ -482,11 +490,25 @@ const sortedBorrowList = computed(() => {
 
 <template>
   <section class="flex flex-col min-h-[calc(100dvh-178px)]">
-    <BasePageHeader
-      title="Borrow/Multiply"
-      description="Borrow against your assets in isolated lending markets."
-      class="mb-16"
-    />
+    <div class="mb-16 flex items-start justify-between gap-16 mobile:flex-col">
+      <BasePageHeader
+        title="Borrow/Multiply"
+        description="Borrow against your assets in isolated lending markets."
+      />
+      <div
+        v-if="correlatedFilteredCount > 0"
+        class="mt-8 inline-flex shrink-0 items-center gap-8 rounded-12 border border-line-default bg-surface-secondary px-12 py-8 text-p3 text-content-secondary mobile:mt-0"
+        data-id="borrow-correlated-pair-count"
+        :data-value="correlatedFilteredCount"
+        title="Pairs eligible for Max ROE under the trusted correlation category rule."
+      >
+        <SvgIcon
+          name="nodes"
+          class="!w-14 !h-14 text-content-muted"
+        />
+        {{ correlatedFilteredCountLabel }}
+      </div>
+    </div>
 
     <div class="mb-16">
       <div class="flex justify-start items-center w-full gap-8 flex-wrap">

--- a/pages/borrow/index.vue
+++ b/pages/borrow/index.vue
@@ -55,6 +55,11 @@ const getSortMaxRoe = (pair: AnyBorrowVaultPair) => {
   return supplyFinal + (maxMultiplier - 1) * (supplyFinal - borrowFinal) + loopingRewards
 }
 
+const getActiveSortYieldScore = (pair: AnyBorrowVaultPair): number => {
+  const maxRoe = getSortMaxRoe(pair)
+  return Number.isFinite(maxRoe) ? maxRoe : getNetApy(pair)
+}
+
 const compareMaxRoeDesc = (a: AnyBorrowVaultPair, b: AnyBorrowVaultPair): number => {
   const aValue = getSortMaxRoe(a)
   const bValue = getSortMaxRoe(b)
@@ -390,25 +395,32 @@ const sortedBorrowList = computed(() => {
       const list = [...filteredBorrowList.value]
 
       const scores = list.map((pair) => {
-        const maxRoe = getSortMaxRoe(pair)
+        const yieldScore = getActiveSortYieldScore(pair)
         const liquidityUsd = pairLiquidityUsd.value.get(getPairKey(pair)) ?? 0
-        return { pair, maxRoe, liquidityUsd }
+        return { pair, yieldScore, liquidityUsd }
       })
 
-      const maxMaxRoe = Math.max(...scores.map(s => s.maxRoe), 0)
+      const maxYieldScore = Math.max(...scores.map(s => s.yieldScore), 0)
       const maxLiquidity = Math.max(...scores.map(s => s.liquidityUsd), 0)
 
-      const scored = scores.map(({ pair, maxRoe, liquidityUsd }) => {
-        const normalizedRoe = maxMaxRoe === 0 ? 0 : maxRoe / maxMaxRoe
+      const scored = scores.map(({ pair, yieldScore, liquidityUsd }) => {
+        const normalizedYield = maxYieldScore === 0 ? 0 : yieldScore / maxYieldScore
         const normalizedLiquidity = maxLiquidity === 0 ? 0 : liquidityUsd / maxLiquidity
-        const roeBucket = maxRoe >= 0 ? 0 : 1
-        const compositeScore = normalizedRoe * normalizedLiquidity
-        return { pair, roeBucket, compositeScore }
+        const yieldBucket = yieldScore >= 0 ? 0 : 1
+        const compositeScore = normalizedYield * normalizedLiquidity
+        return { pair, yieldBucket, compositeScore }
       })
 
       scored.sort((a, b) => {
-        if (a.roeBucket !== b.roeBucket) return a.roeBucket - b.roeBucket
-        return b.compositeScore - a.compositeScore
+        if (a.yieldBucket !== b.yieldBucket) return a.yieldBucket - b.yieldBucket
+
+        const scoreDelta = b.compositeScore - a.compositeScore
+        if (scoreDelta !== 0) return scoreDelta
+
+        const liquidityDelta = comparePairLiquidityDesc(a.pair, b.pair)
+        if (liquidityDelta !== 0) return liquidityDelta
+
+        return comparePairNameAsc(a.pair, b.pair)
       })
 
       // Active sort ignores direction toggle

--- a/pages/borrow/index.vue
+++ b/pages/borrow/index.vue
@@ -367,14 +367,6 @@ const filteredBorrowList = computed(() => {
     .filter(matchesCustomFilters)
 })
 
-const correlatedFilteredCount = computed(() =>
-  filteredBorrowList.value.filter(isCorrelatedPair).length,
-)
-
-const correlatedFilteredCountLabel = computed(() =>
-  `${correlatedFilteredCount.value} correlated pair${correlatedFilteredCount.value === 1 ? '' : 's'}`,
-)
-
 const isPairRecentlyAdded = (pair: AnyBorrowVaultPair) =>
   isVaultRecentlyAdded(pair.collateral.address) || isVaultRecentlyAdded(pair.borrow.address)
 
@@ -495,19 +487,6 @@ const sortedBorrowList = computed(() => {
         title="Borrow/Multiply"
         description="Borrow against your assets in isolated lending markets."
       />
-      <div
-        v-if="correlatedFilteredCount > 0"
-        class="mt-8 inline-flex shrink-0 items-center gap-8 rounded-12 border border-line-default bg-surface-secondary px-12 py-8 text-p3 text-content-secondary mobile:mt-0"
-        data-id="borrow-correlated-pair-count"
-        :data-value="correlatedFilteredCount"
-        title="Pairs eligible for Max ROE under the trusted correlation category rule."
-      >
-        <SvgIcon
-          name="nodes"
-          class="!w-14 !h-14 text-content-muted"
-        />
-        {{ correlatedFilteredCountLabel }}
-      </div>
     </div>
 
     <div class="mb-16">

--- a/pages/borrow/index.vue
+++ b/pages/borrow/index.vue
@@ -60,18 +60,16 @@ const getActiveSortYieldScore = (pair: AnyBorrowVaultPair): number => {
   return Number.isFinite(maxRoe) ? maxRoe : getNetApy(pair)
 }
 
-const compareMaxRoeDesc = (a: AnyBorrowVaultPair, b: AnyBorrowVaultPair): number => {
+const compareMaxRoe = (a: AnyBorrowVaultPair, b: AnyBorrowVaultPair, direction: 'desc' | 'asc' = 'desc'): number => {
   const aValue = getSortMaxRoe(a)
   const bValue = getSortMaxRoe(b)
   const aFinite = Number.isFinite(aValue)
   const bFinite = Number.isFinite(bValue)
+  const directionFactor = direction === 'asc' ? -1 : 1
 
   if (!aFinite && !bFinite) {
-    const netApyDelta = getNetApy(b) - getNetApy(a)
+    const netApyDelta = (getNetApy(b) - getNetApy(a)) * directionFactor
     if (netApyDelta !== 0) return netApyDelta
-
-    const recentlyAddedDelta = compareRecentlyAddedPairBoost(a, b)
-    if (recentlyAddedDelta !== 0) return recentlyAddedDelta
 
     const liquidityDelta = comparePairLiquidityDesc(a, b)
     if (liquidityDelta !== 0) return liquidityDelta
@@ -82,11 +80,8 @@ const compareMaxRoeDesc = (a: AnyBorrowVaultPair, b: AnyBorrowVaultPair): number
   if (!aFinite) return 1
   if (!bFinite) return -1
 
-  const roeDelta = bValue - aValue
+  const roeDelta = (bValue - aValue) * directionFactor
   if (roeDelta !== 0) return roeDelta
-
-  const recentlyAddedDelta = compareRecentlyAddedPairBoost(a, b)
-  if (recentlyAddedDelta !== 0) return recentlyAddedDelta
 
   const liquidityDelta = comparePairLiquidityDesc(a, b)
   if (liquidityDelta !== 0) return liquidityDelta
@@ -469,9 +464,9 @@ const sortedBorrowList = computed(() => {
       break
     case 'Max ROE':
       sorted = [...filteredBorrowList.value].sort((a: AnyBorrowVaultPair, b: AnyBorrowVaultPair) => {
-        return compareMaxRoeDesc(a, b)
+        return compareMaxRoe(a, b, sortDir.value)
       })
-      break
+      return applyDeprecatedPairSort(sorted)
     case 'Net APY':
       sorted = applyRecentlyAddedPairSort([...filteredBorrowList.value].sort((a: AnyBorrowVaultPair, b: AnyBorrowVaultPair) => {
         return getNetApy(b) - getNetApy(a)

--- a/pages/borrow/index.vue
+++ b/pages/borrow/index.vue
@@ -60,10 +60,27 @@ const compareMaxRoeDesc = (a: AnyBorrowVaultPair, b: AnyBorrowVaultPair): number
   const bValue = getSortMaxRoe(b)
   const aFinite = Number.isFinite(aValue)
   const bFinite = Number.isFinite(bValue)
-  if (!aFinite && !bFinite) return 0
+
+  if (!aFinite && !bFinite) {
+    const netApyDelta = getNetApy(b) - getNetApy(a)
+    if (netApyDelta !== 0) return netApyDelta
+
+    const liquidityDelta = comparePairLiquidityDesc(a, b)
+    if (liquidityDelta !== 0) return liquidityDelta
+
+    return comparePairNameAsc(a, b)
+  }
+
   if (!aFinite) return 1
   if (!bFinite) return -1
-  return bValue - aValue
+
+  const roeDelta = bValue - aValue
+  if (roeDelta !== 0) return roeDelta
+
+  const liquidityDelta = comparePairLiquidityDesc(a, b)
+  if (liquidityDelta !== 0) return liquidityDelta
+
+  return comparePairNameAsc(a, b)
 }
 
 defineOptions({
@@ -137,6 +154,18 @@ const pairBorrowedUsd = ref<Map<string, number>>(new Map())
 
 // Helper to create a unique key for a borrow pair
 const getPairKey = (pair: AnyBorrowVaultPair) => `${pair.collateral.address}-${pair.borrow.address}`
+
+const getPairSortName = (pair: AnyBorrowVaultPair): string =>
+  `${pair.collateral.asset.symbol}/${pair.borrow.asset.symbol}`
+
+const comparePairLiquidityDesc = (a: AnyBorrowVaultPair, b: AnyBorrowVaultPair): number =>
+  (pairLiquidityUsd.value.get(getPairKey(b)) ?? 0) - (pairLiquidityUsd.value.get(getPairKey(a)) ?? 0)
+
+const comparePairNameAsc = (a: AnyBorrowVaultPair, b: AnyBorrowVaultPair): number => {
+  const nameDelta = getPairSortName(a).localeCompare(getPairSortName(b))
+  if (nameDelta !== 0) return nameDelta
+  return getPairKey(a).localeCompare(getPairKey(b))
+}
 
 // Fetch USD values for all borrow pairs. Debounced to collapse the
 // bursts of registry updates streamed during loadVaults's RPC refresh
@@ -415,9 +444,9 @@ const sortedBorrowList = computed(() => {
       }))
       break
     case 'Max ROE':
-      sorted = applyRecentlyAddedPairSort([...filteredBorrowList.value].sort((a: AnyBorrowVaultPair, b: AnyBorrowVaultPair) => {
+      sorted = [...filteredBorrowList.value].sort((a: AnyBorrowVaultPair, b: AnyBorrowVaultPair) => {
         return compareMaxRoeDesc(a, b)
-      }))
+      })
       break
     case 'Net APY':
       sorted = applyRecentlyAddedPairSort([...filteredBorrowList.value].sort((a: AnyBorrowVaultPair, b: AnyBorrowVaultPair) => {

--- a/pages/borrow/index.vue
+++ b/pages/borrow/index.vue
@@ -20,7 +20,7 @@ import { areTokenAddressesCorrelatedByTags } from '~/utils/token-categories'
 const { settings } = useUserSettings()
 const enableIntrinsicApy = computed(() => settings.value.enableIntrinsicApy)
 const { getSupplyRewardApy, getBorrowRewardApy, getLoopingRewardApy } = useRewardsApy()
-const { getTokenCategoryTags } = useTokenList()
+const { getTokenCategoryTags, isLoading: isTokenListLoading } = useTokenList()
 
 const isCorrelatedPair = (pair: AnyBorrowVaultPair) =>
   areTokenAddressesCorrelatedByTags(
@@ -98,7 +98,7 @@ const { chainId } = useEulerAddresses()
 
 const isPricesReady = ref(false)
 const { entities, isReady: labelsReady } = useEulerLabels()
-const isLoading = computed(() => isEVaultUpdating.value || isEscrowUpdating.value || !labelsReady.value || !isPricesReady.value)
+const isLoading = computed(() => isEVaultUpdating.value || isEscrowUpdating.value || isTokenListLoading.value || !labelsReady.value || !isPricesReady.value)
 const { isSlow } = useSlowLoading(isLoading)
 const { enableEntityBranding } = useDeployConfig()
 const showAllLabelEntries = useShowAllLabelEntries()

--- a/pages/explore/index.vue
+++ b/pages/explore/index.vue
@@ -22,6 +22,7 @@ const { marketGroups, isResolvingTVL, isReady: marketGroupsReady } = useMarketGr
 const { getBestMaxROE } = useBestMaxROE(marketGroups)
 const { isEVaultUpdating, isEarnUpdating, isSecuritizeUpdating, isEscrowUpdating } = useVaults()
 const { chainId } = useEulerAddresses()
+const { isLoading: isTokenListLoading } = useTokenList()
 const { entities } = useEulerLabels()
 const { enableEntityBranding } = useDeployConfig()
 
@@ -283,7 +284,7 @@ const sortedMarkets = computed(() => {
 
 const isLoading = computed(() =>
   isEVaultUpdating.value || isEarnUpdating.value || isSecuritizeUpdating.value || isEscrowUpdating.value
-  || !marketGroupsReady.value || isResolvingTVL.value,
+  || isTokenListLoading.value || !marketGroupsReady.value || isResolvingTVL.value,
 )
 const { isSlow } = useSlowLoading(isLoading)
 </script>

--- a/pages/explore/index.vue
+++ b/pages/explore/index.vue
@@ -207,24 +207,17 @@ const compareMarketLiquidityDesc = (a: MarketGroup, b: MarketGroup): number =>
 const compareMarketNameAsc = (a: MarketGroup, b: MarketGroup): number =>
   (a.name || a.id).localeCompare(b.name || b.id)
 
-const compareMaxRoeMarketsDesc = (a: MarketGroup, b: MarketGroup): number => {
+const compareMaxRoeMarkets = (a: MarketGroup, b: MarketGroup, direction: 'desc' | 'asc' = 'desc'): number => {
   const aBest = getBestMaxROE(a.id)
   const bBest = getBestMaxROE(b.id)
   const aHasRoe = aBest.metric === 'max-roe'
   const bHasRoe = bBest.metric === 'max-roe'
+  const directionFactor = direction === 'asc' ? -1 : 1
 
   if (aHasRoe !== bHasRoe) return aHasRoe ? -1 : 1
 
-  const metricDelta = bBest.value - aBest.value
+  const metricDelta = (bBest.value - aBest.value) * directionFactor
   if (metricDelta !== 0) return metricDelta
-
-  const recentlyAddedDelta = compareRecentlyAddedBoost(
-    a.metrics.hasRecentlyAdded,
-    a.metrics.totalAvailableLiquidity,
-    b.metrics.hasRecentlyAdded,
-    b.metrics.totalAvailableLiquidity,
-  )
-  if (recentlyAddedDelta !== 0) return recentlyAddedDelta
 
   const liquidityDelta = compareMarketLiquidityDesc(a, b)
   if (liquidityDelta !== 0) return liquidityDelta
@@ -264,8 +257,8 @@ const sortedMarkets = computed(() => {
       return applyDeprecatedGroupSort(applyRecentlyAddedSort(scored.map(s => s.group)))
     }
     case 'Max ROE':
-      sorted = [...filteredMarkets.value].sort(compareMaxRoeMarketsDesc)
-      break
+      sorted = [...filteredMarkets.value].sort((a, b) => compareMaxRoeMarkets(a, b, sortDir.value))
+      return applyDeprecatedGroupSort(sorted)
     case 'Total Supply':
       sorted = applyRecentlyAddedSort([...filteredMarkets.value].sort((a, b) =>
         b.metrics.totalTVL - a.metrics.totalTVL,

--- a/pages/explore/index.vue
+++ b/pages/explore/index.vue
@@ -198,6 +198,29 @@ const applyDeprecatedGroupSort = (sorted: MarketGroup[]): MarketGroup[] => {
   })
 }
 
+const compareMarketLiquidityDesc = (a: MarketGroup, b: MarketGroup): number =>
+  b.metrics.totalAvailableLiquidity - a.metrics.totalAvailableLiquidity
+
+const compareMarketNameAsc = (a: MarketGroup, b: MarketGroup): number =>
+  (a.name || a.id).localeCompare(b.name || b.id)
+
+const compareMaxRoeMarketsDesc = (a: MarketGroup, b: MarketGroup): number => {
+  const aBest = getBestMaxROE(a.id)
+  const bBest = getBestMaxROE(b.id)
+  const aHasRoe = aBest.metric === 'max-roe'
+  const bHasRoe = bBest.metric === 'max-roe'
+
+  if (aHasRoe !== bHasRoe) return aHasRoe ? -1 : 1
+
+  const metricDelta = bBest.value - aBest.value
+  if (metricDelta !== 0) return metricDelta
+
+  const liquidityDelta = compareMarketLiquidityDesc(a, b)
+  if (liquidityDelta !== 0) return liquidityDelta
+
+  return compareMarketNameAsc(a, b)
+}
+
 const sortedMarkets = computed(() => {
   let sorted: MarketGroup[]
   switch (sortBy.value) {
@@ -230,14 +253,7 @@ const sortedMarkets = computed(() => {
       return applyDeprecatedGroupSort(applyRecentlyAddedSort(scored.map(s => s.group)))
     }
     case 'Max ROE':
-      sorted = applyRecentlyAddedSort([...filteredMarkets.value].sort((a, b) => {
-        const aBest = getBestMaxROE(a.id)
-        const bBest = getBestMaxROE(b.id)
-        const aHasRoe = aBest.metric === 'max-roe' ? 1 : 0
-        const bHasRoe = bBest.metric === 'max-roe' ? 1 : 0
-        if (aHasRoe !== bHasRoe) return bHasRoe - aHasRoe
-        return bBest.value - aBest.value
-      }))
+      sorted = [...filteredMarkets.value].sort(compareMaxRoeMarketsDesc)
       break
     case 'Total Supply':
       sorted = applyRecentlyAddedSort([...filteredMarkets.value].sort((a, b) =>

--- a/pages/explore/index.vue
+++ b/pages/explore/index.vue
@@ -70,7 +70,10 @@ const {
     { key: 'totalAvailableLiquidity', label: 'Available liquidity', shortLabel: 'Avail. liquidity', unit: 'usd' },
   ],
   (group, metric) => {
-    if (metric === 'bestMaxROE') return getBestMaxROE(group.id).value
+    if (metric === 'bestMaxROE') {
+      const best = getBestMaxROE(group.id)
+      return best.metric === 'max-roe' ? best.value : Number.NaN
+    }
     const val = group.metrics[metric as keyof typeof group.metrics]
     return typeof val === 'number' ? val : 0
   },
@@ -214,6 +217,14 @@ const compareMaxRoeMarketsDesc = (a: MarketGroup, b: MarketGroup): number => {
 
   const metricDelta = bBest.value - aBest.value
   if (metricDelta !== 0) return metricDelta
+
+  const recentlyAddedDelta = compareRecentlyAddedBoost(
+    a.metrics.hasRecentlyAdded,
+    a.metrics.totalAvailableLiquidity,
+    b.metrics.hasRecentlyAdded,
+    b.metrics.totalAvailableLiquidity,
+  )
+  if (recentlyAddedDelta !== 0) return recentlyAddedDelta
 
   const liquidityDelta = compareMarketLiquidityDesc(a, b)
   if (liquidityDelta !== 0) return liquidityDelta

--- a/pages/explore/index.vue
+++ b/pages/explore/index.vue
@@ -230,9 +230,14 @@ const sortedMarkets = computed(() => {
       return applyDeprecatedGroupSort(applyRecentlyAddedSort(scored.map(s => s.group)))
     }
     case 'Max ROE':
-      sorted = applyRecentlyAddedSort([...filteredMarkets.value].sort((a, b) =>
-        getBestMaxROE(b.id).value - getBestMaxROE(a.id).value,
-      ))
+      sorted = applyRecentlyAddedSort([...filteredMarkets.value].sort((a, b) => {
+        const aBest = getBestMaxROE(a.id)
+        const bBest = getBestMaxROE(b.id)
+        const aHasRoe = aBest.metric === 'max-roe' ? 1 : 0
+        const bHasRoe = bBest.metric === 'max-roe' ? 1 : 0
+        if (aHasRoe !== bHasRoe) return bHasRoe - aHasRoe
+        return bBest.value - aBest.value
+      }))
       break
     case 'Total Supply':
       sorted = applyRecentlyAddedSort([...filteredMarkets.value].sort((a, b) =>

--- a/pages/portfolio.vue
+++ b/pages/portfolio.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
+import { isEVault, type EVault, type PortfolioBorrowPosition, type VaultEntity } from '@eulerxyz/euler-v2-sdk'
 import { formatNumber, formatCompactUsdValue } from '~/utils/string-utils'
 import { POLL_INTERVAL_60S_MS } from '~/entities/tuning-constants'
+import { areRoeCollateralVaultsCorrelatedWithBorrow, getPositionRoeCollateralVaults } from '~/utils/position-roe'
 
 defineOptions({
   name: 'PortfolioPage',
@@ -24,6 +26,7 @@ const { refresh: refreshFreshAccount } = useFreshAccount()
 const { rewards } = useSdkRewards()
 const { locks, refreshLocks } = useREULLocks()
 const { isConnected, address } = useWagmi()
+const { getTokenCategoryTags } = useTokenList()
 const { isLoaded: isBalancesLoaded, updateBalances } = useWallets()
 const { eulerLensAddresses } = useEulerAddresses()
 const { portfolioRefreshCounter } = usePortfolioRefresh()
@@ -71,6 +74,18 @@ const portfolioNetApyDisplay = computed(() =>
 )
 const portfolioRoeDisplay = computed(() =>
   Number.isFinite(portfolioRoe.value) ? `${formatNumber(portfolioRoe.value)}%` : '-',
+)
+const isPortfolioRoeApplicable = computed(() =>
+  borrowPositions.value.length > 0
+  && borrowPositions.value.every((position: PortfolioBorrowPosition<VaultEntity>) => {
+    const borrowVault = position.borrowVault
+    if (!isEVault(borrowVault)) return false
+    return areRoeCollateralVaultsCorrelatedWithBorrow(
+      getPositionRoeCollateralVaults(position),
+      borrowVault as EVault,
+      getTokenCategoryTags,
+    )
+  }),
 )
 const totalSuppliedDisplay = computed(() => {
   const { total, hasMissingPrices } = totalSuppliedValueInfo.value
@@ -179,7 +194,10 @@ watch(showAllLabelEntries, (showAll) => {
             </div>
           </BaseLoadableContent>
         </div>
-        <div class="flex justify-between items-center">
+        <div
+          v-if="isPortfolioRoeApplicable"
+          class="flex justify-between items-center"
+        >
           <div class="flex items-center gap-4 text-p2 text-content-secondary">
             ROE
             <UiFootnote

--- a/pages/portfolio.vue
+++ b/pages/portfolio.vue
@@ -1,8 +1,6 @@
 <script setup lang="ts">
-import { isEVault, type EVault, type PortfolioBorrowPosition, type VaultEntity } from '@eulerxyz/euler-v2-sdk'
 import { formatNumber, formatCompactUsdValue } from '~/utils/string-utils'
 import { POLL_INTERVAL_60S_MS } from '~/entities/tuning-constants'
-import { areRoeCollateralVaultsCorrelatedWithBorrow, getPositionRoeCollateralVaults } from '~/utils/position-roe'
 
 defineOptions({
   name: 'PortfolioPage',
@@ -26,7 +24,6 @@ const { refresh: refreshFreshAccount } = useFreshAccount()
 const { rewards } = useSdkRewards()
 const { locks, refreshLocks } = useREULLocks()
 const { isConnected, address } = useWagmi()
-const { getTokenCategoryTags } = useTokenList()
 const { isLoaded: isBalancesLoaded, updateBalances } = useWallets()
 const { eulerLensAddresses } = useEulerAddresses()
 const { portfolioRefreshCounter } = usePortfolioRefresh()
@@ -74,18 +71,6 @@ const portfolioNetApyDisplay = computed(() =>
 )
 const portfolioRoeDisplay = computed(() =>
   Number.isFinite(portfolioRoe.value) ? `${formatNumber(portfolioRoe.value)}%` : '-',
-)
-const isPortfolioRoeApplicable = computed(() =>
-  borrowPositions.value.length > 0
-  && borrowPositions.value.every((position: PortfolioBorrowPosition<VaultEntity>) => {
-    const borrowVault = position.borrowVault
-    if (!isEVault(borrowVault)) return false
-    return areRoeCollateralVaultsCorrelatedWithBorrow(
-      getPositionRoeCollateralVaults(position),
-      borrowVault as EVault,
-      getTokenCategoryTags,
-    )
-  }),
 )
 const totalSuppliedDisplay = computed(() => {
   const { total, hasMissingPrices } = totalSuppliedValueInfo.value
@@ -194,10 +179,7 @@ watch(showAllLabelEntries, (showAll) => {
             </div>
           </BaseLoadableContent>
         </div>
-        <div
-          v-if="isPortfolioRoeApplicable"
-          class="flex justify-between items-center"
-        >
+        <div class="flex justify-between items-center">
           <div class="flex items-center gap-4 text-p2 text-content-secondary">
             ROE
             <UiFootnote

--- a/pages/portfolio.vue
+++ b/pages/portfolio.vue
@@ -184,7 +184,7 @@ watch(showAllLabelEntries, (showAll) => {
             ROE
             <UiFootnote
               title="Portfolio ROE"
-              text="Return on equity across all positions. Calculated as total net yield divided by total equity (supplied value minus borrowed value)."
+              text="Account-level return on equity. Calculated as total net yield divided by total equity, where equity is supplied value minus borrowed value."
               tooltip-placement="bottom-start"
               class="[--ui-footnote-icon-color:var(--c-content-tertiary)]"
             />

--- a/pages/position/[number]/borrow/swap.vue
+++ b/pages/position/[number]/borrow/swap.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import type { SecuritizeCollateralVault, EVault, PortfolioBorrowPosition, SwapQuote, VaultEntity, TransactionPlan } from '@eulerxyz/euler-v2-sdk'
+import { SwapperMode, type SecuritizeCollateralVault, type EVault, type PortfolioBorrowPosition, type SwapQuote, type VaultEntity, type TransactionPlan } from '@eulerxyz/euler-v2-sdk'
+import { areTokenAddressesCorrelatedByTags } from '~/utils/token-categories'
 import { getAssetUsdValue, getAssetOraclePrice, getCollateralOraclePrice, conservativePriceRatioNumber } from '~/utils/sdk-prices'
 import { useSwapDebtOptions } from '~/composables/useSwapDebtOptions'
-import { SwapperMode } from '@eulerxyz/euler-v2-sdk'
 import { withVaultIntrinsicApy } from '~/utils/vault-intrinsic-apy'
 import { formatNumber, formatSmartAmount, formatHealthScore } from '~/utils/string-utils'
 import { formatLiquidationBuffer as formatLiqBuffer, calculateRoe } from '~/utils/repayUtils'
@@ -21,6 +21,7 @@ const { account: planAccount } = usePlanAccount()
 const { settings } = useUserSettings()
 const enableIntrinsicApy = computed(() => settings.value.enableIntrinsicApy)
 const { getSupplyRewardApy, getBorrowRewardApy } = useRewardsApy()
+const { getTokenCategoryTags } = useTokenList()
 
 const positionIndex = usePositionIndex()
 
@@ -88,6 +89,21 @@ const toBorrowApy = computed(() => {
   const base = getVaultBorrowApy(toVault.value)
   return withVaultIntrinsicApy(base, toVault.value, enableIntrinsicApy.value) - getBorrowRewardApy(toVault.value.address, collateralVault.value?.address)
 })
+const isRoeApplicable = computed(() =>
+  !!collateralVault.value
+  && !!fromVault.value
+  && !!toVault.value
+  && areTokenAddressesCorrelatedByTags(
+    collateralVault.value.asset.address,
+    fromVault.value.asset.address,
+    getTokenCategoryTags,
+  )
+  && areTokenAddressesCorrelatedByTags(
+    collateralVault.value.asset.address,
+    toVault.value.asset.address,
+    getTokenCategoryTags,
+  ),
+)
 
 const supplyValueUsd = ref<number | null>(null)
 watchEffect(async () => {
@@ -480,7 +496,10 @@ const onToVaultChange = (selectedIndex: number) => {
             variant="card"
             class="w-full laptop:max-w-[360px]"
           >
-            <SummaryRow label="ROE">
+            <SummaryRow
+              v-if="isRoeApplicable"
+              label="ROE"
+            >
               <SummaryValue
                 :before="roeBefore !== null ? formatNumber(roeBefore) : undefined"
                 :after="roeAfter !== null && quote ? formatNumber(roeAfter) : undefined"

--- a/pages/position/[number]/borrow/swap.vue
+++ b/pages/position/[number]/borrow/swap.vue
@@ -92,8 +92,12 @@ const toBorrowApy = computed(() => {
   const base = getVaultBorrowApy(toVault.value)
   return withVaultIntrinsicApy(base, toVault.value, enableIntrinsicApy.value) - getBorrowRewardApy(toVault.value.address, collateralVault.value?.address)
 })
-const isRoeApplicable = computed(() =>
+const hasSingleCollateralRoeScope = computed(() =>
   positionCollateralVaults.value.isComplete
+  && positionCollateralVaults.value.vaults.length === 1,
+)
+const isRoeApplicable = computed(() =>
+  hasSingleCollateralRoeScope.value
   && areRoeCollateralVaultsCorrelatedWithBorrow(positionCollateralVaults.value.vaults, fromVault.value, getTokenCategoryTags)
   && areRoeCollateralVaultsCorrelatedWithBorrow(positionCollateralVaults.value.vaults, toVault.value, getTokenCategoryTags),
 )

--- a/pages/position/[number]/borrow/swap.vue
+++ b/pages/position/[number]/borrow/swap.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { SwapperMode, type SecuritizeCollateralVault, type EVault, type PortfolioBorrowPosition, type SwapQuote, type VaultEntity, type TransactionPlan } from '@eulerxyz/euler-v2-sdk'
-import { areTokenAddressesCorrelatedByTags } from '~/utils/token-categories'
+import { areRoeCollateralVaultsCorrelatedWithBorrow, getPositionRoeCollateralVaults } from '~/utils/position-roe'
 import { getAssetUsdValue, getAssetOraclePrice, getCollateralOraclePrice, conservativePriceRatioNumber } from '~/utils/sdk-prices'
 import { useSwapDebtOptions } from '~/composables/useSwapDebtOptions'
 import { withVaultIntrinsicApy } from '~/utils/vault-intrinsic-apy'
@@ -33,6 +33,9 @@ const fromVault = computed<EVault | undefined>(() => position.value ? position.v
 const collateralVault = computed<EVault | SecuritizeCollateralVault | undefined>(() => position.value ? position.value.collateralVault as EVault | SecuritizeCollateralVault | undefined : undefined)
 const toVault: Ref<EVault | undefined> = ref()
 useOperationGuard(computed(() => [fromVault.value?.address, toVault.value?.address, collateralVault.value?.address].filter(Boolean)))
+const positionCollateralVaults = computed(() =>
+  getPositionRoeCollateralVaults(position.value, collateralVault.value),
+)
 
 const { borrowOptions, borrowVaults } = useSwapDebtOptions({
   collateralVault: computed(() => collateralVault.value as EVault | undefined),
@@ -90,19 +93,8 @@ const toBorrowApy = computed(() => {
   return withVaultIntrinsicApy(base, toVault.value, enableIntrinsicApy.value) - getBorrowRewardApy(toVault.value.address, collateralVault.value?.address)
 })
 const isRoeApplicable = computed(() =>
-  !!collateralVault.value
-  && !!fromVault.value
-  && !!toVault.value
-  && areTokenAddressesCorrelatedByTags(
-    collateralVault.value.asset.address,
-    fromVault.value.asset.address,
-    getTokenCategoryTags,
-  )
-  && areTokenAddressesCorrelatedByTags(
-    collateralVault.value.asset.address,
-    toVault.value.asset.address,
-    getTokenCategoryTags,
-  ),
+  areRoeCollateralVaultsCorrelatedWithBorrow(positionCollateralVaults.value, fromVault.value, getTokenCategoryTags)
+  && areRoeCollateralVaultsCorrelatedWithBorrow(positionCollateralVaults.value, toVault.value, getTokenCategoryTags),
 )
 
 const supplyValueUsd = ref<number | null>(null)

--- a/pages/position/[number]/borrow/swap.vue
+++ b/pages/position/[number]/borrow/swap.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { SwapperMode, type SecuritizeCollateralVault, type EVault, type PortfolioBorrowPosition, type SwapQuote, type VaultEntity, type TransactionPlan } from '@eulerxyz/euler-v2-sdk'
-import { areRoeCollateralVaultsCorrelatedWithBorrow, getPositionRoeCollateralVaults } from '~/utils/position-roe'
+import { areRoeCollateralVaultsCorrelatedWithBorrow, resolvePositionRoeCollateralVaults } from '~/utils/position-roe'
 import { getAssetUsdValue, getAssetOraclePrice, getCollateralOraclePrice, conservativePriceRatioNumber } from '~/utils/sdk-prices'
 import { useSwapDebtOptions } from '~/composables/useSwapDebtOptions'
 import { withVaultIntrinsicApy } from '~/utils/vault-intrinsic-apy'
@@ -34,7 +34,7 @@ const collateralVault = computed<EVault | SecuritizeCollateralVault | undefined>
 const toVault: Ref<EVault | undefined> = ref()
 useOperationGuard(computed(() => [fromVault.value?.address, toVault.value?.address, collateralVault.value?.address].filter(Boolean)))
 const positionCollateralVaults = computed(() =>
-  getPositionRoeCollateralVaults(position.value, collateralVault.value),
+  resolvePositionRoeCollateralVaults(position.value, collateralVault.value),
 )
 
 const { borrowOptions, borrowVaults } = useSwapDebtOptions({
@@ -93,8 +93,9 @@ const toBorrowApy = computed(() => {
   return withVaultIntrinsicApy(base, toVault.value, enableIntrinsicApy.value) - getBorrowRewardApy(toVault.value.address, collateralVault.value?.address)
 })
 const isRoeApplicable = computed(() =>
-  areRoeCollateralVaultsCorrelatedWithBorrow(positionCollateralVaults.value, fromVault.value, getTokenCategoryTags)
-  && areRoeCollateralVaultsCorrelatedWithBorrow(positionCollateralVaults.value, toVault.value, getTokenCategoryTags),
+  positionCollateralVaults.value.isComplete
+  && areRoeCollateralVaultsCorrelatedWithBorrow(positionCollateralVaults.value.vaults, fromVault.value, getTokenCategoryTags)
+  && areRoeCollateralVaultsCorrelatedWithBorrow(positionCollateralVaults.value.vaults, toVault.value, getTokenCategoryTags),
 )
 
 const supplyValueUsd = ref<number | null>(null)

--- a/pages/position/[number]/collateral/swap.vue
+++ b/pages/position/[number]/collateral/swap.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import { isSecuritizeCollateralVault, type SwapQuote, type EVault, type PortfolioBorrowPosition, type SecuritizeCollateralVault, type TransactionPlan, type VaultEntity } from '@eulerxyz/euler-v2-sdk'
+import { isSecuritizeCollateralVault, SwapperMode, type SwapQuote, type EVault, type PortfolioBorrowPosition, type SecuritizeCollateralVault, type TransactionPlan, type VaultEntity } from '@eulerxyz/euler-v2-sdk'
+import { areTokenAddressesCorrelatedByTags } from '~/utils/token-categories'
 import { getAssetUsdValue, getAssetOraclePrice, getCollateralOraclePrice, conservativePriceRatioNumber, getCollateralUsdValueOrZero } from '~/utils/sdk-prices'
 import { useSwapCollateralOptions } from '~/composables/useSwapCollateralOptions'
-import { SwapperMode } from '@eulerxyz/euler-v2-sdk'
 import { withVaultIntrinsicApy } from '~/utils/vault-intrinsic-apy'
 import { useVaultRegistry } from '~/composables/useVaultRegistry'
 import { formatNumber, formatSmartAmount, formatHealthScore, trimTrailingZeros } from '~/utils/string-utils'
@@ -35,6 +35,7 @@ const { planCollateralChange } = useEulerTx()
 const { settings } = useUserSettings()
 const enableIntrinsicApy = computed(() => settings.value.enableIntrinsicApy)
 const { getSupplyRewardApy, getBorrowRewardApy } = useRewardsApy()
+const { getTokenCategoryTags } = useTokenList()
 const { isReady: isVaultsReady } = useVaults()
 const { getOrFetch } = useVaultRegistry()
 const { eulerLensAddresses, isReady: isEulerAddressesReady, loadEulerConfig } = useEulerAddresses()
@@ -400,6 +401,21 @@ const borrowApy = computed(() => {
   const base = getVaultBorrowApy(borrowVault.value)
   return withVaultIntrinsicApy(base, borrowVault.value, enableIntrinsicApy.value) - getBorrowRewardApy(borrowVault.value.address, fromVault.value?.address)
 })
+const isRoeApplicable = computed(() =>
+  !!fromVault.value
+  && !!toVault.value
+  && !!borrowVault.value
+  && areTokenAddressesCorrelatedByTags(
+    fromVault.value.asset.address,
+    borrowVault.value.asset.address,
+    getTokenCategoryTags,
+  )
+  && areTokenAddressesCorrelatedByTags(
+    toVault.value.asset.address,
+    borrowVault.value.asset.address,
+    getTokenCategoryTags,
+  ),
+)
 
 // ── Collateral USD valuation (from liability vault's perspective) ─────────
 const getCollateralValueUsdLocal = async (amount: bigint) => {
@@ -836,7 +852,10 @@ watch(() => cowSwapOrderStatus.orderStatus.value, (status) => {
             variant="card"
             class="w-full laptop:max-w-[360px]"
           >
-            <SummaryRow label="ROE">
+            <SummaryRow
+              v-if="isRoeApplicable"
+              label="ROE"
+            >
               <SummaryValue
                 :before="roeBefore !== null ? formatNumber(roeBefore) : undefined"
                 :after="roeAfter !== null && (quote || isSameAsset) ? formatNumber(roeAfter) : undefined"

--- a/pages/position/[number]/collateral/swap.vue
+++ b/pages/position/[number]/collateral/swap.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { isEVault, isSecuritizeCollateralVault, SwapperMode, type SwapQuote, type EVault, type PortfolioBorrowPosition, type SecuritizeCollateralVault, type TransactionPlan, type VaultEntity } from '@eulerxyz/euler-v2-sdk'
-import { areTokenAddressesCorrelatedByTags } from '~/utils/token-categories'
+import { areRoeCollateralVaultsCorrelatedWithBorrow, resolvePositionRoeCollateralVaults } from '~/utils/position-roe'
 import { getAssetUsdValue, getAssetOraclePrice, getCollateralOraclePrice, conservativePriceRatioNumber, getCollateralUsdValueOrZero } from '~/utils/sdk-prices'
 import { useSwapCollateralOptions } from '~/composables/useSwapCollateralOptions'
 import { withVaultIntrinsicApy } from '~/utils/vault-intrinsic-apy'
@@ -431,18 +431,16 @@ const projectedCollateralVaults = computed<Array<EVault | SecuritizeCollateralVa
 
   return [...vaults.values()]
 })
+const positionRoeCollateralVaults = computed(() =>
+  resolvePositionRoeCollateralVaults(position.value, fromVault.value),
+)
 const isRoeApplicable = computed(() => {
   if (!toVault.value || !borrowVault.value) return false
+  if (!positionRoeCollateralVaults.value.isComplete) return false
   const collaterals = projectedCollateralVaults.value
   if (!collaterals.length) return false
 
-  return collaterals.every(collateral =>
-    areTokenAddressesCorrelatedByTags(
-      collateral.asset.address,
-      borrowVault.value!.asset.address,
-      getTokenCategoryTags,
-    ),
-  )
+  return areRoeCollateralVaultsCorrelatedWithBorrow(collaterals, borrowVault.value, getTokenCategoryTags)
 })
 
 // ── Collateral USD valuation (from liability vault's perspective) ─────────

--- a/pages/position/[number]/collateral/swap.vue
+++ b/pages/position/[number]/collateral/swap.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { isSecuritizeCollateralVault, SwapperMode, type SwapQuote, type EVault, type PortfolioBorrowPosition, type SecuritizeCollateralVault, type TransactionPlan, type VaultEntity } from '@eulerxyz/euler-v2-sdk'
+import { isEVault, isSecuritizeCollateralVault, SwapperMode, type SwapQuote, type EVault, type PortfolioBorrowPosition, type SecuritizeCollateralVault, type TransactionPlan, type VaultEntity } from '@eulerxyz/euler-v2-sdk'
 import { areTokenAddressesCorrelatedByTags } from '~/utils/token-categories'
 import { getAssetUsdValue, getAssetOraclePrice, getCollateralOraclePrice, conservativePriceRatioNumber, getCollateralUsdValueOrZero } from '~/utils/sdk-prices'
 import { useSwapCollateralOptions } from '~/composables/useSwapCollateralOptions'
@@ -401,21 +401,49 @@ const borrowApy = computed(() => {
   const base = getVaultBorrowApy(borrowVault.value)
   return withVaultIntrinsicApy(base, borrowVault.value, enableIntrinsicApy.value) - getBorrowRewardApy(borrowVault.value.address, fromVault.value?.address)
 })
-const isRoeApplicable = computed(() =>
-  !!fromVault.value
-  && !!toVault.value
-  && !!borrowVault.value
-  && areTokenAddressesCorrelatedByTags(
-    fromVault.value.asset.address,
-    borrowVault.value.asset.address,
-    getTokenCategoryTags,
+const projectedCollateralVaults = computed<Array<EVault | SecuritizeCollateralVault>>(() => {
+  if (!position.value) return []
+
+  const sourceAddress = normalizeAddress(fromVault.value?.address)
+  const targetAddress = normalizeAddress(toVault.value?.address)
+  const removesSource = isMaxSwap.value
+  const vaults = new Map<string, EVault | SecuritizeCollateralVault>()
+
+  for (const collateralPosition of position.value.collaterals) {
+    const vault = collateralPosition.vault
+    if (!vault || (!isEVault(vault) && !isSecuritizeCollateralVault(vault))) continue
+    const address = normalizeAddress(vault.address)
+    if (!address) continue
+    if (removesSource && sourceAddress && address === sourceAddress) continue
+    vaults.set(address, vault as EVault | SecuritizeCollateralVault)
+  }
+
+  if (!vaults.size && fromVault.value) {
+    const address = normalizeAddress(fromVault.value.address)
+    if (address && !(removesSource && sourceAddress && address === sourceAddress)) {
+      vaults.set(address, fromVault.value)
+    }
+  }
+
+  if (toVault.value && targetAddress) {
+    vaults.set(targetAddress, toVault.value)
+  }
+
+  return [...vaults.values()]
+})
+const isRoeApplicable = computed(() => {
+  if (!toVault.value || !borrowVault.value) return false
+  const collaterals = projectedCollateralVaults.value
+  if (!collaterals.length) return false
+
+  return collaterals.every(collateral =>
+    areTokenAddressesCorrelatedByTags(
+      collateral.asset.address,
+      borrowVault.value!.asset.address,
+      getTokenCategoryTags,
+    ),
   )
-  && areTokenAddressesCorrelatedByTags(
-    toVault.value.asset.address,
-    borrowVault.value.asset.address,
-    getTokenCategoryTags,
-  ),
-)
+})
 
 // ── Collateral USD valuation (from liability vault's perspective) ─────────
 const getCollateralValueUsdLocal = async (amount: bigint) => {

--- a/pages/position/[number]/collateral/swap.vue
+++ b/pages/position/[number]/collateral/swap.vue
@@ -434,9 +434,15 @@ const projectedCollateralVaults = computed<Array<EVault | SecuritizeCollateralVa
 const positionRoeCollateralVaults = computed(() =>
   resolvePositionRoeCollateralVaults(position.value, fromVault.value),
 )
+const hasSingleCollateralFullSwapRoeScope = computed(() =>
+  positionRoeCollateralVaults.value.isComplete
+  && positionRoeCollateralVaults.value.vaults.length === 1
+  && projectedCollateralVaults.value.length === 1
+  && isMaxSwap.value,
+)
 const isRoeApplicable = computed(() => {
   if (!toVault.value || !borrowVault.value) return false
-  if (!positionRoeCollateralVaults.value.isComplete) return false
+  if (!hasSingleCollateralFullSwapRoeScope.value) return false
   const collaterals = projectedCollateralVaults.value
   if (!collaterals.length) return false
 

--- a/pages/position/[number]/index.vue
+++ b/pages/position/[number]/index.vue
@@ -475,7 +475,7 @@ const roeModalData = computed(() => ({
   props: {
     roeBreakdown: visibleRoeBreakdown.value,
     roe: roe.value,
-    multiplier: positionMultiplier.value !== null && Number.isFinite(positionMultiplier.value) ? positionMultiplier.value : 0,
+    multiplier: positionMultiplier.value !== null && Number.isFinite(positionMultiplier.value) ? positionMultiplier.value : null,
     supplyAPY: collateralSupplyApy.value,
     borrowAPY: borrowApy.value,
     supplyRewardAPY: supplyRewardAPY.value || null,

--- a/pages/position/[number]/index.vue
+++ b/pages/position/[number]/index.vue
@@ -804,7 +804,15 @@ watch([isConnected, isSpyMode, address], () => {
         :vault="collateralVault"
         :assets="pairAssets"
         :assets-label="pairAssetsLabel"
-      />
+      >
+        <template #symbol-trailing>
+          <CorrelatedPairBadge
+            v-if="isRoeApplicable"
+            compact
+            title="All collateral assets in this position share a trusted price-correlation category with the borrow asset, so ROE is shown."
+          />
+        </template>
+      </VaultLabelsAndAssets>
 
       <UiAlert
         v-if="hasQueryFailure"
@@ -818,7 +826,11 @@ watch([isConnected, isSpyMode, address], () => {
         v-if="!hasNoBorrow"
         class="flex flex-col gap-16 laptop:flex-row laptop:items-stretch"
       >
-        <div class="flex flex-col gap-16 p-16 rounded-12 border border-line-default bg-card shadow-card laptop:flex-1">
+        <div
+          class="flex flex-col gap-16 p-16 rounded-12 border border-line-default bg-card shadow-card laptop:flex-1"
+          data-id="position-summary"
+          :data-correlated="isRoeApplicable"
+        >
           <div class="text-h4 text-content-primary">
             Position summary
           </div>

--- a/pages/position/[number]/index.vue
+++ b/pages/position/[number]/index.vue
@@ -18,7 +18,7 @@ import { useToast } from '~/components/ui/composables/useToast'
 import { useVaultRegistry } from '~/composables/useVaultRegistry'
 import { getAddress, type Address, type Abi } from 'viem'
 import { eulerAccountLensABI } from '~/entities/euler/abis'
-import { areTokenAddressesCorrelatedByTags } from '~/utils/token-categories'
+import { areRoeCollateralVaultsCorrelatedWithBorrow } from '~/utils/position-roe'
 
 const _route = useRoute()
 const router = useRouter()
@@ -433,12 +433,11 @@ const fallbackRoe = computed(() => {
 const roe = computed(() => visibleRoeBreakdown.value?.total ?? fallbackRoe.value)
 const isRoeApplicable = computed(() => {
   if (!borrowVault.value || !collateralItems.value.length) return false
-  return collateralItems.value.every(item =>
-    areTokenAddressesCorrelatedByTags(
-      item.vault.asset.address,
-      borrowVault.value!.asset.address,
-      getTokenCategoryTags,
-    ),
+  if (positionCollateralAddresses.value.length > collateralItems.value.length) return false
+  return areRoeCollateralVaultsCorrelatedWithBorrow(
+    collateralItems.value.map(item => item.vault),
+    borrowVault.value,
+    getTokenCategoryTags,
   )
 })
 
@@ -446,10 +445,14 @@ const supplyCampaignsForModal = computed(() => getSupplyRewardCampaigns(collater
 const borrowCampaignsForModal = computed(() => getBorrowRewardCampaigns(borrowVault.value?.address || '', collateralVault.value?.address || ''))
 
 const positionMultiplier = computed(() => {
+  if (!collateralValue.value.hasPrice || !borrowMarketValue.value.hasPrice) return null
   const equity = collateralValue.value.usd - borrowMarketValue.value.usd
-  if (equity <= 0) return 0
+  if (equity <= 0) return null
   return collateralValue.value.usd / equity
 })
+const positionMultiplierDisplay = computed(() =>
+  positionMultiplier.value !== null && Number.isFinite(positionMultiplier.value) ? `${formatNumber(positionMultiplier.value, 2, 2)}x` : '-',
+)
 
 const netApyModalData = computed(() => ({
   props: {
@@ -472,7 +475,7 @@ const roeModalData = computed(() => ({
   props: {
     roeBreakdown: visibleRoeBreakdown.value,
     roe: roe.value,
-    multiplier: Number.isFinite(positionMultiplier.value) ? positionMultiplier.value : 0,
+    multiplier: positionMultiplier.value !== null && Number.isFinite(positionMultiplier.value) ? positionMultiplier.value : 0,
     supplyAPY: collateralSupplyApy.value,
     borrowAPY: borrowApy.value,
     supplyRewardAPY: supplyRewardAPY.value || null,
@@ -806,11 +809,19 @@ watch([isConnected, isSpyMode, address], () => {
         :assets-label="pairAssetsLabel"
       >
         <template #symbol-trailing>
-          <CorrelatedPairBadge
-            v-if="isRoeApplicable"
-            compact
-            title="All collateral assets in this position share a trusted price-correlation category with the borrow asset, so ROE is shown."
-          />
+          <span class="inline-flex items-center gap-4">
+            <CorrelatedPairBadge
+              v-if="isRoeApplicable"
+              compact
+              title="Correlated position."
+            />
+            <CorrelatedPairBadge
+              v-if="isRoeApplicable && positionMultiplierDisplay !== '-'"
+              compact
+              :label="positionMultiplierDisplay"
+              title="Effective multiplier at your LTV."
+            />
+          </span>
         </template>
       </VaultLabelsAndAssets>
 

--- a/pages/position/[number]/index.vue
+++ b/pages/position/[number]/index.vue
@@ -18,6 +18,7 @@ import { useToast } from '~/components/ui/composables/useToast'
 import { useVaultRegistry } from '~/composables/useVaultRegistry'
 import { getAddress, type Address, type Abi } from 'viem'
 import { eulerAccountLensABI } from '~/entities/euler/abis'
+import { areTokenAddressesCorrelatedByTags } from '~/utils/token-categories'
 
 const _route = useRoute()
 const router = useRouter()
@@ -30,6 +31,7 @@ const { viewer, visibleBreakdown } = useApyVisibility()
 const { settings } = useUserSettings()
 const enableIntrinsicApy = computed(() => settings.value.enableIntrinsicApy)
 const { getSupplyRewardApy, getBorrowRewardApy, hasSupplyRewards, hasBorrowRewards, getSupplyRewardCampaigns, getBorrowRewardCampaigns } = useRewardsApy()
+const { getTokenCategoryTags } = useTokenList()
 const { planTransfer, executePlan } = useEulerTx()
 const { account: planAccount } = usePlanAccount()
 const {
@@ -429,6 +431,16 @@ const fallbackRoe = computed(() => {
   )
 })
 const roe = computed(() => visibleRoeBreakdown.value?.total ?? fallbackRoe.value)
+const isRoeApplicable = computed(() => {
+  if (!borrowVault.value || !collateralItems.value.length) return false
+  return collateralItems.value.every(item =>
+    areTokenAddressesCorrelatedByTags(
+      item.vault.asset.address,
+      borrowVault.value!.asset.address,
+      getTokenCategoryTags,
+    ),
+  )
+})
 
 const supplyCampaignsForModal = computed(() => getSupplyRewardCampaigns(collateralVault.value?.address || ''))
 const borrowCampaignsForModal = computed(() => getBorrowRewardCampaigns(borrowVault.value?.address || '', collateralVault.value?.address || ''))
@@ -848,7 +860,10 @@ watch([isConnected, isSpyMode, address], () => {
               {{ Number.isFinite(netAPY) ? `${formatNumber(netAPY)}%` : '-' }}
             </div>
           </div>
-          <div class="flex justify-between items-center">
+          <div
+            v-if="isRoeApplicable"
+            class="flex justify-between items-center"
+          >
             <div class="flex items-center gap-4 text-p2 text-content-secondary">
               ROE
               <UiModalPreviewTrigger

--- a/pages/position/[number]/index.vue
+++ b/pages/position/[number]/index.vue
@@ -19,6 +19,7 @@ import { useVaultRegistry } from '~/composables/useVaultRegistry'
 import { getAddress, type Address, type Abi } from 'viem'
 import { eulerAccountLensABI } from '~/entities/euler/abis'
 import { areRoeCollateralVaultsCorrelatedWithBorrow } from '~/utils/position-roe'
+import { getTokenAddressesCorrelationCategoryLabel } from '~/utils/token-categories'
 
 const _route = useRoute()
 const router = useRouter()
@@ -440,6 +441,16 @@ const isRoeApplicable = computed(() => {
     getTokenCategoryTags,
   )
 })
+const correlatedBadgeTitle = computed(() => {
+  const category = getTokenAddressesCorrelationCategoryLabel(
+    [
+      ...collateralItems.value.map(item => item.vault.asset.address),
+      borrowVault.value?.asset.address,
+    ],
+    getTokenCategoryTags,
+  )
+  return category ? `Correlated category: ${category}` : undefined
+})
 
 const supplyCampaignsForModal = computed(() => getSupplyRewardCampaigns(collateralVault.value?.address || ''))
 const borrowCampaignsForModal = computed(() => getBorrowRewardCampaigns(borrowVault.value?.address || '', collateralVault.value?.address || ''))
@@ -813,7 +824,7 @@ watch([isConnected, isSpyMode, address], () => {
             <CorrelatedPairBadge
               v-if="isRoeApplicable"
               compact
-              title="Correlated position."
+              :title="correlatedBadgeTitle"
             />
             <CorrelatedPairBadge
               v-if="isRoeApplicable && positionMultiplierDisplay !== '-'"

--- a/pages/position/[number]/multiply.vue
+++ b/pages/position/[number]/multiply.vue
@@ -9,7 +9,7 @@ import { isAnyVaultBlockedByCountry, isVaultRestrictedByCountry } from '~/compos
 import { useSwapQuotesParallel } from '~/composables/useSwapQuotesParallel'
 import { buildSwapRouteItems } from '~/utils/swapRouteItems'
 import { isEVault, SwapperMode, type EVault, type PortfolioBorrowPosition, type SwapQuote, type TransactionPlan, type TransactionPlanPrepared, type VaultEntity } from '@eulerxyz/euler-v2-sdk'
-import { areRoeCollateralVaultsCorrelatedWithBorrow, getPositionRoeCollateralVaults, mergeRoeCollateralVaults } from '~/utils/position-roe'
+import { areRoeCollateralVaultsCorrelatedWithBorrow, mergeRoeCollateralVaults, resolvePositionRoeCollateralVaults } from '~/utils/position-roe'
 import { withVaultIntrinsicApy } from '~/utils/vault-intrinsic-apy'
 import { formatNumber, formatSmartAmount, formatHealthScore, trimTrailingZeros } from '~/utils/string-utils'
 import { formatLiquidationBuffer as formatLiqBuffer, calculateRoe, computeNextHealth, computeLiquidationPrice } from '~/utils/repayUtils'
@@ -97,15 +97,19 @@ const multiplyLongVault = computed<EVault | undefined>(() => {
 const multiplyShortVault = computed<EVault | undefined>(() => position.value ? position.value.borrowVault as EVault | undefined : undefined)
 const multiplySubAccount = computed(() => position.value?.subAccount || null)
 useOperationGuard(computed(() => [multiplySupplyVault.value?.address, multiplyLongVault.value?.address, multiplyShortVault.value?.address].filter(Boolean)))
+const positionRoeCollateralVaults = computed(() =>
+  resolvePositionRoeCollateralVaults(position.value, multiplyLongVault.value),
+)
 const projectedMultiplyCollateralVaults = computed(() =>
   mergeRoeCollateralVaults([
-    ...getPositionRoeCollateralVaults(position.value, multiplyLongVault.value),
+    ...positionRoeCollateralVaults.value.vaults,
     multiplySupplyVault.value,
     multiplyLongVault.value,
   ]),
 )
 const isMultiplyRoeApplicable = computed(() =>
-  areRoeCollateralVaultsCorrelatedWithBorrow(projectedMultiplyCollateralVaults.value, multiplyShortVault.value, getTokenCategoryTags),
+  positionRoeCollateralVaults.value.isComplete
+  && areRoeCollateralVaultsCorrelatedWithBorrow(projectedMultiplyCollateralVaults.value, multiplyShortVault.value, getTokenCategoryTags),
 )
 
 const pairAssets = computed<VaultAsset[]>(() => {

--- a/pages/position/[number]/multiply.vue
+++ b/pages/position/[number]/multiply.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { VaultAsset } from '~/types/asset'
+import { getNetAPY } from '~/utils/vault/apy'
 import { getAssetUsdValue, getAssetOraclePrice, getCollateralOraclePrice, conservativePriceRatioNumber } from '~/utils/sdk-prices'
 import { computeMultipliedPriceImpact } from '~/utils/priceImpact'
 import { usePriceImpactGate } from '~/composables/usePriceImpactGate'
@@ -315,6 +316,38 @@ const multiplyRoeAfter = computed(() => {
     nextSupplyValueUsd.value,
     nextBorrowValueUsd.value,
     multiplyWeightedSupplyApy.value,
+    multiplyBorrowApy.value,
+  )
+})
+const multiplyNetApyBefore = computed(() => {
+  if (
+    currentSupplyValueUsd.value === null
+    || currentBorrowValueUsd.value === null
+    || multiplyLongApy.value === null
+    || multiplyBorrowApy.value === null
+  ) {
+    return null
+  }
+  return getNetAPY(
+    currentSupplyValueUsd.value,
+    multiplyLongApy.value,
+    currentBorrowValueUsd.value,
+    multiplyBorrowApy.value,
+  )
+})
+const multiplyNetApyAfter = computed(() => {
+  if (
+    nextSupplyValueUsd.value === null
+    || nextBorrowValueUsd.value === null
+    || multiplyWeightedSupplyApy.value === null
+    || multiplyBorrowApy.value === null
+  ) {
+    return null
+  }
+  return getNetAPY(
+    nextSupplyValueUsd.value,
+    multiplyWeightedSupplyApy.value,
+    nextBorrowValueUsd.value,
     multiplyBorrowApy.value,
   )
 })
@@ -854,7 +887,15 @@ watch([multiplyMinMultiplier, multiplyMaxMultiplier], ([min, max]) => {
           :assets="pairAssets"
           :assets-label="pairAssetsLabel"
           size="large"
-        />
+        >
+          <template #symbol-trailing>
+            <CorrelatedPairBadge
+              v-if="isMultiplyRoeApplicable"
+              compact
+              title="This pair shares a trusted price-correlation category, so ROE is shown."
+            />
+          </template>
+        </VaultLabelsAndAssets>
 
         <div class="grid gap-16 laptop:grid-cols-[minmax(0,1fr)_360px] laptop:items-start">
           <div class="flex flex-col gap-16 w-full">
@@ -955,6 +996,16 @@ watch([multiplyMinMultiplier, multiplyMaxMultiplier], ([min, max]) => {
               <SummaryValue
                 :before="multiplyRoeBefore !== null ? formatNumber(multiplyRoeBefore) : undefined"
                 :after="multiplyRoeAfter !== null && multiplySwapReady ? formatNumber(multiplyRoeAfter) : undefined"
+                suffix="%"
+              />
+            </SummaryRow>
+            <SummaryRow
+              v-else
+              label="Net APY"
+            >
+              <SummaryValue
+                :before="multiplyNetApyBefore !== null ? formatNumber(multiplyNetApyBefore) : undefined"
+                :after="multiplyNetApyAfter !== null && multiplySwapReady ? formatNumber(multiplyNetApyAfter) : undefined"
                 suffix="%"
               />
             </SummaryRow>

--- a/pages/position/[number]/multiply.vue
+++ b/pages/position/[number]/multiply.vue
@@ -8,7 +8,7 @@ import { isAnyVaultBlockedByCountry, isVaultRestrictedByCountry } from '~/compos
 import { useSwapQuotesParallel } from '~/composables/useSwapQuotesParallel'
 import { buildSwapRouteItems } from '~/utils/swapRouteItems'
 import { isEVault, SwapperMode, type EVault, type PortfolioBorrowPosition, type SwapQuote, type TransactionPlan, type TransactionPlanPrepared, type VaultEntity } from '@eulerxyz/euler-v2-sdk'
-import { areTokenAddressesCorrelatedByTags } from '~/utils/token-categories'
+import { areRoeCollateralVaultsCorrelatedWithBorrow, getPositionRoeCollateralVaults, mergeRoeCollateralVaults } from '~/utils/position-roe'
 import { withVaultIntrinsicApy } from '~/utils/vault-intrinsic-apy'
 import { formatNumber, formatSmartAmount, formatHealthScore, trimTrailingZeros } from '~/utils/string-utils'
 import { formatLiquidationBuffer as formatLiqBuffer, calculateRoe, computeNextHealth, computeLiquidationPrice } from '~/utils/repayUtils'
@@ -96,14 +96,15 @@ const multiplyLongVault = computed<EVault | undefined>(() => {
 const multiplyShortVault = computed<EVault | undefined>(() => position.value ? position.value.borrowVault as EVault | undefined : undefined)
 const multiplySubAccount = computed(() => position.value?.subAccount || null)
 useOperationGuard(computed(() => [multiplySupplyVault.value?.address, multiplyLongVault.value?.address, multiplyShortVault.value?.address].filter(Boolean)))
+const projectedMultiplyCollateralVaults = computed(() =>
+  mergeRoeCollateralVaults([
+    ...getPositionRoeCollateralVaults(position.value, multiplyLongVault.value),
+    multiplySupplyVault.value,
+    multiplyLongVault.value,
+  ]),
+)
 const isMultiplyRoeApplicable = computed(() =>
-  !!multiplyLongVault.value
-  && !!multiplyShortVault.value
-  && areTokenAddressesCorrelatedByTags(
-    multiplyLongVault.value.asset.address,
-    multiplyShortVault.value.asset.address,
-    getTokenCategoryTags,
-  ),
+  areRoeCollateralVaultsCorrelatedWithBorrow(projectedMultiplyCollateralVaults.value, multiplyShortVault.value, getTokenCategoryTags),
 )
 
 const pairAssets = computed<VaultAsset[]>(() => {

--- a/pages/position/[number]/multiply.vue
+++ b/pages/position/[number]/multiply.vue
@@ -6,9 +6,9 @@ import { usePriceImpactGate } from '~/composables/usePriceImpactGate'
 import { useEulerProductOfVault } from '~/composables/useEulerLabels'
 import { isAnyVaultBlockedByCountry, isVaultRestrictedByCountry } from '~/composables/useGeoBlock'
 import { useSwapQuotesParallel } from '~/composables/useSwapQuotesParallel'
-import { SwapperMode } from '@eulerxyz/euler-v2-sdk'
 import { buildSwapRouteItems } from '~/utils/swapRouteItems'
-import { isEVault, type EVault, type PortfolioBorrowPosition, type SwapQuote, type TransactionPlan, type TransactionPlanPrepared, type VaultEntity } from '@eulerxyz/euler-v2-sdk'
+import { isEVault, SwapperMode, type EVault, type PortfolioBorrowPosition, type SwapQuote, type TransactionPlan, type TransactionPlanPrepared, type VaultEntity } from '@eulerxyz/euler-v2-sdk'
+import { areTokenAddressesCorrelatedByTags } from '~/utils/token-categories'
 import { withVaultIntrinsicApy } from '~/utils/vault-intrinsic-apy'
 import { formatNumber, formatSmartAmount, formatHealthScore, trimTrailingZeros } from '~/utils/string-utils'
 import { formatLiquidationBuffer as formatLiqBuffer, calculateRoe, computeNextHealth, computeLiquidationPrice } from '~/utils/repayUtils'
@@ -33,6 +33,7 @@ const { planMultiply, prepareTransactionPlan, executePreparedPlan, prefetchPlugi
 const { account: planAccount } = usePlanAccount()
 const { eulerLensAddresses } = useEulerAddresses()
 const { getSupplyRewardApy, getBorrowRewardApy } = useRewardsApy()
+const { getTokenCategoryTags } = useTokenList()
 const { settings } = useUserSettings()
 const enableIntrinsicApy = computed(() => settings.value.enableIntrinsicApy)
 const {
@@ -95,6 +96,15 @@ const multiplyLongVault = computed<EVault | undefined>(() => {
 const multiplyShortVault = computed<EVault | undefined>(() => position.value ? position.value.borrowVault as EVault | undefined : undefined)
 const multiplySubAccount = computed(() => position.value?.subAccount || null)
 useOperationGuard(computed(() => [multiplySupplyVault.value?.address, multiplyLongVault.value?.address, multiplyShortVault.value?.address].filter(Boolean)))
+const isMultiplyRoeApplicable = computed(() =>
+  !!multiplyLongVault.value
+  && !!multiplyShortVault.value
+  && areTokenAddressesCorrelatedByTags(
+    multiplyLongVault.value.asset.address,
+    multiplyShortVault.value.asset.address,
+    getTokenCategoryTags,
+  ),
+)
 
 const pairAssets = computed<VaultAsset[]>(() => {
   if (!multiplyLongVault.value || !multiplyShortVault.value) {
@@ -937,7 +947,10 @@ watch([multiplyMinMultiplier, multiplyMaxMultiplier], ([min, max]) => {
             variant="card"
             class="w-full laptop:max-w-[360px]"
           >
-            <SummaryRow label="ROE">
+            <SummaryRow
+              v-if="isMultiplyRoeApplicable"
+              label="ROE"
+            >
               <SummaryValue
                 :before="multiplyRoeBefore !== null ? formatNumber(multiplyRoeBefore) : undefined"
                 :after="multiplyRoeAfter !== null && multiplySwapReady ? formatNumber(multiplyRoeAfter) : undefined"

--- a/pages/position/[number]/multiply.vue
+++ b/pages/position/[number]/multiply.vue
@@ -22,6 +22,7 @@ import { useToast } from '~/components/ui/composables/useToast'
 import { SlippageSettingsModal, OperationReviewModal } from '#components'
 import { formatUnits, type Address } from 'viem'
 import { normalizeAddressOrEmpty } from '~/utils/accountPositionHelpers'
+import { getTokenAddressesCorrelationCategoryLabel } from '~/utils/token-categories'
 
 const route = useRoute()
 const router = useRouter()
@@ -111,6 +112,16 @@ const isMultiplyRoeApplicable = computed(() =>
   positionRoeCollateralVaults.value.isComplete
   && areRoeCollateralVaultsCorrelatedWithBorrow(projectedMultiplyCollateralVaults.value, multiplyShortVault.value, getTokenCategoryTags),
 )
+const correlatedBadgeTitle = computed(() => {
+  const category = getTokenAddressesCorrelationCategoryLabel(
+    [
+      ...projectedMultiplyCollateralVaults.value.map(vault => vault.asset.address),
+      multiplyShortVault.value?.asset.address,
+    ],
+    getTokenCategoryTags,
+  )
+  return category ? `Correlated category: ${category}` : undefined
+})
 
 const pairAssets = computed<VaultAsset[]>(() => {
   if (!multiplyLongVault.value || !multiplyShortVault.value) {
@@ -896,7 +907,7 @@ watch([multiplyMinMultiplier, multiplyMaxMultiplier], ([min, max]) => {
             <CorrelatedPairBadge
               v-if="isMultiplyRoeApplicable"
               compact
-              title="This pair shares a trusted price-correlation category, so ROE is shown."
+              :title="correlatedBadgeTitle"
             />
           </template>
         </VaultLabelsAndAssets>

--- a/pages/position/[number]/repay.vue
+++ b/pages/position/[number]/repay.vue
@@ -19,7 +19,7 @@ import { useCollateralSwapRepay } from '~/composables/repay/useCollateralSwapRep
 import { useSavingsRepay } from '~/composables/repay/useSavingsRepay'
 import { isOperationBlocked } from '~/utils/operationGuardRegistry'
 import type { DisabledReasonInfo } from '~/components/entities/vault/form/types'
-import { areTokenAddressesCorrelatedByTags } from '~/utils/token-categories'
+import { areRoeCollateralVaultsCorrelatedWithBorrow } from '~/utils/position-roe'
 
 const _route = useRoute()
 const _router = useRouter()
@@ -237,24 +237,10 @@ const savings = useSavingsRepay({
 })
 
 const isPositionRoeApplicable = computed(() =>
-  positionCollateralVaults.value.length > 0
-  && !!borrowVault.value
-  && positionCollateralVaults.value.every(collateral =>
-    areTokenAddressesCorrelatedByTags(
-      collateral.asset.address,
-      borrowVault.value!.asset.address,
-      getTokenCategoryTags,
-    ),
-  ),
+  areRoeCollateralVaultsCorrelatedWithBorrow(positionCollateralVaults.value, borrowVault.value, getTokenCategoryTags),
 )
 const isCollateralRepayRoeApplicable = computed(() =>
-  !!collateral.sourceVault.value
-  && !!borrowVault.value
-  && areTokenAddressesCorrelatedByTags(
-    collateral.sourceVault.value.asset.address,
-    borrowVault.value.asset.address,
-    getTokenCategoryTags,
-  ),
+  areRoeCollateralVaultsCorrelatedWithBorrow(positionCollateralVaults.value, borrowVault.value, getTokenCategoryTags),
 )
 
 const { guardWithPriceImpact: guardWithCollateralPriceImpact } = usePriceImpactGate({

--- a/pages/position/[number]/repay.vue
+++ b/pages/position/[number]/repay.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { isEVault, isSecuritizeCollateralVault, type EVault, type PortfolioBorrowPosition, type SecuritizeCollateralVault, type TransactionPlan, type VaultEntity } from '@eulerxyz/euler-v2-sdk'
+import { isEVault, type EVault, type PortfolioBorrowPosition, type SecuritizeCollateralVault, type TransactionPlan, type VaultEntity } from '@eulerxyz/euler-v2-sdk'
 import type { VaultAsset } from '~/types/asset'
 import { getNetAPY } from '~/utils/vault/apy'
 import { withVaultIntrinsicApy } from '~/utils/vault-intrinsic-apy'
@@ -19,7 +19,7 @@ import { useCollateralSwapRepay } from '~/composables/repay/useCollateralSwapRep
 import { useSavingsRepay } from '~/composables/repay/useSavingsRepay'
 import { isOperationBlocked } from '~/utils/operationGuardRegistry'
 import type { DisabledReasonInfo } from '~/components/entities/vault/form/types'
-import { areRoeCollateralVaultsCorrelatedWithBorrow } from '~/utils/position-roe'
+import { areRoeCollateralVaultsCorrelatedWithBorrow, resolvePositionRoeCollateralVaults } from '~/utils/position-roe'
 
 const _route = useRoute()
 const _router = useRouter()
@@ -57,22 +57,9 @@ const walletBalance = ref(0n)
 // --- Shared computeds ---
 const borrowVault = computed<EVault | undefined>(() => position.value ? position.value.borrowVault as EVault | undefined : undefined)
 const collateralVault = computed<EVault | SecuritizeCollateralVault | undefined>(() => position.value ? position.value.collateralVault as EVault | SecuritizeCollateralVault | undefined : undefined)
-const positionCollateralVaults = computed<Array<EVault | SecuritizeCollateralVault>>(() => {
-  if (!position.value) return []
-
-  const collaterals = position.value.collaterals.flatMap((collateralPosition) => {
-    const vault = collateralPosition.vault
-    return vault && (isEVault(vault) || isSecuritizeCollateralVault(vault))
-      ? [vault]
-      : []
-  })
-
-  return collaterals.length
-    ? collaterals
-    : collateralVault.value
-      ? [collateralVault.value]
-      : []
-})
+const positionCollateralVaults = computed(() =>
+  resolvePositionRoeCollateralVaults(position.value, collateralVault.value),
+)
 useOperationGuard(computed(() => [borrowVault.value?.address].filter(Boolean)))
 const assets = computed<VaultAsset[]>(() => [collateralVault.value?.asset, borrowVault.value?.asset].filter((asset): asset is VaultAsset => !!asset))
 const assetsLabel = usePositionPairLabel(position)
@@ -237,10 +224,12 @@ const savings = useSavingsRepay({
 })
 
 const isPositionRoeApplicable = computed(() =>
-  areRoeCollateralVaultsCorrelatedWithBorrow(positionCollateralVaults.value, borrowVault.value, getTokenCategoryTags),
+  positionCollateralVaults.value.isComplete
+  && areRoeCollateralVaultsCorrelatedWithBorrow(positionCollateralVaults.value.vaults, borrowVault.value, getTokenCategoryTags),
 )
 const isCollateralRepayRoeApplicable = computed(() =>
-  areRoeCollateralVaultsCorrelatedWithBorrow(positionCollateralVaults.value, borrowVault.value, getTokenCategoryTags),
+  positionCollateralVaults.value.isComplete
+  && areRoeCollateralVaultsCorrelatedWithBorrow(positionCollateralVaults.value.vaults, borrowVault.value, getTokenCategoryTags),
 )
 
 const { guardWithPriceImpact: guardWithCollateralPriceImpact } = usePriceImpactGate({

--- a/pages/position/[number]/repay.vue
+++ b/pages/position/[number]/repay.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { isEVault, type EVault, type PortfolioBorrowPosition, type SecuritizeCollateralVault, type TransactionPlan, type VaultEntity } from '@eulerxyz/euler-v2-sdk'
+import { isEVault, isSecuritizeCollateralVault, type EVault, type PortfolioBorrowPosition, type SecuritizeCollateralVault, type TransactionPlan, type VaultEntity } from '@eulerxyz/euler-v2-sdk'
 import type { VaultAsset } from '~/types/asset'
 import { getNetAPY } from '~/utils/vault/apy'
 import { withVaultIntrinsicApy } from '~/utils/vault-intrinsic-apy'
@@ -57,6 +57,22 @@ const walletBalance = ref(0n)
 // --- Shared computeds ---
 const borrowVault = computed<EVault | undefined>(() => position.value ? position.value.borrowVault as EVault | undefined : undefined)
 const collateralVault = computed<EVault | SecuritizeCollateralVault | undefined>(() => position.value ? position.value.collateralVault as EVault | SecuritizeCollateralVault | undefined : undefined)
+const positionCollateralVaults = computed<Array<EVault | SecuritizeCollateralVault>>(() => {
+  if (!position.value) return []
+
+  const collaterals = position.value.collaterals.flatMap((collateralPosition) => {
+    const vault = collateralPosition.vault
+    return vault && (isEVault(vault) || isSecuritizeCollateralVault(vault))
+      ? [vault]
+      : []
+  })
+
+  return collaterals.length
+    ? collaterals
+    : collateralVault.value
+      ? [collateralVault.value]
+      : []
+})
 useOperationGuard(computed(() => [borrowVault.value?.address].filter(Boolean)))
 const assets = computed<VaultAsset[]>(() => [collateralVault.value?.asset, borrowVault.value?.asset].filter((asset): asset is VaultAsset => !!asset))
 const assetsLabel = usePositionPairLabel(position)
@@ -221,12 +237,14 @@ const savings = useSavingsRepay({
 })
 
 const isPositionRoeApplicable = computed(() =>
-  !!collateralVault.value
+  positionCollateralVaults.value.length > 0
   && !!borrowVault.value
-  && areTokenAddressesCorrelatedByTags(
-    collateralVault.value.asset.address,
-    borrowVault.value.asset.address,
-    getTokenCategoryTags,
+  && positionCollateralVaults.value.every(collateral =>
+    areTokenAddressesCorrelatedByTags(
+      collateral.asset.address,
+      borrowVault.value!.asset.address,
+      getTokenCategoryTags,
+    ),
   ),
 )
 const isCollateralRepayRoeApplicable = computed(() =>

--- a/pages/position/[number]/repay.vue
+++ b/pages/position/[number]/repay.vue
@@ -19,6 +19,7 @@ import { useCollateralSwapRepay } from '~/composables/repay/useCollateralSwapRep
 import { useSavingsRepay } from '~/composables/repay/useSavingsRepay'
 import { isOperationBlocked } from '~/utils/operationGuardRegistry'
 import type { DisabledReasonInfo } from '~/components/entities/vault/form/types'
+import { areTokenAddressesCorrelatedByTags } from '~/utils/token-categories'
 
 const _route = useRoute()
 const _router = useRouter()
@@ -30,6 +31,7 @@ useFullBalances()
 const positionIndex = usePositionIndex()
 const { isPositionsLoading, isPositionsLoaded, isDepositsLoaded, refreshAllPositions: _refreshAllPositions, getPositionBySubAccountIndex } = useEulerAccount()
 const { getSupplyRewardApy, getBorrowRewardApy } = useRewardsApy()
+const { getTokenCategoryTags } = useTokenList()
 const { settings } = useUserSettings()
 const enableIntrinsicApy = computed(() => settings.value.enableIntrinsicApy)
 const { eulerLensAddresses: _eulerLensAddresses } = useEulerAddresses()
@@ -217,6 +219,25 @@ const savings = useSavingsRepay({
   collateralSupplyApy,
   borrowApy,
 })
+
+const isPositionRoeApplicable = computed(() =>
+  !!collateralVault.value
+  && !!borrowVault.value
+  && areTokenAddressesCorrelatedByTags(
+    collateralVault.value.asset.address,
+    borrowVault.value.asset.address,
+    getTokenCategoryTags,
+  ),
+)
+const isCollateralRepayRoeApplicable = computed(() =>
+  !!collateral.sourceVault.value
+  && !!borrowVault.value
+  && areTokenAddressesCorrelatedByTags(
+    collateral.sourceVault.value.asset.address,
+    borrowVault.value.asset.address,
+    getTokenCategoryTags,
+  ),
+)
 
 const { guardWithPriceImpact: guardWithCollateralPriceImpact } = usePriceImpactGate({
   directPriceImpact: collateral.priceImpact,
@@ -769,7 +790,10 @@ watch(formTab, () => {
               variant="card"
               class="w-full laptop:max-w-[360px]"
             >
-              <SummaryRow label="ROE">
+              <SummaryRow
+                v-if="isCollateralRepayRoeApplicable"
+                label="ROE"
+              >
                 <SummaryValue
                   :before="collateral.roeBefore.value !== null ? formatNumber(collateral.roeBefore.value) : undefined"
                   :after="collateral.roeAfter.value !== null && (collateral.quotes.quote.value || collateral.isSameAsset.value) ? formatNumber(collateral.roeAfter.value) : undefined"
@@ -949,7 +973,10 @@ watch(formTab, () => {
               variant="card"
               class="w-full laptop:max-w-[360px]"
             >
-              <SummaryRow label="ROE">
+              <SummaryRow
+                v-if="isPositionRoeApplicable"
+                label="ROE"
+              >
                 <SummaryValue
                   :before="savings.roeBefore.value !== null ? formatNumber(savings.roeBefore.value) : undefined"
                   :after="savings.roeAfter.value !== null && (savings.quotes.quote.value || savings.isSameAsset.value) ? formatNumber(savings.roeAfter.value) : undefined"

--- a/server/api/token-list.get.ts
+++ b/server/api/token-list.get.ts
@@ -125,6 +125,15 @@ const toTokenEntry = (token: TokenListItem): TokenEntry => ({
   ...(token.tags?.length ? { tags: token.tags } : {}),
 })
 
+const stripUntrustedTokenTags = (token: TokenEntry): TokenEntry => ({
+  chainId: token.chainId,
+  address: token.address,
+  name: token.name,
+  symbol: token.symbol,
+  decimals: token.decimals,
+  ...(token.logoURI ? { logoURI: token.logoURI } : {}),
+})
+
 function refreshEulerSdkTokenList(chainId: number): Promise<TokenEntry[]> {
   const key = String(chainId)
 
@@ -156,7 +165,8 @@ function refreshUniswap(): Promise<TokenEntry[]> {
     .then(async (resp) => {
       if (!resp.ok) throw new Error(`Uniswap upstream returned ${resp.status}`)
       const data = await resp.json()
-      const tokens: TokenEntry[] = data.tokens || []
+      const tokens: TokenEntry[] = (Array.isArray(data.tokens) ? data.tokens : [])
+        .map((token: TokenEntry) => stripUntrustedTokenTags(token))
       uniswapCache.set('all', tokens)
       reportStatus('token-list', 'uniswap:all', 'ok')
       return tokens

--- a/server/api/token-list.get.ts
+++ b/server/api/token-list.get.ts
@@ -18,6 +18,7 @@ interface TokenEntry {
   symbol: string
   decimals: number
   logoURI?: string
+  tags?: string[]
 }
 
 type QueryTokenList = (url: string) => Promise<TokenListItem[]>
@@ -121,6 +122,7 @@ const toTokenEntry = (token: TokenListItem): TokenEntry => ({
   symbol: token.symbol,
   decimals: token.decimals,
   logoURI: token.logoURI || undefined,
+  ...(token.tags?.length ? { tags: token.tags } : {}),
 })
 
 function refreshEulerSdkTokenList(chainId: number): Promise<TokenEntry[]> {

--- a/tests/utils/position-roe.test.ts
+++ b/tests/utils/position-roe.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+import type { EVault, PortfolioBorrowPosition, SecuritizeCollateralVault, VaultEntity } from '@eulerxyz/euler-v2-sdk'
+import {
+  areRoeCollateralVaultsCorrelatedWithBorrow,
+  getPositionRoeCollateralVaults,
+  mergeRoeCollateralVaults,
+} from '~/utils/position-roe'
+
+const USD_A = '0x0000000000000000000000000000000000000011'
+const USD_B = '0x0000000000000000000000000000000000000012'
+const ETH_A = '0x0000000000000000000000000000000000000021'
+const VAULT_A = '0x0000000000000000000000000000000000000101'
+const VAULT_B = '0x0000000000000000000000000000000000000102'
+const VAULT_C = '0x0000000000000000000000000000000000000103'
+
+const makeVault = (address: string, assetAddress: string): EVault => ({
+  type: 'EVault',
+  address,
+  asset: {
+    address: assetAddress,
+    symbol: 'TST',
+  },
+} as unknown as EVault)
+
+const makeSecuritizeVault = (address: string, assetAddress: string): SecuritizeCollateralVault => ({
+  type: 'SecuritizeCollateral',
+  address,
+  asset: {
+    address: assetAddress,
+    symbol: 'EXT',
+  },
+} as unknown as SecuritizeCollateralVault)
+
+const makePosition = (
+  collaterals: Array<EVault | SecuritizeCollateralVault>,
+): PortfolioBorrowPosition<VaultEntity> => ({
+  collaterals: collaterals.map(vault => ({ vault })),
+} as unknown as PortfolioBorrowPosition<VaultEntity>)
+
+const getTags = (address: string) => {
+  const tags = new Map<string, string[]>([
+    [USD_A.toLowerCase(), ['usd']],
+    [USD_B.toLowerCase(), ['usd']],
+    [ETH_A.toLowerCase(), ['eth']],
+  ])
+  return tags.get(address.toLowerCase())
+}
+
+describe('position ROE helpers', () => {
+  it('requires every collateral to correlate with the borrow vault', () => {
+    const usdCollateral = makeVault(VAULT_A, USD_A)
+    const ethCollateral = makeVault(VAULT_B, ETH_A)
+    const usdBorrow = makeVault(VAULT_C, USD_B)
+
+    expect(
+      areRoeCollateralVaultsCorrelatedWithBorrow([usdCollateral], usdBorrow, getTags),
+    ).toBe(true)
+    expect(
+      areRoeCollateralVaultsCorrelatedWithBorrow([usdCollateral, ethCollateral], usdBorrow, getTags),
+    ).toBe(false)
+  })
+
+  it('resolves multi-collateral positions before falling back to the primary collateral', () => {
+    const primary = makeVault(VAULT_A, USD_A)
+    const external = makeSecuritizeVault(VAULT_B, USD_B)
+    const fallback = makeVault(VAULT_C, ETH_A)
+
+    expect(getPositionRoeCollateralVaults(makePosition([primary, external]), fallback)).toEqual([primary, external])
+    expect(getPositionRoeCollateralVaults(makePosition([]), fallback)).toEqual([fallback])
+  })
+
+  it('deduplicates projected collateral vaults by address', () => {
+    const first = makeVault(VAULT_A, USD_A)
+    const duplicate = makeVault(VAULT_A, USD_B)
+    const second = makeVault(VAULT_B, USD_B)
+
+    expect(mergeRoeCollateralVaults([first, duplicate, second])).toEqual([duplicate, second])
+  })
+})

--- a/tests/utils/position-roe.test.ts
+++ b/tests/utils/position-roe.test.ts
@@ -4,11 +4,13 @@ import {
   areRoeCollateralVaultsCorrelatedWithBorrow,
   getPositionRoeCollateralVaults,
   mergeRoeCollateralVaults,
+  resolvePositionRoeCollateralVaults,
 } from '~/utils/position-roe'
 
 const USD_A = '0x0000000000000000000000000000000000000011'
 const USD_B = '0x0000000000000000000000000000000000000012'
 const ETH_A = '0x0000000000000000000000000000000000000021'
+const USD_ETH = '0x0000000000000000000000000000000000000031'
 const VAULT_A = '0x0000000000000000000000000000000000000101'
 const VAULT_B = '0x0000000000000000000000000000000000000102'
 const VAULT_C = '0x0000000000000000000000000000000000000103'
@@ -33,8 +35,10 @@ const makeSecuritizeVault = (address: string, assetAddress: string): SecuritizeC
 
 const makePosition = (
   collaterals: Array<EVault | SecuritizeCollateralVault>,
+  collateralVaults = collaterals.map(vault => vault.address),
 ): PortfolioBorrowPosition<VaultEntity> => ({
   collaterals: collaterals.map(vault => ({ vault })),
+  collateralVaults,
 } as unknown as PortfolioBorrowPosition<VaultEntity>)
 
 const getTags = (address: string) => {
@@ -42,6 +46,7 @@ const getTags = (address: string) => {
     [USD_A.toLowerCase(), ['usd']],
     [USD_B.toLowerCase(), ['usd']],
     [ETH_A.toLowerCase(), ['eth']],
+    [USD_ETH.toLowerCase(), ['usd', 'eth']],
   ])
   return tags.get(address.toLowerCase())
 }
@@ -60,6 +65,22 @@ describe('position ROE helpers', () => {
     ).toBe(false)
   })
 
+  it('requires a single shared category across every collateral and the borrow vault', () => {
+    const usdCollateral = makeVault(VAULT_A, USD_A)
+    const ethCollateral = makeVault(VAULT_B, ETH_A)
+    const hybridBorrow = makeVault(VAULT_C, USD_ETH)
+
+    expect(
+      areRoeCollateralVaultsCorrelatedWithBorrow([usdCollateral], hybridBorrow, getTags),
+    ).toBe(true)
+    expect(
+      areRoeCollateralVaultsCorrelatedWithBorrow([ethCollateral], hybridBorrow, getTags),
+    ).toBe(true)
+    expect(
+      areRoeCollateralVaultsCorrelatedWithBorrow([usdCollateral, ethCollateral], hybridBorrow, getTags),
+    ).toBe(false)
+  })
+
   it('resolves multi-collateral positions before falling back to the primary collateral', () => {
     const primary = makeVault(VAULT_A, USD_A)
     const external = makeSecuritizeVault(VAULT_B, USD_B)
@@ -67,6 +88,24 @@ describe('position ROE helpers', () => {
 
     expect(getPositionRoeCollateralVaults(makePosition([primary, external]), fallback)).toEqual([primary, external])
     expect(getPositionRoeCollateralVaults(makePosition([]), fallback)).toEqual([fallback])
+  })
+
+  it('reports incomplete collateral resolution when a known collateral address is unresolved', () => {
+    const primary = makeVault(VAULT_A, USD_A)
+    const fallback = makeVault(VAULT_C, ETH_A)
+
+    expect(resolvePositionRoeCollateralVaults(makePosition([primary]), fallback)).toEqual({
+      vaults: [primary],
+      isComplete: true,
+    })
+    expect(resolvePositionRoeCollateralVaults(makePosition([primary], [VAULT_A, VAULT_B]), fallback)).toEqual({
+      vaults: [primary],
+      isComplete: false,
+    })
+    expect(resolvePositionRoeCollateralVaults(makePosition([], [VAULT_C]), fallback)).toEqual({
+      vaults: [fallback],
+      isComplete: true,
+    })
   })
 
   it('deduplicates projected collateral vaults by address', () => {

--- a/tests/utils/token-categories.test.ts
+++ b/tests/utils/token-categories.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import {
+  areTokenAddressesInSameCorrelatedCategory,
   areTokenAddressesCorrelatedByTags,
   normalizeTokenCategoryTags,
+  shareCommonTokenCategory,
   shareTokenCategory,
 } from '~/utils/token-categories'
 
@@ -20,11 +22,20 @@ describe('token category helpers', () => {
     expect(shareTokenCategory(undefined, ['usd'])).toBe(false)
   })
 
+  it('requires one shared allowlisted category across a whole token set', () => {
+    expect(shareCommonTokenCategory([['usd', 'eth'], ['usd'], ['USD']])).toBe(true)
+    expect(shareCommonTokenCategory([['usd', 'eth'], ['usd'], ['eth']])).toBe(false)
+    expect(shareCommonTokenCategory([['usd'], ['other'], ['usd']])).toBe(false)
+    expect(shareCommonTokenCategory([['usd']])).toBe(false)
+  })
+
   it('compares addresses through a tag resolver', () => {
     const tags = new Map<string, string[]>([
       ['0x0000000000000000000000000000000000000001', ['usd']],
       ['0x0000000000000000000000000000000000000002', ['USD']],
       ['0x0000000000000000000000000000000000000003', ['other']],
+      ['0x0000000000000000000000000000000000000004', ['usd', 'eth']],
+      ['0x0000000000000000000000000000000000000005', ['eth']],
     ])
     const getTags = (address: string) => tags.get(address.toLowerCase())
 
@@ -40,6 +51,51 @@ describe('token category helpers', () => {
         '0x0000000000000000000000000000000000000001',
         '0x0000000000000000000000000000000000000003',
         getTags,
+      ),
+    ).toBe(false)
+    expect(
+      areTokenAddressesInSameCorrelatedCategory(
+        [
+          '0x0000000000000000000000000000000000000001',
+          '0x0000000000000000000000000000000000000002',
+          '0x0000000000000000000000000000000000000004',
+        ],
+        getTags,
+      ),
+    ).toBe(true)
+    expect(
+      areTokenAddressesInSameCorrelatedCategory(
+        [
+          '0x0000000000000000000000000000000000000001',
+          '0x0000000000000000000000000000000000000005',
+          '0x0000000000000000000000000000000000000004',
+        ],
+        getTags,
+      ),
+    ).toBe(false)
+  })
+
+  it('treats an all-same address set as correlated even without category tags', () => {
+    expect(
+      areTokenAddressesInSameCorrelatedCategory(
+        [
+          '0x0000000000000000000000000000000000000001',
+          '0x0000000000000000000000000000000000000001',
+        ],
+        () => undefined,
+      ),
+    ).toBe(true)
+  })
+
+  it('fails closed when any address in a set is missing', () => {
+    expect(
+      areTokenAddressesInSameCorrelatedCategory(
+        [
+          '0x0000000000000000000000000000000000000001',
+          undefined,
+          '0x0000000000000000000000000000000000000002',
+        ],
+        () => ['usd'],
       ),
     ).toBe(false)
   })

--- a/tests/utils/token-categories.test.ts
+++ b/tests/utils/token-categories.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest'
 import {
   areTokenAddressesInSameCorrelatedCategory,
   areTokenAddressesCorrelatedByTags,
+  getSharedTokenCategory,
+  getTokenAddressesCorrelationCategoryLabel,
   normalizeTokenCategoryTags,
   shareCommonTokenCategory,
   shareTokenCategory,
@@ -16,6 +18,7 @@ describe('token category helpers', () => {
 
   it('requires a shared allowlisted category', () => {
     expect(shareTokenCategory(['usd'], ['USD'])).toBe(true)
+    expect(getSharedTokenCategory([['usd'], ['USD']])).toBe('usd')
     expect(shareTokenCategory(['other'], ['other'])).toBe(false)
     expect(shareTokenCategory(['stablecoin'], ['stablecoin'])).toBe(false)
     expect(shareTokenCategory(['usd'], ['eth'])).toBe(false)
@@ -73,6 +76,26 @@ describe('token category helpers', () => {
         getTags,
       ),
     ).toBe(false)
+    expect(
+      getTokenAddressesCorrelationCategoryLabel(
+        [
+          '0x0000000000000000000000000000000000000001',
+          '0x0000000000000000000000000000000000000002',
+          '0x0000000000000000000000000000000000000004',
+        ],
+        getTags,
+      ),
+    ).toBe('USD')
+    expect(
+      getTokenAddressesCorrelationCategoryLabel(
+        [
+          '0x0000000000000000000000000000000000000001',
+          '0x0000000000000000000000000000000000000005',
+          '0x0000000000000000000000000000000000000004',
+        ],
+        getTags,
+      ),
+    ).toBeUndefined()
   })
 
   it('treats an all-same address set as correlated even without category tags', () => {
@@ -108,5 +131,14 @@ describe('token category helpers', () => {
         () => undefined,
       ),
     ).toBe(true)
+    expect(
+      getTokenAddressesCorrelationCategoryLabel(
+        [
+          '0x0000000000000000000000000000000000000001',
+          '0x0000000000000000000000000000000000000001',
+        ],
+        () => undefined,
+      ),
+    ).toBeUndefined()
   })
 })

--- a/tests/utils/token-categories.test.ts
+++ b/tests/utils/token-categories.test.ts
@@ -8,21 +8,22 @@ import {
 describe('token category helpers', () => {
   it('normalizes token category tags', () => {
     expect(
-      normalizeTokenCategoryTags([' Stablecoin ', 'STABLECOIN', '', 123, 'btc']),
-    ).toEqual(['stablecoin', 'btc'])
+      normalizeTokenCategoryTags([' USD ', 'USD', '', 123, 'btc']),
+    ).toEqual(['usd', 'btc'])
   })
 
-  it('requires a shared non-other category', () => {
-    expect(shareTokenCategory(['stablecoin'], ['Stablecoin'])).toBe(true)
+  it('requires a shared allowlisted category', () => {
+    expect(shareTokenCategory(['usd'], ['USD'])).toBe(true)
     expect(shareTokenCategory(['other'], ['other'])).toBe(false)
-    expect(shareTokenCategory(['stablecoin'], ['eth'])).toBe(false)
-    expect(shareTokenCategory(undefined, ['stablecoin'])).toBe(false)
+    expect(shareTokenCategory(['stablecoin'], ['stablecoin'])).toBe(false)
+    expect(shareTokenCategory(['usd'], ['eth'])).toBe(false)
+    expect(shareTokenCategory(undefined, ['usd'])).toBe(false)
   })
 
   it('compares addresses through a tag resolver', () => {
     const tags = new Map<string, string[]>([
-      ['0x0000000000000000000000000000000000000001', ['stablecoin']],
-      ['0x0000000000000000000000000000000000000002', ['STABLECOIN']],
+      ['0x0000000000000000000000000000000000000001', ['usd']],
+      ['0x0000000000000000000000000000000000000002', ['USD']],
       ['0x0000000000000000000000000000000000000003', ['other']],
     ])
     const getTags = (address: string) => tags.get(address.toLowerCase())

--- a/tests/utils/token-categories.test.ts
+++ b/tests/utils/token-categories.test.ts
@@ -42,4 +42,14 @@ describe('token category helpers', () => {
       ),
     ).toBe(false)
   })
+
+  it('treats the same token address as correlated even without category tags', () => {
+    expect(
+      areTokenAddressesCorrelatedByTags(
+        '0x0000000000000000000000000000000000000001',
+        '0x0000000000000000000000000000000000000001',
+        () => undefined,
+      ),
+    ).toBe(true)
+  })
 })

--- a/tests/utils/token-categories.test.ts
+++ b/tests/utils/token-categories.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import {
+  areTokenAddressesCorrelatedByTags,
+  normalizeTokenCategoryTags,
+  shareTokenCategory,
+} from '~/utils/token-categories'
+
+describe('token category helpers', () => {
+  it('normalizes token category tags', () => {
+    expect(
+      normalizeTokenCategoryTags([' Stablecoin ', 'STABLECOIN', '', 123, 'btc']),
+    ).toEqual(['stablecoin', 'btc'])
+  })
+
+  it('requires a shared non-other category', () => {
+    expect(shareTokenCategory(['stablecoin'], ['Stablecoin'])).toBe(true)
+    expect(shareTokenCategory(['other'], ['other'])).toBe(false)
+    expect(shareTokenCategory(['stablecoin'], ['eth'])).toBe(false)
+    expect(shareTokenCategory(undefined, ['stablecoin'])).toBe(false)
+  })
+
+  it('compares addresses through a tag resolver', () => {
+    const tags = new Map<string, string[]>([
+      ['0x0000000000000000000000000000000000000001', ['stablecoin']],
+      ['0x0000000000000000000000000000000000000002', ['STABLECOIN']],
+      ['0x0000000000000000000000000000000000000003', ['other']],
+    ])
+    const getTags = (address: string) => tags.get(address.toLowerCase())
+
+    expect(
+      areTokenAddressesCorrelatedByTags(
+        '0x0000000000000000000000000000000000000001',
+        '0x0000000000000000000000000000000000000002',
+        getTags,
+      ),
+    ).toBe(true)
+    expect(
+      areTokenAddressesCorrelatedByTags(
+        '0x0000000000000000000000000000000000000001',
+        '0x0000000000000000000000000000000000000003',
+        getTags,
+      ),
+    ).toBe(false)
+  })
+})

--- a/utils/borrow-pair.ts
+++ b/utils/borrow-pair.ts
@@ -5,6 +5,7 @@ import type {
   SecuritizeCollateralVault,
   VaultEntity,
 } from '@eulerxyz/euler-v2-sdk'
+import { isEVault, isSecuritizeCollateralVault } from '@eulerxyz/euler-v2-sdk'
 import type { AnyBorrowVaultPair } from '~/types/borrow-pair'
 import { getBorrowPositionEffectiveLiquidationLTV } from '~/utils/ltv'
 
@@ -18,6 +19,17 @@ export const getPairBorrowVault = (pair: BorrowPairLike): EVault =>
 
 export const getPairCollateralVault = (pair: BorrowPairLike): EVault | SecuritizeCollateralVault =>
   isBorrowVaultPair(pair) ? pair.collateral : pair.collateralVault as EVault | SecuritizeCollateralVault
+
+export const getPairCollateralVaults = (pair: BorrowPairLike): Array<EVault | SecuritizeCollateralVault> => {
+  if (isBorrowVaultPair(pair)) return [pair.collateral]
+
+  const collaterals = pair.collaterals?.flatMap((collateralPosition) => {
+    const vault = collateralPosition.vault
+    return vault && (isEVault(vault) || isSecuritizeCollateralVault(vault)) ? [vault] : []
+  }) ?? []
+
+  return collaterals.length ? collaterals : [getPairCollateralVault(pair)]
+}
 
 export const getPairBorrowLTV = (pair: BorrowPairLike): number | undefined =>
   isBorrowVaultPair(pair) ? pair.ltv.borrowLTV : pair.borrowLTV

--- a/utils/discoveryCalculations.ts
+++ b/utils/discoveryCalculations.ts
@@ -31,6 +31,7 @@ export interface CollateralMatrixData {
 
 export interface BestMaxRoeResult {
   value: number
+  metric: 'max-roe' | 'net-apy'
   hasRewards: boolean
   pair: string
   maxMultiplier: number

--- a/utils/position-roe.ts
+++ b/utils/position-roe.ts
@@ -1,0 +1,64 @@
+import {
+  isEVault,
+  isSecuritizeCollateralVault,
+  type EVault,
+  type PortfolioBorrowPosition,
+  type SecuritizeCollateralVault,
+  type VaultEntity,
+} from '@eulerxyz/euler-v2-sdk'
+import { getAddress } from 'viem'
+import { areTokenAddressesCorrelatedByTags, type TokenCategoryTagSource } from '~/utils/token-categories'
+
+export type RoeCollateralVault = EVault | SecuritizeCollateralVault
+
+export const isRoeCollateralVault = (vault: VaultEntity | RoeCollateralVault | null | undefined): vault is RoeCollateralVault =>
+  !!vault && (isEVault(vault) || isSecuritizeCollateralVault(vault))
+
+const normalizeVaultAddress = (vault: RoeCollateralVault): string => {
+  try {
+    return getAddress(vault.address).toLowerCase()
+  }
+  catch {
+    return vault.address.toLowerCase()
+  }
+}
+
+export const mergeRoeCollateralVaults = (
+  vaults: Array<RoeCollateralVault | null | undefined>,
+): RoeCollateralVault[] => {
+  const merged = new Map<string, RoeCollateralVault>()
+  for (const vault of vaults) {
+    if (!vault) continue
+    merged.set(normalizeVaultAddress(vault), vault)
+  }
+  return [...merged.values()]
+}
+
+export const getPositionRoeCollateralVaults = (
+  position: PortfolioBorrowPosition<VaultEntity> | null | undefined,
+  fallback?: RoeCollateralVault | null,
+): RoeCollateralVault[] => {
+  if (!position) return fallback ? [fallback] : []
+
+  const collaterals = position.collaterals.flatMap((collateralPosition) => {
+    const vault = collateralPosition.vault
+    return isRoeCollateralVault(vault) ? [vault] : []
+  })
+
+  return collaterals.length ? mergeRoeCollateralVaults(collaterals) : fallback ? [fallback] : []
+}
+
+export const areRoeCollateralVaultsCorrelatedWithBorrow = (
+  collaterals: readonly RoeCollateralVault[],
+  borrowVault: EVault | null | undefined,
+  getTokenCategoryTags: (address: string) => TokenCategoryTagSource,
+): boolean => {
+  if (!borrowVault || !collaterals.length) return false
+  return collaterals.every(collateral =>
+    areTokenAddressesCorrelatedByTags(
+      collateral.asset.address,
+      borrowVault.asset.address,
+      getTokenCategoryTags,
+    ),
+  )
+}

--- a/utils/position-roe.ts
+++ b/utils/position-roe.ts
@@ -1,15 +1,18 @@
 import {
   isEVault,
   isSecuritizeCollateralVault,
-  type EVault,
   type PortfolioBorrowPosition,
-  type SecuritizeCollateralVault,
   type VaultEntity,
 } from '@eulerxyz/euler-v2-sdk'
 import { getAddress } from 'viem'
-import { areTokenAddressesCorrelatedByTags, type TokenCategoryTagSource } from '~/utils/token-categories'
+import { areTokenAddressesInSameCorrelatedCategory, type TokenCategoryTagSource } from '~/utils/token-categories'
 
-export type RoeCollateralVault = EVault | SecuritizeCollateralVault
+export type RoeCollateralVault = {
+  address: string
+  asset: {
+    address: string
+  }
+}
 
 export const isRoeCollateralVault = (vault: VaultEntity | RoeCollateralVault | null | undefined): vault is RoeCollateralVault =>
   !!vault && (isEVault(vault) || isSecuritizeCollateralVault(vault))
@@ -20,6 +23,15 @@ const normalizeVaultAddress = (vault: RoeCollateralVault): string => {
   }
   catch {
     return vault.address.toLowerCase()
+  }
+}
+
+const normalizeAddress = (address: string): string => {
+  try {
+    return getAddress(address).toLowerCase()
+  }
+  catch {
+    return address.toLowerCase()
   }
 }
 
@@ -34,31 +46,55 @@ export const mergeRoeCollateralVaults = (
   return [...merged.values()]
 }
 
+export type PositionRoeCollateralVaults = {
+  vaults: RoeCollateralVault[]
+  isComplete: boolean
+}
+
+export const resolvePositionRoeCollateralVaults = (
+  position: PortfolioBorrowPosition<VaultEntity> | null | undefined,
+  fallback?: RoeCollateralVault | null,
+): PositionRoeCollateralVaults => {
+  if (!position) {
+    return { vaults: fallback ? [fallback] : [], isComplete: false }
+  }
+
+  const collaterals = mergeRoeCollateralVaults(position.collaterals.flatMap((collateralPosition) => {
+    const vault = collateralPosition.vault
+    return isRoeCollateralVault(vault) ? [vault] : []
+  }))
+
+  const vaults = collaterals.length ? collaterals : fallback ? [fallback] : []
+  const expectedAddresses = new Set(
+    position.collateralVaults
+      .map(address => normalizeAddress(address))
+      .filter(Boolean),
+  )
+
+  const resolvedAddresses = new Set(vaults.map(vault => normalizeVaultAddress(vault)))
+  const isComplete = expectedAddresses.size === 0
+    ? vaults.length > 0
+    : [...expectedAddresses].every(address => resolvedAddresses.has(address))
+
+  return { vaults, isComplete }
+}
+
 export const getPositionRoeCollateralVaults = (
   position: PortfolioBorrowPosition<VaultEntity> | null | undefined,
   fallback?: RoeCollateralVault | null,
-): RoeCollateralVault[] => {
-  if (!position) return fallback ? [fallback] : []
-
-  const collaterals = position.collaterals.flatMap((collateralPosition) => {
-    const vault = collateralPosition.vault
-    return isRoeCollateralVault(vault) ? [vault] : []
-  })
-
-  return collaterals.length ? mergeRoeCollateralVaults(collaterals) : fallback ? [fallback] : []
-}
+): RoeCollateralVault[] => resolvePositionRoeCollateralVaults(position, fallback).vaults
 
 export const areRoeCollateralVaultsCorrelatedWithBorrow = (
   collaterals: readonly RoeCollateralVault[],
-  borrowVault: EVault | null | undefined,
+  borrowVault: RoeCollateralVault | null | undefined,
   getTokenCategoryTags: (address: string) => TokenCategoryTagSource,
 ): boolean => {
   if (!borrowVault || !collaterals.length) return false
-  return collaterals.every(collateral =>
-    areTokenAddressesCorrelatedByTags(
-      collateral.asset.address,
+  return areTokenAddressesInSameCorrelatedCategory(
+    [
+      ...collaterals.map(collateral => collateral.asset.address),
       borrowVault.asset.address,
-      getTokenCategoryTags,
-    ),
+    ],
+    getTokenCategoryTags,
   )
 }

--- a/utils/token-categories.ts
+++ b/utils/token-categories.ts
@@ -1,0 +1,62 @@
+import { getAddress } from 'viem'
+
+export type TokenCategoryTagSource = readonly unknown[] | undefined | null
+
+export const normalizeTokenCategoryTags = (
+  tags: TokenCategoryTagSource,
+): string[] => {
+  if (!Array.isArray(tags)) return []
+
+  const seen = new Set<string>()
+  const normalized: string[] = []
+  for (const tag of tags) {
+    if (typeof tag !== 'string') continue
+    const value = tag.trim().toLowerCase()
+    if (!value || seen.has(value)) continue
+    seen.add(value)
+    normalized.push(value)
+  }
+  return normalized
+}
+
+const isCorrelatedCategory = (tag: string): boolean => tag !== 'other'
+
+export const shareTokenCategory = (
+  leftTags: TokenCategoryTagSource,
+  rightTags: TokenCategoryTagSource,
+): boolean => {
+  const left = normalizeTokenCategoryTags(leftTags).filter(isCorrelatedCategory)
+  if (!left.length) return false
+
+  const right = new Set(normalizeTokenCategoryTags(rightTags).filter(isCorrelatedCategory))
+  if (!right.size) return false
+
+  return left.some(tag => right.has(tag))
+}
+
+const normalizeComparableAddress = (
+  address: string | undefined | null,
+): string => {
+  if (!address) return ''
+  try {
+    return getAddress(address).toLowerCase()
+  }
+  catch {
+    return address.toLowerCase()
+  }
+}
+
+export const areTokenAddressesCorrelatedByTags = (
+  leftAddress: string | undefined | null,
+  rightAddress: string | undefined | null,
+  getTokenCategoryTags: (address: string) => TokenCategoryTagSource,
+): boolean => {
+  const left = normalizeComparableAddress(leftAddress)
+  const right = normalizeComparableAddress(rightAddress)
+  if (!left || !right) return false
+
+  return shareTokenCategory(
+    getTokenCategoryTags(left),
+    getTokenCategoryTags(right),
+  )
+}

--- a/utils/token-categories.ts
+++ b/utils/token-categories.ts
@@ -19,7 +19,9 @@ export const normalizeTokenCategoryTags = (
   return normalized
 }
 
-const isCorrelatedCategory = (tag: string): boolean => tag !== 'other'
+const CORRELATED_CATEGORY_TAGS = new Set(['usd', 'eth', 'btc'])
+
+const isCorrelatedCategory = (tag: string): boolean => CORRELATED_CATEGORY_TAGS.has(tag)
 
 export const shareTokenCategory = (
   leftTags: TokenCategoryTagSource,

--- a/utils/token-categories.ts
+++ b/utils/token-categories.ts
@@ -54,6 +54,7 @@ export const areTokenAddressesCorrelatedByTags = (
   const left = normalizeComparableAddress(leftAddress)
   const right = normalizeComparableAddress(rightAddress)
   if (!left || !right) return false
+  if (left === right) return true
 
   return shareTokenCategory(
     getTokenCategoryTags(left),

--- a/utils/token-categories.ts
+++ b/utils/token-categories.ts
@@ -36,6 +36,29 @@ export const shareTokenCategory = (
   return left.some(tag => right.has(tag))
 }
 
+export const shareCommonTokenCategory = (
+  tagSources: readonly TokenCategoryTagSource[],
+): boolean => {
+  if (tagSources.length < 2) return false
+
+  let common: Set<string> | null = null
+
+  for (const tags of tagSources) {
+    const correlated = normalizeTokenCategoryTags(tags).filter(isCorrelatedCategory)
+    if (!correlated.length) return false
+
+    if (common === null) {
+      common = new Set(correlated)
+      continue
+    }
+
+    common = new Set(correlated.filter(tag => common!.has(tag)))
+    if (!common.size) return false
+  }
+
+  return (common?.size ?? 0) > 0
+}
+
 const normalizeComparableAddress = (
   address: string | undefined | null,
 ): string => {
@@ -62,4 +85,16 @@ export const areTokenAddressesCorrelatedByTags = (
     getTokenCategoryTags(left),
     getTokenCategoryTags(right),
   )
+}
+
+export const areTokenAddressesInSameCorrelatedCategory = (
+  addresses: readonly (string | undefined | null)[],
+  getTokenCategoryTags: (address: string) => TokenCategoryTagSource,
+): boolean => {
+  const normalized = addresses.map(normalizeComparableAddress)
+  if (normalized.some(address => !address)) return false
+  if (normalized.length < 2) return false
+  if (normalized.every(address => address === normalized[0])) return true
+
+  return shareCommonTokenCategory(normalized.map(address => getTokenCategoryTags(address)))
 }

--- a/utils/token-categories.ts
+++ b/utils/token-categories.ts
@@ -19,33 +19,39 @@ export const normalizeTokenCategoryTags = (
   return normalized
 }
 
-const CORRELATED_CATEGORY_TAGS = new Set(['usd', 'eth', 'btc'])
+const CORRELATED_CATEGORY_LABELS: Record<string, string> = {
+  usd: 'USD',
+  eth: 'ETH',
+  btc: 'BTC',
+}
+
+const CORRELATED_CATEGORY_TAGS = new Set(Object.keys(CORRELATED_CATEGORY_LABELS))
 
 const isCorrelatedCategory = (tag: string): boolean => CORRELATED_CATEGORY_TAGS.has(tag)
+
+const correlatedCategories = (tags: TokenCategoryTagSource): string[] =>
+  normalizeTokenCategoryTags(tags).filter(isCorrelatedCategory)
+
+export const formatTokenCategoryLabel = (tag: string | null | undefined): string | undefined =>
+  tag ? CORRELATED_CATEGORY_LABELS[tag.trim().toLowerCase()] : undefined
 
 export const shareTokenCategory = (
   leftTags: TokenCategoryTagSource,
   rightTags: TokenCategoryTagSource,
 ): boolean => {
-  const left = normalizeTokenCategoryTags(leftTags).filter(isCorrelatedCategory)
-  if (!left.length) return false
-
-  const right = new Set(normalizeTokenCategoryTags(rightTags).filter(isCorrelatedCategory))
-  if (!right.size) return false
-
-  return left.some(tag => right.has(tag))
+  return getSharedTokenCategory([leftTags, rightTags]) !== null
 }
 
-export const shareCommonTokenCategory = (
+export const getSharedTokenCategory = (
   tagSources: readonly TokenCategoryTagSource[],
-): boolean => {
-  if (tagSources.length < 2) return false
+): string | null => {
+  if (tagSources.length < 2) return null
 
   let common: Set<string> | null = null
 
   for (const tags of tagSources) {
-    const correlated = normalizeTokenCategoryTags(tags).filter(isCorrelatedCategory)
-    if (!correlated.length) return false
+    const correlated = correlatedCategories(tags)
+    if (!correlated.length) return null
 
     if (common === null) {
       common = new Set(correlated)
@@ -53,11 +59,15 @@ export const shareCommonTokenCategory = (
     }
 
     common = new Set(correlated.filter(tag => common!.has(tag)))
-    if (!common.size) return false
+    if (!common.size) return null
   }
 
-  return (common?.size ?? 0) > 0
+  return common?.values().next().value ?? null
 }
+
+export const shareCommonTokenCategory = (
+  tagSources: readonly TokenCategoryTagSource[],
+): boolean => getSharedTokenCategory(tagSources) !== null
 
 const normalizeComparableAddress = (
   address: string | undefined | null,
@@ -97,4 +107,17 @@ export const areTokenAddressesInSameCorrelatedCategory = (
   if (normalized.every(address => address === normalized[0])) return true
 
   return shareCommonTokenCategory(normalized.map(address => getTokenCategoryTags(address)))
+}
+
+export const getTokenAddressesCorrelationCategoryLabel = (
+  addresses: readonly (string | undefined | null)[],
+  getTokenCategoryTags: (address: string) => TokenCategoryTagSource,
+): string | undefined => {
+  const normalized = addresses.map(normalizeComparableAddress)
+  if (normalized.some(address => !address)) return undefined
+  if (normalized.length < 2) return undefined
+
+  return formatTokenCategoryLabel(
+    getSharedTokenCategory(normalized.map(address => getTokenCategoryTags(address))),
+  )
 }


### PR DESCRIPTION
## Summary
- Gate opportunity-style Max ROE displays behind trusted v3 token category correlation so ROE is only promoted when collateral and debt prices are expected to move together.
- Keep uncorrelated borrow opportunities visible by falling back to Net APY in discovery, matrix, and borrow row surfaces instead of dropping those rows.
- Preserve account-level portfolio ROE and actual/simulated multiply ROE while tightening per-position and opportunity ROE displays around category-safe pairs.

## Changes
- Pass token category tags from the SDK token list through the Lite token-list API and consume them via `@eulerxyz/euler-v2-sdk@1.0.3`.
- Add reusable token-category helpers that normalize tags, exclude non-correlated categories, and require one shared category across an entire asset set.
- Add position ROE helpers that merge EVault and Securitize collateral vaults, detect incomplete collateral resolution, and fail closed when the full collateral set cannot be proven correlated with the borrow asset.
- Update discovery cards, discovery matrix cells, best Max ROE selection, borrow sorting, borrow rows, and explore surfaces so correlated pairs rank by Max ROE while uncorrelated pairs remain visible with Net APY fallback behavior.
- Remove the Explore market card correlated-pair count while keeping the regular asset and pair counts.
- Update portfolio borrow rows and position detail pages to show separate `Correlated` and multiplier badges only when every collateral asset and the borrow asset share the same trusted category.
- Keep aggregate portfolio ROE visible in the Portfolio performance summary for now, while per-position ROE and position action ROE remain gated by the stricter collateral-set rule.
- Keep actual multiply form ROE visible on borrow pair pages for all pairs, including uncorrelated pairs, because that value comes from the simulated position rather than discovery Max ROE.
- Remove duplicate Net APY rendering from uncorrelated borrow rows and align borrow card metrics so Borrow APY, Max multiplier, and Max ROE or Net APY sit together in the primary metric area.
- Deep-link correlated borrow rows with `tab=multiply`, so correlated borrow opportunities open directly on the Multiply tab; fallback rows open on Borrow.
- Add the Correlated badge component and update tooltip/layout details for liquidity warning and ROE helper text.

## Test plan
- [x] `npm run test:run -- tests/utils/token-categories.test.ts tests/utils/discovery-calculations.test.ts`
- [x] `npm run test:run -- tests/utils/token-categories.test.ts tests/utils/position-roe.test.ts`
- [x] `npm run test:run -- tests/utils/token-categories.test.ts tests/utils/position-roe.test.ts tests/utils/discovery-calculations.test.ts`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm ls @eulerxyz/euler-v2-sdk --depth=0`
- [x] Local `/api/token-list?chainId=1` smoke returns token `tags`.
- [x] Local `/borrow?network=42161` browser smoke: correlated rows render the Correlated badge, link with `tab=multiply`, and open with Multiply selected.
- [x] Local `/borrow?network=42161` browser smoke: uncorrelated rows show Net APY, do not render the Correlated badge, and open with Borrow selected.
- [x] Local Base portfolio smoke: single correlated EVault position shows Correlated plus multiplier badges.
- [x] Local Base portfolio smoke: multi-collateral same-category EVault position shows Correlated plus multiplier badges.
- [x] Local Base portfolio smoke: uncorrelated EVault position hides Correlated, multiplier, and per-position ROE.
- [x] Local mainnet smoke: Securitize collateral pair loads and participates in category correlation handling.
- [x] SDK portfolio scan on Base and mainnet did not find a live incomplete-collateral fixture; the fail-closed branch is covered by the focused helper test.
