### PR TITLE
Fix internal token-list headers

### DIFF
--- a/server/utils/labels-view.ts
+++ b/server/utils/labels-view.ts
@@ -17,6 +17,7 @@ import {
 } from '@eulerxyz/euler-v2-sdk'
 import type { Address } from 'viem'
 import { createInFlightDedup } from './in-flight'
+import { INTERNAL_FETCH_HEADERS } from './internal-headers'
 import { buildEntityAddressSets, declaredKeysOf, tryChecksum } from './labels-helpers'
 import { logger } from './logger'
 import { getServerSdk } from './sdk-server'
@@ -129,8 +130,11 @@ function overrideHasTag(
 // SDK builder shared with vaults-cache via server/utils/sdk-server.ts.
 const getSdk = (chainId: number): Promise<EulerSDK> => getServerSdk(chainId)
 
-async function fetchTokenList(chainId: number): Promise<TokenListEntry[]> {
-  const data = await $fetch<TokenListResponse>('/api/token-list', { query: { chainId } })
+export async function fetchTokenList(chainId: number): Promise<TokenListEntry[]> {
+  const data = await $fetch<TokenListResponse>('/api/token-list', {
+    query: { chainId },
+    headers: INTERNAL_FETCH_HEADERS,
+  })
   return Array.isArray(data?.tokens) ? data.tokens : []
 }
 

--- a/tests/server/labels-view.test.ts
+++ b/tests/server/labels-view.test.ts
@@ -1,5 +1,29 @@
-import { describe, expect, it } from 'vitest'
-import { buildProductDescriptors, buildTokenLogoMap } from '~/server/utils/labels-view'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { buildProductDescriptors, buildTokenLogoMap, fetchTokenList } from '~/server/utils/labels-view'
+import { INTERNAL_FETCH_HEADERS } from '~/server/utils/internal-headers'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('fetchTokenList', () => {
+  it('decorates the internal token-list fetch with the loopback sentinel', async () => {
+    const fetch = vi.fn().mockResolvedValue({
+      tokens: [
+        { address: '0x1111111111111111111111111111111111111111', logoURI: 'https://cdn.example/token.png' },
+      ],
+    })
+    vi.stubGlobal('$fetch', fetch)
+
+    await expect(fetchTokenList(1)).resolves.toEqual([
+      { address: '0x1111111111111111111111111111111111111111', logoURI: 'https://cdn.example/token.png' },
+    ])
+    expect(fetch).toHaveBeenCalledWith('/api/token-list', {
+      query: { chainId: 1 },
+      headers: INTERNAL_FETCH_HEADERS,
+    })
+  })
+})
 
 describe('buildTokenLogoMap', () => {
   it('keeps only http(s) logo URLs', () => {


### PR DESCRIPTION
## Summary
- Ensure the labels-view token-list self-fetch carries the internal loopback sentinel so geo-gate and rate-limit middleware treat it as server-internal traffic.
- Preserve public metadata token logo enrichment in prod-like environments where internal API requests do not have Cloudflare headers.

## Changes
- Reuse `INTERNAL_FETCH_HEADERS` for the `/api/token-list` request from `server/utils/labels-view.ts`.
- Expose `fetchTokenList` for a focused regression test that asserts the sentinel is passed to `$fetch`.

## Test plan
- [x] `npm run test:run -- tests/server/labels-view.test.ts tests/server/internal-request.test.ts`
- [x] `npx eslint server/utils/labels-view.ts tests/server/labels-view.test.ts`
- [x] `npm run typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for token list fetching to ensure reliable functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->