### PR TITLE
fix: surface multiply cap disabled reasons

### DIFF
--- a/composables/borrow/useMultiplyForm.ts
+++ b/composables/borrow/useMultiplyForm.ts
@@ -8,7 +8,7 @@ import { nanoToValue } from '~/utils/crypto-utils'
 import { computeMultipliedPriceImpact } from '~/utils/priceImpact'
 import { calculateRoe, computeNextHealth, computeLiquidationPrice } from '~/utils/repayUtils'
 import { computeMaxMultiplier, computeMinMultiplier, computeWeightedSupplyApy, computeLeverageDebt } from '~/utils/multiply-math'
-import { getPlanHookDisabledWarning, getUtilisationWarning, getBorrowCapWarning } from '~/composables/useVaultWarnings'
+import { getPlanHookDisabledWarning, getUtilisationWarning, getSupplyCapWarning, getBorrowCapWarning } from '~/composables/useVaultWarnings'
 import { isOperationBlocked } from '~/utils/operationGuardRegistry'
 import { useMultiplyCollateralOptions } from '~/composables/useMultiplyCollateralOptions'
 import { withVaultIntrinsicApy } from '~/utils/vault-intrinsic-apy'
@@ -620,6 +620,17 @@ export const useMultiplyForm = (options: UseMultiplyFormOptions) => {
   const isSupplyCapReached = computed(() => multiplySupplyVault.value ? getIsSupplyCapReached(multiplySupplyVault.value) : false)
   const isBorrowCapReached = computed(() => multiplyShortVault.value ? getIsBorrowCapReached(multiplyShortVault.value) : false)
 
+  const multiplyCapErrorText = computed(() => {
+    if (!multiplyInputAmount.value || multiplyDebtAmountNano.value <= 0n) return null
+    if (isSupplyCapReached.value && multiplySupplyVault.value) {
+      return getSupplyCapWarning(multiplySupplyVault.value)?.message || 'The supply cap has been reached. New deposits will fail.'
+    }
+    if (isBorrowCapReached.value && multiplyShortVault.value) {
+      return getBorrowCapWarning(multiplyShortVault.value)?.message || 'The borrow cap has been reached. New borrows will fail.'
+    }
+    return null
+  })
+
   // Multiply supply side: savings-sourced transfers existing shares (OP_TRANSFER);
   // fresh-supply deposits new assets (OP_DEPOSIT). The short vault is always
   // borrowed from, and any swap path touches OP_SKIM on the long vault via the
@@ -664,9 +675,10 @@ export const useMultiplyForm = (options: UseMultiplyFormOptions) => {
 
   // --- Warnings ---
   const multiplyFormWarnings = computed(() => {
-    if (!multiplyShortVault.value) return []
+    if (!multiplySupplyVault.value || !multiplyShortVault.value) return []
     return [
       getPlanHookDisabledWarning(multiplyPlannedOps.value),
+      getSupplyCapWarning(multiplySupplyVault.value),
       getUtilisationWarning(multiplyShortVault.value, 'borrow'),
       getBorrowCapWarning(multiplyShortVault.value),
     ]
@@ -1245,6 +1257,7 @@ export const useMultiplyForm = (options: UseMultiplyFormOptions) => {
 
     // Validation
     multiplyErrorText,
+    multiplyCapErrorText,
     isMultiplySubmitDisabled,
     multiplyFormWarnings,
 

--- a/pages/borrow/[collateral]/[borrow]/index.vue
+++ b/pages/borrow/[collateral]/[borrow]/index.vue
@@ -210,6 +210,7 @@ const multiplyDisabledReasonInfo = computed((): DisabledReasonInfo | undefined =
   if (isGeoBlocked.value) return { message: 'This operation is not available in your region', variant: 'warning' }
   if (isMultiplyRestricted.value) return { message: 'Multiply is not available for this pair in your region', variant: 'warning' }
   if (multiply.multiplyErrorText.value) return { message: multiply.multiplyErrorText.value, variant: 'error' }
+  if (multiply.multiplyCapErrorText.value) return { message: multiply.multiplyCapErrorText.value, variant: 'error' }
   if (multiply.multiplySimulationError.value) return { message: multiply.multiplySimulationError.value, variant: 'error' }
   if (!multiply.multiplyIsSameAsset.value && multiply.isMultiplyQuoteLoading.value && multiply.multiplyDebtAmountNano.value > 0n) return { message: 'Fetching swap quotes...', variant: 'warning' }
   if (!multiply.multiplyIsSameAsset.value && !multiply.multiplySelectedProvider.value && multiply.multiplyDebtAmountNano.value > 0n) return { message: 'Select a swap quote to continue', variant: 'warning' }

--- a/tests/composables/useMultiplyForm.test.ts
+++ b/tests/composables/useMultiplyForm.test.ts
@@ -1,0 +1,297 @@
+import { computed, ref, shallowRef, watch, watchEffect } from 'vue'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Account, EVault, IHasVaultAddress } from '@eulerxyz/euler-v2-sdk'
+import { useMultiplyForm } from '~/composables/borrow/useMultiplyForm'
+
+const { USER, makeVault, planAccount, mocks } = vi.hoisted(() => {
+  const USER = '0x0000000000000000000000000000000000000001'
+  const VAULT = '0x0000000000000000000000000000000000000002'
+  const ASSET = '0x0000000000000000000000000000000000000003'
+
+  const makeVault = (supplyCapUtilization = 0, borrowCapUtilization = 0) => ({
+    address: VAULT,
+    availableLiquidity: 10_000n,
+    totalAssets: 1_000n,
+    borrow: 0n,
+    asset: {
+      address: ASSET,
+      symbol: 'USDC',
+      decimals: 0,
+    },
+    shares: {
+      address: VAULT,
+      symbol: 'eUSDC',
+      decimals: 0,
+    },
+    caps: {
+      supplyCapUtilization,
+      borrowCapUtilization,
+    },
+    collaterals: [
+      {
+        address: VAULT,
+        borrowLTV: 500000000000000000n,
+        liquidationLTV: 750000000000000000n,
+      },
+    ],
+    convertToShares: vi.fn((assets: bigint) => assets),
+  }) as unknown as EVault
+
+  return {
+    USER,
+    VAULT,
+    ASSET,
+    makeVault,
+    planAccount: { chainId: 1 } as Account<IHasVaultAddress>,
+    mocks: {
+      planMultiply: vi.fn(),
+      prepareTransactionPlan: vi.fn(),
+      executePlan: vi.fn(),
+      prefetchPluginData: vi.fn(),
+      preloadSubAccountSnapshot: vi.fn(),
+      fetchSingleBalance: vi.fn(async () => 100n),
+      runPreparedSimulation: vi.fn(),
+      modalOpen: vi.fn(),
+      getSupplyCapWarning: vi.fn(() => ({
+        level: 'info',
+        title: 'Supply cap reached',
+        message: 'The supply cap has been reached. New deposits will fail.',
+      })),
+      getBorrowCapWarning: vi.fn(() => null),
+    },
+  }
+})
+
+vi.mock('#components', () => ({
+  OperationReviewModal: {},
+}))
+
+vi.mock('~/components/ui/composables/useModal', () => ({
+  useModal: () => ({
+    open: mocks.modalOpen,
+    close: vi.fn(),
+  }),
+}))
+
+vi.mock('~/components/ui/composables/useToast', () => ({
+  useToast: () => ({
+    error: vi.fn(),
+  }),
+}))
+
+vi.mock('~/composables/useStateOverrideOptions', () => ({
+  useStateOverrideOptions: () => ({
+    primeSlotHintsFor: vi.fn(),
+    buildStateOverrideOptions: vi.fn(() => ({})),
+  }),
+}))
+
+vi.mock('~/composables/useSwapQuotesParallel', () => ({
+  useSwapQuotesParallel: () => ({
+    sortedQuoteCards: ref([]),
+    selectedProvider: ref(null),
+    selectedQuote: ref(null),
+    selectedQuoteCard: ref(null),
+    effectiveQuote: ref(null),
+    effectiveQuoteFetchedAt: ref(null),
+    providersCount: ref(0),
+    isLoading: ref(false),
+    quoteError: ref(null),
+    statusLabel: ref(''),
+    getQuoteDiffPct: vi.fn(() => null),
+    reset: vi.fn(),
+    requestQuotes: vi.fn(),
+    selectProvider: vi.fn(),
+  }),
+}))
+
+vi.mock('~/composables/useMultiplyCollateralOptions', () => ({
+  useMultiplyCollateralOptions: () => ({
+    collateralOptions: ref([]),
+    collateralVaults: ref([]),
+  }),
+}))
+
+vi.mock('~/composables/useEulerLabels', () => ({
+  useEulerProductOfVault: () => null,
+}))
+
+vi.mock('~/composables/borrow/useMultiplyCowSwap', () => ({
+  useMultiplyCowSwap: () => ({
+    cowSwapExecution: ref(null),
+    cowSwapOrderStatus: ref(null),
+    cowSwapStatusLabel: computed(() => ''),
+    submitCowSwapMultiply: vi.fn(),
+  }),
+}))
+
+vi.mock('~/utils/sdk-prices', () => ({
+  getAssetUsdValue: vi.fn(async () => 0),
+  getAssetUsdValueOrZero: vi.fn(async () => 0),
+  getAssetOraclePrice: vi.fn(() => ({ amountOutMid: 1n, amountOutAsk: 1n })),
+  getCollateralOraclePrice: vi.fn(() => ({ amountOutMid: 1n, amountOutBid: 1n })),
+  getCollateralShareOraclePrice: vi.fn(() => ({ amountIn: 1n })),
+  conservativePriceRatioNumber: vi.fn(() => 1),
+}))
+
+vi.mock('~/utils/vault/apy', () => ({
+  getProjectedRates: vi.fn(async () => null),
+}))
+
+vi.mock('~/utils/multiply-math', () => ({
+  computeLeverageDebt: vi.fn(() => 1n),
+  computeMaxMultiplier: vi.fn(() => 5),
+  computeMinMultiplier: vi.fn(() => 1),
+  computeWeightedSupplyApy: vi.fn(() => 0),
+}))
+
+vi.mock('~/utils/swapRouteItems', () => ({
+  buildSwapRouteItems: vi.fn(() => []),
+}))
+
+vi.mock('~/utils/priceImpact', () => ({
+  computeMultipliedPriceImpact: vi.fn(() => null),
+}))
+
+vi.mock('~/utils/repayUtils', () => ({
+  calculateRoe: vi.fn(() => 0),
+  computeNextHealth: vi.fn(() => null),
+  computeLiquidationPrice: vi.fn(() => null),
+}))
+
+vi.mock('~/utils/operationGuardRegistry', () => ({
+  isOperationBlocked: ref(false),
+}))
+
+vi.mock('~/utils/vault-hooks', () => ({
+  OP_BORROW: 'borrow',
+  OP_DEPOSIT: 'deposit',
+  OP_SKIM: 'skim',
+  OP_TRANSFER: 'transfer',
+  findBlockingDisabledOp: vi.fn(() => false),
+}))
+
+vi.mock('~/composables/useVaultWarnings', () => ({
+  getPlanHookDisabledWarning: vi.fn(() => null),
+  getUtilisationWarning: vi.fn(() => null),
+  getSupplyCapWarning: mocks.getSupplyCapWarning,
+  getBorrowCapWarning: mocks.getBorrowCapWarning,
+}))
+
+vi.mock('~/entities/cowswap', () => ({
+  COWSWAP_ORDER_DEADLINE_SECONDS: 1800,
+  COWSWAP_PROVIDER_EXTRA_DATA: { openPosition: {} },
+  buildOpenPositionQuoteAppData: vi.fn(() => ({})),
+  getCowSwapChainConfig: vi.fn(() => null),
+  isCowProviderOrQuote: vi.fn(() => false),
+}))
+
+const makeForm = (vault: EVault) => useMultiplyForm({
+  pair: ref({
+    collateral: vault,
+    borrow: vault,
+    ltv: {
+      borrowLTV: 500000000000000000n,
+      liquidationLTV: 750000000000000000n,
+    },
+  } as never),
+  borrowVault: computed(() => vault),
+  collateralVault: computed(() => vault),
+  formTab: ref('multiply'),
+  resolvePendingSubAccount: vi.fn(async () => USER),
+  isPendingSubAccountLoading: ref(false),
+  isGeoBlocked: computed(() => false),
+  isMultiplyRestricted: computed(() => false),
+})
+
+describe('useMultiplyForm cap validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubGlobal('ref', ref)
+    vi.stubGlobal('computed', computed)
+    vi.stubGlobal('watch', watch)
+    vi.stubGlobal('watchEffect', watchEffect)
+    vi.stubGlobal('useDebounceFn', (fn: unknown) => fn)
+    vi.stubGlobal('useEulerTx', () => ({
+      planMultiply: mocks.planMultiply,
+      prepareTransactionPlan: mocks.prepareTransactionPlan,
+      executePlan: mocks.executePlan,
+      prefetchPluginData: mocks.prefetchPluginData,
+      preloadSubAccountSnapshot: mocks.preloadSubAccountSnapshot,
+    }))
+    vi.stubGlobal('useWagmi', () => ({
+      address: ref(USER),
+      isConnected: ref(true),
+    }))
+    vi.stubGlobal('useSpyMode', () => ({
+      isSpyMode: ref(true),
+      spyAddress: ref(USER),
+    }))
+    vi.stubGlobal('useEulerAccount', () => ({
+      depositPositions: ref([]),
+    }))
+    vi.stubGlobal('usePlanAccount', () => ({
+      account: shallowRef(planAccount),
+    }))
+    vi.stubGlobal('useEulerAddresses', () => ({
+      chainId: ref(1),
+    }))
+    vi.stubGlobal('useWallets', () => ({
+      fetchSingleBalance: mocks.fetchSingleBalance,
+    }))
+    vi.stubGlobal('useTxFinalization', () => ({
+      finalizeTxAndRedirect: vi.fn(),
+    }))
+    vi.stubGlobal('useRewardsApy', () => ({
+      getSupplyRewardApy: vi.fn(async () => 0),
+      getBorrowRewardApy: vi.fn(async () => 0),
+    }))
+    vi.stubGlobal('useUserSettings', () => ({
+      settings: ref({ enableIntrinsicApy: false }),
+    }))
+    vi.stubGlobal('useTransactionPlanSimulation', () => ({
+      runPreparedSimulation: mocks.runPreparedSimulation,
+      simulationError: ref(null),
+      clearSimulationError: vi.fn(),
+    }))
+    vi.stubGlobal('usePriceInvert', () => ({
+      autoInvert: vi.fn(),
+      invertValue: vi.fn((value: number | null) => value),
+      displaySymbol: 'USDC',
+      toggle: vi.fn(),
+    }))
+    vi.stubGlobal('useSlippage', () => ({
+      slippage: ref(0.5),
+    }))
+    vi.stubGlobal('ltvToPercent', () => 50)
+    vi.stubGlobal('valueToNano', (value: string | number, decimals = 0) => BigInt(Math.round(Number(value || 0) * 10 ** Number(decimals))))
+    vi.stubGlobal('nanoToValue', (value: bigint, decimals = 0) => Number(value) / 10 ** Number(decimals))
+    vi.stubGlobal('getIsSupplyCapReached', (vault: EVault) => vault.caps.supplyCapUtilization >= 100)
+    vi.stubGlobal('getIsBorrowCapReached', (vault: EVault) => vault.caps.borrowCapUtilization >= 100)
+    vi.stubGlobal('getVaultSupplyApy', () => 0)
+    vi.stubGlobal('getVaultBorrowApy', () => 0)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('surfaces a reached supply cap as the multiply disabled reason and form warning', () => {
+    const vault = makeVault(100, 0)
+    const form = makeForm(vault)
+
+    form.initMultiplySupplyVault(vault)
+    form.multiplyAssetBalance.value = 100n
+    form.multiplyInputAmount.value = '1'
+    form.multiplier.value = 2
+
+    expect(form.isMultiplySubmitDisabled.value).toBe(true)
+    expect(form.multiplyCapErrorText.value).toBe('The supply cap has been reached. New deposits will fail.')
+    expect(form.multiplyFormWarnings.value).toContainEqual({
+      level: 'info',
+      title: 'Supply cap reached',
+      message: 'The supply cap has been reached. New deposits will fail.',
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Surface multiply supply/borrow cap failures as explicit disabled reasons instead of falling through to the generic Review Multiply tooltip
- Include supply cap warnings in multiply form warnings, matching the cap condition that already disables submit
- Add a regression test for the reached supply cap path

## Test plan
- `npx vitest run tests/composables/useMultiplyForm.test.ts` — confirmed RED before implementation, then green
- `npx vitest run tests/composables/useMultiplyForm.test.ts tests/composables/useVaultWarnings.test.ts tests/composables/useBorrowForm.test.ts`
- `npx eslint composables/borrow/useMultiplyForm.ts 'pages/borrow/[collateral]/[borrow]/index.vue' tests/composables/useMultiplyForm.test.ts`
- `npm run typecheck`
- `npm run build`

## Context
For the reported mainnet spy route, the collateral/supply vault is already cap-reached/closed to deposits. The form disabled `Review Multiply` via the cap check, but `multiplyDisabledReasonInfo` did not receive a cap-specific message, so `VaultFormSubmit` displayed the generic "Complete the form fields above to continue." fallback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for supply and borrow capacity limits on multiply transactions. When caps are reached, the multiply action is now disabled with a clear warning message displayed to users, preventing potential failed transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->