### PR TITLE
fix: show multiply cap hover reason before amount entry

### DIFF
--- a/composables/borrow/useMultiplyForm.ts
+++ b/composables/borrow/useMultiplyForm.ts
@@ -621,7 +621,6 @@ export const useMultiplyForm = (options: UseMultiplyFormOptions) => {
   const isBorrowCapReached = computed(() => multiplyShortVault.value ? getIsBorrowCapReached(multiplyShortVault.value) : false)
 
   const multiplyCapErrorText = computed(() => {
-    if (!multiplyInputAmount.value || multiplyDebtAmountNano.value <= 0n) return null
     if (isSupplyCapReached.value && multiplySupplyVault.value) {
       return getSupplyCapWarning(multiplySupplyVault.value)?.message || 'The supply cap has been reached. New deposits will fail.'
     }

--- a/tests/composables/useMultiplyForm.test.ts
+++ b/tests/composables/useMultiplyForm.test.ts
@@ -283,6 +283,10 @@ describe('useMultiplyForm cap validation', () => {
 
     form.initMultiplySupplyVault(vault)
     form.multiplyAssetBalance.value = 100n
+
+    expect(form.isMultiplySubmitDisabled.value).toBe(true)
+    expect(form.multiplyCapErrorText.value).toBe('The supply cap has been reached. New deposits will fail.')
+
     form.multiplyInputAmount.value = '1'
     form.multiplier.value = 2
 


### PR DESCRIPTION
Follow-up to merged PR #569: https://github.com/euler-xyz/euler-lite/pull/569

## Summary
- show the multiply supply/borrow cap disabled reason even before amount entry
- keep the existing cap warning behavior after the form is populated
- extend the multiply cap regression test to cover the empty/incomplete form state that drives the CTA hover tooltip

## Validation
- `npx vitest run tests/composables/useMultiplyForm.test.ts tests/composables/useVaultWarnings.test.ts tests/composables/useBorrowForm.test.ts`
- `npx eslint composables/borrow/useMultiplyForm.ts tests/composables/useMultiplyForm.test.ts`
- `npm run typecheck`
- `npm run build`
- local smoke on exact spy route: `/borrow/0xdB6165bd1F90cb507F30AbDb42c4596CE4D894f4/0xba98fC35C9dfd69178AD5dcE9FA29c64554783b5?network=1&spy=0x5BC81274740A73D33ec8539182c326b8b58004C2`
  - HTTP 200
  - hovering disabled `Review Multiply` before amount entry shows `The supply cap has been reached. New deposits will fail.`
  - generic `Complete the form fields above to continue.` text is absent


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Supply and borrow cap validation now triggers during form initialization, displaying warning messages earlier in the user journey. Previously, these capacity limit warnings only appeared after users provided input.

* **Tests**
  * Test coverage enhanced to verify cap validation warnings display at the correct point in form initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
