### PR TITLE
feat(merkl): support optional MERKL_API_KEY in the rewards proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Euler Lite uses the [Euler V2 SDK](https://github.com/euler-xyz/euler-sdks) for 
 | `DEV_GEO_COUNTRY` | Local/preview country fallback when Cloudflare geo headers are absent. Do not set in production behind Cloudflare. |
 | `WALLET_SCREENING_URI` | Optional server-side wallet screening endpoint proxied by `/api/screen-address`. |
 | `STABLEWATCH_API_KEY` | Optional server-side Stablewatch key for intrinsic APY data. |
+| `MERKL_API_KEY` | Optional server-side Merkl key. The Merkl API works anonymously (10 req/sec shared across all users via `/api/proxy/merkl`); set this to send `X-API-Key` upstream for a higher quota. Server-only — never exposed to the browser. |
 | `TENDERLY_ACCESS_KEY`, `TENDERLY_ACCOUNT_SLUG`, `TENDERLY_PROJECT_SLUG` | Optional Tenderly simulation configuration. |
 | `FUUL_API_URL` or `NUXT_PUBLIC_FUUL_API_URL` | Optional Fuul API upstream override. |
 | `INCENTRA_API_URL` or `NUXT_PUBLIC_INCENTRA_API_URL` | Optional Incentra/Brevis API upstream override. |

--- a/server/api/proxy/merkl/[...path].ts
+++ b/server/api/proxy/merkl/[...path].ts
@@ -9,6 +9,7 @@ import { fetchWithTimeout } from '~/server/utils/fetchWithTimeout'
 import { createRateLimiter } from '~/server/utils/rate-limit'
 import { logger } from '~/server/utils/logger'
 import { isAllowedMerklProxyRequest } from '~/server/utils/rewards-proxy-allowlist'
+import { buildMerklProxyRequestHeaders } from '~/server/utils/merkl-proxy'
 
 /**
  * Server-side proxy for Merkl v4 opportunity / user-reward endpoints.
@@ -21,6 +22,11 @@ import { isAllowedMerklProxyRequest } from '~/server/utils/rewards-proxy-allowli
  * and this handler rewrites the path to `https://api.merkl.xyz/v4/<path>`
  * plus the original query string, forwards the response, and tags the
  * response with permissive caching headers so the browser can reuse it.
+ *
+ * Merkl is reachable anonymously (10 req/sec), but that quota is shared across
+ * all users because every request egresses from this one origin. Set the
+ * server-only `MERKL_API_KEY` env var to send `X-API-Key` upstream for a higher
+ * quota — see `buildMerklProxyRequestHeaders` in `server/utils/merkl-proxy.ts`.
  */
 
 const MERKL_UPSTREAM_BASE = 'https://api.merkl.xyz/v4'
@@ -69,7 +75,7 @@ export default defineEventHandler(async (event) => {
   try {
     upstream = await fetchWithTimeout(target, undefined, {
       method,
-      headers: { accept: 'application/json' },
+      headers: buildMerklProxyRequestHeaders(),
     })
   }
   catch (err) {

--- a/server/utils/merkl-proxy.ts
+++ b/server/utils/merkl-proxy.ts
@@ -1,0 +1,20 @@
+import { readMerklApiKey } from '~/utils/api-url-env'
+
+/**
+ * Request headers for the Merkl upstream fetch made by `/api/proxy/merkl`.
+ *
+ * Merkl serves anonymous requests at 10 req/sec, but every user's Merkl read
+ * is funnelled through this one server-side proxy origin, so the anonymous
+ * quota is shared across all traffic and is the binding limit under load. When
+ * `MERKL_API_KEY` is configured we send it as `X-API-Key` for a higher quota;
+ * the key stays server-side and is never exposed to the browser. The shape
+ * mirrors `buildV3ProxyRequestHeaders` in `v3-proxy.ts`.
+ */
+export function buildMerklProxyRequestHeaders(
+  env: NodeJS.ProcessEnv = process.env,
+): Record<string, string> {
+  const headers: Record<string, string> = { accept: 'application/json' }
+  const apiKey = readMerklApiKey(env).trim()
+  if (apiKey) headers['X-API-Key'] = apiKey
+  return headers
+}

--- a/tests/server/merkl-proxy.test.ts
+++ b/tests/server/merkl-proxy.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { buildMerklProxyRequestHeaders } from '~/server/utils/merkl-proxy'
+
+describe('merkl proxy headers', () => {
+  it('sends only the accept header when no API key is configured', () => {
+    const headers = buildMerklProxyRequestHeaders({})
+
+    expect(headers.accept).toBe('application/json')
+    expect(headers['X-API-Key']).toBeUndefined()
+  })
+
+  it('injects the server-side Merkl API key as X-API-Key', () => {
+    const headers = buildMerklProxyRequestHeaders({ MERKL_API_KEY: 'merkl-secret' })
+
+    expect(headers.accept).toBe('application/json')
+    expect(headers['X-API-Key']).toBe('merkl-secret')
+  })
+
+  it('ignores a blank API key', () => {
+    const headers = buildMerklProxyRequestHeaders({ MERKL_API_KEY: '   ' })
+
+    expect(headers['X-API-Key']).toBeUndefined()
+  })
+
+  it('does not read a public Merkl API key variable', () => {
+    const headers = buildMerklProxyRequestHeaders({ NUXT_PUBLIC_MERKL_API_KEY: 'public-key' })
+
+    expect(headers['X-API-Key']).toBeUndefined()
+  })
+})

--- a/tests/utils/api-url-env.test.ts
+++ b/tests/utils/api-url-env.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { DEFAULT_V3_API_URL, readResolvedV3ApiUrl, readV3ApiKey, readV3ApiUrl } from '~/utils/api-url-env'
+import { DEFAULT_V3_API_URL, readMerklApiKey, readResolvedV3ApiUrl, readV3ApiKey, readV3ApiUrl } from '~/utils/api-url-env'
 
 describe('api-url-env', () => {
   it('ignores non-V3 API URL variables', () => {
@@ -39,6 +39,17 @@ describe('api-url-env', () => {
     expect(readV3ApiKey({
       NUXT_PUBLIC_V3_API_KEY: 'public-key',
       VITE_EULER_V3_API_KEY: 'vite-key',
+    })).toBe('')
+  })
+
+  it('reads the server-side Merkl API key', () => {
+    expect(readMerklApiKey({})).toBe('')
+    expect(readMerklApiKey({ MERKL_API_KEY: 'merkl-secret' })).toBe('merkl-secret')
+  })
+
+  it('does not read public Merkl API key variables', () => {
+    expect(readMerklApiKey({
+      NUXT_PUBLIC_MERKL_API_KEY: 'public-key',
     })).toBe('')
   })
 

--- a/utils/api-url-env.ts
+++ b/utils/api-url-env.ts
@@ -13,6 +13,10 @@ const V3_API_KEY_ENV_KEYS = [
   'EULER_V3_API_KEY',
 ] as const
 
+const MERKL_API_KEY_ENV_KEYS = [
+  'MERKL_API_KEY',
+] as const
+
 const SERVER_VAULT_CACHE_SOURCE_ENV_KEYS = [
   'SERVER_VAULT_CACHE_SOURCE',
 ] as const
@@ -75,6 +79,17 @@ export function readV3ApiUrl(env: NodeJS.ProcessEnv = process.env): string {
 
 export function readV3ApiKey(env: NodeJS.ProcessEnv = process.env): string {
   return firstEnv(env, V3_API_KEY_ENV_KEYS)
+}
+
+/**
+ * Server-only Merkl API key. Merkl works anonymously (10 req/sec), but all of
+ * Lite's Merkl traffic egresses from the single `/api/proxy/merkl` origin, so
+ * that shared anonymous quota is the binding limit. When set, the proxy sends
+ * it as `X-API-Key` for a higher quota. Never read from a public/`NUXT_PUBLIC_`
+ * variable — the key must not reach the browser.
+ */
+export function readMerklApiKey(env: NodeJS.ProcessEnv = process.env): string {
+  return firstEnv(env, MERKL_API_KEY_ENV_KEYS)
 }
 
 export function readResolvedV3ApiUrl(env: NodeJS.ProcessEnv = process.env): string {


### PR DESCRIPTION
  ## What

  Adds optional, server-only Merkl API-key support to the `/api/proxy/merkl` rewards proxy.

  When `MERKL_API_KEY` is set, the proxy forwards it as `X-API-Key` to `api.merkl.xyz/v4`. When it's unset, behaviour is unchanged — anonymous, `accept`-only requests.

  ## Why

  All of Lite's Merkl traffic egresses from the single `/api/proxy/merkl` origin, so [Merkl's](https://developers.merkl.xyz/integrate-merkl/quickstart) anonymous **10 req/sec** quota is shared across every
  user and is the binding limit under load. An API key raises that quota (and adds attribution/support).

  The key is **optional** — nothing breaks without it, so this is fully backward-compatible.

  ## Design

  - **Proxy, not SDK.** The key stays server-side and is never exposed to the browser (the SDK runs client-side and only talks to the proxy). The SDK's direct Merkl adapter needs no change for Lite.
  - Mirrors the existing V3 API-key pattern: `readMerklApiKey` in `utils/api-url-env.ts` (next to `readV3ApiKey`) and `buildMerklProxyRequestHeaders` in `server/utils/merkl-proxy.ts` (next to
  `buildV3ProxyRequestHeaders`).
  - Server-only: read from `MERKL_API_KEY`, never from a `NUXT_PUBLIC_*` variable.
