### PR TITLE
Add borrow-more max liquidity context

### DIFF
--- a/pages/position/[number]/borrow/index.vue
+++ b/pages/position/[number]/borrow/index.vue
@@ -15,6 +15,12 @@ import { formatLiquidationBuffer as formatLiqBuffer } from '~/utils/repayUtils'
 import { ltvToPercent, nanoToValue } from '~/utils/crypto-utils'
 import { isOperationBlocked } from '~/utils/operationGuardRegistry'
 import { createRaceGuard } from '~/utils/race-guard'
+import {
+  formatBorrowMoreInputAmount,
+  getBorrowMoreAvailableLiquidityDisplay,
+  getBorrowMoreLtvHeadroomAmount,
+  getBorrowMoreMaxBorrowAmount,
+} from '~/utils/borrow-more'
 import type { DisabledReasonInfo } from '~/components/entities/vault/form/types'
 import { useModal } from '~/components/ui/composables/useModal'
 import { useToast } from '~/components/ui/composables/useToast'
@@ -163,6 +169,8 @@ const borrowApy = computed(() => withVaultIntrinsicApy(
   borrowVault.value,
   enableIntrinsicApy.value,
 ))
+const availableLiquidity = computed(() => borrowVault.value?.availableLiquidity)
+const availableLiquidityDisplay = computed(() => getBorrowMoreAvailableLiquidityDisplay(borrowVault.value))
 
 const load = async () => {
   if (!isConnected.value && !isSpyMode.value) {
@@ -331,6 +339,25 @@ const computedBorrowAmount = computed(() => {
   if (additional.isZero() || additional.isNegative()) return '0'
   return trimTrailingZeros(additional.toString())
 })
+const ltvHeadroomAmount = computed((): bigint | undefined => {
+  if (!pair.value || !borrowVault.value || !position.value) return undefined
+  return getBorrowMoreLtvHeadroomAmount({
+    borrowed: position.value.borrowed || 0n,
+    borrowDecimals: borrowVault.value.shares.decimals,
+    assetDecimals: borrowVault.value.asset.decimals,
+    currentLtvPercent: currentUserLTV.value,
+    maxBorrowLtv: pair.value.ltv.borrowLTV,
+  })
+})
+const maxBorrowAmount = computed(() => getBorrowMoreMaxBorrowAmount({
+  availableLiquidity: availableLiquidity.value,
+  ltvHeadroom: ltvHeadroomAmount.value,
+}))
+const setMaxBorrowAmount = async () => {
+  if (!borrowVault.value || maxBorrowAmount.value === undefined) return
+  borrowAmount.value = formatBorrowMoreInputAmount(maxBorrowAmount.value, borrowVault.value.asset.decimals)
+  await onBorrowInput()
+}
 
 watch(computedBorrowAmount, (val) => {
   if (isLtvDriven.value && val !== null) {
@@ -472,9 +499,11 @@ watch([collateralAmount, borrowAmount], async () => {
               :label="`Borrow ${borrowVault.asset.symbol}`"
               :asset="borrowVault.asset"
               :vault="borrowVault"
+              :balance="maxBorrowAmount"
+              :maxable="maxBorrowAmount !== undefined"
+              :max-handler="setMaxBorrowAmount"
               @input="onBorrowInput"
             />
-
             <UiRange
               v-model="ltv"
               label="LTV"
@@ -523,6 +552,23 @@ watch([collateralAmount, borrowAmount], async () => {
             variant="card"
             class="w-full laptop:max-w-[360px]"
           >
+            <SummaryRow label="Available liquidity">
+              <UiExactAmount
+                v-if="availableLiquidityDisplay"
+                class="text-content-primary text-right"
+                :exact="availableLiquidityDisplay.exact"
+                data-field="available-liquidity"
+              >
+                {{ availableLiquidityDisplay.display }}
+              </UiExactAmount>
+              <span
+                v-else
+                class="text-warning-500"
+                data-field="available-liquidity"
+              >
+                Unknown
+              </span>
+            </SummaryRow>
             <SummaryRow label="Net APY">
               <SummaryValue
                 :before="currentNetAPY != null ? formatNumber(currentNetAPY) : undefined"

--- a/tests/utils/borrow-more.test.ts
+++ b/tests/utils/borrow-more.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import {
+  formatBorrowMoreInputAmount,
+  getBorrowMoreAvailableLiquidityDisplay,
+  getBorrowMoreLtvHeadroomAmount,
+  getBorrowMoreMaxBorrowAmount,
+} from '~/utils/borrow-more'
+
+const usdc = {
+  asset: {
+    decimals: 6,
+    symbol: 'USDC',
+  },
+}
+
+describe('borrow-more liquidity display', () => {
+  it('formats available liquidity for the selected borrow vault', () => {
+    expect(getBorrowMoreAvailableLiquidityDisplay({
+      ...usdc,
+      availableLiquidity: 123_450_000n,
+    })).toEqual({
+      exact: '123.45 USDC',
+      display: '123.45 USDC',
+    })
+  })
+
+  it('returns null for unknown liquidity so the UI can render an explicit fallback', () => {
+    expect(getBorrowMoreAvailableLiquidityDisplay(usdc)).toBeNull()
+    expect(getBorrowMoreAvailableLiquidityDisplay(undefined)).toBeNull()
+  })
+})
+
+describe('borrow-more max borrow amount', () => {
+  const riskHeadroom = getBorrowMoreLtvHeadroomAmount({
+    borrowed: 100_000_000n,
+    borrowDecimals: 6,
+    assetDecimals: 6,
+    currentLtvPercent: 50,
+    maxBorrowLtv: 7500n,
+  })
+
+  it('computes a positive LTV headroom amount for the max action', () => {
+    expect(riskHeadroom).toBe(49_980_000n)
+    expect(formatBorrowMoreInputAmount(riskHeadroom, 6)).toBe('49.98')
+  })
+
+  it('caps Max by available liquidity when liquidity is lower than risk headroom', () => {
+    const maxBorrow = getBorrowMoreMaxBorrowAmount({
+      availableLiquidity: 20_000_000n,
+      ltvHeadroom: riskHeadroom,
+    })
+
+    expect(maxBorrow).toBe(20_000_000n)
+    expect(formatBorrowMoreInputAmount(maxBorrow!, 6)).toBe('20')
+  })
+
+  it('caps Max by position risk headroom when liquidity is higher', () => {
+    const maxBorrow = getBorrowMoreMaxBorrowAmount({
+      availableLiquidity: 1_000_000_000n,
+      ltvHeadroom: riskHeadroom,
+    })
+
+    expect(maxBorrow).toBe(riskHeadroom)
+    expect(formatBorrowMoreInputAmount(maxBorrow!, 6)).toBe('49.98')
+  })
+
+  it('stays unavailable until both liquidity and position risk are known', () => {
+    expect(getBorrowMoreMaxBorrowAmount({
+      availableLiquidity: undefined,
+      ltvHeadroom: riskHeadroom,
+    })).toBeUndefined()
+    expect(getBorrowMoreMaxBorrowAmount({
+      availableLiquidity: 20_000_000n,
+      ltvHeadroom: undefined,
+    })).toBeUndefined()
+  })
+})

--- a/utils/borrow-more.ts
+++ b/utils/borrow-more.ts
@@ -1,0 +1,70 @@
+import { formatUnits } from 'viem'
+import { ltvToPercent, nanoToValue, valueToNano } from '~/utils/crypto-utils'
+import { FixedPoint } from '~/utils/fixed-point'
+import { formatExactAmount, formatSmartAmount, trimTrailingZeros } from '~/utils/string-utils'
+
+type Decimals = number | bigint
+
+export interface BorrowMoreLiquidityVault {
+  availableLiquidity?: bigint
+  asset: {
+    decimals: Decimals
+    symbol: string
+  }
+}
+
+export interface BorrowMoreAvailableLiquidityDisplay {
+  exact: string
+  display: string
+}
+
+export const getBorrowMoreAvailableLiquidityDisplay = (
+  vault: BorrowMoreLiquidityVault | undefined,
+): BorrowMoreAvailableLiquidityDisplay | null => {
+  if (!vault || vault.availableLiquidity === undefined) return null
+
+  return {
+    exact: formatExactAmount(vault.availableLiquidity, vault.asset.decimals, vault.asset.symbol),
+    display: `${formatSmartAmount(nanoToValue(vault.availableLiquidity, vault.asset.decimals))} ${vault.asset.symbol}`,
+  }
+}
+
+export const getBorrowMoreLtvHeadroomAmount = ({
+  borrowed,
+  borrowDecimals,
+  assetDecimals,
+  currentLtvPercent,
+  maxBorrowLtv,
+}: {
+  borrowed: bigint
+  borrowDecimals: Decimals
+  assetDecimals: Decimals
+  currentLtvPercent: number
+  maxBorrowLtv: bigint | number
+}): bigint => {
+  if (borrowed === 0n || currentLtvPercent <= 0) return 0n
+
+  const maxLtvFP = FixedPoint.fromValue(valueToNano(ltvToPercent(maxBorrowLtv), 4), 4)
+    .sub(FixedPoint.fromValue(100n, 4))
+  const currentLtvFP = FixedPoint.fromValue(valueToNano(currentLtvPercent, 4), 4)
+  if (currentLtvFP.isZero() || maxLtvFP.lte(currentLtvFP)) return 0n
+
+  const borrowedFP = FixedPoint.fromValue(borrowed, Number(borrowDecimals))
+  const additional = borrowedFP.mul(maxLtvFP.subUnsafe(currentLtvFP)).div(currentLtvFP)
+  if (additional.isZero() || additional.isNegative()) return 0n
+  return additional.toFormat({ decimals: Number(assetDecimals) }).value
+}
+
+export const getBorrowMoreMaxBorrowAmount = ({
+  availableLiquidity,
+  ltvHeadroom,
+}: {
+  availableLiquidity: bigint | undefined
+  ltvHeadroom: bigint | undefined
+}): bigint | undefined => {
+  if (availableLiquidity === undefined || ltvHeadroom === undefined) return undefined
+  return availableLiquidity < ltvHeadroom ? availableLiquidity : ltvHeadroom
+}
+
+export const formatBorrowMoreInputAmount = (amount: bigint, decimals: Decimals): string =>
+  trimTrailingZeros(formatUnits(amount, Number(decimals)))


### PR DESCRIPTION
## Summary
- Show available liquidity for the selected borrow vault in the borrow-more form so users can see when vault capacity is limiting them.
- Add a Max action that fills the currently borrowable amount while respecting both vault liquidity and the user's LTV headroom.

## Changes
- Compute borrow-more liquidity, LTV headroom, and max amount in a small shared helper for deterministic unit coverage.
- Wire the existing AssetInput Max affordance into the borrow-more form and keep it unavailable until both liquidity and risk data are known.
- Render an explicit Unknown liquidity fallback when the vault does not have a reliable liquidity value.

## Test plan
- [x] npm run test:run -- tests/utils/borrow-more.test.ts
- [x] npx eslint 'pages/position/[number]/borrow/index.vue' utils/borrow-more.ts tests/utils/borrow-more.test.ts
- [x] npm run typecheck
- [x] git diff --check
- [x] Local smoke: position 0 shows 0 USDC available liquidity and 0 USDC Max after data resolves.
- [x] Local smoke: position 1 shows positive WETH liquidity and a nonzero WETH Max capped below liquidity.
- [x] Local smoke: position 4 shows positive wstETH liquidity and a nonzero wstETH Max capped below liquidity.
- [x] Local smoke: position 9 shows positive USDC liquidity and a nonzero USDC Max capped below liquidity.

<img width="1296" height="656" alt="image" src="https://github.com/user-attachments/assets/4f081967-4314-4050-9030-9c0e216b4daf" />
<img width="1357" height="647" alt="image" src="https://github.com/user-attachments/assets/94271fe8-1179-42ee-a5c7-72bcc40ff712" />
<img width="1355" height="580" alt="image" src="https://github.com/user-attachments/assets/4345022f-f00e-49b9-8275-301186e84b96" />
<img width="1276" height="660" alt="image" src="https://github.com/user-attachments/assets/6f34d492-9682-4953-b31e-13db98e1e47a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Available liquidity information now displayed during borrowing operations
  * "Max" selection support added for borrow amount input to quickly set maximum borrowable amount
  * Automatic calculation of maximum borrowable amount based on account LTV headroom

* **Tests**
  * Added comprehensive test coverage for borrow calculation utilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->