### PR TITLE
fix: correct market count grammar

### DIFF
--- a/components/entities/vault/overview/VaultOverviewBlockGeneral.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockGeneral.vue
@@ -56,6 +56,10 @@ const borrowCount = computed(() => {
   return vault.collaterals.filter(ltv => ltv.borrowLTV > 0).length
 })
 
+const formatMarketAvailability = (count: number) => {
+  return count ? `Yes in ${count} ${count === 1 ? 'market' : 'markets'}` : 'No'
+}
+
 const propertyBadgeDetails: Record<VaultPropertyBadge, {
   component: Component
   description: string
@@ -206,7 +210,7 @@ watchEffect(async () => {
           <div class="flex items-center gap-8">
             <UiIcon :name="borrowCount ? 'green-tick' : 'red-cross'" />
             <span class="text-p2 text-content-primary">
-              {{ borrowCount ? `Yes in ${borrowCount} markets` : 'No' }}
+              {{ formatMarketAvailability(borrowCount) }}
             </span>
           </div>
         </VaultOverviewLabelValue>
@@ -214,7 +218,7 @@ watchEffect(async () => {
           <div class="flex items-center gap-8">
             <UiIcon :name="collateralCount ? 'green-tick' : 'red-cross'" />
             <span class="text-p2 text-content-primary">
-              {{ collateralCount ? `Yes in ${collateralCount} markets` : 'No' }}
+              {{ formatMarketAvailability(collateralCount) }}
             </span>
           </div>
         </VaultOverviewLabelValue>


### PR DESCRIPTION
Summary
- Fix singular/plural market count copy in the vault overview general block.
- Reuse the same formatter for borrowable and collateral market availability rows.

Tests
- npx eslint components/entities/vault/overview/VaultOverviewBlockGeneral.vue

Closes #188

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved formatting consistency for market availability text, ensuring correct singular and plural forms ("market" vs "markets") in the vault overview display for "Can be borrowed" and "Can be used as collateral" fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->