### PR TITLE
fix: share market count grammar

### DIFF
--- a/components/entities/vault/overview/SecuritizeVaultOverview.vue
+++ b/components/entities/vault/overview/SecuritizeVaultOverview.vue
@@ -12,6 +12,7 @@ import { formatAssetValue } from '~/utils/sdk-prices'
 import { formatNumber, compactNumber, formatUsdValue, formatCompactUsdValue } from '~/utils/string-utils'
 import { nanoToValue } from '~/utils/crypto-utils'
 import { normalizeAddress } from '~/utils/normalizeAddress'
+import { formatMarketAvailability } from '~/utils/vault-display'
 import { VaultSupplyApyModal } from '#components'
 import { getAddress, type Address, maxUint256 } from 'viem'
 import { logWarn } from '~/utils/errorHandling'
@@ -265,7 +266,7 @@ const supplyCapPercentageDisplay = computed(() => {
               <UiIcon :name="borrowCount ? 'green-tick' : 'red-cross'" />
             </div>
             <span class="text-p2 text-content-primary">
-              {{ borrowCount ? `Yes in ${borrowCount} markets` : 'No' }}
+              {{ formatMarketAvailability(borrowCount) }}
             </span>
           </div>
         </VaultOverviewLabelValue>
@@ -275,7 +276,7 @@ const supplyCapPercentageDisplay = computed(() => {
               <UiIcon :name="collateralCount ? 'green-tick' : 'red-cross'" />
             </div>
             <span class="text-p2 text-content-primary">
-              {{ collateralCount ? `Yes in ${collateralCount} markets` : 'No' }}
+              {{ formatMarketAvailability(collateralCount) }}
             </span>
           </div>
         </VaultOverviewLabelValue>

--- a/components/entities/vault/overview/VaultOverviewBlockGeneral.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockGeneral.vue
@@ -10,6 +10,7 @@ import { getEulerLabelEntityLogo } from '~/entities/euler/labels'
 import { isVaultBlockedByCountry } from '~/composables/useGeoBlock'
 import { autoLink } from '~/utils/autoLink'
 import { normalizeAddress } from '~/utils/normalizeAddress'
+import { formatMarketAvailability } from '~/utils/vault-display'
 import type { VaultTypeBadge } from '~/composables/useVaultTypeBadges'
 import { AccessControlBadge, CyclicalNoteBadge, GovernanceLimitedBadge, KeyringBadge } from '#components'
 
@@ -55,10 +56,6 @@ const collateralCount = computed(() => {
 const borrowCount = computed(() => {
   return vault.collaterals.filter(ltv => ltv.borrowLTV > 0).length
 })
-
-const formatMarketAvailability = (count: number) => {
-  return count ? `Yes in ${count} ${count === 1 ? 'market' : 'markets'}` : 'No'
-}
 
 const propertyBadgeDetails: Record<VaultPropertyBadge, {
   component: Component

--- a/tests/utils/vault-display.test.ts
+++ b/tests/utils/vault-display.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatMarketAvailability } from '~/utils/vault-display'
+
+describe('formatMarketAvailability', () => {
+  it('formats unavailable, singular, and plural market counts', () => {
+    expect(formatMarketAvailability(0)).toBe('No')
+    expect(formatMarketAvailability(1)).toBe('Yes in 1 market')
+    expect(formatMarketAvailability(2)).toBe('Yes in 2 markets')
+  })
+})

--- a/utils/vault-display.ts
+++ b/utils/vault-display.ts
@@ -34,3 +34,7 @@ export const getVaultUtilization = (vault: any): number => {
 
   return Number(((Number(totalBorrowed) / Number(totalAssets)) * 100).toFixed(2))
 }
+
+export const formatMarketAvailability = (count: number) => {
+  return count ? `Yes in ${count} ${count === 1 ? 'market' : 'markets'}` : 'No'
+}


### PR DESCRIPTION
Summary
- Fix the remaining singular/plural market count copy in the Securitize vault overview.
- Move market availability copy into a shared formatter used by both vault overview components.
- Add a focused unit test for unavailable, singular, and plural market counts.

Tests
- npx eslint components/entities/vault/overview/VaultOverviewBlockGeneral.vue components/entities/vault/overview/SecuritizeVaultOverview.vue utils/vault-display.ts tests/utils/vault-display.test.ts
- npx vitest run tests/utils/vault-display.test.ts

Follow-up to #587 / #188.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated market availability formatting logic into a shared utility function across vault components.

* **Tests**
  * Added test coverage for market availability formatting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->