### PR TITLE
Fix batch repay simulated balances

### DIFF
--- a/components/entities/asset/AssetInput.vue
+++ b/components/entities/asset/AssetInput.vue
@@ -37,8 +37,8 @@ const isFocused = ref(false)
 const emitInputTimeout = ref<ReturnType<typeof setTimeout> | null>(null)
 const lastEmittedInputValue = ref(model.value)
 
-const emitInputIfChanged = () => {
-  if (lastEmittedInputValue.value === model.value) return
+const emitInputIfChanged = (force = false) => {
+  if (!force && lastEmittedInputValue.value === model.value) return
   lastEmittedInputValue.value = model.value
   emits('input')
 }
@@ -53,12 +53,12 @@ const emitInputDebounced = () => {
   }, 250)
 }
 
-const emitInputNow = () => {
+const emitInputNow = (force = false) => {
   if (emitInputTimeout.value) {
     clearTimeout(emitInputTimeout.value)
     emitInputTimeout.value = null
   }
-  emitInputIfChanged()
+  emitInputIfChanged(force)
 }
 
 const matchesSelectedSubAccount = (a?: string, b?: string) => {
@@ -136,7 +136,9 @@ const setMax = () => {
     return
   }
   model.value = trimTrailingZeros(formatUnits(props.balance ?? 0n, Number(props.asset.decimals)))
-  emitInputNow()
+  // Max is an explicit command. The parent may have reset this model since
+  // the last emitted input, so do not suppress the handler by cached value.
+  emitInputNow(true)
   if (inputEl.value) {
     inputEl.value.value = model.value || ''
   }

--- a/composables/useTxBatch.ts
+++ b/composables/useTxBatch.ts
@@ -64,6 +64,9 @@ export interface BatchEntry {
    *  batch rows show the same "Position N" tag as the portfolio. New positions
    *  (fresh deposits) leave this undefined and render no tag. */
   subAccount?: Address
+  /** Additional sub-accounts intentionally modified by this entry. Used when a
+   *  position-scoped operation also moves balances to the owner account. */
+  affectedSubAccounts?: Address[]
   /** Multiply flows set this. A multiply is a borrow(+swap) at the plan level, so
    *  it can't be told apart from a plain borrow or a borrow-with-collateral-swap
    *  by the plan alone (and same-asset multiply has no swap step at all). This
@@ -207,6 +210,32 @@ const normalizeTokenKey = (token: string) => {
   }
 }
 
+export const buildScopedEntrySubAccounts = (
+  batchEntries: Pick<BatchEntry, 'subAccount' | 'affectedSubAccounts'>[],
+): Set<string> | undefined => {
+  const set = new Set<string>()
+
+  for (const entry of batchEntries) {
+    const accounts = [
+      entry.subAccount,
+      ...(entry.affectedSubAccounts ?? []),
+    ].filter((account): account is Address => !!account)
+
+    if (!accounts.length) return undefined
+
+    for (const account of accounts) {
+      try {
+        set.add(getAddress(account).toLowerCase())
+      }
+      catch {
+        return undefined
+      }
+    }
+  }
+
+  return set
+}
+
 const registerReviewAssetMeta = (review?: Record<string, unknown>) => {
   const asset = review?.asset as { address?: string, symbol?: string, decimals?: number } | undefined
   if (!asset?.address) return
@@ -282,6 +311,27 @@ export const buildWalletChanges = (
   }
 
   return [...out.values()].filter(change => change.delta !== 0n)
+}
+
+export const collectWalletBalanceTokens = (
+  layers: Record<string, bigint>[],
+): string[] => Array.from(new Set(layers.flatMap(layer => Object.keys(layer))))
+
+export const buildWalletBalanceLayers = (
+  simulatedLayers: Record<string, bigint>[],
+  realWallet: Record<string, bigint>,
+): Record<string, bigint>[] => {
+  const touchedTokens = collectWalletBalanceTokens(simulatedLayers)
+  const baseWb = simulatedLayers[0] ?? {}
+  return simulatedLayers.map((wb) => {
+    const out: Record<string, bigint> = {}
+    for (const token of touchedTokens) {
+      const delta = (wb[token] ?? 0n) - (baseWb[token] ?? 0n)
+      const value = (realWallet[token] ?? 0n) + delta
+      out[token] = value < 0n ? 0n : value
+    }
+    return out
+  })
 }
 
 const syncOverlay = () => {
@@ -1267,7 +1317,7 @@ export const useTxBatch = () => {
         return out
       }
       const simWb = ((sim.simulatedWalletBalances ?? []) as Record<string, bigint>[]).map(normalizeWalletBalances)
-      const touchedTokens = simWb.length ? Array.from(new Set(Object.keys(simWb[0] ?? {}))) : []
+      const touchedTokens = collectWalletBalanceTokens(simWb)
       const realWallet: Record<string, bigint> = {}
       if (touchedTokens.length) {
         try {
@@ -1294,16 +1344,7 @@ export const useTxBatch = () => {
           }
         }
       }
-      const baseWb = simWb[0] ?? {}
-      const walletLayers: Record<string, bigint>[] = simWb.map((wb) => {
-        const out: Record<string, bigint> = {}
-        for (const t of touchedTokens) {
-          const delta = (wb[t] ?? 0n) - (baseWb[t] ?? 0n)
-          const v = (realWallet[t] ?? 0n) + delta
-          out[t] = v < 0n ? 0n : v
-        }
-        return out
-      })
+      const walletLayers = buildWalletBalanceLayers(simWb, realWallet)
 
       // Real-wallet shortfall: the SDK now computes this accurately from the
       // per-layer balances (running-min, nets out intra-batch funding). We just
@@ -1645,17 +1686,7 @@ export const useTxBatch = () => {
   const activeLayerData = computed(() => layers.value[activeLayer.value])
   const entryCount = computed(() => entries.value.length)
   const scopedEntrySubAccounts = computed<Set<string> | undefined>(() => {
-    const set = new Set<string>()
-    for (const entry of entries.value) {
-      if (!entry.subAccount) return undefined
-      try {
-        set.add(getAddress(entry.subAccount).toLowerCase())
-      }
-      catch {
-        return undefined
-      }
-    }
-    return set
+    return buildScopedEntrySubAccounts(entries.value)
   })
 
   // The context label each entry operates in. EVK entries derive it from the

--- a/pages/position/[number]/repay.vue
+++ b/pages/position/[number]/repay.vue
@@ -220,6 +220,22 @@ const redirectAfterRepayAdd = (isClosing: boolean) => {
   redirectAfterAdd('/portfolio', { subAccount: position.value?.subAccount })
 }
 
+const getAffectedSubAccounts = (...accounts: Array<string | undefined | null>): Address[] | undefined => {
+  const seen = new Set<string>()
+  const result: Address[] = []
+  for (const account of accounts) {
+    if (!account) continue
+    const key = account.toLowerCase()
+    if (seen.has(key)) continue
+    seen.add(key)
+    result.push(account as Address)
+  }
+  return result.length ? result : undefined
+}
+
+const getFullRepayAffectedSubAccounts = (isClosing: boolean, ...accounts: Array<string | undefined | null>) =>
+  getAffectedSubAccounts(...accounts, isClosing ? portfolioAddress.value : undefined)
+
 const addToBatchWithoutWarnings = async () => {
   if (!canAddToBatch.value || !borrowVault.value || !position.value) return
   const borrowSymbol = borrowVault.value.asset.symbol
@@ -241,6 +257,7 @@ const addToBatchWithoutWarnings = async () => {
           isFullRepay: isClosing,
         }),
         subAccount: position.value.subAccount as Address,
+        affectedSubAccounts: getFullRepayAffectedSubAccounts(isClosing),
         nameOverride: `Repay ${borrowSymbol}`,
         review: { type: 'repay', asset: swapAsset, amount: swapAmount, swapToAsset: borrowVault.value.asset },
       })
@@ -263,6 +280,7 @@ const addToBatchWithoutWarnings = async () => {
         account,
       }),
       subAccount: position.value.subAccount as Address,
+      affectedSubAccounts: getFullRepayAffectedSubAccounts(isFullRepay),
       review: { type: 'repay', asset: borrowVault.value.asset, amount: wallet.amount.value },
     })
     wallet.amount.value = ''
@@ -290,6 +308,7 @@ const addToBatchWithoutWarnings = async () => {
         isSameAsset,
       }),
       subAccount: position.value.subAccount as Address,
+      affectedSubAccounts: getFullRepayAffectedSubAccounts(isClosing),
       review: { type: 'repay', asset: sourceVault.asset, amount: sourceAmount, swapToAsset: borrowVault.value.asset },
     })
     collateral.amount.value = ''
@@ -320,6 +339,7 @@ const addToBatchWithoutWarnings = async () => {
         isSameAsset,
       }),
       subAccount: position.value.subAccount as Address,
+      affectedSubAccounts: getFullRepayAffectedSubAccounts(isClosing, sourceSubAccount),
       review: { type: 'repay', asset: sourceVault.asset, amount: sourceAmount, swapToAsset: borrowVault.value.asset },
     })
     savings.amount.value = ''

--- a/tests/composables/useRepaySwapCore.test.ts
+++ b/tests/composables/useRepaySwapCore.test.ts
@@ -1,0 +1,150 @@
+import { computed, ref, shallowRef, watch, watchEffect } from 'vue'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { SwapperMode, type EVault, type PortfolioBorrowPosition, type TransactionPlan, type VaultEntity } from '@eulerxyz/euler-v2-sdk'
+import type { Address } from 'viem'
+import { useRepaySwapCore } from '~/composables/repay/useRepaySwapCore'
+
+const { USER, sourceVault, borrowVault, position, mocks } = vi.hoisted(() => {
+  const USER = '0x0000000000000000000000000000000000000001' as Address
+  const SOURCE_VAULT = '0x0000000000000000000000000000000000000002' as Address
+  const SOURCE_ASSET = '0x0000000000000000000000000000000000000003' as Address
+  const BORROW_VAULT = '0x0000000000000000000000000000000000000004' as Address
+  const BORROW_ASSET = '0x0000000000000000000000000000000000000005' as Address
+
+  const sourceVault = {
+    address: SOURCE_VAULT,
+    availableLiquidity: 5_000n,
+    asset: {
+      address: SOURCE_ASSET,
+      symbol: 'WETH',
+      decimals: 0,
+    },
+    shares: {
+      address: SOURCE_VAULT,
+      symbol: 'eWETH',
+      decimals: 0,
+    },
+  } as unknown as EVault
+
+  const borrowVault = {
+    address: BORROW_VAULT,
+    asset: {
+      address: BORROW_ASSET,
+      symbol: 'USDC',
+      decimals: 0,
+    },
+    shares: {
+      address: BORROW_VAULT,
+      symbol: 'eUSDC',
+      decimals: 0,
+    },
+    collaterals: [],
+  } as unknown as EVault
+
+  const position = {
+    subAccount: USER,
+    borrowed: 2_000n,
+  } as unknown as PortfolioBorrowPosition<VaultEntity>
+
+  return {
+    USER,
+    sourceVault,
+    borrowVault,
+    position,
+    mocks: {
+      quoteInstances: [] as Array<{
+        options: { amountField: 'amountIn' | 'amountOut' }
+        requestQuotes: ReturnType<typeof vi.fn>
+        reset: ReturnType<typeof vi.fn>
+      }>,
+    },
+  }
+})
+
+vi.mock('~/utils/sdk-prices', () => ({
+  getAssetUsdValue: vi.fn(async () => null),
+}))
+
+vi.mock('~/composables/useSwapQuotesParallel', () => ({
+  useSwapQuotesParallel: (options: { amountField: 'amountIn' | 'amountOut' }) => {
+    const instance = {
+      sortedQuoteCards: ref([]),
+      selectedProvider: ref(null),
+      selectedQuote: ref(null),
+      effectiveQuote: ref(null),
+      effectiveQuoteFetchedAt: ref(null),
+      providersCount: ref(0),
+      isLoading: ref(false),
+      quoteError: ref(null),
+      statusLabel: ref(null),
+      getQuoteDiffPct: vi.fn(() => null),
+      reset: vi.fn(),
+      requestQuotes: vi.fn(async () => undefined),
+      selectProvider: vi.fn(),
+    }
+    mocks.quoteInstances.push({ options, requestQuotes: instance.requestQuotes, reset: instance.reset })
+    return instance
+  },
+}))
+
+const flushPromises = () => new Promise(resolve => setTimeout(resolve, 0))
+
+describe('useRepaySwapCore', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.quoteInstances.length = 0
+    vi.stubGlobal('ref', ref)
+    vi.stubGlobal('computed', computed)
+    vi.stubGlobal('watch', watch)
+    vi.stubGlobal('watchEffect', watchEffect)
+    vi.stubGlobal('useDebounceFn', (fn: unknown) => fn)
+    vi.stubGlobal('useWagmi', () => ({
+      address: ref(USER),
+    }))
+    vi.stubGlobal('useSpyMode', () => ({
+      isSpyMode: ref(false),
+      spyAddress: ref(undefined),
+    }))
+    vi.stubGlobal('useEulerAddresses', () => ({
+      chainId: ref(999_999),
+    }))
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('requests a target-debt quote when max debt is entered', async () => {
+    const repay = useRepaySwapCore({
+      position: shallowRef<PortfolioBorrowPosition<VaultEntity> | undefined>(position),
+      borrowVault: computed(() => borrowVault),
+      sourceVault: shallowRef<EVault | undefined>(sourceVault),
+      sourceBalance: computed(() => 5_000n),
+      formTab: ref('collateral'),
+      formTabName: 'collateral',
+      slippage: ref(0.5),
+      clearSimulationError: vi.fn(),
+      getCurrentDebt: () => position.borrowed,
+      getQuoteAccounts: () => ({ accountIn: USER, accountOut: USER }),
+      buildTxPlanForQuote: vi.fn(async () => [] as unknown as TransactionPlan),
+    })
+
+    repay.debtAmount.value = '2000'
+    repay.onDebtInput()
+    await flushPromises()
+
+    const exactIn = mocks.quoteInstances.find(instance => instance.options.amountField === 'amountOut')
+    const targetDebt = mocks.quoteInstances.find(instance => instance.options.amountField === 'amountIn')
+    expect(exactIn?.requestQuotes).not.toHaveBeenCalled()
+    expect(targetDebt?.requestQuotes).toHaveBeenCalledWith(expect.objectContaining({
+      tokenIn: sourceVault.asset.address,
+      tokenOut: borrowVault.asset.address,
+      amount: 2_000n,
+      swapperMode: SwapperMode.TARGET_DEBT,
+      isRepay: true,
+      targetDebt: 0n,
+      currentDebt: 2_000n,
+    }))
+  })
+})

--- a/tests/composables/useTxBatch.test.ts
+++ b/tests/composables/useTxBatch.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 import { Account, Portfolio, type IAccountPosition, type IHasVaultAddress, type IAccountLiquidity } from '@eulerxyz/euler-v2-sdk'
 import { getAddress, type Address } from 'viem'
-import { buildWalletChanges, fetchBaseAccountSnapshot, stitchAccount, useTxBatch } from '~/composables/useTxBatch'
+import { buildWalletBalanceLayers, buildWalletChanges, fetchBaseAccountSnapshot, stitchAccount, useTxBatch } from '~/composables/useTxBatch'
 
 const owner = getAddress('0x1000000000000000000000000000000000000000')
 const subAccount = getAddress('0x8A54C278D117854486db0F6460D901a180Fff517')
@@ -456,6 +456,24 @@ describe('buildWalletChanges', () => {
     )
 
     expect(changes).toEqual([{ token, symbol: 'USDC', decimals: 6, delta: 5n }])
+  })
+})
+
+describe('buildWalletBalanceLayers', () => {
+  it('includes tokens that first appear after a later withdraw layer', () => {
+    const token = getAddress('0x2000000000000000000000000000000000000000').toLowerCase()
+
+    const layers = buildWalletBalanceLayers([
+      {},
+      {},
+      { [token]: 42n },
+    ], { [token]: 0n })
+
+    expect(layers).toEqual([
+      { [token]: 0n },
+      { [token]: 0n },
+      { [token]: 42n },
+    ])
   })
 })
 

--- a/tests/composables/useTxBatchModifiedKeys.test.ts
+++ b/tests/composables/useTxBatchModifiedKeys.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { Account, type IHasVaultAddress } from '@eulerxyz/euler-v2-sdk'
 import { getAddress, type Address } from 'viem'
 import {
+  buildScopedEntrySubAccounts,
   buildModifiedPositionKeySets,
   buildRemovedPositionKeySets,
   filterModifiedPositionKeySetsByOwner,
@@ -205,6 +206,24 @@ describe('position key filtering', () => {
       owner.toLowerCase(),
       new Set([owner.toLowerCase()]),
     )).toEqual(keys)
+  })
+
+  it('keeps owner keys when a position-scoped entry declares the owner affected', () => {
+    const sets = {
+      any: new Set([key(collateralVault, owner), key(collateralVault)]),
+      balance: new Set([key(collateralVault, owner), key(collateralVault)]),
+      debt: new Set<string>(),
+    }
+    const scoped = buildScopedEntrySubAccounts([{
+      subAccount,
+      affectedSubAccounts: [owner],
+    }])
+
+    expect(filterModifiedPositionKeySetsByOwner(
+      sets,
+      owner.toLowerCase(),
+      scoped,
+    )).toEqual(sets)
   })
 
   it('leaves keys unfiltered when the batch has an unscoped entry', () => {


### PR DESCRIPTION
## Summary
- Fix repay-with-collateral Max so target-debt quotes are requested even when the same displayed amount was previously emitted.
- Preserve owner-account simulated changes from full repay flows so moved collateral keeps simulated-state highlighting.
- Include wallet tokens that first appear in later simulation layers so downstream supply forms see withdrawn collateral as simulated wallet balance.

## Changes
- Force AssetInput Max to emit input because Max is an explicit action and parent state may have reset between clicks.
- Add affected sub-account metadata for full repay batch entries and use it when filtering simulated modified keys.
- Build wallet balance overlays from the union of all simulated wallet layers, not only the first layer.
- Add focused regression coverage for target-debt quote requests, affected owner keys, and later-layer wallet token overlays.

## Test plan
- [x] npm run test:run -- tests/composables/useTxBatch.test.ts tests/composables/useTxBatchModifiedKeys.test.ts tests/composables/useRepaySwapCore.test.ts tests/composables/useSavingsRepay.test.ts tests/composables/useWalletSwapRepay.test.ts
- [x] lint-staged eslint --fix via commit hook
- [ ] Manually verify repay collateral Max quote loading, full-repay moved-collateral highlighting, and subsequent supply wallet balance in the browser

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Updates

* **Bug Fixes**
  * The "Max" action in asset input now consistently applies the maximum available amount, regardless of previous transaction state.

* **Improvements**
  * Enhanced multi-layer transaction handling for improved accuracy in wallet balance calculations.
  * Improved tracking of affected sub-accounts across batch operations to ensure more reliable transaction execution.

* **Tests**
  * Expanded test coverage for complex repay scenarios and wallet balance layer computations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->