### PR TITLE
fix: wait for lend market data hydration

### DIFF
--- a/pages/lend/[vault]/index.vue
+++ b/pages/lend/[vault]/index.vue
@@ -79,7 +79,7 @@ const { primeSlotHintsFor, buildStateOverrideOptions } = useStateOverrideOptions
 const buildLendStateOverrideOptions = () => buildStateOverrideOptions({ noBalanceOverride: true })
 const lendPluginPrefetch: PluginPrefetchData = { pyth: { entries: [] } }
 const getLendPluginPrefetch = async (): Promise<PluginPrefetchData> => lendPluginPrefetch
-const { getVault, getSecuritizeVault, getEscrowVault, updateVault, isEscrowLoadedOnce } = useVaults()
+const { getVault, getSecuritizeVault, getEscrowVault, updateVault, isEscrowLoadedOnce, isMarketDataResolved } = useVaults()
 const { isReady: isLabelsReady } = useEulerLabels()
 const { get: registryGet, getVault: _registryGetVault, isKnownEscrowAddress } = useVaultRegistry()
 const { isConnected, address } = useWagmi()
@@ -182,6 +182,14 @@ const needsRefresh = (v: EVault | undefined): boolean => {
   return hasPythOracles(v) || hasPriceFailure(v)
 }
 
+const waitForMarketData = async () => {
+  if (isMarketDataResolved.value) return
+  await Promise.race([
+    until(isMarketDataResolved).toBe(true),
+    new Promise<void>(resolve => setTimeout(resolve, 10_000)),
+  ])
+}
+
 // Non-blocking IIFE to avoid Suspense + pageTransition crash on direct navigation
 ;(async () => {
   const isSecuritize = await isSecuritizeVault(vaultAddress)
@@ -193,11 +201,16 @@ const needsRefresh = (v: EVault | undefined): boolean => {
     if (!isLabelsReady.value) {
       await until(isLabelsReady).toBe(true)
     }
+    await waitForMarketData()
     securitizeVault.value = await getSecuritizeVault(vaultAddress)
   }
   else {
     try {
       const normalizedAddress = getAddress(vaultAddress)
+
+      // This page reads rewards and intrinsic APY from the SDK instance during
+      // setup, so wait for snapshot enrichment before capturing the object.
+      await waitForMarketData()
 
       // Fast path: vault already in registry
       const registryEntry = registryGet(normalizedAddress)


### PR DESCRIPTION
## Summary
- Fix intermittent lend detail APY displays caused by resolving the page vault before reward and intrinsic APY enrichment finishes.
- Align the lend deeplink readiness gate with the market-data hydration signal used by direct market routes.

## Changes
- Add a small wait helper for `isMarketDataResolved` on the lend detail page.
- Wait for market data before capturing EVault or securitize vault instances from the registry, including the existing registry fast path.

## Test plan
- [x] npm run typecheck
- [x] npx eslint `pages/lend/[vault]/index.vue`
- [x] Smoke-tested `/lend/0xD8ec5b4917FeF9058545e7D1dc2aC17F1D26305D?network=143` on local port 3001 and confirmed Supply APY settled at 7.80% across reloads

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vault loading reliability by ensuring market data is fully resolved before fetching vault information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->