### PR TITLE
Fix stitched collateral USD totals

### DIFF
--- a/composables/useTxBatch.ts
+++ b/composables/useTxBatch.ts
@@ -818,6 +818,7 @@ const hydrateBorrowLiquidity = (
   for (const collateral of enabledCollateralKeys ?? []) addCollateralAddress(collateral, false)
 
   let totalCollateralValueUsd: number | undefined = collateralAddresses.length ? 0 : liquidity.totalCollateralValueUsd
+  let hasMissingCollateralUsd = false
   const totalCollateralValue = collateralAddresses.length
     ? { borrowing: 0n, liquidation: 0n, oracleMid: 0n }
     : cloneLiquidityValue(liquidity.totalCollateralValue)
@@ -847,7 +848,7 @@ const hydrateBorrowLiquidity = (
       totalCollateralValue.oracleMid = (totalCollateralValue.oracleMid ?? 0n) + (value.oracleMid ?? 0n)
     }
     if (valueUsd === undefined) {
-      totalCollateralValueUsd = undefined
+      hasMissingCollateralUsd = true
       continue
     }
     totalCollateralValueUsd = (totalCollateralValueUsd ?? 0) + valueUsd
@@ -855,7 +856,7 @@ const hydrateBorrowLiquidity = (
 
   liquidity.collaterals = nextCollaterals
   if (totalCollateralValue) liquidity.totalCollateralValue = totalCollateralValue
-  liquidity.totalCollateralValueUsd = totalCollateralValueUsd
+  liquidity.totalCollateralValueUsd = hasMissingCollateralUsd ? undefined : totalCollateralValueUsd
 }
 
 const hydrateStitchedPositions = (

--- a/tests/composables/useTxBatch.test.ts
+++ b/tests/composables/useTxBatch.test.ts
@@ -289,6 +289,69 @@ describe('stitchAccount', () => {
     expect(portfolio.netAssetValueUsd).toBe(30)
   })
 
+  it('keeps borrow collateral USD total unknown when any included collateral has no USD value', () => {
+    const knownCollateralVault = pricedVault(vault, 'USDC')
+    const borrowVaultEntity = pricedVault(borrowVault, 'DEBT', 1, [
+      { address: targetVault },
+      { address: vault, marketPriceUsd: 1, vault: knownCollateralVault },
+    ])
+    const unknownCollateral = pricedPosition({
+      vaultAddress: targetVault,
+      shares: 10_000_000n,
+      assets: 10_000_000n,
+      borrowed: 0n,
+      isCollateral: true,
+    })
+    const borrow = pricedPosition({
+      vaultAddress: borrowVault,
+      vault: borrowVaultEntity,
+      shares: 0n,
+      assets: 0n,
+      borrowed: 50_000_000n,
+      isController: true,
+      marketPriceUsd: 1,
+      borrowedValueUsd: 50,
+      liquidity: {
+        vaultAddress: borrowVault,
+        vault: borrowVaultEntity,
+        unitOfAccount: borrowVault,
+        daysToLiquidation: 'Infinity',
+        liabilityValue: { borrowing: 50n * WAD, liquidation: 50n * WAD, oracleMid: 50n * WAD },
+        totalCollateralValue: { borrowing: 90n * WAD, liquidation: 90n * WAD, oracleMid: 90n * WAD },
+        collaterals: [
+          {
+            address: targetVault,
+            value: { borrowing: 10n * WAD, liquidation: 10n * WAD, oracleMid: 10n * WAD },
+          },
+          {
+            address: vault,
+            vault: knownCollateralVault,
+            value: { borrowing: 80n * WAD, liquidation: 80n * WAD, oracleMid: 80n * WAD },
+            marketPriceUsd: 1,
+            valueUsd: 100,
+          },
+        ],
+        liabilityValueUsd: 50,
+        totalCollateralValueUsd: 100,
+      },
+    })
+    const base = accountWithPositions([
+      unknownCollateral,
+      collateralPosition(100_000_000n),
+      borrow,
+    ], [targetVault, vault], [borrowVault])
+    const touched = accountWithPositions([
+      collateralPosition(80_000_000n),
+    ], [targetVault, vault], [borrowVault])
+
+    const stitched = stitchAccount(base, touched)
+    const stitchedBorrow = stitched.getPosition(subAccount, borrowVault)
+
+    expect(stitchedBorrow?.liquidity?.collaterals[0]?.valueUsd).toBeUndefined()
+    expect(stitchedBorrow?.liquidity?.collaterals[1]?.valueUsd).toBe(80)
+    expect(stitchedBorrow?.liquidity?.totalCollateralValueUsd).toBeUndefined()
+  })
+
   it('hydrates newly enabled collateral into existing borrow liquidity', () => {
     const { sourceVault, destinationVault, borrow } = riskAwareBorrowPosition()
     const base = accountWithPositions([


### PR DESCRIPTION
## Summary
- Keep stitched borrow collateral USD totals unknown when any included collateral lacks a USD value.
- Match the SDK account-price population invariant so batch simulation does not show partial collateral totals as complete values.

## Changes
- Track missing per-collateral USD values separately while summing known collateral values in hydrateBorrowLiquidity.
- Add a regression test where an unknown collateral is followed by a known collateral to prevent order-dependent partial totals.

## Test plan
- [x] npm run test:run -- tests/composables/useTxBatch.test.ts
- [x] npm exec eslint composables/useTxBatch.ts tests/composables/useTxBatch.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced collateral valuation handling in borrow positions. System now correctly processes available liquidity when some collaterals lack USD pricing information.

* **Tests**
  * Added test case validating collateral valuation behavior with missing pricing data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->