### PR TITLE
Silence non-error SDK diagnostics

### DIFF
--- a/server/utils/labels-view.ts
+++ b/server/utils/labels-view.ts
@@ -21,6 +21,7 @@ import { INTERNAL_FETCH_HEADERS } from './internal-headers'
 import { buildEntityAddressSets, declaredKeysOf, tryChecksum } from './labels-helpers'
 import { logger } from './logger'
 import { getServerSdk } from './sdk-server'
+import { isSdkErrorDiagnostic } from './sdk-diagnostics'
 import type { VerificationLabels } from '~/utils/vault/governor-verification'
 
 export interface ChainVaultsSnapshot {
@@ -276,7 +277,9 @@ async function buildSnapshot(
   ])
 
   for (const issue of [...evk.errors, ...securitize.errors, ...earn.errors]) {
-    logger.warn({ ctx: 'labels-view', chainId, issue }, 'sdk vault fetch issue')
+    if (isSdkErrorDiagnostic(issue)) {
+      logger.error({ ctx: 'labels-view', chainId, issue }, 'sdk vault fetch issue')
+    }
   }
 
   const evkVaults = (evk.result.filter(Boolean) as EVault[]).map(vault =>
@@ -298,7 +301,9 @@ async function buildSnapshot(
     ? await sdk.eVaultService.fetchVaults(chainId, referencedEscrowAddresses, vaultOptions)
     : { result: [], errors: [] }
   for (const issue of fetchedEscrow.errors) {
-    logger.warn({ ctx: 'labels-view', chainId, issue }, 'sdk escrow fetch issue')
+    if (isSdkErrorDiagnostic(issue)) {
+      logger.error({ ctx: 'labels-view', chainId, issue }, 'sdk escrow fetch issue')
+    }
   }
 
   const escrowVaults = [

--- a/server/utils/sdk-diagnostics.ts
+++ b/server/utils/sdk-diagnostics.ts
@@ -1,0 +1,6 @@
+import type { DataIssue } from '@eulerxyz/euler-v2-sdk'
+
+export const isSdkErrorDiagnostic = (issue: unknown): issue is DataIssue =>
+  typeof issue === 'object'
+  && issue !== null
+  && (issue as { severity?: unknown }).severity === 'error'

--- a/server/utils/vaults-cache.ts
+++ b/server/utils/vaults-cache.ts
@@ -32,6 +32,7 @@ import { createInFlightDedup } from '~/utils/in-flight'
 import { logger } from './logger'
 import { reportStatus } from './log'
 import { getServerSdk } from './sdk-server'
+import { isSdkErrorDiagnostic } from './sdk-diagnostics'
 import {
   LABEL_FILES,
   refreshLabelFile,
@@ -213,7 +214,9 @@ export const refreshChainVaults = (chainId: number): Promise<SerialisedSnapshot>
       { errors: escrow.errors, ctx: 'escrow' },
     ] as const) {
       for (const issue of errors as unknown[]) {
-        logger.warn({ ctx: 'vaults-cache', chainId, kind: ctx, issue }, 'sdk fetch issue')
+        if (isSdkErrorDiagnostic(issue)) {
+          logger.error({ ctx: 'vaults-cache', chainId, kind: ctx, issue }, 'sdk fetch issue')
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- Keep app server logs focused on actionable SDK diagnostics by suppressing SDK info and warning data issues.
- Preserve visibility for real SDK error diagnostics by emitting them at error level.

## Changes
- Add a small server utility that recognizes SDK diagnostics where severity is error.
- Apply the filter to vault cache, labels-view vault, and labels-view escrow diagnostic logging.

## Test plan
- [x] npm run typecheck
- [x] npx --no-install eslint server/utils/sdk-diagnostics.ts server/utils/vaults-cache.ts server/utils/labels-view.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for vault-fetch operations to more precisely log SDK diagnostic errors, reducing noise by filtering non-critical issues from error logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->