### PR TITLE
fix: warn about stale batch swap quotes

### DIFF
--- a/components/BatchReviewModal.vue
+++ b/components/BatchReviewModal.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, onUnmounted, ref } from 'vue'
 import { encodeFunctionData, getAddress } from 'viem'
 import { flattenBatchEntries, getSubAccountId, type TransactionPlan } from '@eulerxyz/euler-v2-sdk'
 import { getEulerSdk } from '~/composables/useEulerSdk'
@@ -51,6 +51,9 @@ const { chainId: addressesChainId, eulerCoreAddresses } = useEulerAddresses()
 const { buildKnownSymbols, resolveSymbol } = useTokenSymbolResolver()
 const { getVault, isVerifiedVault } = useVaultRegistry()
 const { copied, copyToClipboard } = useClipboardCopy()
+const nowMs = ref(Date.now())
+const staleQuoteThresholdMs = 3 * 60 * 1000
+let nowTimer: ReturnType<typeof setInterval> | undefined
 const owner = computed(() => (isSpyMode.value ? spyAddress.value : walletAddress.value) || '')
 const chainId = computed(() => wagmiChainId.value ?? addressesChainId.value)
 const ownerSubAccountKey = computed(() => {
@@ -150,6 +153,14 @@ const reulUnlockWarnings = computed<Array<{ id: string, description: string }>>(
   }),
 )
 
+const hasStaleSwapQuote = computed(() =>
+  entries.value.some((entry) => {
+    const quoteFetchedAt = entry.review?.quoteFetchedAt
+    return typeof quoteFetchedAt === 'number'
+      && nowMs.value - quoteFetchedAt > staleQuoteThresholdMs
+  }),
+)
+
 // Sub-accounts of entries that revert mid-batch (per-item revert: vault
 // liquidity, vault cap, etc.). The op rolls back so its position SHOULD be
 // unchanged, but in some cases the layer's reported health factor still drifts
@@ -226,6 +237,10 @@ const hasPermit2Approval = computed(() =>
 )
 
 onMounted(async () => {
+  nowTimer = setInterval(() => {
+    nowMs.value = Date.now()
+  }, 1000)
+
   void fetchTenderlyEnabled()
   isPreparing.value = true
   prepareError.value = ''
@@ -249,6 +264,12 @@ onMounted(async () => {
   }
   finally {
     isPreparing.value = false
+  }
+})
+
+onUnmounted(() => {
+  if (nowTimer) {
+    clearInterval(nowTimer)
   }
 })
 
@@ -442,6 +463,14 @@ const handleClose = () => {
         size="compact"
         title="rEUL burn mechanics"
         :description="warning.description"
+      />
+
+      <UiAlert
+        v-if="hasStaleSwapQuote"
+        variant="warning"
+        size="compact"
+        title="Stale swap quote"
+        description="This batch includes a swap quote which is more than 3 minutes old. Consider refreshing it to get the best execution price"
       />
 
       <!-- Wallet changes -->

--- a/composables/borrow/useBorrowForm.ts
+++ b/composables/borrow/useBorrowForm.ts
@@ -1196,6 +1196,7 @@ export const useBorrowForm = (options: UseBorrowFormOptions) => {
     borrowSwapQuoteError,
     borrowSwapQuotesStatusLabel,
     borrowSwapEffectiveQuote,
+    borrowSwapEffectiveQuoteFetchedAt,
     selectBorrowSwapQuote,
 
     // Unknown token warning

--- a/composables/position/useCollateralForm.ts
+++ b/composables/position/useCollateralForm.ts
@@ -959,6 +959,7 @@ export const useCollateralForm = (options: UseCollateralFormOptions) => {
     swapSelectedProvider,
     swapSelectedQuote,
     swapEffectiveQuote,
+    swapEffectiveQuoteFetchedAt,
     swapProvidersCount,
     isSwapQuoteLoading,
     swapQuoteError,

--- a/pages/borrow/[collateral]/[borrow]/index.vue
+++ b/pages/borrow/[collateral]/[borrow]/index.vue
@@ -299,7 +299,7 @@ const addToBatch = async () => {
       quote: borrow.borrowNeedsSwap.value ? borrow.borrowSwapEffectiveQuote.value ?? undefined : undefined,
     }
     const label = `Borrow ${snap.borrowAmount} ${bVault.asset.symbol}`
-    await addBatchEntry({ label, buildPlan: account => borrow.buildBorrowPlan(snap, account), subAccount, review: { type: 'borrow', asset: bVault.asset, amount: snap.borrowAmount } })
+    await addBatchEntry({ label, buildPlan: account => borrow.buildBorrowPlan(snap, account), subAccount, review: { type: 'borrow', asset: bVault.asset, amount: snap.borrowAmount, quoteFetchedAt: snap.needsSwap ? borrow.borrowSwapEffectiveQuoteFetchedAt.value : null } })
     borrow.collateralAmount.value = ''
     borrow.borrowAmount.value = ''
     redirectAfterAdd('/portfolio', { subAccount })
@@ -339,7 +339,7 @@ const addMultiplyToBatch = async () => {
       savingShares: multiply.multiplySavingBalance.value,
       quote: sameAsset ? undefined : multiply.multiplyEffectiveQuote.value ?? undefined,
     }
-    await addBatchEntry({ label: `Multiply → ${longVault.asset.symbol}`, buildPlan: account => multiply.buildMultiplyPlan(snap, account), subAccount, multiply: true, review: { type: 'borrow', asset: shortVault.asset, amount: multiply.multiplyInputAmount.value, swapToAsset: longVault.asset } })
+    await addBatchEntry({ label: `Multiply → ${longVault.asset.symbol}`, buildPlan: account => multiply.buildMultiplyPlan(snap, account), subAccount, multiply: true, review: { type: 'borrow', asset: shortVault.asset, amount: multiply.multiplyInputAmount.value, swapToAsset: longVault.asset, quoteFetchedAt: sameAsset ? null : multiply.multiplyEffectiveQuoteFetchedAt.value } })
     redirectAfterAdd('/portfolio', { subAccount })
   })
 }

--- a/pages/lend/[vault]/[subAccount]/swap.vue
+++ b/pages/lend/[vault]/[subAccount]/swap.vue
@@ -152,6 +152,7 @@ const {
   isSameAsset, sameVaultError, errorText,
   isGeoBlocked, reviewSwapDisabled, reviewSwapLabel, simulationError,
   isQuoteLoading, quoteError, quotesStatusLabel, selectedProvider, selectedQuote,
+  effectiveQuoteFetchedAt,
   fromProduct, toProduct, currentPrice, swapSummary, priceImpact, routedVia,
   swapRouteItems, swapRouteEmptyMessage,
   selectProvider, onFromInput, onToVaultChange, onRefreshQuotes, submit, openSlippageSettings,
@@ -211,7 +212,7 @@ const addToBatch = async () => {
         account,
       }),
       subAccount: positionAccount,
-      review: { type: 'swap', asset: from.asset, amount: fromAmount.value, swapToAsset: to.asset, swapMode: SwapperMode.EXACT_IN },
+      review: { type: 'swap', asset: from.asset, amount: fromAmount.value, swapToAsset: to.asset, swapMode: SwapperMode.EXACT_IN, quoteFetchedAt: sameAsset ? null : effectiveQuoteFetchedAt.value },
     })
     fromAmount.value = ''
     redirectAfterAdd('/portfolio/saving', { subAccount: positionAccount, vault: toAddr })

--- a/pages/lend/[vault]/[subAccount]/withdraw.vue
+++ b/pages/lend/[vault]/[subAccount]/withdraw.vue
@@ -528,7 +528,7 @@ const addToBatch = async () => {
         label: `Withdraw-swap ${amountLabel} ${asset.value.symbol} → ${outputAsset?.symbol ?? ''}`,
         buildPlan: account => buildSwapWithdrawPlanFromQuote(quote, account, snap),
         subAccount: ownerAddr,
-        review: { type: 'swap-withdraw', asset: asset.value, amount: amountLabel, swapToAsset: outputAsset, swapToAmount: outputAmount },
+        review: { type: 'swap-withdraw', asset: asset.value, amount: amountLabel, swapToAsset: outputAsset, swapToAmount: outputAmount, quoteFetchedAt: swapEffectiveQuoteFetchedAt.value },
       })
     }
     else {

--- a/pages/lend/[vault]/index.vue
+++ b/pages/lend/[vault]/index.vue
@@ -549,7 +549,7 @@ const addToBatch = async () => {
         label: `Deposit ${asset.value.symbol}`,
         buildPlan: account => buildSwapSupplyPlanFromQuote(quote, account, { selectedAsset: swapAsset, amount: swapAmount }),
         subAccount: effectiveAddress.value as Address | undefined,
-        review: { type: 'swap-supply', asset: swapAsset, amount: swapAmount, swapToAsset: asset.value, swapToAmount: swapOutput, swapMode: SwapperMode.EXACT_IN },
+        review: { type: 'swap-supply', asset: swapAsset, amount: swapAmount, swapToAsset: asset.value, swapToAmount: swapOutput, swapMode: SwapperMode.EXACT_IN, quoteFetchedAt: swapEffectiveQuoteFetchedAt.value },
       })
     }
     else {

--- a/pages/position/[number]/borrow/swap.vue
+++ b/pages/position/[number]/borrow/swap.vue
@@ -275,6 +275,7 @@ const {
   isSameAsset, sameVaultError, errorText, quote,
   isGeoBlocked, reviewSwapDisabled, reviewSwapLabel, simulationError,
   isQuoteLoading, quoteError, quotesStatusLabel, selectedProvider, selectedQuote,
+  effectiveQuoteFetchedAt,
   fromProduct, toProduct, swapPriceInvert, currentPrice, swapSummary, priceImpact, routedVia,
   swapRouteItems, swapRouteEmptyMessage,
   selectProvider, onFromInput: _onFromInput, onRefreshQuotes, submit, openSlippageSettings,
@@ -334,7 +335,7 @@ const addToBatch = async () => {
         account,
       }),
       subAccount: pos.subAccount as Address,
-      review: { type: 'swap-borrow', asset: from.asset, amount: fromAmount.value, swapToAsset: to.asset, swapMode: SwapperMode.TARGET_DEBT },
+      review: { type: 'swap-borrow', asset: from.asset, amount: fromAmount.value, swapToAsset: to.asset, swapMode: SwapperMode.TARGET_DEBT, quoteFetchedAt: sameAsset ? null : effectiveQuoteFetchedAt.value },
     })
     fromAmount.value = ''
     redirectAfterAdd('/portfolio', { subAccount: pos.subAccount as Address })

--- a/pages/position/[number]/collateral/swap.vue
+++ b/pages/position/[number]/collateral/swap.vue
@@ -318,7 +318,7 @@ const addToBatch = async () => {
         account,
       }),
       subAccount: positionAccount,
-      review: { type: 'swap', asset: from.asset, amount: fromAmount.value, swapToAsset: to.asset, swapMode: SwapperMode.EXACT_IN },
+      review: { type: 'swap', asset: from.asset, amount: fromAmount.value, swapToAsset: to.asset, swapMode: SwapperMode.EXACT_IN, quoteFetchedAt: sameAsset ? null : effectiveQuoteFetchedAt.value },
     })
     fromAmount.value = ''
     redirectAfterAdd('/portfolio', { subAccount: positionAccount })

--- a/pages/position/[number]/multiply.vue
+++ b/pages/position/[number]/multiply.vue
@@ -656,7 +656,7 @@ const addToBatch = async () => {
       }),
       subAccount: receiver,
       multiply: true,
-      review: { type: 'borrow', asset: multiplyShortVault.value!.asset, amount: multiplyShortAmount.value, swapToAsset: multiplyLongVault.value!.asset, swapMode: SwapperMode.EXACT_IN },
+      review: { type: 'borrow', asset: multiplyShortVault.value!.asset, amount: multiplyShortAmount.value, swapToAsset: multiplyLongVault.value!.asset, swapMode: SwapperMode.EXACT_IN, quoteFetchedAt: sameAsset ? null : multiplyEffectiveQuoteFetchedAt.value },
     })
     redirectAfterAdd('/portfolio', { subAccount: receiver })
   })

--- a/pages/position/[number]/repay.vue
+++ b/pages/position/[number]/repay.vue
@@ -259,7 +259,7 @@ const addToBatchWithoutWarnings = async () => {
         subAccount: position.value.subAccount as Address,
         affectedSubAccounts: getFullRepayAffectedSubAccounts(isClosing),
         nameOverride: `Repay ${borrowSymbol}`,
-        review: { type: 'repay', asset: swapAsset, amount: swapAmount, swapToAsset: borrowVault.value.asset },
+        review: { type: 'repay', asset: swapAsset, amount: swapAmount, swapToAsset: borrowVault.value.asset, quoteFetchedAt: walletSwap.quotes.effectiveQuoteFetchedAt.value },
       })
       walletSwap.amount.value = ''
       redirectAfterRepayAdd(isClosing)
@@ -309,7 +309,7 @@ const addToBatchWithoutWarnings = async () => {
       }),
       subAccount: position.value.subAccount as Address,
       affectedSubAccounts: getFullRepayAffectedSubAccounts(isClosing),
-      review: { type: 'repay', asset: sourceVault.asset, amount: sourceAmount, swapToAsset: borrowVault.value.asset },
+      review: { type: 'repay', asset: sourceVault.asset, amount: sourceAmount, swapToAsset: borrowVault.value.asset, quoteFetchedAt: isSameAsset ? null : collateral.quotes.effectiveQuoteFetchedAt.value },
     })
     collateral.amount.value = ''
     collateral.debtAmount.value = ''
@@ -340,7 +340,7 @@ const addToBatchWithoutWarnings = async () => {
       }),
       subAccount: position.value.subAccount as Address,
       affectedSubAccounts: getFullRepayAffectedSubAccounts(isClosing, sourceSubAccount),
-      review: { type: 'repay', asset: sourceVault.asset, amount: sourceAmount, swapToAsset: borrowVault.value.asset },
+      review: { type: 'repay', asset: sourceVault.asset, amount: sourceAmount, swapToAsset: borrowVault.value.asset, quoteFetchedAt: isSameAsset ? null : savings.quotes.effectiveQuoteFetchedAt.value },
     })
     savings.amount.value = ''
     savings.debtAmount.value = ''

--- a/pages/position/[number]/supply.vue
+++ b/pages/position/[number]/supply.vue
@@ -219,7 +219,7 @@ const addToBatch = async () => {
         label: `Swap-supply ${form.amount.value} ${sel.symbol} → ${a.symbol}`,
         buildPlan: account => planDepositWithSwap({ swapQuote: quote, amount: inputAmount, tokenIn, wrappedNativeInfo, account }),
         subAccount: pos.subAccount as Address,
-        review: { type: 'swap-supply', asset: sel, amount: form.amount.value, swapToAsset: a },
+        review: { type: 'swap-supply', asset: sel, amount: form.amount.value, swapToAsset: a, quoteFetchedAt: form.swapEffectiveQuoteFetchedAt.value },
       })
     }
     else {

--- a/pages/position/[number]/withdraw.vue
+++ b/pages/position/[number]/withdraw.vue
@@ -200,7 +200,7 @@ const addToBatch = async () => {
         label: `Withdraw-swap ${form.amount.value} ${a.symbol} → ${selectedOutputAsset.value?.symbol ?? ''}`,
         buildPlan: account => planWithdrawAndSwap({ swapQuote: quote, vaultAddress, assets, owner, account }),
         subAccount: pos.subAccount as Address,
-        review: { type: 'swap-withdraw', asset: a, amount: form.amount.value, swapToAsset: selectedOutputAsset.value },
+        review: { type: 'swap-withdraw', asset: a, amount: form.amount.value, swapToAsset: selectedOutputAsset.value, quoteFetchedAt: form.swapEffectiveQuoteFetchedAt.value },
       })
     }
     else if (isFullCollateralWithdraw(assets)) {


### PR DESCRIPTION
  ## Summary
  - Adds a batch-level stale swap quote warning so users see the same quote-age risk in batch review as
  in operation review.
  - Carries quote fetch timestamps into every swap-backed batch review entry so the warning considers the
  full batch.

  ## Changes
  - BatchReviewModal scans all entries for quoteFetchedAt values older than the existing 3-minute
  threshold and displays the requested warning copy.
  - Exposes quote timestamps from shared borrow and collateral form composables and stores them on swap
  supply, withdraw, repay, borrow, multiply, and refinance batch metadata.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection and warning for stale swap quotes (quotes older than 3 minutes). Users will now see a "Stale swap quote" alert when reviewing batched transactions with outdated pricing information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->