### PR TITLE
lite-233 add vault and token address to search

### DIFF
--- a/pages/borrow/index.vue
+++ b/pages/borrow/index.vue
@@ -16,6 +16,7 @@ import { getVaultAvailableLiquidity, getVaultUtilization } from '~/utils/vault-d
 import { withVaultIntrinsicApy } from '~/utils/vault-intrinsic-apy'
 import { compareRecentlyAddedBoost } from '~/utils/recentlyAddedSort'
 import { areTokenAddressesCorrelatedByTags } from '~/utils/token-categories'
+import { getBorrowPairSearchAddresses } from '~/utils/borrow-pair'
 
 const { settings } = useUserSettings()
 const enableIntrinsicApy = computed(() => settings.value.enableIntrinsicApy)
@@ -125,6 +126,7 @@ const { searchQuery, matchesSearch, clearSearch } = useVaultSearch<AnyBorrowVaul
     pair.borrow.asset.symbol,
     pair.borrow.asset.name,
     pair.borrow.shares.name,
+    ...getBorrowPairSearchAddresses(pair),
     product.name,
     product.description,
     ...getUniqueEntitiesByVaults([pair.collateral, pair.borrow]).map(e => e.name),

--- a/pages/earn/index.vue
+++ b/pages/earn/index.vue
@@ -39,6 +39,8 @@ const { searchQuery, matchesSearch, clearSearch } = useVaultSearch<EulerEarn>((v
     vault.asset.symbol,
     vault.asset.name,
     vault.shares.name,
+    vault.address,
+    vault.asset.address,
     product.name,
     product.description,
     ...getEntitiesByEarnVault(vault).map(e => e.name),

--- a/pages/explore/index.vue
+++ b/pages/explore/index.vue
@@ -30,11 +30,13 @@ const { searchQuery, matchesSearch, clearSearch } = useVaultSearch<MarketGroup>(
   group.name,
   group.curator?.name,
   ...group.metrics.assetSymbols,
-  ...group.vaults.flatMap((vault) => {
+  ...[...group.vaults, ...group.externalCollateral].flatMap((vault) => {
     const addr = getVaultAddress(vault)
     if (!addr) return []
     const product = applyVaultOverrides(getProductByVault(addr), addr)
     return [
+      addr,
+      getVaultAssetAddress(vault),
       product.name,
       product.description,
       ...getEntitiesByVault(vault).map(e => e.name),

--- a/pages/lend/index.vue
+++ b/pages/lend/index.vue
@@ -43,6 +43,8 @@ const { searchQuery, matchesSearch, clearSearch } = useVaultSearch<EVault>((vaul
     vault.asset.symbol,
     vault.asset.name,
     vault.shares.name,
+    vault.address,
+    vault.asset.address,
     product.name,
     product.description,
     ...getEntitiesByVault(vault).map(e => e.name),

--- a/tests/composables/useVaultSearch.test.ts
+++ b/tests/composables/useVaultSearch.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import type { AnyBorrowVaultPair } from '~/types/borrow-pair'
+import { useVaultSearch } from '~/composables/useVaultSearch'
+import { getBorrowPairSearchAddresses } from '~/utils/borrow-pair'
+
+const makeBorrowPair = (): AnyBorrowVaultPair => ({
+  collateral: {
+    address: '0x1905EDDF5943ef6C92Ccf1469bd40fC2cB4A77b0',
+    asset: {
+      address: '0x2222222222222222222222222222222222222222',
+      name: 'Collateral Token',
+      symbol: 'COL',
+    },
+  },
+  borrow: {
+    address: '0x3333333333333333333333333333333333333333',
+    asset: {
+      address: '0x4444444444444444444444444444444444444444',
+      name: 'Borrow Token',
+      symbol: 'BOR',
+    },
+  },
+  ltv: {},
+}) as unknown as AnyBorrowVaultPair
+
+describe('useVaultSearch', () => {
+  it('matches borrow pairs by vault and token addresses', () => {
+    const pair = makeBorrowPair()
+    const { searchQuery, matchesSearch } = useVaultSearch<AnyBorrowVaultPair>(item => [
+      item.collateral.asset.symbol,
+      item.borrow.asset.symbol,
+      ...getBorrowPairSearchAddresses(item),
+    ])
+
+    searchQuery.value = '0x1905eddf5943ef6c92ccf1469bd40fc2cb4a77b0'
+    expect(matchesSearch(pair)).toBe(true)
+
+    searchQuery.value = '0x4444444444444444444444444444444444444444'
+    expect(matchesSearch(pair)).toBe(true)
+  })
+})

--- a/utils/borrow-pair.ts
+++ b/utils/borrow-pair.ts
@@ -37,6 +37,13 @@ export const getPairBorrowLTV = (pair: BorrowPairLike): number | undefined =>
 export const getPairCurrentLiquidationLTV = (pair: BorrowPairLike): number | undefined =>
   isBorrowVaultPair(pair) ? pair.ltv.currentLiquidationLTV : getBorrowPositionEffectiveLiquidationLTV(pair)
 
+export const getBorrowPairSearchAddresses = (pair: AnyBorrowVaultPair): string[] => [
+  pair.collateral.address,
+  pair.collateral.asset.address,
+  pair.borrow.address,
+  pair.borrow.asset.address,
+]
+
 /**
  * Resolve the ramp-bearing collateral edge for a pair.
  *


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced search functionality across Borrow, Earn, Explore, and Lend pages to include blockchain addresses as searchable terms. Users can now search for vaults and markets using their on-chain addresses in addition to symbols and names.

* **Tests**
  * Added test coverage for address-based search functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->