### PR TITLE
fix: improve matrix overlay stacking

### DIFF
--- a/components/entities/vault/discovery/DiscoveryMarketAccordion.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketAccordion.vue
@@ -445,7 +445,7 @@ onMounted(() => {
     <article
       v-for="market in markets"
       :key="market.id"
-      class="bg-surface rounded-12 border border-line-default shadow-card transition-all"
+      class="relative bg-surface rounded-12 border border-line-default shadow-card transition-all"
       data-id="discovery-market-list-item"
       data-list="discovery-market"
       :data-key="market.id"
@@ -453,7 +453,10 @@ onMounted(() => {
       :data-vault-count="market.vaults.length"
       :data-external-collateral-count="market.externalCollateral.length"
       :data-pair-count="getMiniDiagram(market).pairCount"
-      :class="isExpanded(market.id) ? 'shadow-card-hover border-line-emphasis' : 'hover:shadow-card-hover hover:border-line-emphasis'"
+      :class="[
+        isExpanded(market.id) ? 'shadow-card-hover border-line-emphasis' : 'hover:shadow-card-hover hover:border-line-emphasis',
+        isMatrixDropdownOpen(market.id) ? 'z-[60]' : isExpanded(market.id) ? 'z-10' : 'z-0',
+      ]"
     >
       <!-- Collapsed Row Card -->
       <DiscoveryMarketCard
@@ -504,7 +507,7 @@ onMounted(() => {
           >
             <!-- Controls: view toggle + metric dropdown -->
             <div
-              class="px-16 pt-12 pb-8 flex flex-wrap items-center gap-8"
+              class="relative z-[70] px-16 pt-12 pb-8 flex flex-wrap items-center gap-8"
               @click.stop
             >
               <!-- Graph / Matrix toggle -->
@@ -577,7 +580,7 @@ onMounted(() => {
                 </div>
                 <div
                   v-if="isMatrixDropdownOpen(market.id)"
-                  class="absolute left-0 top-full mt-4 z-50 bg-surface border border-line-default rounded-12 shadow-card py-4 min-w-[180px]"
+                  class="absolute left-0 top-full mt-4 z-[120] bg-surface border border-line-default rounded-12 shadow-card py-4 min-w-[180px]"
                 >
                   <button
                     v-for="option in MATRIX_VIEW_OPTIONS"

--- a/components/entities/vault/discovery/DiscoveryMarketAttributeMatrix.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketAttributeMatrix.vue
@@ -78,7 +78,7 @@ const cellDataValue = (cell: AttributeCell): string | number =>
     :data-column-count="attributeColumns.length"
   >
     <div
-      class="relative max-h-[60vh] overflow-auto rounded-8 border border-line-subtle px-12 pb-12 pt-0"
+      class="relative isolate max-h-[60vh] overflow-auto rounded-8 border border-line-subtle px-12 pb-12 pt-0"
     >
       <table class="border-separate border-spacing-0">
         <thead class="sticky top-0 z-30 bg-surface">

--- a/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
@@ -16,7 +16,7 @@ import { getOracleRouteStepKey, useOracleAdapterPrices } from '~/composables/use
 import { getCollateralOracleRouteSteps, getDebtOracleRouteSteps, isOracleAdapterRouteStep } from '~/utils/oracle-route-steps'
 import type { MarketGroup } from '~/entities/lend-discovery'
 import { withVaultIntrinsicApy } from '~/utils/vault-intrinsic-apy'
-import { areTokenAddressesCorrelatedByTags } from '~/utils/token-categories'
+import { areTokenAddressesCorrelatedByTags, getTokenAddressesCorrelationCategoryLabel } from '~/utils/token-categories'
 import type { Address } from 'viem'
 import type { CSSProperties } from 'vue'
 
@@ -119,6 +119,28 @@ const isCorrelatedCell = (
   )
 }
 
+const getCorrelatedCellTitle = (
+  collateralAddr: string,
+  liabilityAddr: string,
+): string => {
+  const collateral = findVault(props.market, collateralAddr)
+  const liability = findVault(props.market, liabilityAddr)
+  const category = getTokenAddressesCorrelationCategoryLabel(
+    [collateral?.asset.address, liability?.asset.address],
+    getTokenCategoryTags,
+  )
+
+  return category ? `Correlated category: ${category}` : 'Correlated pair'
+}
+
+const getCorrelatedCellText = (
+  collateralAddr: string,
+  liabilityAddr: string,
+): string => {
+  const title = getCorrelatedCellTitle(collateralAddr, liabilityAddr)
+  return `${title}. Max ROE is shown for correlated collateral and liability assets.`
+}
+
 const getCellMetricValue = (
   cell: MatrixCell,
   collateralAddr: string,
@@ -166,6 +188,26 @@ const shouldShowSparkles = (
     : false
   return hasSupplyRewardsForCell || hasBorrowRewardsForCell
 }
+
+const hasCorrelatedRoeCells = computed((): boolean => {
+  if (props.dotMetric !== 'roe') return false
+  for (const [rowAddr, cols] of props.matrix.cells) {
+    for (const colAddr of cols.keys()) {
+      if (isCorrelatedCell(rowAddr, colAddr)) return true
+    }
+  }
+  return false
+})
+
+const hasRewardMetricCells = computed((): boolean => {
+  if (props.dotMetric !== 'net-apy' && props.dotMetric !== 'roe') return false
+  for (const [rowAddr, cols] of props.matrix.cells) {
+    for (const colAddr of cols.keys()) {
+      if (shouldShowSparkles(rowAddr, colAddr)) return true
+    }
+  }
+  return false
+})
 
 const metricRange = computed((): { min: number, max: number } => {
   if (props.dotMetric === 'oracle') return { min: 0, max: 0 }
@@ -455,7 +497,7 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
 
 <template>
   <div
-    class="px-16 pb-12 flex items-center justify-center"
+    class="px-16 pb-12 flex flex-col items-center justify-center gap-8"
     data-id="collateral-matrix"
     data-list="collateral-matrix"
     :data-key="market.id"
@@ -465,7 +507,7 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
     :data-column-count="matrix.columns.length"
   >
     <div
-      class="relative max-h-[50vh] overflow-auto rounded-8 border border-line-subtle px-12 pb-12 pt-0"
+      class="relative isolate max-h-[50vh] overflow-auto rounded-8 border border-line-subtle px-12 pb-12 pt-0"
     >
       <table class="border-separate border-spacing-0">
         <thead class="sticky top-0 z-30 bg-surface">
@@ -727,7 +769,7 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
                     v-if="dotMetric === 'roe' && isCorrelatedCell(row.address, col.address)"
                     name="check-circle"
                     class="!w-10 !h-10 text-success-500 shrink-0"
-                    title="Correlated pair"
+                    :aria-label="getCorrelatedCellText(row.address, col.address)"
                   />
                   <SvgIcon
                     v-if="shouldShowSparkles(row.address, col.address)"
@@ -784,6 +826,33 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
           </tr>
         </tbody>
       </table>
+    </div>
+
+    <div
+      v-if="hasCorrelatedRoeCells || hasRewardMetricCells"
+      class="flex flex-wrap items-center justify-center gap-x-10 gap-y-4 text-p5 text-content-muted"
+      data-id="collateral-matrix-legend"
+    >
+      <span
+        v-if="hasCorrelatedRoeCells"
+        class="inline-flex items-center gap-3 whitespace-nowrap"
+      >
+        <SvgIcon
+          name="check-circle"
+          class="!w-10 !h-10 text-success-500 shrink-0"
+        />
+        Correlated pair
+      </span>
+      <span
+        v-if="hasRewardMetricCells"
+        class="inline-flex items-center gap-3 whitespace-nowrap"
+      >
+        <SvgIcon
+          name="sparks"
+          class="!w-10 !h-10 text-accent-500 shrink-0"
+        />
+        Rewards included
+      </span>
     </div>
   </div>
 

--- a/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
@@ -16,7 +16,7 @@ import { getOracleRouteStepKey, useOracleAdapterPrices } from '~/composables/use
 import { getCollateralOracleRouteSteps, getDebtOracleRouteSteps, isOracleAdapterRouteStep } from '~/utils/oracle-route-steps'
 import type { MarketGroup } from '~/entities/lend-discovery'
 import { withVaultIntrinsicApy } from '~/utils/vault-intrinsic-apy'
-import { areTokenAddressesCorrelatedByTags, getTokenAddressesCorrelationCategoryLabel } from '~/utils/token-categories'
+import { areTokenAddressesCorrelatedByTags } from '~/utils/token-categories'
 import type { Address } from 'viem'
 import type { CSSProperties } from 'vue'
 
@@ -119,28 +119,6 @@ const isCorrelatedCell = (
   )
 }
 
-const getCorrelatedCellTitle = (
-  collateralAddr: string,
-  liabilityAddr: string,
-): string => {
-  const collateral = findVault(props.market, collateralAddr)
-  const liability = findVault(props.market, liabilityAddr)
-  const category = getTokenAddressesCorrelationCategoryLabel(
-    [collateral?.asset.address, liability?.asset.address],
-    getTokenCategoryTags,
-  )
-
-  return category ? `Correlated category: ${category}` : 'Correlated pair'
-}
-
-const getCorrelatedCellText = (
-  collateralAddr: string,
-  liabilityAddr: string,
-): string => {
-  const title = getCorrelatedCellTitle(collateralAddr, liabilityAddr)
-  return `${title}. Max ROE is shown for correlated collateral and liability assets.`
-}
-
 const getCellMetricValue = (
   cell: MatrixCell,
   collateralAddr: string,
@@ -188,16 +166,6 @@ const shouldShowSparkles = (
     : false
   return hasSupplyRewardsForCell || hasBorrowRewardsForCell
 }
-
-const hasCorrelatedRoeCells = computed((): boolean => {
-  if (props.dotMetric !== 'roe') return false
-  for (const [rowAddr, cols] of props.matrix.cells) {
-    for (const colAddr of cols.keys()) {
-      if (isCorrelatedCell(rowAddr, colAddr)) return true
-    }
-  }
-  return false
-})
 
 const hasRewardMetricCells = computed((): boolean => {
   if (props.dotMetric !== 'net-apy' && props.dotMetric !== 'roe') return false
@@ -766,12 +734,6 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
                     title="Liquidation LTV ramping down"
                   />
                   <SvgIcon
-                    v-if="dotMetric === 'roe' && isCorrelatedCell(row.address, col.address)"
-                    name="check-circle"
-                    class="!w-10 !h-10 text-success-500 shrink-0"
-                    :aria-label="getCorrelatedCellText(row.address, col.address)"
-                  />
-                  <SvgIcon
                     v-if="shouldShowSparkles(row.address, col.address)"
                     name="sparks"
                     class="!w-10 !h-10 text-accent-500 shrink-0"
@@ -829,20 +791,10 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
     </div>
 
     <div
-      v-if="hasCorrelatedRoeCells || hasRewardMetricCells"
+      v-if="hasRewardMetricCells"
       class="flex flex-wrap items-center justify-center gap-x-10 gap-y-4 text-p5 text-content-muted"
       data-id="collateral-matrix-legend"
     >
-      <span
-        v-if="hasCorrelatedRoeCells"
-        class="inline-flex items-center gap-3 whitespace-nowrap"
-      >
-        <SvgIcon
-          name="check-circle"
-          class="!w-10 !h-10 text-success-500 shrink-0"
-        />
-        Correlated pair
-      </span>
       <span
         v-if="hasRewardMetricCells"
         class="inline-flex items-center gap-3 whitespace-nowrap"


### PR DESCRIPTION
## Summary
- Fix Explore matrix layering so active expanded cards and matrix dropdowns render above sticky table layers and neighboring market cards.
- Remove the redundant correlated-pair tick from Max ROE cells, since numeric Max ROE already only appears for correlated pairs.
- Keep the reward sparkles explained with a compact matrix legend.

## Changes
- Raises the active discovery card and matrix controls while a matrix dropdown is open.
- Isolates pair and attribute matrix scroll containers so sticky headers stay scoped to their own tables.
- Leaves Max ROE cell content clean while preserving the rewards-included indicator.

## Test plan
- [x] npx eslint components/entities/vault/discovery/DiscoveryMarketMatrix.vue components/entities/vault/discovery/DiscoveryMarketAccordion.vue components/entities/vault/discovery/DiscoveryMarketAttributeMatrix.vue
- [x] npm run typecheck
- [x] Open http://127.0.0.1:3001/explore?network=143 and verify the Max ROE matrix dropdown layers above the table and next market card.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved z-index layering for market accordion and dropdown menus to ensure proper UI stacking and visibility.
  * Enhanced positioning and isolation styling for matrix table containers.

* **New Features**
  * Added "Rewards included" legend indicator to market matrix when applicable reward metrics are present.
  * Updated reward metric visualization with improved icon indicators in the matrix display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->