### PR TITLE
Hide multipliers for uncorrelated borrow rows

### DIFF
--- a/components/entities/vault/VaultBorrowItem.vue
+++ b/components/entities/vault/VaultBorrowItem.vue
@@ -346,8 +346,8 @@ const linkPath = computed(() => ({
         </div>
       </div>
       <div
-        class="col-span-3 grid grid-cols-[repeat(3,112px)] justify-end gap-x-24 pr-16 py-16 pb-12 mobile:!grid mobile:w-full mobile:gap-x-12 mobile:border-t mobile:border-line-subtle mobile:pt-12 mobile:!px-0 mobile:!pb-0"
-        :class="showMaxRoe ? 'mobile:grid-cols-3' : 'mobile:grid-cols-2'"
+        class="col-span-3 grid justify-end gap-x-24 pr-16 py-16 pb-12 mobile:!grid mobile:w-full mobile:gap-x-12 mobile:border-t mobile:border-line-subtle mobile:pt-12 mobile:!px-0 mobile:!pb-0"
+        :class="showMaxRoe ? 'grid-cols-[repeat(3,112px)] mobile:grid-cols-3' : 'grid-cols-[repeat(2,112px)] mobile:grid-cols-2'"
       >
         <div class="flex flex-col items-end mobile:items-start mobile:min-w-0">
           <div class="text-content-tertiary text-p3 mb-4 text-right flex items-center justify-end gap-4 mobile:text-left mobile:justify-start">
@@ -387,8 +387,8 @@ const linkPath = computed(() => ({
           </div>
         </div>
         <div
+          v-if="showMaxRoe"
           class="flex flex-col items-end mobile:items-center mobile:min-w-0"
-          :class="{ 'mobile:!hidden': !showMaxRoe }"
         >
           <div class="text-content-tertiary text-p3 mb-4 text-right mobile:text-center">
             Max multiplier


### PR DESCRIPTION
## Summary
- Borrow rows only show the max multiplier metric when the collateral and debt assets are correlated.
- Uncorrelated borrow rows focus the headline metrics on Borrow APY and Net APY without displaying a leverage multiplier.

## Changes
- Gates the top-row Max multiplier block behind the existing correlated-pair display condition.
- Collapses the top metric grid from three columns to two for uncorrelated rows so desktop and mobile layouts stay aligned.

## Test plan
- [x] npm run typecheck
- [x] npx eslint components/entities/vault/VaultBorrowItem.vue
- [x] Previewed locally at http://127.0.0.1:3002/borrow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive layout for the vault borrow statistics display, enhancing visual alignment across desktop and mobile devices.
  * Refined the conditional display of the maximum leverage information for better context-aware visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->