### PR TITLE
fix: clarify Max ROE correlation copy

### DIFF
--- a/components/entities/vault/VaultMaxRoeModal.vue
+++ b/components/entities/vault/VaultMaxRoeModal.vue
@@ -80,8 +80,9 @@ const handleClose = () => {
   >
     <p class="text-content-primary text-p3 mb-16">
       ROE (Return on Equity) estimates the annualized return on your own capital in a multiplied position. A positive ROE means the supply yield exceeds borrowing costs at the given multiplier. A negative ROE means the position is gradually losing value to interest costs.
+      Max ROE is shown only when the collateral and debt assets share a correlated category, such as USD, ETH, or BTC. For uncorrelated pairs, Euler shows Net APY instead because ROE assumes the asset price ratio stays stable.
       <template v-if="isBestInMarket">
-        The value shown is the max modelled ROE across possible collateral/borrow pairs in this market. Not guaranteed. Borrowing and multiplied positions involve changing rates, liquidity constraints, and liquidation risk.
+        The value shown is the max modelled ROE across correlated collateral/borrow pairs in this market. Not guaranteed. Borrowing and multiplied positions involve changing rates, liquidity constraints, and liquidation risk.
       </template>
     </p>
     <div class="mb-24">

--- a/components/entities/vault/discovery/DiscoveryMarketAccordion.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketAccordion.vue
@@ -416,7 +416,7 @@ const hasSelection = (market: MarketGroup): boolean => {
   return !!selectedGraphNode.value && selectedGraphNode.value.marketId === market.id
 }
 
-const maxRoeMatrixNotice = 'Max ROE only applies to correlated collateral/debt assets. Uncorrelated pairs stay visible and show Net APY elsewhere because ROE assumes the asset price ratio stays stable.'
+const maxRoeMatrixNotice = 'Max ROE only shown for correlated pairs.'
 
 // -- Global event handlers --
 
@@ -611,7 +611,7 @@ onMounted(() => {
 
             <p
               v-if="getExpandedView(market.id) === 'matrix' && getMatrixView(market.id) === 'roe'"
-              class="px-16 pb-8 text-p3 text-content-tertiary"
+              class="px-16 pb-8 text-center text-p3 text-content-tertiary"
               data-id="discovery-max-roe-correlation-notice"
               :data-key="market.id"
             >

--- a/components/entities/vault/discovery/DiscoveryMarketAccordion.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketAccordion.vue
@@ -416,6 +416,8 @@ const hasSelection = (market: MarketGroup): boolean => {
   return !!selectedGraphNode.value && selectedGraphNode.value.marketId === market.id
 }
 
+const maxRoeMatrixNotice = 'Max ROE only applies to correlated collateral/debt assets. Uncorrelated pairs stay visible and show Net APY elsewhere because ROE assumes the asset price ratio stays stable.'
+
 // -- Global event handlers --
 
 onMounted(() => {
@@ -606,6 +608,15 @@ onMounted(() => {
                 variant="ghost"
               />
             </div>
+
+            <p
+              v-if="getExpandedView(market.id) === 'matrix' && getMatrixView(market.id) === 'roe'"
+              class="px-16 pb-8 text-p3 text-content-tertiary"
+              data-id="discovery-max-roe-correlation-notice"
+              :data-key="market.id"
+            >
+              {{ maxRoeMatrixNotice }}
+            </p>
 
             <!-- Graph View -->
             <DiscoveryMarketGraph

--- a/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
@@ -51,6 +51,8 @@ const hoveredCell = ref<{
   liabilityAddr: string
 } | null>(null)
 
+const unavailableRoeCellLabel = 'Max ROE is unavailable for uncorrelated pairs. Compare Net APY instead.'
+
 // Row/column highlighting helpers — make it easy to scan a cell back to its
 // row label and column header. A row is "highlighted" when it owns either
 // the hovered cell or the currently selected cell; same for columns.
@@ -558,8 +560,8 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
               :data-field="dotMetric"
               :data-present="!!matrix.cells.get(row.address)?.get(col.address)"
               :data-correlated="matrix.cells.get(row.address)?.get(col.address) ? isCorrelatedCell(row.address, col.address) : undefined"
-              :title="isUnavailableRoeCell(row.address, col.address) ? 'Max ROE only shown for correlated pairs.' : undefined"
-              :aria-label="isUnavailableRoeCell(row.address, col.address) ? 'Max ROE only shown for correlated pairs' : undefined"
+              :title="isUnavailableRoeCell(row.address, col.address) ? unavailableRoeCellLabel : undefined"
+              :aria-label="isUnavailableRoeCell(row.address, col.address) ? unavailableRoeCellLabel : undefined"
               :data-value="
                 (() => {
                   const cell = matrix.cells.get(row.address)?.get(col.address);


### PR DESCRIPTION
## Summary
- Clarifies that Max ROE only applies when collateral and debt assets share a correlated category.
- Adds guidance in the Max ROE matrix so unavailable cells are easier to understand.

## Changes
- Adds correlation-specific explanatory copy to the Max ROE modal.
- Shows a matrix-level notice when the expanded market matrix is set to Max ROE.
- Updates unavailable Max ROE cell title and aria-label text to point users toward Net APY for uncorrelated pairs.

## Test plan
- [x] Ran eslint on the touched Vue files.
- [x] Ran git diff --check.
- [x] Started the local app on 127.0.0.1:3005 and verified /explore?network=1 and /borrow?network=1 return 200.
- [ ] Manually expand an Explore market, switch to Matrix, select Max ROE, and confirm the notice plus unavailable-cell tooltip copy.