### PR TITLE
fix: refresh earn detail reward APY

### DIFF
--- a/pages/earn/[vault]/index.vue
+++ b/pages/earn/[vault]/index.vue
@@ -13,7 +13,6 @@ import { useModal } from '~/components/ui/composables/useModal'
 import { useToast } from '~/components/ui/composables/useToast'
 import type { Address } from 'viem'
 import { VaultUnverifiedDisclaimerModal, OperationReviewModal, VaultSupplyApyModal } from '#components'
-import { rewardCampaignAprPercent } from '~/entities/reward-campaign'
 
 const router = useRouter()
 const route = useRoute()
@@ -42,7 +41,7 @@ useOperationGuard([vaultAddress])
 const { name } = useEulerProductOfVault(vaultAddress)
 const { settings } = useUserSettings()
 const enableIntrinsicApy = computed(() => settings.value.enableIntrinsicApy)
-const { getSupplyRewardCampaignsFromVault } = useRewardsApy()
+const { getSupplyRewardApy, hasSupplyRewards, getSupplyRewardCampaigns } = useRewardsApy()
 
 const isLoading = ref(false)
 const isSubmitting = ref(false)
@@ -105,11 +104,9 @@ const disabledReasonInfo = computed((): DisabledReasonInfo | undefined => {
   if (errorText.value) return { message: errorText.value, variant: 'error' }
   return undefined
 })
-const supplyRewardCampaigns = computed(() => getSupplyRewardCampaignsFromVault(vault.value))
-const totalRewardsAPY = computed(() =>
-  supplyRewardCampaigns.value.reduce((sum, campaign) => sum + rewardCampaignAprPercent(campaign), 0),
-)
-const hasRewards = computed(() => totalRewardsAPY.value > 0)
+const supplyRewardCampaigns = computed(() => getSupplyRewardCampaigns(vaultAddress))
+const totalRewardsAPY = computed(() => getSupplyRewardApy(vaultAddress))
+const hasRewards = computed(() => hasSupplyRewards(vaultAddress))
 const intrinsicApy = computed(() => getVaultIntrinsicApy(vault.value, enableIntrinsicApy.value))
 const supplyAPYDisplay = computed(() => {
   if (!vault.value) return '0.00'


### PR DESCRIPTION
## Summary
- Keep the earn vault detail reward APY and reward modal campaigns tied to the live vault registry.
- Avoid deriving reward state from the one-time earn vault object captured during page load.

## Changes
- Switch the earn deposit page back to address-based reward helpers for APY, campaign lists, and reward visibility.
- Remove the local campaign APR reduction and rely on the shared reward APY helper.

## Test plan
- [x] npx eslint `pages/earn/[vault]/index.vue`
- [x] npm run typecheck
- [x] git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated rewards APY calculation on earn vault pages to use improved data sourcing methods, ensuring more accurate and reliable reward information is displayed to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->