### PR TITLE
feat: add borrow asset category filters

### DIFF
--- a/components/ui/UiSelect.vue
+++ b/components/ui/UiSelect.vue
@@ -1,16 +1,18 @@
 <script setup lang="ts">
 import { useModal } from '~/components/ui/composables/useModal'
 import { UiSelectModal } from '#components'
+import type { SelectOption, SelectQuickFilter } from '~/components/ui/modals/select.types'
 
 const model = defineModel<string[]>({ required: true })
 const props = defineProps<{
-  options: { label: string, value: string, icon?: string }[]
+  options: SelectOption[]
   placeholder?: string
   title?: string
   icon?: string
   showSelectedOptions?: boolean
   modalInputPlaceholder?: string
-  chipOptions?: { label: string, value: string, icon?: string }[]
+  chipOptions?: SelectOption[]
+  quickFilters?: SelectQuickFilter[]
 }>()
 
 const modal = useModal()
@@ -20,7 +22,7 @@ const displayText = computed(() => {
     return props.placeholder || 'Select...'
   }
 
-  return props.options
+  return [...props.options, ...(props.quickFilters ?? [])]
     .filter(opt => model.value.includes(opt.value))
     .map(opt => opt.label)
     .slice(0, 2)
@@ -52,6 +54,7 @@ const open = () => {
     props: {
       selected: model.value,
       options: props.options,
+      quickFilters: props.quickFilters,
       title: props.title,
       inputPlaceholder: props.modalInputPlaceholder,
       onSave: (selected: string[]) => {

--- a/components/ui/modals/UiSelectModal.vue
+++ b/components/ui/modals/UiSelectModal.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
-import type { SelectOption } from './select.types'
+import type { SelectOption, SelectQuickFilter } from './select.types'
 
 const props = defineProps<{
   selected: string[]
   options: SelectOption[]
+  quickFilters?: SelectQuickFilter[]
   title?: string
   inputPlaceholder?: string
   onSave?: (selected: string[]) => void
@@ -13,6 +14,16 @@ const emit = defineEmits(['close'])
 const localSelected = ref<string[]>([...props.selected])
 const selectedPrioritySet = ref(new Set(props.selected))
 const searchModel = ref('')
+const quickFilterValues = computed(() => new Set((props.quickFilters ?? []).map(filter => filter.value)))
+
+const isOptionSelected = (option: SelectOption): boolean => {
+  if (localSelected.value.includes(option.value)) return true
+  return option.quickFilterValues?.some(value => localSelected.value.includes(value)) ?? false
+}
+
+const activeQuickFilterValue = computed(() =>
+  (props.quickFilters ?? []).find(filter => localSelected.value.includes(filter.value))?.value ?? null,
+)
 
 const filteredOptions = computed(() => {
   const options = searchModel.value
@@ -24,7 +35,7 @@ const filteredOptions = computed(() => {
   const selectedFirst: typeof props.options = []
   const unselected: typeof props.options = []
   options.forEach((option) => {
-    if (selectedPrioritySet.value.has(option.value)) {
+    if (selectedPrioritySet.value.has(option.value) || isOptionSelected(option)) {
       selectedFirst.push(option)
       return
     }
@@ -33,13 +44,34 @@ const filteredOptions = computed(() => {
   return [...selectedFirst, ...unselected]
 })
 
-const toggleOption = (value: string) => {
-  const idx = localSelected.value.indexOf(value)
+const toggleQuickFilter = (value: string | null) => {
+  if (!value) {
+    localSelected.value = []
+    return
+  }
+
+  localSelected.value = activeQuickFilterValue.value === value ? [] : [value]
+}
+
+const toggleOption = (option: SelectOption) => {
+  const activeQuickFilter = activeQuickFilterValue.value
+  if (activeQuickFilter && option.quickFilterValues?.includes(activeQuickFilter)) {
+    localSelected.value = props.options
+      .filter(candidate => candidate.quickFilterValues?.includes(activeQuickFilter))
+      .map(candidate => candidate.value)
+      .filter(value => value !== option.value)
+    return
+  }
+
+  const idx = localSelected.value.indexOf(option.value)
   if (idx > -1) {
     localSelected.value.splice(idx, 1)
   }
   else {
-    localSelected.value.push(value)
+    localSelected.value = [
+      ...localSelected.value.filter(value => !quickFilterValues.value.has(value)),
+      option.value,
+    ]
   }
 }
 
@@ -77,9 +109,33 @@ watch(() => props.selected, (val) => {
       <UiInput
         v-model="searchModel"
         :placeholder="inputPlaceholder || 'Search'"
-        class="mb-16"
+        :class="quickFilters?.length ? 'mb-12' : 'mb-16'"
         icon="search"
       />
+      <div
+        v-if="quickFilters?.length"
+        class="ui-select-modal__quick-filters"
+      >
+        <UiButton
+          size="small"
+          :variant="localSelected.length === 0 ? 'primary' : 'primary-stroke'"
+          class="ui-select-modal__quick-filter"
+          @click="toggleQuickFilter(null)"
+        >
+          All
+        </UiButton>
+        <UiButton
+          v-for="filter in quickFilters"
+          :key="filter.value"
+          size="small"
+          :variant="activeQuickFilterValue === filter.value ? 'primary' : 'primary-stroke'"
+          class="ui-select-modal__quick-filter"
+          :data-value="filter.value"
+          @click="toggleQuickFilter(filter.value)"
+        >
+          {{ filter.label }}
+        </UiButton>
+      </div>
       <div class="ui-select-modal__list">
         <div
           v-for="opt in filteredOptions"
@@ -89,7 +145,7 @@ watch(() => props.selected, (val) => {
           :data-key="opt.value"
           data-field="option"
           :data-value="opt.value"
-          @click="toggleOption(opt.value)"
+          @click="toggleOption(opt)"
         >
           <div class="ui-select-modal__asset">
             <slot
@@ -107,6 +163,12 @@ watch(() => props.selected, (val) => {
                 >
               </div>
               <div
+                v-else-if="opt.iconName"
+                class="ui-select-modal__asset-symbol"
+              >
+                <UiIcon :name="opt.iconName" />
+              </div>
+              <div
                 v-else
                 class="ui-select-modal__asset-fallback"
               >
@@ -116,9 +178,9 @@ watch(() => props.selected, (val) => {
             <span class="ui-select-modal__label">{{ opt.label }}</span>
           </div>
           <UiCheckbox
-            :model-value="localSelected.includes(opt.value)"
+            :model-value="isOptionSelected(opt)"
             class="ui-select-modal__checkbox"
-            @update:model-value="() => toggleOption(opt.value)"
+            @update:model-value="() => toggleOption(opt)"
           />
         </div>
       </div>
@@ -131,6 +193,7 @@ watch(() => props.selected, (val) => {
         Save changes
       </UiButton>
       <UiButton
+        v-if="!quickFilters?.length"
         variant="primary-stroke"
         size="xlarge"
         @click="clear"
@@ -160,6 +223,19 @@ watch(() => props.selected, (val) => {
     &::-webkit-scrollbar {
       display: none;
     }
+  }
+
+  &__quick-filters {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 0 0 12px;
+    margin-bottom: 8px;
+    border-bottom: 1px solid var(--line-default);
+  }
+
+  &__quick-filter {
+    flex-shrink: 0;
   }
 
   &__row {
@@ -205,6 +281,23 @@ watch(() => props.selected, (val) => {
     justify-content: center;
     font-weight: 600;
     font-size: 16px;
+  }
+
+  &__asset-symbol {
+    width: 26px;
+    height: 26px;
+    border-radius: 50%;
+    background: var(--bg-surface-secondary);
+    border: 1px solid var(--line-default);
+    color: var(--text-secondary);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    svg {
+      width: 16px;
+      height: 16px;
+    }
   }
 
   &__label {

--- a/components/ui/modals/select.types.ts
+++ b/components/ui/modals/select.types.ts
@@ -2,5 +2,12 @@ export interface SelectOption {
   label: string
   value: string
   icon?: string
+  iconName?: string
   iconFallback?: string
+  quickFilterValues?: string[]
+}
+
+export interface SelectQuickFilter {
+  label: string
+  value: string
 }

--- a/pages/borrow/index.vue
+++ b/pages/borrow/index.vue
@@ -15,9 +15,31 @@ import { getAssetLogoUrl } from '~/composables/useTokenList'
 import { getVaultAvailableLiquidity, getVaultUtilization } from '~/utils/vault-display'
 import { withVaultIntrinsicApy } from '~/utils/vault-intrinsic-apy'
 import { compareRecentlyAddedBoost } from '~/utils/recentlyAddedSort'
-import { areTokenAddressesCorrelatedByTags } from '~/utils/token-categories'
+import {
+  areTokenAddressesCorrelatedByTags,
+  getSupportedTokenCategoryOptions,
+  normalizeTokenCategoryTags,
+  toTokenCategoryFilterValue,
+  tokenAddressMatchesCategoryFilter,
+} from '~/utils/token-categories'
 import { formatCompactUsdValue } from '~/utils/string-utils'
 import { getBorrowPairSearchAddresses } from '~/utils/borrow-pair'
+import type { SelectOption, SelectQuickFilter } from '~/components/ui/modals/select.types'
+
+type AssetFilterOption = SelectOption
+type AssetFilterOptions = { options: AssetFilterOption[], quickFilters: SelectQuickFilter[] }
+
+const CATEGORY_FILTER_LABELS: Record<string, string> = {
+  eth: 'ETH',
+  btc: 'BTC',
+  usd: 'Stables',
+}
+
+const CATEGORY_FILTER_ORDER = ['eth', 'btc', 'usd']
+const getCategoryFilterOrder = (tag: string): number => {
+  const index = CATEGORY_FILTER_ORDER.indexOf(tag)
+  return index === -1 ? CATEGORY_FILTER_ORDER.length : index
+}
 
 const { settings } = useUserSettings()
 const enableIntrinsicApy = computed(() => settings.value.enableIntrinsicApy)
@@ -337,30 +359,58 @@ watch(chainId, (newChainId, oldChainId) => {
   }
 })
 
-const collateralAssetOptions = computed(() => {
-  return activeBorrowList.value
-    .filter((item, idx, self) => idx === self.findIndex(t => t.collateral.asset.address === item.collateral.asset.address))
-    .map(pair => ({
-      label: pair.collateral.asset.symbol,
-      value: pair.collateral.asset.address,
-      icon: getAssetLogoUrl(pair.collateral.asset.address, pair.collateral.asset.symbol),
+const buildAssetFilterOptions = (
+  assets: { address: string, symbol: string }[],
+): AssetFilterOptions => {
+  const seenAssets = new Set<string>()
+  const availableCategoryTags = new Set<string>()
+  const assetOptions: AssetFilterOption[] = []
+
+  for (const asset of assets) {
+    const categoryTags = normalizeTokenCategoryTags(getTokenCategoryTags(asset.address))
+
+    for (const tag of categoryTags) {
+      availableCategoryTags.add(tag)
+    }
+
+    if (seenAssets.has(asset.address)) continue
+    seenAssets.add(asset.address)
+    assetOptions.push({
+      label: asset.symbol,
+      value: asset.address,
+      icon: getAssetLogoUrl(asset.address, asset.symbol),
+      quickFilterValues: categoryTags.map(toTokenCategoryFilterValue),
+    })
+  }
+
+  const quickFilters = getSupportedTokenCategoryOptions()
+    .filter(({ tag }) => availableCategoryTags.has(tag))
+    .sort((a, b) => getCategoryFilterOrder(a.tag) - getCategoryFilterOrder(b.tag) || a.label.localeCompare(b.label))
+    .map(({ tag, label }) => ({
+      label: CATEGORY_FILTER_LABELS[tag] ?? label,
+      value: toTokenCategoryFilterValue(tag),
     }))
-    .reduce((prev, curr) =>
-      prev.find(vault => vault.value === curr.value) ? prev : [...prev, curr], [] as { label: string, value: string, icon: string }[],
-    )
+
+  return { options: assetOptions, quickFilters }
+}
+
+const matchesAssetFilterSelection = (
+  assetAddress: string,
+  selected: readonly string[],
+): boolean => {
+  if (!selected.length) return true
+
+  return selected.some(value =>
+    value === assetAddress || tokenAddressMatchesCategoryFilter(assetAddress, value, getTokenCategoryTags),
+  )
+}
+
+const collateralAssetOptions = computed(() => {
+  return buildAssetFilterOptions(activeBorrowList.value.map(pair => pair.collateral.asset))
 })
 
 const debtAssetOptions = computed(() => {
-  return activeBorrowList.value
-    .filter((item, idx, self) => idx === self.findIndex(t => t.borrow.asset.address === item.borrow.asset.address))
-    .map(pair => ({
-      label: pair.borrow.asset.symbol,
-      value: pair.borrow.asset.address,
-      icon: getAssetLogoUrl(pair.borrow.asset.address, pair.borrow.asset.symbol),
-    }))
-    .reduce((prev, curr) =>
-      prev.find(vault => vault.value === curr.value) ? prev : [...prev, curr], [] as { label: string, value: string, icon: string }[],
-    )
+  return buildAssetFilterOptions(activeBorrowList.value.map(pair => pair.borrow.asset))
 })
 
 const marketOptions = computed(() => {
@@ -397,8 +447,8 @@ const filteredBorrowList = computed(() => {
     .filter(matchesSearch)
     .filter(pair =>
       selectedCollateral.value.length || selectedDebt.value.length
-        ? ((!selectedCollateral.value.length || selectedCollateral.value.includes(pair.collateral.asset.address))
-          && (!selectedDebt.value.length || selectedDebt.value.includes(pair.borrow.asset.address)))
+        ? (matchesAssetFilterSelection(pair.collateral.asset.address, selectedCollateral.value)
+          && matchesAssetFilterSelection(pair.borrow.asset.address, selectedDebt.value))
         : true,
     )
     .filter(pair => selectedMarkets.value.length ? selectedMarkets.value.includes(getProductByVault(pair.collateral.address).name) : true)
@@ -583,7 +633,8 @@ const sortedBorrowList = computed(() => {
           :key="`collateral-${chainId}`"
           v-model="selectedCollateral"
           class="shrink-0 mobile:flex-1 mobile:basis-[calc(50%-4px)]"
-          :options="collateralAssetOptions"
+          :options="collateralAssetOptions.options"
+          :quick-filters="collateralAssetOptions.quickFilters"
           placeholder="Collateral asset"
           title="Collateral asset"
           modal-input-placeholder="Search asset"
@@ -594,7 +645,8 @@ const sortedBorrowList = computed(() => {
           :key="`debt-${chainId}`"
           v-model="selectedDebt"
           class="shrink-0 mobile:flex-1 mobile:basis-[calc(50%-4px)]"
-          :options="debtAssetOptions"
+          :options="debtAssetOptions.options"
+          :quick-filters="debtAssetOptions.quickFilters"
           placeholder="Debt asset"
           title="Debt asset"
           modal-input-placeholder="Search asset"

--- a/pages/borrow/index.vue
+++ b/pages/borrow/index.vue
@@ -32,7 +32,7 @@ type AssetFilterOptions = { options: AssetFilterOption[], quickFilters: SelectQu
 const CATEGORY_FILTER_LABELS: Record<string, string> = {
   eth: 'ETH',
   btc: 'BTC',
-  usd: 'Stables',
+  usd: 'USD',
 }
 
 const CATEGORY_FILTER_ORDER = ['eth', 'btc', 'usd']

--- a/tests/utils/token-categories.test.ts
+++ b/tests/utils/token-categories.test.ts
@@ -2,11 +2,15 @@ import { describe, expect, it } from 'vitest'
 import {
   areTokenAddressesInSameCorrelatedCategory,
   areTokenAddressesCorrelatedByTags,
+  fromTokenCategoryFilterValue,
   getSharedTokenCategory,
+  getSupportedTokenCategoryOptions,
   getTokenAddressesCorrelationCategoryLabel,
   normalizeTokenCategoryTags,
   shareCommonTokenCategory,
   shareTokenCategory,
+  toTokenCategoryFilterValue,
+  tokenAddressMatchesCategoryFilter,
 } from '~/utils/token-categories'
 
 describe('token category helpers', () => {
@@ -27,6 +31,53 @@ describe('token category helpers', () => {
     expect(shareTokenCategory(['stablecoin'], ['stablecoin'])).toBe(false)
     expect(shareTokenCategory(['usd'], ['eth'])).toBe(false)
     expect(shareTokenCategory(undefined, ['usd'])).toBe(false)
+  })
+
+  it('builds stable category filter values for allowlisted categories', () => {
+    expect(getSupportedTokenCategoryOptions()).toEqual([
+      { tag: 'usd', label: 'USD' },
+      { tag: 'eth', label: 'ETH' },
+      { tag: 'btc', label: 'BTC' },
+      { tag: 'mon', label: 'MON' },
+      { tag: 'avax', label: 'AVAX' },
+      { tag: 'hype', label: 'HYPE' },
+      { tag: 'bnb', label: 'BNB' },
+    ])
+    expect(toTokenCategoryFilterValue(' USD ')).toBe('category:usd')
+    expect(fromTokenCategoryFilterValue('category:usd')).toBe('usd')
+    expect(fromTokenCategoryFilterValue('category:stablecoin')).toBeNull()
+    expect(fromTokenCategoryFilterValue('0x0000000000000000000000000000000000000001')).toBeNull()
+  })
+
+  it('matches token addresses against category filter values', () => {
+    const tags = new Map<string, string[]>([
+      ['0x0000000000000000000000000000000000000001', ['usd']],
+      ['0x0000000000000000000000000000000000000002', ['eth']],
+      ['0x0000000000000000000000000000000000000003', ['other']],
+    ])
+    const getTags = (address: string) => tags.get(address.toLowerCase())
+
+    expect(
+      tokenAddressMatchesCategoryFilter(
+        '0x0000000000000000000000000000000000000001',
+        'category:usd',
+        getTags,
+      ),
+    ).toBe(true)
+    expect(
+      tokenAddressMatchesCategoryFilter(
+        '0x0000000000000000000000000000000000000001',
+        'category:eth',
+        getTags,
+      ),
+    ).toBe(false)
+    expect(
+      tokenAddressMatchesCategoryFilter(
+        '0x0000000000000000000000000000000000000003',
+        'category:other',
+        getTags,
+      ),
+    ).toBe(false)
   })
 
   it('requires one shared allowlisted category across a whole token set', () => {

--- a/utils/token-categories.ts
+++ b/utils/token-categories.ts
@@ -19,7 +19,7 @@ export const normalizeTokenCategoryTags = (
   return normalized
 }
 
-const CORRELATED_CATEGORY_LABELS: Record<string, string> = {
+export const CORRELATED_CATEGORY_LABELS: Record<string, string> = {
   usd: 'USD',
   eth: 'ETH',
   btc: 'BTC',
@@ -30,6 +30,7 @@ const CORRELATED_CATEGORY_LABELS: Record<string, string> = {
 }
 
 const CORRELATED_CATEGORY_TAGS = new Set(Object.keys(CORRELATED_CATEGORY_LABELS))
+const TOKEN_CATEGORY_FILTER_PREFIX = 'category:'
 
 const isCorrelatedCategory = (tag: string): boolean => CORRELATED_CATEGORY_TAGS.has(tag)
 
@@ -38,6 +39,34 @@ const correlatedCategories = (tags: TokenCategoryTagSource): string[] =>
 
 export const formatTokenCategoryLabel = (tag: string | null | undefined): string | undefined =>
   tag ? CORRELATED_CATEGORY_LABELS[tag.trim().toLowerCase()] : undefined
+
+export const getSupportedTokenCategoryOptions = (): { tag: string, label: string }[] =>
+  Object.entries(CORRELATED_CATEGORY_LABELS).map(([tag, label]) => ({ tag, label }))
+
+export const toTokenCategoryFilterValue = (tag: string): string =>
+  `${TOKEN_CATEGORY_FILTER_PREFIX}${tag.trim().toLowerCase()}`
+
+export const fromTokenCategoryFilterValue = (value: string): string | null => {
+  if (!value.startsWith(TOKEN_CATEGORY_FILTER_PREFIX)) return null
+
+  const tag = value.slice(TOKEN_CATEGORY_FILTER_PREFIX.length).trim().toLowerCase()
+  return isCorrelatedCategory(tag) ? tag : null
+}
+
+export const isTokenCategoryFilterValue = (value: string): boolean =>
+  fromTokenCategoryFilterValue(value) !== null
+
+export const tokenAddressMatchesCategoryFilter = (
+  address: string | undefined | null,
+  categoryFilterValue: string,
+  getTokenCategoryTags: (address: string) => TokenCategoryTagSource,
+): boolean => {
+  const category = fromTokenCategoryFilterValue(categoryFilterValue)
+  const normalized = normalizeComparableAddress(address)
+  if (!category || !normalized) return false
+
+  return correlatedCategories(getTokenCategoryTags(normalized)).includes(category)
+}
 
 export const shareTokenCategory = (
   leftTags: TokenCategoryTagSource,


### PR DESCRIPTION
## Summary
- Add category quick filters to Borrow/Multiply collateral and debt asset selectors.
- Keep category selections URL-friendly while showing matching token rows as selected in the modal.

## Changes
- Extend shared select options with quick-filter metadata and modal quick-filter controls.
- Add supported token category filter values and matching helpers.
- Build ETH, BTC, and Stables quick filters from token category tags on borrow asset lists.

## Test plan
- [x] npm run test:run -- tests/utils/token-categories.test.ts
- [x] npm run typecheck
- [x] npx eslint components/ui/modals/UiSelectModal.vue pages/borrow/index.vue components/ui/UiSelect.vue components/ui/modals/select.types.ts
- [x] Manually checked the Borrow/Multiply selector modal on localhost with category quick filters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added quick-filter support to selection controls, enabling filtering by individual items and category shortcuts.
  * Borrow page filters now accept either exact token addresses or category-based quick-filter values.
  * Selection menus can display richer icons (via `iconName`) and show a quick-filter button row (including “All”) when available.
* **Bug Fixes**
  * Improved quick-filter-aware selection behavior so selected categories and matching items remain synchronized.
  * Strengthened token-category filter matching to handle invalid or unsupported values safely.
* **Tests**
  * Added unit tests for token-category filter parsing and matching logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->