### PR TITLE
feat: add manager profile pages

### DIFF
--- a/components/entities/manager/ManagerEntityLink.vue
+++ b/components/entities/manager/ManagerEntityLink.vue
@@ -46,6 +46,13 @@ const goToManager = () => {
   if (!isLinked.value) return
   void navigateTo(to.value)
 }
+
+const onSpanKeydown = (event: KeyboardEvent) => {
+  if (event.key !== 'Enter' && event.key !== ' ') return
+  event.preventDefault()
+  event.stopPropagation()
+  goToManager()
+}
 </script>
 
 <template>
@@ -58,12 +65,15 @@ const goToManager = () => {
     />
     <span
       v-if="spanLink && isLinked"
+      role="link"
+      tabindex="0"
       :class="textClass"
       :data-id="dataKey && dataField ? 'data-point' : undefined"
       :data-key="dataKey || undefined"
       :data-field="dataField || undefined"
       :data-value="displayName"
       @click.stop.prevent="goToManager"
+      @keydown="onSpanKeydown"
     >{{ displayName }}</span>
     <NuxtLink
       v-else-if="isLinked"

--- a/components/entities/manager/ManagerEntityLink.vue
+++ b/components/entities/manager/ManagerEntityLink.vue
@@ -1,0 +1,86 @@
+<script setup lang="ts">
+import type { EulerLabelEntity } from '~/entities/euler/labels'
+import { getEulerLabelEntityLogo } from '~/entities/euler/labels'
+import { getEulerLabelEntityDisplayName, getEulerLabelEntitySlug, getManagerProfilePath } from '~/utils/manager-profile'
+
+const props = withDefaults(defineProps<{
+  entities: EulerLabelEntity[]
+  label?: string
+  showAvatar?: boolean
+  spanLink?: boolean
+  textClass?: string
+  avatarClass?: string
+  dataKey?: string
+  dataField?: string
+  disabled?: boolean
+}>(), {
+  label: '',
+  showAvatar: true,
+  spanLink: false,
+  textClass: 'text-p2 text-content-primary hover:text-accent-600 underline transition-colors',
+  avatarClass: 'icon--20',
+  dataKey: '',
+  dataField: '',
+  disabled: false,
+})
+
+const { entities: entityMap } = useEulerLabels()
+const route = useRoute()
+
+const displayName = computed(() => props.label || getEulerLabelEntityDisplayName(props.entities))
+const entityLogos = computed(() => props.entities.map(entity => getEulerLabelEntityLogo(entity.logo)))
+const primarySlug = computed(() => {
+  const first = props.entities[0]
+  return first ? getEulerLabelEntitySlug(entityMap, first) : ''
+})
+const to = computed(() => ({
+  path: getManagerProfilePath(primarySlug.value),
+  query: { network: route.query.network },
+}))
+const isLinked = computed(() => Boolean(primarySlug.value) && props.entities.length === 1 && !props.disabled)
+const fallbackTextClass = computed(() =>
+  props.textClass.replace('hover:text-accent-600 underline transition-colors', ''),
+)
+
+const goToManager = () => {
+  if (!isLinked.value) return
+  void navigateTo(to.value)
+}
+</script>
+
+<template>
+  <span class="inline-flex min-w-0 items-center gap-6">
+    <BaseAvatar
+      v-if="showAvatar"
+      :class="avatarClass"
+      :label="displayName"
+      :src="entityLogos"
+    />
+    <span
+      v-if="spanLink && isLinked"
+      :class="textClass"
+      :data-id="dataKey && dataField ? 'data-point' : undefined"
+      :data-key="dataKey || undefined"
+      :data-field="dataField || undefined"
+      :data-value="displayName"
+      @click.stop.prevent="goToManager"
+    >{{ displayName }}</span>
+    <NuxtLink
+      v-else-if="isLinked"
+      :to="to"
+      :class="textClass"
+      :data-id="dataKey && dataField ? 'data-point' : undefined"
+      :data-key="dataKey || undefined"
+      :data-field="dataField || undefined"
+      :data-value="displayName"
+    >{{ displayName }}</NuxtLink>
+    <span
+      v-else
+      :class="fallbackTextClass"
+      :data-id="dataKey && dataField ? 'data-point' : undefined"
+      :data-key="dataKey || undefined"
+      :data-field="dataField || undefined"
+      :data-value="displayName"
+    >{{ displayName }}</span>
+  </span>
+</template>

--- a/components/entities/vault/SecuritizeVaultItem.vue
+++ b/components/entities/vault/SecuritizeVaultItem.vue
@@ -4,7 +4,6 @@ import { formatAssetValue } from '~/utils/sdk-prices'
 import { isVaultBlockedByCountry } from '~/composables/useGeoBlock'
 import { useEulerProductOfVault, useEulerEntitiesOfVault } from '~/composables/useEulerLabels'
 import { isVaultGovernanceLimited } from '~/utils/eulerLabelsUtils'
-import { getEulerLabelEntityLogo } from '~/entities/euler/labels'
 import { withVaultIntrinsicApy, getVaultIntrinsicApy, getVaultIntrinsicApyInfo } from '~/utils/vault-intrinsic-apy'
 import { formatNumber, formatCompactUsdValue } from '~/utils/string-utils'
 import { VaultApyModal, UiModalPreviewTrigger } from '#components'
@@ -29,10 +28,6 @@ const entityName = computed(() => {
   if (entities.length === 1) return entities[0].name
   if (entities.length === 2) return `${entities[0].name} & ${entities[1].name}`
   return `${entities[0].name} & others`
-})
-const entityLogos = computed(() => {
-  if (!entityName.value || entities.length === 0) return []
-  return entities.map(e => getEulerLabelEntityLogo(e.logo))
 })
 const displayName = computed(() => product.name || vault.shares.name)
 const isGeoBlocked = computed(() => isVaultBlockedByCountry(vault.address))
@@ -198,18 +193,14 @@ watchEffect(async () => {
           class="flex items-center gap-6"
           :class="{ 'opacity-20': isGovernanceLimited }"
         >
-          <BaseAvatar
-            class="icon--20"
+          <ManagerEntityLink
+            :entities="entities"
             :label="entityName"
-            :src="entityLogos"
-          />
-          <span
-            class="text-p2 text-content-primary truncate"
-            data-id="data-point"
+            span-link
+            text-class="text-p2 text-content-primary hover:text-accent-600 underline transition-colors truncate"
             :data-key="vault.address.toLowerCase()"
             data-field="risk-manager"
-            :data-value="entityName"
-          >{{ entityName }}</span>
+          />
         </div>
         <div
           v-else
@@ -275,12 +266,12 @@ watchEffect(async () => {
             class="flex items-center gap-8"
             :class="{ 'opacity-20': isGovernanceLimited }"
           >
-            <BaseAvatar
-              class="icon--20"
+            <ManagerEntityLink
+              :entities="entities"
               :label="entityName"
-              :src="entityLogos"
+              span-link
+              text-class="text-p2 text-content-primary hover:text-accent-600 underline transition-colors truncate"
             />
-            <span class="text-p2 text-content-primary truncate">{{ entityName }}</span>
           </div>
           <div
             v-else

--- a/components/entities/vault/VaultBorrowItem.vue
+++ b/components/entities/vault/VaultBorrowItem.vue
@@ -6,7 +6,6 @@ import { withVaultIntrinsicApy, getVaultIntrinsicApy, getVaultIntrinsicApyInfo }
 import { getVaultAvailableLiquidity, getVaultUtilization } from '~/utils/vault-display'
 import { useEulerProductOfVault } from '~/composables/useEulerLabels'
 import { isVaultGovernanceLimited, isVaultRecentlyAdded, isVaultKeyring, isVaultCyclicalNote, getUniqueEntitiesByVaults } from '~/utils/eulerLabelsUtils'
-import { getEulerLabelEntityLogo } from '~/entities/euler/labels'
 import { isAnyVaultBlockedByCountry, isVaultRestrictedByCountry } from '~/composables/useGeoBlock'
 import { VaultApyModal, VaultMaxRoeModal, VaultNetApyPairModal, UiModalPreviewTrigger } from '#components'
 import { isSecuritizeBorrowPair, type AnyBorrowVaultPair } from '~/types/borrow-pair'
@@ -31,7 +30,7 @@ const isAnyGovernorUnverified = computed(() => {
 
 const entityDisplay = computed(() => {
   const all = getUniqueEntitiesByVaults([pair.collateral, pair.borrow])
-  if (all.length === 0) return { name: '', logos: [] }
+  if (all.length === 0) return { name: '', entities: [] }
   const name = all.length === 1
     ? all[0].name
     : all.length === 2
@@ -39,7 +38,7 @@ const entityDisplay = computed(() => {
       : `${all[0].name} & others`
   return {
     name,
-    logos: all.map(e => getEulerLabelEntityLogo(e.logo)),
+    entities: all,
   }
 })
 
@@ -465,18 +464,14 @@ const linkPath = computed(() => ({
           class="flex items-center gap-6"
           :class="{ 'opacity-20': isAnyGovernanceLimited }"
         >
-          <BaseAvatar
-            class="icon--20"
+          <ManagerEntityLink
+            :entities="entityDisplay.entities"
             :label="entityDisplay.name"
-            :src="entityDisplay.logos"
-          />
-          <span
-            class="text-p2 text-content-primary truncate"
-            data-id="data-point"
+            span-link
+            text-class="text-p2 text-content-primary hover:text-accent-600 underline transition-colors truncate"
             :data-key="pairKey"
             data-field="risk-manager"
-            :data-value="entityDisplay.name"
-          >{{ entityDisplay.name }}</span>
+          />
         </div>
         <div
           v-else
@@ -666,12 +661,12 @@ const linkPath = computed(() => ({
             class="flex items-center gap-8"
             :class="{ 'opacity-20': isAnyGovernanceLimited }"
           >
-            <BaseAvatar
-              class="icon--20"
+            <ManagerEntityLink
+              :entities="entityDisplay.entities"
               :label="entityDisplay.name"
-              :src="entityDisplay.logos"
+              span-link
+              text-class="text-p2 text-content-primary hover:text-accent-600 underline transition-colors truncate"
             />
-            <span class="text-p2 text-content-primary truncate">{{ entityDisplay.name }}</span>
           </div>
           <div
             v-else

--- a/components/entities/vault/VaultEarnItem.vue
+++ b/components/entities/vault/VaultEarnItem.vue
@@ -4,7 +4,6 @@ import { computeSupplyApyBreakdown, isEVault, type EVault, type EulerEarn, type 
 import { formatAssetValue } from '~/utils/sdk-prices'
 import { useEulerProductOfVault, useEulerEntitiesOfEarnVault } from '~/composables/useEulerLabels'
 import { getEarnVaultDescription, isVaultRecentlyAdded } from '~/utils/eulerLabelsUtils'
-import { getEulerLabelEntityLogo } from '~/entities/euler/labels'
 import { getVaultIntrinsicApyInfo } from '~/utils/vault-intrinsic-apy'
 import { isVaultBlockedByCountry } from '~/composables/useGeoBlock'
 import { logWarn } from '~/utils/errorHandling'
@@ -42,10 +41,6 @@ const entityName = computed(() => {
   if (entities.length === 1) return entities[0].name
   if (entities.length === 2) return `${entities[0].name} & ${entities[1].name}`
   return `${entities[0].name} & others`
-})
-const entityLogos = computed(() => {
-  if (!entityName.value || entities.length === 0) return []
-  return entities.map(e => getEulerLabelEntityLogo(e.logo))
 })
 const { getBalance, isLoading: isBalancesLoading } = useWallets()
 const { settings } = useUserSettings()
@@ -327,18 +322,14 @@ const supplyApyModalData = computed(() => ({
           v-else-if="entityName"
           class="flex items-center gap-6"
         >
-          <BaseAvatar
-            class="icon--20"
+          <ManagerEntityLink
+            :entities="entities"
             :label="entityName"
-            :src="entityLogos"
-          />
-          <span
-            class="text-p2 text-content-primary truncate"
-            data-id="data-point"
+            span-link
+            text-class="text-p2 text-content-primary hover:text-accent-600 underline transition-colors truncate"
             :data-key="vault.address.toLowerCase()"
             data-field="capital-allocator"
-            :data-value="entityName"
-          >{{ entityName }}</span>
+          />
         </div>
         <div
           v-else
@@ -432,14 +423,13 @@ const supplyApyModalData = computed(() => ({
             />
             Unknown
           </div>
-          <template v-else-if="entityName">
-            <BaseAvatar
-              class="icon--20"
-              :label="entityName"
-              :src="entityLogos"
-            />
-            <span class="text-p2 text-content-primary truncate">{{ entityName }}</span>
-          </template>
+          <ManagerEntityLink
+            v-else-if="entityName"
+            :entities="entities"
+            :label="entityName"
+            span-link
+            text-class="text-p2 text-content-primary hover:text-accent-600 underline transition-colors truncate"
+          />
           <div
             v-else
             class="text-p2 text-content-primary"

--- a/components/entities/vault/VaultItem.vue
+++ b/components/entities/vault/VaultItem.vue
@@ -5,7 +5,6 @@ import { formatAssetValue } from '~/utils/sdk-prices'
 import { useEulerProductOfVault, useEulerEntitiesOfVault } from '~/composables/useEulerLabels'
 import { isVaultGovernanceLimited, isVaultRecentlyAdded, isVaultKeyring, isVaultCyclicalNote } from '~/utils/eulerLabelsUtils'
 import { withVaultIntrinsicApy, getVaultIntrinsicApy, getVaultIntrinsicApyInfo } from '~/utils/vault-intrinsic-apy'
-import { getEulerLabelEntityLogo } from '~/entities/euler/labels'
 import { isVaultBlockedByCountry } from '~/composables/useGeoBlock'
 import { formatNumber, compactNumber, formatCompactUsdValue } from '~/utils/string-utils'
 import BaseLoadableContent from '~/components/base/BaseLoadableContent.vue'
@@ -39,10 +38,6 @@ const entityName = computed(() => {
   if (entities.length === 1) return entities[0].name
   if (entities.length === 2) return `${entities[0].name} & ${entities[1].name}`
   return `${entities[0].name} & others`
-})
-const entityLogos = computed(() => {
-  if (!entityName.value || entities.length === 0) return []
-  return entities.map(e => getEulerLabelEntityLogo(e.logo))
 })
 const isEscrow = computed(() => getVaultCategory(vault.address) === 'escrow')
 const isBorrowable = computed(() => isVaultBorrowable(vault))
@@ -299,18 +294,14 @@ watchEffect(async () => {
           class="flex items-center gap-6"
           :class="{ 'opacity-20': isGovernanceLimited }"
         >
-          <BaseAvatar
-            class="icon--20"
+          <ManagerEntityLink
+            :entities="entities"
             :label="entityName"
-            :src="entityLogos"
-          />
-          <span
-            class="text-p2 text-content-primary truncate"
-            data-id="data-point"
+            span-link
+            text-class="text-p2 text-content-primary hover:text-accent-600 underline transition-colors truncate"
             :data-key="vault.address.toLowerCase()"
             data-field="risk-manager"
-            :data-value="entityName"
-          >{{ entityName }}</span>
+          />
         </div>
         <div
           v-else
@@ -441,12 +432,12 @@ watchEffect(async () => {
             class="flex items-center gap-8"
             :class="{ 'opacity-20': isGovernanceLimited }"
           >
-            <BaseAvatar
-              class="icon--20"
+            <ManagerEntityLink
+              :entities="entities"
               :label="entityName"
-              :src="entityLogos"
+              span-link
+              text-class="text-p2 text-content-primary hover:text-accent-600 underline transition-colors truncate"
             />
-            <span class="text-p2 text-content-primary truncate">{{ entityName }}</span>
           </div>
           <div
             v-else

--- a/components/entities/vault/overview/SecuritizeVaultOverview.vue
+++ b/components/entities/vault/overview/SecuritizeVaultOverview.vue
@@ -2,7 +2,6 @@
 import type { EVault, SecuritizeCollateralVault } from '@eulerxyz/euler-v2-sdk'
 import { useEulerEntitiesOfVault } from '~/composables/useEulerLabels'
 import { getProductByVault, getProductKeyByVault, isVaultGovernanceLimited } from '~/utils/eulerLabelsUtils'
-import { getEulerLabelEntityLogo } from '~/entities/euler/labels'
 import { isVaultBlockedByCountry } from '~/composables/useGeoBlock'
 import { autoLink } from '~/utils/autoLink'
 import { getExplorerLink } from '~/utils/block-explorer'
@@ -199,17 +198,10 @@ const supplyCapPercentageDisplay = computed(() => {
             class="flex items-center gap-8"
             :class="{ 'opacity-20': isGovernanceLimited }"
           >
-            <BaseAvatar
-              :label="entity.name"
-              :src="getEulerLabelEntityLogo(entity.logo)"
-              class="!w-28 !h-28"
+            <ManagerEntityLink
+              :entities="[entity]"
+              avatar-class="!w-28 !h-28"
             />
-            <a
-              :href="entity.url"
-              target="_blank"
-              rel="noopener noreferrer"
-              class="text-p2 text-content-primary underline"
-            >{{ entity.name }}</a>
           </div>
         </div>
         <VaultTypeChip

--- a/components/entities/vault/overview/VaultOverviewBlockGeneral.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockGeneral.vue
@@ -6,7 +6,6 @@ import type { Component } from 'vue'
 import { formatAssetValue } from '~/utils/sdk-prices'
 import { useEulerEntitiesOfVault, useEulerProductOfVault } from '~/composables/useEulerLabels'
 import { getProductByVault, getProductKeyByVault, isVaultGovernanceLimited } from '~/utils/eulerLabelsUtils'
-import { getEulerLabelEntityLogo } from '~/entities/euler/labels'
 import { isVaultBlockedByCountry } from '~/composables/useGeoBlock'
 import { autoLink } from '~/utils/autoLink'
 import { formatMarketAvailability } from '~/utils/vault-display'
@@ -228,22 +227,10 @@ watchEffect(() => {
             class="flex items-center gap-8"
             :class="{ 'opacity-20': isGovernanceLimited }"
           >
-            <BaseAvatar
-              :label="entity.name"
-              :src="getEulerLabelEntityLogo(entity.logo)"
-              class="!w-28 !h-28"
+            <ManagerEntityLink
+              :entities="[entity]"
+              avatar-class="!w-28 !h-28"
             />
-            <a
-              v-if="entity.url"
-              :href="entity.url"
-              target="_blank"
-              rel="noopener noreferrer"
-              class="text-p2 text-content-primary hover:text-accent-600 underline transition-colors"
-            >{{ entity.name }}</a>
-            <span
-              v-else
-              class="text-p2 text-content-primary"
-            >{{ entity.name }}</span>
           </div>
         </div>
         <div v-else>

--- a/components/entities/vault/overview/earn/VaultOverviewEarnBlockGeneral.vue
+++ b/components/entities/vault/overview/earn/VaultOverviewEarnBlockGeneral.vue
@@ -4,7 +4,6 @@ import { getAddress } from 'viem'
 
 import { formatAssetValue } from '~/utils/sdk-prices'
 import { useEulerEntitiesOfEarnVault, useEulerProductOfVault } from '~/composables/useEulerLabels'
-import { getEulerLabelEntityLogo } from '~/entities/euler/labels'
 import { isVaultBlockedByCountry } from '~/composables/useGeoBlock'
 import { isEarnVaultDeprecated, getEarnVaultDeprecationReason, getEarnVaultDescription } from '~/utils/eulerLabelsUtils'
 import { autoLink } from '~/utils/autoLink'
@@ -103,21 +102,7 @@ const feeDisplay = computed(() => {
             :key="idx"
             class="flex items-center gap-8"
           >
-            <BaseAvatar
-              :label="entity.name"
-              :src="getEulerLabelEntityLogo(entity.logo)"
-            />
-            <a
-              v-if="entity.url"
-              :href="entity.url"
-              target="_blank"
-              rel="noopener noreferrer"
-              class="text-p2 text-neutral-800 hover:text-accent-600 underline transition-colors"
-            >{{ entity.name }}</a>
-            <span
-              v-else
-              class="text-p2 text-neutral-800"
-            >{{ entity.name }}</span>
+            <ManagerEntityLink :entities="[entity]" />
           </div>
         </div>
         <VaultTypeChip

--- a/composables/useEulerManagerProfile.ts
+++ b/composables/useEulerManagerProfile.ts
@@ -1,6 +1,7 @@
-import type { EulerEarn, EVault, SecuritizeCollateralVault } from '@eulerxyz/euler-v2-sdk'
+import type { EulerEarn } from '@eulerxyz/euler-v2-sdk'
+import type { MarketGroup } from '~/entities/lend-discovery'
 import type { EulerLabelProduct } from '~/entities/euler/labels'
-import { getEntitiesByEarnVault, getEntitiesByVault } from '~/utils/eulerLabelsUtils'
+import { getEntitiesByEarnVault } from '~/utils/eulerLabelsUtils'
 import { getEulerLabelEntitySlug, isEulerLabelProductManagedBy } from '~/utils/manager-profile'
 
 export type ManagerProductEntry = {
@@ -10,18 +11,13 @@ export type ManagerProductEntry = {
 
 export const useEulerManagerProfile = (slug: Ref<string>) => {
   const { entities, products, isReady: labelsReady } = useEulerLabels()
+  const { isEarnUpdating } = useVaults()
+  const { getEarnVaults } = useVaultRegistry()
   const {
-    isEVaultUpdating,
-    isEarnUpdating,
-    isSecuritizeUpdating,
-    isEscrowUpdating,
-  } = useVaults()
-  const {
-    getVerifiedEVaults,
-    getEarnVaults,
-    getSecuritizeVaults,
-  } = useVaultRegistry()
-  const showAllLabelEntries = useShowAllLabelEntries()
+    marketGroups,
+    isReady: marketGroupsReady,
+    isResolvingTVL,
+  } = useMarketGroups()
 
   const entity = computed(() => entities[slug.value] ?? null)
 
@@ -32,27 +28,18 @@ export const useEulerManagerProfile = (slug: Ref<string>) => {
       .sort((a, b) => a.product.name.localeCompare(b.product.name)),
   )
 
-  const managesEntity = (candidate: EVault | SecuritizeCollateralVault): boolean =>
-    getEntitiesByVault(candidate as EVault).some(manager =>
-      getEulerLabelEntitySlug(entities, manager) === slug.value,
-    )
+  const managedProductKeys = computed(() => new Set(productEntries.value.map(entry => entry.key)))
+
+  const managedMarkets = computed<MarketGroup[]>(() =>
+    marketGroups.value
+      .filter(group => group.source === 'product' && managedProductKeys.value.has(group.id))
+      .sort((a, b) => b.metrics.totalTVL - a.metrics.totalTVL || a.name.localeCompare(b.name)),
+  )
 
   const managesEarnEntity = (candidate: EulerEarn): boolean =>
     getEntitiesByEarnVault(candidate).some(manager =>
       getEulerLabelEntitySlug(entities, manager) === slug.value,
     )
-
-  const evaults = computed(() =>
-    getVerifiedEVaults(showAllLabelEntries.value)
-      .filter(managesEntity)
-      .sort((a, b) => a.asset.symbol.localeCompare(b.asset.symbol)),
-  )
-
-  const securitizeVaults = computed(() =>
-    getSecuritizeVaults()
-      .filter(managesEntity)
-      .sort((a, b) => a.asset.symbol.localeCompare(b.asset.symbol)),
-  )
 
   const earnVaults = computed(() =>
     getEarnVaults()
@@ -60,25 +47,18 @@ export const useEulerManagerProfile = (slug: Ref<string>) => {
       .sort((a, b) => a.asset.symbol.localeCompare(b.asset.symbol)),
   )
 
-  const vaultCount = computed(() =>
-    evaults.value.length + securitizeVaults.value.length + earnVaults.value.length,
-  )
-
   const isLoading = computed(() =>
     !labelsReady.value
-    || isEVaultUpdating.value
-    || isEarnUpdating.value
-    || isSecuritizeUpdating.value
-    || isEscrowUpdating.value,
+    || !marketGroupsReady.value
+    || isResolvingTVL.value
+    || isEarnUpdating.value,
   )
 
   return {
     entity,
     productEntries,
-    evaults,
-    securitizeVaults,
+    managedMarkets,
     earnVaults,
-    vaultCount,
     isLoading,
   }
 }

--- a/composables/useEulerManagerProfile.ts
+++ b/composables/useEulerManagerProfile.ts
@@ -1,0 +1,84 @@
+import type { EulerEarn, EVault, SecuritizeCollateralVault } from '@eulerxyz/euler-v2-sdk'
+import type { EulerLabelProduct } from '~/entities/euler/labels'
+import { getEntitiesByEarnVault, getEntitiesByVault } from '~/utils/eulerLabelsUtils'
+import { getEulerLabelEntitySlug, isEulerLabelProductManagedBy } from '~/utils/manager-profile'
+
+export type ManagerProductEntry = {
+  key: string
+  product: EulerLabelProduct
+}
+
+export const useEulerManagerProfile = (slug: Ref<string>) => {
+  const { entities, products, isReady: labelsReady } = useEulerLabels()
+  const {
+    isEVaultUpdating,
+    isEarnUpdating,
+    isSecuritizeUpdating,
+    isEscrowUpdating,
+  } = useVaults()
+  const {
+    getVerifiedEVaults,
+    getEarnVaults,
+    getSecuritizeVaults,
+  } = useVaultRegistry()
+  const showAllLabelEntries = useShowAllLabelEntries()
+
+  const entity = computed(() => entities[slug.value] ?? null)
+
+  const productEntries = computed<ManagerProductEntry[]>(() =>
+    Object.entries(products)
+      .filter(([, product]) => isEulerLabelProductManagedBy(product, slug.value))
+      .map(([key, product]) => ({ key, product }))
+      .sort((a, b) => a.product.name.localeCompare(b.product.name)),
+  )
+
+  const managesEntity = (candidate: EVault | SecuritizeCollateralVault): boolean =>
+    getEntitiesByVault(candidate as EVault).some(manager =>
+      getEulerLabelEntitySlug(entities, manager) === slug.value,
+    )
+
+  const managesEarnEntity = (candidate: EulerEarn): boolean =>
+    getEntitiesByEarnVault(candidate).some(manager =>
+      getEulerLabelEntitySlug(entities, manager) === slug.value,
+    )
+
+  const evaults = computed(() =>
+    getVerifiedEVaults(showAllLabelEntries.value)
+      .filter(managesEntity)
+      .sort((a, b) => a.asset.symbol.localeCompare(b.asset.symbol)),
+  )
+
+  const securitizeVaults = computed(() =>
+    getSecuritizeVaults()
+      .filter(managesEntity)
+      .sort((a, b) => a.asset.symbol.localeCompare(b.asset.symbol)),
+  )
+
+  const earnVaults = computed(() =>
+    getEarnVaults()
+      .filter(managesEarnEntity)
+      .sort((a, b) => a.asset.symbol.localeCompare(b.asset.symbol)),
+  )
+
+  const vaultCount = computed(() =>
+    evaults.value.length + securitizeVaults.value.length + earnVaults.value.length,
+  )
+
+  const isLoading = computed(() =>
+    !labelsReady.value
+    || isEVaultUpdating.value
+    || isEarnUpdating.value
+    || isSecuritizeUpdating.value
+    || isEscrowUpdating.value,
+  )
+
+  return {
+    entity,
+    productEntries,
+    evaults,
+    securitizeVaults,
+    earnVaults,
+    vaultCount,
+    isLoading,
+  }
+}

--- a/entities/euler/labels.ts
+++ b/entities/euler/labels.ts
@@ -30,6 +30,7 @@ export type EulerLabelProduct = {
   portfolioNotice?: string
   entity: string[] | string
   url: string
+  logo?: string
   vaults: string[]
   deprecatedVaults?: string[]
   deprecationReason?: string

--- a/entities/euler/labels.ts
+++ b/entities/euler/labels.ts
@@ -4,13 +4,7 @@ export type EulerLabelEntity = {
   description: string
   url: string
   addresses: Record<string, string>
-  social: {
-    twitter: string
-    youtube: string
-    discord: string
-    telegram: string
-    github: string
-  }
+  social: Record<string, string | undefined>
 }
 export type EulerLabelVaultOverride = {
   name?: string

--- a/pages/managers/[slug].vue
+++ b/pages/managers/[slug].vue
@@ -51,19 +51,16 @@ const socialLinks = computed(() => entity.value ? getManagerProfileSocialLinks(e
     </div>
 
     <template v-else>
-      <div class="flex items-center gap-12">
-        <BackButton fallback="/explore" />
-        <p class="text-p3 text-content-tertiary">
-          Manager profile
-        </p>
-      </div>
-
       <section class="flex flex-col gap-24 border-b border-line-subtle pb-24">
-        <div class="flex items-start gap-20 mobile:flex-col">
+        <div class="flex items-start gap-16 mobile:flex-col">
+          <BackButton
+            class="mt-8 mobile:mt-0"
+            fallback="/explore"
+          />
           <BaseAvatar
             :label="entity.name"
             :src="getEulerLabelEntityLogo(entity.logo)"
-            class="!h-72 !w-72"
+            class="!h-72 !w-72 shrink-0"
           />
           <div class="min-w-0 flex-1">
             <h1 class="text-h2 text-content-primary mobile:text-h3">

--- a/pages/managers/[slug].vue
+++ b/pages/managers/[slug].vue
@@ -1,12 +1,8 @@
 <script setup lang="ts">
 import { autoLink } from '~/utils/autoLink'
 import { getEulerLabelEntityLogo } from '~/entities/euler/labels'
-import { getExplorerLink } from '~/utils/block-explorer'
 import {
-  getManagerProfileAddressEntries,
-  getManagerProfileExternalUrl,
   getManagerProfileSocialLinks,
-  getShortAddress,
 } from '~/utils/manager-profile'
 
 defineOptions({
@@ -14,30 +10,16 @@ defineOptions({
 })
 
 const route = useRoute()
-const { chainId } = useEulerAddresses()
 const slug = computed(() => route.params.slug as string)
 const {
   entity,
   productEntries,
-  evaults,
-  securitizeVaults,
+  managedMarkets,
   earnVaults,
-  vaultCount,
   isLoading,
 } = useEulerManagerProfile(slug)
 
 const socialLinks = computed(() => entity.value ? getManagerProfileSocialLinks(entity.value) : [])
-const addressEntries = computed(() => entity.value ? getManagerProfileAddressEntries(entity.value) : [])
-
-const hasVaults = computed(() =>
-  evaults.value.length > 0 || securitizeVaults.value.length > 0 || earnVaults.value.length > 0,
-)
-
-const getExplorerAddressLink = (address: string) => getExplorerLink(address, chainId.value, true)
-
-const copyAddress = (address: string) => {
-  navigator.clipboard.writeText(address)
-}
 </script>
 
 <template>
@@ -103,7 +85,7 @@ const copyAddress = (address: string) => {
           </div>
         </div>
 
-        <div class="grid grid-cols-4 gap-12 mobile:grid-cols-1">
+        <div class="grid grid-cols-3 gap-12 mobile:grid-cols-1">
           <div class="rounded-8 border border-line-subtle bg-surface-secondary p-16">
             <p class="text-p4 uppercase text-content-tertiary">
               Products
@@ -114,10 +96,10 @@ const copyAddress = (address: string) => {
           </div>
           <div class="rounded-8 border border-line-subtle bg-surface-secondary p-16">
             <p class="text-p4 uppercase text-content-tertiary">
-              Vaults
+              Markets
             </p>
             <p class="mt-4 text-h3 text-content-primary">
-              {{ vaultCount }}
+              {{ managedMarkets.length }}
             </p>
           </div>
           <div class="rounded-8 border border-line-subtle bg-surface-secondary p-16">
@@ -126,14 +108,6 @@ const copyAddress = (address: string) => {
             </p>
             <p class="mt-4 text-h3 text-content-primary">
               {{ socialLinks.length }}
-            </p>
-          </div>
-          <div class="rounded-8 border border-line-subtle bg-surface-secondary p-16">
-            <p class="text-p4 uppercase text-content-tertiary">
-              Addresses
-            </p>
-            <p class="mt-4 text-h3 text-content-primary">
-              {{ addressEntries.length }}
             </p>
           </div>
         </div>
@@ -160,148 +134,29 @@ const copyAddress = (address: string) => {
       </section>
 
       <section
-        v-if="addressEntries.length"
-        class="flex flex-col gap-12"
-      >
-        <h2 class="text-h3 text-content-primary">
-          Governance addresses
-        </h2>
-        <div class="grid grid-cols-2 gap-12 mobile:grid-cols-1">
-          <div
-            v-for="entry in addressEntries"
-            :key="entry.address"
-            class="rounded-8 border border-line-subtle bg-surface-secondary p-16"
-          >
-            <p class="text-p3 text-content-primary">
-              {{ entry.label }}
-            </p>
-            <div class="mt-6 flex min-w-0 items-center gap-6">
-              <NuxtLink
-                :to="getExplorerAddressLink(entry.address)"
-                target="_blank"
-                class="min-w-0 truncate text-p3 text-accent-600 underline hover:text-accent-500"
-              >
-                {{ getShortAddress(entry.address) }}
-              </NuxtLink>
-              <button
-                type="button"
-                class="shrink-0 text-content-muted outline-none hover:text-content-secondary active:text-content-primary"
-                aria-label="Copy address"
-                @click="copyAddress(entry.address)"
-              >
-                <SvgIcon
-                  class="!h-16 !w-16"
-                  name="copy"
-                />
-              </button>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <section
-        v-if="productEntries.length"
+        v-if="managedMarkets.length"
         class="flex flex-col gap-12"
       >
         <div class="flex items-center justify-between gap-12">
           <h2 class="text-h3 text-content-primary">
-            Products managed
+            Markets
           </h2>
         </div>
-        <div class="grid grid-cols-2 gap-12 mobile:grid-cols-1">
-          <div
-            v-for="entry in productEntries"
-            :key="entry.key"
-            class="rounded-12 border border-line-default bg-surface p-16 shadow-card"
-          >
-            <div class="flex items-start gap-10">
-              <BaseAvatar
-                v-if="entry.product.logo"
-                :label="entry.product.name"
-                :src="getEulerLabelEntityLogo(entry.product.logo)"
-                class="!h-32 !w-32 shrink-0"
-              />
-              <div class="min-w-0 flex-1">
-                <NuxtLink
-                  :to="{ name: 'explore-market', params: { market: entry.key }, query: { network: route.query.network } }"
-                  class="text-p2 text-content-primary hover:text-accent-600"
-                >
-                  {{ entry.product.name }}
-                </NuxtLink>
-                <p
-                  v-if="entry.product.description"
-                  class="mt-4 line-clamp-2 text-p3 text-content-tertiary"
-                >
-                  {{ entry.product.description }}
-                </p>
-              </div>
-            </div>
-            <div
-              v-if="entry.product.tags?.length || entry.product.url"
-              class="mt-12 flex flex-wrap gap-6"
-            >
-              <span
-                v-for="tag in entry.product.tags"
-                :key="tag"
-                class="rounded-8 bg-surface-secondary px-8 py-4 text-p4 text-content-secondary"
-              >
-                {{ tag }}
-              </span>
-              <a
-                v-if="entry.product.url"
-                :href="getManagerProfileExternalUrl(entry.product.url)"
-                target="_blank"
-                rel="noopener noreferrer"
-                class="rounded-8 bg-surface-secondary px-8 py-4 text-p4 text-accent-600 hover:text-accent-500"
-              >
-                Website
-              </a>
-            </div>
-          </div>
-        </div>
+        <DiscoveryMarketAccordion :markets="managedMarkets" />
       </section>
 
-      <section class="flex flex-col gap-12">
+      <section
+        v-if="earnVaults.length"
+        class="flex flex-col gap-12"
+      >
         <h2 class="text-h3 text-content-primary">
-          Vaults managed
+          Earn vaults
         </h2>
-        <div
-          v-if="!hasVaults"
-          class="rounded-12 border border-line-default bg-surface p-24 text-p2 text-content-tertiary"
-        >
-          No managed vaults are currently available on this network.
-        </div>
-        <div
-          v-if="evaults.length || securitizeVaults.length"
-          class="flex flex-col gap-12"
-        >
-          <h3 class="text-p3 uppercase text-content-tertiary">
-            Lending vaults
-          </h3>
-          <VaultItem
-            v-for="vault in evaults"
-            :key="vault.address"
-            :vault="vault"
-          />
-          <SecuritizeVaultItem
-            v-for="vault in securitizeVaults"
-            :key="vault.address"
-            :vault="vault"
-          />
-        </div>
-        <div
-          v-if="earnVaults.length"
-          class="flex flex-col gap-12"
-        >
-          <h3 class="text-p3 uppercase text-content-tertiary">
-            Earn vaults
-          </h3>
-          <VaultEarnItem
-            v-for="vault in earnVaults"
-            :key="vault.address"
-            :vault="vault"
-          />
-        </div>
+        <VaultEarnItem
+          v-for="vault in earnVaults"
+          :key="vault.address"
+          :vault="vault"
+        />
       </section>
     </template>
   </section>

--- a/pages/managers/[slug].vue
+++ b/pages/managers/[slug].vue
@@ -13,7 +13,6 @@ const route = useRoute()
 const slug = computed(() => route.params.slug as string)
 const {
   entity,
-  productEntries,
   managedMarkets,
   earnVaults,
   isLoading,
@@ -83,46 +82,26 @@ const socialLinks = computed(() => entity.value ? getManagerProfileSocialLinks(e
             >
               No profile description is available yet.
             </p>
+            <div
+              v-if="socialLinks.length"
+              class="mt-16 flex flex-wrap gap-8"
+            >
+              <a
+                v-for="link in socialLinks"
+                :key="link.label"
+                :href="link.url"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="inline-flex items-center gap-6 rounded-8 border border-line-default bg-surface-elevated px-12 py-8 text-p3 text-content-primary hover:border-line-emphasis hover:text-accent-600 transition-colors"
+              >
+                <UiIcon
+                  name="globe"
+                  class="!h-16 !w-16"
+                />
+                {{ link.label }}
+              </a>
+            </div>
           </div>
-        </div>
-
-        <div class="grid grid-cols-2 gap-12 mobile:grid-cols-1">
-          <div class="rounded-8 border border-line-subtle bg-surface-secondary p-16">
-            <p class="text-p4 uppercase text-content-tertiary">
-              Products
-            </p>
-            <p class="mt-4 text-h3 text-content-primary">
-              {{ productEntries.length }}
-            </p>
-          </div>
-          <div class="rounded-8 border border-line-subtle bg-surface-secondary p-16">
-            <p class="text-p4 uppercase text-content-tertiary">
-              Markets
-            </p>
-            <p class="mt-4 text-h3 text-content-primary">
-              {{ managedMarkets.length }}
-            </p>
-          </div>
-        </div>
-
-        <div
-          v-if="socialLinks.length"
-          class="flex flex-wrap gap-8"
-        >
-          <a
-            v-for="link in socialLinks"
-            :key="link.label"
-            :href="link.url"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="inline-flex items-center gap-6 rounded-8 border border-line-default bg-surface-elevated px-12 py-8 text-p3 text-content-primary hover:border-line-emphasis hover:text-accent-600 transition-colors"
-          >
-            <UiIcon
-              name="globe"
-              class="!h-16 !w-16"
-            />
-            {{ link.label }}
-          </a>
         </div>
       </section>
 
@@ -131,8 +110,11 @@ const socialLinks = computed(() => entity.value ? getManagerProfileSocialLinks(e
         class="flex flex-col gap-12"
       >
         <div class="flex items-center justify-between gap-12">
-          <h2 class="text-h3 text-content-primary">
+          <h2 class="flex items-center gap-8 text-h3 text-content-primary">
             Markets
+            <span class="inline-flex min-w-24 items-center justify-center rounded-full bg-surface-secondary px-8 py-2 text-p4 text-content-tertiary">
+              {{ managedMarkets.length }}
+            </span>
           </h2>
         </div>
         <DiscoveryMarketAccordion :markets="managedMarkets" />
@@ -142,8 +124,11 @@ const socialLinks = computed(() => entity.value ? getManagerProfileSocialLinks(e
         v-if="earnVaults.length"
         class="flex flex-col gap-12"
       >
-        <h2 class="text-h3 text-content-primary">
+        <h2 class="flex items-center gap-8 text-h3 text-content-primary">
           Earn vaults
+          <span class="inline-flex min-w-24 items-center justify-center rounded-full bg-surface-secondary px-8 py-2 text-p4 text-content-tertiary">
+            {{ earnVaults.length }}
+          </span>
         </h2>
         <VaultEarnItem
           v-for="vault in earnVaults"

--- a/pages/managers/[slug].vue
+++ b/pages/managers/[slug].vue
@@ -1,12 +1,20 @@
 <script setup lang="ts">
 import { autoLink } from '~/utils/autoLink'
 import { getEulerLabelEntityLogo } from '~/entities/euler/labels'
+import { getExplorerLink } from '~/utils/block-explorer'
+import {
+  getManagerProfileAddressEntries,
+  getManagerProfileExternalUrl,
+  getManagerProfileSocialLinks,
+  getShortAddress,
+} from '~/utils/manager-profile'
 
 defineOptions({
   name: 'ManagerProfilePage',
 })
 
 const route = useRoute()
+const { chainId } = useEulerAddresses()
 const slug = computed(() => route.params.slug as string)
 const {
   entity,
@@ -18,22 +26,18 @@ const {
   isLoading,
 } = useEulerManagerProfile(slug)
 
-const socialLinks = computed(() => {
-  if (!entity.value) return []
-  const social = entity.value.social
-  return [
-    entity.value.url ? { label: 'Website', url: entity.value.url } : null,
-    social.twitter ? { label: 'X', url: social.twitter } : null,
-    social.github ? { label: 'GitHub', url: social.github } : null,
-    social.discord ? { label: 'Discord', url: social.discord } : null,
-    social.telegram ? { label: 'Telegram', url: social.telegram } : null,
-    social.youtube ? { label: 'YouTube', url: social.youtube } : null,
-  ].filter(Boolean) as { label: string, url: string }[]
-})
+const socialLinks = computed(() => entity.value ? getManagerProfileSocialLinks(entity.value) : [])
+const addressEntries = computed(() => entity.value ? getManagerProfileAddressEntries(entity.value) : [])
 
 const hasVaults = computed(() =>
   evaults.value.length > 0 || securitizeVaults.value.length > 0 || earnVaults.value.length > 0,
 )
+
+const getExplorerAddressLink = (address: string) => getExplorerLink(address, chainId.value, true)
+
+const copyAddress = (address: string) => {
+  navigator.clipboard.writeText(address)
+}
 </script>
 
 <template>
@@ -99,7 +103,7 @@ const hasVaults = computed(() =>
           </div>
         </div>
 
-        <div class="grid grid-cols-3 gap-12 mobile:grid-cols-1">
+        <div class="grid grid-cols-4 gap-12 mobile:grid-cols-1">
           <div class="rounded-8 border border-line-subtle bg-surface-secondary p-16">
             <p class="text-p4 uppercase text-content-tertiary">
               Products
@@ -122,6 +126,14 @@ const hasVaults = computed(() =>
             </p>
             <p class="mt-4 text-h3 text-content-primary">
               {{ socialLinks.length }}
+            </p>
+          </div>
+          <div class="rounded-8 border border-line-subtle bg-surface-secondary p-16">
+            <p class="text-p4 uppercase text-content-tertiary">
+              Addresses
+            </p>
+            <p class="mt-4 text-h3 text-content-primary">
+              {{ addressEntries.length }}
             </p>
           </div>
         </div>
@@ -148,6 +160,46 @@ const hasVaults = computed(() =>
       </section>
 
       <section
+        v-if="addressEntries.length"
+        class="flex flex-col gap-12"
+      >
+        <h2 class="text-h3 text-content-primary">
+          Governance addresses
+        </h2>
+        <div class="grid grid-cols-2 gap-12 mobile:grid-cols-1">
+          <div
+            v-for="entry in addressEntries"
+            :key="entry.address"
+            class="rounded-8 border border-line-subtle bg-surface-secondary p-16"
+          >
+            <p class="text-p3 text-content-primary">
+              {{ entry.label }}
+            </p>
+            <div class="mt-6 flex min-w-0 items-center gap-6">
+              <NuxtLink
+                :to="getExplorerAddressLink(entry.address)"
+                target="_blank"
+                class="min-w-0 truncate text-p3 text-accent-600 underline hover:text-accent-500"
+              >
+                {{ getShortAddress(entry.address) }}
+              </NuxtLink>
+              <button
+                type="button"
+                class="shrink-0 text-content-muted outline-none hover:text-content-secondary active:text-content-primary"
+                aria-label="Copy address"
+                @click="copyAddress(entry.address)"
+              >
+                <SvgIcon
+                  class="!h-16 !w-16"
+                  name="copy"
+                />
+              </button>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section
         v-if="productEntries.length"
         class="flex flex-col gap-12"
       >
@@ -157,22 +209,55 @@ const hasVaults = computed(() =>
           </h2>
         </div>
         <div class="grid grid-cols-2 gap-12 mobile:grid-cols-1">
-          <NuxtLink
+          <div
             v-for="entry in productEntries"
             :key="entry.key"
-            :to="{ name: 'explore-market', params: { market: entry.key }, query: { network: route.query.network } }"
-            class="rounded-12 border border-line-default bg-surface p-16 shadow-card transition-all hover:border-line-emphasis hover:shadow-card-hover"
+            class="rounded-12 border border-line-default bg-surface p-16 shadow-card"
           >
-            <p class="text-p2 text-content-primary">
-              {{ entry.product.name }}
-            </p>
-            <p
-              v-if="entry.product.description"
-              class="mt-4 line-clamp-2 text-p3 text-content-tertiary"
+            <div class="flex items-start gap-10">
+              <BaseAvatar
+                v-if="entry.product.logo"
+                :label="entry.product.name"
+                :src="getEulerLabelEntityLogo(entry.product.logo)"
+                class="!h-32 !w-32 shrink-0"
+              />
+              <div class="min-w-0 flex-1">
+                <NuxtLink
+                  :to="{ name: 'explore-market', params: { market: entry.key }, query: { network: route.query.network } }"
+                  class="text-p2 text-content-primary hover:text-accent-600"
+                >
+                  {{ entry.product.name }}
+                </NuxtLink>
+                <p
+                  v-if="entry.product.description"
+                  class="mt-4 line-clamp-2 text-p3 text-content-tertiary"
+                >
+                  {{ entry.product.description }}
+                </p>
+              </div>
+            </div>
+            <div
+              v-if="entry.product.tags?.length || entry.product.url"
+              class="mt-12 flex flex-wrap gap-6"
             >
-              {{ entry.product.description }}
-            </p>
-          </NuxtLink>
+              <span
+                v-for="tag in entry.product.tags"
+                :key="tag"
+                class="rounded-8 bg-surface-secondary px-8 py-4 text-p4 text-content-secondary"
+              >
+                {{ tag }}
+              </span>
+              <a
+                v-if="entry.product.url"
+                :href="getManagerProfileExternalUrl(entry.product.url)"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="rounded-8 bg-surface-secondary px-8 py-4 text-p4 text-accent-600 hover:text-accent-500"
+              >
+                Website
+              </a>
+            </div>
+          </div>
         </div>
       </section>
 

--- a/pages/managers/[slug].vue
+++ b/pages/managers/[slug].vue
@@ -94,11 +94,11 @@ const socialLinks = computed(() => entity.value ? getManagerProfileSocialLinks(e
                 rel="noopener noreferrer"
                 class="inline-flex items-center gap-6 rounded-8 border border-line-default bg-surface-elevated px-12 py-8 text-p3 text-content-primary hover:border-line-emphasis hover:text-accent-600 transition-colors"
               >
+                {{ link.label }}
                 <UiIcon
-                  name="globe"
+                  name="arrow-top-right"
                   class="!h-16 !w-16"
                 />
-                {{ link.label }}
               </a>
             </div>
           </div>

--- a/pages/managers/[slug].vue
+++ b/pages/managers/[slug].vue
@@ -53,7 +53,7 @@ const socialLinks = computed(() => entity.value ? getManagerProfileSocialLinks(e
     <template v-else>
       <section class="relative flex flex-col gap-24 border-b border-line-subtle pb-24">
         <BackButton
-          class="hidden tablet:inline-flex tablet:absolute tablet:top-8 tablet:right-full tablet:mr-12"
+          class="hidden tablet:inline-flex tablet:absolute tablet:top-20 tablet:right-full tablet:mr-12"
           fallback="/explore"
         />
         <div class="flex items-start gap-16 mobile:flex-col">

--- a/pages/managers/[slug].vue
+++ b/pages/managers/[slug].vue
@@ -85,7 +85,7 @@ const socialLinks = computed(() => entity.value ? getManagerProfileSocialLinks(e
           </div>
         </div>
 
-        <div class="grid grid-cols-3 gap-12 mobile:grid-cols-1">
+        <div class="grid grid-cols-2 gap-12 mobile:grid-cols-1">
           <div class="rounded-8 border border-line-subtle bg-surface-secondary p-16">
             <p class="text-p4 uppercase text-content-tertiary">
               Products
@@ -100,14 +100,6 @@ const socialLinks = computed(() => entity.value ? getManagerProfileSocialLinks(e
             </p>
             <p class="mt-4 text-h3 text-content-primary">
               {{ managedMarkets.length }}
-            </p>
-          </div>
-          <div class="rounded-8 border border-line-subtle bg-surface-secondary p-16">
-            <p class="text-p4 uppercase text-content-tertiary">
-              Links
-            </p>
-            <p class="mt-4 text-h3 text-content-primary">
-              {{ socialLinks.length }}
             </p>
           </div>
         </div>

--- a/pages/managers/[slug].vue
+++ b/pages/managers/[slug].vue
@@ -51,10 +51,14 @@ const socialLinks = computed(() => entity.value ? getManagerProfileSocialLinks(e
     </div>
 
     <template v-else>
-      <section class="flex flex-col gap-24 border-b border-line-subtle pb-24">
+      <section class="relative flex flex-col gap-24 border-b border-line-subtle pb-24">
+        <BackButton
+          class="hidden tablet:inline-flex tablet:absolute tablet:top-8 tablet:right-full tablet:mr-12"
+          fallback="/explore"
+        />
         <div class="flex items-start gap-16 mobile:flex-col">
           <BackButton
-            class="mt-8 mobile:mt-0"
+            class="tablet:hidden"
             fallback="/explore"
           />
           <BaseAvatar

--- a/pages/managers/[slug].vue
+++ b/pages/managers/[slug].vue
@@ -1,0 +1,223 @@
+<script setup lang="ts">
+import { autoLink } from '~/utils/autoLink'
+import { getEulerLabelEntityLogo } from '~/entities/euler/labels'
+
+defineOptions({
+  name: 'ManagerProfilePage',
+})
+
+const route = useRoute()
+const slug = computed(() => route.params.slug as string)
+const {
+  entity,
+  productEntries,
+  evaults,
+  securitizeVaults,
+  earnVaults,
+  vaultCount,
+  isLoading,
+} = useEulerManagerProfile(slug)
+
+const socialLinks = computed(() => {
+  if (!entity.value) return []
+  const social = entity.value.social
+  return [
+    entity.value.url ? { label: 'Website', url: entity.value.url } : null,
+    social.twitter ? { label: 'X', url: social.twitter } : null,
+    social.github ? { label: 'GitHub', url: social.github } : null,
+    social.discord ? { label: 'Discord', url: social.discord } : null,
+    social.telegram ? { label: 'Telegram', url: social.telegram } : null,
+    social.youtube ? { label: 'YouTube', url: social.youtube } : null,
+  ].filter(Boolean) as { label: string, url: string }[]
+})
+
+const hasVaults = computed(() =>
+  evaults.value.length > 0 || securitizeVaults.value.length > 0 || earnVaults.value.length > 0,
+)
+</script>
+
+<template>
+  <section class="flex flex-col gap-24">
+    <div
+      v-if="isLoading"
+      class="flex min-h-[calc(100dvh-178px)] items-center justify-center"
+    >
+      <UiLoader />
+    </div>
+
+    <div
+      v-else-if="!entity"
+      class="flex min-h-[calc(100dvh-178px)] flex-col items-center justify-center gap-12 text-content-tertiary"
+    >
+      <UiIcon
+        name="search"
+        class="!w-24 !h-24"
+      />
+      <p class="text-center max-w-[280px]">
+        Manager not found on this network.
+      </p>
+      <NuxtLink
+        to="/explore"
+        class="text-p3 text-accent-600 underline"
+      >
+        Browse all markets
+      </NuxtLink>
+    </div>
+
+    <template v-else>
+      <div class="flex items-center gap-12">
+        <BackButton fallback="/explore" />
+        <p class="text-p3 text-content-tertiary">
+          Manager profile
+        </p>
+      </div>
+
+      <section class="flex flex-col gap-24 border-b border-line-subtle pb-24">
+        <div class="flex items-start gap-20 mobile:flex-col">
+          <BaseAvatar
+            :label="entity.name"
+            :src="getEulerLabelEntityLogo(entity.logo)"
+            class="!h-72 !w-72"
+          />
+          <div class="min-w-0 flex-1">
+            <h1 class="text-h2 text-content-primary mobile:text-h3">
+              {{ entity.name }}
+            </h1>
+            <!-- eslint-disable vue/no-v-html -- trusted label content -->
+            <p
+              v-if="entity.description"
+              class="mt-8 max-w-[760px] text-p2 text-content-secondary auto-link"
+              v-html="autoLink(entity.description)"
+            />
+            <!-- eslint-enable vue/no-v-html -->
+            <p
+              v-else
+              class="mt-8 max-w-[760px] text-p2 text-content-tertiary"
+            >
+              No profile description is available yet.
+            </p>
+          </div>
+        </div>
+
+        <div class="grid grid-cols-3 gap-12 mobile:grid-cols-1">
+          <div class="rounded-8 border border-line-subtle bg-surface-secondary p-16">
+            <p class="text-p4 uppercase text-content-tertiary">
+              Products
+            </p>
+            <p class="mt-4 text-h3 text-content-primary">
+              {{ productEntries.length }}
+            </p>
+          </div>
+          <div class="rounded-8 border border-line-subtle bg-surface-secondary p-16">
+            <p class="text-p4 uppercase text-content-tertiary">
+              Vaults
+            </p>
+            <p class="mt-4 text-h3 text-content-primary">
+              {{ vaultCount }}
+            </p>
+          </div>
+          <div class="rounded-8 border border-line-subtle bg-surface-secondary p-16">
+            <p class="text-p4 uppercase text-content-tertiary">
+              Links
+            </p>
+            <p class="mt-4 text-h3 text-content-primary">
+              {{ socialLinks.length }}
+            </p>
+          </div>
+        </div>
+
+        <div
+          v-if="socialLinks.length"
+          class="flex flex-wrap gap-8"
+        >
+          <a
+            v-for="link in socialLinks"
+            :key="link.label"
+            :href="link.url"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="inline-flex items-center gap-6 rounded-8 border border-line-default bg-surface-elevated px-12 py-8 text-p3 text-content-primary hover:border-line-emphasis hover:text-accent-600 transition-colors"
+          >
+            <UiIcon
+              name="globe"
+              class="!h-16 !w-16"
+            />
+            {{ link.label }}
+          </a>
+        </div>
+      </section>
+
+      <section
+        v-if="productEntries.length"
+        class="flex flex-col gap-12"
+      >
+        <div class="flex items-center justify-between gap-12">
+          <h2 class="text-h3 text-content-primary">
+            Products managed
+          </h2>
+        </div>
+        <div class="grid grid-cols-2 gap-12 mobile:grid-cols-1">
+          <NuxtLink
+            v-for="entry in productEntries"
+            :key="entry.key"
+            :to="{ name: 'explore-market', params: { market: entry.key }, query: { network: route.query.network } }"
+            class="rounded-12 border border-line-default bg-surface p-16 shadow-card transition-all hover:border-line-emphasis hover:shadow-card-hover"
+          >
+            <p class="text-p2 text-content-primary">
+              {{ entry.product.name }}
+            </p>
+            <p
+              v-if="entry.product.description"
+              class="mt-4 line-clamp-2 text-p3 text-content-tertiary"
+            >
+              {{ entry.product.description }}
+            </p>
+          </NuxtLink>
+        </div>
+      </section>
+
+      <section class="flex flex-col gap-12">
+        <h2 class="text-h3 text-content-primary">
+          Vaults managed
+        </h2>
+        <div
+          v-if="!hasVaults"
+          class="rounded-12 border border-line-default bg-surface p-24 text-p2 text-content-tertiary"
+        >
+          No managed vaults are currently available on this network.
+        </div>
+        <div
+          v-if="evaults.length || securitizeVaults.length"
+          class="flex flex-col gap-12"
+        >
+          <h3 class="text-p3 uppercase text-content-tertiary">
+            Lending vaults
+          </h3>
+          <VaultItem
+            v-for="vault in evaults"
+            :key="vault.address"
+            :vault="vault"
+          />
+          <SecuritizeVaultItem
+            v-for="vault in securitizeVaults"
+            :key="vault.address"
+            :vault="vault"
+          />
+        </div>
+        <div
+          v-if="earnVaults.length"
+          class="flex flex-col gap-12"
+        >
+          <h3 class="text-p3 uppercase text-content-tertiary">
+            Earn vaults
+          </h3>
+          <VaultEarnItem
+            v-for="vault in earnVaults"
+            :key="vault.address"
+            :vault="vault"
+          />
+        </div>
+      </section>
+    </template>
+  </section>
+</template>

--- a/tests/utils/manager-profile.test.ts
+++ b/tests/utils/manager-profile.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import type { EulerLabelEntity, EulerLabelProduct } from '~/entities/euler/labels'
+import {
+  getEulerLabelEntityDisplayName,
+  getEulerLabelEntityKeys,
+  getEulerLabelEntitySlug,
+  getManagerProfilePath,
+  isEulerLabelProductManagedBy,
+} from '~/utils/manager-profile'
+
+const entity = (name: string, logo = `${name}.svg`): EulerLabelEntity => ({
+  name,
+  logo,
+  description: '',
+  url: `https://${name.toLowerCase()}.example`,
+  addresses: {},
+  social: {
+    twitter: '',
+    youtube: '',
+    discord: '',
+    telegram: '',
+    github: '',
+  },
+})
+
+describe('manager profile helpers', () => {
+  it('normalizes product entity keys', () => {
+    expect(getEulerLabelEntityKeys({ entity: 'k3' } as EulerLabelProduct)).toEqual(['k3'])
+    expect(getEulerLabelEntityKeys({ entity: ['k3', 're7'] } as EulerLabelProduct)).toEqual(['k3', 're7'])
+    expect(getEulerLabelEntityKeys({ entity: '' } as EulerLabelProduct)).toEqual([])
+  })
+
+  it('detects products managed by a slug', () => {
+    const product = { entity: ['k3', 're7'] } as EulerLabelProduct
+
+    expect(isEulerLabelProductManagedBy(product, 're7')).toBe(true)
+    expect(isEulerLabelProductManagedBy(product, 'mev-capital')).toBe(false)
+  })
+
+  it('resolves an entity slug by reference or stable fields', () => {
+    const k3 = entity('K3')
+    const entities = { k3, re7: entity('Re7') }
+
+    expect(getEulerLabelEntitySlug(entities, k3)).toBe('k3')
+    expect(getEulerLabelEntitySlug(entities, { ...k3 })).toBe('k3')
+  })
+
+  it('formats compact manager labels', () => {
+    expect(getEulerLabelEntityDisplayName([])).toBe('')
+    expect(getEulerLabelEntityDisplayName([entity('K3')])).toBe('K3')
+    expect(getEulerLabelEntityDisplayName([entity('K3'), entity('Re7')])).toBe('K3 & Re7')
+    expect(getEulerLabelEntityDisplayName([entity('K3'), entity('Re7'), entity('MEV Capital')])).toBe('K3 & others')
+  })
+
+  it('builds manager profile paths', () => {
+    expect(getManagerProfilePath('mev-capital')).toBe('/managers/mev-capital')
+  })
+})

--- a/tests/utils/manager-profile.test.ts
+++ b/tests/utils/manager-profile.test.ts
@@ -4,12 +4,10 @@ import {
   getEulerLabelEntityDisplayName,
   getEulerLabelEntityKeys,
   getEulerLabelEntitySlug,
-  getManagerProfileAddressEntries,
   getManagerProfileExternalUrl,
   getManagerProfilePath,
   getManagerProfileSocialLinks,
   getManagerProfileSocialUrl,
-  getShortAddress,
   isEulerLabelProductManagedBy,
 } from '~/utils/manager-profile'
 
@@ -79,31 +77,13 @@ describe('manager profile helpers', () => {
         discord: '',
         telegram: '',
         github: 'k3-capital',
+        legal: 'legal.k3.capital',
       },
     })).toEqual([
       { label: 'Website', url: 'https://k3.capital' },
       { label: 'X', url: 'https://x.com/k3_capital' },
       { label: 'GitHub', url: 'https://github.com/k3-capital' },
+      { label: 'Legal', url: 'https://legal.k3.capital' },
     ])
-  })
-
-  it('formats manager governance address entries', () => {
-    expect(getManagerProfileAddressEntries({
-      ...entity('K3'),
-      addresses: {
-        '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb': 'Timelock',
-        '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa': 'Multisig',
-      },
-    })).toEqual([
-      {
-        address: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-        label: 'Multisig',
-      },
-      {
-        address: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
-        label: 'Timelock',
-      },
-    ])
-    expect(getShortAddress('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')).toBe('0xaaaa...aaaa')
   })
 })

--- a/tests/utils/manager-profile.test.ts
+++ b/tests/utils/manager-profile.test.ts
@@ -4,7 +4,12 @@ import {
   getEulerLabelEntityDisplayName,
   getEulerLabelEntityKeys,
   getEulerLabelEntitySlug,
+  getManagerProfileAddressEntries,
+  getManagerProfileExternalUrl,
   getManagerProfilePath,
+  getManagerProfileSocialLinks,
+  getManagerProfileSocialUrl,
+  getShortAddress,
   isEulerLabelProductManagedBy,
 } from '~/utils/manager-profile'
 
@@ -54,5 +59,51 @@ describe('manager profile helpers', () => {
 
   it('builds manager profile paths', () => {
     expect(getManagerProfilePath('mev-capital')).toBe('/managers/mev-capital')
+  })
+
+  it('normalizes manager social handles into external URLs', () => {
+    expect(getManagerProfileSocialUrl('twitter', '@k3_capital')).toBe('https://x.com/k3_capital')
+    expect(getManagerProfileSocialUrl('github', 'euler-xyz')).toBe('https://github.com/euler-xyz')
+    expect(getManagerProfileSocialUrl('telegram', 'https://t.me/UsualCommunity')).toBe('https://t.me/UsualCommunity')
+    expect(getManagerProfileSocialUrl('discord', 'hhttps://discord.usual.money/')).toBe('https://discord.usual.money/')
+    expect(getManagerProfileExternalUrl('example.com')).toBe('https://example.com')
+  })
+
+  it('builds social links from entity metadata', () => {
+    expect(getManagerProfileSocialLinks({
+      ...entity('K3'),
+      url: 'k3.capital',
+      social: {
+        twitter: 'k3_capital',
+        youtube: '',
+        discord: '',
+        telegram: '',
+        github: 'k3-capital',
+      },
+    })).toEqual([
+      { label: 'Website', url: 'https://k3.capital' },
+      { label: 'X', url: 'https://x.com/k3_capital' },
+      { label: 'GitHub', url: 'https://github.com/k3-capital' },
+    ])
+  })
+
+  it('formats manager governance address entries', () => {
+    expect(getManagerProfileAddressEntries({
+      ...entity('K3'),
+      addresses: {
+        '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb': 'Timelock',
+        '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa': 'Multisig',
+      },
+    })).toEqual([
+      {
+        address: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        label: 'Multisig',
+      },
+      {
+        address: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        label: 'Timelock',
+      },
+    ])
+    expect(getShortAddress('0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')).toBe('0xaaaa...aaaa')
   })
 })

--- a/utils/manager-profile.ts
+++ b/utils/manager-profile.ts
@@ -1,5 +1,88 @@
 import type { EulerLabelEntity, EulerLabelProduct } from '~/entities/euler/labels'
 
+export type ManagerProfileExternalLink = {
+  label: string
+  url: string
+}
+
+export type ManagerProfileAddressEntry = {
+  address: string
+  label: string
+}
+
+const withProtocol = (url: string): string => {
+  if (url.startsWith('hhttps://')) return `https://${url.slice('hhttps://'.length)}`
+  if (/^https?:\/\//i.test(url)) return url
+  return `https://${url}`
+}
+
+const cleanHandle = (value: string): string => value.trim().replace(/^@+/, '').replace(/^\/+/, '')
+
+export const getManagerProfileExternalUrl = (url: string): string => withProtocol(url.trim())
+
+export const getManagerProfileSocialUrl = (platform: string, value: string): string => {
+  const normalized = value.trim()
+  if (!normalized) return ''
+  if (/^h?https?:\/\//i.test(normalized)) return withProtocol(normalized)
+
+  const handle = cleanHandle(normalized)
+  if (!handle) return ''
+
+  switch (platform) {
+    case 'twitter':
+      return `https://x.com/${handle}`
+    case 'github':
+      return `https://github.com/${handle}`
+    case 'discord':
+      return `https://discord.gg/${handle}`
+    case 'telegram':
+      return `https://t.me/${handle}`
+    case 'youtube':
+      return `https://youtube.com/@${handle}`
+    default:
+      return withProtocol(handle)
+  }
+}
+
+export const getManagerProfileSocialLinks = (
+  entity: EulerLabelEntity,
+): ManagerProfileExternalLink[] => {
+  const social = (entity.social ?? {}) as Partial<EulerLabelEntity['social']>
+  const links: Array<ManagerProfileExternalLink | null> = [
+    entity.url ? { label: 'Website', url: withProtocol(entity.url) } : null,
+    social.twitter
+      ? { label: 'X', url: getManagerProfileSocialUrl('twitter', social.twitter) }
+      : null,
+    social.github
+      ? { label: 'GitHub', url: getManagerProfileSocialUrl('github', social.github) }
+      : null,
+    social.discord
+      ? { label: 'Discord', url: getManagerProfileSocialUrl('discord', social.discord) }
+      : null,
+    social.telegram
+      ? { label: 'Telegram', url: getManagerProfileSocialUrl('telegram', social.telegram) }
+      : null,
+    social.youtube
+      ? { label: 'YouTube', url: getManagerProfileSocialUrl('youtube', social.youtube) }
+      : null,
+  ]
+
+  return links.filter((link): link is ManagerProfileExternalLink => Boolean(link?.url))
+}
+
+export const getManagerProfileAddressEntries = (
+  entity: EulerLabelEntity,
+): ManagerProfileAddressEntry[] =>
+  Object.entries(entity.addresses)
+    .map(([address, label]) => ({
+      address,
+      label: label || 'Manager address',
+    }))
+    .sort((a, b) => a.label.localeCompare(b.label) || a.address.localeCompare(b.address))
+
+export const getShortAddress = (address: string): string =>
+  `${address.slice(0, 6)}...${address.slice(-4)}`
+
 export const getEulerLabelEntityKeys = (product: EulerLabelProduct): string[] => {
   if (Array.isArray(product.entity)) return product.entity
   return product.entity ? [product.entity] : []

--- a/utils/manager-profile.ts
+++ b/utils/manager-profile.ts
@@ -1,0 +1,33 @@
+import type { EulerLabelEntity, EulerLabelProduct } from '~/entities/euler/labels'
+
+export const getEulerLabelEntityKeys = (product: EulerLabelProduct): string[] => {
+  if (Array.isArray(product.entity)) return product.entity
+  return product.entity ? [product.entity] : []
+}
+
+export const isEulerLabelProductManagedBy = (product: EulerLabelProduct, slug: string): boolean =>
+  getEulerLabelEntityKeys(product).includes(slug)
+
+export const getEulerLabelEntitySlug = (
+  entities: Record<string, EulerLabelEntity>,
+  entity: EulerLabelEntity,
+): string => {
+  const exact = Object.entries(entities).find(([, value]) => value === entity)
+  if (exact) return exact[0]
+
+  const byStableFields = Object.entries(entities).find(([, value]) =>
+    value.name === entity.name
+    && value.logo === entity.logo
+    && value.url === entity.url,
+  )
+  return byStableFields?.[0] ?? ''
+}
+
+export const getEulerLabelEntityDisplayName = (entities: EulerLabelEntity[]): string => {
+  if (entities.length === 0) return ''
+  if (entities.length === 1) return entities[0].name
+  if (entities.length === 2) return `${entities[0].name} & ${entities[1].name}`
+  return `${entities[0].name} & others`
+}
+
+export const getManagerProfilePath = (slug: string): string => `/managers/${slug}`

--- a/utils/manager-profile.ts
+++ b/utils/manager-profile.ts
@@ -5,11 +5,6 @@ export type ManagerProfileExternalLink = {
   url: string
 }
 
-export type ManagerProfileAddressEntry = {
-  address: string
-  label: string
-}
-
 const withProtocol = (url: string): string => {
   if (url.startsWith('hhttps://')) return `https://${url.slice('hhttps://'.length)}`
   if (/^https?:\/\//i.test(url)) return url
@@ -19,6 +14,21 @@ const withProtocol = (url: string): string => {
 const cleanHandle = (value: string): string => value.trim().replace(/^@+/, '').replace(/^\/+/, '')
 
 export const getManagerProfileExternalUrl = (url: string): string => withProtocol(url.trim())
+
+const SOCIAL_LINK_LABELS: Record<string, string> = {
+  twitter: 'X',
+  github: 'GitHub',
+  discord: 'Discord',
+  telegram: 'Telegram',
+  youtube: 'YouTube',
+}
+
+const getSocialLinkLabel = (platform: string): string =>
+  SOCIAL_LINK_LABELS[platform] ?? platform
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ')
 
 export const getManagerProfileSocialUrl = (platform: string, value: string): string => {
   const normalized = value.trim()
@@ -47,41 +57,27 @@ export const getManagerProfileSocialUrl = (platform: string, value: string): str
 export const getManagerProfileSocialLinks = (
   entity: EulerLabelEntity,
 ): ManagerProfileExternalLink[] => {
-  const social = (entity.social ?? {}) as Partial<EulerLabelEntity['social']>
-  const links: Array<ManagerProfileExternalLink | null> = [
+  const social = entity.social ?? {}
+  const links: ManagerProfileExternalLink[] = ([
     entity.url ? { label: 'Website', url: withProtocol(entity.url) } : null,
-    social.twitter
-      ? { label: 'X', url: getManagerProfileSocialUrl('twitter', social.twitter) }
-      : null,
-    social.github
-      ? { label: 'GitHub', url: getManagerProfileSocialUrl('github', social.github) }
-      : null,
-    social.discord
-      ? { label: 'Discord', url: getManagerProfileSocialUrl('discord', social.discord) }
-      : null,
-    social.telegram
-      ? { label: 'Telegram', url: getManagerProfileSocialUrl('telegram', social.telegram) }
-      : null,
-    social.youtube
-      ? { label: 'YouTube', url: getManagerProfileSocialUrl('youtube', social.youtube) }
-      : null,
-  ]
+    ...Object.entries(social).map(([platform, value]) =>
+      value
+        ? {
+            label: getSocialLinkLabel(platform),
+            url: getManagerProfileSocialUrl(platform, value),
+          }
+        : null,
+    ),
+  ] as Array<ManagerProfileExternalLink | null>).filter((link): link is ManagerProfileExternalLink => Boolean(link?.url))
 
-  return links.filter((link): link is ManagerProfileExternalLink => Boolean(link?.url))
+  const seen = new Set<string>()
+  return links.filter((link) => {
+    const key = `${link.label}:${link.url}`
+    if (seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
 }
-
-export const getManagerProfileAddressEntries = (
-  entity: EulerLabelEntity,
-): ManagerProfileAddressEntry[] =>
-  Object.entries(entity.addresses)
-    .map(([address, label]) => ({
-      address,
-      label: label || 'Manager address',
-    }))
-    .sort((a, b) => a.label.localeCompare(b.label) || a.address.localeCompare(b.address))
-
-export const getShortAddress = (address: string): string =>
-  `${address.slice(0, 6)}...${address.slice(-4)}`
 
 export const getEulerLabelEntityKeys = (product: EulerLabelProduct): string[] => {
   if (Array.isArray(product.entity)) return product.entity


### PR DESCRIPTION
## Summary
- Add dedicated manager profile pages for curator and risk-manager entities.
- Link unambiguous manager displays from vault surfaces to an app-native profile destination.

## Changes
- Adds a /managers/[slug] route with entity details, social links, current-network managed markets, and Earn vaults.
- Adds shared manager-profile helpers and a reusable manager entity link component.
- Keeps multi-manager labels as plain text so ambiguous displays do not route to a single profile.
- Preserves keyboard access for manager links rendered inside clickable vault cards.
- Waits for labels, market groups, TVL, and Earn vault loading before showing empty results.

## Test plan
- [x] npm run test:run -- tests/utils/manager-profile.test.ts (7 tests)
- [x] Run focused ESLint across the 13 changed files
- [x] npm run typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added manager profile pages with descriptions, social links, managed markets, and Earn vaults.
  * Added reusable manager entity links with optional avatars and profile navigation.
  * Improved risk manager and capital allocator displays across vault views.
  * Added support for product logos and flexible social profile metadata.

* **Bug Fixes**
  * Standardized manager names, links, and external URL handling across the application.

* **Tests**
  * Added coverage for manager identification, profile paths, names, and social links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->