### PR TITLE
fix: gate Max multiplier matrix by correlation

### DIFF
--- a/components/entities/vault/discovery/DiscoveryMarketAccordion.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketAccordion.vue
@@ -417,6 +417,7 @@ const hasSelection = (market: MarketGroup): boolean => {
 }
 
 const maxRoeMatrixNotice = 'Max ROE only shown for correlated pairs.'
+const maxMultiplierMatrixNotice = 'Max multiplier only shown for correlated pairs.'
 
 // -- Global event handlers --
 
@@ -619,6 +620,14 @@ onMounted(() => {
               :data-key="market.id"
             >
               {{ maxRoeMatrixNotice }}
+            </p>
+            <p
+              v-if="getExpandedView(market.id) === 'matrix' && getMatrixView(market.id) === 'multiplier'"
+              class="px-16 pb-8 text-center text-p3 text-content-tertiary"
+              data-id="discovery-max-multiplier-correlation-notice"
+              :data-key="market.id"
+            >
+              {{ maxMultiplierMatrixNotice }}
             </p>
 
             <!-- Graph View -->

--- a/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
@@ -52,6 +52,7 @@ const hoveredCell = ref<{
 } | null>(null)
 
 const unavailableRoeCellLabel = 'Max ROE is unavailable for uncorrelated pairs. Compare Net APY instead.'
+const unavailableMultiplierCellLabel = 'Max multiplier is unavailable for uncorrelated pairs.'
 
 // Row/column highlighting helpers — make it easy to scan a cell back to its
 // row label and column header. A row is "highlighted" when it owns either
@@ -132,7 +133,7 @@ const getCellMetricValue = (
     case 'lltv':
       return Number(ltvToPercent(cell.ltv.currentLiquidationLTV))
     case 'multiplier':
-      return getMaxMultiplier(cell.ltv.borrowLTV)
+      return isCorrelatedCell(collateralAddr, liabilityAddr) ? getMaxMultiplier(cell.ltv.borrowLTV) : Number.NaN
     case 'net-apy':
       return computeEnhancedApys(cell, collateralAddr, liabilityAddr).netApy
     case 'roe': {
@@ -151,6 +152,28 @@ const isUnavailableRoeCell = (
   props.dotMetric === 'roe'
   && !!props.matrix.cells.get(collateralAddr)?.get(liabilityAddr)
   && !isCorrelatedCell(collateralAddr, liabilityAddr)
+
+const isUnavailableMultiplierCell = (
+  collateralAddr: string,
+  liabilityAddr: string,
+): boolean =>
+  props.dotMetric === 'multiplier'
+  && !!props.matrix.cells.get(collateralAddr)?.get(liabilityAddr)
+  && !isCorrelatedCell(collateralAddr, liabilityAddr)
+
+const getUnavailableMetricLabel = (
+  collateralAddr: string,
+  liabilityAddr: string,
+): string | undefined => {
+  if (isUnavailableRoeCell(collateralAddr, liabilityAddr)) return unavailableRoeCellLabel
+  if (isUnavailableMultiplierCell(collateralAddr, liabilityAddr)) return unavailableMultiplierCellLabel
+  return undefined
+}
+
+const isUnavailableMetricCell = (
+  collateralAddr: string,
+  liabilityAddr: string,
+): boolean => getUnavailableMetricLabel(collateralAddr, liabilityAddr) !== undefined
 
 const shouldShowSparkles = (
   collateralAddr: string,
@@ -570,8 +593,8 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
               :data-field="dotMetric"
               :data-present="!!matrix.cells.get(row.address)?.get(col.address)"
               :data-correlated="matrix.cells.get(row.address)?.get(col.address) ? isCorrelatedCell(row.address, col.address) : undefined"
-              :title="isUnavailableRoeCell(row.address, col.address) ? unavailableRoeCellLabel : undefined"
-              :aria-label="isUnavailableRoeCell(row.address, col.address) ? unavailableRoeCellLabel : undefined"
+              :title="getUnavailableMetricLabel(row.address, col.address)"
+              :aria-label="getUnavailableMetricLabel(row.address, col.address)"
               :data-value="
                 (() => {
                   const cell = matrix.cells.get(row.address)?.get(col.address);
@@ -741,7 +764,7 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
                     class="!w-10 !h-10 text-accent-500 shrink-0"
                   />
                   <span
-                    v-if="isUnavailableRoeCell(row.address, col.address)"
+                    v-if="isUnavailableMetricCell(row.address, col.address)"
                     class="text-p5 whitespace-nowrap text-content-muted"
                   >
                     -


### PR DESCRIPTION
## Summary
- Applies the correlated-pair treatment from Max ROE to the Explore matrix Max multiplier view.
- Makes uncorrelated Max multiplier cells unavailable instead of rendering leverage values for pairs that should not be treated as multiply opportunities.

## Changes
- Adds a Max multiplier matrix notice matching the existing Max ROE correlation notice.
- Gates multiplier cell values behind the same asset-correlation check used by Max ROE.
- Shares unavailable-cell title and aria-label handling across Max ROE and Max multiplier.

## Test plan
- [x] Ran npm ci in the new worktree to generate Nuxt files and dependencies.
- [x] Ran npx eslint components/entities/vault/discovery/DiscoveryMarketAccordion.vue components/entities/vault/discovery/DiscoveryMarketMatrix.vue.
- [x] Ran git diff --check.
- [ ] Manually expand an Explore market, switch to Matrix, select Multiplier, and confirm uncorrelated cells show as unavailable with the notice above the matrix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Matrix view now marks **multiplier** as unavailable for uncorrelated token pairs, matching the existing behavior for ROE.
  * Unavailable cells now show clearer labels and accessibility text, improving consistency across the table.
  * Added a new notice explaining that **Max multiplier** is only shown for correlated pairs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->