### PR TITLE
feat: add PT filter category

### DIFF
--- a/composables/useTokenList.ts
+++ b/composables/useTokenList.ts
@@ -158,8 +158,10 @@ const getTokenByAddress = (address: string): TokenListEntry | undefined => {
   }
 }
 
-const getTokenCategoryTags = (address: string): string[] =>
-  normalizeTokenCategoryTags(getTokenByAddress(address)?.tags)
+const getTokenCategoryTags = (address: string): string[] => {
+  const token = getTokenByAddress(address)
+  return normalizeTokenCategoryTags(token?.tags)
+}
 
 const getAllTokens = (): TokenListEntry[] => {
   return [...tokenMap.value.values()]

--- a/tests/utils/token-categories.test.ts
+++ b/tests/utils/token-categories.test.ts
@@ -27,6 +27,7 @@ describe('token category helpers', () => {
     expect(shareTokenCategory(['hype'], ['HYPE'])).toBe(true)
     expect(shareTokenCategory(['bnb'], ['BNB'])).toBe(true)
     expect(getSharedTokenCategory([['usd'], ['USD']])).toBe('usd')
+    expect(shareTokenCategory(['pt'], ['PT'])).toBe(false)
     expect(shareTokenCategory(['other'], ['other'])).toBe(false)
     expect(shareTokenCategory(['stablecoin'], ['stablecoin'])).toBe(false)
     expect(shareTokenCategory(['usd'], ['eth'])).toBe(false)
@@ -42,9 +43,11 @@ describe('token category helpers', () => {
       { tag: 'avax', label: 'AVAX' },
       { tag: 'hype', label: 'HYPE' },
       { tag: 'bnb', label: 'BNB' },
+      { tag: 'pt', label: 'PT' },
     ])
     expect(toTokenCategoryFilterValue(' USD ')).toBe('category:usd')
     expect(fromTokenCategoryFilterValue('category:usd')).toBe('usd')
+    expect(fromTokenCategoryFilterValue('category:pt')).toBe('pt')
     expect(fromTokenCategoryFilterValue('category:stablecoin')).toBeNull()
     expect(fromTokenCategoryFilterValue('0x0000000000000000000000000000000000000001')).toBeNull()
   })
@@ -54,6 +57,7 @@ describe('token category helpers', () => {
       ['0x0000000000000000000000000000000000000001', ['usd']],
       ['0x0000000000000000000000000000000000000002', ['eth']],
       ['0x0000000000000000000000000000000000000003', ['other']],
+      ['0x0000000000000000000000000000000000000004', ['pt']],
     ])
     const getTags = (address: string) => tags.get(address.toLowerCase())
 
@@ -78,6 +82,13 @@ describe('token category helpers', () => {
         getTags,
       ),
     ).toBe(false)
+    expect(
+      tokenAddressMatchesCategoryFilter(
+        '0x0000000000000000000000000000000000000004',
+        'category:pt',
+        getTags,
+      ),
+    ).toBe(true)
   })
 
   it('requires one shared allowlisted category across a whole token set', () => {
@@ -102,6 +113,8 @@ describe('token category helpers', () => {
       ['0x000000000000000000000000000000000000000b', ['HYPE']],
       ['0x000000000000000000000000000000000000000c', ['bnb']],
       ['0x000000000000000000000000000000000000000d', ['BNB']],
+      ['0x000000000000000000000000000000000000000e', ['pt']],
+      ['0x000000000000000000000000000000000000000f', ['PT']],
     ])
     const getTags = (address: string) => tags.get(address.toLowerCase())
 
@@ -195,6 +208,22 @@ describe('token category helpers', () => {
         getTags,
       ),
     ).toBe('BNB')
+    expect(
+      areTokenAddressesCorrelatedByTags(
+        '0x000000000000000000000000000000000000000e',
+        '0x000000000000000000000000000000000000000f',
+        getTags,
+      ),
+    ).toBe(false)
+    expect(
+      getTokenAddressesCorrelationCategoryLabel(
+        [
+          '0x000000000000000000000000000000000000000e',
+          '0x000000000000000000000000000000000000000f',
+        ],
+        getTags,
+      ),
+    ).toBeUndefined()
   })
 
   it('treats an all-same address set as correlated even without category tags', () => {

--- a/utils/token-categories.ts
+++ b/utils/token-categories.ts
@@ -29,19 +29,29 @@ export const CORRELATED_CATEGORY_LABELS: Record<string, string> = {
   bnb: 'BNB',
 }
 
+export const FILTER_CATEGORY_LABELS: Record<string, string> = {
+  ...CORRELATED_CATEGORY_LABELS,
+  pt: 'PT',
+}
+
 const CORRELATED_CATEGORY_TAGS = new Set(Object.keys(CORRELATED_CATEGORY_LABELS))
+const FILTER_CATEGORY_TAGS = new Set(Object.keys(FILTER_CATEGORY_LABELS))
 const TOKEN_CATEGORY_FILTER_PREFIX = 'category:'
 
 const isCorrelatedCategory = (tag: string): boolean => CORRELATED_CATEGORY_TAGS.has(tag)
+const isFilterCategory = (tag: string): boolean => FILTER_CATEGORY_TAGS.has(tag)
 
 const correlatedCategories = (tags: TokenCategoryTagSource): string[] =>
   normalizeTokenCategoryTags(tags).filter(isCorrelatedCategory)
+
+const filterCategories = (tags: TokenCategoryTagSource): string[] =>
+  normalizeTokenCategoryTags(tags).filter(isFilterCategory)
 
 export const formatTokenCategoryLabel = (tag: string | null | undefined): string | undefined =>
   tag ? CORRELATED_CATEGORY_LABELS[tag.trim().toLowerCase()] : undefined
 
 export const getSupportedTokenCategoryOptions = (): { tag: string, label: string }[] =>
-  Object.entries(CORRELATED_CATEGORY_LABELS).map(([tag, label]) => ({ tag, label }))
+  Object.entries(FILTER_CATEGORY_LABELS).map(([tag, label]) => ({ tag, label }))
 
 export const toTokenCategoryFilterValue = (tag: string): string =>
   `${TOKEN_CATEGORY_FILTER_PREFIX}${tag.trim().toLowerCase()}`
@@ -50,7 +60,7 @@ export const fromTokenCategoryFilterValue = (value: string): string | null => {
   if (!value.startsWith(TOKEN_CATEGORY_FILTER_PREFIX)) return null
 
   const tag = value.slice(TOKEN_CATEGORY_FILTER_PREFIX.length).trim().toLowerCase()
-  return isCorrelatedCategory(tag) ? tag : null
+  return isFilterCategory(tag) ? tag : null
 }
 
 export const isTokenCategoryFilterValue = (value: string): boolean =>
@@ -65,7 +75,7 @@ export const tokenAddressMatchesCategoryFilter = (
   const normalized = normalizeComparableAddress(address)
   if (!category || !normalized) return false
 
-  return correlatedCategories(getTokenCategoryTags(normalized)).includes(category)
+  return filterCategories(getTokenCategoryTags(normalized)).includes(category)
 }
 
 export const shareTokenCategory = (


### PR DESCRIPTION
## Summary
- Add PT as an asset-filter category so assets tagged pt by V3 can appear under their own quick filter.
- Keep PT out of correlated category logic so PT-to-PT assets are not treated as correlated for multiplier or category-label behavior.
- Leave PT detection/tagging to the V3 token category backend rather than deriving it in Lite.

## Backend dependency
- Depends on https://github.com/euler-xyz/euler-data-v3/pull/210 for emitting `pt` token tags.

## Changes
- Split filter category labels from correlated category labels in the token category helper.
- Validate category filter values against the filter allowlist, including PT.
- Continue using the narrower correlated allowlist for pair correlation and correlation labels.
- Extend category tests to cover PT filter matching and non-correlation behavior.

## Test plan
- [x] npm run test:run -- tests/utils/token-categories.test.ts
- [x] npm run typecheck
- [x] npx eslint utils/token-categories.ts tests/utils/token-categories.test.ts composables/useTokenList.ts pages/borrow/index.vue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the new **PT** token category in filters and matching.
  * Token category filter options now include **PT** alongside existing categories.

* **Bug Fixes**
  * Improved category filtering so addresses are matched against the correct filter tags.
  * Updated token category correlation behavior to avoid treating **PT** as a shared correlation label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->