### PR TITLE
Add bad debt metrics to vault stats

### DIFF
--- a/components/entities/vault/discovery/DiscoveryMarketAccordion.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketAccordion.vue
@@ -35,7 +35,7 @@ const props = defineProps<{
 const { isMarketDataResolved } = useVaults()
 const route = useRoute()
 const { chainId } = useEulerAddresses()
-const { badDebtByChain, loadBadDebtForChain } = useVaultBadDebt()
+const { badDebtByChain, isBadDebtLoaded, loadBadDebtForChain } = useVaultBadDebt()
 const shareLinkQuery = computed(() => {
   const network = route.query.network
 
@@ -670,6 +670,7 @@ onMounted(() => {
               :usd-cache="vaultUsdCache"
               :apy-cache="vaultApyCache"
               :bad-debt-cache="vaultBadDebtCache"
+              :show-bad-debt-column="isBadDebtLoaded"
               :selected-header="selectedMatrixHeader?.marketId === market.id ? { address: selectedMatrixHeader.address, axis: selectedMatrixHeader.axis } : null"
               @select-header="(addr: string, axis: 'row' | 'column') => toggleMatrixHeader(market.id, addr, axis)"
             />

--- a/components/entities/vault/discovery/DiscoveryMarketAccordion.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketAccordion.vue
@@ -23,6 +23,7 @@ import {
   type VaultUsdCacheEntry,
   type VaultApyCacheEntry,
 } from '~/utils/discoveryCalculations'
+import type { VaultBadDebtCacheEntry } from '~/utils/vault-bad-debt'
 import type { MarketGroup } from '~/entities/lend-discovery'
 import { maxUint256 } from 'viem'
 
@@ -34,6 +35,7 @@ const props = defineProps<{
 const { isMarketDataResolved } = useVaults()
 const route = useRoute()
 const { chainId } = useEulerAddresses()
+const { badDebtByChain, loadBadDebtForChain } = useVaultBadDebt()
 const shareLinkQuery = computed(() => {
   const network = route.query.network
 
@@ -160,11 +162,15 @@ const loadExpandedVaultUsdValues = async () => {
 const onToggle = (market: MarketGroup) => {
   const wasExpanded = isExpanded(market.id)
   toggleExpand(market.id)
-  if (!wasExpanded) loadVaultUsdValues(market)
+  if (!wasExpanded) {
+    loadVaultUsdValues(market)
+    void loadBadDebtForChain()
+  }
 }
 
-watch([() => props.markets, isMarketDataResolved], () => {
+watch([() => props.markets, isMarketDataResolved, chainId], () => {
   void loadExpandedVaultUsdValues()
+  if (expandedMarkets.value.size > 0) void loadBadDebtForChain()
 })
 
 // -- Matrix view selector (single dropdown spans Stats, Configuration,
@@ -246,6 +252,10 @@ const vaultApyCache = computed<Map<string, VaultApyCacheEntry>>(() => {
     enableRewardsApy: enableRewardsApy.value,
   })
 })
+
+const vaultBadDebtCache = computed<Map<string, VaultBadDebtCacheEntry>>(() =>
+  badDebtByChain.value.get(chainId.value) ?? new Map(),
+)
 
 // -- Cell selection state (matrix view) --
 
@@ -435,6 +445,7 @@ onMounted(() => {
       loadVaultUsdValues(market)
     }
   }
+  if (expandedMarkets.value.size > 0) void loadBadDebtForChain()
 })
 </script>
 
@@ -658,6 +669,7 @@ onMounted(() => {
               :view="getMatrixView(market.id)"
               :usd-cache="vaultUsdCache"
               :apy-cache="vaultApyCache"
+              :bad-debt-cache="vaultBadDebtCache"
               :selected-header="selectedMatrixHeader?.marketId === market.id ? { address: selectedMatrixHeader.address, axis: selectedMatrixHeader.axis } : null"
               @select-header="(addr: string, axis: 'row' | 'column') => toggleMatrixHeader(market.id, addr, axis)"
             />

--- a/components/entities/vault/discovery/DiscoveryMarketAttributeMatrix.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketAttributeMatrix.vue
@@ -8,6 +8,7 @@ import {
   type VaultUsdCacheEntry,
   type VaultApyCacheEntry,
   buildAttributeRowCells,
+  filterAttributeRowsByBadDebtAvailability,
   isVaultType,
 } from '~/utils/discoveryCalculations'
 import type { VaultBadDebtCacheEntry } from '~/utils/vault-bad-debt'
@@ -21,6 +22,7 @@ const props = defineProps<{
   usdCache: Map<string, VaultUsdCacheEntry>
   apyCache: Map<string, VaultApyCacheEntry>
   badDebtCache: Map<string, VaultBadDebtCacheEntry>
+  showBadDebtColumn: boolean
   selectedHeader: { address: string, axis: 'row' | 'column' } | null
 }>()
 
@@ -37,7 +39,7 @@ interface AttributeColumn {
 }
 
 const attributeColumns = computed<AttributeColumn[]>(() =>
-  props.data.rows.map(attribute => ({
+  filterAttributeRowsByBadDebtAvailability(props.data.rows, props.showBadDebtColumn).map(attribute => ({
     attribute,
     cells: buildAttributeRowCells(attribute, props.data.columns, props.usdCache, props.apyCache, props.badDebtCache),
   })),

--- a/components/entities/vault/discovery/DiscoveryMarketAttributeMatrix.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketAttributeMatrix.vue
@@ -10,6 +10,7 @@ import {
   buildAttributeRowCells,
   isVaultType,
 } from '~/utils/discoveryCalculations'
+import type { VaultBadDebtCacheEntry } from '~/utils/vault-bad-debt'
 import { getEntitiesByVault } from '~/utils/eulerLabelsUtils'
 import { getEulerLabelEntityLogo } from '~/entities/euler/labels'
 import { VaultHooksInfoModal } from '#components'
@@ -19,6 +20,7 @@ const props = defineProps<{
   view: MatrixViewId
   usdCache: Map<string, VaultUsdCacheEntry>
   apyCache: Map<string, VaultApyCacheEntry>
+  badDebtCache: Map<string, VaultBadDebtCacheEntry>
   selectedHeader: { address: string, axis: 'row' | 'column' } | null
 }>()
 
@@ -37,7 +39,7 @@ interface AttributeColumn {
 const attributeColumns = computed<AttributeColumn[]>(() =>
   props.data.rows.map(attribute => ({
     attribute,
-    cells: buildAttributeRowCells(attribute, props.data.columns, props.usdCache, props.apyCache),
+    cells: buildAttributeRowCells(attribute, props.data.columns, props.usdCache, props.apyCache, props.badDebtCache),
   })),
 )
 

--- a/components/entities/vault/overview/VaultOverviewBlockStats.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockStats.vue
@@ -3,6 +3,7 @@ import type { EVault } from '@eulerxyz/euler-v2-sdk'
 import { getUtilisationWarning } from '~/composables/useVaultWarnings'
 import { formatAssetValue } from '~/utils/sdk-prices'
 import { formatNumber, compactNumber, formatCompactUsdValue } from '~/utils/string-utils'
+import { formatBadDebtOverviewValue } from '~/utils/vault-bad-debt'
 import { VaultSupplyApyModal, VaultBorrowApyModal, UiModalPreviewTrigger } from '#components'
 import { withVaultIntrinsicApy, getVaultIntrinsicApy, getVaultIntrinsicApyInfo } from '~/utils/vault-intrinsic-apy'
 import { isVaultBorrowable } from '~/utils/vault/classification'
@@ -13,6 +14,7 @@ const { settings } = useUserSettings()
 const enableIntrinsicApy = computed(() => settings.value.enableIntrinsicApy)
 const { getSupplyRewardApy, getBorrowRewardApy, getSupplyRewardCampaigns, getBorrowRewardCampaigns, hasSupplyRewards, hasBorrowRewards } = useRewardsApy()
 const isBorrowable = computed(() => isVaultBorrowable(vault))
+const { getVaultBadDebt, isBadDebtLoading, loadBadDebtForChain } = useVaultBadDebt()
 
 const supplyApyWithRewards = computed(() => withVaultIntrinsicApy(
   getVaultSupplyApy(vault),
@@ -55,6 +57,7 @@ const utilisationWarning = computed(() => getUtilisationWarning(vault, 'general'
 const totalSupplyDisplay = ref('-')
 const totalBorrowedDisplay = ref('-')
 const availableLiquidityDisplay = ref('-')
+const totalBorrowedUsd = ref<number | undefined>(undefined)
 
 watchEffect(async () => {
   const price = await formatAssetValue(vault.totalAssets, vault, 'off-chain')
@@ -64,12 +67,24 @@ watchEffect(async () => {
 watchEffect(async () => {
   const price = await formatAssetValue(vault.totalBorrowed, vault, 'off-chain')
   totalBorrowedDisplay.value = price.hasPrice ? formatCompactUsdValue(price.usdValue) : price.display
+  totalBorrowedUsd.value = price.hasPrice ? price.usdValue : undefined
 })
 
 watchEffect(async () => {
   const liquidity = vault.availableLiquidity
   const price = await formatAssetValue(liquidity, vault, 'off-chain')
   availableLiquidityDisplay.value = price.hasPrice ? formatCompactUsdValue(price.usdValue) : price.display
+})
+
+watchEffect(() => {
+  if (isBorrowable.value) void loadBadDebtForChain()
+})
+
+const badDebtDisplay = computed(() => {
+  if (!isBorrowable.value) return null
+  const badDebt = getVaultBadDebt(vault.address)
+  if (badDebt) return formatBadDebtOverviewValue(badDebt, totalBorrowedUsd.value)
+  return isBadDebtLoading.value ? '...' : null
 })
 </script>
 
@@ -88,6 +103,12 @@ watchEffect(async () => {
         v-if="isBorrowable"
         label="Total borrowed"
         :value="totalBorrowedDisplay"
+        orientation="horizontal"
+      />
+      <VaultOverviewLabelValue
+        v-if="badDebtDisplay"
+        label="Bad debt"
+        :value="badDebtDisplay"
         orientation="horizontal"
       />
       <VaultOverviewLabelValue

--- a/components/entities/vault/overview/VaultOverviewBlockStats.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockStats.vue
@@ -14,7 +14,7 @@ const { settings } = useUserSettings()
 const enableIntrinsicApy = computed(() => settings.value.enableIntrinsicApy)
 const { getSupplyRewardApy, getBorrowRewardApy, getSupplyRewardCampaigns, getBorrowRewardCampaigns, hasSupplyRewards, hasBorrowRewards } = useRewardsApy()
 const isBorrowable = computed(() => isVaultBorrowable(vault))
-const { getVaultBadDebt, isBadDebtLoading, loadBadDebtForChain } = useVaultBadDebt()
+const { getVaultBadDebt, isBadDebtLoaded, isBadDebtLoading, loadBadDebtForChain } = useVaultBadDebt()
 
 const supplyApyWithRewards = computed(() => withVaultIntrinsicApy(
   getVaultSupplyApy(vault),
@@ -84,7 +84,8 @@ const badDebtDisplay = computed(() => {
   if (!isBorrowable.value) return null
   const badDebt = getVaultBadDebt(vault.address)
   if (badDebt) return formatBadDebtOverviewValue(badDebt, totalBorrowedUsd.value)
-  return isBadDebtLoading.value ? '...' : null
+  if (isBadDebtLoading.value) return '...'
+  return isBadDebtLoaded.value ? '$0' : null
 })
 </script>
 

--- a/composables/useVaultBadDebt.ts
+++ b/composables/useVaultBadDebt.ts
@@ -71,7 +71,6 @@ export const useVaultBadDebt = () => {
     targetChainId = chainId.value,
     { force = false }: { force?: boolean } = {},
   ) => {
-    if (!envConfig.enableV3Backend) return
     if (!force && badDebtByChain.value.has(targetChainId) && !errorByChain.value.has(targetChainId)) return
     const existing = inFlight.get(targetChainId)
     if (existing) return existing
@@ -104,11 +103,15 @@ export const useVaultBadDebt = () => {
 
   const isBadDebtLoading = computed(() => loadingChains.value.has(chainId.value))
   const badDebtError = computed(() => errorByChain.value.get(chainId.value))
+  const isBadDebtLoaded = computed(() =>
+    badDebtByChain.value.has(chainId.value) && !errorByChain.value.has(chainId.value),
+  )
 
   return {
     badDebtByChain,
     badDebtError,
     getVaultBadDebt,
+    isBadDebtLoaded,
     isBadDebtLoading,
     loadBadDebtForChain,
   }

--- a/composables/useVaultBadDebt.ts
+++ b/composables/useVaultBadDebt.ts
@@ -1,0 +1,115 @@
+import {
+  buildBadDebtCache,
+  parseBadDebtResponse,
+  type VaultBadDebtCacheEntry,
+  type V3VaultBadDebtRow,
+} from '~/utils/vault-bad-debt'
+
+const badDebtByChain = shallowRef<Map<number, Map<string, VaultBadDebtCacheEntry>>>(new Map())
+const loadingChains = shallowRef<Set<number>>(new Set())
+const errorByChain = shallowRef<Map<number, Error>>(new Map())
+const inFlight = new Map<number, Promise<void>>()
+
+const setChainLoading = (chainId: number, loading: boolean) => {
+  const next = new Set(loadingChains.value)
+  if (loading) next.add(chainId)
+  else next.delete(chainId)
+  loadingChains.value = next
+}
+
+const setChainCache = (chainId: number, cache: Map<string, VaultBadDebtCacheEntry>) => {
+  badDebtByChain.value = new Map([...badDebtByChain.value, [chainId, cache]])
+}
+
+const setChainError = (chainId: number, error: Error | null) => {
+  const next = new Map(errorByChain.value)
+  if (error) next.set(chainId, error)
+  else next.delete(chainId)
+  errorByChain.value = next
+}
+
+const buildBadDebtUrl = (baseUrl: string, chainId: number, offset: number, limit: number): string => {
+  const base = baseUrl.replace(/\/+$/, '') || '/api/v3'
+  const params = new URLSearchParams({
+    chainId: String(chainId),
+    minBadDebtUsd: '0',
+    offset: String(offset),
+    limit: String(limit),
+  })
+  return `${base}/evk/vaults/bad-debt?${params.toString()}`
+}
+
+const fetchBadDebtRows = async (
+  baseUrl: string,
+  chainId: number,
+): Promise<V3VaultBadDebtRow[]> => {
+  const limit = 100
+  let offset = 0
+  const rows: V3VaultBadDebtRow[] = []
+
+  while (true) {
+    const response = await fetch(buildBadDebtUrl(baseUrl, chainId, offset, limit), {
+      headers: { accept: 'application/json' },
+    })
+    if (!response.ok) {
+      throw new Error(`Bad debt fetch failed with ${response.status}`)
+    }
+
+    const body = await response.json()
+    const page = parseBadDebtResponse(body)
+    rows.push(...page)
+    if (page.length < limit) return rows
+    offset += limit
+  }
+}
+
+export const useVaultBadDebt = () => {
+  const { chainId } = useEulerAddresses()
+  const envConfig = useEnvConfig()
+
+  const loadBadDebtForChain = async (
+    targetChainId = chainId.value,
+    { force = false }: { force?: boolean } = {},
+  ) => {
+    if (!envConfig.enableV3Backend) return
+    if (!force && badDebtByChain.value.has(targetChainId) && !errorByChain.value.has(targetChainId)) return
+    const existing = inFlight.get(targetChainId)
+    if (existing) return existing
+
+    const promise = (async () => {
+      setChainLoading(targetChainId, true)
+      setChainError(targetChainId, null)
+      try {
+        const rows = await fetchBadDebtRows(envConfig.v3ApiUrl, targetChainId)
+        setChainCache(targetChainId, buildBadDebtCache(rows))
+      }
+      catch (err) {
+        setChainError(targetChainId, err instanceof Error ? err : new Error(String(err)))
+      }
+      finally {
+        setChainLoading(targetChainId, false)
+        inFlight.delete(targetChainId)
+      }
+    })()
+
+    inFlight.set(targetChainId, promise)
+    return promise
+  }
+
+  const getVaultBadDebt = (
+    vaultAddress: string,
+    targetChainId = chainId.value,
+  ): VaultBadDebtCacheEntry | undefined =>
+    badDebtByChain.value.get(targetChainId)?.get(vaultAddress.toLowerCase())
+
+  const isBadDebtLoading = computed(() => loadingChains.value.has(chainId.value))
+  const badDebtError = computed(() => errorByChain.value.get(chainId.value))
+
+  return {
+    badDebtByChain,
+    badDebtError,
+    getVaultBadDebt,
+    isBadDebtLoading,
+    loadBadDebtForChain,
+  }
+}

--- a/server/utils/v3-proxy.ts
+++ b/server/utils/v3-proxy.ts
@@ -13,6 +13,7 @@ const GET_ONLY_PATHS = new Set([
   '/v3/apys/rewards',
   '/v3/earn/vaults',
   '/v3/evk/vaults',
+  '/v3/evk/vaults/bad-debt',
   '/v3/prices',
   '/v3/rewards/breakdown',
   '/v3/tokens',

--- a/tests/server/v3-proxy.test.ts
+++ b/tests/server/v3-proxy.test.ts
@@ -34,6 +34,7 @@ describe('v3 proxy utilities', () => {
     expect(isV3ProxyPathAllowed('/v3/apys/intrinsic')).toBe(true)
     expect(isV3ProxyPathAllowed('/v3/apys/rewards')).toBe(true)
     expect(isV3ProxyPathAllowed(`/v3/earn/vaults/1/${VAULT}`)).toBe(true)
+    expect(isV3ProxyPathAllowed('/v3/evk/vaults/bad-debt')).toBe(true)
     expect(isV3ProxyPathAllowed('/v3/evk/vaults/batch')).toBe(true)
     expect(isV3ProxyPathAllowed('/v3/prices')).toBe(true)
     expect(isV3ProxyPathAllowed('/v3/resolve/vaults')).toBe(true)
@@ -44,6 +45,7 @@ describe('v3 proxy utilities', () => {
   it('rejects unrelated V3 paths and prefix lookalikes', () => {
     expect(isV3ProxyPathAllowed('/v3/admin')).toBe(false)
     expect(isV3ProxyPathAllowed('/v3/accounting')).toBe(false)
+    expect(isV3ProxyPathAllowed('/v3/evk/vaults/bad-debt/history')).toBe(false)
     expect(isV3ProxyPathAllowed('/v3/evk/vaults-admin')).toBe(false)
     expect(isV3ProxyPathAllowed('/v3/apys/unknown')).toBe(false)
     expect(isV3ProxyPathAllowed('/v3/resolve')).toBe(false)

--- a/tests/utils/discovery-calculations.test.ts
+++ b/tests/utils/discovery-calculations.test.ts
@@ -4,6 +4,7 @@ import {
   STATS_ROWS,
   buildAttributeRowCells,
   buildVaultApyCache,
+  filterAttributeRowsByBadDebtAvailability,
   getActiveExternalCollateral,
   getAttributeMatrixColumns,
   getCollateralMatrix,
@@ -215,6 +216,14 @@ describe('getActiveExternalCollateral', () => {
 })
 
 describe('attribute stats matrix', () => {
+  it('hides the bad debt attribute when bad debt data is unavailable', () => {
+    const hiddenRows = filterAttributeRowsByBadDebtAvailability(STATS_ROWS, false)
+    const visibleRows = filterAttributeRowsByBadDebtAvailability(STATS_ROWS, true)
+
+    expect(hiddenRows.some(row => row.id === 'badDebt')).toBe(false)
+    expect(visibleRows.some(row => row.id === 'badDebt')).toBe(true)
+  })
+
   it('includes Securitize member vaults in attribute columns', () => {
     const eVault = makeVault('0xBorrow', [])
     const securitizeVault = makeSecuritizeVault('0xSecuritize')

--- a/tests/utils/discovery-calculations.test.ts
+++ b/tests/utils/discovery-calculations.test.ts
@@ -12,6 +12,7 @@ import {
   type VaultApyCacheEntry,
   type VaultUsdCacheEntry,
 } from '~/utils/discoveryCalculations'
+import type { VaultBadDebtCacheEntry } from '~/utils/vault-bad-debt'
 import type { MarketGroup } from '~/entities/lend-discovery'
 import type { EVault, EVaultCollateral, SecuritizeCollateralVault } from '@eulerxyz/euler-v2-sdk'
 import { VaultRewardInfo } from '@eulerxyz/euler-v2-sdk'
@@ -267,6 +268,7 @@ describe('attribute stats matrix', () => {
     expect(byRow.get('totalSupply')!.numeric).toBe(1000)
     expect(byRow.get('totalBorrow')!.numeric).toBe(500)
     expect(byRow.get('liquidity')!.numeric).toBe(500)
+    expect(byRow.get('badDebt')!.display).toBe('—')
     expect(byRow.get('utilization')!.numeric).toBe(50)
     expect(byRow.get('supplyCapUsage')!.numeric).toBe(40)
     expect(byRow.get('borrowCapUsage')!.numeric).toBe(50)
@@ -302,6 +304,50 @@ describe('attribute stats matrix', () => {
     expect(byRow.get('supplyApy')!.display).toBe('5.31%')
     expect(byRow.get('borrowApy')!.numeric).toBeCloseTo(1.25)
     expect(byRow.get('borrowApy')!.display).toBe('1.25%')
+  })
+
+  it('uses the bad debt cache for borrowable vault stats', () => {
+    const vault = {
+      ...makeVault('0xBadDebt', []),
+      totalAssets: 1000n,
+      totalBorrowed: 500n,
+      liquidation: { socializeDebt: true },
+    } as unknown as EVault
+    const columns = [{ address: vault.address.toLowerCase(), symbol: 'TST', assetAddress: vault.asset.address, vault, isExternal: false }]
+    const usdCache = new Map<string, VaultUsdCacheEntry>([
+      [vault.address.toLowerCase(), {
+        supply: '$1K',
+        supplyUsd: 1000,
+        borrow: '$500',
+        borrowUsd: 500,
+        liquidity: '$500',
+        liquidityUsd: 500,
+        supplyCap: '$1K',
+        supplyCapUsd: 1000,
+        borrowCap: '$1K',
+        borrowCapUsd: 1000,
+      }],
+    ])
+    const badDebtCache = new Map<string, VaultBadDebtCacheEntry>([
+      [vault.address.toLowerCase(), {
+        badDebtUsd: 125,
+        debtUsd: 150,
+        collateralUsd: 25,
+        coveredDebtUsd: 25,
+        accountCount: 2,
+        calculationTimestamp: '2026-06-25T10:14:59.000Z',
+        priceTimestamp: '2026-06-25T10:14:24.994Z',
+        refreshedAt: '2026-06-25T10:15:08.039Z',
+      }],
+    ])
+
+    const row = STATS_ROWS.find(row => row.id === 'badDebt')!
+    const cell = buildAttributeRowCells(row, columns, usdCache, undefined, badDebtCache)[0]
+
+    expect(cell.display).toBe('$125')
+    expect(cell.numeric).toBe(125)
+    expect(cell.hint).toContain('25% of total borrows')
+    expect(cell.hint).toContain('2 underwater accounts')
   })
 })
 

--- a/tests/utils/vault-bad-debt.test.ts
+++ b/tests/utils/vault-bad-debt.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildBadDebtCache,
+  formatBadDebtHint,
+  formatBadDebtOverviewValue,
+  parseBadDebtResponse,
+  type V3VaultBadDebtRow,
+} from '~/utils/vault-bad-debt'
+
+const row = (overrides: Partial<V3VaultBadDebtRow> = {}): V3VaultBadDebtRow => ({
+  chainId: 1,
+  borrowVault: '0x481D4909D7ca2eb27c4975f08dCE07DBeF0d3Fa7',
+  borrowAsset: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+  accountCount: 2,
+  debtUsd: 200,
+  collateralUsd: 50,
+  coveredDebtUsd: 50,
+  badDebtUsd: 150,
+  calculationTimestamp: '2026-06-25T10:14:59.000Z',
+  priceTimestamp: '2026-06-25T10:14:24.994Z',
+  refreshedAt: '2026-06-25T10:15:08.039Z',
+  ...overrides,
+})
+
+describe('vault bad debt helpers', () => {
+  it('normalizes v3 rows into an address keyed cache', () => {
+    const cache = buildBadDebtCache([row()])
+    const entry = cache.get('0x481d4909d7ca2eb27c4975f08dce07dbef0d3fa7')
+
+    expect(entry?.badDebtUsd).toBe(150)
+    expect(entry?.accountCount).toBe(2)
+  })
+
+  it('parses malformed v3 responses as empty data', () => {
+    expect(parseBadDebtResponse(null)).toEqual([])
+    expect(parseBadDebtResponse('')).toEqual([])
+    expect(parseBadDebtResponse({})).toEqual([])
+    expect(parseBadDebtResponse({ data: [row()] })).toHaveLength(1)
+  })
+
+  it('formats overview values with total-borrow context when available', () => {
+    const entry = buildBadDebtCache([row({ badDebtUsd: 125 })]).values().next().value!
+
+    expect(formatBadDebtOverviewValue(entry, 500)).toBe('$125 (25%)')
+    expect(formatBadDebtOverviewValue(entry, undefined)).toBe('$125')
+    expect(formatBadDebtHint(entry, 500)).toContain('25% of total borrows')
+  })
+})

--- a/utils/discoveryCalculations.ts
+++ b/utils/discoveryCalculations.ts
@@ -13,6 +13,7 @@ import { INTEREST_RATE_MODEL_TYPE } from '~/entities/constants'
 import { getVaultBorrowApy, getVaultSupplyApy } from '~/utils/vault-display'
 import { computeSupplyApy, computeBorrowApy, type ApyVisibilitySettings } from '~/utils/collateralOptions'
 import { getMaxLiquidationDiscountDisplayPercent } from '~/utils/vault/liquidation'
+import { formatBadDebtHint, formatBadDebtUsd, type VaultBadDebtCacheEntry } from '~/utils/vault-bad-debt'
 
 // ============================================================
 // Types & Constants
@@ -658,6 +659,7 @@ export interface AttributeRow {
     vault: EVault | SecuritizeCollateralVault,
     usd: VaultUsdCacheEntry | undefined,
     apy: VaultApyCacheEntry | undefined,
+    badDebt: VaultBadDebtCacheEntry | undefined,
   ) => AttributeCell
 }
 
@@ -894,6 +896,20 @@ export const STATS_ROWS: AttributeRow[] = [
     },
   },
   {
+    id: 'badDebt',
+    label: 'Bad debt',
+    getValue: (vault, usd, _apy, badDebt) => {
+      if (!isEVault(vault) || isEscrow(vault)) return NA_CELL
+      if (!badDebt) return NA_CELL
+      return {
+        display: formatBadDebtUsd(badDebt),
+        numeric: badDebt.badDebtUsd,
+        hint: formatBadDebtHint(badDebt, usd?.borrowUsd),
+        kind: 'text',
+      }
+    },
+  },
+  {
     id: 'utilization',
     label: 'Utilization',
     getValue: (vault) => {
@@ -1007,9 +1023,11 @@ export const buildAttributeRowCells = (
   columns: AttributeMatrixColumn[],
   usdCache: Map<string, VaultUsdCacheEntry>,
   apyCache?: Map<string, VaultApyCacheEntry>,
+  badDebtCache?: Map<string, VaultBadDebtCacheEntry>,
 ): AttributeCell[] =>
   columns.map(col => row.getValue(
     col.vault,
     usdCache.get(col.address),
     apyCache?.get(col.address),
+    badDebtCache?.get(col.address),
   ))

--- a/utils/discoveryCalculations.ts
+++ b/utils/discoveryCalculations.ts
@@ -1018,6 +1018,12 @@ export const getAttributeMatrix = (
   columns: getAttributeMatrixColumns(market),
 })
 
+export const filterAttributeRowsByBadDebtAvailability = (
+  rows: AttributeRow[],
+  isBadDebtAvailable: boolean,
+): AttributeRow[] =>
+  isBadDebtAvailable ? rows : rows.filter(row => row.id !== 'badDebt')
+
 export const buildAttributeRowCells = (
   row: AttributeRow,
   columns: AttributeMatrixColumn[],

--- a/utils/vault-bad-debt.ts
+++ b/utils/vault-bad-debt.ts
@@ -1,0 +1,91 @@
+import { formatCompactUsdValue, formatNumber } from '~/utils/string-utils'
+
+export interface V3VaultBadDebtRow {
+  chainId: number
+  borrowVault: string
+  borrowAsset: string
+  accountCount: number
+  debtUsd: number
+  collateralUsd: number
+  coveredDebtUsd: number
+  badDebtUsd: number
+  calculationTimestamp: string
+  priceTimestamp: string | null
+  refreshedAt: string
+}
+
+export interface V3VaultBadDebtResponse {
+  data?: V3VaultBadDebtRow[]
+}
+
+export interface VaultBadDebtCacheEntry {
+  badDebtUsd: number
+  debtUsd: number
+  collateralUsd: number
+  coveredDebtUsd: number
+  accountCount: number
+  calculationTimestamp: string
+  priceTimestamp: string | null
+  refreshedAt: string
+}
+
+const normalizeAddress = (address: string) => address.toLowerCase()
+
+export const buildBadDebtCache = (
+  rows: readonly V3VaultBadDebtRow[],
+): Map<string, VaultBadDebtCacheEntry> => {
+  const result = new Map<string, VaultBadDebtCacheEntry>()
+  for (const row of rows) {
+    if (!row.borrowVault || !Number.isFinite(row.badDebtUsd)) continue
+    result.set(normalizeAddress(row.borrowVault), {
+      badDebtUsd: row.badDebtUsd,
+      debtUsd: row.debtUsd,
+      collateralUsd: row.collateralUsd,
+      coveredDebtUsd: row.coveredDebtUsd,
+      accountCount: row.accountCount,
+      calculationTimestamp: row.calculationTimestamp,
+      priceTimestamp: row.priceTimestamp,
+      refreshedAt: row.refreshedAt,
+    })
+  }
+  return result
+}
+
+export const parseBadDebtResponse = (body: unknown): V3VaultBadDebtRow[] => {
+  if (!body || typeof body !== 'object') return []
+  const response = body as V3VaultBadDebtResponse
+  return Array.isArray(response.data) ? response.data : []
+}
+
+export const getBadDebtBorrowRatio = (
+  badDebt: VaultBadDebtCacheEntry,
+  totalBorrowUsd: number | undefined,
+): number | undefined => {
+  if (totalBorrowUsd === undefined || totalBorrowUsd <= 0) return undefined
+  return (badDebt.badDebtUsd / totalBorrowUsd) * 100
+}
+
+export const formatBadDebtUsd = (badDebt: VaultBadDebtCacheEntry): string =>
+  formatCompactUsdValue(badDebt.badDebtUsd)
+
+export const formatBadDebtOverviewValue = (
+  badDebt: VaultBadDebtCacheEntry,
+  totalBorrowUsd: number | undefined,
+): string => {
+  const ratio = getBadDebtBorrowRatio(badDebt, totalBorrowUsd)
+  const value = formatBadDebtUsd(badDebt)
+  return ratio === undefined ? value : `${value} (${formatNumber(ratio, 2, 0)}%)`
+}
+
+export const formatBadDebtHint = (
+  badDebt: VaultBadDebtCacheEntry,
+  totalBorrowUsd: number | undefined,
+): string => {
+  const parts = [`${formatCompactUsdValue(badDebt.badDebtUsd)} bad debt`]
+  const ratio = getBadDebtBorrowRatio(badDebt, totalBorrowUsd)
+  if (ratio !== undefined) parts.push(`${formatNumber(ratio, 2, 0)}% of total borrows`)
+  if (badDebt.accountCount > 0) {
+    parts.push(`${badDebt.accountCount} underwater ${badDebt.accountCount === 1 ? 'account' : 'accounts'}`)
+  }
+  return parts.join(' - ')
+}


### PR DESCRIPTION
## Summary
- Show borrow-vault bad debt from the V3 backend anywhere users compare EVK vault health.
- Add bad debt to borrowable vault overview stats with loaded zero states, and add bad debt to the Explore Stats matrix when chain bad-debt data is available.

## Changes
- Added a shared bad-debt composable that fetches and caches paginated V3 bad-debt rows by chain through the app V3 proxy.
- Added formatting helpers for USD values, borrow-ratio context, and matrix hover hints.
- Allowed the bad-debt V3 endpoint through the local proxy allowlist.
- Wired the shared vault stats card to show positive bad debt, `$0` after the chain cache loads with no matching vault row, and no row while V3 data is unavailable.
- Wired the Explore Stats matrix to load bad-debt data for expanded markets, hide the Bad debt attribute column until chain bad-debt data is loaded, and use the matrix empty-state marker for loaded vaults without a cached bad-debt entry.

## Test plan
- [x] npm run test:run -- tests/server/v3-proxy.test.ts tests/utils/discovery-calculations.test.ts tests/utils/vault-bad-debt.test.ts
- [x] npm run test:run -- tests/utils/vault-bad-debt.test.ts tests/utils/discovery-calculations.test.ts
- [x] npm run test:run -- tests/utils/discovery-calculations.test.ts
- [x] npm run typecheck
- [x] npx eslint composables/useVaultBadDebt.ts components/entities/vault/overview/VaultOverviewBlockStats.vue
- [x] npx eslint components/entities/vault/discovery/DiscoveryMarketAttributeMatrix.vue components/entities/vault/discovery/DiscoveryMarketAccordion.vue utils/discoveryCalculations.ts tests/utils/discovery-calculations.test.ts
- [x] Manually verified a lend vault detail page with positive bad debt renders the value in the Statistics card.
- [x] Manually verified a lend vault detail page with no matching bad-debt row renders `$0` after the chain cache loads.
- [x] Manually verified the Explore Stats matrix shows the Bad debt attribute column for expanded markets after bad-debt data is loaded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Bad debt” metric to vault discovery and overview views.
  * Bad debt details now load per chain and are shown in the stats matrix and market accordion when available.
  * Improved stat hints and formatting with clearer USD values and context about underwater accounts.

* **Bug Fixes**
  * Hid the bad debt row when data isn’t available.
  * Ensured bad debt values fall back gracefully while loading or when no data exists.
  * Expanded supported proxy access for the new bad debt endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->