### PR TITLE
Fix inverted intrinsic APY wording in borrow APY tooltip

### DIFF
--- a/components/entities/vault/VaultBorrowApyModal.vue
+++ b/components/entities/vault/VaultBorrowApyModal.vue
@@ -77,7 +77,7 @@ const handleClose = () => {
               > ({{ intrinsicApyInfo.provider }})</span>
             </p>
             <p class="text-content-primary">
-              Yield intrinsic to the borrowed asset, such as staking yield, which reduces effective borrowing cost
+              Yield intrinsic to the borrowed asset, such as staking yield, which increases effective borrowing cost
             </p>
             <a
               v-if="intrinsicApyInfo?.source"


### PR DESCRIPTION
## Summary
- The borrow APY tooltip described the borrowed asset's intrinsic yield (e.g. staking yield) as something that "reduces effective borrowing cost" — the inverse of the actual economics and of the number already shown.
- Borrowing a yield-bearing asset increases the real cost: the debt is denominated in an appreciating asset, so its intrinsic yield stacks on top of the Euler borrow rate (e.g. 0.10% + 2.43% = 2.53%). The wording now reads "increases effective borrowing cost".

## Changes
- One-word copy fix in `VaultBorrowApyModal.vue`; no calculation changes. `totalBorrowApy` already added the intrinsic APY, so the figure was correct — only the explanatory sentence contradicted it.
- Confirmed no other component repeats the inverted phrasing, and that downstream Net APY / Max ROE already treat the intrinsic borrow APY as a cost, so they stay consistent.

## Test plan
- [ ] Open a market with a yield-bearing borrow asset (e.g. USDT/wstETH), hover the Borrow APY tooltip, and confirm it reads "...which increases effective borrowing cost".
- [ ] Confirm Total borrow APY still equals Borrowing APY + Intrinsic APY (− rewards) and is unchanged from before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the explanatory text in the borrowing APY modal to accurately describe how “Intrinsic APY” affects effective borrowing cost.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->