### PR TITLE
Fix supply APY tooltip zeroing lending APY on borrow page

### DIFF
--- a/components/entities/vault/VaultBorrowItem.vue
+++ b/components/entities/vault/VaultBorrowItem.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import type { EVault } from '@eulerxyz/euler-v2-sdk'
 import { getUtilisationWarning, getBorrowCapWarning, getCollateralSupplyCapWarning } from '~/composables/useVaultWarnings'
 import { formatAssetValue } from '~/utils/sdk-prices'
 import { getMaxMultiplier, getMaxRoe } from '~/utils/leverage'
@@ -192,20 +191,15 @@ const borrowApyModalData = computed(() => ({
   },
 }))
 
-const supplyApyModalData = computed(() => {
-  const baseSupply = 'interestRateInfo' in pair.collateral
-    ? getVaultSupplyApy(pair.collateral as EVault)
-    : 0
-  return {
-    props: {
-      lendingAPY: baseSupply,
-      intrinsicAPY: getVaultIntrinsicApy(pair.collateral, enableIntrinsicApy.value),
-      intrinsicApyInfo: getVaultIntrinsicApyInfo(pair.collateral, enableIntrinsicApy.value),
-      campaigns: getSupplyRewardCampaigns(pair.collateral.address),
-      rewardVaultAddress: pair.collateral.address,
-    },
-  }
-})
+const supplyApyModalData = computed(() => ({
+  props: {
+    lendingAPY: getVaultSupplyApy(pair.collateral),
+    intrinsicAPY: getVaultIntrinsicApy(pair.collateral, enableIntrinsicApy.value),
+    intrinsicApyInfo: getVaultIntrinsicApyInfo(pair.collateral, enableIntrinsicApy.value),
+    campaigns: getSupplyRewardCampaigns(pair.collateral.address),
+    rewardVaultAddress: pair.collateral.address,
+  },
+}))
 
 const netApyModalData = computed(() => ({
   props: {


### PR DESCRIPTION
## Summary
- On the Borrow page, a pair row's Supply APY figure (e.g. 4.08%) did not match its Supply APY tooltip, which showed "Lending APY 0.00%" and "Total supply APY 0.00%".
- The row cell computes its value with `getVaultSupplyApy(pair.collateral)`, but the tooltip's modal data gated the same call behind a `'interestRateInfo' in pair.collateral` check. `pair.collateral` is the SDK `EVault` entity, which exposes `interestRates` (a ready-to-use `number`); `interestRateInfo` is the raw VaultLens shape that the entity never carries. So the guard was always false and forced `lendingAPY` to 0.

## Changes
- `VaultBorrowItem.vue`: pass `lendingAPY: getVaultSupplyApy(pair.collateral)` to the supply APY modal — identical to the row cell — removing the mismatched `interestRateInfo` guard and the now-unused `EVault` import/cast.
- The intrinsic-APY input was already correct; this only restores the lending component, so the tooltip's Lending APY and Total now match the displayed figure.

## Test plan
- [x] On the Borrow page, hover the Supply APY tooltip for a pair whose collateral earns lending yield (e.g. USDC/wstETH): "Lending APY" and "Total supply APY" should equal the row's Supply APY figure (e.g. 4.08%), not 0.00%.
- [x] Verify intrinsic-only collateral rows (e.g. escrow wstETH, zero lending) still show the correct total.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified how supply APY values are prepared for vault borrowing items.
  * Improved consistency in the APY information shown to users by using a direct calculation path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->