### PR TITLE
Include intrinsic APY in Earn supply APY headlines

### DIFF
--- a/components/entities/vault/overview/earn/VaultOverviewEarnBlockStats.vue
+++ b/components/entities/vault/overview/earn/VaultOverviewEarnBlockStats.vue
@@ -13,6 +13,7 @@ const { getSupplyRewardApy, getSupplyRewardCampaigns, hasSupplyRewards } = useRe
 
 const rewardSupplyAPY = computed(() => getSupplyRewardApy(vault.address))
 const intrinsicApy = computed(() => getVaultIntrinsicApy(vault, enableIntrinsicApy.value))
+const supplyApyTotal = computed(() => getVaultSupplyApy(vault) + intrinsicApy.value + rewardSupplyAPY.value)
 
 const totalSupplyDisplay = ref('-')
 
@@ -34,6 +35,7 @@ const supplyApyModalData = computed(() => ({
     intrinsicAPY: getVaultIntrinsicApy(vault, enableIntrinsicApy.value),
     intrinsicApyInfo: getVaultIntrinsicApyInfo(vault, enableIntrinsicApy.value),
     campaigns: getSupplyRewardCampaigns(vault.address),
+    totalSupplyAPY: supplyApyTotal.value,
     rewardVaultAddress: vault.address,
     baseApyAverageLabel: '1h',
   },
@@ -80,7 +82,7 @@ const supplyApyModalData = computed(() => ({
               data-modal-trigger="supply-apy"
             />
           </UiModalPreviewTrigger>
-          {{ formatNumber(getVaultSupplyApy(vault) + intrinsicApy + rewardSupplyAPY) }}%
+          {{ formatNumber(supplyApyTotal) }}%
         </span>
       </VaultOverviewLabelValue>
     </div>

--- a/components/entities/vault/overview/earn/VaultOverviewEarnBlockStats.vue
+++ b/components/entities/vault/overview/earn/VaultOverviewEarnBlockStats.vue
@@ -12,6 +12,7 @@ const enableIntrinsicApy = computed(() => settings.value.enableIntrinsicApy)
 const { getSupplyRewardApy, getSupplyRewardCampaigns, hasSupplyRewards } = useRewardsApy()
 
 const rewardSupplyAPY = computed(() => getSupplyRewardApy(vault.address))
+const intrinsicApy = computed(() => getVaultIntrinsicApy(vault, enableIntrinsicApy.value))
 
 const totalSupplyDisplay = ref('-')
 
@@ -79,7 +80,7 @@ const supplyApyModalData = computed(() => ({
               data-modal-trigger="supply-apy"
             />
           </UiModalPreviewTrigger>
-          {{ formatNumber(getVaultSupplyApy(vault) + rewardSupplyAPY) }}%
+          {{ formatNumber(getVaultSupplyApy(vault) + intrinsicApy + rewardSupplyAPY) }}%
         </span>
       </VaultOverviewLabelValue>
     </div>

--- a/pages/earn/[vault]/index.vue
+++ b/pages/earn/[vault]/index.vue
@@ -108,9 +108,12 @@ const supplyRewardCampaigns = computed(() => getSupplyRewardCampaigns(vaultAddre
 const totalRewardsAPY = computed(() => getSupplyRewardApy(vaultAddress))
 const hasRewards = computed(() => hasSupplyRewards(vaultAddress))
 const intrinsicApy = computed(() => getVaultIntrinsicApy(vault.value, enableIntrinsicApy.value))
+const supplyApyTotal = computed(() =>
+  vault.value ? getVaultSupplyApy(vault.value) + intrinsicApy.value + totalRewardsAPY.value : 0,
+)
 const supplyAPYDisplay = computed(() => {
   if (!vault.value) return '0.00'
-  return formatNumber(getVaultSupplyApy(vault.value) + intrinsicApy.value + totalRewardsAPY.value)
+  return formatNumber(supplyApyTotal.value)
 })
 const estimateSupplyAPYDisplay = computed(() => {
   return formatNumber(estimateSupplyAPY.value)
@@ -224,6 +227,7 @@ const supplyApyModalData = computed(() => ({
     intrinsicAPY: intrinsicApy.value,
     intrinsicApyInfo: getVaultIntrinsicApyInfo(vault.value, enableIntrinsicApy.value),
     campaigns: supplyRewardCampaigns.value,
+    totalSupplyAPY: supplyApyTotal.value,
     rewardVaultAddress: vaultAddress,
     baseApyAverageLabel: '1h',
   },

--- a/pages/earn/[vault]/index.vue
+++ b/pages/earn/[vault]/index.vue
@@ -110,7 +110,7 @@ const hasRewards = computed(() => hasSupplyRewards(vaultAddress))
 const intrinsicApy = computed(() => getVaultIntrinsicApy(vault.value, enableIntrinsicApy.value))
 const supplyAPYDisplay = computed(() => {
   if (!vault.value) return '0.00'
-  return formatNumber(getVaultSupplyApy(vault.value) + totalRewardsAPY.value)
+  return formatNumber(getVaultSupplyApy(vault.value) + intrinsicApy.value + totalRewardsAPY.value)
 })
 const estimateSupplyAPYDisplay = computed(() => {
   return formatNumber(estimateSupplyAPY.value)

--- a/pages/earn/[vault]/index.vue
+++ b/pages/earn/[vault]/index.vue
@@ -212,7 +212,7 @@ const updateEstimates = async () => {
   try {
     vault.value = await updateEarnVault(vault.value.address)
     if (!asset.value?.address) return
-    estimateSupplyAPY.value = getVaultSupplyApy(vault.value) + totalRewardsAPY.value
+    estimateSupplyAPY.value = getVaultSupplyApy(vault.value) + intrinsicApy.value + totalRewardsAPY.value
   }
   catch (e) {
     logWarn('earn-supply/estimates', e)
@@ -234,7 +234,7 @@ const supplyApyModalData = computed(() => ({
 }))
 
 // Initialize estimateSupplyAPY after vault is loaded
-estimateSupplyAPY.value = getVaultSupplyApy(vault.value) + totalRewardsAPY.value
+estimateSupplyAPY.value = getVaultSupplyApy(vault.value) + intrinsicApy.value + totalRewardsAPY.value
 
 watch(amount, () => {
   clearSimulationError()


### PR DESCRIPTION
## Summary
- On Earn surfaces, the supply APY headline omitted the vault's intrinsic APY (staking/underlying yield), even though the Earn list row already includes it and the Supply APY tooltip on these screens already passes `intrinsicAPY`. The result: the same Earn vault showed a different supply APY in the list vs. its detail page, and the detail-page tooltip total didn't match its own headline whenever intrinsic > 0.
- Earn `supplyApy1h` reflects the realized lending yield and does **not** already contain the underlying asset's intrinsic yield, so intrinsic must be added on top — consistent with how the Earn row and the Borrow/Lend screens treat it.

## Changes
- `pages/earn/[vault]/index.vue`: add `intrinsicApy` to the supply APY headline (the `intrinsicApy` computed already existed and is used by the tooltip).
- `VaultOverviewEarnBlockStats.vue`: add an `intrinsicApy` computed and include it in the displayed Supply APY.
- Both surfaces now compute a single numeric `supplyApyTotal` (lending + intrinsic + rewards) used for the headline **and** passed to the tooltip as `totalSupplyAPY`, matching the pattern the Earn list row and Portfolio cards already use. This keeps the tooltip total exactly equal to the headline and makes it robust regardless of how the shared modal combines lending + intrinsic internally.

## Test plan
- [ ] Open an Earn vault whose underlying has intrinsic yield (with "intrinsic APY" enabled in settings): the detail-page header Supply APY and the Statistics block Supply APY should equal the value shown for the same vault in the Earn list row.
- [ ] Hover the Supply APY tooltip on the Earn detail page: "Total supply APY" should equal the header figure.
- [ ] Toggle "intrinsic APY" off in settings: the intrinsic contribution drops from both the headline and the tooltip together.
- [ ] Earn vaults with zero intrinsic APY are unchanged.