### PR TITLE
Align portfolio supply APY tooltips with the SDK breakdown total

### DIFF
--- a/components/entities/portfolio/PortfolioEarnItem.vue
+++ b/components/entities/portfolio/PortfolioEarnItem.vue
@@ -10,7 +10,7 @@ import { VaultOverviewModal, VaultSupplyApyModal, UiModalPreviewTrigger } from '
 import { useModal } from '~/components/ui/composables/useModal'
 import { formatNumber, formatCompactUsdValue, formatExactAmount } from '~/utils/string-utils'
 import { roundAndCompactTokens } from '~/utils/crypto-utils'
-import { getVaultIntrinsicApy, getVaultIntrinsicApyInfo } from '~/utils/vault-intrinsic-apy'
+import { getVaultIntrinsicApyInfo } from '~/utils/vault-intrinsic-apy'
 
 const { position } = defineProps<{ position: PortfolioSavingsPosition<VaultEntity> }>()
 const modal = useModal()
@@ -26,7 +26,7 @@ const subAccountIndex = computed(() => {
 const { getSupplyRewardCampaignsFromVault } = useRewardsApy()
 const { settings } = useUserSettings()
 const enableIntrinsicApy = computed(() => settings.value.enableIntrinsicApy)
-const { viewer, visibleTotal } = useApyVisibility()
+const { viewer, visibleTotal, visibleBreakdown } = useApyVisibility()
 
 const vault = computed(() => position.vault as EulerEarn)
 const positionKey = computed(() => `${position.subAccount.toLowerCase()}:${vault.value.address.toLowerCase()}`)
@@ -58,6 +58,7 @@ watchEffect(() => {
 })
 
 const supplyApyWithRewards = computed(() => visibleTotal(apyBreakdown.value) ?? 0)
+const visibleApyBreakdown = computed(() => visibleBreakdown(apyBreakdown.value))
 
 const hasPrice = ref(false)
 
@@ -70,12 +71,16 @@ watchEffect(() => {
   updateHasPrice()
 })
 
+// Source the breakdown rows and total from the same viewer-aware SDK breakdown
+// the headline uses (visibleApyBreakdown / supplyApyWithRewards), so the tooltip
+// total always matches the displayed figure instead of being recomputed.
 const supplyApyModalData = computed(() => ({
   props: {
-    lendingAPY: getVaultSupplyApy(vault.value),
-    intrinsicAPY: getVaultIntrinsicApy(vault.value, enableIntrinsicApy.value),
+    lendingAPY: visibleApyBreakdown.value?.lending ?? 0,
+    intrinsicAPY: visibleApyBreakdown.value?.intrinsicApy ?? 0,
     intrinsicApyInfo: getVaultIntrinsicApyInfo(vault.value, enableIntrinsicApy.value),
     campaigns: getSupplyRewardCampaignsFromVault(vault.value),
+    totalSupplyAPY: supplyApyWithRewards.value,
     rewardVaultAddress: vault.value.address,
     baseApyAverageLabel: '1h',
   },

--- a/components/entities/portfolio/PortfolioSavingItem.vue
+++ b/components/entities/portfolio/PortfolioSavingItem.vue
@@ -10,7 +10,7 @@ import { formatNumber, formatCompactUsdValue, formatSmartAmount, formatExactAmou
 import { nanoToValue, roundAndCompactTokens } from '~/utils/crypto-utils'
 import { VaultOverviewModal, VaultSupplyApyModal, UiModalPreviewTrigger } from '#components'
 import { useModal } from '~/components/ui/composables/useModal'
-import { getVaultIntrinsicApy, getVaultIntrinsicApyInfo } from '~/utils/vault-intrinsic-apy'
+import { getVaultIntrinsicApyInfo } from '~/utils/vault-intrinsic-apy'
 
 const { position } = defineProps<{ position: PortfolioSavingsPosition<VaultEntity> }>()
 const modal = useModal()
@@ -26,7 +26,7 @@ const subAccountIndex = computed(() => {
 const { settings } = useUserSettings()
 const enableIntrinsicApy = computed(() => settings.value.enableIntrinsicApy)
 const { getSupplyRewardCampaignsFromVault } = useRewardsApy()
-const { viewer, visibleTotal } = useApyVisibility()
+const { viewer, visibleTotal, visibleBreakdown } = useApyVisibility()
 
 const vault = computed(() => position.vault!)
 const positionKey = computed(() => `${position.subAccount.toLowerCase()}:${vault.value.address.toLowerCase()}`)
@@ -46,6 +46,7 @@ const rewardsExist = computed(() =>
   settings.value.enableRewardsApy && (apyBreakdown.value?.rewards ?? 0) > 0,
 )
 const supplyApyWithRewards = computed(() => visibleTotal(apyBreakdown.value) ?? 0)
+const visibleApyBreakdown = computed(() => visibleBreakdown(apyBreakdown.value))
 
 const product = useEulerProductOfVault(computed(() => vault.value.address))
 const { getVaultCategory, isVerifiedVault } = useVaultRegistry()
@@ -86,12 +87,16 @@ const assetAmount = computed(() => {
   return nanoToValue(position.assets, vault.value.asset.decimals)
 })
 
+// Source the breakdown rows and total from the same viewer-aware SDK breakdown
+// the headline uses (visibleApyBreakdown / supplyApyWithRewards), so the tooltip
+// total always matches the displayed figure instead of being recomputed.
 const supplyApyModalData = computed(() => ({
   props: {
-    lendingAPY: getVaultSupplyApy(vault.value),
-    intrinsicAPY: getVaultIntrinsicApy(vault.value, enableIntrinsicApy.value),
+    lendingAPY: visibleApyBreakdown.value?.lending ?? 0,
+    intrinsicAPY: visibleApyBreakdown.value?.intrinsicApy ?? 0,
     intrinsicApyInfo: getVaultIntrinsicApyInfo(vault.value, enableIntrinsicApy.value),
     campaigns: getSupplyRewardCampaignsFromVault(vault.value),
+    totalSupplyAPY: supplyApyWithRewards.value,
     rewardVaultAddress: vault.value.address,
   },
 }))


### PR DESCRIPTION
## Summary
- On the Portfolio saving/earn cards, the Supply APY headline is the SDK position breakdown total (`visibleTotal(position.getApyBreakdown({ viewer }))` — viewer-aware eligibility, settings-gated), but the Supply APY tooltip independently re-sourced its rows (`getVaultSupplyApy(vault)` + `getVaultIntrinsicApy(vault)` + campaign sum) and recomputed its own total. The two could drift — different lending snapshot, viewer-eligibility on rewards, or the breakdown's `borrowing` term the tooltip never accounted for.
- Now the tooltip draws its lending/intrinsic rows and its total from the same `visibleBreakdown` / `supplyApyWithRewards` the headline uses, so the tooltip total always equals the displayed figure.

## Changes
- `PortfolioSavingItem.vue`, `PortfolioEarnItem.vue`:
  - Pull `visibleBreakdown` from `useApyVisibility` and derive `visibleApyBreakdown`.
  - Feed the modal `lendingAPY` / `intrinsicAPY` from the breakdown, and pass `totalSupplyAPY: supplyApyWithRewards` (the exact headline value) so the modal stops recomputing the total.
  - Drop the now-unused `getVaultIntrinsicApy` import; `getVaultIntrinsicApyInfo` is still used for the provider/source link.

## Test plan
- [ ] Open Portfolio with a saving position whose vault has intrinsic yield and/or rewards: the Supply APY tooltip's "Total supply APY" equals the card's headline figure.
- [ ] Repeat for an Earn position card.
- [ ] In spy mode / with a viewer that is reward-ineligible, confirm the tooltip total still tracks the headline (both reflect the viewer-aware breakdown).
- [ ] Toggle intrinsic/rewards settings off: headline and tooltip total move together.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * APY tooltips and modal details now match the viewer-specific APY figures shown in portfolio items.
  * Supply APY breakdown rows and totals are now sourced from the same visible data, reducing mismatches between headline values and tooltip/modal values.
  * Improved consistency for lending, intrinsic, and campaign APY display across earn and saving portfolio views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->