### PR TITLE
Compound intrinsic APY in APY tooltips to match headline figures

### DIFF
--- a/components/entities/vault/VaultBorrowApyModal.vue
+++ b/components/entities/vault/VaultBorrowApyModal.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { formatNumber } from '~/utils/string-utils'
+import { combineApyWithIntrinsic } from '~/utils/vault-intrinsic-apy'
 import type { RewardCampaign } from '~/entities/reward-campaign'
 import { PROVIDER_LABELS, PROVIDER_LOGOS, rewardCampaignAprPercent, rewardCampaignDisplays } from '~/entities/reward-campaign'
 import type { IntrinsicApyInfo } from '@eulerxyz/euler-v2-sdk'
@@ -23,7 +24,7 @@ const rewardsTotalAPY = computed(() => {
 
 const intrinsicApyValue = computed(() => intrinsicAPY ?? 0)
 const hasIntrinsicApy = computed(() => intrinsicApyValue.value > 0)
-const totalBorrowApy = computed(() => borrowingAPY + intrinsicApyValue.value - (rewardsTotalAPY.value || 0))
+const totalBorrowApy = computed(() => combineApyWithIntrinsic(borrowingAPY, intrinsicApyValue.value) - (rewardsTotalAPY.value || 0))
 
 const rewardsInfo = computed(() => {
   return rewardCampaignDisplays(campaigns, 'borrow', rewardVaultAddress)

--- a/components/entities/vault/VaultNetApyPairModal.vue
+++ b/components/entities/vault/VaultNetApyPairModal.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { formatNumber } from '~/utils/string-utils'
+import { combineApyWithIntrinsic } from '~/utils/vault-intrinsic-apy'
 import type { RewardCampaign } from '~/entities/reward-campaign'
 import { PROVIDER_LABELS, PROVIDER_LOGOS, rewardCampaignDisplays } from '~/entities/reward-campaign'
 
@@ -33,10 +34,10 @@ const {
 }>()
 
 const totalSupplyApy = computed(() =>
-  supplyAPY + (intrinsicSupplyAPY ?? 0) + (supplyRewardAPY || 0),
+  combineApyWithIntrinsic(supplyAPY, intrinsicSupplyAPY ?? 0) + (supplyRewardAPY || 0),
 )
 const totalBorrowApy = computed(() =>
-  borrowAPY + (intrinsicBorrowAPY ?? 0) - (borrowRewardAPY || 0),
+  combineApyWithIntrinsic(borrowAPY, intrinsicBorrowAPY ?? 0) - (borrowRewardAPY || 0),
 )
 const netApy = computed(() => totalSupplyApy.value - totalBorrowApy.value + (loopingRewardAPY || 0))
 

--- a/components/entities/vault/VaultSupplyApyModal.vue
+++ b/components/entities/vault/VaultSupplyApyModal.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { formatNumber } from '~/utils/string-utils'
+import { combineApyWithIntrinsic } from '~/utils/vault-intrinsic-apy'
 import type { RewardCampaign } from '~/entities/reward-campaign'
 import { PROVIDER_LABELS, PROVIDER_LOGOS, rewardCampaignAprPercent, rewardCampaignDisplays } from '~/entities/reward-campaign'
 import type { IntrinsicApyInfo } from '@eulerxyz/euler-v2-sdk'
@@ -25,7 +26,7 @@ const rewardsTotalAPY = computed(() => {
 
 const intrinsicApyValue = computed(() => intrinsicAPY ?? 0)
 const hasIntrinsicApy = computed(() => intrinsicApyValue.value > 0)
-const totalSupplyApy = computed(() => totalSupplyAPY ?? lendingAPY + intrinsicApyValue.value + (rewardsTotalAPY.value || 0))
+const totalSupplyApy = computed(() => totalSupplyAPY ?? combineApyWithIntrinsic(lendingAPY, intrinsicApyValue.value) + (rewardsTotalAPY.value || 0))
 
 const rewardsInfo = computed(() => {
   return rewardCampaignDisplays(campaigns, 'supply', rewardVaultAddress)

--- a/pages/lend/[vault]/index.vue
+++ b/pages/lend/[vault]/index.vue
@@ -382,7 +382,9 @@ const load = async () => {
   isLoading.value = true
   try {
     if (features.value.hasInterestRate && eVault.value) {
-      estimateSupplyAPY.value = getVaultSupplyApy(eVault.value) + totalRewardsAPY.value + intrinsicApy.value
+      estimateSupplyAPY.value
+        = combineApyWithIntrinsic(getVaultSupplyApy(eVault.value), intrinsicApy.value)
+          + totalRewardsAPY.value
     }
     else {
       // For vaults without interest rate info, just use rewards
@@ -605,7 +607,9 @@ const updateEstimates = useDebounceFn(async () => {
 
       if (needsSwap.value && !supplyNano) {
         // No swap quote yet — skip projection, keep current rate
-        estimateSupplyAPY.value = getVaultSupplyApy(eVault.value) + totalRewardsAPY.value + intrinsicApy.value
+        estimateSupplyAPY.value
+          = combineApyWithIntrinsic(getVaultSupplyApy(eVault.value), intrinsicApy.value)
+            + totalRewardsAPY.value
       }
       else {
         const projected = await getProjectedRates(
@@ -617,7 +621,9 @@ const updateEstimates = useDebounceFn(async () => {
         )
         if (estimatesGuard.isStale(gen)) return
         const rawAPY = projected ? nanoToValue(projected.supplyAPY, 25) : getVaultSupplyApy(eVault.value)
-        estimateSupplyAPY.value = rawAPY + totalRewardsAPY.value + intrinsicApy.value
+        estimateSupplyAPY.value
+          = combineApyWithIntrinsic(rawAPY, intrinsicApy.value)
+            + totalRewardsAPY.value
       }
     }
     else {

--- a/pages/lend/[vault]/index.vue
+++ b/pages/lend/[vault]/index.vue
@@ -5,7 +5,7 @@ import { isSecuritizeVault } from '~/utils/vault/categories'
 import { getHookDisabledWarning, getUtilisationWarning, getSupplyCapWarning } from '~/composables/useVaultWarnings'
 import { getAssetOraclePrice, getTokenUsdPrice } from '~/utils/sdk-prices'
 import { useEulerProductOfVault } from '~/composables/useEulerLabels'
-import { getVaultIntrinsicApy, getVaultIntrinsicApyInfo } from '~/utils/vault-intrinsic-apy'
+import { getVaultIntrinsicApy, getVaultIntrinsicApyInfo, combineApyWithIntrinsic } from '~/utils/vault-intrinsic-apy'
 import { isVaultBlockedByCountry, isVaultRestrictedByCountry, isAssetBlockedByCountry } from '~/composables/useGeoBlock'
 import { useVaultRegistry } from '~/composables/useVaultRegistry'
 import { useSwapQuotesParallel } from '~/composables/useSwapQuotesParallel'
@@ -350,7 +350,7 @@ const baseSupplyApy = computed(() => {
   if (!eVault.value) return 0
   return getVaultSupplyApy(eVault.value)
 })
-const supplyApyWithIntrinsic = computed(() => baseSupplyApy.value + intrinsicApy.value)
+const supplyApyWithIntrinsic = computed(() => combineApyWithIntrinsic(baseSupplyApy.value, intrinsicApy.value))
 const supplyAPYDisplay = computed(() => {
   if (!eVault.value && !securitizeVault.value) return '0.00'
   return formatNumber(supplyApyWithIntrinsic.value + totalRewardsAPY.value)

--- a/utils/vault-intrinsic-apy.ts
+++ b/utils/vault-intrinsic-apy.ts
@@ -21,12 +21,22 @@ export function getVaultIntrinsicApy(
   return getVaultIntrinsicApyInfo(vault, enabled).apy
 }
 
+/**
+ * Combine a base APY with an intrinsic (e.g. staking) APY the way a yield-bearing
+ * position actually accrues: the intrinsic yield compounds on top of the base
+ * rather than being a flat sum. `combineApyWithIntrinsic(5, 4) = 5 + 1.05 * 4 = 9.2`.
+ * Shared by the headline figures (via withVaultIntrinsicApy) and the APY tooltips
+ * so both report the same total.
+ */
+export function combineApyWithIntrinsic(baseApy: number, intrinsicApy: number): number {
+  if (!intrinsicApy) return baseApy
+  return baseApy + (1 + baseApy / 100) * intrinsicApy
+}
+
 export function withVaultIntrinsicApy(
   baseApy: number,
   vault: VaultWithIntrinsicApy | undefined,
   enabled: boolean,
 ): number {
-  const intrinsic = getVaultIntrinsicApy(vault, enabled)
-  if (intrinsic === 0) return baseApy
-  return baseApy + (1 + baseApy / 100) * intrinsic
+  return combineApyWithIntrinsic(baseApy, getVaultIntrinsicApy(vault, enabled))
 }


### PR DESCRIPTION
## Summary
- Headline APY figures combine a vault's base APY with its intrinsic (staking) APY by **compounding** — `withVaultIntrinsicApy(base, vault)` returns `base + (1 + base/100) * intrinsic`. The Supply, Borrow, and pair Net APY tooltips instead summed the two **linearly** (`base + intrinsic`), so a tooltip's total could sit a fraction of a percent below the headline it explains whenever a vault has both a non-trivial base APY and intrinsic yield.
- This unifies the two: the compounding is extracted into one shared helper used by both paths, so tooltip totals always equal the displayed figure.

## Changes
- `utils/vault-intrinsic-apy.ts`: extract `combineApyWithIntrinsic(base, intrinsic)` (the existing compounding formula) and refactor `withVaultIntrinsicApy` to delegate to it — single source of truth.
- `VaultSupplyApyModal.vue` / `VaultBorrowApyModal.vue`: compute the total via `combineApyWithIntrinsic` instead of a linear sum. (Callsites that pass an explicit `totalSupplyAPY` — Earn row, Portfolio — still win and are unaffected.)
- `VaultNetApyPairModal.vue`: compound the supply and borrow sub-totals the same way before deriving net APY.
- `pages/lend/[vault]/index.vue`: the lend detail headline summed `base + intrinsic` linearly while the lend **list** row already compounds via `withVaultIntrinsicApy`; switch it to `combineApyWithIntrinsic` so the detail page and the list agree.

## Notes
- `VaultNetApyModal` (Portfolio / position pages) already renders the precomputed `apyBreakdown.total`, so it needs no change.
- The discrepancy was sub-0.2% (only visible when base APY and intrinsic are both non-trivial), but it made tooltip totals fail to reconcile with headlines; this removes that class of mismatch.

## Test plan
- [ ] On a vault with both base lending APY and intrinsic yield, hover Supply APY: "Total supply APY" equals the row/header figure exactly.
- [ ] Same for Borrow APY and the pair Net APY tooltip on the Borrow page.
- [ ] Lend detail page header Supply APY now equals the Lend list row for the same vault.
- [ ] Vaults with zero intrinsic (or zero base) are unchanged; Earn/Portfolio tooltips (explicit total) are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * APY totals shown across vault supply, borrow, and net APY views now use a standardized intrinsic+base APY compounding calculation.
  * Vault APY modals (supply, borrow, and supply/borrow pairs) have more consistent displayed totals, especially when rewards are included.
  * The vault lending page’s “Supply APY” estimates now follow the same standardized intrinsic+base method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->