### PR TITLE
Strengthen oracle trust signals on the Oracles block

### DIFF
--- a/components/entities/vault/discovery/DiscoveryMarketAccordion.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketAccordion.vue
@@ -709,9 +709,29 @@ onMounted(() => {
                     </div>
                   </template>
 
-                  <!-- Cell selection: single lend + single borrow card -->
+                  <!-- Cell selection -->
                   <template v-else>
-                    <div class="flex flex-col gap-12">
+                    <!-- Oracle view: dedicated oracle adapters section for the
+                         selected collateral/liability pair (same component as the
+                         borrow page's Oracles block). -->
+                    <template v-if="getMatrixView(market.id) === 'oracle'">
+                      <template
+                        v-for="pair in [getSelectedBorrowPair(market)]"
+                        :key="'oracle-' + (pair ? `${pair.collateral.address}-${pair.borrow.address}` : '')"
+                      >
+                        <VaultOverviewBlockOracleAdapters
+                          v-if="pair"
+                          :vault="pair.borrow"
+                          :collateral-vaults="[pair.collateral]"
+                        />
+                      </template>
+                    </template>
+
+                    <!-- Other metrics: single lend + single borrow card -->
+                    <div
+                      v-else
+                      class="flex flex-col gap-12"
+                    >
                       <template
                         v-for="lendVault in [getSelectedLendVault(market)]"
                         :key="'lend-' + (lendVault ? getVaultAddress(lendVault) : '')"

--- a/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
@@ -1,24 +1,11 @@
 <script setup lang="ts">
-import {
-  isEVault,
-  type SecuritizeCollateralVault,
-  type OracleRouteStep,
-  type EVault,
-} from '@eulerxyz/euler-v2-sdk'
+import { isEVault } from '@eulerxyz/euler-v2-sdk'
 import { getMaxMultiplier, getMaxRoe } from '~/utils/leverage'
 import { findVault, formatMetricValue, getCellBgColor, isMatrixCompatibleVault, type CollateralMatrixData, type MatrixCell, type DotMetric, type EnhancedCellApys } from '~/utils/discoveryCalculations'
-import { getChecksStatus, OracleAdapterCheckSeverity, resolveOracleAdapterIdentity, type OracleAdapterCheck } from '~/entities/oracle'
-import { getOracleProviderLogo } from '~/entities/oracle-providers'
-import { getExplorerLink } from '~/utils/block-explorer'
-import { truncate, formatNumber } from '~/utils/string-utils'
-import { shouldInvertOraclePrice } from '~/utils/oracle-label'
-import { getOracleRouteStepKey, useOracleAdapterPrices } from '~/composables/useOracleAdapterPrices'
-import { getCollateralOracleRouteSteps, getDebtOracleRouteSteps, isOracleAdapterRouteStep } from '~/utils/oracle-route-steps'
+import { buildOracleAdapterViews, collectOracleRouteSteps, type OracleAdapterView } from '~/utils/oracle-adapter-views'
 import type { MarketGroup } from '~/entities/lend-discovery'
 import { withVaultIntrinsicApy } from '~/utils/vault-intrinsic-apy'
 import { areTokenAddressesCorrelatedByTags } from '~/utils/token-categories'
-import type { Address } from 'viem'
-import type { CSSProperties } from 'vue'
 
 const props = defineProps<{
   market: MarketGroup
@@ -28,7 +15,7 @@ const props = defineProps<{
   selectedHeader: { address: string, axis: 'row' | 'column' } | null
 }>()
 
-defineEmits<{
+const emit = defineEmits<{
   selectCell: [collateralAddr: string, liabilityAddr: string]
   selectHeader: [address: string, axis: 'row' | 'column']
 }>()
@@ -218,47 +205,51 @@ const metricRange = computed((): { min: number, max: number } => {
   return Number.isFinite(min) ? { min, max } : { min: 0, max: 0 }
 })
 
-// ── Oracle metric: per-cell adapter list + tooltip ────────────────────────────
+// ── Oracle metric: per-cell adapter views ────────────────────────────────────
 
-const getCollateralOracleSteps = (
-  liability: EVault,
-  collateral: EVault | SecuritizeCollateralVault,
-) => {
-  return getCollateralOracleRouteSteps(liability, collateral)
-}
-
-const cellOracleSteps = computed((): Map<string, OracleRouteStep[]> => {
-  const result = new Map<string, OracleRouteStep[]>()
+// Each off-diagonal cell shows every oracle adapter that prices the pair's
+// collateral AND liability assets — the same set the borrow page's Oracles
+// block renders, via the shared collectOracleRouteSteps + buildOracleAdapterViews.
+// The self-diagonal is intentionally left blank: a liability's own asset->UoA
+// oracle already appears in every cell of its column.
+const cellAdapterViews = computed((): Map<string, OracleAdapterView[]> => {
+  const result = new Map<string, OracleAdapterView[]>()
   if (props.dotMetric !== 'oracle') return result
 
-  for (const [colAddr, rowCells] of props.matrix.cells) {
-    for (const [liabAddr] of rowCells) {
-      const collateral = findVault(props.market, colAddr)
-      const liability = findVault(props.market, liabAddr)
-      if (!collateral || !liability) continue
-      if (!isMatrixCompatibleVault(collateral)) continue
-      if (!isEVault(liability)) continue
-      const steps = getCollateralOracleSteps(liability, collateral)
-      if (steps.length) result.set(`${colAddr}:${liabAddr}`, steps)
+  for (const [collateralAddr, rowCells] of props.matrix.cells) {
+    for (const [liabilityAddr] of rowCells) {
+      if (collateralAddr === liabilityAddr) continue
+      const collateral = findVault(props.market, collateralAddr)
+      const liability = findVault(props.market, liabilityAddr)
+      if (!collateral || !isMatrixCompatibleVault(collateral)) continue
+      if (!liability || !isEVault(liability)) continue
+      const steps = collectOracleRouteSteps([liability], [collateral])
+      if (steps.length) {
+        result.set(`${collateralAddr}:${liabilityAddr}`, buildOracleAdapterViews(steps, oracleAdapters))
+      }
     }
   }
   return result
 })
 
-// Per-borrow-vault asset oracle: resolves the borrow vault's own asset against
-// its unit of account. Same set repeated across every cell in a column, so we
-// surface it once as a header row instead.
-const columnAssetOracleSteps = computed((): Map<string, OracleRouteStep[]> => {
-  const result = new Map<string, OracleRouteStep[]>()
-  if (props.dotMetric !== 'oracle') return result
-  for (const col of props.matrix.columns) {
-    const liability = findVault(props.market, col.address)
-    if (!liability || !isEVault(liability)) continue
-    const steps = getDebtOracleRouteSteps(liability)
-    if (steps.length) result.set(col.address, steps)
+const getCellAdapterViews = (collateralAddr: string, liabilityAddr: string): OracleAdapterView[] =>
+  cellAdapterViews.value.get(`${collateralAddr}:${liabilityAddr}`) ?? []
+
+const isOracleCellSelectable = (collateralAddr: string, liabilityAddr: string): boolean =>
+  getCellAdapterViews(collateralAddr, liabilityAddr).length > 0
+
+// Cell click drives the inline oracle detail section below the matrix. In oracle
+// mode only off-diagonal cells that actually have adapters are selectable; other
+// metrics keep the original "any present cell is selectable" behaviour.
+const onCellClick = (collateralAddr: string, liabilityAddr: string) => {
+  if (props.dotMetric === 'oracle') {
+    if (!isOracleCellSelectable(collateralAddr, liabilityAddr)) return
   }
-  return result
-})
+  else if (!props.matrix.cells.get(collateralAddr)?.get(liabilityAddr)) {
+    return
+  }
+  emit('selectCell', collateralAddr, liabilityAddr)
+}
 
 // Bulk-load adapter metadata for the chain. Heavy call (1+ MB JSON); the
 // `metric !== 'oracle'` guard short-circuits the immediate run on mount and
@@ -273,224 +264,6 @@ watch(
   },
   { immediate: true },
 )
-
-interface AdapterView {
-  key: string
-  kind: OracleRouteStep['kind']
-  oracle: Address
-  name: string
-  base: Address
-  quote: Address
-  metaBase?: Address
-  metaQuote?: Address
-  provider: string
-  methodology?: string
-  logo?: string
-  label?: { primary: string, suffix?: string }
-  checks?: OracleAdapterCheck[]
-  checksStatus: 'positive' | 'warning' | 'negative' | null
-  failedChecks: OracleAdapterCheck[]
-}
-
-const enrichStep = (step: OracleRouteStep): AdapterView => {
-  const isAdapter = isOracleAdapterRouteStep(step)
-  const meta = isAdapter ? oracleAdapters[step.oracle.toLowerCase()] : undefined
-  // LITE-235: an adapter with no curated oracle-checks entry must not fall back to
-  // its self-reported onchain name(); render it as unknown instead. The template's
-  // `|| 'Unknown'` fallbacks turn the empty strings into the displayed label.
-  const { name: resolvedName, provider: resolvedProvider } = resolveOracleAdapterIdentity(step, meta, isAdapter)
-  const provider = resolvedProvider ?? ''
-  const name = resolvedName ?? ''
-  const checks = meta?.checks
-  return {
-    key: getOracleRouteStepKey(step),
-    kind: step.kind,
-    oracle: step.oracle,
-    name,
-    base: step.base,
-    quote: step.quote,
-    metaBase: meta?.base,
-    metaQuote: meta?.quote,
-    provider,
-    methodology: meta?.methodology || (step.kind === 'vault' ? 'Exchange Rate' : undefined),
-    logo: getOracleProviderLogo(provider, name),
-    label: meta?.label
-      ? {
-          primary: meta.label.split('(')[0].trimEnd(),
-          suffix: meta.label.includes('(') ? meta.label.slice(meta.label.indexOf('(')).trim() : undefined,
-        }
-      : undefined,
-    checks,
-    checksStatus: getChecksStatus(checks),
-    failedChecks: checks?.filter(c => !c.pass) ?? [],
-  }
-}
-
-const getCellAdapterViews = (collateralAddr: string, liabilityAddr: string): AdapterView[] => {
-  const list = cellOracleSteps.value.get(`${collateralAddr}:${liabilityAddr}`)
-  if (!list) return []
-  return list.map(enrichStep)
-}
-
-const getColumnAssetAdapterViews = (liabilityAddr: string): AdapterView[] => {
-  const list = columnAssetOracleSteps.value.get(liabilityAddr)
-  if (!list) return []
-  return list.map(enrichStep)
-}
-
-const TOOLTIP_WIDTH = 360
-
-interface TooltipContext {
-  view: AdapterView
-  sourceVault: EVault
-  collateralVault: EVault | SecuritizeCollateralVault | null
-}
-
-const tooltipContext = ref<TooltipContext | null>(null)
-const tooltipAdapter = computed(() => tooltipContext.value?.view ?? null)
-const tooltipStyle = ref<CSSProperties>({})
-
-// Single matrix-wide price fetch: in oracle mode we dedup every route step
-// currently shown, run one batchSimulation, and let tooltips read the results
-// from the same map.
-const allOracleSteps = computed<OracleRouteStep[]>(() => {
-  if (props.dotMetric !== 'oracle') return []
-  const seen = new Map<string, OracleRouteStep>()
-  const ingest = (lists: Iterable<OracleRouteStep[]>) => {
-    for (const list of lists) {
-      for (const step of list) {
-        const key = getOracleRouteStepKey(step)
-        if (!seen.has(key)) seen.set(key, step)
-      }
-    }
-  }
-  ingest(cellOracleSteps.value.values())
-  ingest(columnAssetOracleSteps.value.values())
-  return [...seen.values()]
-})
-
-const oraclePriceSourceVaults = computed<EVault[]>(() => {
-  if (props.dotMetric !== 'oracle') return []
-  const seen = new Map<string, EVault>()
-  for (const col of props.matrix.columns) {
-    const liability = findVault(props.market, col.address)
-    if (liability && isEVault(liability)) {
-      seen.set(liability.address.toLowerCase(), liability)
-    }
-  }
-  return [...seen.values()]
-})
-
-const oraclePriceCollateralVaults = computed<(EVault | SecuritizeCollateralVault)[]>(() => {
-  if (props.dotMetric !== 'oracle') return []
-  const seen = new Map<string, EVault | SecuritizeCollateralVault>()
-  for (const row of props.matrix.rows) {
-    const v = findVault(props.market, row.address)
-    if (v && isMatrixCompatibleVault(v)) {
-      seen.set(row.address.toLowerCase(), v)
-    }
-  }
-  return [...seen.values()]
-})
-
-const { prices: oraclePrices, isLoading: oraclePricesLoading } = useOracleAdapterPrices(
-  allOracleSteps,
-  oraclePriceSourceVaults,
-  oraclePriceCollateralVaults,
-)
-
-const isAdapterPriceFailed = (adapter: { key: string }): boolean => {
-  if (oraclePricesLoading.value) return false
-  const info = oraclePrices.value.get(adapter.key)
-  return info ? !info.success : false
-}
-
-const tooltipPriceText = computed((): string | null => {
-  const ctx = tooltipContext.value
-  if (!ctx) return null
-  const info = oraclePrices.value.get(ctx.view.key)
-  if (!info?.success) return null
-  const invert = shouldInvertOraclePrice({
-    metaBase: ctx.view.metaBase,
-    metaQuote: ctx.view.metaQuote,
-    callerBase: ctx.view.base,
-    callerQuote: ctx.view.quote,
-  })
-  const rate = invert && info.rate > 0 ? 1 / info.rate : info.rate
-  return formatNumber(rate, 4)
-})
-
-const tooltipPriceLoading = computed(() => oraclePricesLoading.value && !oraclePrices.value.size)
-
-const closeTooltip = () => {
-  tooltipContext.value = null
-}
-
-const positionTooltip = (event: MouseEvent) => {
-  const rect = (event.currentTarget as HTMLElement).getBoundingClientRect()
-  const left = Math.max(8, Math.min(rect.left, window.innerWidth - TOOLTIP_WIDTH - 16))
-  const spaceBelow = Math.max(160, window.innerHeight - rect.bottom - 16)
-  const spaceAbove = Math.max(160, rect.top - 16)
-  const flipUp = spaceAbove > spaceBelow
-  tooltipStyle.value = flipUp
-    ? { top: `${rect.top - 8}px`, left: `${left}px`, transform: 'translateY(-100%)', maxHeight: `${spaceAbove}px` }
-    : { top: `${rect.bottom + 8}px`, left: `${left}px`, transform: 'none', maxHeight: `${spaceBelow}px` }
-}
-
-const onCellAdapterClick = (
-  view: AdapterView,
-  event: MouseEvent,
-  collateralAddr: string,
-  liabilityAddr: string,
-) => {
-  if (tooltipContext.value?.view.key === view.key) {
-    closeTooltip()
-    return
-  }
-  const liability = findVault(props.market, liabilityAddr)
-  const collateral = findVault(props.market, collateralAddr)
-  if (!liability || !isEVault(liability)) return
-  positionTooltip(event)
-  tooltipContext.value = {
-    view,
-    sourceVault: liability,
-    collateralVault: collateral && collateral.address.toLowerCase() !== liabilityAddr.toLowerCase() ? collateral : null,
-  }
-}
-
-const onAssetAdapterClick = (
-  view: AdapterView,
-  event: MouseEvent,
-  liabilityAddr: string,
-) => {
-  if (tooltipContext.value?.view.key === view.key) {
-    closeTooltip()
-    return
-  }
-  const liability = findVault(props.market, liabilityAddr)
-  if (!liability || !isEVault(liability)) return
-  positionTooltip(event)
-  tooltipContext.value = {
-    view,
-    sourceVault: liability,
-    collateralVault: null,
-  }
-}
-
-// Document-level bubble-phase listener — `@click.stop` on every logo button
-// and on the tooltip itself prevents this from firing for in-tooltip clicks
-// or for clicks on other adapter triggers. That keeps "click same logo to
-// close" working (vueuse's onClickOutside attaches in capture phase, which
-// would short-circuit the toggle behaviour).
-const onDocumentClick = () => closeTooltip()
-onMounted(() => {
-  document.addEventListener('click', onDocumentClick)
-})
-onUnmounted(() => {
-  document.removeEventListener('click', onDocumentClick)
-})
-
-const explorerLink = (address: string) => getExplorerLink(address, chainId.value, true)
 </script>
 
 <template>
@@ -616,7 +389,9 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
                     : row.address === col.address
                       ? 'bg-white/[0.03]'
                       : '',
-                matrix.cells.get(row.address)?.get(col.address)
+                (dotMetric === 'oracle'
+                  ? isOracleCellSelectable(row.address, col.address)
+                  : !!matrix.cells.get(row.address)?.get(col.address))
                   ? 'cursor-pointer'
                   : '',
               ]"
@@ -649,126 +424,46 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
               "
               @mouseenter="hoveredCell = { collateralAddr: row.address, liabilityAddr: col.address }"
               @mouseleave="hoveredCell = null"
-              @click.stop="
-                matrix.cells.get(row.address)?.get(col.address)
-                  && $emit('selectCell', row.address, col.address)
-              "
+              @click.stop="onCellClick(row.address, col.address)"
             >
-              <!-- Diagonal in oracle mode: surface the borrow vault's own
-                   asset -> UoA oracle (same for every cell in the column,
-                   so we show it once on the self-row instead of repeating). -->
-              <template
-                v-if="dotMetric === 'oracle'
-                  && row.address === col.address
-                  && getColumnAssetAdapterViews(col.address).length"
-              >
-                <div class="inline-flex items-center justify-center gap-4 flex-wrap">
-                  <button
-                    v-for="adapter in getColumnAssetAdapterViews(col.address)"
+              <template v-if="matrix.cells.get(row.address)?.get(col.address)">
+                <!-- Oracle metric: every adapter pricing the pair's collateral &
+                     liability assets. Display-only logos; clicking the cell opens
+                     the inline oracle section below the matrix. -->
+                <div
+                  v-if="dotMetric === 'oracle' && getCellAdapterViews(row.address, col.address).length"
+                  class="inline-flex items-center justify-center gap-4 flex-wrap"
+                >
+                  <span
+                    v-for="adapter in getCellAdapterViews(row.address, col.address)"
                     :key="adapter.key"
-                    type="button"
-                    class="relative inline-flex items-center justify-center cursor-pointer"
+                    class="relative inline-flex items-center justify-center"
                     data-id="oracle-adapter"
-                    :data-key="`${col.address}:${adapter.key}`"
+                    :data-key="`${row.address}:${col.address}:${adapter.key}`"
+                    :data-collateral-address="row.address"
                     :data-borrow-address="col.address"
                     :data-oracle-address="adapter.oracle"
                     :data-base-address="adapter.base"
                     :data-quote-address="adapter.quote"
-                    @click.stop="onAssetAdapterClick(adapter, $event, col.address)"
                   >
-                    <UiHoverPreviewTooltip
-                      :title="adapter.name || 'Unknown'"
-                      :text="adapter.provider || 'Unknown provider'"
-                      placement="top-start"
-                    >
-                      <BaseAvatar
-                        v-if="adapter.logo"
-                        :src="adapter.logo"
-                        :label="adapter.name"
-                        class="icon--16"
-                      />
-                      <SvgIcon
-                        v-else
-                        name="question-circle"
-                        class="!w-16 !h-16 text-content-tertiary"
-                      />
-                    </UiHoverPreviewTooltip>
+                    <BaseAvatar
+                      v-if="adapter.logo"
+                      :src="adapter.logo"
+                      :label="adapter.name"
+                      class="icon--16"
+                    />
+                    <SvgIcon
+                      v-else
+                      name="question-circle"
+                      class="!w-16 !h-16 text-content-tertiary"
+                    />
                     <span
                       v-if="adapter.checksStatus === 'warning' || adapter.checksStatus === 'negative'"
                       class="absolute -top-1 -right-1 w-6 h-6 rounded-full"
                       :class="adapter.checksStatus === 'negative' ? 'bg-error-500' : 'bg-warning-500'"
                     />
-                    <UiHoverPreviewTooltip
-                      v-if="isAdapterPriceFailed(adapter)"
-                      title="getQuote reverted"
-                      text="getQuote reverted"
-                      placement="top-start"
-                      class="absolute -bottom-1 -right-1"
-                    >
-                      <SvgIcon
-                        name="warning"
-                        class="!w-10 !h-10 text-warning-500"
-                      />
-                    </UiHoverPreviewTooltip>
-                  </button>
+                  </span>
                 </div>
-              </template>
-
-              <template v-else-if="matrix.cells.get(row.address)?.get(col.address)">
-                <!-- Oracle metric: render adapter logos -->
-                <template v-if="dotMetric === 'oracle'">
-                  <div class="inline-flex items-center justify-center gap-4 flex-wrap">
-                    <button
-                      v-for="adapter in getCellAdapterViews(row.address, col.address)"
-                      :key="adapter.key"
-                      type="button"
-                      class="relative inline-flex items-center justify-center cursor-pointer"
-                      data-id="oracle-adapter"
-                      :data-key="`${row.address}:${col.address}:${adapter.key}`"
-                      :data-collateral-address="row.address"
-                      :data-borrow-address="col.address"
-                      :data-oracle-address="adapter.oracle"
-                      :data-base-address="adapter.base"
-                      :data-quote-address="adapter.quote"
-                      @click.stop="onCellAdapterClick(adapter, $event, row.address, col.address)"
-                    >
-                      <UiHoverPreviewTooltip
-                        :title="adapter.name || 'Unknown'"
-                        :text="adapter.provider || 'Unknown provider'"
-                        placement="top-start"
-                      >
-                        <BaseAvatar
-                          v-if="adapter.logo"
-                          :src="adapter.logo"
-                          :label="adapter.name"
-                          class="icon--16"
-                        />
-                        <SvgIcon
-                          v-else
-                          name="question-circle"
-                          class="!w-16 !h-16 text-content-tertiary"
-                        />
-                      </UiHoverPreviewTooltip>
-                      <span
-                        v-if="adapter.checksStatus === 'warning' || adapter.checksStatus === 'negative'"
-                        class="absolute -top-1 -right-1 w-6 h-6 rounded-full"
-                        :class="adapter.checksStatus === 'negative' ? 'bg-error-500' : 'bg-warning-500'"
-                      />
-                      <UiHoverPreviewTooltip
-                        v-if="isAdapterPriceFailed(adapter)"
-                        title="getQuote reverted"
-                        text="getQuote reverted"
-                        placement="top-start"
-                        class="absolute -bottom-1 -right-1"
-                      >
-                        <SvgIcon
-                          name="warning"
-                          class="!w-10 !h-10 text-warning-500"
-                        />
-                      </UiHoverPreviewTooltip>
-                    </button>
-                  </div>
-                </template>
 
                 <!-- Numeric metrics: original rendering -->
                 <div
@@ -876,146 +571,4 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
   >
     Tap a cell, row, or column header to see lending/borrowing options below.
   </p>
-
-  <!-- Oracle adapter tooltip — mirrors VaultOverviewBlockOracleAdapters card layout -->
-  <Teleport to="body">
-    <div
-      v-if="tooltipAdapter"
-      class="fixed z-[9999] bg-surface-secondary border border-line-subtle rounded-xl p-16 shadow-card overflow-y-auto flex flex-col gap-12"
-      :style="[tooltipStyle, { width: `${TOOLTIP_WIDTH}px` }]"
-      @click.stop
-    >
-      <!-- Header: oracle label / pair + address & close -->
-      <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-4 sm:gap-8">
-        <div class="text-p2 text-content-primary font-medium">
-          <template v-if="tooltipAdapter.label">
-            {{ tooltipAdapter.label.primary }}
-            <span
-              v-if="tooltipAdapter.label.suffix"
-              class="text-content-tertiary ml-2"
-            >{{ tooltipAdapter.label.suffix }}</span>
-          </template>
-          <template v-else>
-            Oracle
-          </template>
-        </div>
-        <div class="flex items-center gap-8 flex-shrink-0">
-          <NuxtLink
-            :to="explorerLink(tooltipAdapter.oracle)"
-            target="_blank"
-            class="text-accent-600 underline cursor-pointer hover:text-accent-500 text-p3"
-            @click.stop
-          >
-            {{ truncate(tooltipAdapter.oracle, 6) }}
-          </NuxtLink>
-          <button
-            type="button"
-            class="text-content-muted hover:text-content-secondary cursor-pointer"
-            aria-label="Close"
-            @click.stop="closeTooltip"
-          >
-            <SvgIcon
-              name="close"
-              class="!w-14 !h-14"
-            />
-          </button>
-        </div>
-      </div>
-
-      <!-- Provider / Methodology / Price / Checks grid (mirrors borrow page) -->
-      <div class="grid grid-cols-2 gap-12 text-p3">
-        <div class="flex flex-col gap-4">
-          <span class="text-content-tertiary">Provider</span>
-          <div class="flex items-center gap-8">
-            <BaseAvatar
-              v-if="tooltipAdapter.logo"
-              :src="tooltipAdapter.logo"
-              :label="tooltipAdapter.name"
-              class="icon--20"
-            />
-            <SvgIcon
-              v-else
-              name="question-circle"
-              class="!w-20 !h-20 text-content-tertiary"
-            />
-            <span class="text-content-primary">{{ tooltipAdapter.provider || 'Unknown' }}</span>
-          </div>
-        </div>
-        <div class="flex flex-col gap-4">
-          <span class="text-content-tertiary">Methodology</span>
-          <span class="text-content-primary">{{ tooltipAdapter.methodology || 'Unknown' }}</span>
-        </div>
-        <div class="flex flex-col gap-4">
-          <span class="text-content-tertiary">Price</span>
-          <span
-            v-if="tooltipPriceLoading"
-            class="text-content-secondary animate-pulse"
-          >...</span>
-          <span
-            v-else-if="tooltipPriceText === null"
-            class="flex items-center text-warning-500"
-          >
-            <SvgIcon
-              name="warning"
-              class="mr-2 !w-16 !h-16"
-            />
-            Unknown
-          </span>
-          <span
-            v-else
-            class="text-content-primary"
-          >{{ tooltipPriceText }}</span>
-        </div>
-        <div class="flex flex-col gap-4">
-          <span class="text-content-tertiary">Checks</span>
-          <span
-            v-if="!tooltipAdapter.checks?.length"
-            class="text-content-secondary"
-          >N/A</span>
-          <span
-            v-else
-            class="flex items-center gap-6"
-          >
-            <span
-              class="inline-block w-8 h-8 rounded-full flex-shrink-0"
-              :class="{
-                'bg-success-500': tooltipAdapter.checksStatus === 'positive',
-                'bg-warning-500': tooltipAdapter.checksStatus === 'warning',
-                'bg-error-500': tooltipAdapter.checksStatus === 'negative',
-              }"
-            />
-            <span class="text-content-primary">
-              <template v-if="tooltipAdapter.checksStatus === 'positive'">{{ tooltipAdapter.checks.length }} passed</template>
-              <template v-else>{{ tooltipAdapter.failedChecks.length }} failed</template>
-            </span>
-          </span>
-        </div>
-      </div>
-
-      <!-- Failed checks detail -->
-      <div
-        v-if="tooltipAdapter.failedChecks.length"
-        class="flex flex-col gap-6 border-t border-line-subtle pt-12 text-p3"
-      >
-        <div
-          v-for="(check, i) in tooltipAdapter.failedChecks"
-          :key="`${check.id}-${i}`"
-          class="flex items-start gap-8"
-        >
-          <SvgIcon
-            name="warning"
-            class="!w-16 !h-16 mt-1 flex-shrink-0"
-            :class="{
-              'text-error-500': check.severity === OracleAdapterCheckSeverity.High,
-              'text-warning-500': check.severity !== OracleAdapterCheckSeverity.High,
-            }"
-          />
-          <div>
-            <span class="text-content-primary font-medium">{{ check.id }}: </span>
-            <span class="text-content-secondary">{{ check.message }}</span>
-          </div>
-        </div>
-      </div>
-    </div>
-  </Teleport>
 </template>

--- a/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
@@ -288,6 +288,7 @@ interface AdapterView {
   logo?: string
   label?: { primary: string, suffix?: string }
   checks?: OracleAdapterCheck[]
+  isCustomAdapter: boolean
   checksStatus: 'positive' | 'warning' | 'negative' | null
   failedChecks: OracleAdapterCheck[]
 }
@@ -298,7 +299,7 @@ const enrichStep = (step: OracleRouteStep): AdapterView => {
   // LITE-235: an adapter with no curated oracle-checks entry must not fall back to
   // its self-reported onchain name(); render it as unknown instead. The template's
   // `|| 'Unknown'` fallbacks turn the empty strings into the displayed label.
-  const { name: resolvedName, provider: resolvedProvider } = resolveOracleAdapterIdentity(step, meta, isAdapter)
+  const { name: resolvedName, provider: resolvedProvider, isCustomAdapter } = resolveOracleAdapterIdentity(step, meta, isAdapter)
   const provider = resolvedProvider ?? ''
   const name = resolvedName ?? ''
   const checks = meta?.checks
@@ -321,6 +322,7 @@ const enrichStep = (step: OracleRouteStep): AdapterView => {
         }
       : undefined,
     checks,
+    isCustomAdapter,
     checksStatus: getChecksStatus(checks),
     failedChecks: checks?.filter(c => !c.pass) ?? [],
   }
@@ -969,7 +971,11 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
         <div class="flex flex-col gap-4">
           <span class="text-content-tertiary">Checks</span>
           <span
-            v-if="!tooltipAdapter.checks?.length"
+            v-if="tooltipAdapter.isCustomAdapter"
+            class="text-content-secondary"
+          >Custom — set by risk manager</span>
+          <span
+            v-else-if="!tooltipAdapter.checks?.length"
             class="text-content-secondary"
           >N/A</span>
           <span

--- a/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
@@ -458,9 +458,13 @@ watch(
                       class="!w-16 !h-16 text-content-tertiary"
                     />
                     <span
-                      v-if="adapter.checksStatus === 'warning' || adapter.checksStatus === 'negative'"
+                      v-if="adapter.checksStatus"
                       class="absolute -top-1 -right-1 w-6 h-6 rounded-full"
-                      :class="adapter.checksStatus === 'negative' ? 'bg-error-500' : 'bg-warning-500'"
+                      :class="{
+                        'bg-success-500': adapter.checksStatus === 'positive',
+                        'bg-warning-500': adapter.checksStatus === 'warning',
+                        'bg-error-500': adapter.checksStatus === 'negative',
+                      }"
                     />
                   </span>
                 </div>

--- a/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
@@ -7,7 +7,7 @@ import {
 } from '@eulerxyz/euler-v2-sdk'
 import { getMaxMultiplier, getMaxRoe } from '~/utils/leverage'
 import { findVault, formatMetricValue, getCellBgColor, isMatrixCompatibleVault, type CollateralMatrixData, type MatrixCell, type DotMetric, type EnhancedCellApys } from '~/utils/discoveryCalculations'
-import { getChecksStatus, OracleAdapterCheckSeverity, type OracleAdapterCheck } from '~/entities/oracle'
+import { getChecksStatus, OracleAdapterCheckSeverity, resolveOracleAdapterIdentity, type OracleAdapterCheck } from '~/entities/oracle'
 import { getOracleProviderLogo } from '~/entities/oracle-providers'
 import { getExplorerLink } from '~/utils/block-explorer'
 import { truncate, formatNumber } from '~/utils/string-utils'
@@ -293,9 +293,14 @@ interface AdapterView {
 }
 
 const enrichStep = (step: OracleRouteStep): AdapterView => {
-  const meta = isOracleAdapterRouteStep(step) ? oracleAdapters[step.oracle.toLowerCase()] : undefined
-  const provider = meta?.provider || step.name
-  const name = meta?.name || step.name
+  const isAdapter = isOracleAdapterRouteStep(step)
+  const meta = isAdapter ? oracleAdapters[step.oracle.toLowerCase()] : undefined
+  // LITE-235: an adapter with no curated oracle-checks entry must not fall back to
+  // its self-reported onchain name(); render it as unknown instead. The template's
+  // `|| 'Unknown'` fallbacks turn the empty strings into the displayed label.
+  const { name: resolvedName, provider: resolvedProvider } = resolveOracleAdapterIdentity(step, meta, isAdapter)
+  const provider = resolvedProvider ?? ''
+  const name = resolvedName ?? ''
   const checks = meta?.checks
   return {
     key: getOracleRouteStepKey(step),
@@ -672,7 +677,7 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
                     @click.stop="onAssetAdapterClick(adapter, $event, col.address)"
                   >
                     <UiHoverPreviewTooltip
-                      :title="adapter.name"
+                      :title="adapter.name || 'Unknown'"
                       :text="adapter.provider || 'Unknown provider'"
                       placement="top-start"
                     >
@@ -728,7 +733,7 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
                       @click.stop="onCellAdapterClick(adapter, $event, row.address, col.address)"
                     >
                       <UiHoverPreviewTooltip
-                        :title="adapter.name"
+                        :title="adapter.name || 'Unknown'"
                         :text="adapter.provider || 'Unknown provider'"
                         placement="top-start"
                       >

--- a/components/entities/vault/overview/VaultOverviewBlockOracleAdapters.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockOracleAdapters.vue
@@ -4,13 +4,12 @@ import type {
   EVault,
   OracleRouteStep,
 } from '@eulerxyz/euler-v2-sdk'
-import { getChecksStatus, getRouterRecognition, OracleAdapterCheckSeverity, resolveOracleAdapterIdentity, type OracleAdapterMeta } from '~/entities/oracle'
-import { getOracleProviderLogo } from '~/entities/oracle-providers'
+import { getRouterRecognition, OracleAdapterCheckSeverity } from '~/entities/oracle'
 import { getExplorerLink } from '~/utils/block-explorer'
 import { formatNumber } from '~/utils/string-utils'
-import { shouldInvertOraclePrice } from '~/utils/oracle-label'
 import { getOracleRouteStepKey, useOracleAdapterPrices } from '~/composables/useOracleAdapterPrices'
-import { getCollateralOracleRouteSteps, getDebtOracleRouteSteps, isOracleAdapterRouteStep } from '~/utils/oracle-route-steps'
+import { isOracleAdapterRouteStep } from '~/utils/oracle-route-steps'
+import { buildOracleAdapterViews, collectOracleRouteSteps } from '~/utils/oracle-adapter-views'
 import type { CSSProperties } from 'vue'
 
 const props = defineProps<{
@@ -35,33 +34,7 @@ const sourceVaults = computed(() => {
   return []
 })
 
-const getCollateralRouteSteps = (vault: EVault, collateralVault: EVault | SecuritizeCollateralVault) => {
-  return getCollateralOracleRouteSteps(vault, collateralVault)
-}
-
-const routeSteps = computed(() => {
-  const entries: OracleRouteStep[] = []
-  const deduped = new Map<string, OracleRouteStep>()
-
-  sourceVaults.value.forEach((vault) => {
-    entries.push(...getDebtOracleRouteSteps(vault))
-
-    if (props.collateralVaults?.length) {
-      props.collateralVaults.forEach((collateralVault) => {
-        entries.push(...getCollateralRouteSteps(vault, collateralVault))
-      })
-    }
-  })
-
-  entries.forEach((step) => {
-    const key = getOracleRouteStepKey(step)
-    if (!deduped.has(key)) {
-      deduped.set(key, step)
-    }
-  })
-
-  return [...deduped.values()]
-})
+const routeSteps = computed(() => collectOracleRouteSteps(sourceVaults.value, props.collateralVaults ?? []))
 
 const knownSymbols = computed(() => {
   const map = buildKnownSymbols()
@@ -80,39 +53,7 @@ const knownSymbols = computed(() => {
   return map
 })
 
-const adapterViews = computed(() => routeSteps.value.map((step) => {
-  const isAdapter = isOracleAdapterRouteStep(step)
-  const meta: OracleAdapterMeta | undefined = isAdapter
-    ? oracleAdapters[step.oracle.toLowerCase()]
-    : undefined
-  const { name, provider, isCustomAdapter } = resolveOracleAdapterIdentity(step, meta, isAdapter)
-  const checks = meta?.checks
-  const invertPrice = shouldInvertOraclePrice({
-    metaBase: meta?.base,
-    metaQuote: meta?.quote,
-    callerBase: step.base,
-    callerQuote: step.quote,
-  })
-
-  return {
-    ...step,
-    name,
-    provider,
-    isCustomAdapter,
-    methodology: meta?.methodology || (step.kind === 'vault' ? 'Exchange Rate' : undefined),
-    logo: getOracleProviderLogo(provider, name),
-    label: meta?.label
-      ? {
-          primary: meta.label.split('(')[0].trimEnd(),
-          suffix: meta.label.includes('(') ? meta.label.slice(meta.label.indexOf('(')).trim() : undefined,
-        }
-      : undefined,
-    invertPrice,
-    checks,
-    checksStatus: getChecksStatus(checks),
-    failedChecks: checks?.filter(c => !c.pass) ?? [],
-  }
-}))
+const adapterViews = computed(() => buildOracleAdapterViews(routeSteps.value, oracleAdapters))
 
 watch(
   () => routeSteps.value,

--- a/components/entities/vault/overview/VaultOverviewBlockOracleAdapters.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockOracleAdapters.vue
@@ -21,7 +21,7 @@ const props = defineProps<{
 const { oracleAdapters, loadOracleAdapter } = useEulerLabels()
 const { chainId } = useEulerAddresses()
 const { buildKnownSymbols, resolveSymbol: resolveTokenSymbol, shortenAddress } = useTokenSymbolResolver()
-const { recognisedRouters, recognisedRoutersChainId, loadRecognisedRouters } = useEulerOracleRouters()
+const { recognizedRouters, recognizedRoutersChainId, loadRecognizedRouters } = useEulerOracleRouters()
 
 const sourceVaults = computed(() => {
   if (props.vaults?.length) {
@@ -131,18 +131,18 @@ watch(
 watch(
   chainId,
   (id) => {
-    if (id) loadRecognisedRouters(id)
+    if (id) loadRecognizedRouters(id)
   },
   { immediate: true },
 )
 
 // LITE-236: flag whether the vault's price oracle (EulerRouter) was deployed by the
-// recognised EulerRouterFactory. Null while the allowlist is still loading for the
-// active chain or unavailable, so we never show a false "unrecognised" warning.
+// recognized EulerRouterFactory. Null while the allowlist is still loading for the
+// active chain or unavailable, so we never show a false "unrecognized" warning.
 const routerRecognition = computed(() => {
-  if (recognisedRoutersChainId.value !== chainId.value) return null
+  if (recognizedRoutersChainId.value !== chainId.value) return null
   const routerAddresses = sourceVaults.value.map(vault => vault.oracle?.oracle)
-  return getRouterRecognition(routerAddresses, recognisedRouters.value)
+  return getRouterRecognition(routerAddresses, recognizedRouters.value)
 })
 
 const resolveSymbol = (address: string) => resolveTokenSymbol(address, knownSymbols.value)
@@ -326,41 +326,41 @@ const onTooltipMouseLeave = () => {
         Oracles
       </p>
       <UiHoverPreviewTooltip
-        v-if="routerRecognition === 'recognised'"
-        title="Recognised oracle router"
-        text="The vault's price oracle was deployed by the recognised EulerRouterFactory."
+        v-if="routerRecognition === 'recognized'"
+        title="Recognized oracle router"
+        text="The vault's price oracle was deployed by the recognized EulerRouterFactory."
         placement="top-start"
       >
         <span
           class="inline-flex items-center gap-4 rounded-8 px-8 py-2 bg-success-100 text-success-500 text-p5"
           data-id="data-point"
           data-field="oracle-router-recognition"
-          data-value="recognised"
+          data-value="recognized"
         >
           <SvgIcon
             name="check"
             class="!w-12 !h-12"
           />
-          Recognised router
+          Recognized router
         </span>
       </UiHoverPreviewTooltip>
       <UiHoverPreviewTooltip
-        v-else-if="routerRecognition === 'unrecognised'"
-        title="Unrecognised oracle router"
-        text="The vault's price oracle was not deployed by the recognised EulerRouterFactory. Verify the oracle configuration before trusting its prices."
+        v-else-if="routerRecognition === 'unrecognized'"
+        title="Unrecognized oracle router"
+        text="The vault's price oracle was not deployed by the recognized EulerRouterFactory. Verify the oracle configuration before trusting its prices."
         placement="top-start"
       >
         <span
           class="inline-flex items-center gap-4 rounded-8 px-8 py-2 bg-warning-100 text-warning-500 text-p5"
           data-id="data-point"
           data-field="oracle-router-recognition"
-          data-value="unrecognised"
+          data-value="unrecognized"
         >
           <SvgIcon
             name="warning"
             class="!w-12 !h-12"
           />
-          Unrecognised router
+          Unrecognized router
         </span>
       </UiHoverPreviewTooltip>
     </div>

--- a/components/entities/vault/overview/VaultOverviewBlockOracleAdapters.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockOracleAdapters.vue
@@ -528,7 +528,7 @@ const onTooltipMouseLeave = () => {
               }"
             >
               <SvgIcon
-                :name="check.pass ? 'check' : 'x'"
+                :name="check.pass ? 'check' : 'close'"
                 class="!w-10 !h-10 text-white"
               />
             </span>

--- a/components/entities/vault/overview/VaultOverviewBlockOracleAdapters.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockOracleAdapters.vue
@@ -4,7 +4,7 @@ import type {
   EVault,
   OracleRouteStep,
 } from '@eulerxyz/euler-v2-sdk'
-import { getChecksStatus, OracleAdapterCheckSeverity, type OracleAdapterMeta } from '~/entities/oracle'
+import { getChecksStatus, getRouterRecognition, OracleAdapterCheckSeverity, resolveOracleAdapterIdentity, type OracleAdapterMeta } from '~/entities/oracle'
 import { getOracleProviderLogo } from '~/entities/oracle-providers'
 import { getExplorerLink } from '~/utils/block-explorer'
 import { formatNumber } from '~/utils/string-utils'
@@ -21,6 +21,7 @@ const props = defineProps<{
 const { oracleAdapters, loadOracleAdapter } = useEulerLabels()
 const { chainId } = useEulerAddresses()
 const { buildKnownSymbols, resolveSymbol: resolveTokenSymbol, shortenAddress } = useTokenSymbolResolver()
+const { recognisedRouters, recognisedRoutersChainId, loadRecognisedRouters } = useEulerOracleRouters()
 
 const sourceVaults = computed(() => {
   if (props.vaults?.length) {
@@ -80,11 +81,11 @@ const knownSymbols = computed(() => {
 })
 
 const adapterViews = computed(() => routeSteps.value.map((step) => {
-  const meta: OracleAdapterMeta | undefined = isOracleAdapterRouteStep(step)
+  const isAdapter = isOracleAdapterRouteStep(step)
+  const meta: OracleAdapterMeta | undefined = isAdapter
     ? oracleAdapters[step.oracle.toLowerCase()]
     : undefined
-  const provider = meta?.provider || step.name
-  const name = meta?.name || step.name
+  const { name, provider, isCustomAdapter } = resolveOracleAdapterIdentity(step, meta, isAdapter)
   const checks = meta?.checks
   const invertPrice = shouldInvertOraclePrice({
     metaBase: meta?.base,
@@ -97,6 +98,7 @@ const adapterViews = computed(() => routeSteps.value.map((step) => {
     ...step,
     name,
     provider,
+    isCustomAdapter,
     methodology: meta?.methodology || (step.kind === 'vault' ? 'Exchange Rate' : undefined),
     logo: getOracleProviderLogo(provider, name),
     label: meta?.label
@@ -125,6 +127,23 @@ watch(
   },
   { immediate: true },
 )
+
+watch(
+  chainId,
+  (id) => {
+    if (id) loadRecognisedRouters(id)
+  },
+  { immediate: true },
+)
+
+// LITE-236: flag whether the vault's price oracle (EulerRouter) was deployed by the
+// recognised EulerRouterFactory. Null while the allowlist is still loading for the
+// active chain or unavailable, so we never show a false "unrecognised" warning.
+const routerRecognition = computed(() => {
+  if (recognisedRoutersChainId.value !== chainId.value) return null
+  const routerAddresses = sourceVaults.value.map(vault => vault.oracle?.oracle)
+  return getRouterRecognition(routerAddresses, recognisedRouters.value)
+})
 
 const resolveSymbol = (address: string) => resolveTokenSymbol(address, knownSymbols.value)
 
@@ -302,9 +321,49 @@ const onTooltipMouseLeave = () => {
 
 <template>
   <div class="bg-surface-secondary rounded-xl flex flex-col gap-24 p-24 shadow-card">
-    <p class="text-h3 text-content-primary">
-      Oracles
-    </p>
+    <div class="flex flex-wrap items-center gap-8">
+      <p class="text-h3 text-content-primary">
+        Oracles
+      </p>
+      <UiHoverPreviewTooltip
+        v-if="routerRecognition === 'recognised'"
+        title="Recognised oracle router"
+        text="The vault's price oracle was deployed by the recognised EulerRouterFactory."
+        placement="top-start"
+      >
+        <span
+          class="inline-flex items-center gap-4 rounded-8 px-8 py-2 bg-success-100 text-success-500 text-p5"
+          data-id="data-point"
+          data-field="oracle-router-recognition"
+          data-value="recognised"
+        >
+          <SvgIcon
+            name="check"
+            class="!w-12 !h-12"
+          />
+          Recognised router
+        </span>
+      </UiHoverPreviewTooltip>
+      <UiHoverPreviewTooltip
+        v-else-if="routerRecognition === 'unrecognised'"
+        title="Unrecognised oracle router"
+        text="The vault's price oracle was not deployed by the recognised EulerRouterFactory. Verify the oracle configuration before trusting its prices."
+        placement="top-start"
+      >
+        <span
+          class="inline-flex items-center gap-4 rounded-8 px-8 py-2 bg-warning-100 text-warning-500 text-p5"
+          data-id="data-point"
+          data-field="oracle-router-recognition"
+          data-value="unrecognised"
+        >
+          <SvgIcon
+            name="warning"
+            class="!w-12 !h-12"
+          />
+          Unrecognised router
+        </span>
+      </UiHoverPreviewTooltip>
+    </div>
     <div
       v-if="!adapterViews.length"
       class="text-p3 text-content-tertiary"
@@ -388,7 +447,11 @@ const onTooltipMouseLeave = () => {
           >
             <span class="text-content-tertiary">Checks</span>
             <span
-              v-if="!adapter.checks?.length"
+              v-if="adapter.isCustomAdapter"
+              class="text-content-secondary"
+            >Custom — set by risk manager</span>
+            <span
+              v-else-if="!adapter.checks?.length"
               class="text-content-secondary"
             >N/A</span>
             <span

--- a/composables/useEulerOracleAdapters.ts
+++ b/composables/useEulerOracleAdapters.ts
@@ -3,17 +3,11 @@ import { toReactive } from '@vueuse/core'
 import { logWarn } from '~/utils/errorHandling'
 import { normalizeAddress } from '~/utils/normalizeAddress'
 import { getEulerSdk } from '~/composables/useEulerSdk'
-import { type OracleAdapterMeta, OracleAdapterCheckSeverity } from '~/entities/oracle'
+import { type OracleAdapterMeta, normalizeOracleAdapterCheckSeverity } from '~/entities/oracle'
 
 const oracleAdaptersRef = shallowRef<Record<string, OracleAdapterMeta>>({})
 const oracleAdaptersChainId = ref<number | null>(null)
 const pendingOracleAdapterLoads = new Map<number, Promise<Record<string, OracleAdapterMeta>>>()
-
-const normalizeSeverity = (severity: unknown): OracleAdapterCheckSeverity => {
-  return Object.values(OracleAdapterCheckSeverity).includes(severity as OracleAdapterCheckSeverity)
-    ? severity as OracleAdapterCheckSeverity
-    : OracleAdapterCheckSeverity.Info
-}
 
 const toOracleAdapterMeta = (metadata: OracleAdapterMetadata): OracleAdapterMeta => ({
   oracle: metadata.oracle,
@@ -27,7 +21,7 @@ const toOracleAdapterMeta = (metadata: OracleAdapterMetadata): OracleAdapterMeta
     id: typeof check.id === 'string' ? check.id : '',
     message: typeof check.message === 'string' ? check.message : '',
     pass: check.pass === true,
-    severity: normalizeSeverity(check.severity),
+    severity: normalizeOracleAdapterCheckSeverity(check.severity),
   })),
 })
 

--- a/composables/useEulerOracleRouters.ts
+++ b/composables/useEulerOracleRouters.ts
@@ -1,0 +1,55 @@
+import { logWarn } from '~/utils/errorHandling'
+
+// Recognised EulerRouter addresses (deployed by the recognised EulerRouterFactory)
+// are published per chain at `{oracle-checks}/{chainId}/routers/all.json` as a flat
+// array of addresses. We proxy + cache them through `/api/oracle-routers` and keep a
+// lowercased Set per chain so router-recognition lookups are O(1).
+const recognisedRoutersRef = shallowRef<Set<string>>(new Set())
+const recognisedRoutersChainId = ref<number | null>(null)
+const pendingRouterLoads = new Map<number, Promise<Set<string>>>()
+
+const toRecognisedSet = (data: unknown): Set<string> => {
+  if (!Array.isArray(data)) return new Set()
+  return new Set(
+    data
+      .filter((entry): entry is string => typeof entry === 'string')
+      .map(entry => entry.toLowerCase()),
+  )
+}
+
+const loadRecognisedRouters = async (chainId: number): Promise<Set<string>> => {
+  if (!Number.isInteger(chainId) || chainId <= 0) return new Set()
+
+  if (recognisedRoutersChainId.value === chainId) {
+    return recognisedRoutersRef.value
+  }
+
+  const inflight = pendingRouterLoads.get(chainId)
+  if (inflight) return inflight
+
+  const promise = (async () => {
+    const data = await $fetch('/api/oracle-routers', { query: { chainId } })
+    const set = toRecognisedSet(data)
+    recognisedRoutersRef.value = set
+    recognisedRoutersChainId.value = chainId
+    return set
+  })()
+
+  pendingRouterLoads.set(chainId, promise)
+  try {
+    return await promise
+  }
+  catch (err) {
+    logWarn('useEulerOracleRouters', `Failed to load recognised routers for chain ${chainId}: ${err instanceof Error ? err.message : String(err)}`)
+    return new Set()
+  }
+  finally {
+    pendingRouterLoads.delete(chainId)
+  }
+}
+
+export const useEulerOracleRouters = () => ({
+  recognisedRouters: computed(() => recognisedRoutersRef.value),
+  recognisedRoutersChainId: readonly(recognisedRoutersChainId),
+  loadRecognisedRouters,
+})

--- a/composables/useEulerOracleRouters.ts
+++ b/composables/useEulerOracleRouters.ts
@@ -6,6 +6,7 @@ import { logWarn } from '~/utils/errorHandling'
 // lowercased Set per chain so router-recognition lookups are O(1).
 const recognizedRoutersRef = shallowRef<Set<string>>(new Set())
 const recognizedRoutersChainId = ref<number | null>(null)
+const recognizedRoutersByChain = new Map<number, Set<string>>()
 const pendingRouterLoads = new Map<number, Promise<Set<string>>>()
 
 const toRecognizedSet = (data: unknown): Set<string> => {
@@ -20,9 +21,15 @@ const toRecognizedSet = (data: unknown): Set<string> => {
 const loadRecognizedRouters = async (chainId: number): Promise<Set<string>> => {
   if (!Number.isInteger(chainId) || chainId <= 0) return new Set()
 
-  if (recognizedRoutersChainId.value === chainId) {
-    return recognizedRoutersRef.value
+  recognizedRoutersChainId.value = chainId
+
+  const cached = recognizedRoutersByChain.get(chainId)
+  if (cached) {
+    recognizedRoutersRef.value = cached
+    return cached
   }
+
+  recognizedRoutersRef.value = new Set()
 
   const inflight = pendingRouterLoads.get(chainId)
   if (inflight) return inflight
@@ -30,8 +37,10 @@ const loadRecognizedRouters = async (chainId: number): Promise<Set<string>> => {
   const promise = (async () => {
     const data = await $fetch('/api/oracle-routers', { query: { chainId } })
     const set = toRecognizedSet(data)
-    recognizedRoutersRef.value = set
-    recognizedRoutersChainId.value = chainId
+    recognizedRoutersByChain.set(chainId, set)
+    if (recognizedRoutersChainId.value === chainId) {
+      recognizedRoutersRef.value = set
+    }
     return set
   })()
 

--- a/composables/useEulerOracleRouters.ts
+++ b/composables/useEulerOracleRouters.ts
@@ -1,14 +1,14 @@
 import { logWarn } from '~/utils/errorHandling'
 
-// Recognised EulerRouter addresses (deployed by the recognised EulerRouterFactory)
+// Recognized EulerRouter addresses (deployed by the recognized EulerRouterFactory)
 // are published per chain at `{oracle-checks}/{chainId}/routers/all.json` as a flat
 // array of addresses. We proxy + cache them through `/api/oracle-routers` and keep a
 // lowercased Set per chain so router-recognition lookups are O(1).
-const recognisedRoutersRef = shallowRef<Set<string>>(new Set())
-const recognisedRoutersChainId = ref<number | null>(null)
+const recognizedRoutersRef = shallowRef<Set<string>>(new Set())
+const recognizedRoutersChainId = ref<number | null>(null)
 const pendingRouterLoads = new Map<number, Promise<Set<string>>>()
 
-const toRecognisedSet = (data: unknown): Set<string> => {
+const toRecognizedSet = (data: unknown): Set<string> => {
   if (!Array.isArray(data)) return new Set()
   return new Set(
     data
@@ -17,11 +17,11 @@ const toRecognisedSet = (data: unknown): Set<string> => {
   )
 }
 
-const loadRecognisedRouters = async (chainId: number): Promise<Set<string>> => {
+const loadRecognizedRouters = async (chainId: number): Promise<Set<string>> => {
   if (!Number.isInteger(chainId) || chainId <= 0) return new Set()
 
-  if (recognisedRoutersChainId.value === chainId) {
-    return recognisedRoutersRef.value
+  if (recognizedRoutersChainId.value === chainId) {
+    return recognizedRoutersRef.value
   }
 
   const inflight = pendingRouterLoads.get(chainId)
@@ -29,9 +29,9 @@ const loadRecognisedRouters = async (chainId: number): Promise<Set<string>> => {
 
   const promise = (async () => {
     const data = await $fetch('/api/oracle-routers', { query: { chainId } })
-    const set = toRecognisedSet(data)
-    recognisedRoutersRef.value = set
-    recognisedRoutersChainId.value = chainId
+    const set = toRecognizedSet(data)
+    recognizedRoutersRef.value = set
+    recognizedRoutersChainId.value = chainId
     return set
   })()
 
@@ -40,7 +40,7 @@ const loadRecognisedRouters = async (chainId: number): Promise<Set<string>> => {
     return await promise
   }
   catch (err) {
-    logWarn('useEulerOracleRouters', `Failed to load recognised routers for chain ${chainId}: ${err instanceof Error ? err.message : String(err)}`)
+    logWarn('useEulerOracleRouters', `Failed to load recognized routers for chain ${chainId}: ${err instanceof Error ? err.message : String(err)}`)
     return new Set()
   }
   finally {
@@ -49,7 +49,7 @@ const loadRecognisedRouters = async (chainId: number): Promise<Set<string>> => {
 }
 
 export const useEulerOracleRouters = () => ({
-  recognisedRouters: computed(() => recognisedRoutersRef.value),
-  recognisedRoutersChainId: readonly(recognisedRoutersChainId),
-  loadRecognisedRouters,
+  recognizedRouters: computed(() => recognizedRoutersRef.value),
+  recognizedRoutersChainId: readonly(recognizedRoutersChainId),
+  loadRecognizedRouters,
 })

--- a/entities/oracle.ts
+++ b/entities/oracle.ts
@@ -99,7 +99,7 @@ export type OracleAdapterIdentity = {
 // An adapter step (`isAdapter`) only gets a name/provider from the curated
 // oracle-checks dataset (`meta`). When that entry is absent we must NOT fall back
 // to the self-reported onchain `name()` — that value is attacker-controllable and
-// would let an unknown adapter masquerade as a recognised one. Such steps are
+// would let an unknown adapter masquerade as a recognized one. Such steps are
 // flagged as custom adapters and rendered as "Unknown".
 //
 // Structural steps (e.g. ERC-4626 exchange-rate `vault` steps) are not adapters and
@@ -117,20 +117,20 @@ export function resolveOracleAdapterIdentity(
   }
 }
 
-// Classifies a vault's oracle router(s) against the recognised-router allowlist
-// (deployed by the recognised EulerRouterFactory). Returns null — i.e. show
+// Classifies a vault's oracle router(s) against the recognized-router allowlist
+// (deployed by the recognized EulerRouterFactory). Returns null — i.e. show
 // nothing — when the allowlist is unavailable (empty) or there are no routers to
-// check, so a missing dataset never produces a false "unrecognised" warning.
+// check, so a missing dataset never produces a false "unrecognized" warning.
 export function getRouterRecognition(
   routerAddresses: ReadonlyArray<string | undefined | null>,
-  recognised: ReadonlySet<string>,
-): 'recognised' | 'unrecognised' | null {
-  if (!recognised.size) return null
+  recognized: ReadonlySet<string>,
+): 'recognized' | 'unrecognized' | null {
+  if (!recognized.size) return null
   const addresses = routerAddresses
     .filter((address): address is string => typeof address === 'string' && address.length > 0)
     .map(address => address.toLowerCase())
   if (!addresses.length) return null
-  return addresses.every(address => recognised.has(address)) ? 'recognised' : 'unrecognised'
+  return addresses.every(address => recognized.has(address)) ? 'recognized' : 'unrecognized'
 }
 
 type OracleAdapterOptions = {

--- a/entities/oracle.ts
+++ b/entities/oracle.ts
@@ -78,6 +78,24 @@ export type OracleAdapterMeta = {
   checks?: OracleAdapterCheck[]
 }
 
+export function normalizeOracleAdapterCheckSeverity(severity: unknown): OracleAdapterCheckSeverity {
+  if (typeof severity !== 'string') return OracleAdapterCheckSeverity.Info
+
+  switch (severity.trim().toLowerCase()) {
+    case 'high':
+      return OracleAdapterCheckSeverity.High
+    case 'med':
+    case 'medium':
+      return OracleAdapterCheckSeverity.Medium
+    case 'low':
+      return OracleAdapterCheckSeverity.Low
+    case 'info':
+      return OracleAdapterCheckSeverity.Info
+    default:
+      return OracleAdapterCheckSeverity.Info
+  }
+}
+
 export function getChecksStatus(checks: OracleAdapterCheck[] | undefined): 'positive' | 'warning' | 'negative' | null {
   if (!checks?.length) return null
   const failed = checks.filter(c => !c.pass)

--- a/entities/oracle.ts
+++ b/entities/oracle.ts
@@ -86,6 +86,53 @@ export function getChecksStatus(checks: OracleAdapterCheck[] | undefined): 'posi
   return 'warning'
 }
 
+export type OracleAdapterIdentity = {
+  name?: string
+  provider?: string
+  // True when this is an oracle adapter with no entry in the curated oracle-checks
+  // dataset — i.e. a custom oracle configured by the vault's risk manager.
+  isCustomAdapter: boolean
+}
+
+// Resolves the display name/provider for an oracle route step.
+//
+// An adapter step (`isAdapter`) only gets a name/provider from the curated
+// oracle-checks dataset (`meta`). When that entry is absent we must NOT fall back
+// to the self-reported onchain `name()` — that value is attacker-controllable and
+// would let an unknown adapter masquerade as a recognised one. Such steps are
+// flagged as custom adapters and rendered as "Unknown".
+//
+// Structural steps (e.g. ERC-4626 exchange-rate `vault` steps) are not adapters and
+// keep their decoded name, since it is derived from the route, not self-reported.
+export function resolveOracleAdapterIdentity(
+  step: { name: string },
+  meta: OracleAdapterMeta | undefined,
+  isAdapter: boolean,
+): OracleAdapterIdentity {
+  const fallback = isAdapter ? undefined : step.name
+  return {
+    name: meta?.name || fallback,
+    provider: meta?.provider || fallback,
+    isCustomAdapter: isAdapter && !meta,
+  }
+}
+
+// Classifies a vault's oracle router(s) against the recognised-router allowlist
+// (deployed by the recognised EulerRouterFactory). Returns null — i.e. show
+// nothing — when the allowlist is unavailable (empty) or there are no routers to
+// check, so a missing dataset never produces a false "unrecognised" warning.
+export function getRouterRecognition(
+  routerAddresses: ReadonlyArray<string | undefined | null>,
+  recognised: ReadonlySet<string>,
+): 'recognised' | 'unrecognised' | null {
+  if (!recognised.size) return null
+  const addresses = routerAddresses
+    .filter((address): address is string => typeof address === 'string' && address.length > 0)
+    .map(address => address.toLowerCase())
+  if (!addresses.length) return null
+  return addresses.every(address => recognised.has(address)) ? 'recognised' : 'unrecognised'
+}
+
 type OracleAdapterOptions = {
   base?: Address
   quote?: Address

--- a/server/api/oracle-routers.get.ts
+++ b/server/api/oracle-routers.get.ts
@@ -1,0 +1,66 @@
+import { createError, getQuery } from 'h3'
+import { createRateLimiter } from '~/server/utils/rate-limit'
+import { createTtlCache } from '~/server/utils/cache'
+import { fetchWithTimeout } from '~/server/utils/fetchWithTimeout'
+import { logger } from '~/server/utils/logger'
+
+const CACHE_TTL_MS = 300_000
+
+const rateLimiter = createRateLimiter({
+  max: 60,
+  windowMs: 60_000,
+  label: 'oracle-routers',
+})
+
+const cache = createTtlCache<unknown>({ ttlMs: CACHE_TTL_MS, maxEntries: 50 })
+
+function getUpstreamUrl(chainId: number): string {
+  const baseUrl = (process.env.NUXT_PUBLIC_CONFIG_ORACLE_CHECKS_BASE_URL || '').trim().replace(/\/+$/, '')
+  if (baseUrl) {
+    return `${baseUrl}/${chainId}/routers/all.json`
+  }
+
+  const repo = process.env.NUXT_PUBLIC_CONFIG_ORACLE_CHECKS_REPO || 'euler-xyz/oracle-checks'
+  return `https://raw.githubusercontent.com/${repo}/refs/heads/master/data/${chainId}/routers/all.json`
+}
+
+export default defineEventHandler(async (event) => {
+  rateLimiter.consume(event)
+
+  const query = getQuery(event)
+  const chainId = Number(query.chainId)
+  if (!Number.isInteger(chainId) || chainId <= 0) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid chainId' })
+  }
+
+  const key = `${chainId}`
+
+  const cached = cache.get(key)
+  if (cached !== undefined) return cached
+
+  try {
+    const resp = await fetchWithTimeout(getUpstreamUrl(chainId))
+    if (!resp.ok) {
+      // Don't cache the empty fallback for 404 (or any non-OK status). A
+      // missing/transient upstream response would otherwise pin every client
+      // to the empty array for the full TTL window — better to let the next
+      // request retry quickly.
+      if (resp.status === 404) return []
+      throw new Error(`Upstream returned ${resp.status}`)
+    }
+
+    const data: unknown = await resp.json()
+    cache.set(key, data)
+    return data
+  }
+  catch (err) {
+    logger.warn({ ctx: 'oracle-routers', chainId, err }, 'fetch routers all.json failed')
+
+    const stale = cache.getStale(key)
+    if (stale !== undefined) return stale
+
+    // Same reasoning as the 404 branch: don't pollute the cache with an empty
+    // array on transient failures.
+    return []
+  }
+})

--- a/tests/composables/useEulerOracleRouters.test.ts
+++ b/tests/composables/useEulerOracleRouters.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+
+  return { promise, resolve, reject }
+}
+
+describe('useEulerOracleRouters', () => {
+  afterEach(() => {
+    vi.resetModules()
+    vi.unstubAllGlobals()
+  })
+
+  it('does not let a stale chain response overwrite the active chain allowlist', async () => {
+    const chainOne = deferred<string[]>()
+    const chainTwo = deferred<string[]>()
+
+    vi.stubGlobal('$fetch', vi.fn((_url: string, options?: { query?: { chainId?: number } }) => {
+      if (options?.query?.chainId === 1) return chainOne.promise
+      if (options?.query?.chainId === 2) return chainTwo.promise
+      throw new Error('unexpected chain')
+    }))
+
+    const { useEulerOracleRouters } = await import('~/composables/useEulerOracleRouters')
+    const routers = useEulerOracleRouters()
+
+    const firstLoad = routers.loadRecognizedRouters(1)
+    const secondLoad = routers.loadRecognizedRouters(2)
+
+    chainTwo.resolve(['0xBbB0000000000000000000000000000000000002'])
+    await secondLoad
+
+    expect(routers.recognizedRoutersChainId.value).toBe(2)
+    expect(routers.recognizedRouters.value.has('0xbbb0000000000000000000000000000000000002')).toBe(true)
+
+    chainOne.resolve(['0xAaA0000000000000000000000000000000000001'])
+    await firstLoad
+
+    expect(routers.recognizedRoutersChainId.value).toBe(2)
+    expect(routers.recognizedRouters.value.has('0xbbb0000000000000000000000000000000000002')).toBe(true)
+    expect(routers.recognizedRouters.value.has('0xaaa0000000000000000000000000000000000001')).toBe(false)
+
+    await routers.loadRecognizedRouters(1)
+
+    expect(routers.recognizedRoutersChainId.value).toBe(1)
+    expect(routers.recognizedRouters.value.has('0xaaa0000000000000000000000000000000000001')).toBe(true)
+  })
+})

--- a/tests/entities/oracle.test.ts
+++ b/tests/entities/oracle.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import type { Address } from 'viem'
 import {
+  getChecksStatus,
   getRouterRecognition,
+  normalizeOracleAdapterCheckSeverity,
   resolveOracleAdapterIdentity,
   type OracleAdapterMeta,
+  OracleAdapterCheckSeverity,
 } from '~/entities/oracle'
 
 const oracle = '0x0000000000000000000000000000000000000001' as Address
@@ -86,5 +89,30 @@ describe('getRouterRecognition (LITE-236)', () => {
   it('returns "unrecognized" when any router is missing from the allowlist', () => {
     const recognized = new Set([router])
     expect(getRouterRecognition([router, otherRouter], recognized)).toBe('unrecognized')
+  })
+})
+
+describe('normalizeOracleAdapterCheckSeverity', () => {
+  it('accepts oracle-checks wire casing', () => {
+    expect(normalizeOracleAdapterCheckSeverity('High')).toBe(OracleAdapterCheckSeverity.High)
+    expect(normalizeOracleAdapterCheckSeverity('Med')).toBe(OracleAdapterCheckSeverity.Medium)
+    expect(normalizeOracleAdapterCheckSeverity('Info')).toBe(OracleAdapterCheckSeverity.Info)
+  })
+
+  it('keeps enum casing and falls back to info for unknown values', () => {
+    expect(normalizeOracleAdapterCheckSeverity(OracleAdapterCheckSeverity.High)).toBe(OracleAdapterCheckSeverity.High)
+    expect(normalizeOracleAdapterCheckSeverity('wat')).toBe(OracleAdapterCheckSeverity.Info)
+    expect(normalizeOracleAdapterCheckSeverity(undefined)).toBe(OracleAdapterCheckSeverity.Info)
+  })
+})
+
+describe('getChecksStatus', () => {
+  it('treats normalized high-severity failures as negative', () => {
+    expect(getChecksStatus([{
+      id: 'Source code provenance',
+      message: 'Contract metadata hash is not recognized.',
+      pass: false,
+      severity: normalizeOracleAdapterCheckSeverity('High'),
+    }])).toBe('negative')
   })
 })

--- a/tests/entities/oracle.test.ts
+++ b/tests/entities/oracle.test.ts
@@ -14,7 +14,7 @@ const makeMeta = (overrides: Partial<OracleAdapterMeta> = {}): OracleAdapterMeta
 })
 
 describe('resolveOracleAdapterIdentity', () => {
-  it('uses curated name/provider for a recognised adapter', () => {
+  it('uses curated name/provider for a recognized adapter', () => {
     const meta = makeMeta({ name: 'Chainlink WETH/USD', provider: 'Chainlink' })
     const identity = resolveOracleAdapterIdentity({ name: 'ChainlinkOracle' }, meta, true)
 
@@ -39,7 +39,7 @@ describe('resolveOracleAdapterIdentity', () => {
 
     expect(identity.name).toBeUndefined()
     expect(identity.provider).toBeUndefined()
-    // A curated entry exists, so it is recognised — not a custom adapter.
+    // A curated entry exists, so it is recognized — not a custom adapter.
     expect(identity.isCustomAdapter).toBe(false)
   })
 
@@ -63,28 +63,28 @@ describe('getRouterRecognition (LITE-236)', () => {
   })
 
   it('returns null when there are no router addresses to check', () => {
-    const recognised = new Set([router])
-    expect(getRouterRecognition([], recognised)).toBeNull()
-    expect(getRouterRecognition([undefined, null], recognised)).toBeNull()
+    const recognized = new Set([router])
+    expect(getRouterRecognition([], recognized)).toBeNull()
+    expect(getRouterRecognition([undefined, null], recognized)).toBeNull()
   })
 
-  it('returns "recognised" when every router is in the allowlist', () => {
-    const recognised = new Set([router, otherRouter])
-    expect(getRouterRecognition([router, otherRouter], recognised)).toBe('recognised')
+  it('returns "recognized" when every router is in the allowlist', () => {
+    const recognized = new Set([router, otherRouter])
+    expect(getRouterRecognition([router, otherRouter], recognized)).toBe('recognized')
   })
 
   it('matches addresses case-insensitively', () => {
-    const recognised = new Set([router])
-    expect(getRouterRecognition([router.toUpperCase()], recognised)).toBe('recognised')
+    const recognized = new Set([router])
+    expect(getRouterRecognition([router.toUpperCase()], recognized)).toBe('recognized')
   })
 
   it('ignores nullish entries when classifying', () => {
-    const recognised = new Set([router])
-    expect(getRouterRecognition([undefined, router, null], recognised)).toBe('recognised')
+    const recognized = new Set([router])
+    expect(getRouterRecognition([undefined, router, null], recognized)).toBe('recognized')
   })
 
-  it('returns "unrecognised" when any router is missing from the allowlist', () => {
-    const recognised = new Set([router])
-    expect(getRouterRecognition([router, otherRouter], recognised)).toBe('unrecognised')
+  it('returns "unrecognized" when any router is missing from the allowlist', () => {
+    const recognized = new Set([router])
+    expect(getRouterRecognition([router, otherRouter], recognized)).toBe('unrecognized')
   })
 })

--- a/tests/entities/oracle.test.ts
+++ b/tests/entities/oracle.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest'
+import type { Address } from 'viem'
+import {
+  getRouterRecognition,
+  resolveOracleAdapterIdentity,
+  type OracleAdapterMeta,
+} from '~/entities/oracle'
+
+const oracle = '0x0000000000000000000000000000000000000001' as Address
+
+const makeMeta = (overrides: Partial<OracleAdapterMeta> = {}): OracleAdapterMeta => ({
+  oracle,
+  ...overrides,
+})
+
+describe('resolveOracleAdapterIdentity', () => {
+  it('uses curated name/provider for a recognised adapter', () => {
+    const meta = makeMeta({ name: 'Chainlink WETH/USD', provider: 'Chainlink' })
+    const identity = resolveOracleAdapterIdentity({ name: 'ChainlinkOracle' }, meta, true)
+
+    expect(identity).toEqual({
+      name: 'Chainlink WETH/USD',
+      provider: 'Chainlink',
+      isCustomAdapter: false,
+    })
+  })
+
+  it('marks an adapter with no curated entry as custom and does NOT leak the onchain name (LITE-235)', () => {
+    const identity = resolveOracleAdapterIdentity({ name: 'ChainlinkOracle' }, undefined, true)
+
+    expect(identity.name).toBeUndefined()
+    expect(identity.provider).toBeUndefined()
+    expect(identity.isCustomAdapter).toBe(true)
+  })
+
+  it('does not fall back to the onchain name when the curated entry omits name/provider', () => {
+    const meta = makeMeta({ methodology: 'Market price' })
+    const identity = resolveOracleAdapterIdentity({ name: 'ChainlinkOracle' }, meta, true)
+
+    expect(identity.name).toBeUndefined()
+    expect(identity.provider).toBeUndefined()
+    // A curated entry exists, so it is recognised — not a custom adapter.
+    expect(identity.isCustomAdapter).toBe(false)
+  })
+
+  it('keeps the decoded name for non-adapter structural steps (e.g. ERC-4626 exchange rate)', () => {
+    const identity = resolveOracleAdapterIdentity({ name: 'ERC4626Vault' }, undefined, false)
+
+    expect(identity).toEqual({
+      name: 'ERC4626Vault',
+      provider: 'ERC4626Vault',
+      isCustomAdapter: false,
+    })
+  })
+})
+
+describe('getRouterRecognition (LITE-236)', () => {
+  const router = '0xabc0000000000000000000000000000000000001'
+  const otherRouter = '0xdef0000000000000000000000000000000000002'
+
+  it('returns null when the allowlist is unavailable (empty set)', () => {
+    expect(getRouterRecognition([router], new Set())).toBeNull()
+  })
+
+  it('returns null when there are no router addresses to check', () => {
+    const recognised = new Set([router])
+    expect(getRouterRecognition([], recognised)).toBeNull()
+    expect(getRouterRecognition([undefined, null], recognised)).toBeNull()
+  })
+
+  it('returns "recognised" when every router is in the allowlist', () => {
+    const recognised = new Set([router, otherRouter])
+    expect(getRouterRecognition([router, otherRouter], recognised)).toBe('recognised')
+  })
+
+  it('matches addresses case-insensitively', () => {
+    const recognised = new Set([router])
+    expect(getRouterRecognition([router.toUpperCase()], recognised)).toBe('recognised')
+  })
+
+  it('ignores nullish entries when classifying', () => {
+    const recognised = new Set([router])
+    expect(getRouterRecognition([undefined, router, null], recognised)).toBe('recognised')
+  })
+
+  it('returns "unrecognised" when any router is missing from the allowlist', () => {
+    const recognised = new Set([router])
+    expect(getRouterRecognition([router, otherRouter], recognised)).toBe('unrecognised')
+  })
+})

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -6,7 +6,7 @@
  * server/ module that calls one of these globals at module top level.
  */
 
-import { computed, reactive, ref, shallowReactive, shallowRef, watch, watchEffect } from 'vue'
+import { computed, reactive, readonly, ref, shallowReactive, shallowRef, watch, watchEffect } from 'vue'
 
 type AnyFn = (...args: unknown[]) => unknown
 
@@ -26,6 +26,7 @@ const vueGlobals: Record<string, unknown> = {
   shallowRef,
   reactive,
   shallowReactive,
+  readonly,
   computed,
   watch,
   watchEffect,

--- a/tests/utils/oracle-adapter-views.test.ts
+++ b/tests/utils/oracle-adapter-views.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+import type { Address } from 'viem'
+import type { EVault, OracleRouteStep } from '@eulerxyz/euler-v2-sdk'
+import type { OracleAdapterMeta } from '~/entities/oracle'
+import { OracleAdapterCheckSeverity } from '~/entities/oracle'
+import { buildOracleAdapterView, collectOracleRouteSteps } from '~/utils/oracle-adapter-views'
+
+const oracle = '0x000000000000000000000000000000000000A111' as Address
+const weth = '0x000000000000000000000000000000000000E711' as Address
+const usd = '0x0000000000000000000000000000000000000051' as Address
+
+const adapterStep = (overrides: Partial<OracleRouteStep> = {}): OracleRouteStep => ({
+  kind: 'adapter',
+  oracle,
+  base: weth,
+  quote: usd,
+  name: 'ChainlinkOracle',
+  ...overrides,
+} as OracleRouteStep)
+
+describe('buildOracleAdapterView', () => {
+  it('enriches a recognized adapter from curated metadata', () => {
+    const meta: Record<string, OracleAdapterMeta> = {
+      [oracle.toLowerCase()]: {
+        oracle,
+        base: weth,
+        quote: usd,
+        name: 'Chainlink WETH/USD',
+        provider: 'Chainlink',
+        methodology: 'Market price',
+        label: 'Chainlink WETH/USD (Primary)',
+        checks: [{ id: 'staleness', message: 'ok', pass: true, severity: OracleAdapterCheckSeverity.Info }],
+      },
+    }
+    const view = buildOracleAdapterView(adapterStep(), meta)
+
+    expect(view.provider).toBe('Chainlink')
+    expect(view.name).toBe('Chainlink WETH/USD')
+    expect(view.isCustomAdapter).toBe(false)
+    expect(view.methodology).toBe('Market price')
+    expect(view.logo).toBe('/oracles/chainlink.svg')
+    expect(view.label).toEqual({ primary: 'Chainlink WETH/USD', suffix: '(Primary)' })
+    expect(view.checksStatus).toBe('positive')
+  })
+
+  it('flags an adapter with no curated entry as custom (no onchain-name leak, no logo)', () => {
+    const view = buildOracleAdapterView(adapterStep(), {})
+
+    expect(view.name).toBeUndefined()
+    expect(view.provider).toBeUndefined()
+    expect(view.isCustomAdapter).toBe(true)
+    expect(view.logo).toBeUndefined()
+    expect(view.label).toBeUndefined()
+    expect(view.checksStatus).toBeNull()
+  })
+
+  it('keeps the decoded name and "Exchange Rate" methodology for vault (ERC-4626) steps', () => {
+    const view = buildOracleAdapterView(adapterStep({ kind: 'vault', name: 'ERC4626Vault' }), {})
+
+    expect(view.name).toBe('ERC4626Vault')
+    expect(view.isCustomAdapter).toBe(false)
+    expect(view.methodology).toBe('Exchange Rate')
+  })
+
+  it('marks a high-severity failing check as a negative status', () => {
+    const meta: Record<string, OracleAdapterMeta> = {
+      [oracle.toLowerCase()]: {
+        oracle,
+        provider: 'Chainlink',
+        checks: [{ id: 'staleness', message: 'stale', pass: false, severity: OracleAdapterCheckSeverity.High }],
+      },
+    }
+    const view = buildOracleAdapterView(adapterStep(), meta)
+
+    expect(view.checksStatus).toBe('negative')
+    expect(view.failedChecks).toHaveLength(1)
+  })
+})
+
+describe('collectOracleRouteSteps', () => {
+  const debtStep = adapterStep({ oracle: '0x00000000000000000000000000000000000000d1' as Address })
+  const collateralStep = adapterStep({ oracle: '0x00000000000000000000000000000000000000c1' as Address, base: usd, quote: weth })
+
+  const makeVault = (collateralAddr: string): EVault => ({
+    debtPricingOracleRoute: { steps: [debtStep] },
+    collaterals: [
+      { address: collateralAddr, oracleRoute: { steps: [collateralStep] } },
+    ],
+  } as unknown as EVault)
+
+  it('returns the debt route when there are no collaterals', () => {
+    const steps = collectOracleRouteSteps([makeVault('0xdead')])
+    expect(steps).toEqual([debtStep])
+  })
+
+  it('combines debt + collateral routes for the pair', () => {
+    const collateralAddr = '0x00000000000000000000000000000000000000cc'
+    const collateralVault = { address: collateralAddr } as unknown as EVault
+    const steps = collectOracleRouteSteps([makeVault(collateralAddr)], [collateralVault])
+
+    expect(steps).toContain(debtStep)
+    expect(steps).toContain(collateralStep)
+    expect(steps).toHaveLength(2)
+  })
+
+  it('dedupes identical steps across vaults', () => {
+    const v = makeVault('0xdead')
+    const steps = collectOracleRouteSteps([v, v])
+    expect(steps).toHaveLength(1)
+  })
+})

--- a/utils/oracle-adapter-views.ts
+++ b/utils/oracle-adapter-views.ts
@@ -1,0 +1,108 @@
+import type { Address } from 'viem'
+import type { EVault, OracleRouteStep, SecuritizeCollateralVault } from '@eulerxyz/euler-v2-sdk'
+import {
+  getChecksStatus,
+  resolveOracleAdapterIdentity,
+  type OracleAdapterCheck,
+  type OracleAdapterMeta,
+} from '~/entities/oracle'
+import { getOracleProviderLogo } from '~/entities/oracle-providers'
+import { shouldInvertOraclePrice } from '~/utils/oracle-label'
+import { getCollateralOracleRouteSteps, getDebtOracleRouteSteps, isOracleAdapterRouteStep } from '~/utils/oracle-route-steps'
+import { getOracleRouteStepKey } from '~/composables/useOracleAdapterPrices'
+
+// Single source of truth for the oracle adapters shown on the borrow page's
+// Oracles block AND in the explore matrix. Both surfaces must agree on which
+// adapters price a given (liability, collateral) pair, so the collection and
+// per-step enrichment live here rather than being duplicated per component.
+
+export type OracleAdapterView = {
+  key: string
+  kind: OracleRouteStep['kind']
+  oracle: Address
+  base: Address
+  quote: Address
+  metaBase?: Address
+  metaQuote?: Address
+  name?: string
+  provider?: string
+  isCustomAdapter: boolean
+  methodology?: string
+  logo?: string
+  label?: { primary: string, suffix?: string }
+  invertPrice: boolean
+  checks?: OracleAdapterCheck[]
+  checksStatus: 'positive' | 'warning' | 'negative' | null
+  failedChecks: OracleAdapterCheck[]
+}
+
+// Collects the deduped oracle route steps that price the given liability
+// vault(s) together with the given collateral vault(s): each liability's own
+// asset->unit-of-account (debt) route plus the collateral->unit-of-account
+// route for every collateral. Mirrors what the borrow page shows for a pair.
+export const collectOracleRouteSteps = (
+  vaults: EVault[],
+  collateralVaults: (EVault | SecuritizeCollateralVault)[] = [],
+): OracleRouteStep[] => {
+  const deduped = new Map<string, OracleRouteStep>()
+  for (const vault of vaults) {
+    const steps: OracleRouteStep[] = [...getDebtOracleRouteSteps(vault)]
+    for (const collateralVault of collateralVaults) {
+      steps.push(...getCollateralOracleRouteSteps(vault, collateralVault))
+    }
+    for (const step of steps) {
+      const key = getOracleRouteStepKey(step)
+      if (!deduped.has(key)) deduped.set(key, step)
+    }
+  }
+  return [...deduped.values()]
+}
+
+const parseAdapterLabel = (label: string | undefined): { primary: string, suffix?: string } | undefined =>
+  label
+    ? {
+        primary: label.split('(')[0].trimEnd(),
+        suffix: label.includes('(') ? label.slice(label.indexOf('(')).trim() : undefined,
+      }
+    : undefined
+
+// Enriches one oracle route step into a display view, resolving its identity
+// from the curated oracle-checks dataset (see resolveOracleAdapterIdentity).
+export const buildOracleAdapterView = (
+  step: OracleRouteStep,
+  oracleAdapters: Record<string, OracleAdapterMeta>,
+): OracleAdapterView => {
+  const isAdapter = isOracleAdapterRouteStep(step)
+  const meta = isAdapter ? oracleAdapters[step.oracle.toLowerCase()] : undefined
+  const { name, provider, isCustomAdapter } = resolveOracleAdapterIdentity(step, meta, isAdapter)
+  const checks = meta?.checks
+  return {
+    key: getOracleRouteStepKey(step),
+    kind: step.kind,
+    oracle: step.oracle,
+    base: step.base,
+    quote: step.quote,
+    metaBase: meta?.base,
+    metaQuote: meta?.quote,
+    name,
+    provider,
+    isCustomAdapter,
+    methodology: meta?.methodology || (step.kind === 'vault' ? 'Exchange Rate' : undefined),
+    logo: getOracleProviderLogo(provider, name),
+    label: parseAdapterLabel(meta?.label),
+    invertPrice: shouldInvertOraclePrice({
+      metaBase: meta?.base,
+      metaQuote: meta?.quote,
+      callerBase: step.base,
+      callerQuote: step.quote,
+    }),
+    checks,
+    checksStatus: getChecksStatus(checks),
+    failedChecks: checks?.filter(c => !c.pass) ?? [],
+  }
+}
+
+export const buildOracleAdapterViews = (
+  steps: OracleRouteStep[],
+  oracleAdapters: Record<string, OracleAdapterMeta>,
+): OracleAdapterView[] => steps.map(step => buildOracleAdapterView(step, oracleAdapters))


### PR DESCRIPTION
## Summary

Three related improvements to how the vault **Oracles** block communicates oracle trustworthiness, so users can tell a curated/recognized oracle setup from a custom or unknown one. All three hang off the same signal: whether an oracle is present in the curated oracle-checks dataset.

- **Unknown adapters no longer borrow a trusted identity.** Previously, an adapter with no curated oracle-checks entry fell back to its self-reported onchain `name()` — a value anyone can set when deploying an adapter — letting an unknown adapter render as if it were a recognized one. It now renders as **"Unknown"**.
- **Custom oracles are labelled, not blanked.** An adapter with no curated entry showed **"N/A"** in the Checks field, which reads like missing information. It now shows **"Custom — set by risk manager"**, making clear the oracle is a custom one the risk manager wired up (and therefore has no curated checks). Recognized adapters that simply have an empty checks list still show "N/A".
- **Router recognition.** The vault's price oracle is an EulerRouter. The block now shows a **recognized ✓ / unrecognized ⚠** badge indicating whether that router is in the published allowlist of routers deployed by the recognized `EulerRouterFactory`.

## Changes

- **`entities/oracle.ts`** — two pure helpers:
  - `resolveOracleAdapterIdentity(step, meta, isAdapter)` — resolves display name/provider. For adapter steps with no curated `meta`, returns `undefined` (→ "Unknown") instead of the onchain name, and flags `isCustomAdapter`. Structural steps (e.g. ERC-4626 exchange-rate vault steps) keep their decoded name, since it is route-derived, not self-reported.
  - `getRouterRecognition(routerAddresses, recognized)` — classifies a vault's router(s) against the allowlist. Returns `null` (show nothing) when the allowlist is unavailable or there are no routers, so a missing/transient dataset never produces a false "unrecognized" warning.
- **`server/api/oracle-routers.get.ts`** — new endpoint mirroring `oracle-routers`'s sibling `oracle-adapters` (same rate limiter, 5-min TTL cache, base-URL/GitHub fallback). Proxies `{chainId}/routers/all.json` (a flat array of recognized router addresses).
- **`composables/useEulerOracleRouters.ts`** — loads + caches the recognized-router set per chain (lowercased `Set` for O(1) lookups), with in-flight dedup.
- **`VaultOverviewBlockOracleAdapters.vue`** — uses the identity helper; renders the "Custom — set by risk manager" Checks label; renders the recognized/unrecognized router badge (with explanatory tooltip) in the block header.
- **`DiscoveryMarketMatrix.vue`** — applies the same identity helper for consistency, so the explore matrix also stops surfacing self-reported names for unknown adapters.
- **`tests/entities/oracle.test.ts`** — unit tests for both helpers (recognized vs custom adapters, no onchain-name leak, structural-step passthrough; router allowlist empty/missing/case-insensitive/partial cases).

## Notes

- The badge is intentionally quiet when the allowlist can't be loaded — it only asserts "unrecognized" when the dataset is present and the router is genuinely absent from it.
- The new endpoint fetches the same upstream host as the existing adapters endpoint (server-side), so no CSP/connect-src change is needed.

## Test plan

- [ ] `npm run test:run -- tests/entities/oracle.test.ts` — helper unit tests pass.
- [ ] On a vault whose oracle adapter is **not** in the oracle-checks dataset: Provider shows "Unknown" (not the onchain name) and Checks shows "Custom — set by risk manager".
- [ ] On a vault with a fully curated adapter: Provider/checks unchanged from before.
- [ ] Oracles block header shows the **recognized** badge for a vault whose router is in `routers/all.json`, and **unrecognized** for one that isn't; no badge when the allowlist is empty/unavailable.
- [ ] Explore matrix: unknown adapters show the question-circle icon + "Unknown", not a self-reported name.

Addresses LITE-235, LITE-236, LITE-239.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Recognised router” / “Unrecognised router” status to the vault oracle overview, including per-network router checks.
  * Added loading, caching, and rate-limiting for the recognised EulerRouter allowlist.
  * Enhanced oracle adapter views with consistent identity/label/checks rendering across surfaces.
* **Bug Fixes**
  * Prevented oracle adapter identity from falling back to on-chain names when curated metadata is missing.
  * Improved adapter check severity handling and checks-status outcomes.
  * Matrix oracle cells are now only selectable when an oracle adapter is available.
* **Tests**
  * Expanded automated coverage for oracle helpers, router recognition, and the recognised-router composable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
