### PR TITLE
fix(batch): don't surface dust/self collateral rows in simulated borrow

### DIFF
--- a/composables/useTxBatch.ts
+++ b/composables/useTxBatch.ts
@@ -798,6 +798,7 @@ const hydrateBorrowLiquidity = (
   borrow: StitchPosition,
   positions: StitchPosition[],
   enabledCollaterals: Address[] | undefined,
+  baseEnabledCollaterals: Address[] | undefined,
 ): void => {
   const liquidity = borrow.liquidity
   if (!liquidity || (borrow.borrowed ?? 0n) === 0n) return
@@ -805,6 +806,7 @@ const hydrateBorrowLiquidity = (
   const positionsByVault = positionByVault(positions)
   liquidity.vault = liquidity.vault ?? borrow.vault
   liquidity.liabilityValueUsd = borrow.borrowedValueUsd
+  const borrowVaultKey = getAddress(borrow.vaultAddress).toLowerCase()
 
   const existingCollaterals = new Map<string, StitchLiquidityCollateral>()
   for (const collateral of liquidity.collaterals) {
@@ -812,11 +814,23 @@ const hydrateBorrowLiquidity = (
   }
   const enabledCollateralKeys = enabledCollaterals?.map(address => getAddress(address).toLowerCase())
   const enabledCollateralSet = enabledCollateralKeys ? new Set(enabledCollateralKeys) : undefined
+  // Collaterals that were already enabled on the EVC *before* this batch ran.
+  // Used to tell a collateral newly enabled by the batch (e.g. a collateral
+  // swap) apart from a pre-existing, possibly empty, enablement.
+  const baseEnabledCollateralSet = baseEnabledCollaterals
+    ? new Set(baseEnabledCollaterals.map(address => getAddress(address).toLowerCase()))
+    : undefined
   const collateralAddresses: Address[] = []
   const seen = new Set<string>()
   const addCollateralAddress = (address: string, requireEnabledOrValue: boolean) => {
     const key = getAddress(address).toLowerCase()
     if (seen.has(key)) return
+    // A vault is never its own collateral. The EVC can list the borrow vault in
+    // enabledCollaterals, and its own position carries debt (so it passes the
+    // value guard below), but the controller grants it no LTV — the lens omits
+    // it from liquidity.collaterals and so must we, or it surfaces as a spurious
+    // zero-value collateral row.
+    if (key === borrowVaultKey) return
     const collateralPosition = positionsByVault.get(getAddress(address))
     const hasBalance = hasPositionValue(collateralPosition)
     const isEnabled = enabledCollateralSet?.has(key) ?? true
@@ -827,7 +841,19 @@ const hydrateBorrowLiquidity = (
     collateralAddresses.push(getAddress(address) as Address)
   }
   for (const collateral of liquidity.collaterals) addCollateralAddress(collateral.address, true)
-  for (const collateral of enabledCollateralKeys ?? []) addCollateralAddress(collateral, false)
+  // EVC-enabled collaterals. A collateral *newly* enabled by this batch (not in
+  // the base enabled set) is added unconditionally, since its simulated balance
+  // may not be populated on this position yet — this is what surfaces a
+  // collateral-swap's new collateral. A collateral that was already enabled
+  // before the batch is added under the same guard as the lens collaterals
+  // above, so leftover enabled-but-empty vaults (an account can carry several)
+  // don't show up as spurious zero-value collateral rows. When the base set is
+  // unknown (a brand-new sub-account), every enabled collateral is treated as
+  // newly enabled, preserving the prior unconditional behaviour.
+  for (const collateral of enabledCollateralKeys ?? []) {
+    const wasEnabledBeforeBatch = baseEnabledCollateralSet?.has(collateral) ?? false
+    addCollateralAddress(collateral, wasEnabledBeforeBatch)
+  }
 
   let totalCollateralValueUsd: number | undefined = collateralAddresses.length ? 0 : liquidity.totalCollateralValueUsd
   let hasMissingCollateralUsd = false
@@ -874,9 +900,10 @@ const hydrateBorrowLiquidity = (
 const hydrateStitchedPositions = (
   positions: StitchPosition[],
   enabledCollaterals: Address[] | undefined,
+  baseEnabledCollaterals: Address[] | undefined,
 ): StitchPosition[] => {
   for (const position of positions) hydratePositionMarketValues(position)
-  for (const position of positions) hydrateBorrowLiquidity(position, positions, enabledCollaterals)
+  for (const position of positions) hydrateBorrowLiquidity(position, positions, enabledCollaterals, baseEnabledCollaterals)
   return positions
 }
 
@@ -1122,6 +1149,8 @@ export const stitchAccount = (
         positions: hydrateStitchedPositions(
           mergePositionsByVault(tsa.positions.map(position => clonePosition(position as StitchPosition))),
           tsa.enabledCollaterals,
+          // No base sub-account: every enabled collateral is treated as new.
+          undefined,
         ),
       }
       continue
@@ -1132,7 +1161,15 @@ export const stitchAccount = (
       const vault = getAddress(tp.vaultAddress)
       byVault.set(vault, mergePositionData(byVault.get(vault), tp as StitchPosition))
     }
-    const positions = hydrateStitchedPositions(Array.from(byVault.values()), tsa.enabledCollaterals)
+    // `existing` is still the pre-batch (prevFull) sub-account here — it isn't
+    // overwritten with the simulated EVC state until below — so its enabled
+    // collaterals are the base set against which `tsa.enabledCollaterals` is the
+    // post-batch state.
+    const positions = hydrateStitchedPositions(
+      Array.from(byVault.values()),
+      tsa.enabledCollaterals,
+      existing.enabledCollaterals,
+    )
     mergedSubs[key] = {
       ...existing,
       // Post-op EVC state for this sub-account comes from the simulated layer.

--- a/tests/composables/useTxBatch.test.ts
+++ b/tests/composables/useTxBatch.test.ts
@@ -396,6 +396,52 @@ describe('stitchAccount', () => {
     expect(portfolio.borrows[0]?.healthFactor).toBe(1720000000000000000n)
   })
 
+  it('omits a pre-existing enabled-but-empty collateral from simulated borrow liquidity', () => {
+    // `vault` is a funded collateral; `targetVault` is a leftover EVC enablement
+    // with no balance and no entry in the borrow's lens collaterals. A plain
+    // repay leaves the enabled set unchanged, so `targetVault` is enabled both
+    // before and after the batch. It must NOT surface as a zero-value collateral
+    // row — only collaterals newly enabled by the batch are added unconditionally.
+    const base = accountWithPositions(
+      [collateralPosition(100_000_000n), borrowPosition(50_000_000n, 100)],
+      [vault, targetVault],
+      [borrowVault],
+    )
+    const touched = accountWithPositions(
+      [borrowPosition(25_000_000n, 100)],
+      [vault, targetVault],
+      [borrowVault],
+    )
+
+    const stitched = stitchAccount(base, touched)
+    const stitchedBorrow = stitched.getPosition(subAccount, borrowVault)
+
+    expect(stitchedBorrow?.liquidity?.collaterals.map(collateral => getAddress(collateral.address))).toEqual([vault])
+    expect(stitchedBorrow?.liquidity?.totalCollateralValueUsd).toBe(100)
+  })
+
+  it('never lists the borrow vault as its own collateral', () => {
+    // The EVC can have the borrow vault enabled as a collateral. Its own borrow
+    // position carries debt, so it passes hasPositionValue — but a vault is never
+    // its own collateral (the controller grants it no LTV; the lens omits it), so
+    // it must not appear as a spurious zero-value collateral row.
+    const base = accountWithPositions(
+      [collateralPosition(100_000_000n), borrowPosition(50_000_000n, 100)],
+      [vault, borrowVault],
+      [borrowVault],
+    )
+    const touched = accountWithPositions(
+      [borrowPosition(25_000_000n, 100)],
+      [vault, borrowVault],
+      [borrowVault],
+    )
+
+    const stitched = stitchAccount(base, touched)
+    const stitchedBorrow = stitched.getPosition(subAccount, borrowVault)
+
+    expect(stitchedBorrow?.liquidity?.collaterals.map(collateral => getAddress(collateral.address))).toEqual([vault])
+  })
+
   it('scales existing collateral but does not value newly enabled collateral when risk prices are unavailable', () => {
     const { sourceVault, destinationVault, borrow } = riskAwareBorrowPosition(false)
     const base = accountWithPositions([


### PR DESCRIPTION
## Problem

In the **simulated** batch account, a borrow position showed phantom collaterals the real/lens view never lists — e.g. repaying on the `…bfc` USDC/PYUSD position made the collateral read **"PYUSD & others"** instead of just `PYUSD`.

This only affects the simulated account: `hydrateBorrowLiquidity` runs solely from `stitchAccount`, never the base/real portfolio (which gets a clean `liquidity.collaterals` from the SDK lens).

## Root cause — two distinct sources

`hydrateBorrowLiquidity` built the collateral list partly from the EVC `enabledCollaterals` set (added in 50cce753 to surface a collateral-swap's newly-enabled collateral), but it added entries the lens deliberately omits:

1. **Enabled-but-empty dust collaterals.** An account can carry several leftover EVC enablements (here: `eUSDC-2/22/70`, PT-wstUSR, etc., all zero balance). They were added as zero-value rows.
2. **The borrow vault listing itself as collateral** — the actual cause of the visible "& others" on `…bfc`. The EVC has `eUSDC-80` (the borrow vault) enabled as a collateral, and its own borrow position carries debt, so it passed the `hasPositionValue` guard. The SDK lens never includes a vault in its own collateral list.

Confirmed live via instrumentation: `outCollaterals = [ePYUSD-6 (usd 18.5M), eUSDC-80 (usd 0)]`.

## Fix (`composables/useTxBatch.ts`)

- Thread the **pre-batch base enabled set** (`existing.enabledCollaterals`, still prevFull at that point in `stitchAccount`) into `hydrateBorrowLiquidity`. The enabled-collateral loop now adds unconditionally only when a collateral is **newly enabled by the batch** (not in the base set); pre-existing enablements go through the same balance/value guard as the lens collaterals, so empty dust is dropped.
- Skip the borrow vault itself: `if (key === borrowVaultKey) return` — a vault is never its own collateral.

The original collateral-swap behaviour (surfacing a genuinely newly-enabled collateral) is preserved.

## Tests

`tests/composables/useTxBatch.test.ts`:
- "omits a pre-existing enabled-but-empty collateral from simulated borrow liquidity"
- "never lists the borrow vault as its own collateral"

Both reproduce the bug (fail without the fix) and pass with it. Full file: **15/15 green**, eslint clean. The existing "hydrates newly enabled collateral" (collateral-swap) test still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved simulated borrow-liquidity calculations so collaterals enabled before a batch are handled differently from collaterals enabled by that batch.
  * Prevented empty collateral rows from appearing for previously enabled assets with no balance.
  * Ensured the borrow vault is not shown as a collateral asset in simulated results, even when it’s enabled and the position has debt.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->