### PR TITLE
feat: use monadscan

### DIFF
--- a/entities/chainRegistry.ts
+++ b/entities/chainRegistry.ts
@@ -44,6 +44,24 @@ const LEGACY_CHAIN_ALIASES: ReadonlyMap<string, number> = new Map([
   ['lineamainnet', 59144],
 ])
 
+const MONAD_CHAIN_ID = 143
+const MONAD_EXPLORER_URL = 'https://monadscan.com/'
+
+const monad = chainMap.get(MONAD_CHAIN_ID)
+if (monad) {
+  chainMap.set(MONAD_CHAIN_ID, {
+    ...monad,
+    blockExplorers: {
+      ...monad.blockExplorers,
+      default: {
+        ...monad.blockExplorers?.default,
+        name: 'MonadScan',
+        url: MONAD_EXPLORER_URL,
+      },
+    },
+  })
+}
+
 export const getChainIdByName = (name: string): number | undefined => {
   const normalized = name.trim().toLowerCase().replace(/\s+/g, '-')
   if (!normalized) return undefined

--- a/tests/utils/chain-registry.test.ts
+++ b/tests/utils/chain-registry.test.ts
@@ -26,6 +26,14 @@ describe('chainRegistry', () => {
     expect(getDefiLlamaChainName(999)).toBe('Hyperliquid')
   })
 
+  it('uses MonadScan as the Monad block explorer', () => {
+    const chain = getChainById(143)
+
+    expect(chain?.blockExplorers?.default.name).toBe('MonadScan')
+    expect(chain?.blockExplorers?.default.url).toBe('https://monadscan.com/')
+    expect(getChainIdByName('monad')).toBe(143)
+  })
+
   it('keeps reverse slug lookup pinned to canonical chain ID collisions', () => {
     expect(getChainIdByName('hyperEvm')).toBe(999)
     expect(getChainIdByName('hyperliquid')).toBe(999)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Monad network’s block explorer information so it now points to MonadScan with the correct website.
  * Improved chain lookup so searching by the Monad name resolves to the correct network ID.

* **Tests**
  * Added coverage for the updated Monad explorer details.
  * Added a check for name-based chain resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->