### PR TITLE
Redesign explore matrix oracle view with inline detail section

### DIFF
--- a/components/entities/vault/discovery/DiscoveryMarketAccordion.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketAccordion.vue
@@ -709,9 +709,29 @@ onMounted(() => {
                     </div>
                   </template>
 
-                  <!-- Cell selection: single lend + single borrow card -->
+                  <!-- Cell selection -->
                   <template v-else>
-                    <div class="flex flex-col gap-12">
+                    <!-- Oracle view: dedicated oracle adapters section for the
+                         selected collateral/liability pair (same component as the
+                         borrow page's Oracles block). -->
+                    <template v-if="getMatrixView(market.id) === 'oracle'">
+                      <template
+                        v-for="pair in [getSelectedBorrowPair(market)]"
+                        :key="'oracle-' + (pair ? `${pair.collateral.address}-${pair.borrow.address}` : '')"
+                      >
+                        <VaultOverviewBlockOracleAdapters
+                          v-if="pair"
+                          :vault="pair.borrow"
+                          :collateral-vaults="[pair.collateral]"
+                        />
+                      </template>
+                    </template>
+
+                    <!-- Other metrics: single lend + single borrow card -->
+                    <div
+                      v-else
+                      class="flex flex-col gap-12"
+                    >
                       <template
                         v-for="lendVault in [getSelectedLendVault(market)]"
                         :key="'lend-' + (lendVault ? getVaultAddress(lendVault) : '')"

--- a/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
@@ -1,24 +1,11 @@
 <script setup lang="ts">
-import {
-  isEVault,
-  type SecuritizeCollateralVault,
-  type OracleRouteStep,
-  type EVault,
-} from '@eulerxyz/euler-v2-sdk'
+import { isEVault } from '@eulerxyz/euler-v2-sdk'
 import { getMaxMultiplier, getMaxRoe } from '~/utils/leverage'
 import { findVault, formatMetricValue, getCellBgColor, isMatrixCompatibleVault, type CollateralMatrixData, type MatrixCell, type DotMetric, type EnhancedCellApys } from '~/utils/discoveryCalculations'
-import { getChecksStatus, OracleAdapterCheckSeverity, resolveOracleAdapterIdentity, type OracleAdapterCheck } from '~/entities/oracle'
-import { getOracleProviderLogo } from '~/entities/oracle-providers'
-import { getExplorerLink } from '~/utils/block-explorer'
-import { truncate, formatNumber } from '~/utils/string-utils'
-import { shouldInvertOraclePrice } from '~/utils/oracle-label'
-import { getOracleRouteStepKey, useOracleAdapterPrices } from '~/composables/useOracleAdapterPrices'
-import { getCollateralOracleRouteSteps, getDebtOracleRouteSteps, isOracleAdapterRouteStep } from '~/utils/oracle-route-steps'
+import { buildOracleAdapterViews, collectOracleRouteSteps, type OracleAdapterView } from '~/utils/oracle-adapter-views'
 import type { MarketGroup } from '~/entities/lend-discovery'
 import { withVaultIntrinsicApy } from '~/utils/vault-intrinsic-apy'
 import { areTokenAddressesCorrelatedByTags } from '~/utils/token-categories'
-import type { Address } from 'viem'
-import type { CSSProperties } from 'vue'
 
 const props = defineProps<{
   market: MarketGroup
@@ -28,7 +15,7 @@ const props = defineProps<{
   selectedHeader: { address: string, axis: 'row' | 'column' } | null
 }>()
 
-defineEmits<{
+const emit = defineEmits<{
   selectCell: [collateralAddr: string, liabilityAddr: string]
   selectHeader: [address: string, axis: 'row' | 'column']
 }>()
@@ -218,47 +205,51 @@ const metricRange = computed((): { min: number, max: number } => {
   return Number.isFinite(min) ? { min, max } : { min: 0, max: 0 }
 })
 
-// ── Oracle metric: per-cell adapter list + tooltip ────────────────────────────
+// ── Oracle metric: per-cell adapter views ────────────────────────────────────
 
-const getCollateralOracleSteps = (
-  liability: EVault,
-  collateral: EVault | SecuritizeCollateralVault,
-) => {
-  return getCollateralOracleRouteSteps(liability, collateral)
-}
-
-const cellOracleSteps = computed((): Map<string, OracleRouteStep[]> => {
-  const result = new Map<string, OracleRouteStep[]>()
+// Each off-diagonal cell shows every oracle adapter that prices the pair's
+// collateral AND liability assets — the same set the borrow page's Oracles
+// block renders, via the shared collectOracleRouteSteps + buildOracleAdapterViews.
+// The self-diagonal is intentionally left blank: a liability's own asset->UoA
+// oracle already appears in every cell of its column.
+const cellAdapterViews = computed((): Map<string, OracleAdapterView[]> => {
+  const result = new Map<string, OracleAdapterView[]>()
   if (props.dotMetric !== 'oracle') return result
 
-  for (const [colAddr, rowCells] of props.matrix.cells) {
-    for (const [liabAddr] of rowCells) {
-      const collateral = findVault(props.market, colAddr)
-      const liability = findVault(props.market, liabAddr)
-      if (!collateral || !liability) continue
-      if (!isMatrixCompatibleVault(collateral)) continue
-      if (!isEVault(liability)) continue
-      const steps = getCollateralOracleSteps(liability, collateral)
-      if (steps.length) result.set(`${colAddr}:${liabAddr}`, steps)
+  for (const [collateralAddr, rowCells] of props.matrix.cells) {
+    for (const [liabilityAddr] of rowCells) {
+      if (collateralAddr === liabilityAddr) continue
+      const collateral = findVault(props.market, collateralAddr)
+      const liability = findVault(props.market, liabilityAddr)
+      if (!collateral || !isMatrixCompatibleVault(collateral)) continue
+      if (!liability || !isEVault(liability)) continue
+      const steps = collectOracleRouteSteps([liability], [collateral])
+      if (steps.length) {
+        result.set(`${collateralAddr}:${liabilityAddr}`, buildOracleAdapterViews(steps, oracleAdapters))
+      }
     }
   }
   return result
 })
 
-// Per-borrow-vault asset oracle: resolves the borrow vault's own asset against
-// its unit of account. Same set repeated across every cell in a column, so we
-// surface it once as a header row instead.
-const columnAssetOracleSteps = computed((): Map<string, OracleRouteStep[]> => {
-  const result = new Map<string, OracleRouteStep[]>()
-  if (props.dotMetric !== 'oracle') return result
-  for (const col of props.matrix.columns) {
-    const liability = findVault(props.market, col.address)
-    if (!liability || !isEVault(liability)) continue
-    const steps = getDebtOracleRouteSteps(liability)
-    if (steps.length) result.set(col.address, steps)
+const getCellAdapterViews = (collateralAddr: string, liabilityAddr: string): OracleAdapterView[] =>
+  cellAdapterViews.value.get(`${collateralAddr}:${liabilityAddr}`) ?? []
+
+const isOracleCellSelectable = (collateralAddr: string, liabilityAddr: string): boolean =>
+  getCellAdapterViews(collateralAddr, liabilityAddr).length > 0
+
+// Cell click drives the inline oracle detail section below the matrix. In oracle
+// mode only off-diagonal cells that actually have adapters are selectable; other
+// metrics keep the original "any present cell is selectable" behaviour.
+const onCellClick = (collateralAddr: string, liabilityAddr: string) => {
+  if (props.dotMetric === 'oracle') {
+    if (!isOracleCellSelectable(collateralAddr, liabilityAddr)) return
   }
-  return result
-})
+  else if (!props.matrix.cells.get(collateralAddr)?.get(liabilityAddr)) {
+    return
+  }
+  emit('selectCell', collateralAddr, liabilityAddr)
+}
 
 // Bulk-load adapter metadata for the chain. Heavy call (1+ MB JSON); the
 // `metric !== 'oracle'` guard short-circuits the immediate run on mount and
@@ -273,224 +264,6 @@ watch(
   },
   { immediate: true },
 )
-
-interface AdapterView {
-  key: string
-  kind: OracleRouteStep['kind']
-  oracle: Address
-  name: string
-  base: Address
-  quote: Address
-  metaBase?: Address
-  metaQuote?: Address
-  provider: string
-  methodology?: string
-  logo?: string
-  label?: { primary: string, suffix?: string }
-  checks?: OracleAdapterCheck[]
-  checksStatus: 'positive' | 'warning' | 'negative' | null
-  failedChecks: OracleAdapterCheck[]
-}
-
-const enrichStep = (step: OracleRouteStep): AdapterView => {
-  const isAdapter = isOracleAdapterRouteStep(step)
-  const meta = isAdapter ? oracleAdapters[step.oracle.toLowerCase()] : undefined
-  // LITE-235: an adapter with no curated oracle-checks entry must not fall back to
-  // its self-reported onchain name(); render it as unknown instead. The template's
-  // `|| 'Unknown'` fallbacks turn the empty strings into the displayed label.
-  const { name: resolvedName, provider: resolvedProvider } = resolveOracleAdapterIdentity(step, meta, isAdapter)
-  const provider = resolvedProvider ?? ''
-  const name = resolvedName ?? ''
-  const checks = meta?.checks
-  return {
-    key: getOracleRouteStepKey(step),
-    kind: step.kind,
-    oracle: step.oracle,
-    name,
-    base: step.base,
-    quote: step.quote,
-    metaBase: meta?.base,
-    metaQuote: meta?.quote,
-    provider,
-    methodology: meta?.methodology || (step.kind === 'vault' ? 'Exchange Rate' : undefined),
-    logo: getOracleProviderLogo(provider, name),
-    label: meta?.label
-      ? {
-          primary: meta.label.split('(')[0].trimEnd(),
-          suffix: meta.label.includes('(') ? meta.label.slice(meta.label.indexOf('(')).trim() : undefined,
-        }
-      : undefined,
-    checks,
-    checksStatus: getChecksStatus(checks),
-    failedChecks: checks?.filter(c => !c.pass) ?? [],
-  }
-}
-
-const getCellAdapterViews = (collateralAddr: string, liabilityAddr: string): AdapterView[] => {
-  const list = cellOracleSteps.value.get(`${collateralAddr}:${liabilityAddr}`)
-  if (!list) return []
-  return list.map(enrichStep)
-}
-
-const getColumnAssetAdapterViews = (liabilityAddr: string): AdapterView[] => {
-  const list = columnAssetOracleSteps.value.get(liabilityAddr)
-  if (!list) return []
-  return list.map(enrichStep)
-}
-
-const TOOLTIP_WIDTH = 360
-
-interface TooltipContext {
-  view: AdapterView
-  sourceVault: EVault
-  collateralVault: EVault | SecuritizeCollateralVault | null
-}
-
-const tooltipContext = ref<TooltipContext | null>(null)
-const tooltipAdapter = computed(() => tooltipContext.value?.view ?? null)
-const tooltipStyle = ref<CSSProperties>({})
-
-// Single matrix-wide price fetch: in oracle mode we dedup every route step
-// currently shown, run one batchSimulation, and let tooltips read the results
-// from the same map.
-const allOracleSteps = computed<OracleRouteStep[]>(() => {
-  if (props.dotMetric !== 'oracle') return []
-  const seen = new Map<string, OracleRouteStep>()
-  const ingest = (lists: Iterable<OracleRouteStep[]>) => {
-    for (const list of lists) {
-      for (const step of list) {
-        const key = getOracleRouteStepKey(step)
-        if (!seen.has(key)) seen.set(key, step)
-      }
-    }
-  }
-  ingest(cellOracleSteps.value.values())
-  ingest(columnAssetOracleSteps.value.values())
-  return [...seen.values()]
-})
-
-const oraclePriceSourceVaults = computed<EVault[]>(() => {
-  if (props.dotMetric !== 'oracle') return []
-  const seen = new Map<string, EVault>()
-  for (const col of props.matrix.columns) {
-    const liability = findVault(props.market, col.address)
-    if (liability && isEVault(liability)) {
-      seen.set(liability.address.toLowerCase(), liability)
-    }
-  }
-  return [...seen.values()]
-})
-
-const oraclePriceCollateralVaults = computed<(EVault | SecuritizeCollateralVault)[]>(() => {
-  if (props.dotMetric !== 'oracle') return []
-  const seen = new Map<string, EVault | SecuritizeCollateralVault>()
-  for (const row of props.matrix.rows) {
-    const v = findVault(props.market, row.address)
-    if (v && isMatrixCompatibleVault(v)) {
-      seen.set(row.address.toLowerCase(), v)
-    }
-  }
-  return [...seen.values()]
-})
-
-const { prices: oraclePrices, isLoading: oraclePricesLoading } = useOracleAdapterPrices(
-  allOracleSteps,
-  oraclePriceSourceVaults,
-  oraclePriceCollateralVaults,
-)
-
-const isAdapterPriceFailed = (adapter: { key: string }): boolean => {
-  if (oraclePricesLoading.value) return false
-  const info = oraclePrices.value.get(adapter.key)
-  return info ? !info.success : false
-}
-
-const tooltipPriceText = computed((): string | null => {
-  const ctx = tooltipContext.value
-  if (!ctx) return null
-  const info = oraclePrices.value.get(ctx.view.key)
-  if (!info?.success) return null
-  const invert = shouldInvertOraclePrice({
-    metaBase: ctx.view.metaBase,
-    metaQuote: ctx.view.metaQuote,
-    callerBase: ctx.view.base,
-    callerQuote: ctx.view.quote,
-  })
-  const rate = invert && info.rate > 0 ? 1 / info.rate : info.rate
-  return formatNumber(rate, 4)
-})
-
-const tooltipPriceLoading = computed(() => oraclePricesLoading.value && !oraclePrices.value.size)
-
-const closeTooltip = () => {
-  tooltipContext.value = null
-}
-
-const positionTooltip = (event: MouseEvent) => {
-  const rect = (event.currentTarget as HTMLElement).getBoundingClientRect()
-  const left = Math.max(8, Math.min(rect.left, window.innerWidth - TOOLTIP_WIDTH - 16))
-  const spaceBelow = Math.max(160, window.innerHeight - rect.bottom - 16)
-  const spaceAbove = Math.max(160, rect.top - 16)
-  const flipUp = spaceAbove > spaceBelow
-  tooltipStyle.value = flipUp
-    ? { top: `${rect.top - 8}px`, left: `${left}px`, transform: 'translateY(-100%)', maxHeight: `${spaceAbove}px` }
-    : { top: `${rect.bottom + 8}px`, left: `${left}px`, transform: 'none', maxHeight: `${spaceBelow}px` }
-}
-
-const onCellAdapterClick = (
-  view: AdapterView,
-  event: MouseEvent,
-  collateralAddr: string,
-  liabilityAddr: string,
-) => {
-  if (tooltipContext.value?.view.key === view.key) {
-    closeTooltip()
-    return
-  }
-  const liability = findVault(props.market, liabilityAddr)
-  const collateral = findVault(props.market, collateralAddr)
-  if (!liability || !isEVault(liability)) return
-  positionTooltip(event)
-  tooltipContext.value = {
-    view,
-    sourceVault: liability,
-    collateralVault: collateral && collateral.address.toLowerCase() !== liabilityAddr.toLowerCase() ? collateral : null,
-  }
-}
-
-const onAssetAdapterClick = (
-  view: AdapterView,
-  event: MouseEvent,
-  liabilityAddr: string,
-) => {
-  if (tooltipContext.value?.view.key === view.key) {
-    closeTooltip()
-    return
-  }
-  const liability = findVault(props.market, liabilityAddr)
-  if (!liability || !isEVault(liability)) return
-  positionTooltip(event)
-  tooltipContext.value = {
-    view,
-    sourceVault: liability,
-    collateralVault: null,
-  }
-}
-
-// Document-level bubble-phase listener — `@click.stop` on every logo button
-// and on the tooltip itself prevents this from firing for in-tooltip clicks
-// or for clicks on other adapter triggers. That keeps "click same logo to
-// close" working (vueuse's onClickOutside attaches in capture phase, which
-// would short-circuit the toggle behaviour).
-const onDocumentClick = () => closeTooltip()
-onMounted(() => {
-  document.addEventListener('click', onDocumentClick)
-})
-onUnmounted(() => {
-  document.removeEventListener('click', onDocumentClick)
-})
-
-const explorerLink = (address: string) => getExplorerLink(address, chainId.value, true)
 </script>
 
 <template>
@@ -616,7 +389,9 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
                     : row.address === col.address
                       ? 'bg-white/[0.03]'
                       : '',
-                matrix.cells.get(row.address)?.get(col.address)
+                (dotMetric === 'oracle'
+                  ? isOracleCellSelectable(row.address, col.address)
+                  : !!matrix.cells.get(row.address)?.get(col.address))
                   ? 'cursor-pointer'
                   : '',
               ]"
@@ -649,126 +424,46 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
               "
               @mouseenter="hoveredCell = { collateralAddr: row.address, liabilityAddr: col.address }"
               @mouseleave="hoveredCell = null"
-              @click.stop="
-                matrix.cells.get(row.address)?.get(col.address)
-                  && $emit('selectCell', row.address, col.address)
-              "
+              @click.stop="onCellClick(row.address, col.address)"
             >
-              <!-- Diagonal in oracle mode: surface the borrow vault's own
-                   asset -> UoA oracle (same for every cell in the column,
-                   so we show it once on the self-row instead of repeating). -->
-              <template
-                v-if="dotMetric === 'oracle'
-                  && row.address === col.address
-                  && getColumnAssetAdapterViews(col.address).length"
-              >
-                <div class="inline-flex items-center justify-center gap-4 flex-wrap">
-                  <button
-                    v-for="adapter in getColumnAssetAdapterViews(col.address)"
+              <template v-if="matrix.cells.get(row.address)?.get(col.address)">
+                <!-- Oracle metric: every adapter pricing the pair's collateral &
+                     liability assets. Display-only logos; clicking the cell opens
+                     the inline oracle section below the matrix. -->
+                <div
+                  v-if="dotMetric === 'oracle' && getCellAdapterViews(row.address, col.address).length"
+                  class="inline-flex items-center justify-center gap-4 flex-wrap"
+                >
+                  <span
+                    v-for="adapter in getCellAdapterViews(row.address, col.address)"
                     :key="adapter.key"
-                    type="button"
-                    class="relative inline-flex items-center justify-center cursor-pointer"
+                    class="relative inline-flex items-center justify-center"
                     data-id="oracle-adapter"
-                    :data-key="`${col.address}:${adapter.key}`"
+                    :data-key="`${row.address}:${col.address}:${adapter.key}`"
+                    :data-collateral-address="row.address"
                     :data-borrow-address="col.address"
                     :data-oracle-address="adapter.oracle"
                     :data-base-address="adapter.base"
                     :data-quote-address="adapter.quote"
-                    @click.stop="onAssetAdapterClick(adapter, $event, col.address)"
                   >
-                    <UiHoverPreviewTooltip
-                      :title="adapter.name || 'Unknown'"
-                      :text="adapter.provider || 'Unknown provider'"
-                      placement="top-start"
-                    >
-                      <BaseAvatar
-                        v-if="adapter.logo"
-                        :src="adapter.logo"
-                        :label="adapter.name"
-                        class="icon--16"
-                      />
-                      <SvgIcon
-                        v-else
-                        name="question-circle"
-                        class="!w-16 !h-16 text-content-tertiary"
-                      />
-                    </UiHoverPreviewTooltip>
+                    <BaseAvatar
+                      v-if="adapter.logo"
+                      :src="adapter.logo"
+                      :label="adapter.name"
+                      class="icon--16"
+                    />
+                    <SvgIcon
+                      v-else
+                      name="question-circle"
+                      class="!w-16 !h-16 text-content-tertiary"
+                    />
                     <span
                       v-if="adapter.checksStatus === 'warning' || adapter.checksStatus === 'negative'"
                       class="absolute -top-1 -right-1 w-6 h-6 rounded-full"
                       :class="adapter.checksStatus === 'negative' ? 'bg-error-500' : 'bg-warning-500'"
                     />
-                    <UiHoverPreviewTooltip
-                      v-if="isAdapterPriceFailed(adapter)"
-                      title="getQuote reverted"
-                      text="getQuote reverted"
-                      placement="top-start"
-                      class="absolute -bottom-1 -right-1"
-                    >
-                      <SvgIcon
-                        name="warning"
-                        class="!w-10 !h-10 text-warning-500"
-                      />
-                    </UiHoverPreviewTooltip>
-                  </button>
+                  </span>
                 </div>
-              </template>
-
-              <template v-else-if="matrix.cells.get(row.address)?.get(col.address)">
-                <!-- Oracle metric: render adapter logos -->
-                <template v-if="dotMetric === 'oracle'">
-                  <div class="inline-flex items-center justify-center gap-4 flex-wrap">
-                    <button
-                      v-for="adapter in getCellAdapterViews(row.address, col.address)"
-                      :key="adapter.key"
-                      type="button"
-                      class="relative inline-flex items-center justify-center cursor-pointer"
-                      data-id="oracle-adapter"
-                      :data-key="`${row.address}:${col.address}:${adapter.key}`"
-                      :data-collateral-address="row.address"
-                      :data-borrow-address="col.address"
-                      :data-oracle-address="adapter.oracle"
-                      :data-base-address="adapter.base"
-                      :data-quote-address="adapter.quote"
-                      @click.stop="onCellAdapterClick(adapter, $event, row.address, col.address)"
-                    >
-                      <UiHoverPreviewTooltip
-                        :title="adapter.name || 'Unknown'"
-                        :text="adapter.provider || 'Unknown provider'"
-                        placement="top-start"
-                      >
-                        <BaseAvatar
-                          v-if="adapter.logo"
-                          :src="adapter.logo"
-                          :label="adapter.name"
-                          class="icon--16"
-                        />
-                        <SvgIcon
-                          v-else
-                          name="question-circle"
-                          class="!w-16 !h-16 text-content-tertiary"
-                        />
-                      </UiHoverPreviewTooltip>
-                      <span
-                        v-if="adapter.checksStatus === 'warning' || adapter.checksStatus === 'negative'"
-                        class="absolute -top-1 -right-1 w-6 h-6 rounded-full"
-                        :class="adapter.checksStatus === 'negative' ? 'bg-error-500' : 'bg-warning-500'"
-                      />
-                      <UiHoverPreviewTooltip
-                        v-if="isAdapterPriceFailed(adapter)"
-                        title="getQuote reverted"
-                        text="getQuote reverted"
-                        placement="top-start"
-                        class="absolute -bottom-1 -right-1"
-                      >
-                        <SvgIcon
-                          name="warning"
-                          class="!w-10 !h-10 text-warning-500"
-                        />
-                      </UiHoverPreviewTooltip>
-                    </button>
-                  </div>
-                </template>
 
                 <!-- Numeric metrics: original rendering -->
                 <div
@@ -876,146 +571,4 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
   >
     Tap a cell, row, or column header to see lending/borrowing options below.
   </p>
-
-  <!-- Oracle adapter tooltip — mirrors VaultOverviewBlockOracleAdapters card layout -->
-  <Teleport to="body">
-    <div
-      v-if="tooltipAdapter"
-      class="fixed z-[9999] bg-surface-secondary border border-line-subtle rounded-xl p-16 shadow-card overflow-y-auto flex flex-col gap-12"
-      :style="[tooltipStyle, { width: `${TOOLTIP_WIDTH}px` }]"
-      @click.stop
-    >
-      <!-- Header: oracle label / pair + address & close -->
-      <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-4 sm:gap-8">
-        <div class="text-p2 text-content-primary font-medium">
-          <template v-if="tooltipAdapter.label">
-            {{ tooltipAdapter.label.primary }}
-            <span
-              v-if="tooltipAdapter.label.suffix"
-              class="text-content-tertiary ml-2"
-            >{{ tooltipAdapter.label.suffix }}</span>
-          </template>
-          <template v-else>
-            Oracle
-          </template>
-        </div>
-        <div class="flex items-center gap-8 flex-shrink-0">
-          <NuxtLink
-            :to="explorerLink(tooltipAdapter.oracle)"
-            target="_blank"
-            class="text-accent-600 underline cursor-pointer hover:text-accent-500 text-p3"
-            @click.stop
-          >
-            {{ truncate(tooltipAdapter.oracle, 6) }}
-          </NuxtLink>
-          <button
-            type="button"
-            class="text-content-muted hover:text-content-secondary cursor-pointer"
-            aria-label="Close"
-            @click.stop="closeTooltip"
-          >
-            <SvgIcon
-              name="close"
-              class="!w-14 !h-14"
-            />
-          </button>
-        </div>
-      </div>
-
-      <!-- Provider / Methodology / Price / Checks grid (mirrors borrow page) -->
-      <div class="grid grid-cols-2 gap-12 text-p3">
-        <div class="flex flex-col gap-4">
-          <span class="text-content-tertiary">Provider</span>
-          <div class="flex items-center gap-8">
-            <BaseAvatar
-              v-if="tooltipAdapter.logo"
-              :src="tooltipAdapter.logo"
-              :label="tooltipAdapter.name"
-              class="icon--20"
-            />
-            <SvgIcon
-              v-else
-              name="question-circle"
-              class="!w-20 !h-20 text-content-tertiary"
-            />
-            <span class="text-content-primary">{{ tooltipAdapter.provider || 'Unknown' }}</span>
-          </div>
-        </div>
-        <div class="flex flex-col gap-4">
-          <span class="text-content-tertiary">Methodology</span>
-          <span class="text-content-primary">{{ tooltipAdapter.methodology || 'Unknown' }}</span>
-        </div>
-        <div class="flex flex-col gap-4">
-          <span class="text-content-tertiary">Price</span>
-          <span
-            v-if="tooltipPriceLoading"
-            class="text-content-secondary animate-pulse"
-          >...</span>
-          <span
-            v-else-if="tooltipPriceText === null"
-            class="flex items-center text-warning-500"
-          >
-            <SvgIcon
-              name="warning"
-              class="mr-2 !w-16 !h-16"
-            />
-            Unknown
-          </span>
-          <span
-            v-else
-            class="text-content-primary"
-          >{{ tooltipPriceText }}</span>
-        </div>
-        <div class="flex flex-col gap-4">
-          <span class="text-content-tertiary">Checks</span>
-          <span
-            v-if="!tooltipAdapter.checks?.length"
-            class="text-content-secondary"
-          >N/A</span>
-          <span
-            v-else
-            class="flex items-center gap-6"
-          >
-            <span
-              class="inline-block w-8 h-8 rounded-full flex-shrink-0"
-              :class="{
-                'bg-success-500': tooltipAdapter.checksStatus === 'positive',
-                'bg-warning-500': tooltipAdapter.checksStatus === 'warning',
-                'bg-error-500': tooltipAdapter.checksStatus === 'negative',
-              }"
-            />
-            <span class="text-content-primary">
-              <template v-if="tooltipAdapter.checksStatus === 'positive'">{{ tooltipAdapter.checks.length }} passed</template>
-              <template v-else>{{ tooltipAdapter.failedChecks.length }} failed</template>
-            </span>
-          </span>
-        </div>
-      </div>
-
-      <!-- Failed checks detail -->
-      <div
-        v-if="tooltipAdapter.failedChecks.length"
-        class="flex flex-col gap-6 border-t border-line-subtle pt-12 text-p3"
-      >
-        <div
-          v-for="(check, i) in tooltipAdapter.failedChecks"
-          :key="`${check.id}-${i}`"
-          class="flex items-start gap-8"
-        >
-          <SvgIcon
-            name="warning"
-            class="!w-16 !h-16 mt-1 flex-shrink-0"
-            :class="{
-              'text-error-500': check.severity === OracleAdapterCheckSeverity.High,
-              'text-warning-500': check.severity !== OracleAdapterCheckSeverity.High,
-            }"
-          />
-          <div>
-            <span class="text-content-primary font-medium">{{ check.id }}: </span>
-            <span class="text-content-secondary">{{ check.message }}</span>
-          </div>
-        </div>
-      </div>
-    </div>
-  </Teleport>
 </template>

--- a/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
@@ -458,9 +458,13 @@ watch(
                       class="!w-16 !h-16 text-content-tertiary"
                     />
                     <span
-                      v-if="adapter.checksStatus === 'warning' || adapter.checksStatus === 'negative'"
+                      v-if="adapter.checksStatus"
                       class="absolute -top-1 -right-1 w-6 h-6 rounded-full"
-                      :class="adapter.checksStatus === 'negative' ? 'bg-error-500' : 'bg-warning-500'"
+                      :class="{
+                        'bg-success-500': adapter.checksStatus === 'positive',
+                        'bg-warning-500': adapter.checksStatus === 'warning',
+                        'bg-error-500': adapter.checksStatus === 'negative',
+                      }"
                     />
                   </span>
                 </div>

--- a/components/entities/vault/overview/VaultOverviewBlockOracleAdapters.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockOracleAdapters.vue
@@ -4,13 +4,12 @@ import type {
   EVault,
   OracleRouteStep,
 } from '@eulerxyz/euler-v2-sdk'
-import { getChecksStatus, getRouterRecognition, OracleAdapterCheckSeverity, resolveOracleAdapterIdentity, type OracleAdapterMeta } from '~/entities/oracle'
-import { getOracleProviderLogo } from '~/entities/oracle-providers'
+import { getRouterRecognition, OracleAdapterCheckSeverity } from '~/entities/oracle'
 import { getExplorerLink } from '~/utils/block-explorer'
 import { formatNumber } from '~/utils/string-utils'
-import { shouldInvertOraclePrice } from '~/utils/oracle-label'
 import { getOracleRouteStepKey, useOracleAdapterPrices } from '~/composables/useOracleAdapterPrices'
-import { getCollateralOracleRouteSteps, getDebtOracleRouteSteps, isOracleAdapterRouteStep } from '~/utils/oracle-route-steps'
+import { isOracleAdapterRouteStep } from '~/utils/oracle-route-steps'
+import { buildOracleAdapterViews, collectOracleRouteSteps } from '~/utils/oracle-adapter-views'
 import type { CSSProperties } from 'vue'
 
 const props = defineProps<{
@@ -35,33 +34,7 @@ const sourceVaults = computed(() => {
   return []
 })
 
-const getCollateralRouteSteps = (vault: EVault, collateralVault: EVault | SecuritizeCollateralVault) => {
-  return getCollateralOracleRouteSteps(vault, collateralVault)
-}
-
-const routeSteps = computed(() => {
-  const entries: OracleRouteStep[] = []
-  const deduped = new Map<string, OracleRouteStep>()
-
-  sourceVaults.value.forEach((vault) => {
-    entries.push(...getDebtOracleRouteSteps(vault))
-
-    if (props.collateralVaults?.length) {
-      props.collateralVaults.forEach((collateralVault) => {
-        entries.push(...getCollateralRouteSteps(vault, collateralVault))
-      })
-    }
-  })
-
-  entries.forEach((step) => {
-    const key = getOracleRouteStepKey(step)
-    if (!deduped.has(key)) {
-      deduped.set(key, step)
-    }
-  })
-
-  return [...deduped.values()]
-})
+const routeSteps = computed(() => collectOracleRouteSteps(sourceVaults.value, props.collateralVaults ?? []))
 
 const knownSymbols = computed(() => {
   const map = buildKnownSymbols()
@@ -80,39 +53,7 @@ const knownSymbols = computed(() => {
   return map
 })
 
-const adapterViews = computed(() => routeSteps.value.map((step) => {
-  const isAdapter = isOracleAdapterRouteStep(step)
-  const meta: OracleAdapterMeta | undefined = isAdapter
-    ? oracleAdapters[step.oracle.toLowerCase()]
-    : undefined
-  const { name, provider, isCustomAdapter } = resolveOracleAdapterIdentity(step, meta, isAdapter)
-  const checks = meta?.checks
-  const invertPrice = shouldInvertOraclePrice({
-    metaBase: meta?.base,
-    metaQuote: meta?.quote,
-    callerBase: step.base,
-    callerQuote: step.quote,
-  })
-
-  return {
-    ...step,
-    name,
-    provider,
-    isCustomAdapter,
-    methodology: meta?.methodology || (step.kind === 'vault' ? 'Exchange Rate' : undefined),
-    logo: getOracleProviderLogo(provider, name),
-    label: meta?.label
-      ? {
-          primary: meta.label.split('(')[0].trimEnd(),
-          suffix: meta.label.includes('(') ? meta.label.slice(meta.label.indexOf('(')).trim() : undefined,
-        }
-      : undefined,
-    invertPrice,
-    checks,
-    checksStatus: getChecksStatus(checks),
-    failedChecks: checks?.filter(c => !c.pass) ?? [],
-  }
-}))
+const adapterViews = computed(() => buildOracleAdapterViews(routeSteps.value, oracleAdapters))
 
 watch(
   () => routeSteps.value,

--- a/components/entities/vault/overview/VaultOverviewBlockOracleAdapters.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockOracleAdapters.vue
@@ -528,7 +528,7 @@ const onTooltipMouseLeave = () => {
               }"
             >
               <SvgIcon
-                :name="check.pass ? 'check' : 'x'"
+                :name="check.pass ? 'check' : 'close'"
                 class="!w-10 !h-10 text-white"
               />
             </span>

--- a/composables/useEulerOracleAdapters.ts
+++ b/composables/useEulerOracleAdapters.ts
@@ -3,17 +3,11 @@ import { toReactive } from '@vueuse/core'
 import { logWarn } from '~/utils/errorHandling'
 import { normalizeAddress } from '~/utils/normalizeAddress'
 import { getEulerSdk } from '~/composables/useEulerSdk'
-import { type OracleAdapterMeta, OracleAdapterCheckSeverity } from '~/entities/oracle'
+import { type OracleAdapterMeta, normalizeOracleAdapterCheckSeverity } from '~/entities/oracle'
 
 const oracleAdaptersRef = shallowRef<Record<string, OracleAdapterMeta>>({})
 const oracleAdaptersChainId = ref<number | null>(null)
 const pendingOracleAdapterLoads = new Map<number, Promise<Record<string, OracleAdapterMeta>>>()
-
-const normalizeSeverity = (severity: unknown): OracleAdapterCheckSeverity => {
-  return Object.values(OracleAdapterCheckSeverity).includes(severity as OracleAdapterCheckSeverity)
-    ? severity as OracleAdapterCheckSeverity
-    : OracleAdapterCheckSeverity.Info
-}
 
 const toOracleAdapterMeta = (metadata: OracleAdapterMetadata): OracleAdapterMeta => ({
   oracle: metadata.oracle,
@@ -27,7 +21,7 @@ const toOracleAdapterMeta = (metadata: OracleAdapterMetadata): OracleAdapterMeta
     id: typeof check.id === 'string' ? check.id : '',
     message: typeof check.message === 'string' ? check.message : '',
     pass: check.pass === true,
-    severity: normalizeSeverity(check.severity),
+    severity: normalizeOracleAdapterCheckSeverity(check.severity),
   })),
 })
 

--- a/entities/oracle.ts
+++ b/entities/oracle.ts
@@ -78,6 +78,24 @@ export type OracleAdapterMeta = {
   checks?: OracleAdapterCheck[]
 }
 
+export function normalizeOracleAdapterCheckSeverity(severity: unknown): OracleAdapterCheckSeverity {
+  if (typeof severity !== 'string') return OracleAdapterCheckSeverity.Info
+
+  switch (severity.trim().toLowerCase()) {
+    case 'high':
+      return OracleAdapterCheckSeverity.High
+    case 'med':
+    case 'medium':
+      return OracleAdapterCheckSeverity.Medium
+    case 'low':
+      return OracleAdapterCheckSeverity.Low
+    case 'info':
+      return OracleAdapterCheckSeverity.Info
+    default:
+      return OracleAdapterCheckSeverity.Info
+  }
+}
+
 export function getChecksStatus(checks: OracleAdapterCheck[] | undefined): 'positive' | 'warning' | 'negative' | null {
   if (!checks?.length) return null
   const failed = checks.filter(c => !c.pass)

--- a/tests/entities/oracle.test.ts
+++ b/tests/entities/oracle.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import type { Address } from 'viem'
 import {
+  getChecksStatus,
   getRouterRecognition,
+  normalizeOracleAdapterCheckSeverity,
   resolveOracleAdapterIdentity,
   type OracleAdapterMeta,
+  OracleAdapterCheckSeverity,
 } from '~/entities/oracle'
 
 const oracle = '0x0000000000000000000000000000000000000001' as Address
@@ -86,5 +89,30 @@ describe('getRouterRecognition (LITE-236)', () => {
   it('returns "unrecognized" when any router is missing from the allowlist', () => {
     const recognized = new Set([router])
     expect(getRouterRecognition([router, otherRouter], recognized)).toBe('unrecognized')
+  })
+})
+
+describe('normalizeOracleAdapterCheckSeverity', () => {
+  it('accepts oracle-checks wire casing', () => {
+    expect(normalizeOracleAdapterCheckSeverity('High')).toBe(OracleAdapterCheckSeverity.High)
+    expect(normalizeOracleAdapterCheckSeverity('Med')).toBe(OracleAdapterCheckSeverity.Medium)
+    expect(normalizeOracleAdapterCheckSeverity('Info')).toBe(OracleAdapterCheckSeverity.Info)
+  })
+
+  it('keeps enum casing and falls back to info for unknown values', () => {
+    expect(normalizeOracleAdapterCheckSeverity(OracleAdapterCheckSeverity.High)).toBe(OracleAdapterCheckSeverity.High)
+    expect(normalizeOracleAdapterCheckSeverity('wat')).toBe(OracleAdapterCheckSeverity.Info)
+    expect(normalizeOracleAdapterCheckSeverity(undefined)).toBe(OracleAdapterCheckSeverity.Info)
+  })
+})
+
+describe('getChecksStatus', () => {
+  it('treats normalized high-severity failures as negative', () => {
+    expect(getChecksStatus([{
+      id: 'Source code provenance',
+      message: 'Contract metadata hash is not recognized.',
+      pass: false,
+      severity: normalizeOracleAdapterCheckSeverity('High'),
+    }])).toBe('negative')
   })
 })

--- a/tests/utils/oracle-adapter-views.test.ts
+++ b/tests/utils/oracle-adapter-views.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+import type { Address } from 'viem'
+import type { EVault, OracleRouteStep } from '@eulerxyz/euler-v2-sdk'
+import type { OracleAdapterMeta } from '~/entities/oracle'
+import { OracleAdapterCheckSeverity } from '~/entities/oracle'
+import { buildOracleAdapterView, collectOracleRouteSteps } from '~/utils/oracle-adapter-views'
+
+const oracle = '0x000000000000000000000000000000000000A111' as Address
+const weth = '0x000000000000000000000000000000000000E711' as Address
+const usd = '0x0000000000000000000000000000000000000051' as Address
+
+const adapterStep = (overrides: Partial<OracleRouteStep> = {}): OracleRouteStep => ({
+  kind: 'adapter',
+  oracle,
+  base: weth,
+  quote: usd,
+  name: 'ChainlinkOracle',
+  ...overrides,
+} as OracleRouteStep)
+
+describe('buildOracleAdapterView', () => {
+  it('enriches a recognized adapter from curated metadata', () => {
+    const meta: Record<string, OracleAdapterMeta> = {
+      [oracle.toLowerCase()]: {
+        oracle,
+        base: weth,
+        quote: usd,
+        name: 'Chainlink WETH/USD',
+        provider: 'Chainlink',
+        methodology: 'Market price',
+        label: 'Chainlink WETH/USD (Primary)',
+        checks: [{ id: 'staleness', message: 'ok', pass: true, severity: OracleAdapterCheckSeverity.Info }],
+      },
+    }
+    const view = buildOracleAdapterView(adapterStep(), meta)
+
+    expect(view.provider).toBe('Chainlink')
+    expect(view.name).toBe('Chainlink WETH/USD')
+    expect(view.isCustomAdapter).toBe(false)
+    expect(view.methodology).toBe('Market price')
+    expect(view.logo).toBe('/oracles/chainlink.svg')
+    expect(view.label).toEqual({ primary: 'Chainlink WETH/USD', suffix: '(Primary)' })
+    expect(view.checksStatus).toBe('positive')
+  })
+
+  it('flags an adapter with no curated entry as custom (no onchain-name leak, no logo)', () => {
+    const view = buildOracleAdapterView(adapterStep(), {})
+
+    expect(view.name).toBeUndefined()
+    expect(view.provider).toBeUndefined()
+    expect(view.isCustomAdapter).toBe(true)
+    expect(view.logo).toBeUndefined()
+    expect(view.label).toBeUndefined()
+    expect(view.checksStatus).toBeNull()
+  })
+
+  it('keeps the decoded name and "Exchange Rate" methodology for vault (ERC-4626) steps', () => {
+    const view = buildOracleAdapterView(adapterStep({ kind: 'vault', name: 'ERC4626Vault' }), {})
+
+    expect(view.name).toBe('ERC4626Vault')
+    expect(view.isCustomAdapter).toBe(false)
+    expect(view.methodology).toBe('Exchange Rate')
+  })
+
+  it('marks a high-severity failing check as a negative status', () => {
+    const meta: Record<string, OracleAdapterMeta> = {
+      [oracle.toLowerCase()]: {
+        oracle,
+        provider: 'Chainlink',
+        checks: [{ id: 'staleness', message: 'stale', pass: false, severity: OracleAdapterCheckSeverity.High }],
+      },
+    }
+    const view = buildOracleAdapterView(adapterStep(), meta)
+
+    expect(view.checksStatus).toBe('negative')
+    expect(view.failedChecks).toHaveLength(1)
+  })
+})
+
+describe('collectOracleRouteSteps', () => {
+  const debtStep = adapterStep({ oracle: '0x00000000000000000000000000000000000000d1' as Address })
+  const collateralStep = adapterStep({ oracle: '0x00000000000000000000000000000000000000c1' as Address, base: usd, quote: weth })
+
+  const makeVault = (collateralAddr: string): EVault => ({
+    debtPricingOracleRoute: { steps: [debtStep] },
+    collaterals: [
+      { address: collateralAddr, oracleRoute: { steps: [collateralStep] } },
+    ],
+  } as unknown as EVault)
+
+  it('returns the debt route when there are no collaterals', () => {
+    const steps = collectOracleRouteSteps([makeVault('0xdead')])
+    expect(steps).toEqual([debtStep])
+  })
+
+  it('combines debt + collateral routes for the pair', () => {
+    const collateralAddr = '0x00000000000000000000000000000000000000cc'
+    const collateralVault = { address: collateralAddr } as unknown as EVault
+    const steps = collectOracleRouteSteps([makeVault(collateralAddr)], [collateralVault])
+
+    expect(steps).toContain(debtStep)
+    expect(steps).toContain(collateralStep)
+    expect(steps).toHaveLength(2)
+  })
+
+  it('dedupes identical steps across vaults', () => {
+    const v = makeVault('0xdead')
+    const steps = collectOracleRouteSteps([v, v])
+    expect(steps).toHaveLength(1)
+  })
+})

--- a/utils/oracle-adapter-views.ts
+++ b/utils/oracle-adapter-views.ts
@@ -1,0 +1,108 @@
+import type { Address } from 'viem'
+import type { EVault, OracleRouteStep, SecuritizeCollateralVault } from '@eulerxyz/euler-v2-sdk'
+import {
+  getChecksStatus,
+  resolveOracleAdapterIdentity,
+  type OracleAdapterCheck,
+  type OracleAdapterMeta,
+} from '~/entities/oracle'
+import { getOracleProviderLogo } from '~/entities/oracle-providers'
+import { shouldInvertOraclePrice } from '~/utils/oracle-label'
+import { getCollateralOracleRouteSteps, getDebtOracleRouteSteps, isOracleAdapterRouteStep } from '~/utils/oracle-route-steps'
+import { getOracleRouteStepKey } from '~/composables/useOracleAdapterPrices'
+
+// Single source of truth for the oracle adapters shown on the borrow page's
+// Oracles block AND in the explore matrix. Both surfaces must agree on which
+// adapters price a given (liability, collateral) pair, so the collection and
+// per-step enrichment live here rather than being duplicated per component.
+
+export type OracleAdapterView = {
+  key: string
+  kind: OracleRouteStep['kind']
+  oracle: Address
+  base: Address
+  quote: Address
+  metaBase?: Address
+  metaQuote?: Address
+  name?: string
+  provider?: string
+  isCustomAdapter: boolean
+  methodology?: string
+  logo?: string
+  label?: { primary: string, suffix?: string }
+  invertPrice: boolean
+  checks?: OracleAdapterCheck[]
+  checksStatus: 'positive' | 'warning' | 'negative' | null
+  failedChecks: OracleAdapterCheck[]
+}
+
+// Collects the deduped oracle route steps that price the given liability
+// vault(s) together with the given collateral vault(s): each liability's own
+// asset->unit-of-account (debt) route plus the collateral->unit-of-account
+// route for every collateral. Mirrors what the borrow page shows for a pair.
+export const collectOracleRouteSteps = (
+  vaults: EVault[],
+  collateralVaults: (EVault | SecuritizeCollateralVault)[] = [],
+): OracleRouteStep[] => {
+  const deduped = new Map<string, OracleRouteStep>()
+  for (const vault of vaults) {
+    const steps: OracleRouteStep[] = [...getDebtOracleRouteSteps(vault)]
+    for (const collateralVault of collateralVaults) {
+      steps.push(...getCollateralOracleRouteSteps(vault, collateralVault))
+    }
+    for (const step of steps) {
+      const key = getOracleRouteStepKey(step)
+      if (!deduped.has(key)) deduped.set(key, step)
+    }
+  }
+  return [...deduped.values()]
+}
+
+const parseAdapterLabel = (label: string | undefined): { primary: string, suffix?: string } | undefined =>
+  label
+    ? {
+        primary: label.split('(')[0].trimEnd(),
+        suffix: label.includes('(') ? label.slice(label.indexOf('(')).trim() : undefined,
+      }
+    : undefined
+
+// Enriches one oracle route step into a display view, resolving its identity
+// from the curated oracle-checks dataset (see resolveOracleAdapterIdentity).
+export const buildOracleAdapterView = (
+  step: OracleRouteStep,
+  oracleAdapters: Record<string, OracleAdapterMeta>,
+): OracleAdapterView => {
+  const isAdapter = isOracleAdapterRouteStep(step)
+  const meta = isAdapter ? oracleAdapters[step.oracle.toLowerCase()] : undefined
+  const { name, provider, isCustomAdapter } = resolveOracleAdapterIdentity(step, meta, isAdapter)
+  const checks = meta?.checks
+  return {
+    key: getOracleRouteStepKey(step),
+    kind: step.kind,
+    oracle: step.oracle,
+    base: step.base,
+    quote: step.quote,
+    metaBase: meta?.base,
+    metaQuote: meta?.quote,
+    name,
+    provider,
+    isCustomAdapter,
+    methodology: meta?.methodology || (step.kind === 'vault' ? 'Exchange Rate' : undefined),
+    logo: getOracleProviderLogo(provider, name),
+    label: parseAdapterLabel(meta?.label),
+    invertPrice: shouldInvertOraclePrice({
+      metaBase: meta?.base,
+      metaQuote: meta?.quote,
+      callerBase: step.base,
+      callerQuote: step.quote,
+    }),
+    checks,
+    checksStatus: getChecksStatus(checks),
+    failedChecks: checks?.filter(c => !c.pass) ?? [],
+  }
+}
+
+export const buildOracleAdapterViews = (
+  steps: OracleRouteStep[],
+  oracleAdapters: Record<string, OracleAdapterMeta>,
+): OracleAdapterView[] => steps.map(step => buildOracleAdapterView(step, oracleAdapters))


### PR DESCRIPTION
## Summary

Reworks the **Oracles** view of the explore matrix so it's legible and consistent with the borrow page, and removes the floating popover in favour of an inline detail section.

Previously each matrix cell showed a single oracle logo with a hover tooltip, the self-diagonal carried the borrow vault's own oracle, and clicking a logo opened a floating card over the grid. Feedback: the bare logos aren't self-explanatory, the floating card is awkward, and an asset that's never used as collateral had no discoverable oracle.

Now:
- Each off-diagonal cell shows **every** oracle adapter that prices that pair's collateral **and** liability assets, as display-only logos (with the existing check-status dot). The self-diagonal is left blank — a liability's own asset→unit-of-account oracle already appears in every cell of its column.
- The **whole cell** is the click target (individual logos are no longer clickable). Clicking opens a **dedicated oracle section inline below the matrix**, rendering the same `VaultOverviewBlockOracleAdapters` component the borrow page uses for that collateral/liability pair.
- The per-logo hover tooltips and the floating popover card are gone.

## Changes

- **`utils/oracle-adapter-views.ts` (new)** — single source of truth for the oracle adapters of a `(liability, collateral)` pair:
  - `collectOracleRouteSteps(liabilities, collaterals)` — deduped debt + collateral route steps (identical to what the borrow page computes for a pair).
  - `buildOracleAdapterView(step, oracleAdapters)` / `buildOracleAdapterViews(...)` — per-adapter enrichment (identity, provider logo, label, methodology, checks, invert-price).
- **`VaultOverviewBlockOracleAdapters.vue`** — now consumes the shared helpers instead of its own inline `routeSteps`/`adapterViews`, so the borrow page and the matrix can't drift.
- **`DiscoveryMarketMatrix.vue`** — cells render the shared adapter views as display-only logos; the diagonal is blank; the cell drives selection through a guard (`isOracleCellSelectable`). Removes the old `enrichStep`/per-cell step maps, the matrix-wide price fetch, and the entire floating tooltip card (net −267 lines).
- **`DiscoveryMarketAccordion.vue`** — in oracle view, a selected cell renders the inline `VaultOverviewBlockOracleAdapters` for the pair instead of the lend/borrow cards.
- **`tests/utils/oracle-adapter-views.test.ts` (new)** — unit tests for the shared collection + enrichment helpers.

## Notes

- **Stacked on `feature/lite-235-236-239-oracle-trust-checks` (PR #638).** This work imports `resolveOracleAdapterIdentity` (added there) and builds on that PR's version of the Oracles block, so it targets the #638 branch. When #638 merges, GitHub will retarget this PR to `development`.

## Test plan

- [ ] `npm run test:run -- tests/utils/oracle-adapter-views.test.ts` passes.
- [ ] Explore a market, switch the matrix to **Oracles**: each off-diagonal cell shows the logos of all adapters pricing that pair; the diagonal is blank.
- [ ] Clicking a cell opens an oracle section below the matrix (same layout as the borrow page) for that collateral/liability pair; the logos themselves are not separately clickable and show no hover tooltip.
- [ ] The set of adapters in a cell/section matches the borrow page's Oracles block for the same pair.
- [ ] Cells with no adapters (and the diagonal) are not clickable.

Addresses LITE-259.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Oracle market views now show adapter details inline in the selection area when relevant.
  * Oracle cells in the matrix now behave more clearly, with selection enabled only where adapter data is available.

* **Bug Fixes**
  * Improved how oracle routes are gathered and displayed, reducing duplicate or inconsistent adapter entries.
  * Simplified oracle view rendering so the selected market card stays consistent across view types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->