### PR TITLE
Master<>Dev Sync

### DIFF
--- a/components/BatchReviewModal.vue
+++ b/components/BatchReviewModal.vue
@@ -376,7 +376,7 @@ const handleClose = () => {
 
       <UiAlert
         v-if="hasPermit2Approval"
-        variant="warning"
+        variant="info"
         size="compact"
         title="Infinite approval"
         description="You are granting the Permit2 contract an unlimited token allowance. Permit2 is a Uniswap contract that lets you approve once, then sign per-action permissions without new onchain approvals."

--- a/components/entities/operation/OperationReviewModal.vue
+++ b/components/entities/operation/OperationReviewModal.vue
@@ -70,6 +70,7 @@ const {
 
 const tenderlyEnabled = ref(false)
 const { copied, copyToClipboard } = useClipboardCopy()
+const hasCopiedCalldata = ref(false)
 const nowMs = ref(Date.now())
 const staleQuoteThresholdMs = 3 * 60 * 1000
 let nowTimer: ReturnType<typeof setInterval> | undefined
@@ -269,7 +270,8 @@ const copyCalldata = async () => {
       }
     }
 
-    copyToClipboard(JSON.stringify(entries, null, 2), 'calldata')
+    await copyToClipboard(JSON.stringify(entries, null, 2), 'calldata')
+    hasCopiedCalldata.value = true
   }
   catch (err) {
     logWarn('OperationReviewModal/copyCalldata', err)
@@ -373,9 +375,11 @@ const confirmLabel = computed(() => {
         </div>
         <div
           v-if="displaySteps.length"
-          class="bg-surface-secondary rounded-12 p-12 flex flex-col gap-8"
+          class="w-full rounded-8 border border-line-default bg-card px-12 py-10 shadow-xs"
         >
-          <OperationStepsList :steps="displaySteps" />
+          <div class="flex w-full flex-col gap-8">
+            <OperationStepsList :steps="displaySteps" />
+          </div>
         </div>
       </div>
 
@@ -385,7 +389,7 @@ const confirmLabel = computed(() => {
       >
         <button
           type="button"
-          class="flex items-center gap-6 text-p3 text-content-primary hover:text-content-primary transition-colors"
+          class="inline-flex h-36 items-center gap-6 rounded-8 border border-line-default bg-card px-12 text-p3 text-content-primary hover:border-line-emphasis hover:bg-card-hover transition-colors"
           @click="copyCalldata"
         >
           <SvgIcon
@@ -399,10 +403,10 @@ const confirmLabel = computed(() => {
           :href="tenderlyUrl"
           target="_blank"
           rel="noopener noreferrer"
-          class="flex items-center gap-6 text-p3 transition-colors"
+          class="inline-flex h-36 items-center gap-6 rounded-8 border border-line-default bg-card px-12 text-p3 transition-colors hover:border-line-emphasis hover:bg-card-hover"
           :class="hasTenderlyFailedSimulation
-            ? 'text-error-500 hover:text-error-600'
-            : 'text-success-500 hover:text-success-600'"
+            ? 'text-error-500 hover:text-error-500'
+            : 'text-success-500 hover:text-success-500'"
         >
           <SvgIcon
             :name="hasTenderlyFailedSimulation ? 'warning-circle' : 'check-circle'"
@@ -418,7 +422,7 @@ const confirmLabel = computed(() => {
         <button
           v-else-if="tenderlyEnabled"
           type="button"
-          class="flex items-center gap-6 text-p3 text-content-primary hover:text-content-primary transition-colors"
+          class="inline-flex h-36 items-center gap-6 rounded-8 border border-line-default bg-card px-12 text-p3 text-content-primary hover:border-line-emphasis hover:bg-card-hover disabled:cursor-not-allowed disabled:opacity-60 transition-colors"
           :disabled="isTenderlyPreparing"
           @click="handleTenderlySimulate"
         >
@@ -431,7 +435,7 @@ const confirmLabel = computed(() => {
         </button>
       </div>
       <p
-        v-if="usesPermit2 && !hideExecute"
+        v-if="usesPermit2 && !hideExecute && hasCopiedCalldata"
         class="text-p4 text-content-primary text-center"
       >
         Copied calldata does not contain the permit() call. It is only known after the permit2 message is signed.

--- a/components/entities/operation/OperationReviewModal.vue
+++ b/components/entities/operation/OperationReviewModal.vue
@@ -105,6 +105,7 @@ watch(
   () => [prepared, plan, walletAddress.value, currentChainId.value] as const,
   async () => {
     const requestId = ++prepareRequestId
+    hasCopiedCalldata.value = false
     prepareError.value = ''
     preparedPlan.value = undefined
 

--- a/components/entities/portfolio/PortfolioEarnItem.vue
+++ b/components/entities/portfolio/PortfolioEarnItem.vue
@@ -10,7 +10,7 @@ import { VaultOverviewModal, VaultSupplyApyModal, UiModalPreviewTrigger } from '
 import { useModal } from '~/components/ui/composables/useModal'
 import { formatNumber, formatCompactUsdValue, formatExactAmount } from '~/utils/string-utils'
 import { roundAndCompactTokens } from '~/utils/crypto-utils'
-import { getVaultIntrinsicApy, getVaultIntrinsicApyInfo } from '~/utils/vault-intrinsic-apy'
+import { getVaultIntrinsicApyInfo } from '~/utils/vault-intrinsic-apy'
 
 const { position } = defineProps<{ position: PortfolioSavingsPosition<VaultEntity> }>()
 const modal = useModal()
@@ -26,7 +26,7 @@ const subAccountIndex = computed(() => {
 const { getSupplyRewardCampaignsFromVault } = useRewardsApy()
 const { settings } = useUserSettings()
 const enableIntrinsicApy = computed(() => settings.value.enableIntrinsicApy)
-const { viewer, visibleTotal } = useApyVisibility()
+const { viewer, visibleTotal, visibleBreakdown } = useApyVisibility()
 
 const vault = computed(() => position.vault as EulerEarn)
 const positionKey = computed(() => `${position.subAccount.toLowerCase()}:${vault.value.address.toLowerCase()}`)
@@ -58,6 +58,7 @@ watchEffect(() => {
 })
 
 const supplyApyWithRewards = computed(() => visibleTotal(apyBreakdown.value) ?? 0)
+const visibleApyBreakdown = computed(() => visibleBreakdown(apyBreakdown.value))
 
 const hasPrice = ref(false)
 
@@ -70,12 +71,16 @@ watchEffect(() => {
   updateHasPrice()
 })
 
+// Source the breakdown rows and total from the same viewer-aware SDK breakdown
+// the headline uses (visibleApyBreakdown / supplyApyWithRewards), so the tooltip
+// total always matches the displayed figure instead of being recomputed.
 const supplyApyModalData = computed(() => ({
   props: {
-    lendingAPY: getVaultSupplyApy(vault.value),
-    intrinsicAPY: getVaultIntrinsicApy(vault.value, enableIntrinsicApy.value),
+    lendingAPY: visibleApyBreakdown.value?.lending ?? 0,
+    intrinsicAPY: visibleApyBreakdown.value?.intrinsicApy ?? 0,
     intrinsicApyInfo: getVaultIntrinsicApyInfo(vault.value, enableIntrinsicApy.value),
     campaigns: getSupplyRewardCampaignsFromVault(vault.value),
+    totalSupplyAPY: supplyApyWithRewards.value,
     rewardVaultAddress: vault.value.address,
     baseApyAverageLabel: '1h',
   },

--- a/components/entities/portfolio/PortfolioEarnItem.vue
+++ b/components/entities/portfolio/PortfolioEarnItem.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { EulerEarn, PortfolioSavingsPosition, VaultEntity } from '@eulerxyz/euler-v2-sdk'
-import { getSubAccountId as getSubAccountIndex } from '@eulerxyz/euler-v2-sdk'
+import { computeSupplyApyBreakdown, getSubAccountId as getSubAccountIndex } from '@eulerxyz/euler-v2-sdk'
 import { getAddress } from 'viem'
 import { formatAssetValue, getAssetUsdValue } from '~/utils/sdk-prices'
 import { isVaultBlockedByCountry } from '~/composables/useGeoBlock'
@@ -28,16 +28,18 @@ const { settings } = useUserSettings()
 const enableIntrinsicApy = computed(() => settings.value.enableIntrinsicApy)
 const { viewer, visibleTotal, visibleBreakdown } = useApyVisibility()
 
-const vault = computed(() => position.vault as EulerEarn)
+const { getVault: getRegistryVault, isVerifiedVault } = useVaultRegistry()
+const vault = computed(() =>
+  (getRegistryVault(position.vault!.address) as EulerEarn | undefined) ?? (position.vault as EulerEarn),
+)
 const positionKey = computed(() => `${position.subAccount.toLowerCase()}:${vault.value.address.toLowerCase()}`)
 const { modifiedKeys, removedKeys } = useTxBatch()
 const isSimulatedRemoved = computed(() => removedKeys.value.has(positionKey.value))
 const isSimulatedModified = computed(() => !isSimulatedRemoved.value && modifiedKeys.value.has(positionKey.value))
-const apyBreakdown = computed(() => position.getApyBreakdown({ viewer: viewer.value }))
+const apyBreakdown = computed(() => computeSupplyApyBreakdown(vault.value, viewer.value))
 const rewardsExist = computed(() =>
   settings.value.enableRewardsApy && (apyBreakdown.value?.rewards ?? 0) > 0,
 )
-const { isVerifiedVault } = useVaultRegistry()
 
 const product = useEulerProductOfVault(computed(() => vault.value.address))
 const isGeoBlocked = computed(() => isVaultBlockedByCountry(vault.value.address))

--- a/components/entities/portfolio/PortfolioSavingItem.vue
+++ b/components/entities/portfolio/PortfolioSavingItem.vue
@@ -10,7 +10,7 @@ import { formatNumber, formatCompactUsdValue, formatSmartAmount, formatExactAmou
 import { nanoToValue, roundAndCompactTokens } from '~/utils/crypto-utils'
 import { VaultOverviewModal, VaultSupplyApyModal, UiModalPreviewTrigger } from '#components'
 import { useModal } from '~/components/ui/composables/useModal'
-import { getVaultIntrinsicApy, getVaultIntrinsicApyInfo } from '~/utils/vault-intrinsic-apy'
+import { getVaultIntrinsicApyInfo } from '~/utils/vault-intrinsic-apy'
 
 const { position } = defineProps<{ position: PortfolioSavingsPosition<VaultEntity> }>()
 const modal = useModal()
@@ -26,7 +26,7 @@ const subAccountIndex = computed(() => {
 const { settings } = useUserSettings()
 const enableIntrinsicApy = computed(() => settings.value.enableIntrinsicApy)
 const { getSupplyRewardCampaignsFromVault } = useRewardsApy()
-const { viewer, visibleTotal } = useApyVisibility()
+const { viewer, visibleTotal, visibleBreakdown } = useApyVisibility()
 
 const vault = computed(() => position.vault!)
 const positionKey = computed(() => `${position.subAccount.toLowerCase()}:${vault.value.address.toLowerCase()}`)
@@ -46,6 +46,7 @@ const rewardsExist = computed(() =>
   settings.value.enableRewardsApy && (apyBreakdown.value?.rewards ?? 0) > 0,
 )
 const supplyApyWithRewards = computed(() => visibleTotal(apyBreakdown.value) ?? 0)
+const visibleApyBreakdown = computed(() => visibleBreakdown(apyBreakdown.value))
 
 const product = useEulerProductOfVault(computed(() => vault.value.address))
 const { getVaultCategory, isVerifiedVault } = useVaultRegistry()
@@ -86,12 +87,16 @@ const assetAmount = computed(() => {
   return nanoToValue(position.assets, vault.value.asset.decimals)
 })
 
+// Source the breakdown rows and total from the same viewer-aware SDK breakdown
+// the headline uses (visibleApyBreakdown / supplyApyWithRewards), so the tooltip
+// total always matches the displayed figure instead of being recomputed.
 const supplyApyModalData = computed(() => ({
   props: {
-    lendingAPY: getVaultSupplyApy(vault.value),
-    intrinsicAPY: getVaultIntrinsicApy(vault.value, enableIntrinsicApy.value),
+    lendingAPY: visibleApyBreakdown.value?.lending ?? 0,
+    intrinsicAPY: visibleApyBreakdown.value?.intrinsicApy ?? 0,
     intrinsicApyInfo: getVaultIntrinsicApyInfo(vault.value, enableIntrinsicApy.value),
     campaigns: getSupplyRewardCampaignsFromVault(vault.value),
+    totalSupplyAPY: supplyApyWithRewards.value,
     rewardVaultAddress: vault.value.address,
   },
 }))

--- a/components/entities/portfolio/PortfolioSavingItem.vue
+++ b/components/entities/portfolio/PortfolioSavingItem.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { getSubAccountId as getSubAccountIndex, isSecuritizeCollateralVault, type EVault, type PortfolioSavingsPosition, type VaultEntity } from '@eulerxyz/euler-v2-sdk'
+import { computeSupplyApyBreakdown, getSubAccountId as getSubAccountIndex, isSecuritizeCollateralVault, type EVault, type PortfolioSavingsPosition, type VaultEntity } from '@eulerxyz/euler-v2-sdk'
 import { getAddress } from 'viem'
 
 import { getUtilisationWarning } from '~/composables/useVaultWarnings'
@@ -28,7 +28,10 @@ const enableIntrinsicApy = computed(() => settings.value.enableIntrinsicApy)
 const { getSupplyRewardCampaignsFromVault } = useRewardsApy()
 const { viewer, visibleTotal, visibleBreakdown } = useApyVisibility()
 
-const vault = computed(() => position.vault!)
+const { getVault: getRegistryVault, getVaultCategory, isVerifiedVault } = useVaultRegistry()
+const vault = computed(() =>
+  (getRegistryVault(position.vault!.address) as VaultEntity | undefined) ?? position.vault!,
+)
 const positionKey = computed(() => `${position.subAccount.toLowerCase()}:${vault.value.address.toLowerCase()}`)
 // Positions the active simulated batch layer modified get a dotted border.
 const { modifiedKeys, removedKeys } = useTxBatch()
@@ -41,7 +44,7 @@ const utilisationWarning = computed(() => {
 
 const isSecuritize = computed(() => isSecuritizeCollateralVault(vault.value))
 
-const apyBreakdown = computed(() => position.getApyBreakdown({ viewer: viewer.value }))
+const apyBreakdown = computed(() => computeSupplyApyBreakdown(vault.value, viewer.value))
 const rewardsExist = computed(() =>
   settings.value.enableRewardsApy && (apyBreakdown.value?.rewards ?? 0) > 0,
 )
@@ -49,7 +52,6 @@ const supplyApyWithRewards = computed(() => visibleTotal(apyBreakdown.value) ?? 
 const visibleApyBreakdown = computed(() => visibleBreakdown(apyBreakdown.value))
 
 const product = useEulerProductOfVault(computed(() => vault.value.address))
-const { getVaultCategory, isVerifiedVault } = useVaultRegistry()
 const isGeoBlocked = computed(() => isVaultBlockedByCountry(vault.value.address))
 const isDeprecated = computed(() => isVaultDeprecated(vault.value.address))
 const isEscrow = computed(() => getVaultCategory(vault.value.address) === 'escrow')

--- a/components/entities/vault/VaultBorrowApyModal.vue
+++ b/components/entities/vault/VaultBorrowApyModal.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { formatNumber } from '~/utils/string-utils'
+import { combineApyWithIntrinsic } from '~/utils/vault-intrinsic-apy'
 import type { RewardCampaign } from '~/entities/reward-campaign'
 import { PROVIDER_LABELS, PROVIDER_LOGOS, rewardCampaignAprPercent, rewardCampaignDisplays } from '~/entities/reward-campaign'
 import type { IntrinsicApyInfo } from '@eulerxyz/euler-v2-sdk'
@@ -23,7 +24,7 @@ const rewardsTotalAPY = computed(() => {
 
 const intrinsicApyValue = computed(() => intrinsicAPY ?? 0)
 const hasIntrinsicApy = computed(() => intrinsicApyValue.value > 0)
-const totalBorrowApy = computed(() => borrowingAPY + intrinsicApyValue.value - (rewardsTotalAPY.value || 0))
+const totalBorrowApy = computed(() => combineApyWithIntrinsic(borrowingAPY, intrinsicApyValue.value) - (rewardsTotalAPY.value || 0))
 
 const rewardsInfo = computed(() => {
   return rewardCampaignDisplays(campaigns, 'borrow', rewardVaultAddress)

--- a/components/entities/vault/VaultBorrowApyModal.vue
+++ b/components/entities/vault/VaultBorrowApyModal.vue
@@ -77,7 +77,7 @@ const handleClose = () => {
               > ({{ intrinsicApyInfo.provider }})</span>
             </p>
             <p class="text-content-primary">
-              Yield intrinsic to the borrowed asset, such as staking yield, which reduces effective borrowing cost
+              Yield intrinsic to the borrowed asset, such as staking yield, which increases effective borrowing cost
             </p>
             <a
               v-if="intrinsicApyInfo?.source"

--- a/components/entities/vault/VaultBorrowItem.vue
+++ b/components/entities/vault/VaultBorrowItem.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import type { EVault } from '@eulerxyz/euler-v2-sdk'
 import { getUtilisationWarning, getBorrowCapWarning, getCollateralSupplyCapWarning } from '~/composables/useVaultWarnings'
 import { formatAssetValue } from '~/utils/sdk-prices'
 import { getMaxMultiplier, getMaxRoe } from '~/utils/leverage'
@@ -192,20 +191,15 @@ const borrowApyModalData = computed(() => ({
   },
 }))
 
-const supplyApyModalData = computed(() => {
-  const baseSupply = 'interestRateInfo' in pair.collateral
-    ? getVaultSupplyApy(pair.collateral as EVault)
-    : 0
-  return {
-    props: {
-      lendingAPY: baseSupply,
-      intrinsicAPY: getVaultIntrinsicApy(pair.collateral, enableIntrinsicApy.value),
-      intrinsicApyInfo: getVaultIntrinsicApyInfo(pair.collateral, enableIntrinsicApy.value),
-      campaigns: getSupplyRewardCampaigns(pair.collateral.address),
-      rewardVaultAddress: pair.collateral.address,
-    },
-  }
-})
+const supplyApyModalData = computed(() => ({
+  props: {
+    lendingAPY: getVaultSupplyApy(pair.collateral),
+    intrinsicAPY: getVaultIntrinsicApy(pair.collateral, enableIntrinsicApy.value),
+    intrinsicApyInfo: getVaultIntrinsicApyInfo(pair.collateral, enableIntrinsicApy.value),
+    campaigns: getSupplyRewardCampaigns(pair.collateral.address),
+    rewardVaultAddress: pair.collateral.address,
+  },
+}))
 
 const netApyModalData = computed(() => ({
   props: {

--- a/components/entities/vault/VaultNetApyPairModal.vue
+++ b/components/entities/vault/VaultNetApyPairModal.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { formatNumber } from '~/utils/string-utils'
+import { combineApyWithIntrinsic } from '~/utils/vault-intrinsic-apy'
 import type { RewardCampaign } from '~/entities/reward-campaign'
 import { PROVIDER_LABELS, PROVIDER_LOGOS, rewardCampaignDisplays } from '~/entities/reward-campaign'
 
@@ -33,10 +34,10 @@ const {
 }>()
 
 const totalSupplyApy = computed(() =>
-  supplyAPY + (intrinsicSupplyAPY ?? 0) + (supplyRewardAPY || 0),
+  combineApyWithIntrinsic(supplyAPY, intrinsicSupplyAPY ?? 0) + (supplyRewardAPY || 0),
 )
 const totalBorrowApy = computed(() =>
-  borrowAPY + (intrinsicBorrowAPY ?? 0) - (borrowRewardAPY || 0),
+  combineApyWithIntrinsic(borrowAPY, intrinsicBorrowAPY ?? 0) - (borrowRewardAPY || 0),
 )
 const netApy = computed(() => totalSupplyApy.value - totalBorrowApy.value + (loopingRewardAPY || 0))
 

--- a/components/entities/vault/VaultSupplyApyModal.vue
+++ b/components/entities/vault/VaultSupplyApyModal.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { formatNumber } from '~/utils/string-utils'
+import { combineApyWithIntrinsic } from '~/utils/vault-intrinsic-apy'
 import type { RewardCampaign } from '~/entities/reward-campaign'
 import { PROVIDER_LABELS, PROVIDER_LOGOS, rewardCampaignAprPercent, rewardCampaignDisplays } from '~/entities/reward-campaign'
 import type { IntrinsicApyInfo } from '@eulerxyz/euler-v2-sdk'
@@ -25,7 +26,7 @@ const rewardsTotalAPY = computed(() => {
 
 const intrinsicApyValue = computed(() => intrinsicAPY ?? 0)
 const hasIntrinsicApy = computed(() => intrinsicApyValue.value > 0)
-const totalSupplyApy = computed(() => totalSupplyAPY ?? lendingAPY + intrinsicApyValue.value + (rewardsTotalAPY.value || 0))
+const totalSupplyApy = computed(() => totalSupplyAPY ?? combineApyWithIntrinsic(lendingAPY, intrinsicApyValue.value) + (rewardsTotalAPY.value || 0))
 
 const rewardsInfo = computed(() => {
   return rewardCampaignDisplays(campaigns, 'supply', rewardVaultAddress)

--- a/components/entities/vault/discovery/DiscoveryMarketAccordion.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketAccordion.vue
@@ -709,9 +709,29 @@ onMounted(() => {
                     </div>
                   </template>
 
-                  <!-- Cell selection: single lend + single borrow card -->
+                  <!-- Cell selection -->
                   <template v-else>
-                    <div class="flex flex-col gap-12">
+                    <!-- Oracle view: dedicated oracle adapters section for the
+                         selected collateral/liability pair (same component as the
+                         borrow page's Oracles block). -->
+                    <template v-if="getMatrixView(market.id) === 'oracle'">
+                      <template
+                        v-for="pair in [getSelectedBorrowPair(market)]"
+                        :key="'oracle-' + (pair ? `${pair.collateral.address}-${pair.borrow.address}` : '')"
+                      >
+                        <VaultOverviewBlockOracleAdapters
+                          v-if="pair"
+                          :vault="pair.borrow"
+                          :collateral-vaults="[pair.collateral]"
+                        />
+                      </template>
+                    </template>
+
+                    <!-- Other metrics: single lend + single borrow card -->
+                    <div
+                      v-else
+                      class="flex flex-col gap-12"
+                    >
                       <template
                         v-for="lendVault in [getSelectedLendVault(market)]"
                         :key="'lend-' + (lendVault ? getVaultAddress(lendVault) : '')"

--- a/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
@@ -1,24 +1,11 @@
 <script setup lang="ts">
-import {
-  isEVault,
-  type SecuritizeCollateralVault,
-  type OracleRouteStep,
-  type EVault,
-} from '@eulerxyz/euler-v2-sdk'
+import { isEVault } from '@eulerxyz/euler-v2-sdk'
 import { getMaxMultiplier, getMaxRoe } from '~/utils/leverage'
 import { findVault, formatMetricValue, getCellBgColor, isMatrixCompatibleVault, type CollateralMatrixData, type MatrixCell, type DotMetric, type EnhancedCellApys } from '~/utils/discoveryCalculations'
-import { getChecksStatus, OracleAdapterCheckSeverity, resolveOracleAdapterIdentity, type OracleAdapterCheck } from '~/entities/oracle'
-import { getOracleProviderLogo } from '~/entities/oracle-providers'
-import { getExplorerLink } from '~/utils/block-explorer'
-import { truncate, formatNumber } from '~/utils/string-utils'
-import { shouldInvertOraclePrice } from '~/utils/oracle-label'
-import { getOracleRouteStepKey, useOracleAdapterPrices } from '~/composables/useOracleAdapterPrices'
-import { getCollateralOracleRouteSteps, getDebtOracleRouteSteps, isOracleAdapterRouteStep } from '~/utils/oracle-route-steps'
+import { buildOracleAdapterViews, collectOracleRouteSteps, type OracleAdapterView } from '~/utils/oracle-adapter-views'
 import type { MarketGroup } from '~/entities/lend-discovery'
 import { withVaultIntrinsicApy } from '~/utils/vault-intrinsic-apy'
 import { areTokenAddressesCorrelatedByTags } from '~/utils/token-categories'
-import type { Address } from 'viem'
-import type { CSSProperties } from 'vue'
 
 const props = defineProps<{
   market: MarketGroup
@@ -28,7 +15,7 @@ const props = defineProps<{
   selectedHeader: { address: string, axis: 'row' | 'column' } | null
 }>()
 
-defineEmits<{
+const emit = defineEmits<{
   selectCell: [collateralAddr: string, liabilityAddr: string]
   selectHeader: [address: string, axis: 'row' | 'column']
 }>()
@@ -218,47 +205,51 @@ const metricRange = computed((): { min: number, max: number } => {
   return Number.isFinite(min) ? { min, max } : { min: 0, max: 0 }
 })
 
-// ── Oracle metric: per-cell adapter list + tooltip ────────────────────────────
+// ── Oracle metric: per-cell adapter views ────────────────────────────────────
 
-const getCollateralOracleSteps = (
-  liability: EVault,
-  collateral: EVault | SecuritizeCollateralVault,
-) => {
-  return getCollateralOracleRouteSteps(liability, collateral)
-}
-
-const cellOracleSteps = computed((): Map<string, OracleRouteStep[]> => {
-  const result = new Map<string, OracleRouteStep[]>()
+// Each off-diagonal cell shows every oracle adapter that prices the pair's
+// collateral AND liability assets — the same set the borrow page's Oracles
+// block renders, via the shared collectOracleRouteSteps + buildOracleAdapterViews.
+// The self-diagonal is intentionally left blank: a liability's own asset->UoA
+// oracle already appears in every cell of its column.
+const cellAdapterViews = computed((): Map<string, OracleAdapterView[]> => {
+  const result = new Map<string, OracleAdapterView[]>()
   if (props.dotMetric !== 'oracle') return result
 
-  for (const [colAddr, rowCells] of props.matrix.cells) {
-    for (const [liabAddr] of rowCells) {
-      const collateral = findVault(props.market, colAddr)
-      const liability = findVault(props.market, liabAddr)
-      if (!collateral || !liability) continue
-      if (!isMatrixCompatibleVault(collateral)) continue
-      if (!isEVault(liability)) continue
-      const steps = getCollateralOracleSteps(liability, collateral)
-      if (steps.length) result.set(`${colAddr}:${liabAddr}`, steps)
+  for (const [collateralAddr, rowCells] of props.matrix.cells) {
+    for (const [liabilityAddr] of rowCells) {
+      if (collateralAddr === liabilityAddr) continue
+      const collateral = findVault(props.market, collateralAddr)
+      const liability = findVault(props.market, liabilityAddr)
+      if (!collateral || !isMatrixCompatibleVault(collateral)) continue
+      if (!liability || !isEVault(liability)) continue
+      const steps = collectOracleRouteSteps([liability], [collateral])
+      if (steps.length) {
+        result.set(`${collateralAddr}:${liabilityAddr}`, buildOracleAdapterViews(steps, oracleAdapters))
+      }
     }
   }
   return result
 })
 
-// Per-borrow-vault asset oracle: resolves the borrow vault's own asset against
-// its unit of account. Same set repeated across every cell in a column, so we
-// surface it once as a header row instead.
-const columnAssetOracleSteps = computed((): Map<string, OracleRouteStep[]> => {
-  const result = new Map<string, OracleRouteStep[]>()
-  if (props.dotMetric !== 'oracle') return result
-  for (const col of props.matrix.columns) {
-    const liability = findVault(props.market, col.address)
-    if (!liability || !isEVault(liability)) continue
-    const steps = getDebtOracleRouteSteps(liability)
-    if (steps.length) result.set(col.address, steps)
+const getCellAdapterViews = (collateralAddr: string, liabilityAddr: string): OracleAdapterView[] =>
+  cellAdapterViews.value.get(`${collateralAddr}:${liabilityAddr}`) ?? []
+
+const isOracleCellSelectable = (collateralAddr: string, liabilityAddr: string): boolean =>
+  getCellAdapterViews(collateralAddr, liabilityAddr).length > 0
+
+// Cell click drives the inline oracle detail section below the matrix. In oracle
+// mode only off-diagonal cells that actually have adapters are selectable; other
+// metrics keep the original "any present cell is selectable" behaviour.
+const onCellClick = (collateralAddr: string, liabilityAddr: string) => {
+  if (props.dotMetric === 'oracle') {
+    if (!isOracleCellSelectable(collateralAddr, liabilityAddr)) return
   }
-  return result
-})
+  else if (!props.matrix.cells.get(collateralAddr)?.get(liabilityAddr)) {
+    return
+  }
+  emit('selectCell', collateralAddr, liabilityAddr)
+}
 
 // Bulk-load adapter metadata for the chain. Heavy call (1+ MB JSON); the
 // `metric !== 'oracle'` guard short-circuits the immediate run on mount and
@@ -273,224 +264,6 @@ watch(
   },
   { immediate: true },
 )
-
-interface AdapterView {
-  key: string
-  kind: OracleRouteStep['kind']
-  oracle: Address
-  name: string
-  base: Address
-  quote: Address
-  metaBase?: Address
-  metaQuote?: Address
-  provider: string
-  methodology?: string
-  logo?: string
-  label?: { primary: string, suffix?: string }
-  checks?: OracleAdapterCheck[]
-  checksStatus: 'positive' | 'warning' | 'negative' | null
-  failedChecks: OracleAdapterCheck[]
-}
-
-const enrichStep = (step: OracleRouteStep): AdapterView => {
-  const isAdapter = isOracleAdapterRouteStep(step)
-  const meta = isAdapter ? oracleAdapters[step.oracle.toLowerCase()] : undefined
-  // LITE-235: an adapter with no curated oracle-checks entry must not fall back to
-  // its self-reported onchain name(); render it as unknown instead. The template's
-  // `|| 'Unknown'` fallbacks turn the empty strings into the displayed label.
-  const { name: resolvedName, provider: resolvedProvider } = resolveOracleAdapterIdentity(step, meta, isAdapter)
-  const provider = resolvedProvider ?? ''
-  const name = resolvedName ?? ''
-  const checks = meta?.checks
-  return {
-    key: getOracleRouteStepKey(step),
-    kind: step.kind,
-    oracle: step.oracle,
-    name,
-    base: step.base,
-    quote: step.quote,
-    metaBase: meta?.base,
-    metaQuote: meta?.quote,
-    provider,
-    methodology: meta?.methodology || (step.kind === 'vault' ? 'Exchange Rate' : undefined),
-    logo: getOracleProviderLogo(provider, name),
-    label: meta?.label
-      ? {
-          primary: meta.label.split('(')[0].trimEnd(),
-          suffix: meta.label.includes('(') ? meta.label.slice(meta.label.indexOf('(')).trim() : undefined,
-        }
-      : undefined,
-    checks,
-    checksStatus: getChecksStatus(checks),
-    failedChecks: checks?.filter(c => !c.pass) ?? [],
-  }
-}
-
-const getCellAdapterViews = (collateralAddr: string, liabilityAddr: string): AdapterView[] => {
-  const list = cellOracleSteps.value.get(`${collateralAddr}:${liabilityAddr}`)
-  if (!list) return []
-  return list.map(enrichStep)
-}
-
-const getColumnAssetAdapterViews = (liabilityAddr: string): AdapterView[] => {
-  const list = columnAssetOracleSteps.value.get(liabilityAddr)
-  if (!list) return []
-  return list.map(enrichStep)
-}
-
-const TOOLTIP_WIDTH = 360
-
-interface TooltipContext {
-  view: AdapterView
-  sourceVault: EVault
-  collateralVault: EVault | SecuritizeCollateralVault | null
-}
-
-const tooltipContext = ref<TooltipContext | null>(null)
-const tooltipAdapter = computed(() => tooltipContext.value?.view ?? null)
-const tooltipStyle = ref<CSSProperties>({})
-
-// Single matrix-wide price fetch: in oracle mode we dedup every route step
-// currently shown, run one batchSimulation, and let tooltips read the results
-// from the same map.
-const allOracleSteps = computed<OracleRouteStep[]>(() => {
-  if (props.dotMetric !== 'oracle') return []
-  const seen = new Map<string, OracleRouteStep>()
-  const ingest = (lists: Iterable<OracleRouteStep[]>) => {
-    for (const list of lists) {
-      for (const step of list) {
-        const key = getOracleRouteStepKey(step)
-        if (!seen.has(key)) seen.set(key, step)
-      }
-    }
-  }
-  ingest(cellOracleSteps.value.values())
-  ingest(columnAssetOracleSteps.value.values())
-  return [...seen.values()]
-})
-
-const oraclePriceSourceVaults = computed<EVault[]>(() => {
-  if (props.dotMetric !== 'oracle') return []
-  const seen = new Map<string, EVault>()
-  for (const col of props.matrix.columns) {
-    const liability = findVault(props.market, col.address)
-    if (liability && isEVault(liability)) {
-      seen.set(liability.address.toLowerCase(), liability)
-    }
-  }
-  return [...seen.values()]
-})
-
-const oraclePriceCollateralVaults = computed<(EVault | SecuritizeCollateralVault)[]>(() => {
-  if (props.dotMetric !== 'oracle') return []
-  const seen = new Map<string, EVault | SecuritizeCollateralVault>()
-  for (const row of props.matrix.rows) {
-    const v = findVault(props.market, row.address)
-    if (v && isMatrixCompatibleVault(v)) {
-      seen.set(row.address.toLowerCase(), v)
-    }
-  }
-  return [...seen.values()]
-})
-
-const { prices: oraclePrices, isLoading: oraclePricesLoading } = useOracleAdapterPrices(
-  allOracleSteps,
-  oraclePriceSourceVaults,
-  oraclePriceCollateralVaults,
-)
-
-const isAdapterPriceFailed = (adapter: { key: string }): boolean => {
-  if (oraclePricesLoading.value) return false
-  const info = oraclePrices.value.get(adapter.key)
-  return info ? !info.success : false
-}
-
-const tooltipPriceText = computed((): string | null => {
-  const ctx = tooltipContext.value
-  if (!ctx) return null
-  const info = oraclePrices.value.get(ctx.view.key)
-  if (!info?.success) return null
-  const invert = shouldInvertOraclePrice({
-    metaBase: ctx.view.metaBase,
-    metaQuote: ctx.view.metaQuote,
-    callerBase: ctx.view.base,
-    callerQuote: ctx.view.quote,
-  })
-  const rate = invert && info.rate > 0 ? 1 / info.rate : info.rate
-  return formatNumber(rate, 4)
-})
-
-const tooltipPriceLoading = computed(() => oraclePricesLoading.value && !oraclePrices.value.size)
-
-const closeTooltip = () => {
-  tooltipContext.value = null
-}
-
-const positionTooltip = (event: MouseEvent) => {
-  const rect = (event.currentTarget as HTMLElement).getBoundingClientRect()
-  const left = Math.max(8, Math.min(rect.left, window.innerWidth - TOOLTIP_WIDTH - 16))
-  const spaceBelow = Math.max(160, window.innerHeight - rect.bottom - 16)
-  const spaceAbove = Math.max(160, rect.top - 16)
-  const flipUp = spaceAbove > spaceBelow
-  tooltipStyle.value = flipUp
-    ? { top: `${rect.top - 8}px`, left: `${left}px`, transform: 'translateY(-100%)', maxHeight: `${spaceAbove}px` }
-    : { top: `${rect.bottom + 8}px`, left: `${left}px`, transform: 'none', maxHeight: `${spaceBelow}px` }
-}
-
-const onCellAdapterClick = (
-  view: AdapterView,
-  event: MouseEvent,
-  collateralAddr: string,
-  liabilityAddr: string,
-) => {
-  if (tooltipContext.value?.view.key === view.key) {
-    closeTooltip()
-    return
-  }
-  const liability = findVault(props.market, liabilityAddr)
-  const collateral = findVault(props.market, collateralAddr)
-  if (!liability || !isEVault(liability)) return
-  positionTooltip(event)
-  tooltipContext.value = {
-    view,
-    sourceVault: liability,
-    collateralVault: collateral && collateral.address.toLowerCase() !== liabilityAddr.toLowerCase() ? collateral : null,
-  }
-}
-
-const onAssetAdapterClick = (
-  view: AdapterView,
-  event: MouseEvent,
-  liabilityAddr: string,
-) => {
-  if (tooltipContext.value?.view.key === view.key) {
-    closeTooltip()
-    return
-  }
-  const liability = findVault(props.market, liabilityAddr)
-  if (!liability || !isEVault(liability)) return
-  positionTooltip(event)
-  tooltipContext.value = {
-    view,
-    sourceVault: liability,
-    collateralVault: null,
-  }
-}
-
-// Document-level bubble-phase listener — `@click.stop` on every logo button
-// and on the tooltip itself prevents this from firing for in-tooltip clicks
-// or for clicks on other adapter triggers. That keeps "click same logo to
-// close" working (vueuse's onClickOutside attaches in capture phase, which
-// would short-circuit the toggle behaviour).
-const onDocumentClick = () => closeTooltip()
-onMounted(() => {
-  document.addEventListener('click', onDocumentClick)
-})
-onUnmounted(() => {
-  document.removeEventListener('click', onDocumentClick)
-})
-
-const explorerLink = (address: string) => getExplorerLink(address, chainId.value, true)
 </script>
 
 <template>
@@ -616,7 +389,9 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
                     : row.address === col.address
                       ? 'bg-white/[0.03]'
                       : '',
-                matrix.cells.get(row.address)?.get(col.address)
+                (dotMetric === 'oracle'
+                  ? isOracleCellSelectable(row.address, col.address)
+                  : !!matrix.cells.get(row.address)?.get(col.address))
                   ? 'cursor-pointer'
                   : '',
               ]"
@@ -649,126 +424,46 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
               "
               @mouseenter="hoveredCell = { collateralAddr: row.address, liabilityAddr: col.address }"
               @mouseleave="hoveredCell = null"
-              @click.stop="
-                matrix.cells.get(row.address)?.get(col.address)
-                  && $emit('selectCell', row.address, col.address)
-              "
+              @click.stop="onCellClick(row.address, col.address)"
             >
-              <!-- Diagonal in oracle mode: surface the borrow vault's own
-                   asset -> UoA oracle (same for every cell in the column,
-                   so we show it once on the self-row instead of repeating). -->
-              <template
-                v-if="dotMetric === 'oracle'
-                  && row.address === col.address
-                  && getColumnAssetAdapterViews(col.address).length"
-              >
-                <div class="inline-flex items-center justify-center gap-4 flex-wrap">
-                  <button
-                    v-for="adapter in getColumnAssetAdapterViews(col.address)"
+              <template v-if="matrix.cells.get(row.address)?.get(col.address)">
+                <!-- Oracle metric: every adapter pricing the pair's collateral &
+                     liability assets. Display-only logos; clicking the cell opens
+                     the inline oracle section below the matrix. -->
+                <div
+                  v-if="dotMetric === 'oracle' && getCellAdapterViews(row.address, col.address).length"
+                  class="inline-flex items-center justify-center gap-4 flex-wrap"
+                >
+                  <span
+                    v-for="adapter in getCellAdapterViews(row.address, col.address)"
                     :key="adapter.key"
-                    type="button"
-                    class="relative inline-flex items-center justify-center cursor-pointer"
+                    class="relative inline-flex items-center justify-center"
                     data-id="oracle-adapter"
-                    :data-key="`${col.address}:${adapter.key}`"
+                    :data-key="`${row.address}:${col.address}:${adapter.key}`"
+                    :data-collateral-address="row.address"
                     :data-borrow-address="col.address"
                     :data-oracle-address="adapter.oracle"
                     :data-base-address="adapter.base"
                     :data-quote-address="adapter.quote"
-                    @click.stop="onAssetAdapterClick(adapter, $event, col.address)"
                   >
-                    <UiHoverPreviewTooltip
-                      :title="adapter.name || 'Unknown'"
-                      :text="adapter.provider || 'Unknown provider'"
-                      placement="top-start"
-                    >
-                      <BaseAvatar
-                        v-if="adapter.logo"
-                        :src="adapter.logo"
-                        :label="adapter.name"
-                        class="icon--16"
-                      />
-                      <SvgIcon
-                        v-else
-                        name="question-circle"
-                        class="!w-16 !h-16 text-content-tertiary"
-                      />
-                    </UiHoverPreviewTooltip>
+                    <BaseAvatar
+                      v-if="adapter.logo"
+                      :src="adapter.logo"
+                      :label="adapter.name"
+                      class="icon--16"
+                    />
+                    <SvgIcon
+                      v-else
+                      name="question-circle"
+                      class="!w-16 !h-16 text-content-tertiary"
+                    />
                     <span
                       v-if="adapter.checksStatus === 'warning' || adapter.checksStatus === 'negative'"
                       class="absolute -top-1 -right-1 w-6 h-6 rounded-full"
                       :class="adapter.checksStatus === 'negative' ? 'bg-error-500' : 'bg-warning-500'"
                     />
-                    <UiHoverPreviewTooltip
-                      v-if="isAdapterPriceFailed(adapter)"
-                      title="getQuote reverted"
-                      text="getQuote reverted"
-                      placement="top-start"
-                      class="absolute -bottom-1 -right-1"
-                    >
-                      <SvgIcon
-                        name="warning"
-                        class="!w-10 !h-10 text-warning-500"
-                      />
-                    </UiHoverPreviewTooltip>
-                  </button>
+                  </span>
                 </div>
-              </template>
-
-              <template v-else-if="matrix.cells.get(row.address)?.get(col.address)">
-                <!-- Oracle metric: render adapter logos -->
-                <template v-if="dotMetric === 'oracle'">
-                  <div class="inline-flex items-center justify-center gap-4 flex-wrap">
-                    <button
-                      v-for="adapter in getCellAdapterViews(row.address, col.address)"
-                      :key="adapter.key"
-                      type="button"
-                      class="relative inline-flex items-center justify-center cursor-pointer"
-                      data-id="oracle-adapter"
-                      :data-key="`${row.address}:${col.address}:${adapter.key}`"
-                      :data-collateral-address="row.address"
-                      :data-borrow-address="col.address"
-                      :data-oracle-address="adapter.oracle"
-                      :data-base-address="adapter.base"
-                      :data-quote-address="adapter.quote"
-                      @click.stop="onCellAdapterClick(adapter, $event, row.address, col.address)"
-                    >
-                      <UiHoverPreviewTooltip
-                        :title="adapter.name || 'Unknown'"
-                        :text="adapter.provider || 'Unknown provider'"
-                        placement="top-start"
-                      >
-                        <BaseAvatar
-                          v-if="adapter.logo"
-                          :src="adapter.logo"
-                          :label="adapter.name"
-                          class="icon--16"
-                        />
-                        <SvgIcon
-                          v-else
-                          name="question-circle"
-                          class="!w-16 !h-16 text-content-tertiary"
-                        />
-                      </UiHoverPreviewTooltip>
-                      <span
-                        v-if="adapter.checksStatus === 'warning' || adapter.checksStatus === 'negative'"
-                        class="absolute -top-1 -right-1 w-6 h-6 rounded-full"
-                        :class="adapter.checksStatus === 'negative' ? 'bg-error-500' : 'bg-warning-500'"
-                      />
-                      <UiHoverPreviewTooltip
-                        v-if="isAdapterPriceFailed(adapter)"
-                        title="getQuote reverted"
-                        text="getQuote reverted"
-                        placement="top-start"
-                        class="absolute -bottom-1 -right-1"
-                      >
-                        <SvgIcon
-                          name="warning"
-                          class="!w-10 !h-10 text-warning-500"
-                        />
-                      </UiHoverPreviewTooltip>
-                    </button>
-                  </div>
-                </template>
 
                 <!-- Numeric metrics: original rendering -->
                 <div
@@ -876,146 +571,4 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
   >
     Tap a cell, row, or column header to see lending/borrowing options below.
   </p>
-
-  <!-- Oracle adapter tooltip — mirrors VaultOverviewBlockOracleAdapters card layout -->
-  <Teleport to="body">
-    <div
-      v-if="tooltipAdapter"
-      class="fixed z-[9999] bg-surface-secondary border border-line-subtle rounded-xl p-16 shadow-card overflow-y-auto flex flex-col gap-12"
-      :style="[tooltipStyle, { width: `${TOOLTIP_WIDTH}px` }]"
-      @click.stop
-    >
-      <!-- Header: oracle label / pair + address & close -->
-      <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-4 sm:gap-8">
-        <div class="text-p2 text-content-primary font-medium">
-          <template v-if="tooltipAdapter.label">
-            {{ tooltipAdapter.label.primary }}
-            <span
-              v-if="tooltipAdapter.label.suffix"
-              class="text-content-tertiary ml-2"
-            >{{ tooltipAdapter.label.suffix }}</span>
-          </template>
-          <template v-else>
-            Oracle
-          </template>
-        </div>
-        <div class="flex items-center gap-8 flex-shrink-0">
-          <NuxtLink
-            :to="explorerLink(tooltipAdapter.oracle)"
-            target="_blank"
-            class="text-accent-600 underline cursor-pointer hover:text-accent-500 text-p3"
-            @click.stop
-          >
-            {{ truncate(tooltipAdapter.oracle, 6) }}
-          </NuxtLink>
-          <button
-            type="button"
-            class="text-content-muted hover:text-content-secondary cursor-pointer"
-            aria-label="Close"
-            @click.stop="closeTooltip"
-          >
-            <SvgIcon
-              name="close"
-              class="!w-14 !h-14"
-            />
-          </button>
-        </div>
-      </div>
-
-      <!-- Provider / Methodology / Price / Checks grid (mirrors borrow page) -->
-      <div class="grid grid-cols-2 gap-12 text-p3">
-        <div class="flex flex-col gap-4">
-          <span class="text-content-tertiary">Provider</span>
-          <div class="flex items-center gap-8">
-            <BaseAvatar
-              v-if="tooltipAdapter.logo"
-              :src="tooltipAdapter.logo"
-              :label="tooltipAdapter.name"
-              class="icon--20"
-            />
-            <SvgIcon
-              v-else
-              name="question-circle"
-              class="!w-20 !h-20 text-content-tertiary"
-            />
-            <span class="text-content-primary">{{ tooltipAdapter.provider || 'Unknown' }}</span>
-          </div>
-        </div>
-        <div class="flex flex-col gap-4">
-          <span class="text-content-tertiary">Methodology</span>
-          <span class="text-content-primary">{{ tooltipAdapter.methodology || 'Unknown' }}</span>
-        </div>
-        <div class="flex flex-col gap-4">
-          <span class="text-content-tertiary">Price</span>
-          <span
-            v-if="tooltipPriceLoading"
-            class="text-content-secondary animate-pulse"
-          >...</span>
-          <span
-            v-else-if="tooltipPriceText === null"
-            class="flex items-center text-warning-500"
-          >
-            <SvgIcon
-              name="warning"
-              class="mr-2 !w-16 !h-16"
-            />
-            Unknown
-          </span>
-          <span
-            v-else
-            class="text-content-primary"
-          >{{ tooltipPriceText }}</span>
-        </div>
-        <div class="flex flex-col gap-4">
-          <span class="text-content-tertiary">Checks</span>
-          <span
-            v-if="!tooltipAdapter.checks?.length"
-            class="text-content-secondary"
-          >N/A</span>
-          <span
-            v-else
-            class="flex items-center gap-6"
-          >
-            <span
-              class="inline-block w-8 h-8 rounded-full flex-shrink-0"
-              :class="{
-                'bg-success-500': tooltipAdapter.checksStatus === 'positive',
-                'bg-warning-500': tooltipAdapter.checksStatus === 'warning',
-                'bg-error-500': tooltipAdapter.checksStatus === 'negative',
-              }"
-            />
-            <span class="text-content-primary">
-              <template v-if="tooltipAdapter.checksStatus === 'positive'">{{ tooltipAdapter.checks.length }} passed</template>
-              <template v-else>{{ tooltipAdapter.failedChecks.length }} failed</template>
-            </span>
-          </span>
-        </div>
-      </div>
-
-      <!-- Failed checks detail -->
-      <div
-        v-if="tooltipAdapter.failedChecks.length"
-        class="flex flex-col gap-6 border-t border-line-subtle pt-12 text-p3"
-      >
-        <div
-          v-for="(check, i) in tooltipAdapter.failedChecks"
-          :key="`${check.id}-${i}`"
-          class="flex items-start gap-8"
-        >
-          <SvgIcon
-            name="warning"
-            class="!w-16 !h-16 mt-1 flex-shrink-0"
-            :class="{
-              'text-error-500': check.severity === OracleAdapterCheckSeverity.High,
-              'text-warning-500': check.severity !== OracleAdapterCheckSeverity.High,
-            }"
-          />
-          <div>
-            <span class="text-content-primary font-medium">{{ check.id }}: </span>
-            <span class="text-content-secondary">{{ check.message }}</span>
-          </div>
-        </div>
-      </div>
-    </div>
-  </Teleport>
 </template>

--- a/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
@@ -288,6 +288,7 @@ interface AdapterView {
   logo?: string
   label?: { primary: string, suffix?: string }
   checks?: OracleAdapterCheck[]
+  isCustomAdapter: boolean
   checksStatus: 'positive' | 'warning' | 'negative' | null
   failedChecks: OracleAdapterCheck[]
 }
@@ -298,7 +299,7 @@ const enrichStep = (step: OracleRouteStep): AdapterView => {
   // LITE-235: an adapter with no curated oracle-checks entry must not fall back to
   // its self-reported onchain name(); render it as unknown instead. The template's
   // `|| 'Unknown'` fallbacks turn the empty strings into the displayed label.
-  const { name: resolvedName, provider: resolvedProvider } = resolveOracleAdapterIdentity(step, meta, isAdapter)
+  const { name: resolvedName, provider: resolvedProvider, isCustomAdapter } = resolveOracleAdapterIdentity(step, meta, isAdapter)
   const provider = resolvedProvider ?? ''
   const name = resolvedName ?? ''
   const checks = meta?.checks
@@ -321,6 +322,7 @@ const enrichStep = (step: OracleRouteStep): AdapterView => {
         }
       : undefined,
     checks,
+    isCustomAdapter,
     checksStatus: getChecksStatus(checks),
     failedChecks: checks?.filter(c => !c.pass) ?? [],
   }
@@ -969,7 +971,11 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
         <div class="flex flex-col gap-4">
           <span class="text-content-tertiary">Checks</span>
           <span
-            v-if="!tooltipAdapter.checks?.length"
+            v-if="tooltipAdapter.isCustomAdapter"
+            class="text-content-secondary"
+          >Custom — set by risk manager</span>
+          <span
+            v-else-if="!tooltipAdapter.checks?.length"
             class="text-content-secondary"
           >N/A</span>
           <span

--- a/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
@@ -458,9 +458,13 @@ watch(
                       class="!w-16 !h-16 text-content-tertiary"
                     />
                     <span
-                      v-if="adapter.checksStatus === 'warning' || adapter.checksStatus === 'negative'"
+                      v-if="adapter.checksStatus"
                       class="absolute -top-1 -right-1 w-6 h-6 rounded-full"
-                      :class="adapter.checksStatus === 'negative' ? 'bg-error-500' : 'bg-warning-500'"
+                      :class="{
+                        'bg-success-500': adapter.checksStatus === 'positive',
+                        'bg-warning-500': adapter.checksStatus === 'warning',
+                        'bg-error-500': adapter.checksStatus === 'negative',
+                      }"
                     />
                   </span>
                 </div>

--- a/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
@@ -7,7 +7,7 @@ import {
 } from '@eulerxyz/euler-v2-sdk'
 import { getMaxMultiplier, getMaxRoe } from '~/utils/leverage'
 import { findVault, formatMetricValue, getCellBgColor, isMatrixCompatibleVault, type CollateralMatrixData, type MatrixCell, type DotMetric, type EnhancedCellApys } from '~/utils/discoveryCalculations'
-import { getChecksStatus, OracleAdapterCheckSeverity, type OracleAdapterCheck } from '~/entities/oracle'
+import { getChecksStatus, OracleAdapterCheckSeverity, resolveOracleAdapterIdentity, type OracleAdapterCheck } from '~/entities/oracle'
 import { getOracleProviderLogo } from '~/entities/oracle-providers'
 import { getExplorerLink } from '~/utils/block-explorer'
 import { truncate, formatNumber } from '~/utils/string-utils'
@@ -293,9 +293,14 @@ interface AdapterView {
 }
 
 const enrichStep = (step: OracleRouteStep): AdapterView => {
-  const meta = isOracleAdapterRouteStep(step) ? oracleAdapters[step.oracle.toLowerCase()] : undefined
-  const provider = meta?.provider || step.name
-  const name = meta?.name || step.name
+  const isAdapter = isOracleAdapterRouteStep(step)
+  const meta = isAdapter ? oracleAdapters[step.oracle.toLowerCase()] : undefined
+  // LITE-235: an adapter with no curated oracle-checks entry must not fall back to
+  // its self-reported onchain name(); render it as unknown instead. The template's
+  // `|| 'Unknown'` fallbacks turn the empty strings into the displayed label.
+  const { name: resolvedName, provider: resolvedProvider } = resolveOracleAdapterIdentity(step, meta, isAdapter)
+  const provider = resolvedProvider ?? ''
+  const name = resolvedName ?? ''
   const checks = meta?.checks
   return {
     key: getOracleRouteStepKey(step),
@@ -672,7 +677,7 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
                     @click.stop="onAssetAdapterClick(adapter, $event, col.address)"
                   >
                     <UiHoverPreviewTooltip
-                      :title="adapter.name"
+                      :title="adapter.name || 'Unknown'"
                       :text="adapter.provider || 'Unknown provider'"
                       placement="top-start"
                     >
@@ -728,7 +733,7 @@ const explorerLink = (address: string) => getExplorerLink(address, chainId.value
                       @click.stop="onCellAdapterClick(adapter, $event, row.address, col.address)"
                     >
                       <UiHoverPreviewTooltip
-                        :title="adapter.name"
+                        :title="adapter.name || 'Unknown'"
                         :text="adapter.provider || 'Unknown provider'"
                         placement="top-start"
                       >

--- a/components/entities/vault/overview/VaultOverviewBlockOracleAdapters.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockOracleAdapters.vue
@@ -4,13 +4,12 @@ import type {
   EVault,
   OracleRouteStep,
 } from '@eulerxyz/euler-v2-sdk'
-import { getChecksStatus, getRouterRecognition, OracleAdapterCheckSeverity, resolveOracleAdapterIdentity, type OracleAdapterMeta } from '~/entities/oracle'
-import { getOracleProviderLogo } from '~/entities/oracle-providers'
+import { getRouterRecognition, OracleAdapterCheckSeverity } from '~/entities/oracle'
 import { getExplorerLink } from '~/utils/block-explorer'
 import { formatNumber } from '~/utils/string-utils'
-import { shouldInvertOraclePrice } from '~/utils/oracle-label'
 import { getOracleRouteStepKey, useOracleAdapterPrices } from '~/composables/useOracleAdapterPrices'
-import { getCollateralOracleRouteSteps, getDebtOracleRouteSteps, isOracleAdapterRouteStep } from '~/utils/oracle-route-steps'
+import { isOracleAdapterRouteStep } from '~/utils/oracle-route-steps'
+import { buildOracleAdapterViews, collectOracleRouteSteps } from '~/utils/oracle-adapter-views'
 import type { CSSProperties } from 'vue'
 
 const props = defineProps<{
@@ -35,33 +34,7 @@ const sourceVaults = computed(() => {
   return []
 })
 
-const getCollateralRouteSteps = (vault: EVault, collateralVault: EVault | SecuritizeCollateralVault) => {
-  return getCollateralOracleRouteSteps(vault, collateralVault)
-}
-
-const routeSteps = computed(() => {
-  const entries: OracleRouteStep[] = []
-  const deduped = new Map<string, OracleRouteStep>()
-
-  sourceVaults.value.forEach((vault) => {
-    entries.push(...getDebtOracleRouteSteps(vault))
-
-    if (props.collateralVaults?.length) {
-      props.collateralVaults.forEach((collateralVault) => {
-        entries.push(...getCollateralRouteSteps(vault, collateralVault))
-      })
-    }
-  })
-
-  entries.forEach((step) => {
-    const key = getOracleRouteStepKey(step)
-    if (!deduped.has(key)) {
-      deduped.set(key, step)
-    }
-  })
-
-  return [...deduped.values()]
-})
+const routeSteps = computed(() => collectOracleRouteSteps(sourceVaults.value, props.collateralVaults ?? []))
 
 const knownSymbols = computed(() => {
   const map = buildKnownSymbols()
@@ -80,39 +53,7 @@ const knownSymbols = computed(() => {
   return map
 })
 
-const adapterViews = computed(() => routeSteps.value.map((step) => {
-  const isAdapter = isOracleAdapterRouteStep(step)
-  const meta: OracleAdapterMeta | undefined = isAdapter
-    ? oracleAdapters[step.oracle.toLowerCase()]
-    : undefined
-  const { name, provider, isCustomAdapter } = resolveOracleAdapterIdentity(step, meta, isAdapter)
-  const checks = meta?.checks
-  const invertPrice = shouldInvertOraclePrice({
-    metaBase: meta?.base,
-    metaQuote: meta?.quote,
-    callerBase: step.base,
-    callerQuote: step.quote,
-  })
-
-  return {
-    ...step,
-    name,
-    provider,
-    isCustomAdapter,
-    methodology: meta?.methodology || (step.kind === 'vault' ? 'Exchange Rate' : undefined),
-    logo: getOracleProviderLogo(provider, name),
-    label: meta?.label
-      ? {
-          primary: meta.label.split('(')[0].trimEnd(),
-          suffix: meta.label.includes('(') ? meta.label.slice(meta.label.indexOf('(')).trim() : undefined,
-        }
-      : undefined,
-    invertPrice,
-    checks,
-    checksStatus: getChecksStatus(checks),
-    failedChecks: checks?.filter(c => !c.pass) ?? [],
-  }
-}))
+const adapterViews = computed(() => buildOracleAdapterViews(routeSteps.value, oracleAdapters))
 
 watch(
   () => routeSteps.value,

--- a/components/entities/vault/overview/VaultOverviewBlockOracleAdapters.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockOracleAdapters.vue
@@ -21,7 +21,7 @@ const props = defineProps<{
 const { oracleAdapters, loadOracleAdapter } = useEulerLabels()
 const { chainId } = useEulerAddresses()
 const { buildKnownSymbols, resolveSymbol: resolveTokenSymbol, shortenAddress } = useTokenSymbolResolver()
-const { recognisedRouters, recognisedRoutersChainId, loadRecognisedRouters } = useEulerOracleRouters()
+const { recognizedRouters, recognizedRoutersChainId, loadRecognizedRouters } = useEulerOracleRouters()
 
 const sourceVaults = computed(() => {
   if (props.vaults?.length) {
@@ -131,18 +131,18 @@ watch(
 watch(
   chainId,
   (id) => {
-    if (id) loadRecognisedRouters(id)
+    if (id) loadRecognizedRouters(id)
   },
   { immediate: true },
 )
 
 // LITE-236: flag whether the vault's price oracle (EulerRouter) was deployed by the
-// recognised EulerRouterFactory. Null while the allowlist is still loading for the
-// active chain or unavailable, so we never show a false "unrecognised" warning.
+// recognized EulerRouterFactory. Null while the allowlist is still loading for the
+// active chain or unavailable, so we never show a false "unrecognized" warning.
 const routerRecognition = computed(() => {
-  if (recognisedRoutersChainId.value !== chainId.value) return null
+  if (recognizedRoutersChainId.value !== chainId.value) return null
   const routerAddresses = sourceVaults.value.map(vault => vault.oracle?.oracle)
-  return getRouterRecognition(routerAddresses, recognisedRouters.value)
+  return getRouterRecognition(routerAddresses, recognizedRouters.value)
 })
 
 const resolveSymbol = (address: string) => resolveTokenSymbol(address, knownSymbols.value)
@@ -326,41 +326,41 @@ const onTooltipMouseLeave = () => {
         Oracles
       </p>
       <UiHoverPreviewTooltip
-        v-if="routerRecognition === 'recognised'"
-        title="Recognised oracle router"
-        text="The vault's price oracle was deployed by the recognised EulerRouterFactory."
+        v-if="routerRecognition === 'recognized'"
+        title="Recognized oracle router"
+        text="The vault's price oracle was deployed by the recognized EulerRouterFactory."
         placement="top-start"
       >
         <span
           class="inline-flex items-center gap-4 rounded-8 px-8 py-2 bg-success-100 text-success-500 text-p5"
           data-id="data-point"
           data-field="oracle-router-recognition"
-          data-value="recognised"
+          data-value="recognized"
         >
           <SvgIcon
             name="check"
             class="!w-12 !h-12"
           />
-          Recognised router
+          Recognized router
         </span>
       </UiHoverPreviewTooltip>
       <UiHoverPreviewTooltip
-        v-else-if="routerRecognition === 'unrecognised'"
-        title="Unrecognised oracle router"
-        text="The vault's price oracle was not deployed by the recognised EulerRouterFactory. Verify the oracle configuration before trusting its prices."
+        v-else-if="routerRecognition === 'unrecognized'"
+        title="Unrecognized oracle router"
+        text="The vault's price oracle was not deployed by the recognized EulerRouterFactory. Verify the oracle configuration before trusting its prices."
         placement="top-start"
       >
         <span
           class="inline-flex items-center gap-4 rounded-8 px-8 py-2 bg-warning-100 text-warning-500 text-p5"
           data-id="data-point"
           data-field="oracle-router-recognition"
-          data-value="unrecognised"
+          data-value="unrecognized"
         >
           <SvgIcon
             name="warning"
             class="!w-12 !h-12"
           />
-          Unrecognised router
+          Unrecognized router
         </span>
       </UiHoverPreviewTooltip>
     </div>

--- a/components/entities/vault/overview/VaultOverviewBlockOracleAdapters.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockOracleAdapters.vue
@@ -528,7 +528,7 @@ const onTooltipMouseLeave = () => {
               }"
             >
               <SvgIcon
-                :name="check.pass ? 'check' : 'x'"
+                :name="check.pass ? 'check' : 'close'"
                 class="!w-10 !h-10 text-white"
               />
             </span>

--- a/components/entities/vault/overview/VaultOverviewBlockOracleAdapters.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockOracleAdapters.vue
@@ -4,7 +4,7 @@ import type {
   EVault,
   OracleRouteStep,
 } from '@eulerxyz/euler-v2-sdk'
-import { getChecksStatus, OracleAdapterCheckSeverity, type OracleAdapterMeta } from '~/entities/oracle'
+import { getChecksStatus, getRouterRecognition, OracleAdapterCheckSeverity, resolveOracleAdapterIdentity, type OracleAdapterMeta } from '~/entities/oracle'
 import { getOracleProviderLogo } from '~/entities/oracle-providers'
 import { getExplorerLink } from '~/utils/block-explorer'
 import { formatNumber } from '~/utils/string-utils'
@@ -21,6 +21,7 @@ const props = defineProps<{
 const { oracleAdapters, loadOracleAdapter } = useEulerLabels()
 const { chainId } = useEulerAddresses()
 const { buildKnownSymbols, resolveSymbol: resolveTokenSymbol, shortenAddress } = useTokenSymbolResolver()
+const { recognisedRouters, recognisedRoutersChainId, loadRecognisedRouters } = useEulerOracleRouters()
 
 const sourceVaults = computed(() => {
   if (props.vaults?.length) {
@@ -80,11 +81,11 @@ const knownSymbols = computed(() => {
 })
 
 const adapterViews = computed(() => routeSteps.value.map((step) => {
-  const meta: OracleAdapterMeta | undefined = isOracleAdapterRouteStep(step)
+  const isAdapter = isOracleAdapterRouteStep(step)
+  const meta: OracleAdapterMeta | undefined = isAdapter
     ? oracleAdapters[step.oracle.toLowerCase()]
     : undefined
-  const provider = meta?.provider || step.name
-  const name = meta?.name || step.name
+  const { name, provider, isCustomAdapter } = resolveOracleAdapterIdentity(step, meta, isAdapter)
   const checks = meta?.checks
   const invertPrice = shouldInvertOraclePrice({
     metaBase: meta?.base,
@@ -97,6 +98,7 @@ const adapterViews = computed(() => routeSteps.value.map((step) => {
     ...step,
     name,
     provider,
+    isCustomAdapter,
     methodology: meta?.methodology || (step.kind === 'vault' ? 'Exchange Rate' : undefined),
     logo: getOracleProviderLogo(provider, name),
     label: meta?.label
@@ -125,6 +127,23 @@ watch(
   },
   { immediate: true },
 )
+
+watch(
+  chainId,
+  (id) => {
+    if (id) loadRecognisedRouters(id)
+  },
+  { immediate: true },
+)
+
+// LITE-236: flag whether the vault's price oracle (EulerRouter) was deployed by the
+// recognised EulerRouterFactory. Null while the allowlist is still loading for the
+// active chain or unavailable, so we never show a false "unrecognised" warning.
+const routerRecognition = computed(() => {
+  if (recognisedRoutersChainId.value !== chainId.value) return null
+  const routerAddresses = sourceVaults.value.map(vault => vault.oracle?.oracle)
+  return getRouterRecognition(routerAddresses, recognisedRouters.value)
+})
 
 const resolveSymbol = (address: string) => resolveTokenSymbol(address, knownSymbols.value)
 
@@ -302,9 +321,49 @@ const onTooltipMouseLeave = () => {
 
 <template>
   <div class="bg-surface-secondary rounded-xl flex flex-col gap-24 p-24 shadow-card">
-    <p class="text-h3 text-content-primary">
-      Oracles
-    </p>
+    <div class="flex flex-wrap items-center gap-8">
+      <p class="text-h3 text-content-primary">
+        Oracles
+      </p>
+      <UiHoverPreviewTooltip
+        v-if="routerRecognition === 'recognised'"
+        title="Recognised oracle router"
+        text="The vault's price oracle was deployed by the recognised EulerRouterFactory."
+        placement="top-start"
+      >
+        <span
+          class="inline-flex items-center gap-4 rounded-8 px-8 py-2 bg-success-100 text-success-500 text-p5"
+          data-id="data-point"
+          data-field="oracle-router-recognition"
+          data-value="recognised"
+        >
+          <SvgIcon
+            name="check"
+            class="!w-12 !h-12"
+          />
+          Recognised router
+        </span>
+      </UiHoverPreviewTooltip>
+      <UiHoverPreviewTooltip
+        v-else-if="routerRecognition === 'unrecognised'"
+        title="Unrecognised oracle router"
+        text="The vault's price oracle was not deployed by the recognised EulerRouterFactory. Verify the oracle configuration before trusting its prices."
+        placement="top-start"
+      >
+        <span
+          class="inline-flex items-center gap-4 rounded-8 px-8 py-2 bg-warning-100 text-warning-500 text-p5"
+          data-id="data-point"
+          data-field="oracle-router-recognition"
+          data-value="unrecognised"
+        >
+          <SvgIcon
+            name="warning"
+            class="!w-12 !h-12"
+          />
+          Unrecognised router
+        </span>
+      </UiHoverPreviewTooltip>
+    </div>
     <div
       v-if="!adapterViews.length"
       class="text-p3 text-content-tertiary"
@@ -388,7 +447,11 @@ const onTooltipMouseLeave = () => {
           >
             <span class="text-content-tertiary">Checks</span>
             <span
-              v-if="!adapter.checks?.length"
+              v-if="adapter.isCustomAdapter"
+              class="text-content-secondary"
+            >Custom — set by risk manager</span>
+            <span
+              v-else-if="!adapter.checks?.length"
               class="text-content-secondary"
             >N/A</span>
             <span

--- a/components/entities/vault/overview/earn/VaultOverviewEarnBlockStats.vue
+++ b/components/entities/vault/overview/earn/VaultOverviewEarnBlockStats.vue
@@ -13,6 +13,7 @@ const { getSupplyRewardApy, getSupplyRewardCampaigns, hasSupplyRewards } = useRe
 
 const rewardSupplyAPY = computed(() => getSupplyRewardApy(vault.address))
 const intrinsicApy = computed(() => getVaultIntrinsicApy(vault, enableIntrinsicApy.value))
+const supplyApyTotal = computed(() => getVaultSupplyApy(vault) + intrinsicApy.value + rewardSupplyAPY.value)
 
 const totalSupplyDisplay = ref('-')
 
@@ -34,6 +35,7 @@ const supplyApyModalData = computed(() => ({
     intrinsicAPY: getVaultIntrinsicApy(vault, enableIntrinsicApy.value),
     intrinsicApyInfo: getVaultIntrinsicApyInfo(vault, enableIntrinsicApy.value),
     campaigns: getSupplyRewardCampaigns(vault.address),
+    totalSupplyAPY: supplyApyTotal.value,
     rewardVaultAddress: vault.address,
     baseApyAverageLabel: '1h',
   },
@@ -80,7 +82,7 @@ const supplyApyModalData = computed(() => ({
               data-modal-trigger="supply-apy"
             />
           </UiModalPreviewTrigger>
-          {{ formatNumber(getVaultSupplyApy(vault) + intrinsicApy + rewardSupplyAPY) }}%
+          {{ formatNumber(supplyApyTotal) }}%
         </span>
       </VaultOverviewLabelValue>
     </div>

--- a/components/entities/vault/overview/earn/VaultOverviewEarnBlockStats.vue
+++ b/components/entities/vault/overview/earn/VaultOverviewEarnBlockStats.vue
@@ -12,6 +12,7 @@ const enableIntrinsicApy = computed(() => settings.value.enableIntrinsicApy)
 const { getSupplyRewardApy, getSupplyRewardCampaigns, hasSupplyRewards } = useRewardsApy()
 
 const rewardSupplyAPY = computed(() => getSupplyRewardApy(vault.address))
+const intrinsicApy = computed(() => getVaultIntrinsicApy(vault, enableIntrinsicApy.value))
 
 const totalSupplyDisplay = ref('-')
 
@@ -79,7 +80,7 @@ const supplyApyModalData = computed(() => ({
               data-modal-trigger="supply-apy"
             />
           </UiModalPreviewTrigger>
-          {{ formatNumber(getVaultSupplyApy(vault) + rewardSupplyAPY) }}%
+          {{ formatNumber(getVaultSupplyApy(vault) + intrinsicApy + rewardSupplyAPY) }}%
         </span>
       </VaultOverviewLabelValue>
     </div>

--- a/components/entities/vault/overview/earn/VaultOverviewEarnBlockStats.vue
+++ b/components/entities/vault/overview/earn/VaultOverviewEarnBlockStats.vue
@@ -1,19 +1,21 @@
 <script setup lang="ts">
-import type { EulerEarn } from '@eulerxyz/euler-v2-sdk'
+import { computeSupplyApyBreakdown, type EulerEarn } from '@eulerxyz/euler-v2-sdk'
 import { formatAssetValue } from '~/utils/sdk-prices'
 import { formatNumber, formatCompactUsdValue } from '~/utils/string-utils'
 import { VaultSupplyApyModal, UiModalPreviewTrigger } from '#components'
-import { getVaultIntrinsicApy, getVaultIntrinsicApyInfo } from '~/utils/vault-intrinsic-apy'
+import { getVaultIntrinsicApyInfo } from '~/utils/vault-intrinsic-apy'
 
 const { vault } = defineProps<{ vault: EulerEarn }>()
 
 const { settings } = useUserSettings()
 const enableIntrinsicApy = computed(() => settings.value.enableIntrinsicApy)
-const { getSupplyRewardApy, getSupplyRewardCampaigns, hasSupplyRewards } = useRewardsApy()
+const { getSupplyRewardCampaigns, hasSupplyRewards } = useRewardsApy()
+const { viewer, visibleTotal, visibleBreakdown } = useApyVisibility()
 
-const rewardSupplyAPY = computed(() => getSupplyRewardApy(vault.address))
-const intrinsicApy = computed(() => getVaultIntrinsicApy(vault, enableIntrinsicApy.value))
-const supplyApyTotal = computed(() => getVaultSupplyApy(vault) + intrinsicApy.value + rewardSupplyAPY.value)
+const supplyApyBreakdown = computed(() => computeSupplyApyBreakdown(vault, viewer.value))
+const visibleApyBreakdown = computed(() => visibleBreakdown(supplyApyBreakdown.value))
+const supplyApyTotal = computed(() => visibleTotal(supplyApyBreakdown.value) ?? 0)
+const hasRewards = computed(() => settings.value.enableRewardsApy && hasSupplyRewards(vault.address))
 
 const totalSupplyDisplay = ref('-')
 
@@ -31,10 +33,10 @@ watchEffect(async () => {
 
 const supplyApyModalData = computed(() => ({
   props: {
-    lendingAPY: getVaultSupplyApy(vault),
-    intrinsicAPY: getVaultIntrinsicApy(vault, enableIntrinsicApy.value),
+    lendingAPY: visibleApyBreakdown.value?.lending ?? 0,
+    intrinsicAPY: visibleApyBreakdown.value?.intrinsicApy ?? 0,
     intrinsicApyInfo: getVaultIntrinsicApyInfo(vault, enableIntrinsicApy.value),
-    campaigns: getSupplyRewardCampaigns(vault.address),
+    campaigns: settings.value.enableRewardsApy ? getSupplyRewardCampaigns(vault.address) : [],
     totalSupplyAPY: supplyApyTotal.value,
     rewardVaultAddress: vault.address,
     baseApyAverageLabel: '1h',
@@ -71,7 +73,7 @@ const supplyApyModalData = computed(() => ({
         </template>
         <span class="flex items-center gap-4">
           <UiModalPreviewTrigger
-            v-if="hasSupplyRewards(vault.address)"
+            v-if="hasRewards"
             :component="VaultSupplyApyModal"
             :modal-data="supplyApyModalData"
             aria-label="Show supply APY rewards breakdown"

--- a/components/ui/styles/main.scss
+++ b/components/ui/styles/main.scss
@@ -150,9 +150,9 @@
   --ui-toast-background-color: #ffffff;
   --ui-toast-box-shadow: var(--shadow-md);
 
-  --ui-toast-info-border-color: rgba(var(--accent-rgb), 0.3);
-  --ui-toast-info-background-color: rgba(var(--accent-rgb), 0.1);
-  --ui-toast-info-text-color: var(--accent-700);
+  --ui-toast-info-border-color: rgba(var(--accent-rgb), 0.42);
+  --ui-toast-info-background-color: rgba(var(--accent-rgb), 0.14);
+  --ui-toast-info-text-color: var(--accent-300);
   --ui-toast-info-splitter-color: rgba(var(--accent-rgb), 0.3);
   --ui-toast-info-action-background-color: rgba(var(--accent-rgb), 0.1);
 
@@ -292,6 +292,9 @@
 
   // Toast
   --ui-toast-background-color: #0c1d2f;
+  --ui-toast-info-border-color: rgba(var(--accent-rgb), 0.45);
+  --ui-toast-info-background-color: rgba(var(--accent-rgb), 0.12);
+  --ui-toast-info-text-color: #a1f4e0;
   --ui-toast-neutral-background-color: #0c1d2f;
   --ui-toast-neutral-border-color: #14304e;
   --ui-toast-neutral-text-color: #f7f7f8;

--- a/composables/useEulerOracleAdapters.ts
+++ b/composables/useEulerOracleAdapters.ts
@@ -3,17 +3,11 @@ import { toReactive } from '@vueuse/core'
 import { logWarn } from '~/utils/errorHandling'
 import { normalizeAddress } from '~/utils/normalizeAddress'
 import { getEulerSdk } from '~/composables/useEulerSdk'
-import { type OracleAdapterMeta, OracleAdapterCheckSeverity } from '~/entities/oracle'
+import { type OracleAdapterMeta, normalizeOracleAdapterCheckSeverity } from '~/entities/oracle'
 
 const oracleAdaptersRef = shallowRef<Record<string, OracleAdapterMeta>>({})
 const oracleAdaptersChainId = ref<number | null>(null)
 const pendingOracleAdapterLoads = new Map<number, Promise<Record<string, OracleAdapterMeta>>>()
-
-const normalizeSeverity = (severity: unknown): OracleAdapterCheckSeverity => {
-  return Object.values(OracleAdapterCheckSeverity).includes(severity as OracleAdapterCheckSeverity)
-    ? severity as OracleAdapterCheckSeverity
-    : OracleAdapterCheckSeverity.Info
-}
 
 const toOracleAdapterMeta = (metadata: OracleAdapterMetadata): OracleAdapterMeta => ({
   oracle: metadata.oracle,
@@ -27,7 +21,7 @@ const toOracleAdapterMeta = (metadata: OracleAdapterMetadata): OracleAdapterMeta
     id: typeof check.id === 'string' ? check.id : '',
     message: typeof check.message === 'string' ? check.message : '',
     pass: check.pass === true,
-    severity: normalizeSeverity(check.severity),
+    severity: normalizeOracleAdapterCheckSeverity(check.severity),
   })),
 })
 

--- a/composables/useEulerOracleRouters.ts
+++ b/composables/useEulerOracleRouters.ts
@@ -1,0 +1,55 @@
+import { logWarn } from '~/utils/errorHandling'
+
+// Recognised EulerRouter addresses (deployed by the recognised EulerRouterFactory)
+// are published per chain at `{oracle-checks}/{chainId}/routers/all.json` as a flat
+// array of addresses. We proxy + cache them through `/api/oracle-routers` and keep a
+// lowercased Set per chain so router-recognition lookups are O(1).
+const recognisedRoutersRef = shallowRef<Set<string>>(new Set())
+const recognisedRoutersChainId = ref<number | null>(null)
+const pendingRouterLoads = new Map<number, Promise<Set<string>>>()
+
+const toRecognisedSet = (data: unknown): Set<string> => {
+  if (!Array.isArray(data)) return new Set()
+  return new Set(
+    data
+      .filter((entry): entry is string => typeof entry === 'string')
+      .map(entry => entry.toLowerCase()),
+  )
+}
+
+const loadRecognisedRouters = async (chainId: number): Promise<Set<string>> => {
+  if (!Number.isInteger(chainId) || chainId <= 0) return new Set()
+
+  if (recognisedRoutersChainId.value === chainId) {
+    return recognisedRoutersRef.value
+  }
+
+  const inflight = pendingRouterLoads.get(chainId)
+  if (inflight) return inflight
+
+  const promise = (async () => {
+    const data = await $fetch('/api/oracle-routers', { query: { chainId } })
+    const set = toRecognisedSet(data)
+    recognisedRoutersRef.value = set
+    recognisedRoutersChainId.value = chainId
+    return set
+  })()
+
+  pendingRouterLoads.set(chainId, promise)
+  try {
+    return await promise
+  }
+  catch (err) {
+    logWarn('useEulerOracleRouters', `Failed to load recognised routers for chain ${chainId}: ${err instanceof Error ? err.message : String(err)}`)
+    return new Set()
+  }
+  finally {
+    pendingRouterLoads.delete(chainId)
+  }
+}
+
+export const useEulerOracleRouters = () => ({
+  recognisedRouters: computed(() => recognisedRoutersRef.value),
+  recognisedRoutersChainId: readonly(recognisedRoutersChainId),
+  loadRecognisedRouters,
+})

--- a/composables/useEulerOracleRouters.ts
+++ b/composables/useEulerOracleRouters.ts
@@ -6,6 +6,7 @@ import { logWarn } from '~/utils/errorHandling'
 // lowercased Set per chain so router-recognition lookups are O(1).
 const recognizedRoutersRef = shallowRef<Set<string>>(new Set())
 const recognizedRoutersChainId = ref<number | null>(null)
+const recognizedRoutersByChain = new Map<number, Set<string>>()
 const pendingRouterLoads = new Map<number, Promise<Set<string>>>()
 
 const toRecognizedSet = (data: unknown): Set<string> => {
@@ -20,9 +21,15 @@ const toRecognizedSet = (data: unknown): Set<string> => {
 const loadRecognizedRouters = async (chainId: number): Promise<Set<string>> => {
   if (!Number.isInteger(chainId) || chainId <= 0) return new Set()
 
-  if (recognizedRoutersChainId.value === chainId) {
-    return recognizedRoutersRef.value
+  recognizedRoutersChainId.value = chainId
+
+  const cached = recognizedRoutersByChain.get(chainId)
+  if (cached) {
+    recognizedRoutersRef.value = cached
+    return cached
   }
+
+  recognizedRoutersRef.value = new Set()
 
   const inflight = pendingRouterLoads.get(chainId)
   if (inflight) return inflight
@@ -30,8 +37,10 @@ const loadRecognizedRouters = async (chainId: number): Promise<Set<string>> => {
   const promise = (async () => {
     const data = await $fetch('/api/oracle-routers', { query: { chainId } })
     const set = toRecognizedSet(data)
-    recognizedRoutersRef.value = set
-    recognizedRoutersChainId.value = chainId
+    recognizedRoutersByChain.set(chainId, set)
+    if (recognizedRoutersChainId.value === chainId) {
+      recognizedRoutersRef.value = set
+    }
     return set
   })()
 

--- a/composables/useEulerOracleRouters.ts
+++ b/composables/useEulerOracleRouters.ts
@@ -1,14 +1,14 @@
 import { logWarn } from '~/utils/errorHandling'
 
-// Recognised EulerRouter addresses (deployed by the recognised EulerRouterFactory)
+// Recognized EulerRouter addresses (deployed by the recognized EulerRouterFactory)
 // are published per chain at `{oracle-checks}/{chainId}/routers/all.json` as a flat
 // array of addresses. We proxy + cache them through `/api/oracle-routers` and keep a
 // lowercased Set per chain so router-recognition lookups are O(1).
-const recognisedRoutersRef = shallowRef<Set<string>>(new Set())
-const recognisedRoutersChainId = ref<number | null>(null)
+const recognizedRoutersRef = shallowRef<Set<string>>(new Set())
+const recognizedRoutersChainId = ref<number | null>(null)
 const pendingRouterLoads = new Map<number, Promise<Set<string>>>()
 
-const toRecognisedSet = (data: unknown): Set<string> => {
+const toRecognizedSet = (data: unknown): Set<string> => {
   if (!Array.isArray(data)) return new Set()
   return new Set(
     data
@@ -17,11 +17,11 @@ const toRecognisedSet = (data: unknown): Set<string> => {
   )
 }
 
-const loadRecognisedRouters = async (chainId: number): Promise<Set<string>> => {
+const loadRecognizedRouters = async (chainId: number): Promise<Set<string>> => {
   if (!Number.isInteger(chainId) || chainId <= 0) return new Set()
 
-  if (recognisedRoutersChainId.value === chainId) {
-    return recognisedRoutersRef.value
+  if (recognizedRoutersChainId.value === chainId) {
+    return recognizedRoutersRef.value
   }
 
   const inflight = pendingRouterLoads.get(chainId)
@@ -29,9 +29,9 @@ const loadRecognisedRouters = async (chainId: number): Promise<Set<string>> => {
 
   const promise = (async () => {
     const data = await $fetch('/api/oracle-routers', { query: { chainId } })
-    const set = toRecognisedSet(data)
-    recognisedRoutersRef.value = set
-    recognisedRoutersChainId.value = chainId
+    const set = toRecognizedSet(data)
+    recognizedRoutersRef.value = set
+    recognizedRoutersChainId.value = chainId
     return set
   })()
 
@@ -40,7 +40,7 @@ const loadRecognisedRouters = async (chainId: number): Promise<Set<string>> => {
     return await promise
   }
   catch (err) {
-    logWarn('useEulerOracleRouters', `Failed to load recognised routers for chain ${chainId}: ${err instanceof Error ? err.message : String(err)}`)
+    logWarn('useEulerOracleRouters', `Failed to load recognized routers for chain ${chainId}: ${err instanceof Error ? err.message : String(err)}`)
     return new Set()
   }
   finally {
@@ -49,7 +49,7 @@ const loadRecognisedRouters = async (chainId: number): Promise<Set<string>> => {
 }
 
 export const useEulerOracleRouters = () => ({
-  recognisedRouters: computed(() => recognisedRoutersRef.value),
-  recognisedRoutersChainId: readonly(recognisedRoutersChainId),
-  loadRecognisedRouters,
+  recognizedRouters: computed(() => recognizedRoutersRef.value),
+  recognizedRoutersChainId: readonly(recognizedRoutersChainId),
+  loadRecognizedRouters,
 })

--- a/composables/useTxBatch.ts
+++ b/composables/useTxBatch.ts
@@ -213,6 +213,44 @@ const pendingAddSignatures = new Set<string>()
 const walletAssetMeta: Record<string, { symbol: string, decimals: number }> = {}
 let batchSlotHints: SlotHints = {}
 
+// TEMP DIAGNOSTICS — hunting an unreproducible "Batch simulation not loaded"
+// error that some users hit when adding a second operation to the batch. Every
+// call snapshots the full resim state machine (token, entry/layer counts,
+// promise + error state) so a single field report is self-contained.
+//
+// IMPORTANT: client `logger.warn` is dropped unless `?verbose` /
+// localStorage.euler_verbose=1 is set (see utils/logger.ts), so the trace level
+// only shows up for devs / on the server. The moments that actually pin the bug
+// (the throw, the version guard, supersessions that fire during a plan-time
+// await) are logged at `severity: 'error'`, which surfaces in every browser.
+// Remove this whole block (and its call sites) once the cause is captured.
+const logBatchDiag = (
+  event: string,
+  extra?: Record<string, unknown>,
+  severity: 'warn' | 'error' = 'warn',
+) => {
+  logWarn('useTxBatch/diag', event, {
+    severity,
+    data: {
+      event,
+      resimToken,
+      hasResimPromise: resimulatePromise !== null,
+      isSimulating: isSimulating.value,
+      entryCount: entries.value.length,
+      layerCount: layers.value.length,
+      activeLayer: activeLayer.value,
+      simError: simError.value ?? null,
+      entries: entries.value.map(e => ({
+        id: e.id,
+        label: e.label,
+        subAccount: e.subAccount,
+        planItems: e.plan?.length ?? 0,
+      })),
+      ...extra,
+    },
+  })
+}
+
 const normalizeTokenKey = (token: string) => {
   try {
     return getAddress(token).toLowerCase()
@@ -1221,8 +1259,13 @@ export const useTxBatch = () => {
     const token = ++resimToken
     const o = owner.value
     const cid = chainId.value
+    logBatchDiag('resimulate:start', { token, owner: o, chainId: cid })
 
     if (!o || !cid || entries.value.length === 0) {
+      logBatchDiag('resimulate:empty-batch-reset', {
+        token,
+        reason: !o ? 'no-owner' : !cid ? 'no-chain' : 'no-entries',
+      })
       layers.value = []
       activeLayer.value = 0
       simError.value = undefined
@@ -1277,13 +1320,12 @@ export const useTxBatch = () => {
       )
 
       if (token !== resimToken) {
-        // Diagnostic (temporary): a newer resimulation superseded this one after
-        // the sim resolved, so this run bails before populating layers. When that
-        // happens during a plan-time await it's exactly what surfaces as the
-        // misleading "Batch simulation not loaded" (see getEntryPlanningAccount).
-        // Logging the token transition + entry count confirms the trigger in the
-        // field. Safe to remove once the race is confirmed fixed.
-        logWarn('useTxBatch/resimulate', `superseded after sim (token ${token} → ${resimToken}, entries=${entries.value.length})`)
+        // A newer resimulation superseded this one after the sim resolved, so this
+        // run bails before populating layers. When that happens during a plan-time
+        // await it's exactly what surfaces as the misleading "Batch simulation not
+        // loaded" (see getEntryPlanningAccount). Logged at error so it surfaces in
+        // the field even without verbose mode.
+        logBatchDiag('resimulate:superseded-after-sim', { token, supersededBy: resimToken }, 'error')
         return
       }
 
@@ -1307,11 +1349,35 @@ export const useTxBatch = () => {
       // layer's touched positions onto the previous full account. This preserves
       // the user's existing positions in vaults the batch never touched.
       const simAccounts = (sim.simulatedAccounts ?? []) as Account<IHasVaultAddress>[]
+      // A healthy sim returns exactly one account per operation on top of the
+      // pre-batch snapshot, i.e. simAccounts.length === plans.length + 1. Anything
+      // else is the smoking gun for the "not loaded" symptom (getCurrentFinalLayer
+      // needs layers.length === entries.length + 1), so escalate to error on a
+      // mismatch.
+      logBatchDiag(
+        'resimulate:sim-resolved',
+        {
+          token,
+          simAccounts: simAccounts.length,
+          plans: plans.length,
+          expectedLayers: plans.length + 1,
+          countMatchesExpected: simAccounts.length === plans.length + 1,
+          simulationError: !!sim.simulationError,
+          statusCheckFailed,
+          simError: simError.value ?? null,
+        },
+        simAccounts.length === plans.length + 1 ? 'warn' : 'error',
+      )
       // Version guard: the builder needs one simulated account per operation on
       // top of the pre-batch snapshot (the layered simulation API). An SDK build
       // without it (e.g. the published 0.2.16-beta, which returns only the final
       // account) would otherwise silently render the real state forever.
       if (!simError.value && simAccounts.length < plans.length + 1) {
+        logBatchDiag('resimulate:version-guard-tripped', {
+          token,
+          simAccounts: simAccounts.length,
+          plans: plans.length,
+        }, 'error')
         simError.value = 'Batch simulation did not return per-operation state layers — the installed @eulerxyz/euler-v2-sdk build does not support the batch builder.'
       }
       const fullLayers: Account<IHasVaultAddress>[] = [baseAccount]
@@ -1354,7 +1420,12 @@ export const useTxBatch = () => {
           logWarn('useTxBatch/fetchWallet', error)
         }
       }
-      if (token !== resimToken) return
+      if (token !== resimToken) {
+        // Superseded during the post-sim wallet fetch — same race as above, just a
+        // later checkpoint. Bails before populating layers.
+        logBatchDiag('resimulate:superseded-after-wallet-fetch', { token, supersededBy: resimToken }, 'error')
+        return
+      }
       // Asset metadata (symbol/decimals) for the touched tokens, resolved from
       // the simulated vault entities, for the wallet-changes summary.
       for (const vault of sim.simulatedVaults ?? []) {
@@ -1414,9 +1485,21 @@ export const useTxBatch = () => {
       })
       activeLayer.value = layers.value.length - 1
       syncOverlay()
+      // Completion checkpoint: layerCount/entryCount come from the helper snapshot.
+      // getCurrentFinalLayer needs layerCount === entryCount + 1; escalate to error
+      // if this run finished without satisfying that (the bug condition).
+      logBatchDiag(
+        'resimulate:complete',
+        { token, layersBuilt: layers.value.length },
+        layers.value.length === entries.value.length + 1 ? 'warn' : 'error',
+      )
     }
     catch (error) {
-      if (token !== resimToken) return
+      if (token !== resimToken) {
+        logBatchDiag('resimulate:superseded-in-catch', { token, supersededBy: resimToken }, 'error')
+        return
+      }
+      logBatchDiag('resimulate:threw', { token, error: error instanceof Error ? error.message : String(error) }, 'error')
       logWarn('useTxBatch/resimulate', error)
       simError.value = error instanceof Error ? error.message : String(error)
     }
@@ -1430,9 +1513,14 @@ export const useTxBatch = () => {
     // promise — otherwise the guard never matches and resimulatePromise is never
     // cleared, leaving callers (getEntryPlanningAccount) awaiting a stale run.
     const wrapped: Promise<void> = resimulate().finally(() => {
-      if (resimulatePromise === wrapped) resimulatePromise = null
+      // `cleared === false` means a newer run already replaced this promise, so a
+      // caller awaiting `resimulatePromise` will pick up the newer run next pass.
+      const cleared = resimulatePromise === wrapped
+      if (cleared) resimulatePromise = null
+      logBatchDiag('runResimulate:settled', { cleared })
     })
     resimulatePromise = wrapped
+    logBatchDiag('runResimulate:kicked')
     return wrapped
   }
 
@@ -1444,12 +1532,14 @@ export const useTxBatch = () => {
       // Any edit to the cart invalidates a prior Tenderly run (it simulated a
       // different fixed plan list), so drop the stale URL before re-simulating.
       watch(entries, () => {
+        logBatchDiag('watch:entries-changed')
         tenderly.clearSimulation()
         void runResimulate()
       })
       watch([activeLayer, layers], syncOverlay)
       // Reset the cart when the account or chain changes — layers would be stale.
       watch([owner, chainId], () => {
+        logBatchDiag('watch:owner-or-chain-reset', {}, 'error')
         resimToken++
         entries.value = []
         layers.value = []
@@ -1476,6 +1566,7 @@ export const useTxBatch = () => {
     )
 
     const finalLayer = getCurrentFinalLayer()
+    logBatchDiag('getEntryPlanningAccount:enter', { fastPathHit: finalLayer !== undefined })
     if (finalLayer) return finalLayer
 
     if (entries.value.length > 0) {
@@ -1487,23 +1578,46 @@ export const useTxBatch = () => {
       // misleading "Batch simulation not loaded". Re-await the current run until
       // the final layer for the present entries settles or a real error appears.
       for (let attempt = 0; attempt < 8; attempt++) {
+        const awaitedExisting = resimulatePromise !== null
         await (resimulatePromise ?? runResimulate())
         const refreshedFinalLayer = getCurrentFinalLayer()
+        // Found on attempt 0 is the healthy path (warn/quiet). Not finding it —
+        // i.e. the awaited run resolved without our layers — is the suspected race;
+        // log it at error so we capture each re-attempt in the field.
+        logBatchDiag('getEntryPlanningAccount:attempt', {
+          attempt,
+          awaitedExisting,
+          finalLayerFound: refreshedFinalLayer !== undefined,
+        }, refreshedFinalLayer !== undefined ? 'warn' : 'error')
         if (refreshedFinalLayer) return refreshedFinalLayer
-        if (simError.value) break
+        if (simError.value) {
+          logBatchDiag('getEntryPlanningAccount:simError-break', { attempt }, 'error')
+          break
+        }
         // Resolved without our layers and no error: a newer run superseded this
         // one. If it's already in flight, the next pass awaits it; otherwise kick
         // a fresh run. The bounded loop guarantees we can't spin forever.
         if (!resimulatePromise) runResimulate()
       }
+      // This is THE event we're hunting. Full state is in the helper snapshot.
+      logBatchDiag('getEntryPlanningAccount:throw', {
+        thrownMessage: simError.value ?? 'Batch simulation not loaded',
+      }, 'error')
       throw new Error(simError.value ?? 'Batch simulation not loaded')
     }
 
-    if (baseAccountSnapshot) return baseAccountSnapshot
+    if (baseAccountSnapshot) {
+      logBatchDiag('getEntryPlanningAccount:base-snapshot-cached')
+      return baseAccountSnapshot
+    }
 
     const o = owner.value
     const cid = chainId.value
-    if (!o || !cid) throw new Error('Account not loaded')
+    if (!o || !cid) {
+      logBatchDiag('getEntryPlanningAccount:account-not-loaded', { owner: o, chainId: cid }, 'error')
+      throw new Error('Account not loaded')
+    }
+    logBatchDiag('getEntryPlanningAccount:base-snapshot-fetch', { owner: o, chainId: cid })
     const sdk = await getEulerSdkFresh()
     baseAccountSnapshot = await fetchBaseAccountSnapshot(sdk, cid, getAddress(o))
     return baseAccountSnapshot
@@ -1519,6 +1633,11 @@ export const useTxBatch = () => {
 
     const add = async () => {
       execError.value = undefined
+      logBatchDiag('addEntry:building', {
+        label: entry.label,
+        subAccount: entry.subAccount,
+        requiresPlanningAccount: entry.requiresPlanningAccount !== false,
+      })
       const plan = entry.requiresPlanningAccount === false
         ? await entry.buildPlan()
         : await entry.buildPlan(await getEntryPlanningAccount())
@@ -1529,6 +1648,7 @@ export const useTxBatch = () => {
       const { buildPlan: _buildPlan, requiresPlanningAccount: _requiresPlanningAccount, ...fixedEntry } = entry
       registerReviewAssetMeta(fixedEntry.review)
       entries.value = [...entries.value, { ...fixedEntry, plan, id: `entry-${++idSeq}` }]
+      logBatchDiag('addEntry:added', { label: entry.label, newEntryCount: entries.value.length })
     }
 
     const nextAdd = addEntryQueue.then(add, add)
@@ -1538,6 +1658,10 @@ export const useTxBatch = () => {
       await nextAdd
     }
     catch (error) {
+      logBatchDiag('addEntry:threw', {
+        label: entry.label,
+        error: error instanceof Error ? error.message : String(error),
+      }, 'error')
       logWarn('useTxBatch/addEntry', error)
       simError.value = error instanceof Error ? error.message : String(error)
       throw error

--- a/composables/useTxBatch.ts
+++ b/composables/useTxBatch.ts
@@ -1236,6 +1236,44 @@ const getEntryMarketLabelOverride = (entry: BatchEntry): string | undefined => {
   return typeof label === 'string' && label.trim() ? label : undefined
 }
 
+/**
+ * Resolve the post-cart "final layer" account for planning the next batch op,
+ * retrying across superseded resimulations.
+ *
+ * A resimulation can be superseded mid-flight (a newer run shares `resimToken`
+ * and the loser returns early WITHOUT populating layers or `simError`), so a
+ * single await can resolve before our final layer exists. Each pass awaits the
+ * current run — `getInFlight() ?? startRun()` both starts a fresh run when none
+ * is in flight AND awaits it — so every run this loop starts is awaited before
+ * we re-check or fall through to the throw. (Critically: no run is ever started
+ * on the terminal iteration without being awaited, which would otherwise re-throw
+ * "Batch simulation not loaded" while a fresh run was still in flight.)
+ *
+ * Extracted from `getEntryPlanningAccount` so the superseded-run/retry invariant
+ * is unit-testable without the SDK; see tests/composables/useTxBatch.test.ts.
+ */
+export const awaitFinalPlanningLayer = async <T>(opts: {
+  getFinalLayer: () => T | undefined
+  getSimError: () => string | undefined
+  getInFlight: () => Promise<void> | null
+  startRun: () => Promise<void>
+  maxAttempts?: number
+  onAttempt?: (info: { attempt: number, awaitedExisting: boolean, found: boolean }) => void
+}): Promise<T> => {
+  const { getFinalLayer, getSimError, getInFlight, startRun, maxAttempts = 8, onAttempt } = opts
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const inFlight = getInFlight()
+    await (inFlight ?? startRun())
+    const layer = getFinalLayer()
+    onAttempt?.({ attempt, awaitedExisting: inFlight !== null, found: layer !== undefined })
+    if (layer !== undefined) return layer
+    // A real error is terminal; stop retrying and surface it below. Otherwise the
+    // run was superseded — loop and await whatever run is current next pass.
+    if (getSimError()) break
+  }
+  throw new Error(getSimError() ?? 'Batch simulation not loaded')
+}
+
 export const useTxBatch = () => {
   const { address: walletAddress, chainId: wagmiChainId } = useWagmi()
   const { isSpyMode, spyAddress } = useSpyMode()
@@ -1570,40 +1608,32 @@ export const useTxBatch = () => {
     if (finalLayer) return finalLayer
 
     if (entries.value.length > 0) {
-      // A resimulation can be superseded mid-flight: both the entries watcher and
-      // this call kick off runs sharing resimToken, and the loser returns early
-      // (the `token !== resimToken` guard) WITHOUT populating layers or simError.
-      // A single await can therefore resolve on the superseded run, before the
-      // winning run has produced our final layer — which used to surface as a
-      // misleading "Batch simulation not loaded". Re-await the current run until
-      // the final layer for the present entries settles or a real error appears.
-      for (let attempt = 0; attempt < 8; attempt++) {
-        const awaitedExisting = resimulatePromise !== null
-        await (resimulatePromise ?? runResimulate())
-        const refreshedFinalLayer = getCurrentFinalLayer()
-        // Found on attempt 0 is the healthy path (warn/quiet). Not finding it —
-        // i.e. the awaited run resolved without our layers — is the suspected race;
-        // log it at error so we capture each re-attempt in the field.
-        logBatchDiag('getEntryPlanningAccount:attempt', {
-          attempt,
-          awaitedExisting,
-          finalLayerFound: refreshedFinalLayer !== undefined,
-        }, refreshedFinalLayer !== undefined ? 'warn' : 'error')
-        if (refreshedFinalLayer) return refreshedFinalLayer
-        if (simError.value) {
-          logBatchDiag('getEntryPlanningAccount:simError-break', { attempt }, 'error')
-          break
-        }
-        // Resolved without our layers and no error: a newer run superseded this
-        // one. If it's already in flight, the next pass awaits it; otherwise kick
-        // a fresh run. The bounded loop guarantees we can't spin forever.
-        if (!resimulatePromise) runResimulate()
+      // Retry across superseded resimulations until the final layer for the
+      // present entries settles or a real error appears (see awaitFinalPlanningLayer).
+      try {
+        return await awaitFinalPlanningLayer<Account<IHasVaultAddress>>({
+          getFinalLayer: getCurrentFinalLayer,
+          getSimError: () => simError.value,
+          getInFlight: () => resimulatePromise,
+          startRun: runResimulate,
+          // Found on attempt 0 is the healthy path (warn/quiet). Not finding it —
+          // i.e. the awaited run resolved without our layers — is the suspected
+          // race; log at error so we capture each re-attempt in the field.
+          onAttempt: ({ attempt, awaitedExisting, found }) =>
+            logBatchDiag('getEntryPlanningAccount:attempt', {
+              attempt,
+              awaitedExisting,
+              finalLayerFound: found,
+            }, found ? 'warn' : 'error'),
+        })
       }
-      // This is THE event we're hunting. Full state is in the helper snapshot.
-      logBatchDiag('getEntryPlanningAccount:throw', {
-        thrownMessage: simError.value ?? 'Batch simulation not loaded',
-      }, 'error')
-      throw new Error(simError.value ?? 'Batch simulation not loaded')
+      catch (error) {
+        // This is THE event we're hunting. Full state is in the helper snapshot.
+        logBatchDiag('getEntryPlanningAccount:throw', {
+          thrownMessage: simError.value ?? 'Batch simulation not loaded',
+        }, 'error')
+        throw error
+      }
     }
 
     if (baseAccountSnapshot) {

--- a/composables/useTxBatch.ts
+++ b/composables/useTxBatch.ts
@@ -798,6 +798,7 @@ const hydrateBorrowLiquidity = (
   borrow: StitchPosition,
   positions: StitchPosition[],
   enabledCollaterals: Address[] | undefined,
+  baseEnabledCollaterals: Address[] | undefined,
 ): void => {
   const liquidity = borrow.liquidity
   if (!liquidity || (borrow.borrowed ?? 0n) === 0n) return
@@ -805,6 +806,7 @@ const hydrateBorrowLiquidity = (
   const positionsByVault = positionByVault(positions)
   liquidity.vault = liquidity.vault ?? borrow.vault
   liquidity.liabilityValueUsd = borrow.borrowedValueUsd
+  const borrowVaultKey = getAddress(borrow.vaultAddress).toLowerCase()
 
   const existingCollaterals = new Map<string, StitchLiquidityCollateral>()
   for (const collateral of liquidity.collaterals) {
@@ -812,11 +814,23 @@ const hydrateBorrowLiquidity = (
   }
   const enabledCollateralKeys = enabledCollaterals?.map(address => getAddress(address).toLowerCase())
   const enabledCollateralSet = enabledCollateralKeys ? new Set(enabledCollateralKeys) : undefined
+  // Collaterals that were already enabled on the EVC *before* this batch ran.
+  // Used to tell a collateral newly enabled by the batch (e.g. a collateral
+  // swap) apart from a pre-existing, possibly empty, enablement.
+  const baseEnabledCollateralSet = baseEnabledCollaterals
+    ? new Set(baseEnabledCollaterals.map(address => getAddress(address).toLowerCase()))
+    : undefined
   const collateralAddresses: Address[] = []
   const seen = new Set<string>()
   const addCollateralAddress = (address: string, requireEnabledOrValue: boolean) => {
     const key = getAddress(address).toLowerCase()
     if (seen.has(key)) return
+    // A vault is never its own collateral. The EVC can list the borrow vault in
+    // enabledCollaterals, and its own position carries debt (so it passes the
+    // value guard below), but the controller grants it no LTV — the lens omits
+    // it from liquidity.collaterals and so must we, or it surfaces as a spurious
+    // zero-value collateral row.
+    if (key === borrowVaultKey) return
     const collateralPosition = positionsByVault.get(getAddress(address))
     const hasBalance = hasPositionValue(collateralPosition)
     const isEnabled = enabledCollateralSet?.has(key) ?? true
@@ -827,7 +841,19 @@ const hydrateBorrowLiquidity = (
     collateralAddresses.push(getAddress(address) as Address)
   }
   for (const collateral of liquidity.collaterals) addCollateralAddress(collateral.address, true)
-  for (const collateral of enabledCollateralKeys ?? []) addCollateralAddress(collateral, false)
+  // EVC-enabled collaterals. A collateral *newly* enabled by this batch (not in
+  // the base enabled set) is added unconditionally, since its simulated balance
+  // may not be populated on this position yet — this is what surfaces a
+  // collateral-swap's new collateral. A collateral that was already enabled
+  // before the batch is added under the same guard as the lens collaterals
+  // above, so leftover enabled-but-empty vaults (an account can carry several)
+  // don't show up as spurious zero-value collateral rows. When the base set is
+  // unknown (a brand-new sub-account), every enabled collateral is treated as
+  // newly enabled, preserving the prior unconditional behaviour.
+  for (const collateral of enabledCollateralKeys ?? []) {
+    const wasEnabledBeforeBatch = baseEnabledCollateralSet?.has(collateral) ?? false
+    addCollateralAddress(collateral, wasEnabledBeforeBatch)
+  }
 
   let totalCollateralValueUsd: number | undefined = collateralAddresses.length ? 0 : liquidity.totalCollateralValueUsd
   let hasMissingCollateralUsd = false
@@ -874,9 +900,10 @@ const hydrateBorrowLiquidity = (
 const hydrateStitchedPositions = (
   positions: StitchPosition[],
   enabledCollaterals: Address[] | undefined,
+  baseEnabledCollaterals: Address[] | undefined,
 ): StitchPosition[] => {
   for (const position of positions) hydratePositionMarketValues(position)
-  for (const position of positions) hydrateBorrowLiquidity(position, positions, enabledCollaterals)
+  for (const position of positions) hydrateBorrowLiquidity(position, positions, enabledCollaterals, baseEnabledCollaterals)
   return positions
 }
 
@@ -1122,6 +1149,8 @@ export const stitchAccount = (
         positions: hydrateStitchedPositions(
           mergePositionsByVault(tsa.positions.map(position => clonePosition(position as StitchPosition))),
           tsa.enabledCollaterals,
+          // No base sub-account: every enabled collateral is treated as new.
+          undefined,
         ),
       }
       continue
@@ -1132,7 +1161,15 @@ export const stitchAccount = (
       const vault = getAddress(tp.vaultAddress)
       byVault.set(vault, mergePositionData(byVault.get(vault), tp as StitchPosition))
     }
-    const positions = hydrateStitchedPositions(Array.from(byVault.values()), tsa.enabledCollaterals)
+    // `existing` is still the pre-batch (prevFull) sub-account here — it isn't
+    // overwritten with the simulated EVC state until below — so its enabled
+    // collaterals are the base set against which `tsa.enabledCollaterals` is the
+    // post-batch state.
+    const positions = hydrateStitchedPositions(
+      Array.from(byVault.values()),
+      tsa.enabledCollaterals,
+      existing.enabledCollaterals,
+    )
     mergedSubs[key] = {
       ...existing,
       // Post-op EVC state for this sub-account comes from the simulated layer.

--- a/composables/useTxBatch.ts
+++ b/composables/useTxBatch.ts
@@ -1276,7 +1276,16 @@ export const useTxBatch = () => {
         },
       )
 
-      if (token !== resimToken) return
+      if (token !== resimToken) {
+        // Diagnostic (temporary): a newer resimulation superseded this one after
+        // the sim resolved, so this run bails before populating layers. When that
+        // happens during a plan-time await it's exactly what surfaces as the
+        // misleading "Batch simulation not loaded" (see getEntryPlanningAccount).
+        // Logging the token transition + entry count confirms the trigger in the
+        // field. Safe to remove once the race is confirmed fixed.
+        logWarn('useTxBatch/resimulate', `superseded after sim (token ${token} → ${resimToken}, entries=${entries.value.length})`)
+        return
+      }
 
       // Two distinct failure shapes, both blocking but handled differently:
       //  - simulationError: the EVC call reverted at the top level (couldn't even
@@ -1417,11 +1426,14 @@ export const useTxBatch = () => {
   }
 
   const runResimulate = (): Promise<void> => {
-    const promise = resimulate()
-    resimulatePromise = promise.finally(() => {
-      if (resimulatePromise === promise) resimulatePromise = null
+    // Compare against the *wrapped* promise we store, not the raw resimulate()
+    // promise — otherwise the guard never matches and resimulatePromise is never
+    // cleared, leaving callers (getEntryPlanningAccount) awaiting a stale run.
+    const wrapped: Promise<void> = resimulate().finally(() => {
+      if (resimulatePromise === wrapped) resimulatePromise = null
     })
-    return resimulatePromise
+    resimulatePromise = wrapped
+    return wrapped
   }
 
   // Wire reactivity exactly once, in a detached scope that outlives any single
@@ -1467,9 +1479,23 @@ export const useTxBatch = () => {
     if (finalLayer) return finalLayer
 
     if (entries.value.length > 0) {
-      await (resimulatePromise ?? runResimulate())
-      const refreshedFinalLayer = getCurrentFinalLayer()
-      if (refreshedFinalLayer) return refreshedFinalLayer
+      // A resimulation can be superseded mid-flight: both the entries watcher and
+      // this call kick off runs sharing resimToken, and the loser returns early
+      // (the `token !== resimToken` guard) WITHOUT populating layers or simError.
+      // A single await can therefore resolve on the superseded run, before the
+      // winning run has produced our final layer — which used to surface as a
+      // misleading "Batch simulation not loaded". Re-await the current run until
+      // the final layer for the present entries settles or a real error appears.
+      for (let attempt = 0; attempt < 8; attempt++) {
+        await (resimulatePromise ?? runResimulate())
+        const refreshedFinalLayer = getCurrentFinalLayer()
+        if (refreshedFinalLayer) return refreshedFinalLayer
+        if (simError.value) break
+        // Resolved without our layers and no error: a newer run superseded this
+        // one. If it's already in flight, the next pass awaits it; otherwise kick
+        // a fresh run. The bounded loop guarantees we can't spin forever.
+        if (!resimulatePromise) runResimulate()
+      }
       throw new Error(simError.value ?? 'Batch simulation not loaded')
     }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -251,6 +251,27 @@ The `useMarketGroups` composable (`composables/useMarketGroups.ts`) implements a
 3. **Orphan clustering** — Vaults not assigned to any product are clustered using a BFS connected-component algorithm over their collateral relationships. This produces "Ungrouped" markets.
 4. **Async TVL resolution** — Group metrics (TVL, available liquidity, borrowed) are resolved asynchronously using USD pricing.
 
+### Correlated Pairs, Max ROE, and Max Multiplier
+
+Leveraged return metrics are only shown when the collateral and debt assets are treated as price-correlated. The source of truth is token-list metadata: `useTokenList().getTokenCategoryTags(address)` returns normalized `tags`, and `utils/token-categories.ts` only considers tags present in `CORRELATED_CATEGORY_LABELS` (`usd`, `eth`, `btc`, `mon`, `avax`, `hype`, `bnb`).
+
+Correlation rules:
+
+- **Pair-level**: `areTokenAddressesCorrelatedByTags()` returns true when both assets share an allowlisted category tag, or when they are the same asset address.
+- **Portfolio-level**: `areRoeCollateralVaultsCorrelatedWithBorrow()` requires every resolved collateral asset and the borrow asset to share one allowlisted category.
+- **Math**: `utils/leverage.ts` delegates max multiplier and max ROE formulas to the SDK, then adds looping rewards flat because those rewards are paid per unit of equity rather than scaled by leverage.
+
+The correlation decision is shared across discovery, borrow, and portfolio surfaces:
+
+| Surface | Correlated assets | Uncorrelated assets |
+|---|---|---|
+| Explore market card (`useBestMaxROE`) | Best Max ROE across eligible LTV pairs | Best visible Net APY fallback |
+| Explore matrix (`DiscoveryMarketMatrix.vue`) | Numeric cells in `roe` and `multiplier` views | `-` cell with unavailable-metric tooltip and accordion notice |
+| Borrow pair card (`VaultBorrowItem.vue`) | Max ROE headline, correlated-category badge, Max multiplier column, Multiply tab link | Net APY headline; multiplier column and Multiply tab shortcut are hidden |
+| Portfolio borrow card (`PortfolioBorrowItem.vue`) | Position ROE when all collateral vaults resolve and share the category | Net APY path |
+
+Borrow-page collateral and debt filters reuse the same category metadata. `pages/borrow/index.vue` builds quick-filter values such as `category:usd` from tags present in the active pair list, and matching accepts either an explicit token address or a category match via `tokenAddressMatchesCategoryFilter()`.
+
 ### Key Types
 
 - `MarketGroup` — Core group with vaults, external collateral, metrics, and curator info

--- a/docs/intrinsic-apy.md
+++ b/docs/intrinsic-apy.md
@@ -2,7 +2,7 @@
 
 Intrinsic APY is yield native to the underlying asset — independent of the Euler lending market. Examples: wstETH earns staking yield from Lido, sDAI earns the DAI Savings Rate, Pendle PT tokens earn implied yield from the fixed-rate market.
 
-Euler Lite compounds this intrinsic yield onto the vault's lending/borrowing APY so users see the total effective return.
+Euler Lite includes this intrinsic yield in APY displays so users see the effective economics of the asset. For supplied assets it increases effective return; for borrowed assets it increases effective borrowing cost.
 
 ## Architecture
 
@@ -85,6 +85,18 @@ export function withVaultIntrinsicApy(baseApy: number, vault, enabled: boolean):
 - `getVaultIntrinsicApyInfo` returns the full info object including `provider` and `source` for use in APY-breakdown modals.
 
 The SDK exposes an equivalent on its side: `computeSupplyApyBreakdown(vault)` returns `{ lending, intrinsicApy, rewards, total }` with the compounding pre-applied. Use whichever fits the call site; both produce the same numbers for supply.
+
+## Borrow-side display
+
+Borrow views call the same helper path, but the UI copy treats intrinsic APY as cost-side yield. `VaultBorrowItem.vue` passes `getVaultIntrinsicApyInfo()` into `VaultBorrowApyModal.vue`; that modal describes intrinsic APY as "yield intrinsic to the borrowed asset ... which increases effective borrowing cost".
+
+The borrow APY modal's breakdown is additive:
+
+```text
+total borrow APY = borrowing APY + intrinsic APY - reward APY
+```
+
+Pair-level Net APY and Max ROE screens still use the compounded helper for consistency with vault headline APYs. When changing borrow-side APY copy, keep the direction explicit: intrinsic yield on the debt asset makes borrowing more expensive, while borrow rewards reduce the displayed cost.
 
 ## User toggle
 

--- a/docs/intrinsic-apy.md
+++ b/docs/intrinsic-apy.md
@@ -90,13 +90,13 @@ The SDK exposes an equivalent on its side: `computeSupplyApyBreakdown(vault)` re
 
 Borrow views call the same helper path, but the UI copy treats intrinsic APY as cost-side yield. `VaultBorrowItem.vue` passes `getVaultIntrinsicApyInfo()` into `VaultBorrowApyModal.vue`; that modal describes intrinsic APY as "yield intrinsic to the borrowed asset ... which increases effective borrowing cost".
 
-The borrow APY modal's breakdown is additive:
+The borrow APY modal uses the same compounded intrinsic helper as supply-side displays, then subtracts borrow rewards:
 
 ```text
-total borrow APY = borrowing APY + intrinsic APY - reward APY
+total borrow APY = borrowing APY + (1 + borrowing APY / 100) * intrinsic APY - reward APY
 ```
 
-Pair-level Net APY and Max ROE screens still use the compounded helper for consistency with vault headline APYs. When changing borrow-side APY copy, keep the direction explicit: intrinsic yield on the debt asset makes borrowing more expensive, while borrow rewards reduce the displayed cost.
+Pair-level Net APY and Max ROE screens use the same compounded helper for consistency with vault headline APYs. When changing borrow-side APY copy, keep the direction explicit: intrinsic yield on the debt asset makes borrowing more expensive, while borrow rewards reduce the displayed cost.
 
 ## User toggle
 

--- a/docs/token-list.md
+++ b/docs/token-list.md
@@ -1,6 +1,6 @@
 # Token List
 
-The token list provides token metadata (name, symbol, decimals, logo URL) used across the app for asset logos, the swap token selector, and wallet balance fetching.
+The token list provides token metadata (name, symbol, decimals, logo URL, and optional category tags) used across the app for asset logos, the swap token selector, wallet balance fetching, correlated-asset logic, and borrow-page asset filters.
 
 ## Architecture
 
@@ -57,6 +57,7 @@ Singleton state with a `shallowRef` token map, keyed by normalized address.
 - **Cache TTL**: 5 minutes. The client skips the API call if the same chain's data was fetched within the last 5 minutes (bypassed by `forceRefresh`).
 - **Race guard**: prevents stale responses (from a previous chain) from overwriting current data.
 - **`filterByChain()`**: filters the raw token array by `chainId`, normalizes addresses, and conditionally includes the native currency (address zero) when the wrapped variant exists.
+- **Tags**: token entries may include `tags?: string[]`. `filterByChain()` normalizes tags with `normalizeTokenCategoryTags()` and copies wrapped-native tags to the native zero-address entry.
 
 ### Exported functions
 
@@ -66,8 +67,22 @@ Singleton state with a `shallowRef` token map, keyed by normalized address.
 | `getAssetLogoUrl(address, symbol)` | Returns logo URL. Checks local overrides (`assets/tokens/`) first, then token list, then `''`. |
 | `getTokenListLogoUrl(address)` | Returns logo URL from token list only. Upgrades CoinGecko `/thumb/` to `/small/`. |
 | `hasToken(address)` | Check if a token is in the current map. |
+| `getTokenByAddress(address)` | Return the normalized token-list entry, including `tags` when present. |
+| `getTokenCategoryTags(address)` | Return normalized category tags from the token entry. Used by correlated-pair checks and borrow-page asset category filters. |
 | `getAllTokens()` | Get all tokens for the current chain. |
 | `toVaultAsset(entry)` | Convert a token list entry to a `VaultAsset`. |
+
+## Category Tags
+
+Category tags are an operational input, not just display metadata. `utils/token-categories.ts` allowlists correlated categories (`usd`, `eth`, `btc`, `mon`, `avax`, `hype`, `bnb`) and uses them to decide whether leveraged metrics are meaningful for a pair or portfolio position.
+
+Current consumers:
+
+- `areTokenAddressesCorrelatedByTags()` gates Max ROE and Max multiplier for pair-level surfaces such as Explore and Borrow.
+- `areTokenAddressesInSameCorrelatedCategory()` gates portfolio ROE when a borrow position has one or more collateral vaults.
+- `toTokenCategoryFilterValue()` and `tokenAddressMatchesCategoryFilter()` power Borrow quick filters such as `category:usd`.
+
+When adding or changing token metadata, keep category tags lowercase and stable. Unsupported tags remain available on the token entry after normalization, but they do not participate in correlation or category quick filters unless added to `CORRELATED_CATEGORY_LABELS`.
 
 ## Loading Strategy
 

--- a/entities/chainRegistry.ts
+++ b/entities/chainRegistry.ts
@@ -44,6 +44,24 @@ const LEGACY_CHAIN_ALIASES: ReadonlyMap<string, number> = new Map([
   ['lineamainnet', 59144],
 ])
 
+const MONAD_CHAIN_ID = 143
+const MONAD_EXPLORER_URL = 'https://monadscan.com/'
+
+const monad = chainMap.get(MONAD_CHAIN_ID)
+if (monad) {
+  chainMap.set(MONAD_CHAIN_ID, {
+    ...monad,
+    blockExplorers: {
+      ...monad.blockExplorers,
+      default: {
+        ...monad.blockExplorers?.default,
+        name: 'MonadScan',
+        url: MONAD_EXPLORER_URL,
+      },
+    },
+  })
+}
+
 export const getChainIdByName = (name: string): number | undefined => {
   const normalized = name.trim().toLowerCase().replace(/\s+/g, '-')
   if (!normalized) return undefined

--- a/entities/oracle.ts
+++ b/entities/oracle.ts
@@ -99,7 +99,7 @@ export type OracleAdapterIdentity = {
 // An adapter step (`isAdapter`) only gets a name/provider from the curated
 // oracle-checks dataset (`meta`). When that entry is absent we must NOT fall back
 // to the self-reported onchain `name()` — that value is attacker-controllable and
-// would let an unknown adapter masquerade as a recognised one. Such steps are
+// would let an unknown adapter masquerade as a recognized one. Such steps are
 // flagged as custom adapters and rendered as "Unknown".
 //
 // Structural steps (e.g. ERC-4626 exchange-rate `vault` steps) are not adapters and
@@ -117,20 +117,20 @@ export function resolveOracleAdapterIdentity(
   }
 }
 
-// Classifies a vault's oracle router(s) against the recognised-router allowlist
-// (deployed by the recognised EulerRouterFactory). Returns null — i.e. show
+// Classifies a vault's oracle router(s) against the recognized-router allowlist
+// (deployed by the recognized EulerRouterFactory). Returns null — i.e. show
 // nothing — when the allowlist is unavailable (empty) or there are no routers to
-// check, so a missing dataset never produces a false "unrecognised" warning.
+// check, so a missing dataset never produces a false "unrecognized" warning.
 export function getRouterRecognition(
   routerAddresses: ReadonlyArray<string | undefined | null>,
-  recognised: ReadonlySet<string>,
-): 'recognised' | 'unrecognised' | null {
-  if (!recognised.size) return null
+  recognized: ReadonlySet<string>,
+): 'recognized' | 'unrecognized' | null {
+  if (!recognized.size) return null
   const addresses = routerAddresses
     .filter((address): address is string => typeof address === 'string' && address.length > 0)
     .map(address => address.toLowerCase())
   if (!addresses.length) return null
-  return addresses.every(address => recognised.has(address)) ? 'recognised' : 'unrecognised'
+  return addresses.every(address => recognized.has(address)) ? 'recognized' : 'unrecognized'
 }
 
 type OracleAdapterOptions = {

--- a/entities/oracle.ts
+++ b/entities/oracle.ts
@@ -78,6 +78,24 @@ export type OracleAdapterMeta = {
   checks?: OracleAdapterCheck[]
 }
 
+export function normalizeOracleAdapterCheckSeverity(severity: unknown): OracleAdapterCheckSeverity {
+  if (typeof severity !== 'string') return OracleAdapterCheckSeverity.Info
+
+  switch (severity.trim().toLowerCase()) {
+    case 'high':
+      return OracleAdapterCheckSeverity.High
+    case 'med':
+    case 'medium':
+      return OracleAdapterCheckSeverity.Medium
+    case 'low':
+      return OracleAdapterCheckSeverity.Low
+    case 'info':
+      return OracleAdapterCheckSeverity.Info
+    default:
+      return OracleAdapterCheckSeverity.Info
+  }
+}
+
 export function getChecksStatus(checks: OracleAdapterCheck[] | undefined): 'positive' | 'warning' | 'negative' | null {
   if (!checks?.length) return null
   const failed = checks.filter(c => !c.pass)

--- a/entities/oracle.ts
+++ b/entities/oracle.ts
@@ -86,6 +86,53 @@ export function getChecksStatus(checks: OracleAdapterCheck[] | undefined): 'posi
   return 'warning'
 }
 
+export type OracleAdapterIdentity = {
+  name?: string
+  provider?: string
+  // True when this is an oracle adapter with no entry in the curated oracle-checks
+  // dataset — i.e. a custom oracle configured by the vault's risk manager.
+  isCustomAdapter: boolean
+}
+
+// Resolves the display name/provider for an oracle route step.
+//
+// An adapter step (`isAdapter`) only gets a name/provider from the curated
+// oracle-checks dataset (`meta`). When that entry is absent we must NOT fall back
+// to the self-reported onchain `name()` — that value is attacker-controllable and
+// would let an unknown adapter masquerade as a recognised one. Such steps are
+// flagged as custom adapters and rendered as "Unknown".
+//
+// Structural steps (e.g. ERC-4626 exchange-rate `vault` steps) are not adapters and
+// keep their decoded name, since it is derived from the route, not self-reported.
+export function resolveOracleAdapterIdentity(
+  step: { name: string },
+  meta: OracleAdapterMeta | undefined,
+  isAdapter: boolean,
+): OracleAdapterIdentity {
+  const fallback = isAdapter ? undefined : step.name
+  return {
+    name: meta?.name || fallback,
+    provider: meta?.provider || fallback,
+    isCustomAdapter: isAdapter && !meta,
+  }
+}
+
+// Classifies a vault's oracle router(s) against the recognised-router allowlist
+// (deployed by the recognised EulerRouterFactory). Returns null — i.e. show
+// nothing — when the allowlist is unavailable (empty) or there are no routers to
+// check, so a missing dataset never produces a false "unrecognised" warning.
+export function getRouterRecognition(
+  routerAddresses: ReadonlyArray<string | undefined | null>,
+  recognised: ReadonlySet<string>,
+): 'recognised' | 'unrecognised' | null {
+  if (!recognised.size) return null
+  const addresses = routerAddresses
+    .filter((address): address is string => typeof address === 'string' && address.length > 0)
+    .map(address => address.toLowerCase())
+  if (!addresses.length) return null
+  return addresses.every(address => recognised.has(address)) ? 'recognised' : 'unrecognised'
+}
+
 type OracleAdapterOptions = {
   base?: Address
   quote?: Address

--- a/pages/earn/[vault]/index.vue
+++ b/pages/earn/[vault]/index.vue
@@ -108,9 +108,12 @@ const supplyRewardCampaigns = computed(() => getSupplyRewardCampaigns(vaultAddre
 const totalRewardsAPY = computed(() => getSupplyRewardApy(vaultAddress))
 const hasRewards = computed(() => hasSupplyRewards(vaultAddress))
 const intrinsicApy = computed(() => getVaultIntrinsicApy(vault.value, enableIntrinsicApy.value))
+const supplyApyTotal = computed(() =>
+  vault.value ? getVaultSupplyApy(vault.value) + intrinsicApy.value + totalRewardsAPY.value : 0,
+)
 const supplyAPYDisplay = computed(() => {
   if (!vault.value) return '0.00'
-  return formatNumber(getVaultSupplyApy(vault.value) + intrinsicApy.value + totalRewardsAPY.value)
+  return formatNumber(supplyApyTotal.value)
 })
 const estimateSupplyAPYDisplay = computed(() => {
   return formatNumber(estimateSupplyAPY.value)
@@ -224,6 +227,7 @@ const supplyApyModalData = computed(() => ({
     intrinsicAPY: intrinsicApy.value,
     intrinsicApyInfo: getVaultIntrinsicApyInfo(vault.value, enableIntrinsicApy.value),
     campaigns: supplyRewardCampaigns.value,
+    totalSupplyAPY: supplyApyTotal.value,
     rewardVaultAddress: vaultAddress,
     baseApyAverageLabel: '1h',
   },

--- a/pages/earn/[vault]/index.vue
+++ b/pages/earn/[vault]/index.vue
@@ -110,7 +110,7 @@ const hasRewards = computed(() => hasSupplyRewards(vaultAddress))
 const intrinsicApy = computed(() => getVaultIntrinsicApy(vault.value, enableIntrinsicApy.value))
 const supplyAPYDisplay = computed(() => {
   if (!vault.value) return '0.00'
-  return formatNumber(getVaultSupplyApy(vault.value) + totalRewardsAPY.value)
+  return formatNumber(getVaultSupplyApy(vault.value) + intrinsicApy.value + totalRewardsAPY.value)
 })
 const estimateSupplyAPYDisplay = computed(() => {
   return formatNumber(estimateSupplyAPY.value)

--- a/pages/earn/[vault]/index.vue
+++ b/pages/earn/[vault]/index.vue
@@ -212,7 +212,7 @@ const updateEstimates = async () => {
   try {
     vault.value = await updateEarnVault(vault.value.address)
     if (!asset.value?.address) return
-    estimateSupplyAPY.value = getVaultSupplyApy(vault.value) + totalRewardsAPY.value
+    estimateSupplyAPY.value = getVaultSupplyApy(vault.value) + intrinsicApy.value + totalRewardsAPY.value
   }
   catch (e) {
     logWarn('earn-supply/estimates', e)
@@ -234,7 +234,7 @@ const supplyApyModalData = computed(() => ({
 }))
 
 // Initialize estimateSupplyAPY after vault is loaded
-estimateSupplyAPY.value = getVaultSupplyApy(vault.value) + totalRewardsAPY.value
+estimateSupplyAPY.value = getVaultSupplyApy(vault.value) + intrinsicApy.value + totalRewardsAPY.value
 
 watch(amount, () => {
   clearSimulationError()

--- a/pages/earn/[vault]/index.vue
+++ b/pages/earn/[vault]/index.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import type { VaultAsset } from '~/types/asset'
-import type { TransactionPlan, EulerEarn } from '@eulerxyz/euler-v2-sdk'
+import { computeSupplyApyBreakdown, type TransactionPlan, type EulerEarn } from '@eulerxyz/euler-v2-sdk'
 import { useEulerProductOfVault } from '~/composables/useEulerLabels'
-import { getVaultIntrinsicApy, getVaultIntrinsicApyInfo } from '~/utils/vault-intrinsic-apy'
+import { getVaultIntrinsicApyInfo } from '~/utils/vault-intrinsic-apy'
 import { isVaultBlockedByCountry } from '~/composables/useGeoBlock'
 import VaultFormInfoBlock from '~/components/entities/vault/form/VaultFormInfoBlock.vue'
 import VaultFormSubmit from '~/components/entities/vault/form/VaultFormSubmit.vue'
@@ -41,7 +41,8 @@ useOperationGuard([vaultAddress])
 const { name } = useEulerProductOfVault(vaultAddress)
 const { settings } = useUserSettings()
 const enableIntrinsicApy = computed(() => settings.value.enableIntrinsicApy)
-const { getSupplyRewardApy, hasSupplyRewards, getSupplyRewardCampaigns } = useRewardsApy()
+const { hasSupplyRewards, getSupplyRewardCampaigns } = useRewardsApy()
+const { viewer, visibleTotal, visibleBreakdown } = useApyVisibility()
 
 const isLoading = ref(false)
 const isSubmitting = ref(false)
@@ -56,6 +57,11 @@ const earnVaultMarketLabel = computed(() => unref(name) || vault.value?.shares.n
 // Wallet balance from the central (layer-aware) wallet entity — reactive, no
 // direct balanceOf.
 const balance = computed(() => asset.value?.address ? getBalance(asset.value.address as Address) : 0n)
+const supplyRewardCampaigns = computed(() => getSupplyRewardCampaigns(vaultAddress))
+const hasRewards = computed(() => settings.value.enableRewardsApy && hasSupplyRewards(vaultAddress))
+const supplyApyBreakdown = computed(() => vault.value ? computeSupplyApyBreakdown(vault.value, viewer.value) : undefined)
+const visibleApyBreakdown = computed(() => visibleBreakdown(supplyApyBreakdown.value))
+const supplyApyTotal = computed(() => visibleTotal(supplyApyBreakdown.value) ?? 0)
 
 // Non-blocking to avoid Suspense + pageTransition crash on direct navigation
 ;(async () => {
@@ -68,6 +74,7 @@ const balance = computed(() => asset.value?.address ? getBalance(asset.value.add
     }
     vault.value = await updateEarnVault(vaultAddress)
     asset.value = vault.value?.asset
+    estimateSupplyAPY.value = supplyApyTotal.value
 
     if (!useVaultRegistry().isVerifiedVault(vault.value.address)) {
       modal.open(VaultUnverifiedDisclaimerModal, {
@@ -104,13 +111,6 @@ const disabledReasonInfo = computed((): DisabledReasonInfo | undefined => {
   if (errorText.value) return { message: errorText.value, variant: 'error' }
   return undefined
 })
-const supplyRewardCampaigns = computed(() => getSupplyRewardCampaigns(vaultAddress))
-const totalRewardsAPY = computed(() => getSupplyRewardApy(vaultAddress))
-const hasRewards = computed(() => hasSupplyRewards(vaultAddress))
-const intrinsicApy = computed(() => getVaultIntrinsicApy(vault.value, enableIntrinsicApy.value))
-const supplyApyTotal = computed(() =>
-  vault.value ? getVaultSupplyApy(vault.value) + intrinsicApy.value + totalRewardsAPY.value : 0,
-)
 const supplyAPYDisplay = computed(() => {
   if (!vault.value) return '0.00'
   return formatNumber(supplyApyTotal.value)
@@ -212,7 +212,7 @@ const updateEstimates = async () => {
   try {
     vault.value = await updateEarnVault(vault.value.address)
     if (!asset.value?.address) return
-    estimateSupplyAPY.value = getVaultSupplyApy(vault.value) + intrinsicApy.value + totalRewardsAPY.value
+    estimateSupplyAPY.value = supplyApyTotal.value
   }
   catch (e) {
     logWarn('earn-supply/estimates', e)
@@ -223,18 +223,15 @@ const updateEstimates = async () => {
 }
 const supplyApyModalData = computed(() => ({
   props: {
-    lendingAPY: getVaultSupplyApy(vault.value),
-    intrinsicAPY: intrinsicApy.value,
+    lendingAPY: visibleApyBreakdown.value?.lending ?? 0,
+    intrinsicAPY: visibleApyBreakdown.value?.intrinsicApy ?? 0,
     intrinsicApyInfo: getVaultIntrinsicApyInfo(vault.value, enableIntrinsicApy.value),
-    campaigns: supplyRewardCampaigns.value,
+    campaigns: settings.value.enableRewardsApy ? supplyRewardCampaigns.value : [],
     totalSupplyAPY: supplyApyTotal.value,
     rewardVaultAddress: vaultAddress,
     baseApyAverageLabel: '1h',
   },
 }))
-
-// Initialize estimateSupplyAPY after vault is loaded
-estimateSupplyAPY.value = getVaultSupplyApy(vault.value) + intrinsicApy.value + totalRewardsAPY.value
 
 watch(amount, () => {
   clearSimulationError()

--- a/pages/lend/[vault]/index.vue
+++ b/pages/lend/[vault]/index.vue
@@ -382,7 +382,9 @@ const load = async () => {
   isLoading.value = true
   try {
     if (features.value.hasInterestRate && eVault.value) {
-      estimateSupplyAPY.value = getVaultSupplyApy(eVault.value) + totalRewardsAPY.value + intrinsicApy.value
+      estimateSupplyAPY.value
+        = combineApyWithIntrinsic(getVaultSupplyApy(eVault.value), intrinsicApy.value)
+          + totalRewardsAPY.value
     }
     else {
       // For vaults without interest rate info, just use rewards
@@ -605,7 +607,9 @@ const updateEstimates = useDebounceFn(async () => {
 
       if (needsSwap.value && !supplyNano) {
         // No swap quote yet — skip projection, keep current rate
-        estimateSupplyAPY.value = getVaultSupplyApy(eVault.value) + totalRewardsAPY.value + intrinsicApy.value
+        estimateSupplyAPY.value
+          = combineApyWithIntrinsic(getVaultSupplyApy(eVault.value), intrinsicApy.value)
+            + totalRewardsAPY.value
       }
       else {
         const projected = await getProjectedRates(
@@ -617,7 +621,9 @@ const updateEstimates = useDebounceFn(async () => {
         )
         if (estimatesGuard.isStale(gen)) return
         const rawAPY = projected ? nanoToValue(projected.supplyAPY, 25) : getVaultSupplyApy(eVault.value)
-        estimateSupplyAPY.value = rawAPY + totalRewardsAPY.value + intrinsicApy.value
+        estimateSupplyAPY.value
+          = combineApyWithIntrinsic(rawAPY, intrinsicApy.value)
+            + totalRewardsAPY.value
       }
     }
     else {

--- a/pages/lend/[vault]/index.vue
+++ b/pages/lend/[vault]/index.vue
@@ -5,7 +5,7 @@ import { isSecuritizeVault } from '~/utils/vault/categories'
 import { getHookDisabledWarning, getUtilisationWarning, getSupplyCapWarning } from '~/composables/useVaultWarnings'
 import { getAssetOraclePrice, getTokenUsdPrice } from '~/utils/sdk-prices'
 import { useEulerProductOfVault } from '~/composables/useEulerLabels'
-import { getVaultIntrinsicApy, getVaultIntrinsicApyInfo } from '~/utils/vault-intrinsic-apy'
+import { getVaultIntrinsicApy, getVaultIntrinsicApyInfo, combineApyWithIntrinsic } from '~/utils/vault-intrinsic-apy'
 import { isVaultBlockedByCountry, isVaultRestrictedByCountry, isAssetBlockedByCountry } from '~/composables/useGeoBlock'
 import { useVaultRegistry } from '~/composables/useVaultRegistry'
 import { useSwapQuotesParallel } from '~/composables/useSwapQuotesParallel'
@@ -350,7 +350,7 @@ const baseSupplyApy = computed(() => {
   if (!eVault.value) return 0
   return getVaultSupplyApy(eVault.value)
 })
-const supplyApyWithIntrinsic = computed(() => baseSupplyApy.value + intrinsicApy.value)
+const supplyApyWithIntrinsic = computed(() => combineApyWithIntrinsic(baseSupplyApy.value, intrinsicApy.value))
 const supplyAPYDisplay = computed(() => {
   if (!eVault.value && !securitizeVault.value) return '0.00'
   return formatNumber(supplyApyWithIntrinsic.value + totalRewardsAPY.value)

--- a/server/api/oracle-routers.get.ts
+++ b/server/api/oracle-routers.get.ts
@@ -1,0 +1,66 @@
+import { createError, getQuery } from 'h3'
+import { createRateLimiter } from '~/server/utils/rate-limit'
+import { createTtlCache } from '~/server/utils/cache'
+import { fetchWithTimeout } from '~/server/utils/fetchWithTimeout'
+import { logger } from '~/server/utils/logger'
+
+const CACHE_TTL_MS = 300_000
+
+const rateLimiter = createRateLimiter({
+  max: 60,
+  windowMs: 60_000,
+  label: 'oracle-routers',
+})
+
+const cache = createTtlCache<unknown>({ ttlMs: CACHE_TTL_MS, maxEntries: 50 })
+
+function getUpstreamUrl(chainId: number): string {
+  const baseUrl = (process.env.NUXT_PUBLIC_CONFIG_ORACLE_CHECKS_BASE_URL || '').trim().replace(/\/+$/, '')
+  if (baseUrl) {
+    return `${baseUrl}/${chainId}/routers/all.json`
+  }
+
+  const repo = process.env.NUXT_PUBLIC_CONFIG_ORACLE_CHECKS_REPO || 'euler-xyz/oracle-checks'
+  return `https://raw.githubusercontent.com/${repo}/refs/heads/master/data/${chainId}/routers/all.json`
+}
+
+export default defineEventHandler(async (event) => {
+  rateLimiter.consume(event)
+
+  const query = getQuery(event)
+  const chainId = Number(query.chainId)
+  if (!Number.isInteger(chainId) || chainId <= 0) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid chainId' })
+  }
+
+  const key = `${chainId}`
+
+  const cached = cache.get(key)
+  if (cached !== undefined) return cached
+
+  try {
+    const resp = await fetchWithTimeout(getUpstreamUrl(chainId))
+    if (!resp.ok) {
+      // Don't cache the empty fallback for 404 (or any non-OK status). A
+      // missing/transient upstream response would otherwise pin every client
+      // to the empty array for the full TTL window — better to let the next
+      // request retry quickly.
+      if (resp.status === 404) return []
+      throw new Error(`Upstream returned ${resp.status}`)
+    }
+
+    const data: unknown = await resp.json()
+    cache.set(key, data)
+    return data
+  }
+  catch (err) {
+    logger.warn({ ctx: 'oracle-routers', chainId, err }, 'fetch routers all.json failed')
+
+    const stale = cache.getStale(key)
+    if (stale !== undefined) return stale
+
+    // Same reasoning as the 404 branch: don't pollute the cache with an empty
+    // array on transient failures.
+    return []
+  }
+})

--- a/tests/composables/useEulerOracleRouters.test.ts
+++ b/tests/composables/useEulerOracleRouters.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+
+  return { promise, resolve, reject }
+}
+
+describe('useEulerOracleRouters', () => {
+  afterEach(() => {
+    vi.resetModules()
+    vi.unstubAllGlobals()
+  })
+
+  it('does not let a stale chain response overwrite the active chain allowlist', async () => {
+    const chainOne = deferred<string[]>()
+    const chainTwo = deferred<string[]>()
+
+    vi.stubGlobal('$fetch', vi.fn((_url: string, options?: { query?: { chainId?: number } }) => {
+      if (options?.query?.chainId === 1) return chainOne.promise
+      if (options?.query?.chainId === 2) return chainTwo.promise
+      throw new Error('unexpected chain')
+    }))
+
+    const { useEulerOracleRouters } = await import('~/composables/useEulerOracleRouters')
+    const routers = useEulerOracleRouters()
+
+    const firstLoad = routers.loadRecognizedRouters(1)
+    const secondLoad = routers.loadRecognizedRouters(2)
+
+    chainTwo.resolve(['0xBbB0000000000000000000000000000000000002'])
+    await secondLoad
+
+    expect(routers.recognizedRoutersChainId.value).toBe(2)
+    expect(routers.recognizedRouters.value.has('0xbbb0000000000000000000000000000000000002')).toBe(true)
+
+    chainOne.resolve(['0xAaA0000000000000000000000000000000000001'])
+    await firstLoad
+
+    expect(routers.recognizedRoutersChainId.value).toBe(2)
+    expect(routers.recognizedRouters.value.has('0xbbb0000000000000000000000000000000000002')).toBe(true)
+    expect(routers.recognizedRouters.value.has('0xaaa0000000000000000000000000000000000001')).toBe(false)
+
+    await routers.loadRecognizedRouters(1)
+
+    expect(routers.recognizedRoutersChainId.value).toBe(1)
+    expect(routers.recognizedRouters.value.has('0xaaa0000000000000000000000000000000000001')).toBe(true)
+  })
+})

--- a/tests/composables/useTxBatch.test.ts
+++ b/tests/composables/useTxBatch.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 import { Account, Portfolio, type IAccountPosition, type IHasVaultAddress, type IAccountLiquidity } from '@eulerxyz/euler-v2-sdk'
 import { getAddress, type Address } from 'viem'
-import { buildWalletBalanceLayers, buildWalletChanges, fetchBaseAccountSnapshot, stitchAccount, useTxBatch } from '~/composables/useTxBatch'
+import { awaitFinalPlanningLayer, buildWalletBalanceLayers, buildWalletChanges, fetchBaseAccountSnapshot, stitchAccount, useTxBatch } from '~/composables/useTxBatch'
 
 const owner = getAddress('0x1000000000000000000000000000000000000000')
 const subAccount = getAddress('0x8A54C278D117854486db0F6460D901a180Fff517')
@@ -557,5 +557,93 @@ describe('useTxBatch execution errors', () => {
     batch.clearBatch()
 
     expect(batch.execError.value).toBeUndefined()
+  })
+})
+
+describe('awaitFinalPlanningLayer', () => {
+  it('returns the final layer once a superseded run is followed by a populated one', async () => {
+    // attempt 0 + 1: superseded (no layer, no error); attempt 2: layer settles.
+    const sequence: Array<{ account: string } | undefined> = [undefined, undefined, { account: 'final' }]
+    let started = 0
+    const attempts: Array<{ attempt: number, awaitedExisting: boolean, found: boolean }> = []
+
+    const result = await awaitFinalPlanningLayer<{ account: string }>({
+      getFinalLayer: () => sequence.shift(),
+      getSimError: () => undefined,
+      getInFlight: () => null,
+      startRun: () => {
+        started++
+        return Promise.resolve()
+      },
+      onAttempt: info => attempts.push(info),
+    })
+
+    expect(result).toEqual({ account: 'final' })
+    expect(started).toBe(3) // one awaited run per attempt until the layer appears
+    expect(attempts).toEqual([
+      { attempt: 0, awaitedExisting: false, found: false },
+      { attempt: 1, awaitedExisting: false, found: false },
+      { attempt: 2, awaitedExisting: false, found: true },
+    ])
+  })
+
+  it('awaits an in-flight run without starting a new one', async () => {
+    let started = 0
+    let inFlightAwaited = false
+    const inFlight = Promise.resolve().then(() => {
+      inFlightAwaited = true
+    })
+
+    const result = await awaitFinalPlanningLayer<{ account: string }>({
+      getFinalLayer: () => (inFlightAwaited ? { account: 'ready' } : undefined),
+      getSimError: () => undefined,
+      getInFlight: () => inFlight,
+      startRun: () => {
+        started++
+        return Promise.resolve()
+      },
+    })
+
+    expect(result).toEqual({ account: 'ready' })
+    expect(started).toBe(0) // awaited the existing run; never kicked a fresh one
+  })
+
+  it('rejects with the real simError instead of the generic message', async () => {
+    let started = 0
+    await expect(awaitFinalPlanningLayer({
+      getFinalLayer: () => undefined,
+      getSimError: () => 'Vault status check failed',
+      getInFlight: () => null,
+      startRun: () => {
+        started++
+        return Promise.resolve()
+      },
+    })).rejects.toThrow('Vault status check failed')
+    expect(started).toBe(1) // breaks as soon as the first run surfaces a real error
+  })
+
+  it('throws the generic error after exhausting attempts and awaits every run it starts', async () => {
+    // Regression guard for the terminal-iteration race: the old loop kicked a
+    // fresh resimulation on the last pass and then threw WITHOUT awaiting it,
+    // preserving a tail "Batch simulation not loaded". The fixed loop starts
+    // exactly one run per attempt and awaits each before falling through.
+    let started = 0
+    let resolved = 0
+
+    await expect(awaitFinalPlanningLayer({
+      getFinalLayer: () => undefined,
+      getSimError: () => undefined,
+      getInFlight: () => null,
+      startRun: () => {
+        started++
+        return Promise.resolve().then(() => {
+          resolved++
+        })
+      },
+      maxAttempts: 3,
+    })).rejects.toThrow('Batch simulation not loaded')
+
+    expect(started).toBe(3) // no extra un-awaited run kicked on the terminal iteration
+    expect(resolved).toBe(3) // every started run completed (was awaited) before the throw
   })
 })

--- a/tests/composables/useTxBatch.test.ts
+++ b/tests/composables/useTxBatch.test.ts
@@ -396,6 +396,52 @@ describe('stitchAccount', () => {
     expect(portfolio.borrows[0]?.healthFactor).toBe(1720000000000000000n)
   })
 
+  it('omits a pre-existing enabled-but-empty collateral from simulated borrow liquidity', () => {
+    // `vault` is a funded collateral; `targetVault` is a leftover EVC enablement
+    // with no balance and no entry in the borrow's lens collaterals. A plain
+    // repay leaves the enabled set unchanged, so `targetVault` is enabled both
+    // before and after the batch. It must NOT surface as a zero-value collateral
+    // row — only collaterals newly enabled by the batch are added unconditionally.
+    const base = accountWithPositions(
+      [collateralPosition(100_000_000n), borrowPosition(50_000_000n, 100)],
+      [vault, targetVault],
+      [borrowVault],
+    )
+    const touched = accountWithPositions(
+      [borrowPosition(25_000_000n, 100)],
+      [vault, targetVault],
+      [borrowVault],
+    )
+
+    const stitched = stitchAccount(base, touched)
+    const stitchedBorrow = stitched.getPosition(subAccount, borrowVault)
+
+    expect(stitchedBorrow?.liquidity?.collaterals.map(collateral => getAddress(collateral.address))).toEqual([vault])
+    expect(stitchedBorrow?.liquidity?.totalCollateralValueUsd).toBe(100)
+  })
+
+  it('never lists the borrow vault as its own collateral', () => {
+    // The EVC can have the borrow vault enabled as a collateral. Its own borrow
+    // position carries debt, so it passes hasPositionValue — but a vault is never
+    // its own collateral (the controller grants it no LTV; the lens omits it), so
+    // it must not appear as a spurious zero-value collateral row.
+    const base = accountWithPositions(
+      [collateralPosition(100_000_000n), borrowPosition(50_000_000n, 100)],
+      [vault, borrowVault],
+      [borrowVault],
+    )
+    const touched = accountWithPositions(
+      [borrowPosition(25_000_000n, 100)],
+      [vault, borrowVault],
+      [borrowVault],
+    )
+
+    const stitched = stitchAccount(base, touched)
+    const stitchedBorrow = stitched.getPosition(subAccount, borrowVault)
+
+    expect(stitchedBorrow?.liquidity?.collaterals.map(collateral => getAddress(collateral.address))).toEqual([vault])
+  })
+
   it('scales existing collateral but does not value newly enabled collateral when risk prices are unavailable', () => {
     const { sourceVault, destinationVault, borrow } = riskAwareBorrowPosition(false)
     const base = accountWithPositions([

--- a/tests/entities/oracle.test.ts
+++ b/tests/entities/oracle.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import type { Address } from 'viem'
 import {
+  getChecksStatus,
   getRouterRecognition,
+  normalizeOracleAdapterCheckSeverity,
   resolveOracleAdapterIdentity,
   type OracleAdapterMeta,
+  OracleAdapterCheckSeverity,
 } from '~/entities/oracle'
 
 const oracle = '0x0000000000000000000000000000000000000001' as Address
@@ -86,5 +89,30 @@ describe('getRouterRecognition (LITE-236)', () => {
   it('returns "unrecognized" when any router is missing from the allowlist', () => {
     const recognized = new Set([router])
     expect(getRouterRecognition([router, otherRouter], recognized)).toBe('unrecognized')
+  })
+})
+
+describe('normalizeOracleAdapterCheckSeverity', () => {
+  it('accepts oracle-checks wire casing', () => {
+    expect(normalizeOracleAdapterCheckSeverity('High')).toBe(OracleAdapterCheckSeverity.High)
+    expect(normalizeOracleAdapterCheckSeverity('Med')).toBe(OracleAdapterCheckSeverity.Medium)
+    expect(normalizeOracleAdapterCheckSeverity('Info')).toBe(OracleAdapterCheckSeverity.Info)
+  })
+
+  it('keeps enum casing and falls back to info for unknown values', () => {
+    expect(normalizeOracleAdapterCheckSeverity(OracleAdapterCheckSeverity.High)).toBe(OracleAdapterCheckSeverity.High)
+    expect(normalizeOracleAdapterCheckSeverity('wat')).toBe(OracleAdapterCheckSeverity.Info)
+    expect(normalizeOracleAdapterCheckSeverity(undefined)).toBe(OracleAdapterCheckSeverity.Info)
+  })
+})
+
+describe('getChecksStatus', () => {
+  it('treats normalized high-severity failures as negative', () => {
+    expect(getChecksStatus([{
+      id: 'Source code provenance',
+      message: 'Contract metadata hash is not recognized.',
+      pass: false,
+      severity: normalizeOracleAdapterCheckSeverity('High'),
+    }])).toBe('negative')
   })
 })

--- a/tests/entities/oracle.test.ts
+++ b/tests/entities/oracle.test.ts
@@ -14,7 +14,7 @@ const makeMeta = (overrides: Partial<OracleAdapterMeta> = {}): OracleAdapterMeta
 })
 
 describe('resolveOracleAdapterIdentity', () => {
-  it('uses curated name/provider for a recognised adapter', () => {
+  it('uses curated name/provider for a recognized adapter', () => {
     const meta = makeMeta({ name: 'Chainlink WETH/USD', provider: 'Chainlink' })
     const identity = resolveOracleAdapterIdentity({ name: 'ChainlinkOracle' }, meta, true)
 
@@ -39,7 +39,7 @@ describe('resolveOracleAdapterIdentity', () => {
 
     expect(identity.name).toBeUndefined()
     expect(identity.provider).toBeUndefined()
-    // A curated entry exists, so it is recognised — not a custom adapter.
+    // A curated entry exists, so it is recognized — not a custom adapter.
     expect(identity.isCustomAdapter).toBe(false)
   })
 
@@ -63,28 +63,28 @@ describe('getRouterRecognition (LITE-236)', () => {
   })
 
   it('returns null when there are no router addresses to check', () => {
-    const recognised = new Set([router])
-    expect(getRouterRecognition([], recognised)).toBeNull()
-    expect(getRouterRecognition([undefined, null], recognised)).toBeNull()
+    const recognized = new Set([router])
+    expect(getRouterRecognition([], recognized)).toBeNull()
+    expect(getRouterRecognition([undefined, null], recognized)).toBeNull()
   })
 
-  it('returns "recognised" when every router is in the allowlist', () => {
-    const recognised = new Set([router, otherRouter])
-    expect(getRouterRecognition([router, otherRouter], recognised)).toBe('recognised')
+  it('returns "recognized" when every router is in the allowlist', () => {
+    const recognized = new Set([router, otherRouter])
+    expect(getRouterRecognition([router, otherRouter], recognized)).toBe('recognized')
   })
 
   it('matches addresses case-insensitively', () => {
-    const recognised = new Set([router])
-    expect(getRouterRecognition([router.toUpperCase()], recognised)).toBe('recognised')
+    const recognized = new Set([router])
+    expect(getRouterRecognition([router.toUpperCase()], recognized)).toBe('recognized')
   })
 
   it('ignores nullish entries when classifying', () => {
-    const recognised = new Set([router])
-    expect(getRouterRecognition([undefined, router, null], recognised)).toBe('recognised')
+    const recognized = new Set([router])
+    expect(getRouterRecognition([undefined, router, null], recognized)).toBe('recognized')
   })
 
-  it('returns "unrecognised" when any router is missing from the allowlist', () => {
-    const recognised = new Set([router])
-    expect(getRouterRecognition([router, otherRouter], recognised)).toBe('unrecognised')
+  it('returns "unrecognized" when any router is missing from the allowlist', () => {
+    const recognized = new Set([router])
+    expect(getRouterRecognition([router, otherRouter], recognized)).toBe('unrecognized')
   })
 })

--- a/tests/entities/oracle.test.ts
+++ b/tests/entities/oracle.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest'
+import type { Address } from 'viem'
+import {
+  getRouterRecognition,
+  resolveOracleAdapterIdentity,
+  type OracleAdapterMeta,
+} from '~/entities/oracle'
+
+const oracle = '0x0000000000000000000000000000000000000001' as Address
+
+const makeMeta = (overrides: Partial<OracleAdapterMeta> = {}): OracleAdapterMeta => ({
+  oracle,
+  ...overrides,
+})
+
+describe('resolveOracleAdapterIdentity', () => {
+  it('uses curated name/provider for a recognised adapter', () => {
+    const meta = makeMeta({ name: 'Chainlink WETH/USD', provider: 'Chainlink' })
+    const identity = resolveOracleAdapterIdentity({ name: 'ChainlinkOracle' }, meta, true)
+
+    expect(identity).toEqual({
+      name: 'Chainlink WETH/USD',
+      provider: 'Chainlink',
+      isCustomAdapter: false,
+    })
+  })
+
+  it('marks an adapter with no curated entry as custom and does NOT leak the onchain name (LITE-235)', () => {
+    const identity = resolveOracleAdapterIdentity({ name: 'ChainlinkOracle' }, undefined, true)
+
+    expect(identity.name).toBeUndefined()
+    expect(identity.provider).toBeUndefined()
+    expect(identity.isCustomAdapter).toBe(true)
+  })
+
+  it('does not fall back to the onchain name when the curated entry omits name/provider', () => {
+    const meta = makeMeta({ methodology: 'Market price' })
+    const identity = resolveOracleAdapterIdentity({ name: 'ChainlinkOracle' }, meta, true)
+
+    expect(identity.name).toBeUndefined()
+    expect(identity.provider).toBeUndefined()
+    // A curated entry exists, so it is recognised — not a custom adapter.
+    expect(identity.isCustomAdapter).toBe(false)
+  })
+
+  it('keeps the decoded name for non-adapter structural steps (e.g. ERC-4626 exchange rate)', () => {
+    const identity = resolveOracleAdapterIdentity({ name: 'ERC4626Vault' }, undefined, false)
+
+    expect(identity).toEqual({
+      name: 'ERC4626Vault',
+      provider: 'ERC4626Vault',
+      isCustomAdapter: false,
+    })
+  })
+})
+
+describe('getRouterRecognition (LITE-236)', () => {
+  const router = '0xabc0000000000000000000000000000000000001'
+  const otherRouter = '0xdef0000000000000000000000000000000000002'
+
+  it('returns null when the allowlist is unavailable (empty set)', () => {
+    expect(getRouterRecognition([router], new Set())).toBeNull()
+  })
+
+  it('returns null when there are no router addresses to check', () => {
+    const recognised = new Set([router])
+    expect(getRouterRecognition([], recognised)).toBeNull()
+    expect(getRouterRecognition([undefined, null], recognised)).toBeNull()
+  })
+
+  it('returns "recognised" when every router is in the allowlist', () => {
+    const recognised = new Set([router, otherRouter])
+    expect(getRouterRecognition([router, otherRouter], recognised)).toBe('recognised')
+  })
+
+  it('matches addresses case-insensitively', () => {
+    const recognised = new Set([router])
+    expect(getRouterRecognition([router.toUpperCase()], recognised)).toBe('recognised')
+  })
+
+  it('ignores nullish entries when classifying', () => {
+    const recognised = new Set([router])
+    expect(getRouterRecognition([undefined, router, null], recognised)).toBe('recognised')
+  })
+
+  it('returns "unrecognised" when any router is missing from the allowlist', () => {
+    const recognised = new Set([router])
+    expect(getRouterRecognition([router, otherRouter], recognised)).toBe('unrecognised')
+  })
+})

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -6,7 +6,7 @@
  * server/ module that calls one of these globals at module top level.
  */
 
-import { computed, reactive, ref, shallowReactive, shallowRef, watch, watchEffect } from 'vue'
+import { computed, reactive, readonly, ref, shallowReactive, shallowRef, watch, watchEffect } from 'vue'
 
 type AnyFn = (...args: unknown[]) => unknown
 
@@ -26,6 +26,7 @@ const vueGlobals: Record<string, unknown> = {
   shallowRef,
   reactive,
   shallowReactive,
+  readonly,
   computed,
   watch,
   watchEffect,

--- a/tests/utils/chain-registry.test.ts
+++ b/tests/utils/chain-registry.test.ts
@@ -26,6 +26,14 @@ describe('chainRegistry', () => {
     expect(getDefiLlamaChainName(999)).toBe('Hyperliquid')
   })
 
+  it('uses MonadScan as the Monad block explorer', () => {
+    const chain = getChainById(143)
+
+    expect(chain?.blockExplorers?.default.name).toBe('MonadScan')
+    expect(chain?.blockExplorers?.default.url).toBe('https://monadscan.com/')
+    expect(getChainIdByName('monad')).toBe(143)
+  })
+
   it('keeps reverse slug lookup pinned to canonical chain ID collisions', () => {
     expect(getChainIdByName('hyperEvm')).toBe(999)
     expect(getChainIdByName('hyperliquid')).toBe(999)

--- a/tests/utils/oracle-adapter-views.test.ts
+++ b/tests/utils/oracle-adapter-views.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+import type { Address } from 'viem'
+import type { EVault, OracleRouteStep } from '@eulerxyz/euler-v2-sdk'
+import type { OracleAdapterMeta } from '~/entities/oracle'
+import { OracleAdapterCheckSeverity } from '~/entities/oracle'
+import { buildOracleAdapterView, collectOracleRouteSteps } from '~/utils/oracle-adapter-views'
+
+const oracle = '0x000000000000000000000000000000000000A111' as Address
+const weth = '0x000000000000000000000000000000000000E711' as Address
+const usd = '0x0000000000000000000000000000000000000051' as Address
+
+const adapterStep = (overrides: Partial<OracleRouteStep> = {}): OracleRouteStep => ({
+  kind: 'adapter',
+  oracle,
+  base: weth,
+  quote: usd,
+  name: 'ChainlinkOracle',
+  ...overrides,
+} as OracleRouteStep)
+
+describe('buildOracleAdapterView', () => {
+  it('enriches a recognized adapter from curated metadata', () => {
+    const meta: Record<string, OracleAdapterMeta> = {
+      [oracle.toLowerCase()]: {
+        oracle,
+        base: weth,
+        quote: usd,
+        name: 'Chainlink WETH/USD',
+        provider: 'Chainlink',
+        methodology: 'Market price',
+        label: 'Chainlink WETH/USD (Primary)',
+        checks: [{ id: 'staleness', message: 'ok', pass: true, severity: OracleAdapterCheckSeverity.Info }],
+      },
+    }
+    const view = buildOracleAdapterView(adapterStep(), meta)
+
+    expect(view.provider).toBe('Chainlink')
+    expect(view.name).toBe('Chainlink WETH/USD')
+    expect(view.isCustomAdapter).toBe(false)
+    expect(view.methodology).toBe('Market price')
+    expect(view.logo).toBe('/oracles/chainlink.svg')
+    expect(view.label).toEqual({ primary: 'Chainlink WETH/USD', suffix: '(Primary)' })
+    expect(view.checksStatus).toBe('positive')
+  })
+
+  it('flags an adapter with no curated entry as custom (no onchain-name leak, no logo)', () => {
+    const view = buildOracleAdapterView(adapterStep(), {})
+
+    expect(view.name).toBeUndefined()
+    expect(view.provider).toBeUndefined()
+    expect(view.isCustomAdapter).toBe(true)
+    expect(view.logo).toBeUndefined()
+    expect(view.label).toBeUndefined()
+    expect(view.checksStatus).toBeNull()
+  })
+
+  it('keeps the decoded name and "Exchange Rate" methodology for vault (ERC-4626) steps', () => {
+    const view = buildOracleAdapterView(adapterStep({ kind: 'vault', name: 'ERC4626Vault' }), {})
+
+    expect(view.name).toBe('ERC4626Vault')
+    expect(view.isCustomAdapter).toBe(false)
+    expect(view.methodology).toBe('Exchange Rate')
+  })
+
+  it('marks a high-severity failing check as a negative status', () => {
+    const meta: Record<string, OracleAdapterMeta> = {
+      [oracle.toLowerCase()]: {
+        oracle,
+        provider: 'Chainlink',
+        checks: [{ id: 'staleness', message: 'stale', pass: false, severity: OracleAdapterCheckSeverity.High }],
+      },
+    }
+    const view = buildOracleAdapterView(adapterStep(), meta)
+
+    expect(view.checksStatus).toBe('negative')
+    expect(view.failedChecks).toHaveLength(1)
+  })
+})
+
+describe('collectOracleRouteSteps', () => {
+  const debtStep = adapterStep({ oracle: '0x00000000000000000000000000000000000000d1' as Address })
+  const collateralStep = adapterStep({ oracle: '0x00000000000000000000000000000000000000c1' as Address, base: usd, quote: weth })
+
+  const makeVault = (collateralAddr: string): EVault => ({
+    debtPricingOracleRoute: { steps: [debtStep] },
+    collaterals: [
+      { address: collateralAddr, oracleRoute: { steps: [collateralStep] } },
+    ],
+  } as unknown as EVault)
+
+  it('returns the debt route when there are no collaterals', () => {
+    const steps = collectOracleRouteSteps([makeVault('0xdead')])
+    expect(steps).toEqual([debtStep])
+  })
+
+  it('combines debt + collateral routes for the pair', () => {
+    const collateralAddr = '0x00000000000000000000000000000000000000cc'
+    const collateralVault = { address: collateralAddr } as unknown as EVault
+    const steps = collectOracleRouteSteps([makeVault(collateralAddr)], [collateralVault])
+
+    expect(steps).toContain(debtStep)
+    expect(steps).toContain(collateralStep)
+    expect(steps).toHaveLength(2)
+  })
+
+  it('dedupes identical steps across vaults', () => {
+    const v = makeVault('0xdead')
+    const steps = collectOracleRouteSteps([v, v])
+    expect(steps).toHaveLength(1)
+  })
+})

--- a/tests/utils/vault-intrinsic-apy.test.ts
+++ b/tests/utils/vault-intrinsic-apy.test.ts
@@ -24,6 +24,7 @@
 import { describe, expect, it } from 'vitest'
 import type { IntrinsicApyInfo } from '@eulerxyz/euler-v2-sdk'
 import {
+  combineApyWithIntrinsic,
   EMPTY_INTRINSIC_APY,
   getVaultIntrinsicApy,
   getVaultIntrinsicApyInfo,
@@ -86,6 +87,29 @@ describe('getVaultIntrinsicApy', () => {
 
   it('returns 0 for an undefined vault', () => {
     expect(getVaultIntrinsicApy(undefined, true)).toBe(0)
+  })
+})
+
+describe('combineApyWithIntrinsic', () => {
+  it('pins the compounded total used by Earn/Supply displays and APY modals', () => {
+    const base = 4
+    const intrinsic = 1
+    const rewards = 0.5
+
+    const compounded = combineApyWithIntrinsic(base, intrinsic)
+
+    expect(compounded).toBeCloseTo(4 + (1 + 4 / 100) * 1)
+    expect(compounded + rewards).toBeCloseTo(5.54)
+    expect(base + intrinsic + rewards).toBe(5.5)
+  })
+
+  it('pins borrow-side totals as compounded intrinsic minus rewards', () => {
+    const borrowing = 6
+    const intrinsic = 2
+    const rewards = 0.25
+
+    expect(combineApyWithIntrinsic(borrowing, intrinsic) - rewards)
+      .toBeCloseTo(6 + (1 + 6 / 100) * 2 - 0.25)
   })
 })
 

--- a/utils/oracle-adapter-views.ts
+++ b/utils/oracle-adapter-views.ts
@@ -1,0 +1,108 @@
+import type { Address } from 'viem'
+import type { EVault, OracleRouteStep, SecuritizeCollateralVault } from '@eulerxyz/euler-v2-sdk'
+import {
+  getChecksStatus,
+  resolveOracleAdapterIdentity,
+  type OracleAdapterCheck,
+  type OracleAdapterMeta,
+} from '~/entities/oracle'
+import { getOracleProviderLogo } from '~/entities/oracle-providers'
+import { shouldInvertOraclePrice } from '~/utils/oracle-label'
+import { getCollateralOracleRouteSteps, getDebtOracleRouteSteps, isOracleAdapterRouteStep } from '~/utils/oracle-route-steps'
+import { getOracleRouteStepKey } from '~/composables/useOracleAdapterPrices'
+
+// Single source of truth for the oracle adapters shown on the borrow page's
+// Oracles block AND in the explore matrix. Both surfaces must agree on which
+// adapters price a given (liability, collateral) pair, so the collection and
+// per-step enrichment live here rather than being duplicated per component.
+
+export type OracleAdapterView = {
+  key: string
+  kind: OracleRouteStep['kind']
+  oracle: Address
+  base: Address
+  quote: Address
+  metaBase?: Address
+  metaQuote?: Address
+  name?: string
+  provider?: string
+  isCustomAdapter: boolean
+  methodology?: string
+  logo?: string
+  label?: { primary: string, suffix?: string }
+  invertPrice: boolean
+  checks?: OracleAdapterCheck[]
+  checksStatus: 'positive' | 'warning' | 'negative' | null
+  failedChecks: OracleAdapterCheck[]
+}
+
+// Collects the deduped oracle route steps that price the given liability
+// vault(s) together with the given collateral vault(s): each liability's own
+// asset->unit-of-account (debt) route plus the collateral->unit-of-account
+// route for every collateral. Mirrors what the borrow page shows for a pair.
+export const collectOracleRouteSteps = (
+  vaults: EVault[],
+  collateralVaults: (EVault | SecuritizeCollateralVault)[] = [],
+): OracleRouteStep[] => {
+  const deduped = new Map<string, OracleRouteStep>()
+  for (const vault of vaults) {
+    const steps: OracleRouteStep[] = [...getDebtOracleRouteSteps(vault)]
+    for (const collateralVault of collateralVaults) {
+      steps.push(...getCollateralOracleRouteSteps(vault, collateralVault))
+    }
+    for (const step of steps) {
+      const key = getOracleRouteStepKey(step)
+      if (!deduped.has(key)) deduped.set(key, step)
+    }
+  }
+  return [...deduped.values()]
+}
+
+const parseAdapterLabel = (label: string | undefined): { primary: string, suffix?: string } | undefined =>
+  label
+    ? {
+        primary: label.split('(')[0].trimEnd(),
+        suffix: label.includes('(') ? label.slice(label.indexOf('(')).trim() : undefined,
+      }
+    : undefined
+
+// Enriches one oracle route step into a display view, resolving its identity
+// from the curated oracle-checks dataset (see resolveOracleAdapterIdentity).
+export const buildOracleAdapterView = (
+  step: OracleRouteStep,
+  oracleAdapters: Record<string, OracleAdapterMeta>,
+): OracleAdapterView => {
+  const isAdapter = isOracleAdapterRouteStep(step)
+  const meta = isAdapter ? oracleAdapters[step.oracle.toLowerCase()] : undefined
+  const { name, provider, isCustomAdapter } = resolveOracleAdapterIdentity(step, meta, isAdapter)
+  const checks = meta?.checks
+  return {
+    key: getOracleRouteStepKey(step),
+    kind: step.kind,
+    oracle: step.oracle,
+    base: step.base,
+    quote: step.quote,
+    metaBase: meta?.base,
+    metaQuote: meta?.quote,
+    name,
+    provider,
+    isCustomAdapter,
+    methodology: meta?.methodology || (step.kind === 'vault' ? 'Exchange Rate' : undefined),
+    logo: getOracleProviderLogo(provider, name),
+    label: parseAdapterLabel(meta?.label),
+    invertPrice: shouldInvertOraclePrice({
+      metaBase: meta?.base,
+      metaQuote: meta?.quote,
+      callerBase: step.base,
+      callerQuote: step.quote,
+    }),
+    checks,
+    checksStatus: getChecksStatus(checks),
+    failedChecks: checks?.filter(c => !c.pass) ?? [],
+  }
+}
+
+export const buildOracleAdapterViews = (
+  steps: OracleRouteStep[],
+  oracleAdapters: Record<string, OracleAdapterMeta>,
+): OracleAdapterView[] => steps.map(step => buildOracleAdapterView(step, oracleAdapters))

--- a/utils/vault-intrinsic-apy.ts
+++ b/utils/vault-intrinsic-apy.ts
@@ -21,12 +21,22 @@ export function getVaultIntrinsicApy(
   return getVaultIntrinsicApyInfo(vault, enabled).apy
 }
 
+/**
+ * Combine a base APY with an intrinsic (e.g. staking) APY the way a yield-bearing
+ * position actually accrues: the intrinsic yield compounds on top of the base
+ * rather than being a flat sum. `combineApyWithIntrinsic(5, 4) = 5 + 1.05 * 4 = 9.2`.
+ * Shared by the headline figures (via withVaultIntrinsicApy) and the APY tooltips
+ * so both report the same total.
+ */
+export function combineApyWithIntrinsic(baseApy: number, intrinsicApy: number): number {
+  if (!intrinsicApy) return baseApy
+  return baseApy + (1 + baseApy / 100) * intrinsicApy
+}
+
 export function withVaultIntrinsicApy(
   baseApy: number,
   vault: VaultWithIntrinsicApy | undefined,
   enabled: boolean,
 ): number {
-  const intrinsic = getVaultIntrinsicApy(vault, enabled)
-  if (intrinsic === 0) return baseApy
-  return baseApy + (1 + baseApy / 100) * intrinsic
+  return combineApyWithIntrinsic(baseApy, getVaultIntrinsicApy(vault, enabled))
 }


### PR DESCRIPTION
## Summary
Syncs `development` into `master` for the next release. Changelist is based on the net diff `origin/master..origin/development` at base `d15b4cb` and head `f285139c`.

## Changelist

### Features
- Strengthen oracle trust and display signals: unknown adapters render as `Unknown` instead of self-reported names, custom adapters get explicit `Custom - set by risk manager` checks copy, vault oracle routers are checked against the recognized EulerRouter allowlist, and the Explore matrix shows pair oracle adapter logos with an inline Oracles detail section instead of floating logo popovers (#638, #641) @kasperpawlowski
- Update Monad explorer metadata to MonadScan and cover name-based chain lookup (#640) @kanvgupta

### Fixes
- Reconcile intrinsic APY across supply, borrow, net APY, Earn, Lend, Borrow, Portfolio tooltips/headlines, Earn detail/list/card/modal totals, and Portfolio deposit cards by using the shared intrinsic compounding path and SDK supply APY breakdowns with the active viewer (#632, #634, #635, #636, #637, #645) @kasperpawlowski @Seranged
- Harden batch simulation/resimulation around superseded runs, stale in-flight promises, and missing final planning layers to reduce false `Batch simulation not loaded` errors (#631) @dglowinski
- Keep simulated borrow liquidity from surfacing pre-existing empty collateral enablements or the borrow vault itself as collateral (#639) @dglowinski
- Improve transaction review modal contrast and action styling, switch the Permit2 infinite-approval alert to info treatment, refresh info toast colors, and show the copied-calldata Permit2 note only after calldata is copied (#642) @kanvgupta

### Docs
- Document correlated-asset metrics, token category tags, borrow filter inputs, and borrow-side intrinsic APY semantics (#633) @cursor[bot]

## Validation
- Rebuilt changelist from `git diff --stat --find-renames origin/master..origin/development` and `git diff --name-status --find-renames origin/master..origin/development`
- Cross-checked first-parent merges, PR metadata, and the nested oracle-matrix PR that survives in the final diff
- Tests not re-run for this description-only update