### PR TITLE
fix: align supply APY totals

### DIFF
--- a/components/entities/portfolio/PortfolioEarnItem.vue
+++ b/components/entities/portfolio/PortfolioEarnItem.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { EulerEarn, PortfolioSavingsPosition, VaultEntity } from '@eulerxyz/euler-v2-sdk'
-import { getSubAccountId as getSubAccountIndex } from '@eulerxyz/euler-v2-sdk'
+import { computeSupplyApyBreakdown, getSubAccountId as getSubAccountIndex } from '@eulerxyz/euler-v2-sdk'
 import { getAddress } from 'viem'
 import { formatAssetValue, getAssetUsdValue } from '~/utils/sdk-prices'
 import { isVaultBlockedByCountry } from '~/composables/useGeoBlock'
@@ -28,16 +28,18 @@ const { settings } = useUserSettings()
 const enableIntrinsicApy = computed(() => settings.value.enableIntrinsicApy)
 const { viewer, visibleTotal, visibleBreakdown } = useApyVisibility()
 
-const vault = computed(() => position.vault as EulerEarn)
+const { getVault: getRegistryVault, isVerifiedVault } = useVaultRegistry()
+const vault = computed(() =>
+  (getRegistryVault(position.vault!.address) as EulerEarn | undefined) ?? (position.vault as EulerEarn),
+)
 const positionKey = computed(() => `${position.subAccount.toLowerCase()}:${vault.value.address.toLowerCase()}`)
 const { modifiedKeys, removedKeys } = useTxBatch()
 const isSimulatedRemoved = computed(() => removedKeys.value.has(positionKey.value))
 const isSimulatedModified = computed(() => !isSimulatedRemoved.value && modifiedKeys.value.has(positionKey.value))
-const apyBreakdown = computed(() => position.getApyBreakdown({ viewer: viewer.value }))
+const apyBreakdown = computed(() => computeSupplyApyBreakdown(vault.value, viewer.value))
 const rewardsExist = computed(() =>
   settings.value.enableRewardsApy && (apyBreakdown.value?.rewards ?? 0) > 0,
 )
-const { isVerifiedVault } = useVaultRegistry()
 
 const product = useEulerProductOfVault(computed(() => vault.value.address))
 const isGeoBlocked = computed(() => isVaultBlockedByCountry(vault.value.address))

--- a/components/entities/portfolio/PortfolioSavingItem.vue
+++ b/components/entities/portfolio/PortfolioSavingItem.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { getSubAccountId as getSubAccountIndex, isSecuritizeCollateralVault, type EVault, type PortfolioSavingsPosition, type VaultEntity } from '@eulerxyz/euler-v2-sdk'
+import { computeSupplyApyBreakdown, getSubAccountId as getSubAccountIndex, isSecuritizeCollateralVault, type EVault, type PortfolioSavingsPosition, type VaultEntity } from '@eulerxyz/euler-v2-sdk'
 import { getAddress } from 'viem'
 
 import { getUtilisationWarning } from '~/composables/useVaultWarnings'
@@ -28,7 +28,10 @@ const enableIntrinsicApy = computed(() => settings.value.enableIntrinsicApy)
 const { getSupplyRewardCampaignsFromVault } = useRewardsApy()
 const { viewer, visibleTotal, visibleBreakdown } = useApyVisibility()
 
-const vault = computed(() => position.vault!)
+const { getVault: getRegistryVault, getVaultCategory, isVerifiedVault } = useVaultRegistry()
+const vault = computed(() =>
+  (getRegistryVault(position.vault!.address) as VaultEntity | undefined) ?? position.vault!,
+)
 const positionKey = computed(() => `${position.subAccount.toLowerCase()}:${vault.value.address.toLowerCase()}`)
 // Positions the active simulated batch layer modified get a dotted border.
 const { modifiedKeys, removedKeys } = useTxBatch()
@@ -41,7 +44,7 @@ const utilisationWarning = computed(() => {
 
 const isSecuritize = computed(() => isSecuritizeCollateralVault(vault.value))
 
-const apyBreakdown = computed(() => position.getApyBreakdown({ viewer: viewer.value }))
+const apyBreakdown = computed(() => computeSupplyApyBreakdown(vault.value, viewer.value))
 const rewardsExist = computed(() =>
   settings.value.enableRewardsApy && (apyBreakdown.value?.rewards ?? 0) > 0,
 )
@@ -49,7 +52,6 @@ const supplyApyWithRewards = computed(() => visibleTotal(apyBreakdown.value) ?? 
 const visibleApyBreakdown = computed(() => visibleBreakdown(apyBreakdown.value))
 
 const product = useEulerProductOfVault(computed(() => vault.value.address))
-const { getVaultCategory, isVerifiedVault } = useVaultRegistry()
 const isGeoBlocked = computed(() => isVaultBlockedByCountry(vault.value.address))
 const isDeprecated = computed(() => isVaultDeprecated(vault.value.address))
 const isEscrow = computed(() => getVaultCategory(vault.value.address) === 'escrow')

--- a/components/entities/vault/overview/earn/VaultOverviewEarnBlockStats.vue
+++ b/components/entities/vault/overview/earn/VaultOverviewEarnBlockStats.vue
@@ -1,19 +1,21 @@
 <script setup lang="ts">
-import type { EulerEarn } from '@eulerxyz/euler-v2-sdk'
+import { computeSupplyApyBreakdown, type EulerEarn } from '@eulerxyz/euler-v2-sdk'
 import { formatAssetValue } from '~/utils/sdk-prices'
 import { formatNumber, formatCompactUsdValue } from '~/utils/string-utils'
 import { VaultSupplyApyModal, UiModalPreviewTrigger } from '#components'
-import { getVaultIntrinsicApy, getVaultIntrinsicApyInfo } from '~/utils/vault-intrinsic-apy'
+import { getVaultIntrinsicApyInfo } from '~/utils/vault-intrinsic-apy'
 
 const { vault } = defineProps<{ vault: EulerEarn }>()
 
 const { settings } = useUserSettings()
 const enableIntrinsicApy = computed(() => settings.value.enableIntrinsicApy)
-const { getSupplyRewardApy, getSupplyRewardCampaigns, hasSupplyRewards } = useRewardsApy()
+const { getSupplyRewardCampaigns, hasSupplyRewards } = useRewardsApy()
+const { viewer, visibleTotal, visibleBreakdown } = useApyVisibility()
 
-const rewardSupplyAPY = computed(() => getSupplyRewardApy(vault.address))
-const intrinsicApy = computed(() => getVaultIntrinsicApy(vault, enableIntrinsicApy.value))
-const supplyApyTotal = computed(() => getVaultSupplyApy(vault) + intrinsicApy.value + rewardSupplyAPY.value)
+const supplyApyBreakdown = computed(() => computeSupplyApyBreakdown(vault, viewer.value))
+const visibleApyBreakdown = computed(() => visibleBreakdown(supplyApyBreakdown.value))
+const supplyApyTotal = computed(() => visibleTotal(supplyApyBreakdown.value) ?? 0)
+const hasRewards = computed(() => settings.value.enableRewardsApy && hasSupplyRewards(vault.address))
 
 const totalSupplyDisplay = ref('-')
 
@@ -31,10 +33,10 @@ watchEffect(async () => {
 
 const supplyApyModalData = computed(() => ({
   props: {
-    lendingAPY: getVaultSupplyApy(vault),
-    intrinsicAPY: getVaultIntrinsicApy(vault, enableIntrinsicApy.value),
+    lendingAPY: visibleApyBreakdown.value?.lending ?? 0,
+    intrinsicAPY: visibleApyBreakdown.value?.intrinsicApy ?? 0,
     intrinsicApyInfo: getVaultIntrinsicApyInfo(vault, enableIntrinsicApy.value),
-    campaigns: getSupplyRewardCampaigns(vault.address),
+    campaigns: settings.value.enableRewardsApy ? getSupplyRewardCampaigns(vault.address) : [],
     totalSupplyAPY: supplyApyTotal.value,
     rewardVaultAddress: vault.address,
     baseApyAverageLabel: '1h',
@@ -71,7 +73,7 @@ const supplyApyModalData = computed(() => ({
         </template>
         <span class="flex items-center gap-4">
           <UiModalPreviewTrigger
-            v-if="hasSupplyRewards(vault.address)"
+            v-if="hasRewards"
             :component="VaultSupplyApyModal"
             :modal-data="supplyApyModalData"
             aria-label="Show supply APY rewards breakdown"

--- a/docs/intrinsic-apy.md
+++ b/docs/intrinsic-apy.md
@@ -90,13 +90,13 @@ The SDK exposes an equivalent on its side: `computeSupplyApyBreakdown(vault)` re
 
 Borrow views call the same helper path, but the UI copy treats intrinsic APY as cost-side yield. `VaultBorrowItem.vue` passes `getVaultIntrinsicApyInfo()` into `VaultBorrowApyModal.vue`; that modal describes intrinsic APY as "yield intrinsic to the borrowed asset ... which increases effective borrowing cost".
 
-The borrow APY modal's breakdown is additive:
+The borrow APY modal uses the same compounded intrinsic helper as supply-side displays, then subtracts borrow rewards:
 
 ```text
-total borrow APY = borrowing APY + intrinsic APY - reward APY
+total borrow APY = borrowing APY + (1 + borrowing APY / 100) * intrinsic APY - reward APY
 ```
 
-Pair-level Net APY and Max ROE screens still use the compounded helper for consistency with vault headline APYs. When changing borrow-side APY copy, keep the direction explicit: intrinsic yield on the debt asset makes borrowing more expensive, while borrow rewards reduce the displayed cost.
+Pair-level Net APY and Max ROE screens use the same compounded helper for consistency with vault headline APYs. When changing borrow-side APY copy, keep the direction explicit: intrinsic yield on the debt asset makes borrowing more expensive, while borrow rewards reduce the displayed cost.
 
 ## User toggle
 

--- a/pages/earn/[vault]/index.vue
+++ b/pages/earn/[vault]/index.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import type { VaultAsset } from '~/types/asset'
-import type { TransactionPlan, EulerEarn } from '@eulerxyz/euler-v2-sdk'
+import { computeSupplyApyBreakdown, type TransactionPlan, type EulerEarn } from '@eulerxyz/euler-v2-sdk'
 import { useEulerProductOfVault } from '~/composables/useEulerLabels'
-import { getVaultIntrinsicApy, getVaultIntrinsicApyInfo } from '~/utils/vault-intrinsic-apy'
+import { getVaultIntrinsicApyInfo } from '~/utils/vault-intrinsic-apy'
 import { isVaultBlockedByCountry } from '~/composables/useGeoBlock'
 import VaultFormInfoBlock from '~/components/entities/vault/form/VaultFormInfoBlock.vue'
 import VaultFormSubmit from '~/components/entities/vault/form/VaultFormSubmit.vue'
@@ -41,7 +41,8 @@ useOperationGuard([vaultAddress])
 const { name } = useEulerProductOfVault(vaultAddress)
 const { settings } = useUserSettings()
 const enableIntrinsicApy = computed(() => settings.value.enableIntrinsicApy)
-const { getSupplyRewardApy, hasSupplyRewards, getSupplyRewardCampaigns } = useRewardsApy()
+const { hasSupplyRewards, getSupplyRewardCampaigns } = useRewardsApy()
+const { viewer, visibleTotal, visibleBreakdown } = useApyVisibility()
 
 const isLoading = ref(false)
 const isSubmitting = ref(false)
@@ -56,6 +57,11 @@ const earnVaultMarketLabel = computed(() => unref(name) || vault.value?.shares.n
 // Wallet balance from the central (layer-aware) wallet entity — reactive, no
 // direct balanceOf.
 const balance = computed(() => asset.value?.address ? getBalance(asset.value.address as Address) : 0n)
+const supplyRewardCampaigns = computed(() => getSupplyRewardCampaigns(vaultAddress))
+const hasRewards = computed(() => settings.value.enableRewardsApy && hasSupplyRewards(vaultAddress))
+const supplyApyBreakdown = computed(() => vault.value ? computeSupplyApyBreakdown(vault.value, viewer.value) : undefined)
+const visibleApyBreakdown = computed(() => visibleBreakdown(supplyApyBreakdown.value))
+const supplyApyTotal = computed(() => visibleTotal(supplyApyBreakdown.value) ?? 0)
 
 // Non-blocking to avoid Suspense + pageTransition crash on direct navigation
 ;(async () => {
@@ -68,6 +74,7 @@ const balance = computed(() => asset.value?.address ? getBalance(asset.value.add
     }
     vault.value = await updateEarnVault(vaultAddress)
     asset.value = vault.value?.asset
+    estimateSupplyAPY.value = supplyApyTotal.value
 
     if (!useVaultRegistry().isVerifiedVault(vault.value.address)) {
       modal.open(VaultUnverifiedDisclaimerModal, {
@@ -104,13 +111,6 @@ const disabledReasonInfo = computed((): DisabledReasonInfo | undefined => {
   if (errorText.value) return { message: errorText.value, variant: 'error' }
   return undefined
 })
-const supplyRewardCampaigns = computed(() => getSupplyRewardCampaigns(vaultAddress))
-const totalRewardsAPY = computed(() => getSupplyRewardApy(vaultAddress))
-const hasRewards = computed(() => hasSupplyRewards(vaultAddress))
-const intrinsicApy = computed(() => getVaultIntrinsicApy(vault.value, enableIntrinsicApy.value))
-const supplyApyTotal = computed(() =>
-  vault.value ? getVaultSupplyApy(vault.value) + intrinsicApy.value + totalRewardsAPY.value : 0,
-)
 const supplyAPYDisplay = computed(() => {
   if (!vault.value) return '0.00'
   return formatNumber(supplyApyTotal.value)
@@ -212,7 +212,7 @@ const updateEstimates = async () => {
   try {
     vault.value = await updateEarnVault(vault.value.address)
     if (!asset.value?.address) return
-    estimateSupplyAPY.value = getVaultSupplyApy(vault.value) + intrinsicApy.value + totalRewardsAPY.value
+    estimateSupplyAPY.value = supplyApyTotal.value
   }
   catch (e) {
     logWarn('earn-supply/estimates', e)
@@ -223,18 +223,15 @@ const updateEstimates = async () => {
 }
 const supplyApyModalData = computed(() => ({
   props: {
-    lendingAPY: getVaultSupplyApy(vault.value),
-    intrinsicAPY: intrinsicApy.value,
+    lendingAPY: visibleApyBreakdown.value?.lending ?? 0,
+    intrinsicAPY: visibleApyBreakdown.value?.intrinsicApy ?? 0,
     intrinsicApyInfo: getVaultIntrinsicApyInfo(vault.value, enableIntrinsicApy.value),
-    campaigns: supplyRewardCampaigns.value,
+    campaigns: settings.value.enableRewardsApy ? supplyRewardCampaigns.value : [],
     totalSupplyAPY: supplyApyTotal.value,
     rewardVaultAddress: vaultAddress,
     baseApyAverageLabel: '1h',
   },
 }))
-
-// Initialize estimateSupplyAPY after vault is loaded
-estimateSupplyAPY.value = getVaultSupplyApy(vault.value) + intrinsicApy.value + totalRewardsAPY.value
 
 watch(amount, () => {
   clearSimulationError()

--- a/tests/utils/vault-intrinsic-apy.test.ts
+++ b/tests/utils/vault-intrinsic-apy.test.ts
@@ -24,6 +24,7 @@
 import { describe, expect, it } from 'vitest'
 import type { IntrinsicApyInfo } from '@eulerxyz/euler-v2-sdk'
 import {
+  combineApyWithIntrinsic,
   EMPTY_INTRINSIC_APY,
   getVaultIntrinsicApy,
   getVaultIntrinsicApyInfo,
@@ -86,6 +87,29 @@ describe('getVaultIntrinsicApy', () => {
 
   it('returns 0 for an undefined vault', () => {
     expect(getVaultIntrinsicApy(undefined, true)).toBe(0)
+  })
+})
+
+describe('combineApyWithIntrinsic', () => {
+  it('pins the compounded total used by Earn/Supply displays and APY modals', () => {
+    const base = 4
+    const intrinsic = 1
+    const rewards = 0.5
+
+    const compounded = combineApyWithIntrinsic(base, intrinsic)
+
+    expect(compounded).toBeCloseTo(4 + (1 + 4 / 100) * 1)
+    expect(compounded + rewards).toBeCloseTo(5.54)
+    expect(base + intrinsic + rewards).toBe(5.5)
+  })
+
+  it('pins borrow-side totals as compounded intrinsic minus rewards', () => {
+    const borrowing = 6
+    const intrinsic = 2
+    const rewards = 0.25
+
+    expect(combineApyWithIntrinsic(borrowing, intrinsic) - rewards)
+      .toBeCloseTo(6 + (1 + 6 / 100) * 2 - 0.25)
   })
 })
 


### PR DESCRIPTION
## Summary
- Align Supply APY totals across Earn detail, Earn list, and Portfolio deposit cards for the same vault/viewer.
- Route Earn and Portfolio deposit APY displays through the SDK supply APY breakdown so intrinsic APY is compounded consistently and reward eligibility uses the active viewer.
- Clarify borrow-side intrinsic APY docs so they match the compounded implementation.

## Changes
- Use `computeSupplyApyBreakdown` for the Earn detail headline, estimate, APY modal rows, and Earn Statistics card.
- Resolve Portfolio Earn/direct deposit cards through the canonical vault registry before computing the APY breakdown, while keeping balances/subaccounts sourced from the portfolio position.
- Apply intrinsic/reward visibility settings through the shared APY visibility helper and hide reward affordances when rewards APY is disabled.
- Add focused intrinsic APY fixtures that distinguish compounded totals from linear base + intrinsic + rewards totals.

## Test plan
- [x] npx eslint `pages/earn/[vault]/index.vue` components/entities/vault/overview/earn/VaultOverviewEarnBlockStats.vue
- [x] npx eslint components/entities/portfolio/PortfolioEarnItem.vue components/entities/portfolio/PortfolioSavingItem.vue
- [x] npm run typecheck
- [x] npm run test:run -- tests/utils/vault-intrinsic-apy.test.ts tests/utils/discovery-calculations.test.ts
- [x] git diff --check