### PR TITLE
Rank asset-selector tokens by relevance; tolerate bytes32 token metadata

### DIFF
--- a/abis/erc20.ts
+++ b/abis/erc20.ts
@@ -63,3 +63,25 @@ export const erc20NameAbi = [
     stateMutability: 'view',
   },
 ] as const
+
+// Legacy tokens (e.g. MKR) declare name()/symbol() as returning bytes32 instead
+// of the ERC-20-standard string. Used as a fallback when the string ABI fails.
+export const erc20NameBytes32Abi = [
+  {
+    type: 'function',
+    name: 'name',
+    inputs: [],
+    outputs: [{ name: '', type: 'bytes32' }],
+    stateMutability: 'view',
+  },
+] as const
+
+export const erc20SymbolBytes32Abi = [
+  {
+    type: 'function',
+    name: 'symbol',
+    inputs: [],
+    outputs: [{ name: '', type: 'bytes32' }],
+    stateMutability: 'view',
+  },
+] as const

--- a/components/entities/asset/SwapTokenSelector.vue
+++ b/components/entities/asset/SwapTokenSelector.vue
@@ -275,68 +275,72 @@ const handleSelectCustomToken = () => {
             size="36"
             class="mr-10"
           />
-          <div class="flex-grow">
+          <div class="flex-grow min-w-0">
             <div class="text-content-primary mb-2">
               {{ opt.asset.name }}
             </div>
-            <div class="text-h5 flex items-center">
-              {{ opt.asset.symbol }}
+            <div class="text-h5 flex flex-wrap items-center gap-y-4 mobile:flex-col mobile:items-start">
+              <div class="flex min-w-0 items-center">
+                <span class="min-w-0 break-words">{{ opt.asset.symbol }}</span>
+                <span
+                  v-if="rowGeo(opt.asset.address).showChip"
+                  class="ml-6 inline-flex items-center rounded-8 px-8 py-2 bg-warning-100 text-warning-500 text-p5"
+                >
+                  Restricted
+                </span>
+              </div>
               <template v-if="shouldShowAddress(opt.asset.address)">
-                <UiHoverPreviewTooltip
-                  title="Token address"
-                  :text="opt.asset.address"
-                  placement="top-start"
-                >
-                  <span class="ml-6 text-content-tertiary text-p5 font-normal">
-                    {{ truncate(opt.asset.address) }}
-                  </span>
-                </UiHoverPreviewTooltip>
-                <UiHoverPreviewTooltip
-                  :title="isCopied(`asset-${opt.asset.address.toLowerCase()}`) ? 'Copied' : 'Copy address'"
-                  :text="isCopied(`asset-${opt.asset.address.toLowerCase()}`) ? 'Copied' : 'Copy address'"
-                  placement="top-start"
-                >
-                  <button
-                    type="button"
-                    class="ml-4 inline-flex h-20 w-20 items-center justify-center rounded-6 text-content-muted outline-none hover:bg-surface-secondary hover:text-content-secondary active:text-content-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-600"
-                    :aria-label="`Copy ${opt.asset.symbol} address`"
-                    @click.stop.prevent="copyAssetAddress(opt.asset.address)"
+                <div class="ml-6 inline-flex min-w-0 items-center mobile:ml-0 mobile:w-full">
+                  <UiHoverPreviewTooltip
+                    title="Token address"
+                    :text="opt.asset.address"
+                    placement="top-start"
                   >
-                    <SvgIcon
-                      class="!w-14 !h-14"
-                      :name="isCopied(`asset-${opt.asset.address.toLowerCase()}`) ? 'check' : 'copy'"
-                    />
-                  </button>
-                </UiHoverPreviewTooltip>
-                <UiHoverPreviewTooltip
-                  title="Open in block explorer"
-                  text="Open in block explorer"
-                  placement="top-start"
-                >
-                  <NuxtLink
-                    :to="getExplorerAddressLink(opt.asset.address)"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="ml-2 inline-flex h-20 w-20 items-center justify-center rounded-6 text-content-muted outline-none hover:bg-surface-secondary hover:text-content-secondary active:text-content-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-600"
-                    :aria-label="`Open ${opt.asset.symbol} address in block explorer`"
-                    @click.stop
+                    <span class="text-content-tertiary text-p5 font-normal">
+                      {{ truncate(opt.asset.address) }}
+                    </span>
+                  </UiHoverPreviewTooltip>
+                  <UiHoverPreviewTooltip
+                    :title="isCopied(`asset-${opt.asset.address.toLowerCase()}`) ? 'Copied' : 'Copy address'"
+                    :text="isCopied(`asset-${opt.asset.address.toLowerCase()}`) ? 'Copied' : 'Copy address'"
+                    placement="top-start"
                   >
-                    <SvgIcon
-                      class="!w-14 !h-14"
-                      name="arrow-top-right"
-                    />
-                  </NuxtLink>
-                </UiHoverPreviewTooltip>
+                    <button
+                      type="button"
+                      class="ml-4 inline-flex h-20 w-20 items-center justify-center rounded-6 text-content-muted outline-none hover:bg-surface-secondary hover:text-content-secondary active:text-content-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-600"
+                      :aria-label="`Copy ${opt.asset.symbol} address`"
+                      @click.stop.prevent="copyAssetAddress(opt.asset.address)"
+                    >
+                      <SvgIcon
+                        class="!w-14 !h-14"
+                        :name="isCopied(`asset-${opt.asset.address.toLowerCase()}`) ? 'check' : 'copy'"
+                      />
+                    </button>
+                  </UiHoverPreviewTooltip>
+                  <UiHoverPreviewTooltip
+                    title="Open in block explorer"
+                    text="Open in block explorer"
+                    placement="top-start"
+                  >
+                    <NuxtLink
+                      :to="getExplorerAddressLink(opt.asset.address)"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      class="ml-2 inline-flex h-20 w-20 items-center justify-center rounded-6 text-content-muted outline-none hover:bg-surface-secondary hover:text-content-secondary active:text-content-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-600"
+                      :aria-label="`Open ${opt.asset.symbol} address in block explorer`"
+                      @click.stop
+                    >
+                      <SvgIcon
+                        class="!w-14 !h-14"
+                        name="arrow-top-right"
+                      />
+                    </NuxtLink>
+                  </UiHoverPreviewTooltip>
+                </div>
               </template>
-              <span
-                v-if="rowGeo(opt.asset.address).showChip"
-                class="ml-6 inline-flex items-center rounded-8 px-8 py-2 bg-warning-100 text-warning-500 text-p5"
-              >
-                Restricted
-              </span>
             </div>
           </div>
-          <div class="text-right">
+          <div class="text-right shrink-0 pl-8">
             <div class="text-content-primary mb-2">
               Balance
             </div>
@@ -381,7 +385,7 @@ const handleSelectCustomToken = () => {
             size="36"
             class="mr-10"
           />
-          <div class="flex-grow">
+          <div class="flex-grow min-w-0">
             <div class="flex items-center gap-6 mb-2">
               <span class="text-content-primary">{{ customToken.name }}</span>
               <span class="inline-flex items-center rounded-8 px-8 py-2 bg-warning-100 text-warning-500 text-p5">
@@ -394,58 +398,60 @@ const handleSelectCustomToken = () => {
                 Restricted
               </span>
             </div>
-            <div class="text-h5 flex items-center">
-              {{ customToken.symbol }}
+            <div class="text-h5 flex flex-wrap items-center gap-y-4 mobile:flex-col mobile:items-start">
+              <span class="min-w-0 break-words">{{ customToken.symbol }}</span>
               <template v-if="shouldShowAddress(customToken.address)">
-                <UiHoverPreviewTooltip
-                  title="Token address"
-                  :text="customToken.address"
-                  placement="top-start"
-                >
-                  <span class="ml-6 text-content-tertiary text-p5 font-normal">
-                    {{ truncate(customToken.address) }}
-                  </span>
-                </UiHoverPreviewTooltip>
-                <UiHoverPreviewTooltip
-                  :title="isCopied(`asset-${customToken.address.toLowerCase()}`) ? 'Copied' : 'Copy address'"
-                  :text="isCopied(`asset-${customToken.address.toLowerCase()}`) ? 'Copied' : 'Copy address'"
-                  placement="top-start"
-                >
-                  <button
-                    type="button"
-                    class="ml-4 inline-flex h-20 w-20 items-center justify-center rounded-6 text-content-muted outline-none hover:bg-surface-secondary hover:text-content-secondary active:text-content-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-600"
-                    :aria-label="`Copy ${customToken.symbol} address`"
-                    @click.stop.prevent="copyAssetAddress(customToken.address)"
+                <div class="ml-6 inline-flex min-w-0 items-center mobile:ml-0 mobile:w-full">
+                  <UiHoverPreviewTooltip
+                    title="Token address"
+                    :text="customToken.address"
+                    placement="top-start"
                   >
-                    <SvgIcon
-                      class="!w-14 !h-14"
-                      :name="isCopied(`asset-${customToken.address.toLowerCase()}`) ? 'check' : 'copy'"
-                    />
-                  </button>
-                </UiHoverPreviewTooltip>
-                <UiHoverPreviewTooltip
-                  title="Open in block explorer"
-                  text="Open in block explorer"
-                  placement="top-start"
-                >
-                  <NuxtLink
-                    :to="getExplorerAddressLink(customToken.address)"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="ml-2 inline-flex h-20 w-20 items-center justify-center rounded-6 text-content-muted outline-none hover:bg-surface-secondary hover:text-content-secondary active:text-content-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-600"
-                    :aria-label="`Open ${customToken.symbol} address in block explorer`"
-                    @click.stop
+                    <span class="text-content-tertiary text-p5 font-normal">
+                      {{ truncate(customToken.address) }}
+                    </span>
+                  </UiHoverPreviewTooltip>
+                  <UiHoverPreviewTooltip
+                    :title="isCopied(`asset-${customToken.address.toLowerCase()}`) ? 'Copied' : 'Copy address'"
+                    :text="isCopied(`asset-${customToken.address.toLowerCase()}`) ? 'Copied' : 'Copy address'"
+                    placement="top-start"
                   >
-                    <SvgIcon
-                      class="!w-14 !h-14"
-                      name="arrow-top-right"
-                    />
-                  </NuxtLink>
-                </UiHoverPreviewTooltip>
+                    <button
+                      type="button"
+                      class="ml-4 inline-flex h-20 w-20 items-center justify-center rounded-6 text-content-muted outline-none hover:bg-surface-secondary hover:text-content-secondary active:text-content-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-600"
+                      :aria-label="`Copy ${customToken.symbol} address`"
+                      @click.stop.prevent="copyAssetAddress(customToken.address)"
+                    >
+                      <SvgIcon
+                        class="!w-14 !h-14"
+                        :name="isCopied(`asset-${customToken.address.toLowerCase()}`) ? 'check' : 'copy'"
+                      />
+                    </button>
+                  </UiHoverPreviewTooltip>
+                  <UiHoverPreviewTooltip
+                    title="Open in block explorer"
+                    text="Open in block explorer"
+                    placement="top-start"
+                  >
+                    <NuxtLink
+                      :to="getExplorerAddressLink(customToken.address)"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      class="ml-2 inline-flex h-20 w-20 items-center justify-center rounded-6 text-content-muted outline-none hover:bg-surface-secondary hover:text-content-secondary active:text-content-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-600"
+                      :aria-label="`Open ${customToken.symbol} address in block explorer`"
+                      @click.stop
+                    >
+                      <SvgIcon
+                        class="!w-14 !h-14"
+                        name="arrow-top-right"
+                      />
+                    </NuxtLink>
+                  </UiHoverPreviewTooltip>
+                </div>
               </template>
             </div>
           </div>
-          <div class="text-right">
+          <div class="text-right shrink-0 pl-8">
             <div class="text-content-primary mb-2">
               Balance
             </div>

--- a/components/entities/asset/SwapTokenSelector.vue
+++ b/components/entities/asset/SwapTokenSelector.vue
@@ -6,6 +6,7 @@ import { formatNumber, truncate } from '~/utils/string-utils'
 import { nanoToValue } from '~/utils/crypto-utils'
 import { isAssetBlockedByCountry, isAssetRestrictedByCountry } from '~/composables/useGeoBlock'
 import { getExplorerLink } from '~/utils/block-explorer'
+import { filterSelectableTokens, sortSelectableTokens } from '~/utils/token-selector'
 
 export interface SwapTokenSelectMeta {
   isUnknownToken?: boolean
@@ -118,16 +119,9 @@ const tokenOptions = computed((): TokenOption[] => {
     })
   }
 
-  // Sort: tokens with balance first (desc by balance), then vault tokens alphabetically
-  return options.sort((a, b) => {
-    if (a.balance > 0n && b.balance <= 0n) return -1
-    if (a.balance <= 0n && b.balance > 0n) return 1
-    if (a.balance > 0n && b.balance > 0n) {
-      if (a.balanceFormatted > b.balanceFormatted) return -1
-      if (a.balanceFormatted < b.balanceFormatted) return 1
-    }
-    return a.asset.symbol.localeCompare(b.asset.symbol)
-  })
+  // Bubble the relevant tokens to the top (held → Euler assets → the rest); the
+  // full list stays present and reachable by scrolling / searching.
+  return sortSelectableTokens(options)
 })
 
 // Include both vault and token list addresses in known set
@@ -144,23 +138,31 @@ const isUnknownAddress = computed(() => {
   return isAddress(q) && !knownAddresses.value.has(q.toLowerCase())
 })
 
-const filteredOptions = computed(() => {
-  const base = searchQuery.value
-    ? tokenOptions.value.filter((opt) => {
-        const q = searchQuery.value.toLowerCase()
-        return opt.asset.symbol.toLowerCase().includes(q)
-          || opt.asset.name.toLowerCase().includes(q)
-          || opt.asset.address.toLowerCase().includes(q)
-      })
-    : tokenOptions.value
+// Output ("Receive as") shows the full list with relevant tokens bubbled to the
+// top (see sortSelectableTokens); input ("Pay with") narrows to held tokens.
+const filteredOptions = computed(() => filterSelectableTokens(tokenOptions.value, mode, searchQuery.value))
 
-  // For input mode (pay with): filter zero-balance tokens when not searching
-  // For output mode (receive as): always show all tokens
-  if (mode === 'input' && !searchQuery.value) {
-    return base.filter(opt => opt.balance > 0n)
-  }
-  return base
+// Incrementally render rows — and therefore token-icon requests — instead of
+// mounting the whole list at once: start with a capped batch and grow on scroll.
+// Together with the curated default this keeps the picker from firing thousands
+// of icon fetches (the source of the llama.fi 404 flood).
+const INITIAL_RENDER_COUNT = 50
+const RENDER_BATCH = 50
+const renderLimit = ref(INITIAL_RENDER_COUNT)
+const visibleOptions = computed(() => filteredOptions.value.slice(0, renderLimit.value))
+const hasMoreToRender = computed(() => renderLimit.value < filteredOptions.value.length)
+
+watch(searchQuery, () => {
+  renderLimit.value = INITIAL_RENDER_COUNT
 })
+
+const onListScroll = (event: Event) => {
+  if (!hasMoreToRender.value) return
+  const el = event.target as HTMLElement
+  if (el.scrollHeight - el.scrollTop - el.clientHeight < 240) {
+    renderLimit.value += RENDER_BATCH
+  }
+}
 
 // Compute geo state once per visible row rather than 3x per render
 // (class binding + bg-card-hover + click guard).
@@ -247,9 +249,12 @@ const handleSelectCustomToken = () => {
           clearable
         />
       </div>
-      <div class="flex-1 min-h-0 overflow-auto styled-scrollbar">
+      <div
+        class="flex-1 min-h-0 overflow-auto styled-scrollbar"
+        @scroll="onListScroll"
+      >
         <div
-          v-for="opt in filteredOptions"
+          v-for="opt in visibleOptions"
           :key="opt.asset.address"
           data-id="swap-token-option"
           :data-token-name="opt.asset.name"
@@ -340,6 +345,14 @@ const handleSelectCustomToken = () => {
             </div>
           </div>
         </div>
+        <!-- More rows render as the user scrolls (keeps icon requests bounded) -->
+        <div
+          v-if="hasMoreToRender"
+          class="py-12 text-center text-content-tertiary text-p3"
+        >
+          Scroll or search to see more tokens
+        </div>
+
         <!-- Custom token: loading -->
         <div
           v-if="isUnknownAddress && isCustomTokenLoading"

--- a/composables/useCustomTokenResolver.ts
+++ b/composables/useCustomTokenResolver.ts
@@ -1,6 +1,7 @@
 import type { VaultAsset } from '~/types/asset'
 import { isAddress, type Address } from 'viem'
-import { erc20SymbolAbi, erc20DecimalsAbi, erc20NameAbi } from '~/abis/erc20'
+import { erc20DecimalsAbi } from '~/abis/erc20'
+import { readErc20StringField } from '~/utils/erc20-metadata'
 
 import { createRaceGuard } from '~/utils/race-guard'
 
@@ -27,24 +28,16 @@ export const useCustomTokenResolver = () => {
 
     try {
       const [symbolResult, decimalsResult, nameResult, balance] = await Promise.all([
-        rpcClient.value!.readContract({
-          address,
-          abi: erc20SymbolAbi,
-          functionName: 'symbol',
-          authorizationList: undefined,
-        }).catch(() => null),
+        // name()/symbol() may be bytes32 on legacy tokens (e.g. MKR), so read via
+        // the string→bytes32 fallback helper rather than a string-only ABI.
+        readErc20StringField(rpcClient.value!, address, 'symbol'),
         rpcClient.value!.readContract({
           address,
           abi: erc20DecimalsAbi,
           functionName: 'decimals',
           authorizationList: undefined,
         }).catch(() => null),
-        rpcClient.value!.readContract({
-          address,
-          abi: erc20NameAbi,
-          functionName: 'name',
-          authorizationList: undefined,
-        }).catch(() => null),
+        readErc20StringField(rpcClient.value!, address, 'name'),
         fetchSingleBalance(input).catch(() => 0n),
       ])
 
@@ -55,9 +48,9 @@ export const useCustomTokenResolver = () => {
         return
       }
 
-      const symbol = symbolResult as string
+      const symbol = symbolResult
       const decimals = decimalsResult as number
-      const name = (nameResult as string) || symbol
+      const name = nameResult || symbol
 
       customToken.value = { address: input, symbol, decimals, name }
       customTokenBalance.value = balance

--- a/composables/useTokenSymbolResolver.ts
+++ b/composables/useTokenSymbolResolver.ts
@@ -1,7 +1,7 @@
 import type { Address } from 'viem'
 import { logWarn } from '~/utils/errorHandling'
 import { USD_ADDRESS, EUR_ADDRESS, BTC_ADDRESS, ETH_ADDRESS } from '~/entities/constants'
-import { erc20SymbolAbi } from '~/abis/erc20'
+import { readErc20StringField } from '~/utils/erc20-metadata'
 
 const resolvedSymbols: Ref<Map<string, string>> = shallowRef(new Map())
 const pendingAddresses = new Set<string>()
@@ -50,13 +50,12 @@ export const useTokenSymbolResolver = () => {
     pendingAddresses.add(key)
     const client = ensureClient()
 
-    client.readContract({
-      address: address as Address,
-      abi: erc20SymbolAbi,
-      functionName: 'symbol',
-      authorizationList: undefined,
-    })
-      .then((symbol: string) => {
+    readErc20StringField(client, address as Address, 'symbol')
+      .then((symbol) => {
+        if (!symbol) {
+          failedAddresses.add(key)
+          return
+        }
         const updated = new Map(resolvedSymbols.value)
         updated.set(key, symbol)
         resolvedSymbols.value = updated

--- a/tests/utils/erc20-metadata.test.ts
+++ b/tests/utils/erc20-metadata.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { stringToHex } from 'viem'
+import { bytes32ToString } from '~/utils/erc20-metadata'
+
+describe('bytes32ToString', () => {
+  it('decodes a right-NUL-padded bytes32 name to its string (e.g. MKR returns bytes32 "Maker")', () => {
+    expect(bytes32ToString(stringToHex('Maker', { size: 32 }))).toBe('Maker')
+  })
+
+  it('decodes a bytes32 symbol', () => {
+    expect(bytes32ToString(stringToHex('MKR', { size: 32 }))).toBe('MKR')
+  })
+
+  it('returns an empty string for an all-zero bytes32', () => {
+    expect(bytes32ToString(stringToHex('', { size: 32 }))).toBe('')
+  })
+})

--- a/tests/utils/token-selector.test.ts
+++ b/tests/utils/token-selector.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import { filterSelectableTokens, sortSelectableTokens, type SelectableToken } from '~/utils/token-selector'
+
+const tok = (over: Partial<SelectableToken> & { asset?: Partial<SelectableToken['asset']> } = {}): SelectableToken => ({
+  balance: 0n,
+  balanceFormatted: 0,
+  source: 'tokenList',
+  ...over,
+  asset: {
+    symbol: 'TKN',
+    name: 'Token',
+    address: '0x0000000000000000000000000000000000000000',
+    ...over.asset,
+  },
+})
+
+const vaultAsset = tok({ source: 'vault', asset: { symbol: 'USDC', name: 'USD Coin', address: '0xUSDC' } })
+const held = tok({ source: 'tokenList', balance: 5n, balanceFormatted: 5, asset: { symbol: 'HELD', name: 'Held Token', address: '0xHELD' } })
+const spam = tok({ source: 'tokenList', asset: { symbol: 'SPROUT', name: 'Sprout', address: '0xSPROUT' } })
+
+const all = [vaultAsset, held, spam]
+
+describe('filterSelectableTokens', () => {
+  it('input mode without search shows only tokens the user holds', () => {
+    expect(filterSelectableTokens(all, 'input', '')).toEqual([held])
+  })
+
+  it('output mode without search shows the full list (nothing hidden)', () => {
+    expect(filterSelectableTokens(all, 'output', '')).toEqual(all)
+  })
+
+  it('searching reaches the full list regardless of mode or balance', () => {
+    expect(filterSelectableTokens(all, 'output', 'sprout')).toEqual([spam])
+    expect(filterSelectableTokens(all, 'input', 'sprout')).toEqual([spam])
+  })
+
+  it('search matches symbol, name, or address, case-insensitively', () => {
+    expect(filterSelectableTokens(all, 'output', 'USD COIN')).toEqual([vaultAsset])
+    expect(filterSelectableTokens(all, 'output', '0xheld')).toEqual([held])
+  })
+
+  it('treats a whitespace-only query as no search', () => {
+    expect(filterSelectableTokens(all, 'output', '   ')).toEqual(all)
+  })
+})
+
+describe('sortSelectableTokens', () => {
+  it('bubbles held tokens (by amount desc), then Euler vault assets, then the rest alphabetically', () => {
+    const held5 = tok({ balance: 5n, balanceFormatted: 5, asset: { symbol: 'ZZZ', name: 'Z', address: '0x1' } })
+    const held10 = tok({ balance: 10n, balanceFormatted: 10, asset: { symbol: 'AAA', name: 'A', address: '0x2' } })
+    const vault0 = tok({ source: 'vault', asset: { symbol: 'WETH', name: 'Wrapped Ether', address: '0x3' } })
+    const otherB = tok({ asset: { symbol: 'BBB', name: 'B', address: '0x4' } })
+    const otherA = tok({ asset: { symbol: 'AAB', name: 'A2', address: '0x5' } })
+
+    const sorted = sortSelectableTokens([otherB, vault0, held5, otherA, held10])
+
+    expect(sorted.map(t => t.asset.symbol)).toEqual(['AAA', 'ZZZ', 'WETH', 'AAB', 'BBB'])
+  })
+
+  it('orders held tokens by amount (balanceFormatted), not raw bigint balance', () => {
+    // 1 ETH (18 decimals) has a far larger raw balance than 5 USDC (6 decimals),
+    // but the larger *amount* (5 USDC) must rank first.
+    const oneEth = tok({ balance: 10n ** 18n, balanceFormatted: 1, asset: { symbol: 'ETH', name: 'Ether', address: '0xeth' } })
+    const fiveUsdc = tok({ balance: 5_000_000n, balanceFormatted: 5, asset: { symbol: 'USDC', name: 'USD Coin', address: '0xusdc' } })
+
+    const sorted = sortSelectableTokens([oneEth, fiveUsdc])
+
+    expect(sorted.map(t => t.asset.symbol)).toEqual(['USDC', 'ETH'])
+  })
+
+  it('does not mutate the input array', () => {
+    const input = [spam, held]
+    const snapshot = [...input]
+    sortSelectableTokens(input)
+    expect(input).toEqual(snapshot)
+  })
+})

--- a/utils/erc20-metadata.ts
+++ b/utils/erc20-metadata.ts
@@ -1,0 +1,48 @@
+import { hexToString, type Address, type Hex, type PublicClient } from 'viem'
+import {
+  erc20NameAbi,
+  erc20NameBytes32Abi,
+  erc20SymbolAbi,
+  erc20SymbolBytes32Abi,
+} from '~/abis/erc20'
+
+// Legacy tokens such as MKR return bytes32 from name()/symbol() instead of the
+// ERC-20-standard string. hexToString keeps the right-NUL padding of a fixed
+// bytes32, so cut at the first NUL byte — e.g. MKR's name decodes to "Maker".
+export function bytes32ToString(value: Hex): string {
+  return hexToString(value).split(String.fromCharCode(0))[0]
+}
+
+// Reads an ERC-20 name/symbol, tolerating tokens that return bytes32 rather than
+// string (e.g. MKR). Tries the string ABI first, then the bytes32 variant, and
+// returns null when neither yields a non-empty value.
+export async function readErc20StringField(
+  client: PublicClient,
+  address: Address,
+  field: 'name' | 'symbol',
+): Promise<string | null> {
+  try {
+    const value = field === 'name'
+      ? await client.readContract({ address, abi: erc20NameAbi, functionName: 'name', authorizationList: undefined })
+      : await client.readContract({ address, abi: erc20SymbolAbi, functionName: 'symbol', authorizationList: undefined })
+    if (typeof value === 'string' && value.length > 0) return value
+  }
+  catch {
+    // Standard string decode failed — fall through to the bytes32 variant.
+  }
+
+  try {
+    const value = field === 'name'
+      ? await client.readContract({ address, abi: erc20NameBytes32Abi, functionName: 'name', authorizationList: undefined })
+      : await client.readContract({ address, abi: erc20SymbolBytes32Abi, functionName: 'symbol', authorizationList: undefined })
+    if (typeof value === 'string' && value.startsWith('0x')) {
+      const decoded = bytes32ToString(value as Hex)
+      if (decoded.length > 0) return decoded
+    }
+  }
+  catch {
+    // Not decodable as bytes32 either — give up.
+  }
+
+  return null
+}

--- a/utils/token-selector.ts
+++ b/utils/token-selector.ts
@@ -1,0 +1,61 @@
+// Ordering + narrowing for the asset selector.
+//
+// The merged token list (Euler SDK + DefiLlama + Uniswap + Merkl) contains many
+// thousands of tokens. Rather than hiding the long tail, we bubble the relevant
+// tokens to the top and leave the rest reachable by scrolling / searching. The
+// picker also renders rows incrementally, so the full list never fires a
+// token-icon request per row up front.
+
+export type SelectableToken = {
+  balance: bigint
+  // Decimal-adjusted balance — used to order held tokens by actual amount
+  // (raw `balance` is not comparable across tokens with different decimals).
+  balanceFormatted: number
+  source: 'vault' | 'tokenList'
+  asset: { symbol: string, name: string, address: string }
+}
+
+// Relevance buckets: tokens the user holds first, then Euler vault assets, then
+// everything else.
+const selectableRank = (token: SelectableToken): number =>
+  token.balance > 0n ? 0 : token.source === 'vault' ? 1 : 2
+
+// Sorts so relevant tokens bubble to the top — held (by amount, desc), then
+// Euler vault assets, then the rest — alphabetical within each bucket. Returns a
+// new array (does not mutate the input).
+export function sortSelectableTokens<T extends SelectableToken>(options: T[]): T[] {
+  return [...options].sort((a, b) => {
+    const rankA = selectableRank(a)
+    const rankB = selectableRank(b)
+    if (rankA !== rankB) return rankA - rankB
+    if (rankA === 0 && a.balanceFormatted !== b.balanceFormatted) {
+      return b.balanceFormatted - a.balanceFormatted
+    }
+    return a.asset.symbol.localeCompare(b.asset.symbol)
+  })
+}
+
+// Narrows the list for the picker:
+// - any mode + search: match symbol / name / address.
+// - input ("Pay with") + no search: only tokens the user holds (you can only pay
+//   with what you have).
+// - output ("Receive as") + no search: the full list, unchanged — relevant
+//   tokens are bubbled to the top by sortSelectableTokens, nothing is hidden.
+export function filterSelectableTokens<T extends SelectableToken>(
+  options: T[],
+  mode: 'input' | 'output',
+  searchQuery: string,
+): T[] {
+  const query = searchQuery.trim().toLowerCase()
+  if (query) {
+    return options.filter(opt =>
+      opt.asset.symbol.toLowerCase().includes(query)
+      || opt.asset.name.toLowerCase().includes(query)
+      || opt.asset.address.toLowerCase().includes(query),
+    )
+  }
+  if (mode === 'input') {
+    return options.filter(opt => opt.balance > 0n)
+  }
+  return options
+}


### PR DESCRIPTION
## Summary

Fixes the withdraw "Receive as" / swap asset selector, which dumped the entire merged token list (Euler SDK + DefiLlama + Uniswap + Merkl — thousands of unvetted tokens) in arbitrary order. That surfaced spam/random tokens at the top and fired one token-icon request per row, flooding the console with `coins.llama.fi` 404s (and the deployment's monitoring with the resulting noise). It also makes token metadata reads tolerate legacy `bytes32` tokens.

## Changes

- **Rank by relevance instead of hiding.** `sortSelectableTokens` bubbles the relevant tokens to the top — tokens you hold (by amount), then Euler vault assets, then everything else (alphabetical within each bucket). The full list stays present and reachable by scrolling / searching; nothing is filtered out of "Receive as".
- **Bounded rendering.** Rows render incrementally (a batch of 50, growing on scroll) so the picker never mounts thousands of `AssetAvatar`s — and therefore never fires thousands of icon requests — at once. This is what removes the llama.fi 404 flood.
- **"Pay with" (input) unchanged:** still narrows to tokens you hold by default (you can only pay with what you have), full list on search.
- **bytes32 token metadata (e.g. MKR).** `name()` / `symbol()` are now read with a string→bytes32 fallback (`readErc20StringField`), so tokens that return `bytes32` (like MKR) resolve correctly instead of being rejected as "Not a valid ERC-20 token" or showing a shortened address. New `utils/erc20-metadata.ts` + bytes32 ABIs, wired into `useCustomTokenResolver` and `useTokenSymbolResolver`.
- **Extracted + tested logic:** `utils/token-selector.ts` (`sortSelectableTokens`, `filterSelectableTokens`) and `utils/erc20-metadata.ts` (`bytes32ToString`, `readErc20StringField`).

## Notes

- Held tokens sort by `balanceFormatted` (decimal-adjusted amount), not raw `balance`, so amounts are comparable across tokens with different decimals.
- There is no in-repo Sentry; the "uncaught Sentry errors" came from the deployment's monitor capturing the browser 404s. Bounding the icon requests removes the source.

## Test plan

- [ ] `npm run test:run -- tests/utils/token-selector.test.ts tests/utils/erc20-metadata.test.ts` passes.
- [ ] Withdraw → "Receive as": tokens you hold and Euler assets appear at the top; spam tokens are pushed down, not shown up front; the console is no longer flooded with token-icon 404s.
- [ ] Scrolling the list loads more rows; searching by name / symbol / address still finds any token.
- [ ] "Pay with" still lists only held tokens by default and finds any token on search.
- [ ] Pasting / selecting MKR resolves its name and symbol correctly (not "Not a valid ERC-20 token").

Addresses LITE-253, LITE-96, LITE-7.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Token pickers now sort and filter results more intelligently (held tokens, vault assets, then alphabetically) and support incremental rendering with “scroll or search” loading.
  * Improved legacy token support so name/symbol are resolved even when contracts return `bytes32`.
* **Bug Fixes**
  * Enhanced ERC-20 metadata reads to reduce blank or missing token names/symbols.
* **Tests**
  * Added unit tests for `bytes32` decoding and token selector filter/sort behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->