### PR TITLE
Title savings-source picker "Select savings" on repay

### DIFF
--- a/pages/position/[number]/repay.vue
+++ b/pages/position/[number]/repay.vue
@@ -1070,6 +1070,7 @@ watch(formTab, () => {
                 :asset="savings.sourceVault.value.asset"
                 :vault="savings.sourceVault.value"
                 :collateral-options="savings.savingsOptions.value"
+                collateral-modal-title="Select savings"
                 :selected-source="'vault'"
                 :selected-sub-account="savings.selectedSavingSubAccount.value"
                 :selected-vault-address="savings.sourceVault.value.address"


### PR DESCRIPTION
## Summary
- On the repay flow's "From savings" tab, the source-position picker modal opened with the title **"Select collateral"**, which is misleading — the savings position is being spent to repay debt, not enabled as collateral.

## Changes
- Pass `collateral-modal-title="Select savings"` to the savings-tab `AssetInput`, so `ChooseCollateralModal` no longer falls back to its default `"Select collateral"`.
- Other call sites already set their own titles (collateral-swap picker, lend swap → "Select vault", borrow swap → "Select debt") and are unaffected.

## Test plan
- [ ] Open a position with debt → Repay → "From savings" tab.
- [ ] Tap the savings-source selector; the modal title reads **"Select savings"**.
- [ ] Confirm the other pickers are unchanged: lend swap ("Select vault"), borrow swap ("Select debt"), and the repay "From collateral" tab.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **User Experience**
  * Updated the savings-selection modal title to **“Select savings”** when using the **From savings** input on the repay screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->