### PR TITLE
Hide share token exchange rate on non-borrowable vaults

### DIFF
--- a/components/entities/vault/overview/SecuritizeVaultOverview.vue
+++ b/components/entities/vault/overview/SecuritizeVaultOverview.vue
@@ -10,12 +10,10 @@ import { getExplorerLink } from '~/utils/block-explorer'
 import { getSpecialAddressLabel } from '~/utils/special-addresses'
 import { formatAssetValue } from '~/utils/sdk-prices'
 import { formatNumber, compactNumber, formatUsdValue, formatCompactUsdValue } from '~/utils/string-utils'
-import { nanoToValue } from '~/utils/crypto-utils'
 import { normalizeAddress } from '~/utils/normalizeAddress'
 import { formatMarketAvailability } from '~/utils/vault-display'
 import { VaultSupplyApyModal } from '#components'
 import { getAddress, maxUint256 } from 'viem'
-import { logWarn } from '~/utils/errorHandling'
 import { getVaultIntrinsicApy, getVaultIntrinsicApyInfo } from '~/utils/vault-intrinsic-apy'
 
 const { vault } = defineProps<{ vault: SecuritizeCollateralVault, desktopOverview?: boolean }>()
@@ -94,22 +92,6 @@ const supplyApyModalData = computed(() => ({
     rewardVaultAddress: vault.address,
   },
 }))
-
-// Risk parameters - fetch share token exchange rate (ERC4626 standard)
-const shareTokenExchangeRate: Ref<bigint | undefined> = ref()
-
-const loadRiskParameters = () => {
-  try {
-    // Share→asset exchange rate from the SDK vault entity (was a direct
-    // convertToAssets RPC read); the entity derives it from the same data.
-    shareTokenExchangeRate.value = vault.convertToAssets(1n * 10n ** BigInt(vault.shares.decimals))
-  }
-  catch (e) {
-    logWarn('SecuritizeVaultOverview/shareTokenExchangeRate', e)
-  }
-}
-
-loadRiskParameters()
 
 // Price display
 const priceDisplay = ref('-')
@@ -338,17 +320,6 @@ const supplyCapPercentageDisplay = computed(() => {
               :max="100"
             />
           </div>
-        </VaultOverviewLabelValue>
-        <VaultOverviewLabelValue
-          label="Share token exchange rate"
-          orientation="horizontal"
-        >
-          <template v-if="shareTokenExchangeRate !== undefined">
-            {{ formatNumber(nanoToValue(shareTokenExchangeRate, vault.asset.decimals), 6, 2) }}
-          </template>
-          <template v-else>
-            -
-          </template>
         </VaultOverviewLabelValue>
       </div>
     </div>

--- a/components/entities/vault/overview/VaultOverviewBlockRiskParameters.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockRiskParameters.vue
@@ -24,9 +24,14 @@ const supplyCapPercentageDisplay = computed(() => vault.caps.supplyCapUtilizatio
 const borrowCapPercentageDisplay = computed(() => vault.caps.borrowCapUtilization)
 const hookedOperations = computed(() => getVaultHookedOperations(vault))
 const liquidationBonusRange = computed(() => formatLiquidationBonusRange(vault))
+// The share/asset rate only moves as borrow interest accrues, so it is only
+// meaningful on borrowable vaults. A collateral-only vault can have a non-zero
+// borrowCap configured yet still be non-borrowable (no collateral carries a
+// borrow LTV — e.g. "Can be borrowed: No"), so gate on actual borrowability
+// rather than the cap. isVaultBorrowable also keeps the rate visible during
+// wind-down (residual debt) via its `totalBorrowed > 0n` branch.
 const showShareTokenExchangeRate = computed(() =>
-  getVaultCategory(vault.address) !== 'escrow'
-  && (vault.caps.borrowCap !== 0n || vault.totalBorrowed > 0n),
+  getVaultCategory(vault.address) !== 'escrow' && isBorrowable.value,
 )
 
 const supplyCapDisplay = ref('-')


### PR DESCRIPTION
## Summary
- A collateral-only vault was displaying a "Share token exchange rate" (e.g. a static `1.00`) even though it can't be borrowed. The share/asset rate only moves as borrow interest accrues, so it's meaningless — and contradicts the same panel's "Can be borrowed: No".
- The visibility gate keyed off `borrowCap !== 0n`, but a vault can have a non-zero borrow cap configured while still being non-borrowable (no collateral carries a borrow LTV), so the rate leaked through.

## Changes
- **Standard vault overview:** gate the "Share token exchange rate" row on actual borrowability (the panel's existing `isBorrowable`, i.e. `isVaultBorrowable`) instead of `borrowCap`. This also keeps the rate visible during wind-down — a vault that is no longer borrowable but still carries residual debt (`totalBorrowed > 0n`) — and makes the row consistent with the "Can be borrowed" indicator and the other borrow-side rows in the same block.
- **Securitize/RWA overview:** these vaults can never be a borrow destination (`borrowCount` is hardcoded to 0) and have no borrow interest, so the rate is always the same static value. Removed the row entirely, along with its now-unused `shareTokenExchangeRate` ref, loader, and the orphaned `nanoToValue` / `logWarn` imports.

## Test plan
- [ ] Open a collateral-only vault that has a borrow cap set but cannot be borrowed (shows "Can be borrowed: No") → "Share token exchange rate" row is no longer shown.
- [ ] Open a borrowable vault → the row still appears with its rate.
- [ ] Open a borrowable vault that has been wound down (no new borrows, but outstanding debt remains) → the row still appears.
- [ ] Open a Securitize/RWA vault → "Risk parameters" no longer shows a share token exchange rate row.
- [ ] `npm run test:run -- tests/utils/vault/classification.test.ts` passes (covers the wind-down borrowability case the gate relies on).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved when the “Share token exchange rate” is shown in vault risk parameters so it only appears for borrowable vaults, including during debt wind-down.
  * Removed the “Share token exchange rate” row from vault overview risk parameters, so the section now starts with “Supply cap.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->