### PR TITLE
fix: render IRM kink chart without smoothing

### DIFF
--- a/components/entities/vault/overview/VaultOverviewBlockIRM.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockIRM.vue
@@ -396,7 +396,7 @@ const renderChart = async () => {
           pointRadius: 0,
           pointHoverRadius: 6,
           pointHitRadius: 30,
-          tension: 0.4,
+          tension: 0,
           fill: true,
         },
         {
@@ -408,7 +408,7 @@ const renderChart = async () => {
           pointRadius: 0,
           pointHoverRadius: 6,
           pointHitRadius: 30,
-          tension: 0.4,
+          tension: 0,
           fill: true,
         },
       ],


### PR DESCRIPTION
## Summary
- Preserve the visible slope change in kinked IRM charts by rendering sampled APY points with straight line segments.
- Avoid Chart.js curve smoothing inventing a rounded bend around the kink point.

## Changes
- Set both borrow and supply APY line datasets to zero tension in the vault overview IRM chart.
- Keep the existing kink sample injection and annotation behavior unchanged.

## Test plan
- [x] Ran `npx eslint components/entities/vault/overview/VaultOverviewBlockIRM.vue`.
- [x] Ran `npm run typecheck`.
- [x] Smoke-tested `/lend/0xD8b27CF359b7D15710a5BE299AF6e7Bf904984C2?network=1` locally and verified the IRM chart renders with one canvas and no chart error.
- [x] Captured high-DPI before/after crops around the 90% kink to verify the rounded smoothed bend becomes a hard kink.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the IRM overview chart so the Borrow APY and Supply APY lines now render as straight segments instead of curved lines.
  * This makes the visualization clearer and more consistent without changing any underlying data or interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->