### PR TITLE
Reduce V3 proxy retry amplification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@eulerxyz/euler-v2-sdk": "1.0.9",
+        "@eulerxyz/euler-v2-sdk": "1.0.10",
         "@floating-ui/vue": "2.0.0",
         "@gvade/nuxt3-svg-sprite": "1.0.3",
         "@keyringnetwork/keyring-connect-sdk": "3.2.0",
@@ -1469,9 +1469,9 @@
       }
     },
     "node_modules/@eulerxyz/euler-v2-sdk": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@eulerxyz/euler-v2-sdk/-/euler-v2-sdk-1.0.9.tgz",
-      "integrity": "sha512-l7MbvMQP2bgUGv1R2yEMxhWYX8WdRfTKit8phd+EVHbkr3ZpOiDfiEA0wPN79ojpAU61L1ttWWfg4WbMcybBeQ==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@eulerxyz/euler-v2-sdk/-/euler-v2-sdk-1.0.10.tgz",
+      "integrity": "sha512-YUIvZX/2zez1NnjypwRVwlll1zKbNjtzuLQSqhIR1qEKmFVXaU651LitN5jfIIXFcb6++JZFsOwT6OWNPX9JGQ==",
       "license": "MIT",
       "dependencies": {
         "viem": "2.48.8"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     ]
   },
   "dependencies": {
-    "@eulerxyz/euler-v2-sdk": "1.0.9",
+    "@eulerxyz/euler-v2-sdk": "1.0.10",
     "@floating-ui/vue": "2.0.0",
     "@gvade/nuxt3-svg-sprite": "1.0.3",
     "@keyringnetwork/keyring-connect-sdk": "3.2.0",

--- a/server/api/v3/[...path].ts
+++ b/server/api/v3/[...path].ts
@@ -3,14 +3,23 @@ import {
   getMethod,
   getRequestURL,
   readRawBody,
+  setResponseHeader,
   setResponseHeaders,
   setResponseStatus,
 } from 'h3'
 import { fetchWithTimeout } from '~/server/utils/fetchWithTimeout'
 import { createRateLimiter } from '~/server/utils/rate-limit'
 import {
+  buildV3ProxyBackoffKey,
+  readV3ProxyBackoffMs,
+  recordV3ProxyBackoff,
+  updateV3ProxyBackoffFromResponse,
+  V3_PROXY_FAILURE_BACKOFF_MS,
+} from '~/server/utils/v3-proxy-backoff'
+import {
   buildV3ProxyRequestHeaders,
   buildV3ProxyTarget,
+  getV3ProxyPath,
   readForwardedV3ResponseHeaders,
   validateV3ProxyUrl,
 } from '~/server/utils/v3-proxy'
@@ -37,14 +46,34 @@ export default defineEventHandler(async (event) => {
   rateLimiter.consume(event, method === 'POST' ? 5 : 1)
 
   const target = buildV3ProxyTarget(requestUrl)
+  const backoffKey = buildV3ProxyBackoffKey(method, getV3ProxyPath(requestUrl))
+  const backoffMs = readV3ProxyBackoffMs(backoffKey)
+  if (backoffMs > 0) {
+    setResponseHeader(event, 'retry-after', Math.ceil(backoffMs / 1_000))
+    throw createError({ statusCode: 503, statusMessage: 'V3 upstream cooling down' })
+  }
+
   const headers = buildV3ProxyRequestHeaders(method)
   const body = method === 'POST' ? await readRawBody(event) : undefined
 
-  const upstream = await fetchWithTimeout(target, undefined, {
-    method,
-    headers,
-    body,
-  })
+  let upstream: Response
+  try {
+    upstream = await fetchWithTimeout(target, undefined, {
+      method,
+      headers,
+      body,
+    })
+  }
+  catch {
+    recordV3ProxyBackoff(backoffKey)
+    setResponseHeader(event, 'retry-after', Math.ceil(V3_PROXY_FAILURE_BACKOFF_MS / 1_000))
+    throw createError({ statusCode: 503, statusMessage: 'V3 upstream unavailable' })
+  }
+
+  updateV3ProxyBackoffFromResponse(backoffKey, upstream.status)
+  if ([429, 500, 502, 503, 504].includes(upstream.status)) {
+    setResponseHeader(event, 'retry-after', Math.ceil(V3_PROXY_FAILURE_BACKOFF_MS / 1_000))
+  }
 
   setResponseStatus(event, upstream.status, upstream.statusText)
   setResponseHeaders(event, readForwardedV3ResponseHeaders(upstream.headers))

--- a/server/utils/v3-proxy-backoff.ts
+++ b/server/utils/v3-proxy-backoff.ts
@@ -8,8 +8,18 @@ type V3ProxyBackoffEntry = {
 
 const backoffs = new Map<string, V3ProxyBackoffEntry>()
 
+const normalizeV3ProxyBackoffPath = (pathname: string) => {
+  if (/^\/v3\/accounts\/[^/]+\/positions$/.test(pathname)) {
+    return '/v3/accounts/:address/positions'
+  }
+  if (/^\/v3\/earn\/vaults\/[^/]+\/[^/]+$/.test(pathname)) {
+    return '/v3/earn/vaults/:chainId/:vault'
+  }
+  return pathname
+}
+
 export const buildV3ProxyBackoffKey = (method: string, pathname: string) =>
-  `${method.toUpperCase()} ${pathname}`
+  `${method.toUpperCase()} ${normalizeV3ProxyBackoffPath(pathname)}`
 
 export const readV3ProxyBackoffMs = (
   key: string,

--- a/server/utils/v3-proxy-backoff.ts
+++ b/server/utils/v3-proxy-backoff.ts
@@ -43,9 +43,7 @@ export const updateV3ProxyBackoffFromResponse = (
 ) => {
   if (RETRYABLE_V3_PROXY_STATUSES.has(status)) {
     recordV3ProxyBackoff(key, now)
-    return
   }
-  clearV3ProxyBackoff(key)
 }
 
 export const resetV3ProxyBackoffsForTest = () => {

--- a/server/utils/v3-proxy-backoff.ts
+++ b/server/utils/v3-proxy-backoff.ts
@@ -1,0 +1,53 @@
+export const V3_PROXY_FAILURE_BACKOFF_MS = 10_000
+
+const RETRYABLE_V3_PROXY_STATUSES = new Set([429, 500, 502, 503, 504])
+
+type V3ProxyBackoffEntry = {
+  until: number
+}
+
+const backoffs = new Map<string, V3ProxyBackoffEntry>()
+
+export const buildV3ProxyBackoffKey = (method: string, pathname: string) =>
+  `${method.toUpperCase()} ${pathname}`
+
+export const readV3ProxyBackoffMs = (
+  key: string,
+  now = Date.now(),
+): number => {
+  const entry = backoffs.get(key)
+  if (!entry) return 0
+  const remainingMs = entry.until - now
+  if (remainingMs <= 0) {
+    backoffs.delete(key)
+    return 0
+  }
+  return remainingMs
+}
+
+export const recordV3ProxyBackoff = (
+  key: string,
+  now = Date.now(),
+) => {
+  backoffs.set(key, { until: now + V3_PROXY_FAILURE_BACKOFF_MS })
+}
+
+export const clearV3ProxyBackoff = (key: string) => {
+  backoffs.delete(key)
+}
+
+export const updateV3ProxyBackoffFromResponse = (
+  key: string,
+  status: number,
+  now = Date.now(),
+) => {
+  if (RETRYABLE_V3_PROXY_STATUSES.has(status)) {
+    recordV3ProxyBackoff(key, now)
+    return
+  }
+  clearV3ProxyBackoff(key)
+}
+
+export const resetV3ProxyBackoffsForTest = () => {
+  backoffs.clear()
+}

--- a/tests/server/v3-proxy-route.test.ts
+++ b/tests/server/v3-proxy-route.test.ts
@@ -53,6 +53,9 @@ type TestEvent = H3Event & {
 }
 
 const ACCOUNT = '0x0000000000000000000000000000000000000001'
+const OTHER_ACCOUNT = '0x0000000000000000000000000000000000000002'
+const VAULT = '0x0000000000000000000000000000000000000003'
+const OTHER_VAULT = '0x0000000000000000000000000000000000000004'
 
 const handler = (await import('~/server/api/v3/[...path]')).default
 const { resetV3ProxyBackoffsForTest } = await import('~/server/utils/v3-proxy-backoff')
@@ -213,6 +216,41 @@ describe('/api/v3 proxy route', () => {
 
     expect(first.context.responseHeaders?.['retry-after']).toBe('10')
     expect(second.context.responseHeaders?.['retry-after']).toBe('10')
+    expect(mocks.fetchWithTimeout).toHaveBeenCalledTimes(1)
+  })
+
+  it('shares cooldown across dynamic account position paths', async () => {
+    mocks.fetchWithTimeout.mockRejectedValueOnce(new Error('timeout'))
+    const first = makeEvent('GET', `https://app.example/api/v3/accounts/${ACCOUNT}/positions?chainId=1`)
+    const second = makeEvent('GET', `https://app.example/api/v3/accounts/${OTHER_ACCOUNT}/positions?chainId=1`)
+
+    await expect(handler(first)).rejects.toMatchObject({
+      statusCode: 503,
+      statusMessage: 'V3 upstream unavailable',
+    })
+    await expect(handler(second)).rejects.toMatchObject({
+      statusCode: 503,
+      statusMessage: 'V3 upstream cooling down',
+    })
+
+    expect(mocks.fetchWithTimeout).toHaveBeenCalledTimes(1)
+  })
+
+  it('shares cooldown across dynamic earn vault detail paths', async () => {
+    mocks.fetchWithTimeout.mockResolvedValueOnce(new Response('{"error":true}', {
+      status: 502,
+      statusText: 'Bad Gateway',
+      headers: { 'content-type': 'application/json' },
+    }))
+    const first = makeEvent('GET', `https://app.example/api/v3/earn/vaults/1/${VAULT}`)
+    const second = makeEvent('GET', `https://app.example/api/v3/earn/vaults/1/${OTHER_VAULT}`)
+
+    await expect(handler(first)).resolves.toBe('{"error":true}')
+    await expect(handler(second)).rejects.toMatchObject({
+      statusCode: 503,
+      statusMessage: 'V3 upstream cooling down',
+    })
+
     expect(mocks.fetchWithTimeout).toHaveBeenCalledTimes(1)
   })
 })

--- a/tests/server/v3-proxy-route.test.ts
+++ b/tests/server/v3-proxy-route.test.ts
@@ -13,7 +13,16 @@ vi.mock('h3', () => ({
   getRequestURL: (event: TestEvent) => new URL(event.url),
   readRawBody: (event: TestEvent) => event.body,
   setResponseHeaders: (event: TestEvent, headers: Record<string, string>) => {
-    event.context.responseHeaders = headers
+    event.context.responseHeaders = {
+      ...event.context.responseHeaders,
+      ...headers,
+    }
+  },
+  setResponseHeader: (event: TestEvent, name: string, value: number | string) => {
+    event.context.responseHeaders = {
+      ...event.context.responseHeaders,
+      [name]: String(value),
+    }
   },
   setResponseStatus: (event: TestEvent, status: number, statusText?: string) => {
     event.context.status = status
@@ -46,6 +55,7 @@ type TestEvent = H3Event & {
 const ACCOUNT = '0x0000000000000000000000000000000000000001'
 
 const handler = (await import('~/server/api/v3/[...path]')).default
+const { resetV3ProxyBackoffsForTest } = await import('~/server/utils/v3-proxy-backoff')
 
 const makeEvent = (method: string, url: string, body?: string): TestEvent => ({
   method,
@@ -66,6 +76,7 @@ const makeEvent = (method: string, url: string, body?: string): TestEvent => ({
 describe('/api/v3 proxy route', () => {
   afterEach(() => {
     delete process.env.EULER_SDK_V3_API_KEY
+    resetV3ProxyBackoffsForTest()
     vi.clearAllMocks()
   })
 
@@ -119,5 +130,45 @@ describe('/api/v3 proxy route', () => {
     })
     expect(mocks.consume).not.toHaveBeenCalled()
     expect(mocks.fetchWithTimeout).not.toHaveBeenCalled()
+  })
+
+  it('backs off repeated requests after a retryable upstream response', async () => {
+    mocks.fetchWithTimeout.mockResolvedValueOnce(new Response('{"error":true}', {
+      status: 502,
+      statusText: 'Bad Gateway',
+      headers: { 'content-type': 'application/json' },
+    }))
+    const first = makeEvent('POST', 'https://app.example/api/v3/resolve/vaults', '{"chainId":1,"addresses":[]}')
+    const second = makeEvent('POST', 'https://app.example/api/v3/resolve/vaults', '{"chainId":1,"addresses":[]}')
+
+    await expect(handler(first)).resolves.toBe('{"error":true}')
+    await expect(handler(second)).rejects.toMatchObject({
+      statusCode: 503,
+      statusMessage: 'V3 upstream cooling down',
+    })
+
+    expect(first.context.status).toBe(502)
+    expect(first.context.responseHeaders?.['retry-after']).toBe('10')
+    expect(second.context.responseHeaders?.['retry-after']).toBe('10')
+    expect(mocks.fetchWithTimeout).toHaveBeenCalledTimes(1)
+  })
+
+  it('backs off after transport failures instead of surfacing a generic 500', async () => {
+    mocks.fetchWithTimeout.mockRejectedValueOnce(new Error('timeout'))
+    const first = makeEvent('GET', `https://app.example/api/v3/accounts/${ACCOUNT}/positions?chainId=1`)
+    const second = makeEvent('GET', `https://app.example/api/v3/accounts/${ACCOUNT}/positions?chainId=1`)
+
+    await expect(handler(first)).rejects.toMatchObject({
+      statusCode: 503,
+      statusMessage: 'V3 upstream unavailable',
+    })
+    await expect(handler(second)).rejects.toMatchObject({
+      statusCode: 503,
+      statusMessage: 'V3 upstream cooling down',
+    })
+
+    expect(first.context.responseHeaders?.['retry-after']).toBe('10')
+    expect(second.context.responseHeaders?.['retry-after']).toBe('10')
+    expect(mocks.fetchWithTimeout).toHaveBeenCalledTimes(1)
   })
 })

--- a/tests/server/v3-proxy-route.test.ts
+++ b/tests/server/v3-proxy-route.test.ts
@@ -153,6 +153,50 @@ describe('/api/v3 proxy route', () => {
     expect(mocks.fetchWithTimeout).toHaveBeenCalledTimes(1)
   })
 
+  it('keeps cooldown when an overlapping success returns after a retryable failure', async () => {
+    let resolveRetryable: (response: Response) => void = () => {}
+    let resolveSuccess: (response: Response) => void = () => {}
+    mocks.fetchWithTimeout
+      .mockReturnValueOnce(new Promise<Response>((resolve) => {
+        resolveRetryable = resolve
+      }))
+      .mockReturnValueOnce(new Promise<Response>((resolve) => {
+        resolveSuccess = resolve
+      }))
+
+    const retryable = makeEvent('POST', 'https://app.example/api/v3/resolve/vaults', '{"chainId":1,"addresses":[]}')
+    const success = makeEvent('POST', 'https://app.example/api/v3/resolve/vaults', '{"chainId":1,"addresses":[]}')
+
+    const retryableResult = handler(retryable)
+    const successResult = handler(success)
+
+    await Promise.resolve()
+
+    expect(mocks.fetchWithTimeout).toHaveBeenCalledTimes(2)
+
+    resolveRetryable(new Response('{"error":true}', {
+      status: 502,
+      statusText: 'Bad Gateway',
+      headers: { 'content-type': 'application/json' },
+    }))
+    await expect(retryableResult).resolves.toBe('{"error":true}')
+
+    resolveSuccess(new Response('{"ok":true}', {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }))
+    await expect(successResult).resolves.toBe('{"ok":true}')
+
+    const blocked = makeEvent('POST', 'https://app.example/api/v3/resolve/vaults', '{"chainId":1,"addresses":[]}')
+    await expect(handler(blocked)).rejects.toMatchObject({
+      statusCode: 503,
+      statusMessage: 'V3 upstream cooling down',
+    })
+
+    expect(blocked.context.responseHeaders?.['retry-after']).toBe('10')
+    expect(mocks.fetchWithTimeout).toHaveBeenCalledTimes(2)
+  })
+
   it('backs off after transport failures instead of surfacing a generic 500', async () => {
     mocks.fetchWithTimeout.mockRejectedValueOnce(new Error('timeout'))
     const first = makeEvent('GET', `https://app.example/api/v3/accounts/${ACCOUNT}/positions?chainId=1`)

--- a/tests/utils/sdk-query-cache.test.ts
+++ b/tests/utils/sdk-query-cache.test.ts
@@ -7,9 +7,9 @@ describe('sdkBuildQuery', () => {
     sdkQueryClient.clear()
   })
 
-  it('uses a dedicated query client with default retries', () => {
+  it('uses a dedicated query client without default retries', () => {
     expect(sdkQueryClient).not.toBe(queryClient)
-    expect(sdkQueryClient.getDefaultOptions().queries?.retry).toBeUndefined()
+    expect(sdkQueryClient.getDefaultOptions().queries?.retry).toBe(0)
     expect(queryClient.getDefaultOptions().queries?.retry).toBe(0)
   })
 

--- a/tests/utils/sdk-query-cache.test.ts
+++ b/tests/utils/sdk-query-cache.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { sdkBuildQuery, sdkQueryClient } from '~/utils/sdk-query-cache'
+import { clearSdkQueryFailureCacheForTest, sdkBuildQuery, sdkQueryClient } from '~/utils/sdk-query-cache'
 import { queryClient } from '~/utils/query-client'
 
 describe('sdkBuildQuery', () => {
   afterEach(() => {
     sdkQueryClient.clear()
+    clearSdkQueryFailureCacheForTest()
+    vi.useRealTimers()
   })
 
   it('uses a dedicated query client without default retries', () => {
@@ -61,5 +63,29 @@ describe('sdkBuildQuery', () => {
       'SDK query arguments for queryBatchSimulation are not serializable',
     )
     expect(query).not.toHaveBeenCalled()
+  })
+
+  it('briefly caches failed SDK queries to suppress repeated backend calls', async () => {
+    vi.useFakeTimers()
+    const error = new Error('backend unavailable')
+    const query = vi.fn(async (_arg: { vault: string }) => {
+      throw error
+    })
+    const wrapped = sdkBuildQuery('queryVaultAccountInfo', query, {})
+
+    await expect(wrapped({ vault: '0x0000000000000000000000000000000000000001' })).rejects.toThrow(error)
+    await expect(wrapped({ vault: '0x0000000000000000000000000000000000000001' })).rejects.toThrow(error)
+
+    expect(query).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(4_000)
+    await expect(wrapped({ vault: '0x0000000000000000000000000000000000000001' })).rejects.toThrow(error)
+
+    expect(query).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(1_001)
+    await expect(wrapped({ vault: '0x0000000000000000000000000000000000000001' })).rejects.toThrow(error)
+
+    expect(query).toHaveBeenCalledTimes(2)
   })
 })

--- a/utils/sdk-query-cache.ts
+++ b/utils/sdk-query-cache.ts
@@ -3,7 +3,15 @@ import { QueryClient } from '@tanstack/vue-query'
 import { serializeQueryArgs, type BuildQueryFn, type EulerSDKQueryName } from '@eulerxyz/euler-v2-sdk'
 import { DEFAULT_STALE_TIME_MS, FORM_STALE_TIMES, STALE_TIMES } from '~/utils/sdk-query-policy'
 
-export const sdkQueryClient = new QueryClient()
+// Match the app QueryClient: SDK queries already wrap RPC/V3 callers that have
+// their own retry behavior, so TanStack's default 3 retries amplifies outages.
+export const sdkQueryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: 0,
+    },
+  },
+})
 
 type SdkQueryRecord = {
   queryName: string

--- a/utils/sdk-query-cache.ts
+++ b/utils/sdk-query-cache.ts
@@ -3,6 +3,8 @@ import { QueryClient } from '@tanstack/vue-query'
 import { serializeQueryArgs, type BuildQueryFn, type EulerSDKQueryName } from '@eulerxyz/euler-v2-sdk'
 import { DEFAULT_STALE_TIME_MS, FORM_STALE_TIMES, STALE_TIMES } from '~/utils/sdk-query-policy'
 
+const DEFAULT_FAILURE_TTL_MS = 5_000
+
 // Match the app QueryClient: SDK queries already wrap RPC/V3 callers that have
 // their own retry behavior, so TanStack's default 3 retries amplifies outages.
 export const sdkQueryClient = new QueryClient({
@@ -28,6 +30,8 @@ type SdkQueryRecorderWindow = Window & {
   __EULER_SDK_QUERY_RECORDER__?: (record: SdkQueryRecord) => Promise<void> | void
 }
 
+const failureCache = new Map<string, { error: unknown, expiresAt: number }>()
+
 const buildSdkQuery = (staleTimes: Partial<Record<EulerSDKQueryName, number>>): BuildQueryFn => {
   return ((queryName: string, fn, _target: object, context) => {
     const wrapped = (async (...args: Parameters<typeof fn>) => {
@@ -38,9 +42,21 @@ const buildSdkQuery = (staleTimes: Partial<Record<EulerSDKQueryName, number>>): 
 
       const startedAt = queryTimerNow()
       const stack = captureSdkQueryStack()
+      const queryKey = ['sdk', queryName, serializedArgs] as const
+      const failureKey = JSON.stringify(queryKey)
+      let usedCachedFailure = false
       try {
+        const failure = failureCache.get(failureKey)
+        if (failure) {
+          if (failure.expiresAt > Date.now()) {
+            usedCachedFailure = true
+            throw failure.error
+          }
+          failureCache.delete(failureKey)
+        }
+
         const result = await sdkQueryClient.fetchQuery({
-          queryKey: ['sdk', queryName, serializedArgs],
+          queryKey,
           queryFn: async () => {
             const value = await fn(...args)
             return value === undefined ? null : value
@@ -48,11 +64,18 @@ const buildSdkQuery = (staleTimes: Partial<Record<EulerSDKQueryName, number>>): 
           staleTime: staleTimes[queryName as EulerSDKQueryName] ?? DEFAULT_STALE_TIME_MS,
         })
 
+        failureCache.delete(failureKey)
         const value = result === null ? undefined : result
         recordSdkQueryIfRequested({ queryName, serializedArgs, args, status: 'success', durationMs: queryTimerElapsed(startedAt), stack, result: value })
         return value
       }
       catch (error) {
+        if (!usedCachedFailure) {
+          failureCache.set(failureKey, {
+            error,
+            expiresAt: Date.now() + DEFAULT_FAILURE_TTL_MS,
+          })
+        }
         recordSdkQueryIfRequested({ queryName, serializedArgs, args, status: 'error', durationMs: queryTimerElapsed(startedAt), stack, error })
         throw error
       }
@@ -113,10 +136,18 @@ export const sdkFreshBuildQuery = buildSdkQuery(FORM_STALE_TIMES)
 
 export const invalidateSdkQueries = (queryNames: EulerSDKQueryName[]) => {
   const names = new Set<string>(queryNames)
+  for (const key of failureCache.keys()) {
+    const [, queryName] = JSON.parse(key) as [string, string, string]
+    if (names.has(queryName)) failureCache.delete(key)
+  }
   return sdkQueryClient.invalidateQueries({
     predicate: query =>
       query.queryKey[0] === 'sdk'
       && typeof query.queryKey[1] === 'string'
       && names.has(query.queryKey[1]),
   })
+}
+
+export const clearSdkQueryFailureCacheForTest = () => {
+  failureCache.clear()
 }


### PR DESCRIPTION
## Summary
- Reduce retry amplification when V3 is timing out or returning retryable errors.
- Bound repeated Lite SDK query failures so shared query keys fail locally for a short window instead of repeatedly hitting the backend.
- Consume the published `@eulerxyz/euler-v2-sdk@1.0.10` release that carries the matching SDK-side failure-cache behavior.

## Changes
- Disable TanStack default retries for SDK queries to match the main app query client.
- Record a 10-second in-process V3 proxy backoff after 429/5xx responses or transport failures, returning 503 with `Retry-After` while the cooldown is active.
- Convert transport failures from generic 500s into explicit V3 upstream unavailable responses.
- Add a short Lite-side failed SDK query cache so repeated consumers of the same failing SDK query do not create same-key request storms.
- Bump Lite to the published SDK `1.0.10` package and lockfile integrity.

## Test plan
- [x] `npm run test:run -- tests/utils/sdk-query-cache.test.ts tests/server/v3-proxy-route.test.ts` — 14 tests passed.
- [x] `npx eslint utils/sdk-query-cache.ts tests/utils/sdk-query-cache.test.ts "server/api/v3/[...path].ts" tests/server/v3-proxy-route.test.ts`
- [x] `npm run typecheck`
- [x] `npm ls @eulerxyz/euler-v2-sdk --depth=0` resolves `@eulerxyz/euler-v2-sdk@1.0.10`.
- [x] Browser smoke, live V3: disconnected `/portfolio/rewards` renders rewards content; V3 traffic is bounded to initial fan-out (`resolve/vaults` 7x 200, `evk/vaults/batch` 9x 200, `prices` 9x 200, APY endpoints 1x each); no relevant V3 calls after ~3.2s on warm pass.
- [x] Browser smoke, dead upstream: disconnected `/portfolio/rewards` still renders; V3 failures are bounded (`resolve/vaults` 7x 503, `evk/vaults/batch` 8x 503, `prices` 9x 503, APY endpoints 1x each); no exact duplicate request keys and no relevant V3 calls after ~8.7s.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of the v3 API proxy with upstream failure cooldown/backoff, returning consistent `503` responses and setting `Retry-After` for retryable error statuses. Prevents redundant upstream calls and shares cooldown across equivalent dynamic v3 routes.
  * Reduced amplified traffic for SDK queries by disabling automatic retries and briefly caching failed results to suppress repeated backend calls until the cache window expires.
* **Tests**
  * Expanded v3 proxy tests for cooldown behavior (including persistence across overlapping failures and transport errors) and shared cooldown keying; added SDK query cache tests and updated expectations for retry defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->