### PR TITLE
Only warn on unrecognized oracle router

### DIFF
--- a/components/entities/vault/overview/VaultOverviewBlockOracleAdapters.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockOracleAdapters.vue
@@ -267,32 +267,13 @@ const onTooltipMouseLeave = () => {
         Oracles
       </p>
       <UiHoverPreviewTooltip
-        v-if="routerRecognition === 'recognized'"
-        title="Recognized oracle router"
-        text="The vault's price oracle was deployed by the recognized EulerRouterFactory."
-        placement="top-start"
-      >
-        <span
-          class="inline-flex items-center gap-4 rounded-8 px-8 py-2 bg-success-100 text-success-500 text-p5"
-          data-id="data-point"
-          data-field="oracle-router-recognition"
-          data-value="recognized"
-        >
-          <SvgIcon
-            name="check"
-            class="!w-12 !h-12"
-          />
-          Recognized router
-        </span>
-      </UiHoverPreviewTooltip>
-      <UiHoverPreviewTooltip
-        v-else-if="routerRecognition === 'unrecognized'"
+        v-if="routerRecognition === 'unrecognized'"
         title="Unrecognized oracle router"
         text="The vault's price oracle was not deployed by the recognized EulerRouterFactory. Verify the oracle configuration before trusting its prices."
         placement="top-start"
       >
         <span
-          class="inline-flex items-center gap-4 rounded-8 px-8 py-2 bg-warning-100 text-warning-500 text-p5"
+          class="inline-flex items-center gap-4 rounded-8 px-8 py-2 bg-error-100 text-error-500 text-p5"
           data-id="data-point"
           data-field="oracle-router-recognition"
           data-value="unrecognized"


### PR DESCRIPTION
## Summary

Follow-up tweak to the oracle router-recognition signal added in #638 (LITE-236).

The Oracles block header previously rendered **two** badges based on whether the vault's price oracle was deployed by the recognized `EulerRouterFactory`:

- a green ✓ **"Recognized router"** badge when the check passed, and
- a yellow ⚠ **"Unrecognized router"** badge when it failed.

The positive case is the common one, so the green badge mostly added noise to the header. This PR makes the signal quiet-by-default:

- **Removes the "Recognized router" badge entirely** — nothing is shown when the check passes (and, as before, nothing is shown while the allowlist is loading or unavailable, since `getRouterRecognition()` returns `null` there).
- **Switches the "Unrecognized router" badge from warning (yellow) to error (red)** colors so a failed router-recognition check reads as a stronger alert.

## Changes

- **`VaultOverviewBlockOracleAdapters.vue`** — drop the `routerRecognition === 'recognized'` branch; turn the unrecognized branch into the sole `v-if`; swap `bg-warning-100 text-warning-500` → `bg-error-100 text-error-500` on the badge.

The `getRouterRecognition()` helper, the `useEulerOracleRouters` composable, and the `/api/oracle-routers` endpoint are untouched — they're still needed to compute the unrecognized case, and the helper's existing unit tests (which assert the `'recognized'` return value) remain valid.

## Test plan

- [ ] On a vault whose router **is** in `routers/all.json`: no badge shown in the Oracles block header.
- [ ] On a vault whose router is **not** in the allowlist: red ⚠ "Unrecognized router" badge shown.
- [ ] Allowlist empty/unavailable: no badge shown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the oracle router recognition tooltip in the vault overview to show only when a router is unrecognized.
  * Improved the tooltip’s visual emphasis for unrecognized status with clearer error styling.
  * Removed the previous recognized-status tooltip from this section for simpler, more consistent messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->