### PR TITLE
fix: address observability review feedback

### DIFF
--- a/pages/earn/[vault]/[subAccount]/withdraw.vue
+++ b/pages/earn/[vault]/[subAccount]/withdraw.vue
@@ -161,6 +161,7 @@ const submit = async () => {
         phase: 'build',
         operationType: 'withdraw',
         vaultAddress,
+        assetAddress: asset.value?.address,
       }, e)
       plan.value = null
     }

--- a/server/api/client-error.post.ts
+++ b/server/api/client-error.post.ts
@@ -16,6 +16,7 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 405, statusMessage: 'Method not allowed' })
   }
 
+  // Defense-in-depth if this handler is mounted without body-limit middleware.
   const contentLength = Number(event.node.req.headers['content-length'] ?? 0)
   if (Number.isFinite(contentLength) && contentLength > MAX_PAYLOAD_BYTES) {
     logger.warn({ ctx: 'client-error', reason: 'payload-too-large', contentLength, limit: MAX_PAYLOAD_BYTES }, 'request rejected')

--- a/server/api/proxy/fuul/[...path].ts
+++ b/server/api/proxy/fuul/[...path].ts
@@ -18,7 +18,7 @@ import {
 } from 'h3'
 import { createRateLimiter } from '~/server/utils/rate-limit'
 import { logger } from '~/server/utils/logger'
-import { errorStatus, safePathTemplate, searchKeys, urlHost } from '~/server/utils/observability'
+import { errorStatus, safePathTemplate, safeUrlLogFields, searchKeys } from '~/server/utils/observability'
 import {
   createProxyCache,
   createProxyInFlight,
@@ -103,13 +103,10 @@ export default defineEventHandler(async (event) => {
     return res.body
   }
   catch (err) {
-    const targetUrl = new URL(target)
     logger.warn(
       {
         ctx: 'fuul-proxy',
-        upstreamHost: urlHost(target),
-        pathTemplate: safePathTemplate(targetUrl.pathname),
-        searchKeys: searchKeys(targetUrl.searchParams),
+        ...safeUrlLogFields(target),
         status: errorStatus(err),
         err,
       },

--- a/server/api/proxy/incentra/[...path].ts
+++ b/server/api/proxy/incentra/[...path].ts
@@ -22,7 +22,7 @@ import {
 } from 'h3'
 import { createRateLimiter } from '~/server/utils/rate-limit'
 import { logger } from '~/server/utils/logger'
-import { errorStatus, safePathTemplate, searchKeys, urlHost } from '~/server/utils/observability'
+import { errorStatus, safePathTemplate, safeUrlLogFields, searchKeys } from '~/server/utils/observability'
 import {
   createProxyCache,
   createProxyInFlight,
@@ -110,13 +110,10 @@ export default defineEventHandler(async (event) => {
     return res.body
   }
   catch (err) {
-    const targetUrl = new URL(target)
     logger.warn(
       {
         ctx: 'incentra-proxy',
-        upstreamHost: urlHost(target),
-        pathTemplate: safePathTemplate(targetUrl.pathname),
-        searchKeys: searchKeys(targetUrl.searchParams),
+        ...safeUrlLogFields(target),
         bodyBytes: body?.length,
         status: errorStatus(err),
         err,

--- a/server/utils/external-proxy.ts
+++ b/server/utils/external-proxy.ts
@@ -15,7 +15,7 @@ import { fetchWithTimeout } from './fetchWithTimeout'
 import { createTtlCache } from './cache'
 import { createInFlightDedup, type InFlightDedup } from '~/utils/in-flight'
 import { logger } from './logger'
-import { errorStatus, safePathTemplate, urlHost } from './observability'
+import { errorStatus, safeUrlLogFields } from './observability'
 
 export interface ExternalProxyCache {
   get: (key: string) => string | undefined
@@ -107,12 +107,10 @@ export async function forwardProxied(args: ProxyForwardArgs): Promise<ProxyForwa
   catch (err) {
     const stale = cache.getStale(cacheKey)
     if (stale !== undefined) {
-      const targetUrl = new URL(target)
       logger.warn(
         {
           ctx,
-          upstreamHost: urlHost(target),
-          pathTemplate: safePathTemplate(targetUrl.pathname),
+          ...safeUrlLogFields(target),
           status: errorStatus(err),
           err: (err as Error).message,
         },

--- a/server/utils/observability.ts
+++ b/server/utils/observability.ts
@@ -4,6 +4,12 @@ type IssueLike = Record<string, unknown>
 
 const ADDRESS_RE = /^0x[a-fA-F0-9]{40}$/
 
+export interface SafeUrlLogFields {
+  upstreamHost?: string
+  pathTemplate?: string
+  searchKeys: string[]
+}
+
 export function hashIdentifier(value: unknown): string | undefined {
   if (typeof value !== 'string' || !value.trim()) return undefined
   return createHash('sha256').update(value.trim().toLowerCase()).digest('hex').slice(0, 16)
@@ -32,6 +38,26 @@ export function safePathTemplate(pathname: string): string {
 
 export function searchKeys(params: URLSearchParams): string[] {
   return [...new Set([...params.keys()])].sort()
+}
+
+export function safeUrlLogFields(value: unknown): SafeUrlLogFields {
+  if (typeof value !== 'string' || !value.trim()) {
+    return { searchKeys: [] }
+  }
+  try {
+    const url = new URL(value)
+    return {
+      upstreamHost: url.host,
+      pathTemplate: safePathTemplate(url.pathname),
+      searchKeys: searchKeys(url.searchParams),
+    }
+  }
+  catch {
+    return {
+      upstreamHost: urlHost(value),
+      searchKeys: [],
+    }
+  }
 }
 
 export function errorStatus(error: unknown): number | undefined {

--- a/tests/server/observability.test.ts
+++ b/tests/server/observability.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { safePathTemplate, searchKeys, summarizeSdkIssue, urlHost } from '~/server/utils/observability'
+import { safePathTemplate, safeUrlLogFields, searchKeys, summarizeSdkIssue, urlHost } from '~/server/utils/observability'
 
 describe('server observability helpers', () => {
   it('summarizes SDK issues without raw nested diagnostics', () => {
@@ -26,5 +26,14 @@ describe('server observability helpers', () => {
     expect(urlHost(url.toString())).toBe('api.example')
     expect(safePathTemplate(url.pathname)).toBe('/private/key/users/:address/rewards')
     expect(searchKeys(url.searchParams)).toEqual(['chain_id', 'user_address'])
+    expect(safeUrlLogFields(url.toString())).toEqual({
+      upstreamHost: 'api.example',
+      pathTemplate: '/private/key/users/:address/rewards',
+      searchKeys: ['chain_id', 'user_address'],
+    })
+  })
+
+  it('does not throw or leak raw malformed URLs in log metadata', () => {
+    expect(safeUrlLogFields('not a url / secret-key')).toEqual({ searchKeys: [] })
   })
 })

--- a/tests/utils/client-observability.test.ts
+++ b/tests/utils/client-observability.test.ts
@@ -69,4 +69,15 @@ describe('client observability payloads', () => {
     expect(JSON.stringify(payload)).not.toContain('walletAddress')
     expect(JSON.stringify(payload)).not.toContain('private-rpc')
   })
+
+  it('rejects forged error kind values from client input', () => {
+    const payload = sanitizeClientObservabilityInput({
+      source: 'client',
+      event: 'client_invariant_missing',
+      fingerprint: 'abc123',
+      error: { kind: 'not-real', name: 'Error', shortMessage: 'boom', isTransport: true },
+    })
+
+    expect(payload?.error?.kind).toBe('unknown')
+  })
 })

--- a/utils/client-observability.ts
+++ b/utils/client-observability.ts
@@ -37,6 +37,16 @@ const ADDRESS_RE = /^0x[a-fA-F0-9]{40}$/
 const ALLOWED_EVENTS = new Set<string>(CLIENT_EVENTS)
 const TEXT_FIELDS = ['flow', 'phase', 'routeTemplate', 'operationType', 'quoteProvider', 'reason', 'invariant'] as const
 const NUMBER_FIELDS = ['chainId', 'count'] as const
+const ERROR_KINDS = new Set<ReturnType<typeof summarizeViemError>['kind']>([
+  'rpc-timeout',
+  'rpc-http',
+  'rpc-rate-limited',
+  'rpc-resource-unavailable',
+  'rpc-socket-closed',
+  'rpc-unreachable',
+  'contract-revert',
+  'unknown',
+])
 
 export function routeTemplate(pathname: string): string {
   return pathname
@@ -48,6 +58,8 @@ export function routeTemplate(pathname: string): string {
 const truncate = (value: string, max: number): string => value.length > max ? value.slice(0, max) : value
 const isEvent = (value: unknown): value is ClientObservabilityEvent => typeof value === 'string' && ALLOWED_EVENTS.has(value)
 const isAddress = (value: unknown): value is string => typeof value === 'string' && ADDRESS_RE.test(value)
+const isErrorKind = (value: unknown): value is ReturnType<typeof summarizeViemError>['kind'] =>
+  typeof value === 'string' && ERROR_KINDS.has(value as ReturnType<typeof summarizeViemError>['kind'])
 
 function redactText(value: string): string {
   return value
@@ -171,7 +183,7 @@ export function sanitizeClientObservabilityInput(input: unknown): ClientObservab
   if (error && typeof error === 'object') {
     const err = error as Record<string, unknown>
     payload.error = {
-      kind: typeof err.kind === 'string' ? err.kind as ReturnType<typeof summarizeViemError>['kind'] : 'unknown',
+      kind: isErrorKind(err.kind) ? err.kind : 'unknown',
       name: cleanString(err.name, 80) || 'Error',
       shortMessage: cleanString(err.shortMessage, 240) || '',
       isTransport: typeof err.isTransport === 'boolean' ? err.isTransport : false,
@@ -190,7 +202,9 @@ export function shouldSampleClientPayload(payload: ClientObservabilityPayload): 
 }
 
 export async function reportClientEvent(fields: ClientObservabilityFields, error?: unknown): Promise<void> {
-  if (!import.meta.client || import.meta.dev) return
+  // Production-only by default; set NUXT_PUBLIC_OBSERVABILITY_DEV=true to test
+  // the browser-to-/api/client-error path during local development.
+  if (!import.meta.client || (import.meta.dev && import.meta.env.NUXT_PUBLIC_OBSERVABILITY_DEV !== 'true')) return
   const payload = normalizeClientObservabilityPayload({
     routeTemplate: routeTemplate(window.location.pathname),
     ...fields,


### PR DESCRIPTION
## Summary
- guard proxy observability logging against malformed target URLs
- validate client-supplied observability error kinds
- add earn-withdraw asset context and document the client-error size guard

## Tests
- npm run typecheck
- npm run test:run -- tests/server/observability.test.ts tests/utils/client-observability.test.ts tests/server/client-error.test.ts tests/server/screen-address.test.ts tests/server/v3-proxy-route.test.ts tests/server/v3-proxy.test.ts
- npx eslint server/utils/observability.ts server/utils/external-proxy.ts server/api/proxy/fuul/[...path].ts server/api/proxy/incentra/[...path].ts utils/client-observability.ts pages/earn/[vault]/[subAccount]/withdraw.vue server/api/client-error.post.ts tests/server/observability.test.ts tests/utils/client-observability.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for failed withdrawal actions with more complete diagnostic details.
  * Strengthened handling of proxy failures and client-submitted error data to avoid misleading or unsafe diagnostics.
  * Added safer handling for URL-based log details, including malformed inputs.

* **Chores**
  * Updated internal observability behavior so production logging is more consistent, with optional development logging support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->