### PR TITLE
fix: redact upstream URL paths in logs

### DIFF
--- a/server/api/proxy/subgraph/[chainId].post.ts
+++ b/server/api/proxy/subgraph/[chainId].post.ts
@@ -35,7 +35,7 @@ import {
 } from 'h3'
 import { createRateLimiter } from '~/server/utils/rate-limit'
 import { logger } from '~/server/utils/logger'
-import { safePathTemplate, urlHost } from '~/server/utils/observability'
+import { safeUrlLogFields } from '~/server/utils/observability'
 import {
   createProxyCache,
   createProxyInFlight,
@@ -114,13 +114,11 @@ export default defineEventHandler(async (event) => {
     return res.body
   }
   catch (err) {
-    const targetUrl = new URL(target)
     logger.warn(
       {
         ctx: 'subgraph-proxy',
         chainId,
-        upstreamHost: urlHost(target),
-        pathTemplate: safePathTemplate(targetUrl.pathname),
+        ...safeUrlLogFields(target),
         err,
       },
       'upstream failed',

--- a/server/utils/observability.ts
+++ b/server/utils/observability.ts
@@ -6,7 +6,6 @@ const ADDRESS_RE = /^0x[a-fA-F0-9]{40}$/
 
 export interface SafeUrlLogFields {
   upstreamHost?: string
-  pathTemplate?: string
   searchKeys: string[]
 }
 
@@ -48,7 +47,6 @@ export function safeUrlLogFields(value: unknown): SafeUrlLogFields {
     const url = new URL(value)
     return {
       upstreamHost: url.host,
-      pathTemplate: safePathTemplate(url.pathname),
       searchKeys: searchKeys(url.searchParams),
     }
   }

--- a/tests/server/observability.test.ts
+++ b/tests/server/observability.test.ts
@@ -28,9 +28,18 @@ describe('server observability helpers', () => {
     expect(searchKeys(url.searchParams)).toEqual(['chain_id', 'user_address'])
     expect(safeUrlLogFields(url.toString())).toEqual({
       upstreamHost: 'api.example',
-      pathTemplate: '/private/key/users/:address/rewards',
       searchKeys: ['chain_id', 'user_address'],
     })
+  })
+
+  it('does not include path-embedded provider tokens in URL log metadata', () => {
+    const fields = safeUrlLogFields('https://provider.example/v2/secret-token/rpc?key=x')
+
+    expect(fields).toEqual({
+      upstreamHost: 'provider.example',
+      searchKeys: ['key'],
+    })
+    expect(JSON.stringify(fields)).not.toContain('secret-token')
   })
 
   it('does not throw or leak raw malformed URLs in log metadata', () => {

--- a/tests/server/subgraph-proxy-route.test.ts
+++ b/tests/server/subgraph-proxy-route.test.ts
@@ -1,0 +1,99 @@
+import type { H3Event } from 'h3'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  consume: vi.fn(),
+  forwardProxied: vi.fn(),
+  warn: vi.fn(),
+}))
+
+vi.mock('h3', () => ({
+  createError: (error: unknown) => error,
+  getMethod: (event: TestEvent) => event.method,
+  getRouterParam: (event: TestEvent, name: string) => event.params[name],
+  readRawBody: (event: TestEvent) => event.body,
+  setResponseHeaders: (event: TestEvent, headers: Record<string, string>) => {
+    event.context.responseHeaders = {
+      ...event.context.responseHeaders,
+      ...headers,
+    }
+  },
+  setResponseStatus: (event: TestEvent, status: number, statusText?: string) => {
+    event.context.status = status
+    event.context.statusText = statusText
+  },
+}))
+
+vi.mock('~/server/utils/rate-limit', () => ({
+  createRateLimiter: () => ({ consume: mocks.consume }),
+}))
+
+vi.mock('~/server/utils/logger', () => ({
+  logger: { warn: mocks.warn },
+}))
+
+vi.mock('~/server/utils/external-proxy', () => ({
+  createProxyCache: () => ({}),
+  createProxyInFlight: () => ({}),
+  forwardProxied: mocks.forwardProxied,
+}))
+
+type TestEvent = H3Event & {
+  method: string
+  params: Record<string, string>
+  body?: string
+  context: {
+    responseHeaders?: Record<string, string>
+    status?: number
+    statusText?: string
+  }
+}
+
+const handler = (await import('~/server/api/proxy/subgraph/[chainId].post')).default
+
+const makeEvent = (chainId: string, body = '{"query":"{ vaults { id } }"}'): TestEvent => ({
+  method: 'POST',
+  params: { chainId },
+  body,
+  context: {},
+  node: {
+    req: {
+      headers: {
+        'cf-connecting-ip': '127.0.0.1',
+      },
+      socket: {},
+    },
+    res: {},
+  },
+} as unknown as TestEvent)
+
+describe('/api/proxy/subgraph route', () => {
+  afterEach(() => {
+    delete process.env.SUBGRAPH_URL_1
+    delete process.env.NUXT_PUBLIC_SUBGRAPH_URI_1
+    vi.clearAllMocks()
+  })
+
+  it('returns a sanitized 502 when the configured upstream URL is malformed', async () => {
+    process.env.SUBGRAPH_URL_1 = 'not a url'
+    mocks.forwardProxied.mockRejectedValueOnce(new TypeError('Invalid URL'))
+
+    await expect(handler(makeEvent('1'))).rejects.toMatchObject({
+      statusCode: 502,
+      statusMessage: 'Subgraph upstream unavailable',
+    })
+
+    expect(mocks.forwardProxied).toHaveBeenCalledWith(expect.objectContaining({
+      target: 'not a url',
+    }))
+    expect(mocks.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ctx: 'subgraph-proxy',
+        chainId: 1,
+        searchKeys: [],
+      }),
+      'upstream failed',
+    )
+    expect(JSON.stringify(mocks.warn.mock.calls[0][0])).not.toContain('not a url')
+  })
+})


### PR DESCRIPTION
## Summary
- Prevent upstream URL path segments from being emitted in structured log metadata, since provider URLs can embed secrets in paths.
- Make subgraph upstream failure logging tolerate malformed configured URLs and still return the normalized 502 response.

## Changes
- Reduced safeUrlLogFields output to upstreamHost and query-key metadata only.
- Kept caller-owned static path templating available through safePathTemplate.
- Switched the subgraph proxy catch handler to safeUrlLogFields and added route coverage for malformed configured upstream URLs.

## Test plan
- [x] npx vitest run tests/server/observability.test.ts tests/server/subgraph-proxy-route.test.ts
- [x] npx eslint server/utils/observability.ts 'server/api/proxy/subgraph/[chainId].post.ts' tests/server/observability.test.ts tests/server/subgraph-proxy-route.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subgraph proxy error handling so malformed upstream URLs return a sanitized 502 response.
  * Reduced sensitive URL details in warning logs while preserving useful host and query information.

* **Tests**
  * Added coverage for observability logging to ensure path tokens are not exposed.
  * Added route-level tests for malformed upstream configuration and sanitized failure behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->