### PR TITLE
fix: preserve client error fingerprints

### DIFF
--- a/tests/utils/client-observability.test.ts
+++ b/tests/utils/client-observability.test.ts
@@ -70,6 +70,27 @@ describe('client observability payloads', () => {
     expect(JSON.stringify(payload)).not.toContain('private-rpc')
   })
 
+  it('fingerprints sanitized server input after preserving error details', () => {
+    const first = sanitizeClientObservabilityInput({
+      source: 'client',
+      event: 'tx_execute_failed',
+      fingerprint: 'client-sampled',
+      message: 'first rpc failure',
+      error: { kind: 'rpc-http', name: 'HttpRequestError', shortMessage: 'HTTP request failed', isTransport: true },
+    })
+    const second = sanitizeClientObservabilityInput({
+      source: 'client',
+      event: 'tx_execute_failed',
+      fingerprint: 'client-sampled',
+      message: 'second rpc failure',
+      error: { kind: 'rpc-timeout', name: 'TimeoutError', shortMessage: 'Timed out', isTransport: true },
+    })
+
+    expect(first?.fingerprint).toMatch(/^[0-9a-f]{8}$/)
+    expect(second?.fingerprint).toMatch(/^[0-9a-f]{8}$/)
+    expect(first?.fingerprint).not.toBe(second?.fingerprint)
+  })
+
   it('rejects forged error kind values from client input', () => {
     const payload = sanitizeClientObservabilityInput({
       source: 'client',

--- a/utils/client-observability.ts
+++ b/utils/client-observability.ts
@@ -80,6 +80,19 @@ function stableHash(input: string): string {
   return (hash >>> 0).toString(16).padStart(8, '0')
 }
 
+function clientPayloadFingerprint(payload: ClientObservabilityPayload): string {
+  return stableHash(JSON.stringify({
+    event: payload.event,
+    flow: payload.flow,
+    phase: payload.phase,
+    routeTemplate: payload.routeTemplate,
+    chainId: payload.chainId,
+    name: payload.name,
+    message: payload.message,
+    kind: payload.error?.kind,
+  }))
+}
+
 function errorCode(error: unknown): number | string | undefined {
   let current = error
   const seen = new WeakSet<object>()
@@ -151,16 +164,7 @@ export function normalizeClientObservabilityPayload(
   }
   addAllowlistedFields(payload, fields as unknown as Record<string, unknown>)
   addErrorSummary(payload, error)
-  payload.fingerprint = stableHash(JSON.stringify({
-    event: payload.event,
-    flow: payload.flow,
-    phase: payload.phase,
-    routeTemplate: payload.routeTemplate,
-    chainId: payload.chainId,
-    name: payload.name,
-    message: payload.message,
-    kind: payload.error?.kind,
-  }))
+  payload.fingerprint = clientPayloadFingerprint(payload)
 
   return payload
 }
@@ -193,6 +197,8 @@ export function sanitizeClientObservabilityInput(input: unknown): ClientObservab
       ...(typeof err.causeName === 'string' ? { causeName: truncate(err.causeName, 80) } : {}),
     }
   }
+
+  payload.fingerprint = clientPayloadFingerprint(payload)
 
   return payload
 }


### PR DESCRIPTION
## Summary
- Recompute sanitized client error fingerprints after the server preserves inbound message, name, and error metadata.
- Prevent distinct client-side failures from collapsing into the same server-side fingerprint or being sampled differently after upload.

## Changes
- Extracted the client observability fingerprint projection into one helper shared by browser-created and server-sanitized payloads.
- Recomputed the sanitized payload fingerprint after copying allowlisted inbound error details.
- Added regression coverage for two uploaded execution failures with the same client fingerprint but different sanitized error details.

## Test plan
- [x] npx vitest run tests/utils/client-observability.test.ts tests/server/client-error.test.ts
- [x] npx eslint utils/client-observability.ts tests/utils/client-observability.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how client observability fingerprints are generated after input sanitization, helping ensure consistent and distinct tracking for similar errors.
  * Fixed fingerprint handling so sanitized events now produce the expected short hexadecimal format.

* **Tests**
  * Added coverage to verify sanitized observability data recalculates fingerprints correctly and keeps different errors separated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->