### PR TITLE
fix: show zero loaded bad debt

### DIFF
--- a/components/entities/vault/discovery/DiscoveryMarketAttributeMatrix.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketAttributeMatrix.vue
@@ -41,7 +41,7 @@ interface AttributeColumn {
 const attributeColumns = computed<AttributeColumn[]>(() =>
   filterAttributeRowsByBadDebtAvailability(props.data.rows, props.showBadDebtColumn).map(attribute => ({
     attribute,
-    cells: buildAttributeRowCells(attribute, props.data.columns, props.usdCache, props.apyCache, props.badDebtCache),
+    cells: buildAttributeRowCells(attribute, props.data.columns, props.usdCache, props.apyCache, props.badDebtCache, props.showBadDebtColumn),
   })),
 )
 

--- a/tests/utils/discovery-calculations.test.ts
+++ b/tests/utils/discovery-calculations.test.ts
@@ -358,6 +358,26 @@ describe('attribute stats matrix', () => {
     expect(cell.hint).toContain('25% of total borrows')
     expect(cell.hint).toContain('2 underwater accounts')
   })
+
+  it('shows zero bad debt for borrowable vaults when loaded data has no row', () => {
+    const vault = {
+      ...makeVault('0xNoBadDebt', []),
+      totalAssets: 1000n,
+      totalBorrowed: 500n,
+    } as unknown as EVault
+    const columns = [{ address: vault.address.toLowerCase(), symbol: 'TST', assetAddress: vault.asset.address, vault, isExternal: false }]
+    const row = STATS_ROWS.find(row => row.id === 'badDebt')!
+
+    const loadingCell = buildAttributeRowCells(row, columns, new Map(), undefined, new Map(), false)[0]
+    const loadedCell = buildAttributeRowCells(row, columns, new Map(), undefined, new Map(), true)[0]
+
+    expect(loadingCell.display).toBe('—')
+    expect(loadedCell).toMatchObject({
+      display: '$0',
+      numeric: 0,
+      kind: 'text',
+    })
+  })
 })
 
 describe('getMarketEntities', () => {

--- a/utils/discoveryCalculations.ts
+++ b/utils/discoveryCalculations.ts
@@ -660,6 +660,7 @@ export interface AttributeRow {
     usd: VaultUsdCacheEntry | undefined,
     apy: VaultApyCacheEntry | undefined,
     badDebt: VaultBadDebtCacheEntry | undefined,
+    isBadDebtLoaded: boolean,
   ) => AttributeCell
 }
 
@@ -898,9 +899,13 @@ export const STATS_ROWS: AttributeRow[] = [
   {
     id: 'badDebt',
     label: 'Bad debt',
-    getValue: (vault, usd, _apy, badDebt) => {
+    getValue: (vault, usd, _apy, badDebt, isBadDebtLoaded) => {
       if (!isEVault(vault) || isEscrow(vault)) return NA_CELL
-      if (!badDebt) return NA_CELL
+      if (!badDebt) {
+        return isBadDebtLoaded
+          ? { display: '$0', numeric: 0, kind: 'text' }
+          : NA_CELL
+      }
       return {
         display: formatBadDebtUsd(badDebt),
         numeric: badDebt.badDebtUsd,
@@ -1030,10 +1035,12 @@ export const buildAttributeRowCells = (
   usdCache: Map<string, VaultUsdCacheEntry>,
   apyCache?: Map<string, VaultApyCacheEntry>,
   badDebtCache?: Map<string, VaultBadDebtCacheEntry>,
+  isBadDebtLoaded = false,
 ): AttributeCell[] =>
   columns.map(col => row.getValue(
     col.vault,
     usdCache.get(col.address),
     apyCache?.get(col.address),
     badDebtCache?.get(col.address),
+    isBadDebtLoaded,
   ))


### PR DESCRIPTION
## Summary
- Render loaded-but-missing bad-debt rows as `$0` for borrowable vaults in the Explore stats matrix.
- Keep escrow and non-borrowable rows as unavailable, and keep not-yet-loaded bad-debt data as unavailable.

## Changes
- Passed the existing bad-debt loaded signal into discovery attribute cell construction.
- Updated the bad-debt stats row to distinguish loaded cache misses from unloaded data.
- Added regression coverage for a borrowable vault with loaded bad-debt data but no bad-debt row.

## Test plan
- [x] `npx vitest run tests/utils/discovery-calculations.test.ts`
- [x] `npm run typecheck`
- [x] `npx eslint utils/discoveryCalculations.ts components/entities/vault/discovery/DiscoveryMarketAttributeMatrix.vue tests/utils/discovery-calculations.test.ts`

Note: ESLint reports the existing `no-explicit-any` warning at `tests/utils/discovery-calculations.test.ts:39`; this PR does not add that warning.