### PR TITLE
fix: gate v3-only metrics

### DIFF
--- a/components/entities/vault/VaultCollateralExposureModal.vue
+++ b/components/entities/vault/VaultCollateralExposureModal.vue
@@ -14,6 +14,7 @@ const {
   getOpenInterestForVault,
   hasError: hasOpenInterestError,
   isLoaded: isOpenInterestLoaded,
+  isOpenInterestEnabled,
 } = useCollateralOpenInterest()
 
 const allCollateralPairs = computed(() =>
@@ -23,7 +24,9 @@ const allCollateralPairs = computed(() =>
   ),
 )
 
-const openInterestUsdByCollateral = computed(() => getOpenInterestForVault(vault.address))
+const openInterestUsdByCollateral = computed<Record<string, number>>(() =>
+  isOpenInterestEnabled.value ? getOpenInterestForVault(vault.address) : {},
+)
 const collateralGroups = computed(() =>
   getCollateralExposureGroups(allCollateralPairs.value, openInterestUsdByCollateral.value),
 )
@@ -36,7 +39,9 @@ const getPairOpenInterestUsd = (pair: { collateral: EVault | SecuritizeCollatera
     .find(([address]) => address.toLowerCase() === pair.collateral.address.toLowerCase())
   return entry?.[1] ?? 0
 }
-const hasLiveExposureData = computed(() => isOpenInterestLoaded.value && !hasOpenInterestError.value)
+const hasLiveExposureData = computed(() =>
+  isOpenInterestEnabled.value && isOpenInterestLoaded.value && !hasOpenInterestError.value,
+)
 const formatExposurePercent = (valueUsd: number) =>
   !hasLiveExposureData.value
     ? '-'
@@ -63,7 +68,7 @@ const onCollateralClick = (address: string) => {
 }
 
 watchEffect(() => {
-  if (!vault.address) return
+  if (!vault.address || !isOpenInterestEnabled.value) return
   void loadOpenInterest()
 })
 </script>
@@ -74,7 +79,7 @@ watchEffect(() => {
     @close="$emit('close')"
   >
     <div
-      v-if="collateralGroups.length > 0"
+      v-if="isOpenInterestEnabled && collateralGroups.length > 0"
       class="flex flex-col gap-12"
     >
       <p class="text-p3 text-content-secondary mb-4">

--- a/components/entities/vault/VaultEarnItem.vue
+++ b/components/entities/vault/VaultEarnItem.vue
@@ -33,6 +33,7 @@ const {
   getOpenInterestForVault,
   hasError: hasOpenInterestError,
   isLoaded: isOpenInterestLoaded,
+  isOpenInterestEnabled,
 } = useCollateralOpenInterest()
 const entities = useEulerEntitiesOfEarnVault(vault)
 const isOwnerVerified = computed(() => isEarnVaultOwnerVerified(vault))
@@ -101,7 +102,9 @@ const getStrategyMarketSource = (strategyVault: EVault) => {
     },
   }
 }
-const hasLiveExposureData = computed(() => isOpenInterestLoaded.value && !hasOpenInterestError.value)
+const hasLiveExposureData = computed(() =>
+  isOpenInterestEnabled.value && isOpenInterestLoaded.value && !hasOpenInterestError.value,
+)
 const isStrategyAllocationUsdLoaded = computed(() =>
   vault.strategies.every((strategy) => {
     const strategyVault = getStrategyVault(strategy)
@@ -133,6 +136,7 @@ const hasUnavailableExposureSplit = computed(() => {
   })
 })
 const exposureValueState = computed<ExposureValueState>(() => {
+  if (!isOpenInterestEnabled.value) return 'unavailable'
   if (!isStrategyAllocationUsdLoaded.value) return 'loading'
   if (hasOpenInterestError.value) return 'unavailable'
   if (hasUnavailableStrategyAllocationUsd.value) return 'unavailable'
@@ -164,7 +168,7 @@ const exposureDisplayItems = computed(() =>
 )
 
 watchEffect(() => {
-  if (!vault.strategies.length) return
+  if (!vault.strategies.length || !isOpenInterestEnabled.value) return
   void loadOpenInterest()
 })
 
@@ -218,7 +222,7 @@ const statsGridCols = computed(() => {
   if (enableEntityBranding) cols.push('1fr')
   cols.push('1fr') // Total supply
   cols.push('1fr') // Available liquidity
-  cols.push('1fr') // Exposure
+  if (isOpenInterestEnabled.value) cols.push('1fr') // Exposure
   if (isConnected.value) cols.push('1fr') // In wallet
   return cols.join(' ')
 })
@@ -400,6 +404,7 @@ const supplyApyModalData = computed(() => ({
         </div>
       </div>
       <div
+        v-if="isOpenInterestEnabled"
         class="flex flex-col flex-1 mobile:!hidden"
         :class="isConnected ? 'items-center' : 'items-end text-right'"
       >
@@ -474,7 +479,10 @@ const supplyApyModalData = computed(() => ({
           >-</div>
         </div>
       </div>
-      <div class="flex w-full justify-between">
+      <div
+        v-if="isOpenInterestEnabled"
+        class="flex w-full justify-between"
+      >
         <div class="text-content-tertiary text-p3">
           Exposure
         </div>

--- a/components/entities/vault/VaultItem.vue
+++ b/components/entities/vault/VaultItem.vue
@@ -29,6 +29,7 @@ const {
   getOpenInterestForVault,
   hasError: hasOpenInterestError,
   isLoaded: isOpenInterestLoaded,
+  isOpenInterestEnabled,
 } = useCollateralOpenInterest()
 const isUnverified = computed(() => !isVerifiedVault(vault.address))
 const isGovernorVerified = computed(() => isVaultGovernorVerified(vault))
@@ -64,13 +65,16 @@ const collateralExposureGroups = computed(() => {
     getOpenInterestForVault(vault.address),
   )
 })
-const hasLiveExposureData = computed(() => isOpenInterestLoaded.value && !hasOpenInterestError.value)
+const hasLiveExposureData = computed(() =>
+  isOpenInterestEnabled.value && isOpenInterestLoaded.value && !hasOpenInterestError.value,
+)
 const hasUnavailableExposureSplit = computed(() =>
   hasLiveExposureData.value
   && priceValues.value.totalSupplyState === 'ready'
   && hasMissingUtilizedExposureSplit(collateralExposureGroups.value, vault.utilization),
 )
 const exposureValueState = computed<ExposureValueState>(() => {
+  if (!isOpenInterestEnabled.value) return 'unavailable'
   if (hasOpenInterestError.value) return 'unavailable'
   if (priceValues.value.totalSupplyState === 'unavailable') return 'unavailable'
   if (hasUnavailableExposureSplit.value) return 'unavailable'
@@ -90,7 +94,7 @@ const exposureDisplayItems = computed(() => {
 })
 
 watchEffect(() => {
-  if (!isBorrowable.value) return
+  if (!isBorrowable.value || !isOpenInterestEnabled.value) return
   void loadOpenInterest()
 })
 
@@ -123,7 +127,7 @@ const statsGridCols = computed(() => {
   cols.push('1fr') // Total supply
   if (isBorrowable.value) {
     cols.push('1fr') // Available liquidity
-    cols.push('1fr') // Exposure
+    if (isOpenInterestEnabled.value) cols.push('1fr') // Exposure
     cols.push('1fr') // Utilization
   }
   if (isConnected.value) cols.push('1fr') // In wallet
@@ -361,7 +365,7 @@ watchEffect(async () => {
         </div>
       </div>
       <div
-        v-if="isBorrowable"
+        v-if="isBorrowable && isOpenInterestEnabled"
         class="flex flex-col flex-1 mobile:!hidden"
         :class="isConnected ? 'items-center' : 'items-end text-right'"
       >
@@ -463,7 +467,7 @@ watchEffect(async () => {
         </div>
       </div>
       <div
-        v-if="isBorrowable"
+        v-if="isBorrowable && isOpenInterestEnabled"
         class="flex w-full justify-between"
       >
         <div class="flex-1">

--- a/components/entities/vault/discovery/DiscoveryMarketAccordion.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketAccordion.vue
@@ -35,7 +35,7 @@ const props = defineProps<{
 const { isMarketDataResolved } = useVaults()
 const route = useRoute()
 const { chainId } = useEulerAddresses()
-const { badDebtByChain, isBadDebtLoaded, loadBadDebtForChain } = useVaultBadDebt()
+const { badDebtByChain, isBadDebtEnabled, isBadDebtLoaded, loadBadDebtForChain } = useVaultBadDebt()
 const shareLinkQuery = computed(() => {
   const network = route.query.network
 
@@ -164,13 +164,13 @@ const onToggle = (market: MarketGroup) => {
   toggleExpand(market.id)
   if (!wasExpanded) {
     loadVaultUsdValues(market)
-    void loadBadDebtForChain()
+    if (isBadDebtEnabled.value) void loadBadDebtForChain()
   }
 }
 
 watch([() => props.markets, isMarketDataResolved, chainId], () => {
   void loadExpandedVaultUsdValues()
-  if (expandedMarkets.value.size > 0) void loadBadDebtForChain()
+  if (isBadDebtEnabled.value && expandedMarkets.value.size > 0) void loadBadDebtForChain()
 })
 
 // -- Matrix view selector (single dropdown spans Stats, Configuration,
@@ -445,7 +445,7 @@ onMounted(() => {
       loadVaultUsdValues(market)
     }
   }
-  if (expandedMarkets.value.size > 0) void loadBadDebtForChain()
+  if (isBadDebtEnabled.value && expandedMarkets.value.size > 0) void loadBadDebtForChain()
 })
 </script>
 
@@ -670,7 +670,7 @@ onMounted(() => {
               :usd-cache="vaultUsdCache"
               :apy-cache="vaultApyCache"
               :bad-debt-cache="vaultBadDebtCache"
-              :show-bad-debt-column="isBadDebtLoaded"
+              :show-bad-debt-column="isBadDebtEnabled && isBadDebtLoaded"
               :selected-header="selectedMatrixHeader?.marketId === market.id ? { address: selectedMatrixHeader.address, axis: selectedMatrixHeader.axis } : null"
               @select-header="(addr: string, axis: 'row' | 'column') => toggleMatrixHeader(market.id, addr, axis)"
             />

--- a/components/entities/vault/discovery/DiscoveryMarketAttributeMatrix.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketAttributeMatrix.vue
@@ -40,6 +40,7 @@ const {
   getOpenInterestForVault,
   hasError: hasOpenInterestError,
   isLoaded: isOpenInterestLoaded,
+  isOpenInterestEnabled,
 } = useCollateralOpenInterest()
 
 // Each AttributeRow renders as a *table column*; each vault renders as a *table row*.
@@ -49,10 +50,12 @@ interface AttributeColumn {
 }
 
 const attributeColumns = computed<AttributeColumn[]>(() =>
-  filterAttributeRowsByBadDebtAvailability(props.data.rows, props.showBadDebtColumn).map(attribute => ({
-    attribute,
-    cells: buildAttributeRowCells(attribute, props.data.columns, props.usdCache, props.apyCache, props.badDebtCache, props.showBadDebtColumn),
-  })),
+  filterAttributeRowsByBadDebtAvailability(props.data.rows, props.showBadDebtColumn)
+    .filter(attribute => isOpenInterestEnabled.value || attribute.id !== 'exposure')
+    .map(attribute => ({
+      attribute,
+      cells: buildAttributeRowCells(attribute, props.data.columns, props.usdCache, props.apyCache, props.badDebtCache, props.showBadDebtColumn),
+    })),
 )
 
 const getHooksModalData = (vault: AttributeMatrixColumn) => ({
@@ -65,8 +68,11 @@ const canShowHooksModal = (vault: AttributeMatrixColumn, cell: AttributeCell) =>
   cell.hookable && isVaultType(vault.vault)
 
 const entitiesFor = (vault: AttributeMatrixColumn) => getEntitiesByVault(vault.vault)
-const hasLiveExposureData = computed(() => isOpenInterestLoaded.value && !hasOpenInterestError.value)
+const hasLiveExposureData = computed(() =>
+  isOpenInterestEnabled.value && isOpenInterestLoaded.value && !hasOpenInterestError.value,
+)
 const exposureValueState = computed<ExposureValueState>(() => {
+  if (!isOpenInterestEnabled.value) return 'unavailable'
   if (hasLiveExposureData.value) return 'ready'
   if (hasOpenInterestError.value) return 'unavailable'
   return 'loading'
@@ -123,6 +129,7 @@ const getVaultExposureValueState = (vault: AttributeMatrixColumn): ExposureValue
 
 watchEffect(() => {
   if (props.view !== 'stats') return
+  if (!isOpenInterestEnabled.value) return
   if (!props.data.columns.some(column => isEVault(column.vault))) return
   void loadOpenInterest()
 })

--- a/components/entities/vault/overview/VaultOverviewBlockBorrow.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockBorrow.vue
@@ -16,6 +16,7 @@ const {
   getOpenInterestForVault,
   hasError: hasOpenInterestError,
   isLoaded: isOpenInterestLoaded,
+  isOpenInterestEnabled,
 } = useCollateralOpenInterest()
 
 const onCollateralClick = (address: string) => {
@@ -52,7 +53,9 @@ const allCollateralPairs = computed(() =>
   ),
 )
 
-const openInterestUsdByCollateral = computed(() => getOpenInterestForVault(vault.address))
+const openInterestUsdByCollateral = computed<Record<string, number>>(() =>
+  isOpenInterestEnabled.value ? getOpenInterestForVault(vault.address) : {},
+)
 const collateralGroups = computed(() =>
   getCollateralExposureGroups(allCollateralPairs.value, openInterestUsdByCollateral.value),
 )
@@ -65,7 +68,9 @@ const getPairOpenInterestUsd = (pair: { collateral: EVault | SecuritizeCollatera
     .find(([address]) => address.toLowerCase() === pair.collateral.address.toLowerCase())
   return entry?.[1] ?? 0
 }
-const hasLiveExposureData = computed(() => isOpenInterestLoaded.value && !hasOpenInterestError.value)
+const hasLiveExposureData = computed(() =>
+  isOpenInterestEnabled.value && isOpenInterestLoaded.value && !hasOpenInterestError.value,
+)
 const formatExposurePercent = (valueUsd: number) =>
   !hasLiveExposureData.value
     ? '-'
@@ -74,14 +79,14 @@ const formatLiveExposureUsd = (valueUsd: number) =>
   hasLiveExposureData.value ? formatCompactUsdValue(valueUsd) : '-'
 
 watchEffect(() => {
-  if (!vault.address) return
+  if (!vault.address || !isOpenInterestEnabled.value) return
   void loadOpenInterest()
 })
 </script>
 
 <template>
   <VaultOverviewAccordionSection
-    v-if="collateralGroups.length"
+    v-if="isOpenInterestEnabled && collateralGroups.length"
     title="Exposure"
     :default-open="defaultOpen"
     content-class="flex flex-col gap-24"

--- a/components/entities/vault/overview/VaultOverviewBlockGeneral.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockGeneral.vue
@@ -30,6 +30,7 @@ const {
   getOpenInterestForVault,
   hasError: hasOpenInterestError,
   isLoaded: isOpenInterestLoaded,
+  isOpenInterestEnabled,
 } = useCollateralOpenInterest()
 
 type VaultPropertyBadge = Extract<VaultTypeBadge, 'private' | 'accessControl' | 'governanceLimited' | 'cyclicalNote'>
@@ -58,13 +59,16 @@ const borrowCount = computed(() => {
   return vault.collaterals.filter(ltv => ltv.borrowLTV > 0).length
 })
 const hasBorrowSideExposure = computed(() => isVaultBorrowable(vault))
-const hasLiveExposureData = computed(() => isOpenInterestLoaded.value && !hasOpenInterestError.value)
+const hasLiveExposureData = computed(() =>
+  isOpenInterestEnabled.value && isOpenInterestLoaded.value && !hasOpenInterestError.value,
+)
 const hasUnavailableExposureSplit = computed(() =>
   hasLiveExposureData.value
   && totalSupplyState.value === 'ready'
   && hasMissingUtilizedExposureSplit(collateralExposureGroups.value, vault.utilization),
 )
 const exposureValueState = computed<ExposureValueState>(() => {
+  if (!isOpenInterestEnabled.value) return 'unavailable'
   if (hasOpenInterestError.value) return 'unavailable'
   if (totalSupplyState.value === 'unavailable') return 'unavailable'
   if (hasUnavailableExposureSplit.value) return 'unavailable'
@@ -144,7 +148,7 @@ watchEffect(async () => {
 })
 
 watchEffect(() => {
-  if (!hasBorrowSideExposure.value) return
+  if (!hasBorrowSideExposure.value || !isOpenInterestEnabled.value) return
   void loadOpenInterest()
 })
 </script>
@@ -266,7 +270,7 @@ watchEffect(() => {
         </div>
       </VaultOverviewLabelValue>
       <VaultOverviewLabelValue
-        v-if="hasBorrowSideExposure"
+        v-if="hasBorrowSideExposure && isOpenInterestEnabled"
         label="Exposure"
       >
         <VaultExposureSummary

--- a/components/entities/vault/overview/VaultOverviewBlockOpenInterest.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockOpenInterest.vue
@@ -25,6 +25,7 @@ const {
   hasError,
   isLoaded: isOpenInterestLoaded,
   isLoading,
+  isOpenInterestEnabled,
 } = useCollateralOpenInterest()
 
 const chartData = shallowRef<ChartData<'doughnut', number[], string> | null>(null)
@@ -32,7 +33,8 @@ const chartOptions = shallowRef<ChartOptions<'doughnut'> | null>(null)
 const vaultDataKey = computed(() => normalizeOpenInterestAddress(vault.address))
 
 const canLoadOpenInterest = computed(() =>
-  vault.collaterals.some(ltv => ltv.currentLiquidationLTV > 0 || ltv.borrowLTV > 0),
+  isOpenInterestEnabled.value
+  && vault.collaterals.some(ltv => ltv.currentLiquidationLTV > 0 || ltv.borrowLTV > 0),
 )
 
 const getCollateralInput = (address: string, valueUsd: number): OpenInterestCollateralInput => {
@@ -49,7 +51,7 @@ const getCollateralInput = (address: string, valueUsd: number): OpenInterestColl
 }
 
 const openInterestModel = computed(() => {
-  const exposure = isOpenInterestLoaded.value ? getOpenInterestForVault(vault.address) : {}
+  const exposure: Record<string, number> = isOpenInterestLoaded.value ? getOpenInterestForVault(vault.address) : {}
   const collaterals = Object.entries(exposure).map(([address, valueUsd]) =>
     getCollateralInput(address, valueUsd),
   )

--- a/components/entities/vault/overview/VaultOverviewBlockStats.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockStats.vue
@@ -14,7 +14,7 @@ const { settings } = useUserSettings()
 const enableIntrinsicApy = computed(() => settings.value.enableIntrinsicApy)
 const { getSupplyRewardApy, getBorrowRewardApy, getSupplyRewardCampaigns, getBorrowRewardCampaigns, hasSupplyRewards, hasBorrowRewards } = useRewardsApy()
 const isBorrowable = computed(() => isVaultBorrowable(vault))
-const { getVaultBadDebt, isBadDebtLoaded, isBadDebtLoading, loadBadDebtForChain } = useVaultBadDebt()
+const { getVaultBadDebt, isBadDebtEnabled, isBadDebtLoaded, isBadDebtLoading, loadBadDebtForChain } = useVaultBadDebt()
 
 const supplyApyWithRewards = computed(() => withVaultIntrinsicApy(
   getVaultSupplyApy(vault),
@@ -77,11 +77,11 @@ watchEffect(async () => {
 })
 
 watchEffect(() => {
-  if (isBorrowable.value) void loadBadDebtForChain()
+  if (isBorrowable.value && isBadDebtEnabled.value) void loadBadDebtForChain()
 })
 
 const badDebtDisplay = computed(() => {
-  if (!isBorrowable.value) return null
+  if (!isBorrowable.value || !isBadDebtEnabled.value) return null
   const badDebt = getVaultBadDebt(vault.address)
   if (badDebt) return formatBadDebtOverviewValue(badDebt, totalBorrowedUsd.value)
   if (isBadDebtLoading.value) return '...'

--- a/components/entities/vault/overview/earn/VaultOverviewEarnBlockExposure.vue
+++ b/components/entities/vault/overview/earn/VaultOverviewEarnBlockExposure.vue
@@ -38,6 +38,7 @@ const {
   getOpenInterestForVault,
   hasError: hasOpenInterestError,
   isLoaded: isOpenInterestLoaded,
+  isOpenInterestEnabled,
 } = useCollateralOpenInterest()
 const { isEscrowLoadedOnce, isMarketDataResolved } = useVaults()
 const { settings } = useUserSettings()
@@ -181,6 +182,7 @@ const getStrategyMarketSource = (strategyVault: EVault) => {
 
 const getStrategyExposureValueState = (strategyVault: EVault | undefined): ExposureValueState => {
   if (!strategyVault) return 'unavailable'
+  if (!isOpenInterestEnabled.value) return 'unavailable'
 
   const key = strategyVault.address.toLowerCase()
   if (hasOpenInterestError.value) return 'unavailable'
@@ -224,7 +226,7 @@ watch(isMarketDataResolved, () => {
 })
 
 watchEffect(() => {
-  if (!exposureRows.value.length) return
+  if (!exposureRows.value.length || !isOpenInterestEnabled.value) return
   void loadOpenInterest()
 })
 
@@ -392,6 +394,7 @@ load()
             </template>
           </VaultOverviewLabelValue>
           <VaultOverviewLabelValue
+            v-if="isOpenInterestEnabled"
             label="Exposure"
             orientation="horizontal"
             data-list="earn-exposure-strategy"

--- a/components/entities/vault/overview/earn/VaultOverviewEarnBlockStats.vue
+++ b/components/entities/vault/overview/earn/VaultOverviewEarnBlockStats.vue
@@ -27,6 +27,7 @@ const {
   getOpenInterestForVault,
   hasError: hasOpenInterestError,
   isLoaded: isOpenInterestLoaded,
+  isOpenInterestEnabled,
 } = useCollateralOpenInterest()
 
 const supplyApyBreakdown = computed(() => computeSupplyApyBreakdown(vault, viewer.value))
@@ -61,7 +62,9 @@ const getStrategyMarketSource = (strategyVault: EVault) => {
   }
 }
 
-const hasLiveExposureData = computed(() => isOpenInterestLoaded.value && !hasOpenInterestError.value)
+const hasLiveExposureData = computed(() =>
+  isOpenInterestEnabled.value && isOpenInterestLoaded.value && !hasOpenInterestError.value,
+)
 const isStrategyAllocationUsdLoaded = computed(() =>
   vault.strategies.every((strategy) => {
     const strategyVault = getStrategyVault(strategy)
@@ -93,6 +96,7 @@ const hasUnavailableExposureSplit = computed(() => {
   })
 })
 const exposureValueState = computed<ExposureValueState>(() => {
+  if (!isOpenInterestEnabled.value) return 'unavailable'
   if (!vault.strategies.length) return 'ready'
   if (!isStrategyAllocationUsdLoaded.value) return 'loading'
   if (hasOpenInterestError.value) return 'unavailable'
@@ -124,7 +128,7 @@ const exposureDisplayItems = computed(() =>
 )
 
 watchEffect(() => {
-  if (!vault.strategies.length) return
+  if (!vault.strategies.length || !isOpenInterestEnabled.value) return
   void loadOpenInterest()
 })
 
@@ -221,13 +225,15 @@ const supplyApyModalData = computed(() => ({
           <span class="text-p2 text-content-primary">
             {{ vault.strategies.length }}
           </span>
-          <span class="h-16 w-1 shrink-0 bg-line-subtle" />
-          <VaultExposureSummary
-            :items="exposureDisplayItems"
-            :value-state="exposureValueState"
-            :max-visible="5"
-            avatar-size="20"
-          />
+          <template v-if="isOpenInterestEnabled">
+            <span class="h-16 w-1 shrink-0 bg-line-subtle" />
+            <VaultExposureSummary
+              :items="exposureDisplayItems"
+              :value-state="exposureValueState"
+              :max-visible="5"
+              avatar-size="20"
+            />
+          </template>
         </div>
       </VaultOverviewLabelValue>
       <VaultOverviewLabelValue

--- a/composables/useCollateralOpenInterest.ts
+++ b/composables/useCollateralOpenInterest.ts
@@ -9,14 +9,26 @@ let activeRequestId = 0
 
 export const useCollateralOpenInterest = () => {
   const { chainId } = useEulerAddresses()
+  const { enableV3Backend } = useEnvConfig()
   const data = useState<Record<string, Record<string, number>>>('collateral-open-interest:data', () => ({}))
   const loadedChainId = useState<string | null>('collateral-open-interest:chain-id', () => null)
   const isLoading = useState('collateral-open-interest:is-loading', () => false)
   const hasError = useState('collateral-open-interest:has-error', () => false)
   const currentChainId = computed(() => chainId.value ? String(chainId.value) : '')
-  const isLoaded = computed(() => !!currentChainId.value && loadedChainId.value === currentChainId.value && !hasError.value)
+  const isOpenInterestEnabled = computed(() => enableV3Backend)
+  const isLoaded = computed(() =>
+    isOpenInterestEnabled.value
+    && !!currentChainId.value
+    && loadedChainId.value === currentChainId.value
+    && !hasError.value,
+  )
 
   const load = async () => {
+    if (!isOpenInterestEnabled.value) {
+      isLoading.value = false
+      hasError.value = false
+      return
+    }
     const chainIdToLoad = currentChainId.value
     if (!chainIdToLoad) return
     if (loadedChainId.value === chainIdToLoad) return
@@ -62,6 +74,7 @@ export const useCollateralOpenInterest = () => {
     hasError,
     isLoaded,
     isLoading,
+    isOpenInterestEnabled,
     load,
     getOpenInterestForVault,
   }

--- a/composables/useVaultBadDebt.ts
+++ b/composables/useVaultBadDebt.ts
@@ -66,11 +66,17 @@ const fetchBadDebtRows = async (
 export const useVaultBadDebt = () => {
   const { chainId } = useEulerAddresses()
   const envConfig = useEnvConfig()
+  const isBadDebtEnabled = computed(() => envConfig.enableV3Backend)
 
   const loadBadDebtForChain = async (
     targetChainId = chainId.value,
     { force = false }: { force?: boolean } = {},
   ) => {
+    if (!isBadDebtEnabled.value) {
+      setChainLoading(targetChainId, false)
+      setChainError(targetChainId, null)
+      return
+    }
     if (!force && badDebtByChain.value.has(targetChainId) && !errorByChain.value.has(targetChainId)) return
     const existing = inFlight.get(targetChainId)
     if (existing) return existing
@@ -101,16 +107,17 @@ export const useVaultBadDebt = () => {
   ): VaultBadDebtCacheEntry | undefined =>
     badDebtByChain.value.get(targetChainId)?.get(vaultAddress.toLowerCase())
 
-  const isBadDebtLoading = computed(() => loadingChains.value.has(chainId.value))
-  const badDebtError = computed(() => errorByChain.value.get(chainId.value))
+  const isBadDebtLoading = computed(() => isBadDebtEnabled.value && loadingChains.value.has(chainId.value))
+  const badDebtError = computed(() => isBadDebtEnabled.value ? errorByChain.value.get(chainId.value) : undefined)
   const isBadDebtLoaded = computed(() =>
-    badDebtByChain.value.has(chainId.value) && !errorByChain.value.has(chainId.value),
+    isBadDebtEnabled.value && badDebtByChain.value.has(chainId.value) && !errorByChain.value.has(chainId.value),
   )
 
   return {
     badDebtByChain,
     badDebtError,
     getVaultBadDebt,
+    isBadDebtEnabled,
     isBadDebtLoaded,
     isBadDebtLoading,
     loadBadDebtForChain,

--- a/tests/composables/useCollateralOpenInterest.test.ts
+++ b/tests/composables/useCollateralOpenInterest.test.ts
@@ -24,6 +24,56 @@ describe('useCollateralOpenInterest', () => {
     vi.unstubAllGlobals()
   })
 
+  it('does not request open interest when v3 is disabled', async () => {
+    const chainId = ref(1)
+    const states = new Map<string, Ref<unknown>>()
+    const fetchMock = vi.fn()
+
+    vi.stubGlobal('computed', computed)
+    vi.stubGlobal('useEulerAddresses', () => ({ chainId }))
+    vi.stubGlobal('useEnvConfig', () => ({ enableV3Backend: false }))
+    vi.stubGlobal('useState', <T>(key: string, init: () => T) => {
+      if (!states.has(key)) states.set(key, ref(init()))
+      return states.get(key) as Ref<T>
+    })
+    vi.stubGlobal('$fetch', fetchMock)
+
+    const { useCollateralOpenInterest } = await import('~/composables/useCollateralOpenInterest')
+    const openInterest = useCollateralOpenInterest()
+
+    await openInterest.load()
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(openInterest.isOpenInterestEnabled.value).toBe(false)
+    expect(openInterest.isLoading.value).toBe(false)
+    expect(openInterest.hasError.value).toBe(false)
+    expect(openInterest.isLoaded.value).toBe(false)
+  })
+
+  it('marks enabled fetch failures as errors', async () => {
+    const chainId = ref(1)
+    const states = new Map<string, Ref<unknown>>()
+
+    vi.stubGlobal('computed', computed)
+    vi.stubGlobal('useEulerAddresses', () => ({ chainId }))
+    vi.stubGlobal('useEnvConfig', () => ({ enableV3Backend: true }))
+    vi.stubGlobal('useState', <T>(key: string, init: () => T) => {
+      if (!states.has(key)) states.set(key, ref(init()))
+      return states.get(key) as Ref<T>
+    })
+    vi.stubGlobal('$fetch', vi.fn(() => Promise.reject(new Error('backend down'))))
+
+    const { useCollateralOpenInterest } = await import('~/composables/useCollateralOpenInterest')
+    const openInterest = useCollateralOpenInterest()
+
+    await openInterest.load()
+
+    expect(openInterest.isLoading.value).toBe(false)
+    expect(openInterest.hasError.value).toBe(true)
+    expect(openInterest.isLoaded.value).toBe(false)
+    expect(openInterest.data.value).toEqual({})
+  })
+
   it('ignores stale overlapping chain loads', async () => {
     const chainId = ref(1)
     const states = new Map<string, Ref<unknown>>()
@@ -34,6 +84,7 @@ describe('useCollateralOpenInterest', () => {
 
     vi.stubGlobal('computed', computed)
     vi.stubGlobal('useEulerAddresses', () => ({ chainId }))
+    vi.stubGlobal('useEnvConfig', () => ({ enableV3Backend: true }))
     vi.stubGlobal('useState', <T>(key: string, init: () => T) => {
       if (!states.has(key)) states.set(key, ref(init()))
       return states.get(key) as Ref<T>

--- a/tests/composables/useVaultBadDebt.test.ts
+++ b/tests/composables/useVaultBadDebt.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { computed, ref, shallowRef } from 'vue'
+
+describe('useVaultBadDebt', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.unstubAllGlobals()
+  })
+
+  it('does not request bad debt when v3 is disabled', async () => {
+    const chainId = ref(1)
+    const fetchMock = vi.fn()
+
+    vi.stubGlobal('computed', computed)
+    vi.stubGlobal('shallowRef', shallowRef)
+    vi.stubGlobal('useEulerAddresses', () => ({ chainId }))
+    vi.stubGlobal('useEnvConfig', () => ({
+      enableV3Backend: false,
+      v3ApiUrl: '/api/v3',
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { useVaultBadDebt } = await import('~/composables/useVaultBadDebt')
+    const badDebt = useVaultBadDebt()
+
+    await badDebt.loadBadDebtForChain()
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(badDebt.isBadDebtEnabled.value).toBe(false)
+    expect(badDebt.isBadDebtLoading.value).toBe(false)
+    expect(badDebt.isBadDebtLoaded.value).toBe(false)
+    expect(badDebt.badDebtError.value).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary
- Gate bad debt and open-interest composables on `useEnvConfig().enableV3Backend` so disabled V3 does not fetch, load forever, or render optional backend-only metrics.
- Hide open-interest exposure summaries/sections and bad-debt rows/columns when V3 is disabled, while preserving soft unavailable/error states when V3 is enabled but failing.
- Add composable coverage for disabled V3 and enabled open-interest fetch failures.

## Tests
- `./node_modules/.bin/vitest run tests/composables/useCollateralOpenInterest.test.ts tests/composables/useVaultBadDebt.test.ts tests/utils/vault-bad-debt.test.ts tests/utils/open-interest.test.ts tests/server/v3-proxy.test.ts`
- `./node_modules/.bin/eslint composables/useCollateralOpenInterest.ts composables/useVaultBadDebt.ts components/entities/vault/VaultItem.vue components/entities/vault/VaultEarnItem.vue components/entities/vault/VaultCollateralExposureModal.vue components/entities/vault/discovery/DiscoveryMarketAccordion.vue components/entities/vault/discovery/DiscoveryMarketAttributeMatrix.vue components/entities/vault/overview/VaultOverviewBlockBorrow.vue components/entities/vault/overview/VaultOverviewBlockGeneral.vue components/entities/vault/overview/VaultOverviewBlockOpenInterest.vue components/entities/vault/overview/VaultOverviewBlockStats.vue components/entities/vault/overview/earn/VaultOverviewEarnBlockExposure.vue components/entities/vault/overview/earn/VaultOverviewEarnBlockStats.vue tests/composables/useCollateralOpenInterest.test.ts tests/composables/useVaultBadDebt.test.ts`

## Notes
- `./node_modules/.bin/nuxt typecheck` is currently blocked before TypeScript by `Maximum call stack size exceeded` in `@gvade/nuxt3-svg-sprite` / `unstorage` during Nuxt initialization on this worktree.
- Direct `vue-tsc --noEmit -p tsconfig.json` is also blocked without successful Nuxt generation by missing generated auto-import/component declarations.