### PR TITLE
fix: preserve collateral config without v3

### DIFF
--- a/components/entities/vault/VaultCollateralExposureModal.vue
+++ b/components/entities/vault/VaultCollateralExposureModal.vue
@@ -42,6 +42,14 @@ const getPairOpenInterestUsd = (pair: { collateral: EVault | SecuritizeCollatera
 const hasLiveExposureData = computed(() =>
   isOpenInterestEnabled.value && isOpenInterestLoaded.value && !hasOpenInterestError.value,
 )
+const modalTitle = computed(() =>
+  isOpenInterestEnabled.value ? 'Exposure' : 'Collateral exposure',
+)
+const description = computed(() =>
+  isOpenInterestEnabled.value
+    ? 'Make sure you\'re comfortable with the live exposure assets and configured collateral vaults before supplying.'
+    : 'Make sure you\'re comfortable with the configured collateral vaults and LTVs before supplying.',
+)
 const formatExposurePercent = (valueUsd: number) =>
   !hasLiveExposureData.value
     ? '-'
@@ -75,16 +83,16 @@ watchEffect(() => {
 
 <template>
   <BaseModalWrapper
-    title="Exposure"
+    :title="modalTitle"
     @close="$emit('close')"
   >
     <div
-      v-if="isOpenInterestEnabled && collateralGroups.length > 0"
+      v-if="collateralGroups.length > 0"
       class="flex flex-col gap-12"
     >
       <p class="text-p3 text-content-secondary mb-4">
         Deposits in this vault can be borrowed.
-        Make sure you're comfortable with the exposure assets and vaults listed below before supplying.
+        {{ description }}
       </p>
       <div
         v-for="pair in collateralPairs"
@@ -107,6 +115,7 @@ watchEffect(() => {
         </div>
         <div class="flex flex-col gap-12 pt-12">
           <VaultOverviewLabelValue
+            v-if="isOpenInterestEnabled"
             label="Live exposure"
             orientation="horizontal"
           >

--- a/components/entities/vault/overview/VaultOverviewBlockBorrow.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockBorrow.vue
@@ -71,6 +71,14 @@ const getPairOpenInterestUsd = (pair: { collateral: EVault | SecuritizeCollatera
 const hasLiveExposureData = computed(() =>
   isOpenInterestEnabled.value && isOpenInterestLoaded.value && !hasOpenInterestError.value,
 )
+const sectionTitle = computed(() =>
+  isOpenInterestEnabled.value ? 'Exposure' : 'Collateral exposure',
+)
+const sectionDescription = computed(() =>
+  isOpenInterestEnabled.value
+    ? 'Review live borrow exposure and configured collateral vaults before supplying.'
+    : 'Review configured collateral vaults and LTVs before supplying.',
+)
 const formatExposurePercent = (valueUsd: number) =>
   !hasLiveExposureData.value
     ? '-'
@@ -86,15 +94,15 @@ watchEffect(() => {
 
 <template>
   <VaultOverviewAccordionSection
-    v-if="isOpenInterestEnabled && collateralGroups.length"
-    title="Exposure"
+    v-if="collateralGroups.length"
+    :title="sectionTitle"
     :default-open="defaultOpen"
     content-class="flex flex-col gap-24"
   >
     <div>
       <p class="text-content-secondary">
         Deposits in this vault can be borrowed.
-        Review live borrow exposure and configured collateral vaults before supplying.
+        {{ sectionDescription }}
       </p>
     </div>
 
@@ -111,6 +119,7 @@ watchEffect(() => {
         />
         <div class="mt-12 grid grid-cols-1 gap-12">
           <VaultOverviewLabelValue
+            v-if="isOpenInterestEnabled"
             label="Live exposure"
             orientation="horizontal"
           >


### PR DESCRIPTION
## Summary
- keep the borrow-side collateral/LTV section visible when V3 is disabled
- relabel that static fallback as Collateral configuration and hide only the live exposure value row
- apply the same fallback behavior in the collateral exposure modal

## Tests
- npx eslint components/entities/vault/overview/VaultOverviewBlockBorrow.vue components/entities/vault/VaultCollateralExposureModal.vue
- ./node_modules/.bin/vitest run tests/composables/useCollateralOpenInterest.test.ts tests/utils/vault/collateral-exposure.test.ts tests/utils/vault/exposure-display.test.ts
- ./node_modules/.bin/nuxt typecheck