### PR TITLE
fix: sanitize proxy error logs

### DIFF
--- a/server/api/proxy/fuul/[...path].ts
+++ b/server/api/proxy/fuul/[...path].ts
@@ -18,7 +18,7 @@ import {
 } from 'h3'
 import { createRateLimiter } from '~/server/utils/rate-limit'
 import { logger } from '~/server/utils/logger'
-import { errorStatus, safePathTemplate, safeUrlLogFields, searchKeys } from '~/server/utils/observability'
+import { safeErrorLogFields, safePathTemplate, safeUrlLogFields, searchKeys } from '~/server/utils/observability'
 import {
   createProxyCache,
   createProxyInFlight,
@@ -107,8 +107,7 @@ export default defineEventHandler(async (event) => {
       {
         ctx: 'fuul-proxy',
         ...safeUrlLogFields(target),
-        status: errorStatus(err),
-        err,
+        err: safeErrorLogFields(err),
       },
       'upstream failed',
     )

--- a/server/api/proxy/incentra/[...path].ts
+++ b/server/api/proxy/incentra/[...path].ts
@@ -22,7 +22,7 @@ import {
 } from 'h3'
 import { createRateLimiter } from '~/server/utils/rate-limit'
 import { logger } from '~/server/utils/logger'
-import { errorStatus, safePathTemplate, safeUrlLogFields, searchKeys } from '~/server/utils/observability'
+import { safeErrorLogFields, safePathTemplate, safeUrlLogFields, searchKeys } from '~/server/utils/observability'
 import {
   createProxyCache,
   createProxyInFlight,
@@ -115,8 +115,7 @@ export default defineEventHandler(async (event) => {
         ctx: 'incentra-proxy',
         ...safeUrlLogFields(target),
         bodyBytes: body?.length,
-        status: errorStatus(err),
-        err,
+        err: safeErrorLogFields(err),
       },
       'upstream failed',
     )

--- a/server/api/proxy/subgraph/[chainId].post.ts
+++ b/server/api/proxy/subgraph/[chainId].post.ts
@@ -35,7 +35,7 @@ import {
 } from 'h3'
 import { createRateLimiter } from '~/server/utils/rate-limit'
 import { logger } from '~/server/utils/logger'
-import { safeUrlLogFields } from '~/server/utils/observability'
+import { safeErrorLogFields, safeUrlLogFields } from '~/server/utils/observability'
 import {
   createProxyCache,
   createProxyInFlight,
@@ -119,7 +119,7 @@ export default defineEventHandler(async (event) => {
         ctx: 'subgraph-proxy',
         chainId,
         ...safeUrlLogFields(target),
-        err,
+        err: safeErrorLogFields(err),
       },
       'upstream failed',
     )

--- a/server/api/proxy/turtle/[...path].ts
+++ b/server/api/proxy/turtle/[...path].ts
@@ -17,6 +17,7 @@ import {
 } from 'h3'
 import { createRateLimiter } from '~/server/utils/rate-limit'
 import { logger } from '~/server/utils/logger'
+import { safeErrorLogFields, safeUrlLogFields } from '~/server/utils/observability'
 import {
   createProxyCache,
   createProxyInFlight,
@@ -90,7 +91,14 @@ export default defineEventHandler(async (event) => {
     return res.body
   }
   catch (err) {
-    logger.warn({ ctx: 'turtle-proxy', target, err }, 'upstream failed')
+    logger.warn(
+      {
+        ctx: 'turtle-proxy',
+        ...safeUrlLogFields(target),
+        err: safeErrorLogFields(err),
+      },
+      'upstream failed',
+    )
     throw createError({ statusCode: 502, statusMessage: 'Turtle upstream unavailable' })
   }
 })

--- a/server/utils/external-proxy.ts
+++ b/server/utils/external-proxy.ts
@@ -15,7 +15,7 @@ import { fetchWithTimeout } from './fetchWithTimeout'
 import { createTtlCache } from './cache'
 import { createInFlightDedup, type InFlightDedup } from '~/utils/in-flight'
 import { logger } from './logger'
-import { errorStatus, safeUrlLogFields } from './observability'
+import { safeErrorLogFields, safeUrlLogFields } from './observability'
 
 export interface ExternalProxyCache {
   get: (key: string) => string | undefined
@@ -111,8 +111,7 @@ export async function forwardProxied(args: ProxyForwardArgs): Promise<ProxyForwa
         {
           ctx,
           ...safeUrlLogFields(target),
-          status: errorStatus(err),
-          err: (err as Error).message,
+          err: safeErrorLogFields(err),
         },
         'serving stale on upstream failure',
       )

--- a/server/utils/observability.ts
+++ b/server/utils/observability.ts
@@ -9,6 +9,13 @@ export interface SafeUrlLogFields {
   searchKeys: string[]
 }
 
+export interface SafeErrorLogFields {
+  name: string
+  status?: number
+  code?: string | number
+  causeName?: string
+}
+
 export function hashIdentifier(value: unknown): string | undefined {
   if (typeof value !== 'string' || !value.trim()) return undefined
   return createHash('sha256').update(value.trim().toLowerCase()).digest('hex').slice(0, 16)
@@ -63,6 +70,27 @@ export function errorStatus(error: unknown): number | undefined {
   const status = (error as { status?: unknown, statusCode?: unknown }).status
     ?? (error as { status?: unknown, statusCode?: unknown }).statusCode
   return typeof status === 'number' && Number.isFinite(status) ? status : undefined
+}
+
+const errorCode = (error: unknown): string | number | undefined => {
+  if (!error || typeof error !== 'object') return undefined
+  const code = (error as { code?: unknown }).code
+  return typeof code === 'string' || typeof code === 'number' ? code : undefined
+}
+
+const errorCauseName = (error: unknown): string | undefined => {
+  if (!error || typeof error !== 'object') return undefined
+  const cause = (error as { cause?: unknown }).cause
+  return cause instanceof Error ? cause.name : undefined
+}
+
+export function safeErrorLogFields(error: unknown): SafeErrorLogFields {
+  return {
+    name: error instanceof Error ? error.name : typeof error,
+    ...(errorStatus(error) !== undefined ? { status: errorStatus(error) } : {}),
+    ...(errorCode(error) !== undefined ? { code: errorCode(error) } : {}),
+    ...(errorCauseName(error) !== undefined ? { causeName: errorCauseName(error) } : {}),
+  }
 }
 
 export function summarizeSdkIssue(issue: unknown): Record<string, unknown> {

--- a/tests/server/observability.test.ts
+++ b/tests/server/observability.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { safePathTemplate, safeUrlLogFields, searchKeys, summarizeSdkIssue, urlHost } from '~/server/utils/observability'
+import { safeErrorLogFields, safePathTemplate, safeUrlLogFields, searchKeys, summarizeSdkIssue, urlHost } from '~/server/utils/observability'
 
 describe('server observability helpers', () => {
   it('summarizes SDK issues without raw nested diagnostics', () => {
@@ -44,5 +44,23 @@ describe('server observability helpers', () => {
 
   it('does not throw or leak raw malformed URLs in log metadata', () => {
     expect(safeUrlLogFields('not a url / secret-key')).toEqual({ searchKeys: [] })
+  })
+
+  it('summarizes proxy errors without URL-bearing messages', () => {
+    const cause = new TypeError('Failed to parse URL from not a url / secret-key')
+    const error = Object.assign(new Error('Failed to parse URL from https://rpc.example/private-token'), {
+      code: 'ERR_INVALID_URL',
+      cause,
+    })
+
+    const fields = safeErrorLogFields(error)
+
+    expect(fields).toEqual({
+      name: 'Error',
+      code: 'ERR_INVALID_URL',
+      causeName: 'TypeError',
+    })
+    expect(JSON.stringify(fields)).not.toContain('private-token')
+    expect(JSON.stringify(fields)).not.toContain('secret-key')
   })
 })

--- a/tests/server/subgraph-proxy-route.test.ts
+++ b/tests/server/subgraph-proxy-route.test.ts
@@ -76,7 +76,7 @@ describe('/api/proxy/subgraph route', () => {
 
   it('returns a sanitized 502 when the configured upstream URL is malformed', async () => {
     process.env.SUBGRAPH_URL_1 = 'not a url'
-    mocks.forwardProxied.mockRejectedValueOnce(new TypeError('Invalid URL'))
+    mocks.forwardProxied.mockRejectedValueOnce(new TypeError('Failed to parse URL from not a url'))
 
     await expect(handler(makeEvent('1'))).rejects.toMatchObject({
       statusCode: 502,
@@ -91,6 +91,9 @@ describe('/api/proxy/subgraph route', () => {
         ctx: 'subgraph-proxy',
         chainId: 1,
         searchKeys: [],
+        err: {
+          name: 'TypeError',
+        },
       }),
       'upstream failed',
     )


### PR DESCRIPTION
## Summary
- Prevent proxy failure logs from reintroducing raw upstream URLs through error messages.
- Preserve useful debugging metadata with a bounded error shape for proxy failures.

## Changes
- Add a safe proxy error summary that includes name, status, code, and cause name without raw message text.
- Use sanitized error and URL metadata in external proxy stale-fallback logs and reward/subgraph proxy catch blocks.
- Cover URL-bearing error messages in observability and subgraph proxy tests.

## Test plan
- [x] npm run test:run -- tests/server/observability.test.ts tests/server/subgraph-proxy-route.test.ts
- [x] npm run typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in proxy requests so failures are logged with safer, more structured details.
  * Reduced the chance of sensitive information appearing in logs from upstream errors and malformed URLs.
  * Kept all user-facing proxy responses and status codes unchanged when upstream services are unavailable.

* **Tests**
  * Expanded coverage to verify sanitized error logging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->