### PR TITLE
fix: add earn overview accordions

### DIFF
--- a/components/entities/vault/overview/earn/VaultOverviewEarn.vue
+++ b/components/entities/vault/overview/earn/VaultOverviewEarn.vue
@@ -14,23 +14,28 @@ const { vault } = defineProps<{ vault: EulerEarn, desktopOverview?: boolean }>()
   >
     <VaultOverviewEarnBlockGeneral
       :vault="vault"
+      :default-open="true"
     />
 
     <VaultOverviewEarnBlockStats
       :vault="vault"
+      :default-open="true"
     />
 
     <VaultOverviewEarnBlockExposure
       :vault="vault"
+      :default-open="false"
       @vault-click="(address: string) => emits('vault-click', address)"
     />
 
     <VaultOverviewEarnBlockManagement
       :vault="vault"
+      :default-open="false"
     />
 
     <VaultOverviewEarnBlockAddresses
       :vault="vault"
+      :default-open="false"
     />
   </div>
 </template>

--- a/components/entities/vault/overview/earn/VaultOverviewEarnBlockAddresses.vue
+++ b/components/entities/vault/overview/earn/VaultOverviewEarnBlockAddresses.vue
@@ -3,7 +3,7 @@ import type { EulerEarn } from '@eulerxyz/euler-v2-sdk'
 import { getExplorerLink } from '~/utils/block-explorer'
 import { getSpecialAddressLabel } from '~/utils/special-addresses'
 
-const { vault } = defineProps<{ vault: EulerEarn }>()
+const { vault, defaultOpen = true } = defineProps<{ vault: EulerEarn, defaultOpen?: boolean }>()
 const { chainId } = useEulerAddresses()
 
 const vaultAddresesInfo = computed(() => ([
@@ -33,36 +33,35 @@ const getExplorerAddressLink = (address: string) => getExplorerLink(address, cha
 </script>
 
 <template>
-  <div class="bg-surface-secondary rounded-xl flex flex-col gap-24 p-24 shadow-card">
-    <p class="text-h3 text-content-primary">
-      Addresses
-    </p>
-    <div class="flex flex-col items-start gap-24">
-      <VaultOverviewLabelValue
-        v-for="infoItem in vaultAddresesInfo"
-        :key="infoItem.title"
-        :label="infoItem.title"
-        orientation="horizontal"
-      >
-        <div class="flex gap-4 items-center">
-          <NuxtLink
-            :to="getExplorerAddressLink(infoItem.address)"
-            class="text-accent-600 underline cursor-pointer hover:text-accent-500"
-            target="_blank"
-          >
-            {{ getSpecialAddressLabel(infoItem.address) || shortenAddress(infoItem.address) }}
-          </NuxtLink>
-          <button
-            class="text-neutral-400 cursor-pointer outline-none hover:text-neutral-600 active:text-neutral-700"
-            @click="onCopyClick(infoItem.address)"
-          >
-            <SvgIcon
-              class="!w-18 !h-18"
-              name="copy"
-            />
-          </button>
-        </div>
-      </VaultOverviewLabelValue>
-    </div>
-  </div>
+  <VaultOverviewAccordionSection
+    title="Addresses"
+    :default-open="defaultOpen"
+    content-class="flex flex-col items-start gap-24"
+  >
+    <VaultOverviewLabelValue
+      v-for="infoItem in vaultAddresesInfo"
+      :key="infoItem.title"
+      :label="infoItem.title"
+      orientation="horizontal"
+    >
+      <div class="flex gap-4 items-center">
+        <NuxtLink
+          :to="getExplorerAddressLink(infoItem.address)"
+          class="text-accent-600 underline cursor-pointer hover:text-accent-500"
+          target="_blank"
+        >
+          {{ getSpecialAddressLabel(infoItem.address) || shortenAddress(infoItem.address) }}
+        </NuxtLink>
+        <button
+          class="text-neutral-400 cursor-pointer outline-none hover:text-neutral-600 active:text-neutral-700"
+          @click="onCopyClick(infoItem.address)"
+        >
+          <SvgIcon
+            class="!w-18 !h-18"
+            name="copy"
+          />
+        </button>
+      </div>
+    </VaultOverviewLabelValue>
+  </VaultOverviewAccordionSection>
 </template>

--- a/components/entities/vault/overview/earn/VaultOverviewEarnBlockExposure.vue
+++ b/components/entities/vault/overview/earn/VaultOverviewEarnBlockExposure.vue
@@ -29,7 +29,7 @@ const emits = defineEmits<{
 const onExposureClick = (address: string) => {
   emits('vault-click', address)
 }
-const { vault } = defineProps<{ vault: EulerEarn }>()
+const { vault, defaultOpen = true } = defineProps<{ vault: EulerEarn, defaultOpen?: boolean }>()
 const route = useRoute()
 
 const { getOrFetch, get: registryGet } = useVaultRegistry()
@@ -268,16 +268,12 @@ load()
 </script>
 
 <template>
-  <div
+  <VaultOverviewAccordionSection
     v-if="exposureList.length"
-    class="bg-surface-secondary rounded-xl flex flex-col gap-24 p-24 shadow-card"
+    title="Exposure"
+    :default-open="defaultOpen"
+    content-class="flex flex-col gap-12"
   >
-    <div>
-      <p class="text-h3 text-content-primary mb-12">
-        Exposure
-      </p>
-    </div>
-
     <div
       v-if="isLoading"
       class="flex items-center justify-center py-32"
@@ -454,7 +450,7 @@ load()
         </div>
       </div>
     </div>
-  </div>
+  </VaultOverviewAccordionSection>
 </template>
 
 <style lang="scss" scoped>

--- a/components/entities/vault/overview/earn/VaultOverviewEarnBlockGeneral.vue
+++ b/components/entities/vault/overview/earn/VaultOverviewEarnBlockGeneral.vue
@@ -9,7 +9,7 @@ import { isVaultBlockedByCountry } from '~/composables/useGeoBlock'
 import { isEarnVaultDeprecated, getEarnVaultDeprecationReason, getEarnVaultDescription } from '~/utils/eulerLabelsUtils'
 import { autoLink } from '~/utils/autoLink'
 
-const { vault } = defineProps<{ vault: EulerEarn }>()
+const { vault, defaultOpen = true } = defineProps<{ vault: EulerEarn, defaultOpen?: boolean }>()
 const { enableEntityBranding: enableEntityBrandingDisplay, enableVaultType: enableVaultTypeDisplay } = useDeployConfig()
 
 const { isEarnVaultOwnerVerified } = useVaults()
@@ -46,98 +46,97 @@ const feeDisplay = computed(() => {
 </script>
 
 <template>
-  <div class="bg-surface-secondary rounded-xl flex flex-col gap-24 p-24 shadow-card">
-    <p class="text-h3 text-content-primary">
-      Overview
-    </p>
-    <div class="flex flex-col gap-20">
-      <VaultDeprecationBanner
-        v-if="isDeprecated"
-        :reason="deprecationReason"
-      />
-      <div
-        v-if="isRestricted"
-        class="w-full rounded-12 p-16 bg-warning-100 text-warning-500"
-      >
-        <div class="flex items-center gap-8">
-          <SvgIcon
-            name="warning"
-            class="!w-20 !h-20 flex-shrink-0"
-          />
-          <p class="text-p3 text-warning-500">
-            This vault is not available in your region.
-          </p>
-        </div>
-      </div>
-      <!-- eslint-disable vue/no-v-html -- trusted label content -->
-      <p
-        v-if="earnDescription"
-        class="text-p2 text-content-secondary auto-link"
-        v-html="autoLink(earnDescription)"
-      />
-      <p
-        v-if="product.description"
-        class="text-p2 text-content-secondary auto-link"
-        v-html="autoLink(product.description)"
-      />
-      <!-- eslint-enable vue/no-v-html -->
-      <div class="grid grid-cols-2 gap-x-32 gap-y-24">
-        <VaultOverviewLabelValue
-          label="Price"
-          :value="priceDisplay"
+  <VaultOverviewAccordionSection
+    title="Overview"
+    :default-open="defaultOpen"
+    content-class="flex flex-col gap-20"
+  >
+    <VaultDeprecationBanner
+      v-if="isDeprecated"
+      :reason="deprecationReason"
+    />
+    <div
+      v-if="isRestricted"
+      class="w-full rounded-12 p-16 bg-warning-100 text-warning-500"
+    >
+      <div class="flex items-center gap-8">
+        <SvgIcon
+          name="warning"
+          class="!w-20 !h-20 flex-shrink-0"
         />
-        <VaultOverviewLabelValue
-          label="Performance fee"
-          :value="feeDisplay"
-        />
-        <VaultOverviewLabelValue
-          v-if="enableEntityBrandingDisplay"
-          label="Curator"
-        >
-          <div
-            v-if="entities.length && isOwnerVerified"
-            class="flex flex-col gap-8"
-          >
-            <div
-              v-for="(entity, idx) in entities"
-              :key="idx"
-              class="flex items-center gap-8"
-            >
-              <BaseAvatar
-                :label="entity.name"
-                :src="getEulerLabelEntityLogo(entity.logo)"
-              />
-              <a
-                v-if="entity.url"
-                :href="entity.url"
-                target="_blank"
-                rel="noopener noreferrer"
-                class="text-p2 text-neutral-800 hover:text-accent-600 underline transition-colors"
-              >{{ entity.name }}</a>
-              <span
-                v-else
-                class="text-p2 text-neutral-800"
-              >{{ entity.name }}</span>
-            </div>
-          </div>
-          <VaultTypeChip
-            v-else
-            :vault="vault"
-            type="unknown"
-            nudge
-            class="w-fit"
-          />
-        </VaultOverviewLabelValue>
-        <VaultOverviewLabelValue
-          v-if="enableVaultTypeDisplay"
-          label="Vault type"
-        >
-          <VaultTypeBadges
-            :vault="vault"
-            nudge
-          />
-        </VaultOverviewLabelValue>
+        <p class="text-p3 text-warning-500">
+          This vault is not available in your region.
+        </p>
       </div>
     </div>
-  </div>
+    <!-- eslint-disable vue/no-v-html -- trusted label content -->
+    <p
+      v-if="earnDescription"
+      class="text-p2 text-content-secondary auto-link"
+      v-html="autoLink(earnDescription)"
+    />
+    <p
+      v-if="product.description"
+      class="text-p2 text-content-secondary auto-link"
+      v-html="autoLink(product.description)"
+    />
+    <!-- eslint-enable vue/no-v-html -->
+    <div class="grid grid-cols-2 gap-x-32 gap-y-24">
+      <VaultOverviewLabelValue
+        label="Price"
+        :value="priceDisplay"
+      />
+      <VaultOverviewLabelValue
+        label="Performance fee"
+        :value="feeDisplay"
+      />
+      <VaultOverviewLabelValue
+        v-if="enableEntityBrandingDisplay"
+        label="Curator"
+      >
+        <div
+          v-if="entities.length && isOwnerVerified"
+          class="flex flex-col gap-8"
+        >
+          <div
+            v-for="(entity, idx) in entities"
+            :key="idx"
+            class="flex items-center gap-8"
+          >
+            <BaseAvatar
+              :label="entity.name"
+              :src="getEulerLabelEntityLogo(entity.logo)"
+            />
+            <a
+              v-if="entity.url"
+              :href="entity.url"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="text-p2 text-neutral-800 hover:text-accent-600 underline transition-colors"
+            >{{ entity.name }}</a>
+            <span
+              v-else
+              class="text-p2 text-neutral-800"
+            >{{ entity.name }}</span>
+          </div>
+        </div>
+        <VaultTypeChip
+          v-else
+          :vault="vault"
+          type="unknown"
+          nudge
+          class="w-fit"
+        />
+      </VaultOverviewLabelValue>
+      <VaultOverviewLabelValue
+        v-if="enableVaultTypeDisplay"
+        label="Vault type"
+      >
+        <VaultTypeBadges
+          :vault="vault"
+          nudge
+        />
+      </VaultOverviewLabelValue>
+    </div>
+  </VaultOverviewAccordionSection>
 </template>

--- a/components/entities/vault/overview/earn/VaultOverviewEarnBlockManagement.vue
+++ b/components/entities/vault/overview/earn/VaultOverviewEarnBlockManagement.vue
@@ -4,7 +4,7 @@ import { formatTtl } from '~/utils/crypto-utils'
 import { getExplorerLink } from '~/utils/block-explorer'
 import { getSpecialAddressLabel } from '~/utils/special-addresses'
 
-const { vault } = defineProps<{ vault: EulerEarn }>()
+const { vault, defaultOpen = true } = defineProps<{ vault: EulerEarn, defaultOpen?: boolean }>()
 const { chainId } = useEulerAddresses()
 
 const vaultAddressesInfo = computed(() => ([
@@ -44,42 +44,41 @@ const getExplorerAddressLink = (address: string) => getExplorerLink(address, cha
 </script>
 
 <template>
-  <div class="bg-surface-secondary rounded-xl flex flex-col gap-24 p-24 shadow-card">
-    <p class="text-h3 text-content-primary">
-      Management
-    </p>
-    <div class="flex flex-col items-start gap-24">
-      <VaultOverviewLabelValue
-        v-for="infoItem in vaultAddressesInfo"
-        :key="infoItem.title"
-        :label="infoItem.title"
-        orientation="horizontal"
-      >
-        <div class="flex gap-4 items-center">
-          <NuxtLink
-            :to="getExplorerAddressLink(infoItem.address)"
-            class="text-accent-600 underline cursor-pointer hover:text-accent-500"
-            target="_blank"
-          >
-            {{ getSpecialAddressLabel(infoItem.address) || shortenAddress(infoItem.address) }}
-          </NuxtLink>
-          <button
-            class="text-neutral-400 cursor-pointer outline-none hover:text-neutral-600 active:text-neutral-700"
-            @click="onCopyClick(infoItem.address)"
-          >
-            <SvgIcon
-              class="!w-18 !h-18"
-              name="copy"
-            />
-          </button>
-        </div>
-      </VaultOverviewLabelValue>
-      <VaultOverviewLabelValue
-        label="Timelock"
-        orientation="horizontal"
-      >
-        <span class="pr-[22px]">{{ timelockDisplay }}</span>
-      </VaultOverviewLabelValue>
-    </div>
-  </div>
+  <VaultOverviewAccordionSection
+    title="Management"
+    :default-open="defaultOpen"
+    content-class="flex flex-col items-start gap-24"
+  >
+    <VaultOverviewLabelValue
+      v-for="infoItem in vaultAddressesInfo"
+      :key="infoItem.title"
+      :label="infoItem.title"
+      orientation="horizontal"
+    >
+      <div class="flex gap-4 items-center">
+        <NuxtLink
+          :to="getExplorerAddressLink(infoItem.address)"
+          class="text-accent-600 underline cursor-pointer hover:text-accent-500"
+          target="_blank"
+        >
+          {{ getSpecialAddressLabel(infoItem.address) || shortenAddress(infoItem.address) }}
+        </NuxtLink>
+        <button
+          class="text-neutral-400 cursor-pointer outline-none hover:text-neutral-600 active:text-neutral-700"
+          @click="onCopyClick(infoItem.address)"
+        >
+          <SvgIcon
+            class="!w-18 !h-18"
+            name="copy"
+          />
+        </button>
+      </div>
+    </VaultOverviewLabelValue>
+    <VaultOverviewLabelValue
+      label="Timelock"
+      orientation="horizontal"
+    >
+      <span class="pr-[22px]">{{ timelockDisplay }}</span>
+    </VaultOverviewLabelValue>
+  </VaultOverviewAccordionSection>
 </template>

--- a/components/entities/vault/overview/earn/VaultOverviewEarnBlockStats.vue
+++ b/components/entities/vault/overview/earn/VaultOverviewEarnBlockStats.vue
@@ -14,7 +14,7 @@ import {
 } from '~/utils/vault/exposure-display'
 import { logWarn } from '~/utils/errorHandling'
 
-const { vault } = defineProps<{ vault: EulerEarn }>()
+const { vault, defaultOpen = true } = defineProps<{ vault: EulerEarn, defaultOpen?: boolean }>()
 const route = useRoute()
 
 const { settings } = useUserSettings()
@@ -200,69 +200,68 @@ const supplyApyModalData = computed(() => ({
 </script>
 
 <template>
-  <div class="bg-surface-secondary rounded-xl flex flex-col gap-24 p-24 shadow-card">
-    <p class="text-h3 text-content-primary">
-      Statistics
-    </p>
-    <div class="flex flex-col items-start gap-24">
-      <VaultOverviewLabelValue
-        label="Total supply"
-        :value="totalSupplyDisplay"
-        orientation="horizontal"
-      />
-      <VaultOverviewLabelValue
-        label="Available liquidity"
-        :value="availableLiquidityDisplay"
-        orientation="horizontal"
-      />
-      <VaultOverviewLabelValue
-        label="Total strategies"
-        orientation="horizontal"
-        data-field="Total strategies"
-        :data-value="vault.strategies.length"
-      >
-        <div class="flex min-w-0 items-center justify-end gap-12">
-          <span class="text-p2 text-content-primary">
-            {{ vault.strategies.length }}
-          </span>
-          <template v-if="isOpenInterestEnabled">
-            <span class="h-16 w-1 shrink-0 bg-line-subtle" />
-            <VaultExposureSummary
-              :items="exposureDisplayItems"
-              :value-state="exposureValueState"
-              :max-visible="5"
-              avatar-size="20"
-            />
-          </template>
-        </div>
-      </VaultOverviewLabelValue>
-      <VaultOverviewLabelValue
-        orientation="horizontal"
-      >
-        <template #label>
-          <span class="flex items-center gap-6">
-            Supply APY
-            <span class="inline-flex items-center rounded-8 px-8 py-2 bg-accent-100 text-accent-600 text-p5">
-              1h
-            </span>
-          </span>
-        </template>
-        <span class="flex items-center gap-4">
-          <UiModalPreviewTrigger
-            v-if="hasRewards"
-            :component="VaultSupplyApyModal"
-            :modal-data="supplyApyModalData"
-            aria-label="Show supply APY rewards breakdown"
-          >
-            <SvgIcon
-              class="!w-20 !h-20 text-accent-500 cursor-pointer"
-              name="sparks"
-              data-modal-trigger="supply-apy"
-            />
-          </UiModalPreviewTrigger>
-          {{ formatNumber(supplyApyTotal) }}%
+  <VaultOverviewAccordionSection
+    title="Statistics"
+    :default-open="defaultOpen"
+    content-class="flex flex-col items-start gap-24"
+  >
+    <VaultOverviewLabelValue
+      label="Total supply"
+      :value="totalSupplyDisplay"
+      orientation="horizontal"
+    />
+    <VaultOverviewLabelValue
+      label="Available liquidity"
+      :value="availableLiquidityDisplay"
+      orientation="horizontal"
+    />
+    <VaultOverviewLabelValue
+      label="Total strategies"
+      orientation="horizontal"
+      data-field="Total strategies"
+      :data-value="vault.strategies.length"
+    >
+      <div class="flex min-w-0 items-center justify-end gap-12">
+        <span class="text-p2 text-content-primary">
+          {{ vault.strategies.length }}
         </span>
-      </VaultOverviewLabelValue>
-    </div>
-  </div>
+        <template v-if="isOpenInterestEnabled">
+          <span class="h-16 w-1 shrink-0 bg-line-subtle" />
+          <VaultExposureSummary
+            :items="exposureDisplayItems"
+            :value-state="exposureValueState"
+            :max-visible="5"
+            avatar-size="20"
+          />
+        </template>
+      </div>
+    </VaultOverviewLabelValue>
+    <VaultOverviewLabelValue
+      orientation="horizontal"
+    >
+      <template #label>
+        <span class="flex items-center gap-6">
+          Supply APY
+          <span class="inline-flex items-center rounded-8 px-8 py-2 bg-accent-100 text-accent-600 text-p5">
+            1h
+          </span>
+        </span>
+      </template>
+      <span class="flex items-center gap-4">
+        <UiModalPreviewTrigger
+          v-if="hasRewards"
+          :component="VaultSupplyApyModal"
+          :modal-data="supplyApyModalData"
+          aria-label="Show supply APY rewards breakdown"
+        >
+          <SvgIcon
+            class="!w-20 !h-20 text-accent-500 cursor-pointer"
+            name="sparks"
+            data-modal-trigger="supply-apy"
+          />
+        </UiModalPreviewTrigger>
+        {{ formatNumber(supplyApyTotal) }}%
+      </span>
+    </VaultOverviewLabelValue>
+  </VaultOverviewAccordionSection>
 </template>


### PR DESCRIPTION
## Summary
- Restore accordion behavior on Earn vault detail overview sections after the vault overview accordion update.
- Keep Overview and Statistics expanded by default while collapsing lower-priority Earn sections to match the standard vault overview flow.

## Changes
- Reuse VaultOverviewAccordionSection for Earn Overview, Statistics, Exposure, Management, and Addresses blocks.
- Pass explicit defaultOpen values from the Earn overview container.

## Test plan
- [x] npx eslint components/entities/vault/overview/earn/VaultOverviewEarn.vue components/entities/vault/overview/earn/VaultOverviewEarnBlockGeneral.vue components/entities/vault/overview/earn/VaultOverviewEarnBlockStats.vue components/entities/vault/overview/earn/VaultOverviewEarnBlockExposure.vue components/entities/vault/overview/earn/VaultOverviewEarnBlockManagement.vue components/entities/vault/overview/earn/VaultOverviewEarnBlockAddresses.vue
- [x] npm run typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Vault overview sections now open and close in an accordion style for easier scanning.
  - General and Statistics sections open by default, while Exposure, Management, and Addresses start collapsed.
  - The Addresses, Exposure, Management, General, and Statistics areas now share a more consistent, expandable layout.

- **Bug Fixes**
  - Preserved existing vault details, links, copy actions, and APY/statistics displays while updating the section layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->