### PR TITLE
fix: show disconnected rewards empty state

### DIFF
--- a/composables/useSdkRewards.ts
+++ b/composables/useSdkRewards.ts
@@ -20,7 +20,9 @@ let delayedRefreshTimers: ReturnType<typeof setTimeout>[] = []
 export const useSdkRewards = () => {
   const { portfolio, isPositionsLoading, refreshAllPositions } = useEulerAccount()
   const { chainId } = useEulerAddresses()
-  const { address: walletAddress } = useWagmi()
+  const { address: walletAddress, isConnected } = useWagmi()
+  const { isSpyMode } = useSpyMode()
+  const hasActiveSession = computed(() => isConnected.value || isSpyMode.value)
 
   const rewards = computed<UserReward[]>(() => {
     const items = portfolio.value?.account.userRewards ?? []
@@ -28,7 +30,7 @@ export const useSdkRewards = () => {
     if (!currentChainId) return []
     return items.filter(reward => reward.chainId === currentChainId)
   })
-  const isRewardsLoading = computed(() => isPositionsLoading.value)
+  const isRewardsLoading = computed(() => hasActiveSession.value && isPositionsLoading.value)
 
   const buildClaimRewardPlan = async (reward: UserReward): Promise<TransactionPlan> => {
     if (!walletAddress.value) {

--- a/composables/useSdkRewards.ts
+++ b/composables/useSdkRewards.ts
@@ -20,9 +20,11 @@ let delayedRefreshTimers: ReturnType<typeof setTimeout>[] = []
 export const useSdkRewards = () => {
   const { portfolio, isPositionsLoading, refreshAllPositions } = useEulerAccount()
   const { chainId } = useEulerAddresses()
-  const { address: walletAddress, isConnected } = useWagmi()
+  const { address: walletAddress, isConnected, isConnecting, isReconnecting } = useWagmi()
   const { isSpyMode } = useSpyMode()
-  const hasActiveSession = computed(() => isConnected.value || isSpyMode.value)
+  const hasActiveSession = computed(() =>
+    isConnected.value || isConnecting.value || isReconnecting.value || isSpyMode.value,
+  )
 
   const rewards = computed<UserReward[]>(() => {
     const items = portfolio.value?.account.userRewards ?? []

--- a/tests/composables/useSdkRewards.test.ts
+++ b/tests/composables/useSdkRewards.test.ts
@@ -6,7 +6,13 @@ import type { UserReward } from '@eulerxyz/euler-v2-sdk'
 const owner = '0x1000000000000000000000000000000000000000' as Address
 
 const importUseSdkRewards = async (
-  options: { isConnected?: boolean, isSpyMode?: boolean, isPositionsLoading?: boolean } = {},
+  options: {
+    isConnected?: boolean
+    isConnecting?: boolean
+    isReconnecting?: boolean
+    isSpyMode?: boolean
+    isPositionsLoading?: boolean
+  } = {},
 ) => {
   vi.resetModules()
   const currentChainId = ref(1)
@@ -61,6 +67,8 @@ const importUseSdkRewards = async (
   vi.stubGlobal('useWagmi', () => ({
     address: ref(owner),
     isConnected: ref(options.isConnected ?? true),
+    isConnecting: ref(options.isConnecting ?? false),
+    isReconnecting: ref(options.isReconnecting ?? false),
   }))
   vi.stubGlobal('useSpyMode', () => ({
     isSpyMode: ref(options.isSpyMode ?? false),
@@ -116,6 +124,30 @@ describe('useSdkRewards', () => {
   it('stays loading while rewards load for an active session', async () => {
     const { useSdkRewards } = await importUseSdkRewards({
       isConnected: true,
+      isPositionsLoading: true,
+    })
+
+    const { isRewardsLoading } = useSdkRewards()
+
+    expect(isRewardsLoading.value).toBe(true)
+  })
+
+  it('stays loading while rewards load during wallet auto-reconnect', async () => {
+    const { useSdkRewards } = await importUseSdkRewards({
+      isConnected: false,
+      isReconnecting: true,
+      isPositionsLoading: true,
+    })
+
+    const { isRewardsLoading } = useSdkRewards()
+
+    expect(isRewardsLoading.value).toBe(true)
+  })
+
+  it('stays loading while rewards load during wallet connect', async () => {
+    const { useSdkRewards } = await importUseSdkRewards({
+      isConnected: false,
+      isConnecting: true,
       isPositionsLoading: true,
     })
 

--- a/tests/composables/useSdkRewards.test.ts
+++ b/tests/composables/useSdkRewards.test.ts
@@ -5,7 +5,9 @@ import type { UserReward } from '@eulerxyz/euler-v2-sdk'
 
 const owner = '0x1000000000000000000000000000000000000000' as Address
 
-const importUseSdkRewards = async () => {
+const importUseSdkRewards = async (
+  options: { isConnected?: boolean, isSpyMode?: boolean, isPositionsLoading?: boolean } = {},
+) => {
   vi.resetModules()
   const currentChainId = ref(1)
 
@@ -50,7 +52,7 @@ const importUseSdkRewards = async () => {
   }))
   vi.stubGlobal('useEulerAccount', () => ({
     portfolio: ref({ account: { userRewards: [reward, turtleReward, crossChainTurtleReward] } }),
-    isPositionsLoading: ref(false),
+    isPositionsLoading: ref(options.isPositionsLoading ?? false),
     refreshAllPositions,
   }))
   vi.stubGlobal('useEulerAddresses', () => ({
@@ -58,6 +60,10 @@ const importUseSdkRewards = async () => {
   }))
   vi.stubGlobal('useWagmi', () => ({
     address: ref(owner),
+    isConnected: ref(options.isConnected ?? true),
+  }))
+  vi.stubGlobal('useSpyMode', () => ({
+    isSpyMode: ref(options.isSpyMode ?? false),
   }))
   vi.stubGlobal('useEulerSdk', () => ({
     getEulerSdk: vi.fn(async () => ({
@@ -93,6 +99,29 @@ describe('useSdkRewards', () => {
 
     expect(rewards.value).toEqual([reward, turtleReward])
     expect(isRewardsLoading.value).toBe(false)
+  })
+
+  it('does not stay loading without a wallet or spy session', async () => {
+    const { useSdkRewards } = await importUseSdkRewards({
+      isConnected: false,
+      isSpyMode: false,
+      isPositionsLoading: true,
+    })
+
+    const { isRewardsLoading } = useSdkRewards()
+
+    expect(isRewardsLoading.value).toBe(false)
+  })
+
+  it('stays loading while rewards load for an active session', async () => {
+    const { useSdkRewards } = await importUseSdkRewards({
+      isConnected: true,
+      isPositionsLoading: true,
+    })
+
+    const { isRewardsLoading } = useSdkRewards()
+
+    expect(isRewardsLoading.value).toBe(true)
   })
 
   it('updates visible rewards when the selected chain changes', async () => {


### PR DESCRIPTION
## Summary
- Fix the disconnected portfolio rewards tab so it reaches the existing wallet-connect empty state instead of staying on a spinner.
- Preserve loading behavior for connected wallets, wallet connect/reconnect transitions, and spy sessions while rewards are still being fetched.

## Changes
- Gate `useSdkRewards().isRewardsLoading` on an active wallet, connecting/reconnecting wallet, or spy session before reflecting portfolio loading state.
- Extend `useSdkRewards` coverage for disconnected, connected, connecting, and reconnecting loading behavior.

## Test plan
- [x] `./node_modules/.bin/vitest run tests/composables/useSdkRewards.test.ts`
- [x] `./node_modules/.bin/eslint composables/useSdkRewards.ts tests/composables/useSdkRewards.test.ts`
- [ ] `./node_modules/.bin/nuxt typecheck` (blocked locally: Nuxt svg-sprite/unstorage fails during init with `Maximum call stack size exceeded`)
- [ ] Browser smoke at `http://127.0.0.1:3000/portfolio/rewards?network=1` (blocked locally by the same Nuxt init failure before the dev server serves)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rewards loading so it only shows loading when there is an active wallet or spy session (including connect/reconnect states), not merely while positions are loading.
  * Prevents the rewards view from getting stuck in a loading state when no session is connected.
* **Tests**
  * Added additional coverage for rewards loading across connected, disconnected, connecting, reconnecting, and spy-mode scenarios.
  * Updated test mocks to accurately simulate wallet connection flags and spy-mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->