### PR TITLE
Remove Earn APY 1h badges

### DIFF
--- a/components/entities/portfolio/PortfolioEarnItem.vue
+++ b/components/entities/portfolio/PortfolioEarnItem.vue
@@ -84,7 +84,6 @@ const supplyApyModalData = computed(() => ({
     campaigns: getSupplyRewardCampaignsFromVault(vault.value),
     totalSupplyAPY: supplyApyWithRewards.value,
     rewardVaultAddress: vault.value.address,
-    baseApyAverageLabel: '1h',
   },
 }))
 
@@ -189,9 +188,6 @@ const onClick = () => {
           <div class="flex flex-col items-end">
             <div class="text-content-tertiary text-p3 mb-4 flex items-center gap-4">
               Supply APY
-              <span class="inline-flex items-center rounded-8 px-8 py-2 bg-accent-100 text-accent-600 text-p5">
-                1h
-              </span>
               <UiModalPreviewTrigger
                 :component="VaultSupplyApyModal"
                 :modal-data="supplyApyModalData"

--- a/components/entities/vault/VaultEarnItem.vue
+++ b/components/entities/vault/VaultEarnItem.vue
@@ -235,7 +235,6 @@ const supplyApyModalData = computed(() => ({
     campaigns: settings.value.enableRewardsApy ? getSupplyRewardCampaigns(vault.address) : [],
     totalSupplyAPY: visibleSupplyApy.value,
     rewardVaultAddress: vault.address,
-    baseApyAverageLabel: '1h',
   },
 }))
 </script>
@@ -295,9 +294,6 @@ const supplyApyModalData = computed(() => ({
       <div class="flex flex-col items-end shrink-0 ml-16">
         <div class="text-content-tertiary text-p3 mb-4 text-right flex items-center gap-4">
           Supply APY
-          <span class="inline-flex items-center rounded-8 px-8 py-2 bg-accent-100 text-accent-600 text-p5">
-            1h
-          </span>
           <UiModalPreviewTrigger
             :component="VaultSupplyApyModal"
             :modal-data="supplyApyModalData"

--- a/components/entities/vault/overview/earn/VaultOverviewEarnBlockStats.vue
+++ b/components/entities/vault/overview/earn/VaultOverviewEarnBlockStats.vue
@@ -194,7 +194,6 @@ const supplyApyModalData = computed(() => ({
     campaigns: settings.value.enableRewardsApy ? getSupplyRewardCampaigns(vault.address) : [],
     totalSupplyAPY: supplyApyTotal.value,
     rewardVaultAddress: vault.address,
-    baseApyAverageLabel: '1h',
   },
 }))
 </script>
@@ -240,12 +239,7 @@ const supplyApyModalData = computed(() => ({
       orientation="horizontal"
     >
       <template #label>
-        <span class="flex items-center gap-6">
-          Supply APY
-          <span class="inline-flex items-center rounded-8 px-8 py-2 bg-accent-100 text-accent-600 text-p5">
-            1h
-          </span>
-        </span>
+        Supply APY
       </template>
       <span class="flex items-center gap-4">
         <UiModalPreviewTrigger

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@eulerxyz/euler-v2-sdk": "1.0.10",
+        "@eulerxyz/euler-v2-sdk": "1.1.0",
         "@floating-ui/vue": "2.0.0",
         "@gvade/nuxt3-svg-sprite": "1.0.3",
         "@keyringnetwork/keyring-connect-sdk": "3.2.0",
@@ -1469,9 +1469,9 @@
       }
     },
     "node_modules/@eulerxyz/euler-v2-sdk": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@eulerxyz/euler-v2-sdk/-/euler-v2-sdk-1.0.10.tgz",
-      "integrity": "sha512-YUIvZX/2zez1NnjypwRVwlll1zKbNjtzuLQSqhIR1qEKmFVXaU651LitN5jfIIXFcb6++JZFsOwT6OWNPX9JGQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@eulerxyz/euler-v2-sdk/-/euler-v2-sdk-1.1.0.tgz",
+      "integrity": "sha512-dXuR9C2Pe47prGggdKpnqqE1Y0oSK7inO/QMpmWKn5vo5ZxupinIIAy6Ev8mKx8ezGljRGVhShyS0VhM0kPkow==",
       "license": "MIT",
       "dependencies": {
         "viem": "2.48.8"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     ]
   },
   "dependencies": {
-    "@eulerxyz/euler-v2-sdk": "1.0.10",
+    "@eulerxyz/euler-v2-sdk": "1.1.0",
     "@floating-ui/vue": "2.0.0",
     "@gvade/nuxt3-svg-sprite": "1.0.3",
     "@keyringnetwork/keyring-connect-sdk": "3.2.0",

--- a/pages/earn/[vault]/index.vue
+++ b/pages/earn/[vault]/index.vue
@@ -229,7 +229,6 @@ const supplyApyModalData = computed(() => ({
     campaigns: settings.value.enableRewardsApy ? supplyRewardCampaigns.value : [],
     totalSupplyAPY: supplyApyTotal.value,
     rewardVaultAddress: vaultAddress,
-    baseApyAverageLabel: '1h',
   },
 }))
 
@@ -293,9 +292,6 @@ watch(amount, () => {
             >
               <p class="text-h3 text-content-tertiary flex items-center gap-4">
                 Supply APY
-                <span class="inline-flex items-center rounded-8 px-8 py-2 bg-accent-100 text-accent-600 text-p5">
-                  1h
-                </span>
                 <UiModalPreviewTrigger
                   :component="VaultSupplyApyModal"
                   :modal-data="supplyApyModalData"

--- a/scripts/parity-sdk-diagnostics.mjs
+++ b/scripts/parity-sdk-diagnostics.mjs
@@ -47,7 +47,8 @@ const apiKey = process.env.EULER_SDK_V3_API_KEY
   || process.env.VITE_EULER_V3_API_KEY
 const rpcUrls = collectRpcUrls()
 const observations = collectObservations(diff)
-const vaultAddresses = [...new Set(observations.map(obs => obs.vaultAddress).filter(Boolean))]
+const vaultAddressGroups = collectVaultAddressGroups(observations)
+const vaultAddresses = [...new Set([...vaultAddressGroups.evault, ...vaultAddressGroups.earn])]
 
 if (!vaultAddresses.length) {
   throw new Error(`No vault-scoped observations found in ${diffPath}`)
@@ -75,6 +76,7 @@ const report = {
   endpoint,
   rpcChainIds: Object.keys(rpcUrls).map(Number).sort((a, b) => a - b),
   fetchOptions: FETCH_OPTIONS,
+  vaultAddressGroups,
   summary,
   sourceRule: 'If onchain matches the baseline while v3 differs, the V3 source or V3 adapter interpretation is the suspect.',
   observations: rows,
@@ -199,22 +201,39 @@ async function buildSdk(adapter) {
 
 async function fetchSnapshot(adapter, vaultAddresses) {
   const sdk = await buildSdk(adapter)
-  const normalized = vaultAddresses.map(addr => getAddress(addr))
-  const result = await sdk.eVaultService.fetchVaults(1, normalized, FETCH_OPTIONS)
+  const evaultAddresses = vaultAddresses.evault.map(addr => getAddress(addr))
+  const earnAddresses = vaultAddresses.earn.map(addr => getAddress(addr))
   const vaults = {}
-  result.result.forEach((vault, index) => {
-    const address = normalized[index].toLowerCase()
-    vaults[address] = vault ? summarizeVault(vault) : null
-  })
+  const errors = []
+
+  if (evaultAddresses.length) {
+    const result = await sdk.eVaultService.fetchVaults(1, evaultAddresses, FETCH_OPTIONS)
+    result.result.forEach((vault, index) => {
+      const address = evaultAddresses[index].toLowerCase()
+      vaults[address] = vault ? summarizeVault(vault) : null
+    })
+    errors.push(...(result.errors || []))
+  }
+
+  if (earnAddresses.length) {
+    const result = await sdk.eulerEarnService.fetchVaults(1, earnAddresses, FETCH_OPTIONS)
+    result.result.forEach((vault, index) => {
+      const address = earnAddresses[index].toLowerCase()
+      vaults[address] = vault ? summarizeEarnVault(vault) : null
+    })
+    errors.push(...(result.errors || []))
+  }
+
   return {
     adapter,
     vaults,
-    errors: (result.errors || []).map(summarizeDataIssue),
+    errors: errors.map(summarizeDataIssue),
   }
 }
 
 function summarizeVault(vault) {
   return {
+    kind: 'evault',
     address: vault.address.toLowerCase(),
     asset: summarizeToken(vault.asset),
     shares: summarizeToken(vault.shares),
@@ -245,6 +264,20 @@ function summarizeVault(vault) {
       includeInAppExposure: collateral.borrowLTV > 0 && collateral.currentLiquidationLTV > 0,
     })),
     appCollateralDisplayAssets: computeAppCollateralDisplayAssets(vault),
+  }
+}
+
+function summarizeEarnVault(vault) {
+  return {
+    kind: 'earn',
+    address: vault.address.toLowerCase(),
+    asset: summarizeToken(vault.asset),
+    shares: summarizeToken(vault.shares),
+    totalAssets: vault.totalAssets,
+    availableLiquidity: vault.availableLiquidity,
+    supplyApy: Number.isFinite(vault.supplyApy) ? vault.supplyApy : null,
+    rewards: summarizeRewards(vault.rewards),
+    intrinsicApy: vault.intrinsicApy ?? null,
   }
 }
 
@@ -315,6 +348,7 @@ function collectObservations(report) {
       if (!vaultAddress) continue
       observations.push({
         pageId: page.pageId,
+        path: page.path,
         label: page.label,
         status: diff.status,
         field,
@@ -328,6 +362,49 @@ function collectObservations(report) {
     }
   }
   return observations
+}
+
+function collectVaultAddressGroups(observations) {
+  const groups = {
+    evault: new Set(),
+    earn: new Set(),
+  }
+  for (const observation of observations) {
+    const target = isEarnObservation(observation) ? groups.earn : groups.evault
+    target.add(observation.vaultAddress)
+  }
+  return {
+    evault: [...groups.evault],
+    earn: [...groups.earn],
+  }
+}
+
+function isEarnObservation(observation) {
+  const pathVaultAddress = earnVaultAddressFromPath(observation.path)
+  if (pathVaultAddress && pathVaultAddress === observation.vaultAddress) return true
+
+  const text = [
+    observation.pageId,
+    observation.path,
+    observation.label,
+    observation.key,
+    observation.baseKey,
+    observation.baseline?.key,
+    observation.candidate?.key,
+  ].filter(Boolean).join('\n').toLowerCase()
+
+  if (text.includes('data-list="earn"')
+    || text.includes('data-list=\'earn\'')
+  ) return true
+
+  return normalizeField(observation.field, observation) === 'supply-apy'
+    && /\bearn\b/.test(text)
+}
+
+function earnVaultAddressFromPath(pathname) {
+  if (typeof pathname !== 'string') return null
+  const match = pathname.match(/\/earn\/(?:\d+\/)?(0x[a-fA-F0-9]{40})(?:[/?#]|$)/)
+  return match?.[1]?.toLowerCase() ?? null
 }
 
 function fieldFromBaseKey(baseKey) {
@@ -422,6 +499,18 @@ function readField(vault, field, observation) {
   if (!vault) return { comparable: null, raw: null }
   switch (field) {
     case 'supply-apy':
+      if (vault.kind === 'earn') {
+        const supplyApy = vault.supplyApy
+        return {
+          comparable: supplyApy == null ? null : supplyApy + vault.rewards.supplyApr,
+          raw: {
+            baseSupplyAPY: supplyApy,
+            supplyRewardApr: vault.rewards.supplyApr,
+            finalSupplyAPY: supplyApy == null ? null : supplyApy + vault.rewards.supplyApr,
+            intrinsicApy: vault.intrinsicApy,
+          },
+        }
+      }
       return {
         comparable: vault.interestRates.supplyAPY + vault.rewards.supplyApr,
         raw: {

--- a/scripts/parity-sdk-diagnostics.mjs
+++ b/scripts/parity-sdk-diagnostics.mjs
@@ -381,7 +381,10 @@ function collectVaultAddressGroups(observations) {
 
 function isEarnObservation(observation) {
   const pathVaultAddress = earnVaultAddressFromPath(observation.path)
-  if (pathVaultAddress && pathVaultAddress === observation.vaultAddress) return true
+  const observedVaultAddress = typeof observation.vaultAddress === 'string'
+    ? observation.vaultAddress.toLowerCase()
+    : null
+  if (pathVaultAddress && pathVaultAddress === observedVaultAddress) return true
 
   const text = [
     observation.pageId,

--- a/tests/utils/vault-display.test.ts
+++ b/tests/utils/vault-display.test.ts
@@ -1,6 +1,20 @@
 import { describe, expect, it } from 'vitest'
 
-import { formatMarketAvailability } from '~/utils/vault-display'
+import { formatMarketAvailability, getVaultSupplyApy } from '~/utils/vault-display'
+
+describe('getVaultSupplyApy', () => {
+  it('reads EVault interest rate supply APY', () => {
+    expect(getVaultSupplyApy({ interestRates: { supplyAPY: 4.2 } })).toBe(4.2)
+  })
+
+  it('reads Earn supplyApy', () => {
+    expect(getVaultSupplyApy({ supplyApy: 3.1 })).toBe(3.1)
+  })
+
+  it('returns zero when Earn supply APY is missing', () => {
+    expect(getVaultSupplyApy({ totalAssets: 100n })).toBe(0)
+  })
+})
 
 describe('formatMarketAvailability', () => {
   it('formats unavailable, singular, and plural market counts', () => {

--- a/utils/vault-display.ts
+++ b/utils/vault-display.ts
@@ -2,7 +2,6 @@ export const getVaultSupplyApy = (vault: any): number => {
   if (!vault) return 0
   if ('interestRates' in vault) return vault.interestRates.supplyAPY
   if ('supplyApy' in vault) return vault.supplyApy ?? 0
-  if ('supplyApy1h' in vault) return vault.supplyApy1h ?? 0
   return 0
 }
 

--- a/utils/vault-display.ts
+++ b/utils/vault-display.ts
@@ -1,6 +1,7 @@
 export const getVaultSupplyApy = (vault: any): number => {
   if (!vault) return 0
   if ('interestRates' in vault) return vault.interestRates.supplyAPY
+  if ('supplyApy' in vault) return vault.supplyApy ?? 0
   if ('supplyApy1h' in vault) return vault.supplyApy1h ?? 0
   return 0
 }


### PR DESCRIPTION
## Summary

Removes the visible `1h` Earn APY presentation and consumes the SDK `EulerEarn.supplyApy` field directly.

This PR is paired with the SDK minor-version release in https://github.com/euler-xyz/euler-sdks/pull/69, where `EulerEarn.supplyApy1h` is intentionally removed from the public SDK entity/type surface.

SDK PR: https://github.com/euler-xyz/euler-sdks/pull/69

## Changes

- Removes `1h` APY badges from Earn vault cards, portfolio Earn rows, and the Earn vault overview/detail stats.
- Stops passing `baseApyAverageLabel: "1h"` to the APY modal for Earn surfaces.
- Reads Earn APY from `vault.supplyApy` only.
- Updates Lite parity diagnostics to fetch Earn vaults through `sdk.eulerEarnService` and compare Earn `supplyApy` as percentage points.

## Test plan

- Linked Lite to the matching local SDK worktree per the README local development flow.
- `npm run test:run -- tests/utils/vault-display.test.ts`
- `npx eslint scripts/parity-sdk-diagnostics.mjs`
- `node --check scripts/parity-sdk-diagnostics.mjs`
- Started linked Lite locally at `http://127.0.0.1:3000/earn?network=1`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved vault APY displays to support both eVault and Earn vaults.
  * APY breakdowns now open via an info icon in place of the inline “1h” badge.

* **Bug Fixes**
  * Corrected APY values for Earn vaults by using the appropriate reward-inclusive calculation.
  * Removed the misleading “1h” label from Supply APY sections where it no longer applied.

* **Tests**
  * Added coverage for APY calculation behavior across vault types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
