### PR TITLE
fix: update unhead override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18145,9 +18145,9 @@
       }
     },
     "node_modules/unhead": {
-      "version": "2.1.12",
-      "resolved": "https://registry.npmjs.org/unhead/-/unhead-2.1.12.tgz",
-      "integrity": "sha512-iTHdWD9ztTunOErtfUFk6Wr11BxvzumcYJ0CzaSCBUOEtg+DUZ9+gnE99i8QkLFT2q1rZD48BYYGXpOZVDLYkA==",
+      "version": "2.1.15",
+      "resolved": "https://registry.npmjs.org/unhead/-/unhead-2.1.15.tgz",
+      "integrity": "sha512-MCt5T90mCWyr3Z6pUCdM9lVRXoMoVBlL7z7U4CYVIiaDiuzad/UCfLuMqz5MeNmpZUgoBCQnrucJimU7EZR+XA==",
       "license": "MIT",
       "dependencies": {
         "hookable": "^6.0.1"

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   "overrides": {
     "@wagmi/connectors": "8.0.16",
     "serialize-javascript": "7.0.4",
-    "unhead": "2.1.12"
+    "unhead": "2.1.15"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
## Summary
- Update the root `unhead` override from `2.1.12` to `2.1.15`.
- Refresh `package-lock.json` so the resolved top-level `unhead` package uses `2.1.15`.

## Validation
- `npm install --package-lock-only --ignore-scripts`
- `npm ls unhead` resolves `unhead@2.1.15`
- `npm audit --omit=dev --audit-level=moderate` no longer reports `unhead`; existing non-unhead advisories remain in the baseline
- `npm run typecheck`
- `npm run test:run` - 114 files passed, 1 skipped; 1082 tests passed, 1 skipped
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a package override to a newer version, which may improve compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->