### PR TITLE
fix: preserve vault cache on chunk failure

### DIFF
--- a/server/utils/vaults-cache.ts
+++ b/server/utils/vaults-cache.ts
@@ -192,7 +192,14 @@ const fetchEVaultsForSnapshot = async (
       errors.push(...(fetched.errors as unknown[]))
     }
     catch (err) {
-      errors.push(err)
+      logger.warn({
+        ctx: 'vaults-cache',
+        chainId,
+        chunkIndex: i / EVAULT_FETCH_CHUNK_SIZE,
+        chunkSize: chunk.length,
+        err,
+      }, 'eVault chunk fetch failed')
+      throw err
     }
 
     if (i + EVAULT_FETCH_CHUNK_SIZE < addresses.length) {

--- a/tests/server/vaults-cache.test.ts
+++ b/tests/server/vaults-cache.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SerialisedSnapshot } from '~/server/utils/vaults-cache'
+
+const VAULTS = [
+  '0x0000000000000000000000000000000000000001',
+  '0x0000000000000000000000000000000000000002',
+  '0x0000000000000000000000000000000000000003',
+  '0x0000000000000000000000000000000000000004',
+  '0x0000000000000000000000000000000000000005',
+  '0x0000000000000000000000000000000000000006',
+  '0x0000000000000000000000000000000000000007',
+] as const
+
+const mocks = vi.hoisted(() => ({
+  fetchVaults: vi.fn(),
+  fetchVerifiedVaultAddresses: vi.fn(),
+  fetchVaultTypes: vi.fn(),
+  refreshLabelFile: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}))
+
+vi.mock('@eulerxyz/euler-v2-sdk', () => ({
+  StandardEVaultPerspectives: {
+    ESCROW: 'escrow',
+  },
+  VaultType: {
+    EulerEarn: 'EulerEarn',
+    SecuritizeCollateral: 'SecuritizeCollateral',
+  },
+}))
+
+vi.mock('~/server/api/labels/[file].get', () => ({
+  LABEL_FILES: [],
+  refreshLabelFile: mocks.refreshLabelFile,
+}))
+
+vi.mock('~/server/utils/sdk-server', () => ({
+  getServerSdk: vi.fn(async () => ({
+    eVaultService: {
+      fetchVaults: mocks.fetchVaults,
+      fetchVerifiedVaultAddresses: mocks.fetchVerifiedVaultAddresses,
+    },
+    eulerEarnService: {
+      fetchVaults: vi.fn(async () => ({ result: [], errors: [] })),
+    },
+    securitizeVaultService: {
+      fetchVaults: vi.fn(async () => ({ result: [], errors: [] })),
+    },
+    vaultMetaService: {
+      fetchVaultTypes: mocks.fetchVaultTypes,
+    },
+  })),
+}))
+
+vi.mock('~/server/utils/logger', () => ({
+  logger: {
+    warn: mocks.warn,
+    error: mocks.error,
+  },
+}))
+
+describe('vaults cache', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    mocks.fetchVaults.mockReset()
+    mocks.fetchVerifiedVaultAddresses.mockReset()
+    mocks.fetchVaultTypes.mockReset()
+    mocks.refreshLabelFile.mockReset()
+    mocks.warn.mockReset()
+    mocks.error.mockReset()
+    process.env.EVAULT_FETCH_CHUNK_CHAINS = '146'
+
+    mocks.fetchVerifiedVaultAddresses.mockResolvedValue([])
+    mocks.fetchVaultTypes.mockResolvedValue({})
+    mocks.refreshLabelFile.mockImplementation(async (_scope, file) => {
+      if (file === 'products.json') {
+        return {
+          test: {
+            vaults: [...VAULTS],
+          },
+        }
+      }
+      return []
+    })
+  })
+
+  it('does not replace the previous snapshot when a chunked eVault refresh throws', async () => {
+    const { refreshChainVaults, vaultsCache } = await import('~/server/utils/vaults-cache')
+    const previous: SerialisedSnapshot = {
+      chainId: 146,
+      fetchedAt: 123,
+      evkVaults: [{ kind: 'evk', data: { address: VAULTS[0] } }],
+      earnVaults: [],
+      securitizeVaults: [],
+      escrowVaults: [],
+    }
+
+    vaultsCache.set('146', previous)
+    mocks.fetchVaults
+      .mockResolvedValueOnce({
+        result: VAULTS.slice(0, 6).map(address => ({ address })),
+        errors: [],
+      })
+      .mockRejectedValueOnce(new Error('chunk failed'))
+
+    await expect(refreshChainVaults(146)).rejects.toThrow('chunk failed')
+
+    expect(vaultsCache.getStale('146')).toBe(previous)
+    expect(mocks.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chainId: 146,
+        chunkIndex: 1,
+        chunkSize: 1,
+        ctx: 'vaults-cache',
+      }),
+      'eVault chunk fetch failed',
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- Fail the server vault snapshot refresh when a chunked EVault fetch throws instead of returning a partial result.
- Log chunk fetch failures with generic chunk metadata so the warm-cache failure is visible without listing vault addresses.
- Add a regression test proving a chunk failure rejects the refresh and preserves the previous cached snapshot.

## Validation
- `npm run test:run -- tests/server/vaults-cache.test.ts`
- `npm run typecheck`
- `npm run test:run` - 115 files passed, 1 skipped; 1083 tests passed, 1 skipped
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability during chunked cache refreshes by keeping the existing snapshot if a later fetch chunk fails.
  * Added clearer warning logs with structured context when a chunk fetch fails.

* **Tests**
  * Added coverage for failed chunk refreshes to verify the cache is preserved and the warning is emitted as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->