### PR TITLE
fix: use shared oracle checks tooltip

### DIFF
--- a/components/base/BaseModalWrapper.vue
+++ b/components/base/BaseModalWrapper.vue
@@ -128,8 +128,11 @@ const bodyTopPaddingClass = computed(() => {
     <!-- Drag zone: pill + header, outside the scroll container -->
     <div
       v-if="hasHeaderChrome"
-      class="shrink-0 mobile:pt-0 touch-none select-none"
-      :class="compact ? 'px-12 pt-10' : 'px-16 pt-12'"
+      class="shrink-0 touch-none select-none"
+      :class="[
+        compact ? 'px-12 pt-14' : 'px-16 pt-12',
+        !inline ? 'mobile:pt-0' : '',
+      ]"
       @pointerdown="onPointerDown"
       @pointermove="onPointerMove"
       @pointerup="onPointerUp"

--- a/components/entities/vault/overview/OracleAdapterChecksModal.vue
+++ b/components/entities/vault/overview/OracleAdapterChecksModal.vue
@@ -1,0 +1,57 @@
+<script setup lang="ts">
+import { OracleAdapterCheckSeverity, type OracleAdapterCheck } from '~/entities/oracle'
+
+defineEmits(['close'])
+
+const {
+  modalTitle = 'Checks',
+  checks,
+  inline = false,
+  close = true,
+} = defineProps<{
+  modalTitle?: string
+  checks: OracleAdapterCheck[]
+  inline?: boolean
+  close?: boolean
+}>()
+</script>
+
+<template>
+  <BaseModalWrapper
+    :title="modalTitle"
+    :inline="inline"
+    :close="close"
+    :compact="inline && !close"
+    @close="$emit('close')"
+  >
+    <div class="flex flex-col gap-10">
+      <div
+        v-for="(check, i) in checks"
+        :key="`${check.id}-${i}`"
+        class="flex items-start gap-10"
+      >
+        <span
+          class="flex-shrink-0 w-20 h-20 rounded-full flex items-center justify-center mt-8"
+          :class="{
+            'bg-success-500': check.pass,
+            'bg-error-500': !check.pass && check.severity === OracleAdapterCheckSeverity.High,
+            'bg-warning-500': !check.pass && check.severity !== OracleAdapterCheckSeverity.High,
+          }"
+        >
+          <SvgIcon
+            :name="check.pass ? 'check' : 'close'"
+            class="!w-10 !h-10 text-white"
+          />
+        </span>
+        <div class="min-w-0">
+          <p class="text-p3 font-medium text-content-primary break-words">
+            {{ check.id }}
+          </p>
+          <p class="text-p3 text-content-secondary break-words">
+            {{ check.message }}
+          </p>
+        </div>
+      </div>
+    </div>
+  </BaseModalWrapper>
+</template>

--- a/components/entities/vault/overview/OracleAdapterChecksModal.vue
+++ b/components/entities/vault/overview/OracleAdapterChecksModal.vue
@@ -120,7 +120,7 @@ const copyAddress = (address: string) => {
               <button
                 v-if="part.address"
                 type="button"
-                class="inline-flex max-w-full items-center gap-4 align-baseline text-accent-600 outline-none hover:text-accent-500 focus-visible:rounded-4 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-600"
+                class="inline text-left align-baseline text-accent-600 outline-none hover:text-accent-500 focus-visible:rounded-4 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-600"
                 :aria-label="`Copy address ${part.address}`"
                 @pointerdown.stop.prevent="copyAddress(part.address)"
                 @mousedown.stop.prevent
@@ -128,9 +128,9 @@ const copyAddress = (address: string) => {
                 @keydown.enter.stop.prevent="copyAddress(part.address)"
                 @keydown.space.stop.prevent="copyAddress(part.address)"
               >
-                <span class="min-w-0 break-all">{{ part.text }}</span>
+                <span class="break-all">{{ part.text }}</span>
                 <SvgIcon
-                  class="!w-12 !h-12 shrink-0"
+                  class="ml-4 inline-block !w-12 !h-12 align-[-1px]"
                   :name="isCopied(getAddressCopyKey(part.address)) ? 'check' : 'copy'"
                 />
               </button>

--- a/components/entities/vault/overview/OracleAdapterChecksModal.vue
+++ b/components/entities/vault/overview/OracleAdapterChecksModal.vue
@@ -122,7 +122,6 @@ const copyAddress = (address: string) => {
                 type="button"
                 class="group inline-flex max-w-full items-center gap-4 rounded-4 border border-line-subtle bg-surface-secondary px-5 py-1 align-baseline font-mono text-[13px] leading-[18px] text-accent-600 outline-none transition-colors hover:border-line-default hover:text-accent-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-600"
                 :aria-label="`Copy address ${part.address}`"
-                @pointerdown.stop.prevent="copyAddress(part.address)"
                 @mousedown.stop.prevent
                 @click.stop.prevent="copyAddress(part.address)"
                 @keydown.enter.stop.prevent="copyAddress(part.address)"

--- a/components/entities/vault/overview/OracleAdapterChecksModal.vue
+++ b/components/entities/vault/overview/OracleAdapterChecksModal.vue
@@ -120,7 +120,7 @@ const copyAddress = (address: string) => {
               <button
                 v-if="part.address"
                 type="button"
-                class="group inline-flex max-w-full items-center gap-4 rounded-4 bg-surface px-4 py-1 align-baseline font-mono text-p4 text-accent-600 outline-none transition-colors hover:bg-surface-secondary hover:text-accent-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-600"
+                class="group inline-flex max-w-full items-center gap-4 rounded-4 border border-line-subtle bg-surface-secondary px-5 py-1 align-baseline font-mono text-[13px] leading-[18px] text-accent-600 outline-none transition-colors hover:border-line-default hover:text-accent-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-600"
                 :aria-label="`Copy address ${part.address}`"
                 @pointerdown.stop.prevent="copyAddress(part.address)"
                 @mousedown.stop.prevent

--- a/components/entities/vault/overview/OracleAdapterChecksModal.vue
+++ b/components/entities/vault/overview/OracleAdapterChecksModal.vue
@@ -14,6 +14,71 @@ const {
   inline?: boolean
   close?: boolean
 }>()
+
+const addressPattern = /\b0x[a-fA-F0-9]{40}\b/g
+
+type CheckMessagePart = {
+  text: string
+  address?: string
+}
+
+const getAddressCopyKey = (address: string) => `oracle-check-address-${address.toLowerCase()}`
+
+const fallbackCopy = (text: string) => {
+  const textarea = document.createElement('textarea')
+  textarea.value = text
+  textarea.setAttribute('readonly', '')
+  textarea.style.position = 'fixed'
+  textarea.style.opacity = '0'
+  document.body.appendChild(textarea)
+  textarea.select()
+  const copied = document.execCommand('copy')
+  document.body.removeChild(textarea)
+  return copied
+}
+
+const writeAddressToClipboard = async (address: string) => {
+  if (navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(address)
+      return
+    }
+    catch {
+      // Fall through to the textarea fallback used by older or restricted browsers.
+    }
+  }
+
+  if (!fallbackCopy(address)) {
+    throw new Error('Unable to copy address')
+  }
+}
+
+const { isCopied, copyToClipboard } = useClipboardCopy({ write: writeAddressToClipboard })
+
+const getCheckMessageParts = (message: string): CheckMessagePart[] => {
+  const parts: CheckMessagePart[] = []
+  let lastIndex = 0
+
+  for (const match of message.matchAll(addressPattern)) {
+    const address = match[0]
+    const index = match.index ?? 0
+    if (index > lastIndex) {
+      parts.push({ text: message.slice(lastIndex, index) })
+    }
+    parts.push({ text: address, address })
+    lastIndex = index + address.length
+  }
+
+  if (lastIndex < message.length) {
+    parts.push({ text: message.slice(lastIndex) })
+  }
+
+  return parts.length ? parts : [{ text: message }]
+}
+
+const copyAddress = (address: string) => {
+  copyToClipboard(address, getAddressCopyKey(address)).catch(() => {})
+}
 </script>
 
 <template>
@@ -48,7 +113,31 @@ const {
             {{ check.id }}
           </p>
           <p class="text-p3 text-content-secondary break-words">
-            {{ check.message }}
+            <template
+              v-for="(part, partIndex) in getCheckMessageParts(check.message)"
+              :key="`${check.id}-${i}-${partIndex}`"
+            >
+              <button
+                v-if="part.address"
+                type="button"
+                class="inline-flex max-w-full items-center gap-4 align-baseline text-accent-600 outline-none hover:text-accent-500 focus-visible:rounded-4 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-600"
+                :aria-label="`Copy address ${part.address}`"
+                @pointerdown.stop.prevent="copyAddress(part.address)"
+                @mousedown.stop.prevent
+                @click.stop.prevent="copyAddress(part.address)"
+                @keydown.enter.stop.prevent="copyAddress(part.address)"
+                @keydown.space.stop.prevent="copyAddress(part.address)"
+              >
+                <span class="min-w-0 break-all">{{ part.text }}</span>
+                <SvgIcon
+                  class="!w-12 !h-12 shrink-0"
+                  :name="isCopied(getAddressCopyKey(part.address)) ? 'check' : 'copy'"
+                />
+              </button>
+              <template v-else>
+                {{ part.text }}
+              </template>
+            </template>
           </p>
         </div>
       </div>

--- a/components/entities/vault/overview/OracleAdapterChecksModal.vue
+++ b/components/entities/vault/overview/OracleAdapterChecksModal.vue
@@ -120,7 +120,7 @@ const copyAddress = (address: string) => {
               <button
                 v-if="part.address"
                 type="button"
-                class="inline text-left align-baseline text-accent-600 outline-none hover:text-accent-500 focus-visible:rounded-4 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-600"
+                class="group inline-flex max-w-full items-center gap-4 rounded-4 bg-surface px-4 py-1 align-baseline font-mono text-p4 text-accent-600 outline-none transition-colors hover:bg-surface-secondary hover:text-accent-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-600"
                 :aria-label="`Copy address ${part.address}`"
                 @pointerdown.stop.prevent="copyAddress(part.address)"
                 @mousedown.stop.prevent
@@ -128,9 +128,9 @@ const copyAddress = (address: string) => {
                 @keydown.enter.stop.prevent="copyAddress(part.address)"
                 @keydown.space.stop.prevent="copyAddress(part.address)"
               >
-                <span class="break-all">{{ part.text }}</span>
+                <span class="min-w-0 break-all">{{ part.text }}</span>
                 <SvgIcon
-                  class="ml-4 inline-block !w-12 !h-12 align-[-1px]"
+                  class="!w-12 !h-12 shrink-0 opacity-70 transition-opacity group-hover:opacity-100"
                   :name="isCopied(getAddressCopyKey(part.address)) ? 'check' : 'copy'"
                 />
               </button>

--- a/components/entities/vault/overview/VaultOverviewBlockOracleAdapters.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockOracleAdapters.vue
@@ -9,8 +9,8 @@ import { getExplorerLink } from '~/utils/block-explorer'
 import { formatNumber } from '~/utils/string-utils'
 import { getOracleRouteStepKey, useOracleAdapterPrices } from '~/composables/useOracleAdapterPrices'
 import { isOracleAdapterRouteStep } from '~/utils/oracle-route-steps'
-import { buildOracleAdapterViews, collectOracleRouteSteps } from '~/utils/oracle-adapter-views'
-import type { CSSProperties } from 'vue'
+import { buildOracleAdapterViews, collectOracleRouteSteps, type OracleAdapterView } from '~/utils/oracle-adapter-views'
+import { OracleAdapterChecksModal } from '#components'
 
 const props = defineProps<{
   vault?: EVault
@@ -117,148 +117,12 @@ const formatAdapterPrice = (adapter: RouteStepKeyInput & { invertPrice: boolean 
   return formatNumber(rate, 4)
 }
 
-const hoveredChecksAdapter = ref<(typeof adapterViews.value)[0] | null>(null)
-const tooltipStyle = ref<CSSProperties>({})
-const TOOLTIP_WIDTH = 520
-let hideTimer: ReturnType<typeof setTimeout> | null = null
-
-const isMobile = ref(false)
-const updateIsMobile = () => {
-  isMobile.value = window.innerWidth < 768
-}
-onMounted(() => {
-  updateIsMobile()
-  window.addEventListener('resize', updateIsMobile)
+const getChecksModalData = (adapter: OracleAdapterView) => ({
+  props: {
+    modalTitle: 'Checks',
+    checks: adapter.checks ?? [],
+  },
 })
-onUnmounted(() => {
-  window.removeEventListener('resize', updateIsMobile)
-  if (hideTimer) clearTimeout(hideTimer)
-})
-
-// ── Bottom sheet swipe-to-close (mirrors BaseModalWrapper) ───────────────────
-const sheetEl = ref<HTMLElement>()
-const sheetDragY = ref(0)
-let sheetStartY = 0
-
-const onSheetPointerDown = (e: PointerEvent) => {
-  if (e.pointerType !== 'touch') return
-  sheetStartY = e.clientY
-  sheetDragY.value = 0
-  ;(e.currentTarget as HTMLElement).setPointerCapture(e.pointerId)
-}
-const onSheetPointerMove = (e: PointerEvent) => {
-  if (!(e.currentTarget as HTMLElement).hasPointerCapture(e.pointerId)) return
-  sheetDragY.value = Math.max(0, e.clientY - sheetStartY)
-}
-const onSheetPointerUp = (e: PointerEvent) => {
-  if (!(e.currentTarget as HTMLElement).hasPointerCapture(e.pointerId)) return
-  if (sheetDragY.value > 80) hoveredChecksAdapter.value = null
-  sheetDragY.value = 0
-}
-const onSheetPointerCancel = () => {
-  sheetDragY.value = 0
-}
-
-const isTouchTargetScrolled = (target: EventTarget | null): boolean => {
-  let el = target as HTMLElement | null
-  while (el && el !== sheetEl.value) {
-    if (el.scrollTop > 0) return true
-    el = el.parentElement
-  }
-  return false
-}
-
-let scrollTouchStartY = 0
-let scrollGestureDecided = false
-let scrollDragActive = false
-
-const onScrollTouchStart = (e: TouchEvent) => {
-  scrollTouchStartY = e.touches[0].clientY
-  scrollGestureDecided = false
-  scrollDragActive = false
-}
-const onScrollTouchMove = (e: TouchEvent) => {
-  const delta = e.touches[0].clientY - scrollTouchStartY
-  if (!scrollGestureDecided) {
-    scrollGestureDecided = true
-    if (delta > 0 && !isTouchTargetScrolled(e.target)) scrollDragActive = true
-  }
-  if (!scrollDragActive) return
-  e.preventDefault()
-  sheetDragY.value = Math.max(0, delta)
-}
-const onScrollTouchEnd = () => {
-  scrollGestureDecided = false
-  if (!scrollDragActive) return
-  scrollDragActive = false
-  if (sheetDragY.value > 80) hoveredChecksAdapter.value = null
-  sheetDragY.value = 0
-}
-const onScrollTouchCancel = () => {
-  scrollGestureDecided = false
-  scrollDragActive = false
-  sheetDragY.value = 0
-}
-
-const sheetDragStyle = computed(() => ({
-  transform: sheetDragY.value ? `translateY(${sheetDragY.value}px)` : undefined,
-  transition: sheetDragY.value ? 'none' : 'transform 0.3s ease',
-}))
-
-const onChecksClick = (adapter: (typeof adapterViews.value)[0], event?: MouseEvent | KeyboardEvent) => {
-  if (!adapter.checks?.length) return
-  if (hoveredChecksAdapter.value === adapter) {
-    hoveredChecksAdapter.value = null
-    return
-  }
-  // On desktop, position the tooltip using the trigger element's bounding rect
-  if (!isMobile.value && event?.currentTarget) {
-    const rect = (event.currentTarget as HTMLElement).getBoundingClientRect()
-    const left = Math.min(rect.left, window.innerWidth - TOOLTIP_WIDTH - 16)
-    const spaceBelow = window.innerHeight - rect.bottom - 16
-    const spaceAbove = rect.top - 16
-    const flipUp = spaceAbove > spaceBelow
-    tooltipStyle.value = flipUp
-      ? { top: `${rect.top - 8}px`, left: `${left}px`, transform: 'translateY(-100%)', maxHeight: `${spaceAbove}px` }
-      : { top: `${rect.bottom + 8}px`, left: `${left}px`, transform: 'none', maxHeight: `${spaceBelow}px` }
-  }
-  hoveredChecksAdapter.value = adapter
-}
-
-const onChecksMouseEnter = (adapter: (typeof adapterViews.value)[0], event: MouseEvent) => {
-  if (isMobile.value || !adapter.checks?.length) return
-  if (hideTimer) {
-    clearTimeout(hideTimer)
-    hideTimer = null
-  }
-  const rect = (event.currentTarget as HTMLElement).getBoundingClientRect()
-  const left = Math.min(rect.left, window.innerWidth - TOOLTIP_WIDTH - 16)
-  const spaceBelow = window.innerHeight - rect.bottom - 16
-  const spaceAbove = rect.top - 16
-  const flipUp = spaceAbove > spaceBelow
-  tooltipStyle.value = flipUp
-    ? { top: `${rect.top - 8}px`, left: `${left}px`, transform: 'translateY(-100%)', maxHeight: `${spaceAbove}px` }
-    : { top: `${rect.bottom + 8}px`, left: `${left}px`, transform: 'none', maxHeight: `${spaceBelow}px` }
-  hoveredChecksAdapter.value = adapter
-}
-
-const onChecksMouseLeave = () => {
-  if (isMobile.value) return
-  hideTimer = setTimeout(() => {
-    hoveredChecksAdapter.value = null
-  }, 150)
-}
-
-const onTooltipMouseEnter = () => {
-  if (hideTimer) {
-    clearTimeout(hideTimer)
-    hideTimer = null
-  }
-}
-
-const onTooltipMouseLeave = () => {
-  hoveredChecksAdapter.value = null
-}
 </script>
 
 <template>
@@ -359,29 +223,17 @@ const onTooltipMouseLeave = () => {
             <span class="text-content-tertiary">Methodology</span>
             <span class="text-content-primary">{{ adapter.methodology || 'Unknown' }}</span>
           </div>
-          <div
-            class="flex flex-col gap-4 order-4 md:order-3"
-            :role="adapter.checks?.length ? 'button' : undefined"
-            :tabindex="adapter.checks?.length ? 0 : undefined"
-            @mouseenter="onChecksMouseEnter(adapter, $event)"
-            @mouseleave="onChecksMouseLeave"
-            @click.stop="onChecksClick(adapter, $event)"
-            @keydown.enter.stop="onChecksClick(adapter, $event)"
-            @keydown.space.stop.prevent="onChecksClick(adapter, $event)"
+          <UiModalPreviewTrigger
+            v-if="adapter.checks?.length"
+            class="flex flex-col gap-4 order-4 md:order-3 items-start cursor-default text-left"
+            :component="OracleAdapterChecksModal"
+            :modal-data="getChecksModalData(adapter)"
+            aria-label="Show oracle adapter checks"
+            placement="top-start"
+            :clickable="false"
           >
             <span class="text-content-tertiary">Checks</span>
-            <span
-              v-if="adapter.isCustomAdapter"
-              class="text-content-secondary"
-            >Custom — set by risk manager</span>
-            <span
-              v-else-if="!adapter.checks?.length"
-              class="text-content-secondary"
-            >N/A</span>
-            <span
-              v-else
-              class="flex items-center gap-6 cursor-default"
-            >
+            <span class="flex items-center gap-6 cursor-default">
               <span
                 class="inline-block w-8 h-8 rounded-full flex-shrink-0"
                 :class="{
@@ -399,6 +251,20 @@ const onTooltipMouseLeave = () => {
                 </template>
               </span>
             </span>
+          </UiModalPreviewTrigger>
+          <div
+            v-else
+            class="flex flex-col gap-4 order-4 md:order-3"
+          >
+            <span class="text-content-tertiary">Checks</span>
+            <span
+              v-if="adapter.isCustomAdapter"
+              class="text-content-secondary"
+            >Custom — set by risk manager</span>
+            <span
+              v-else
+              class="text-content-secondary"
+            >N/A</span>
           </div>
           <div class="flex flex-col gap-4 order-2 md:order-4">
             <span class="text-content-tertiary">Price</span>
@@ -448,86 +314,6 @@ const onTooltipMouseLeave = () => {
       </div>
     </div>
   </VaultOverviewAccordionSection>
-
-  <Teleport to="body">
-    <template v-if="hoveredChecksAdapter?.checks?.length">
-      <!-- Mobile backdrop -->
-      <div
-        v-if="isMobile"
-        class="fixed inset-0 z-[9998] bg-black/50"
-        @click="hoveredChecksAdapter = null"
-      />
-      <!-- Tooltip (desktop) / Bottom sheet (mobile) -->
-      <div
-        ref="sheetEl"
-        class="fixed z-[9999] bg-surface-secondary border border-line-subtle overflow-x-hidden"
-        :class="isMobile
-          ? 'bottom-0 left-0 right-0 rounded-t-2xl max-h-[70vh] shadow-card flex flex-col'
-          : 'rounded-xl p-16 shadow-card overflow-y-auto'"
-        :style="isMobile ? sheetDragStyle : [tooltipStyle, { width: `${TOOLTIP_WIDTH}px` }]"
-        @mouseenter="onTooltipMouseEnter"
-        @mouseleave="onTooltipMouseLeave"
-      >
-        <!-- Drag handle zone (mobile only) -->
-        <div
-          v-if="isMobile"
-          class="shrink-0 px-24 pt-12 touch-none select-none"
-          @pointerdown="onSheetPointerDown"
-          @pointermove="onSheetPointerMove"
-          @pointerup="onSheetPointerUp"
-          @pointercancel="onSheetPointerCancel"
-        >
-          <div class="w-32 h-4 rounded-full bg-line-subtle mx-auto mb-16" />
-          <p class="text-p3 font-medium text-content-primary mb-12">
-            Checks
-          </p>
-        </div>
-        <p
-          v-else
-          class="text-p3 font-medium text-content-primary mb-12"
-        >
-          Checks
-        </p>
-        <!-- Scroll container -->
-        <div
-          class="flex flex-col gap-10 overflow-y-auto overscroll-contain [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
-          :class="isMobile ? 'px-24 pb-24' : ''"
-          @touchstart.passive="onScrollTouchStart"
-          @touchmove="onScrollTouchMove"
-          @touchend.passive="onScrollTouchEnd"
-          @touchcancel.passive="onScrollTouchCancel"
-        >
-          <div
-            v-for="(check, i) in hoveredChecksAdapter.checks"
-            :key="`${check.id}-${i}`"
-            class="flex items-start gap-10"
-          >
-            <span
-              class="flex-shrink-0 w-20 h-20 rounded-full flex items-center justify-center mt-8"
-              :class="{
-                'bg-success-500': check.pass,
-                'bg-error-500': !check.pass && check.severity === OracleAdapterCheckSeverity.High,
-                'bg-warning-500': !check.pass && check.severity !== OracleAdapterCheckSeverity.High,
-              }"
-            >
-              <SvgIcon
-                :name="check.pass ? 'check' : 'close'"
-                class="!w-10 !h-10 text-white"
-              />
-            </span>
-            <div class="min-w-0">
-              <p class="text-p3 font-medium text-content-primary break-words">
-                {{ check.id }}
-              </p>
-              <p class="text-p3 text-content-secondary break-words">
-                {{ check.message }}
-              </p>
-            </div>
-          </div>
-        </div>
-      </div>
-    </template>
-  </Teleport>
 </template>
 
 <style module lang="scss">

--- a/components/entities/vault/overview/VaultOverviewBlockOracleAdapters.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockOracleAdapters.vue
@@ -231,6 +231,7 @@ const getChecksModalData = (adapter: OracleAdapterView) => ({
             aria-label="Show oracle adapter checks"
             placement="top-start"
             :clickable="false"
+            popover-width="wide"
           >
             <span class="text-content-tertiary">Checks</span>
             <span class="flex items-center gap-6 cursor-default">

--- a/components/ui/UiModalPreviewTrigger.vue
+++ b/components/ui/UiModalPreviewTrigger.vue
@@ -15,6 +15,7 @@ const {
   ariaLabel = 'Show details',
   placement = 'top',
   clickable = true,
+  popoverWidth = 'default',
 } = defineProps<{
   component: Component
   modalData?: ModalData | (() => ModalData)
@@ -23,6 +24,7 @@ const {
   ariaLabel?: string
   placement?: Placement
   clickable?: boolean
+  popoverWidth?: 'default' | 'wide'
 }>()
 
 const modal = useModal()
@@ -98,6 +100,10 @@ const arrowSide = computed(() =>
 
 const slideDirection = computed(() =>
   resolvedPlacement.value.startsWith('bottom') ? 'slide-down' : 'slide-up',
+)
+
+const popoverWidthClass = computed(() =>
+  popoverWidth === 'wide' ? 'ui-modal-preview-trigger__popover--wide' : undefined,
 )
 
 const clearOpenTimer = () => {
@@ -377,7 +383,10 @@ onBeforeUnmount(() => {
       v-if="isRendered"
       ref="floating"
       class="ui-modal-preview-trigger__popover"
-      :class="{ 'ui-modal-preview-trigger__popover--hover-only': !clickable }"
+      :class="[
+        { 'ui-modal-preview-trigger__popover--hover-only': !clickable },
+        popoverWidthClass,
+      ]"
       :style="floatingStyles"
       @click.stop
       @mouseenter="onPopoverMouseEnter"
@@ -435,6 +444,10 @@ onBeforeUnmount(() => {
 
   &--hover-only {
     width: min(360px, calc(100vw - 24px));
+  }
+
+  &--wide {
+    width: min(520px, calc(100vw - 24px));
   }
 }
 

--- a/components/ui/UiModalPreviewTrigger.vue
+++ b/components/ui/UiModalPreviewTrigger.vue
@@ -447,7 +447,7 @@ onBeforeUnmount(() => {
   }
 
   &--wide {
-    width: min(680px, calc(100vw - 24px));
+    width: min(580px, calc(100vw - 24px));
   }
 }
 

--- a/components/ui/UiModalPreviewTrigger.vue
+++ b/components/ui/UiModalPreviewTrigger.vue
@@ -447,7 +447,7 @@ onBeforeUnmount(() => {
   }
 
   &--wide {
-    width: min(520px, calc(100vw - 24px));
+    width: min(680px, calc(100vw - 24px));
   }
 }
 


### PR DESCRIPTION
## Summary
- Move oracle adapter check details onto the shared preview-tooltip interaction so desktop hover/focus and touch activation follow the same UX as other UI tooltips.
- Keep the existing check status summary and detailed check-row content while removing the custom fixed tooltip and mobile sheet implementation.
- Make full EVM addresses inside check messages clickable copy controls, including special designator addresses like 0x0000000000000000000000000000000000000348.
- Give the oracle checks popover a wider opt-in layout so full addresses have more room.

## Changes
- Add a small OracleAdapterChecksModal component for rendering pass/fail check rows inside the shared modal wrapper.
- Replace the bespoke checks trigger, timers, positioning, Teleport, and swipe handling in VaultOverviewBlockOracleAdapters with UiModalPreviewTrigger.
- Parse address-like substrings in check messages into inline copy buttons with copied-state feedback and a clipboard fallback.
- Add a wide popover option to UiModalPreviewTrigger and enable it for oracle adapter checks only.

## Test plan
- [x] npx eslint components/entities/vault/overview/VaultOverviewBlockOracleAdapters.vue components/entities/vault/overview/OracleAdapterChecksModal.vue
- [x] npx eslint components/entities/vault/overview/OracleAdapterChecksModal.vue
- [x] npx eslint components/ui/UiModalPreviewTrigger.vue components/entities/vault/overview/VaultOverviewBlockOracleAdapters.vue
- [x] npm run typecheck
- [x] Local smoke at http://localhost:3000/borrow/0xCf4846E0d8A8667c516B844EB72A4d6e7430101D/0x2Ff596321782FE034102f55af5ad707A4Ce0d6a7?network=1&tab=multiply; opened the Checks trigger and verified the shared popover renders adapter check rows and address copy controls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Oracle adapter “Checks” now open in a modal preview for easier review without hover or swipe interactions.
  * Check messages that include Ethereum-style `0x…` addresses now render those addresses as copyable buttons.
  * Modal preview popovers support a wider layout via a new `popoverWidth` option.
* **Bug Fixes**
  * Adapters with no available checks now show clearer, non-interactive status text instead of an empty/interactive panel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->