### PR TITLE
chore: bump Euler SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@eulerxyz/euler-v2-sdk": "1.1.0",
+        "@eulerxyz/euler-v2-sdk": "1.1.1",
         "@floating-ui/vue": "2.0.0",
         "@gvade/nuxt3-svg-sprite": "1.0.3",
         "@keyringnetwork/keyring-connect-sdk": "3.2.0",
@@ -1469,9 +1469,9 @@
       }
     },
     "node_modules/@eulerxyz/euler-v2-sdk": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@eulerxyz/euler-v2-sdk/-/euler-v2-sdk-1.1.0.tgz",
-      "integrity": "sha512-dXuR9C2Pe47prGggdKpnqqE1Y0oSK7inO/QMpmWKn5vo5ZxupinIIAy6Ev8mKx8ezGljRGVhShyS0VhM0kPkow==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@eulerxyz/euler-v2-sdk/-/euler-v2-sdk-1.1.1.tgz",
+      "integrity": "sha512-TxZbzD3hghLr7Fp/U2IpXe5LU+GKpAzPhxMyUReSD9G0IjTlEuhWvtdTuBaBgTqchq0J4gzfivZTzeUBjSH9vw==",
       "license": "MIT",
       "dependencies": {
         "viem": "2.48.8"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     ]
   },
   "dependencies": {
-    "@eulerxyz/euler-v2-sdk": "1.1.0",
+    "@eulerxyz/euler-v2-sdk": "1.1.1",
     "@floating-ui/vue": "2.0.0",
     "@gvade/nuxt3-svg-sprite": "1.0.3",
     "@keyringnetwork/keyring-connect-sdk": "3.2.0",


### PR DESCRIPTION
## Summary
- Bump @eulerxyz/euler-v2-sdk from 1.1.0 to 1.1.1.
- Refresh package-lock.json with the published 1.1.1 tarball and integrity.

## Validation
- npm ls @eulerxyz/euler-v2-sdk viem
- npm run typecheck
- npm run test:run -- tests/composables/useEulerSdk.test.ts tests/server/sdk-server.test.ts tests/composables/useSdkRewards.test.ts
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Euler v2 SDK to the latest patch release, helping keep the app aligned with the newest upstream improvements and compatibility updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->