### PR TITLE
Fix vault history liquidity label

### DIFF
--- a/components/entities/vault/overview/VaultOverview.vue
+++ b/components/entities/vault/overview/VaultOverview.vue
@@ -29,7 +29,7 @@ const isCyclicalIRM = computed(() => isVaultCyclicalNote(vault.address))
 
     <VaultOverviewBlockHistory
       :vault="vault"
-      :default-open="false"
+      :default-open="true"
     />
 
     <VaultOverviewBlockRiskParameters

--- a/components/entities/vault/overview/VaultOverviewBlockHistory.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockHistory.vue
@@ -113,13 +113,13 @@ const metricOptions = computed<MetricOption[]>(() => {
       { value: 'totalSupply', label: 'Total supply' },
       { value: 'totalBorrows', label: 'Total borrowed' },
       { value: 'utilization', label: 'Utilization' },
-      { value: 'cash', label: 'Cash' },
+      { value: 'cash', label: 'Available Liquidity' },
     ]
   }
 
   return [
     { value: 'totalSupply', label: 'Total supply' },
-    { value: 'cash', label: 'Cash' },
+    { value: 'cash', label: 'Available Liquidity' },
   ]
 })
 


### PR DESCRIPTION
## Summary
- Rename the vault history chart cash metric to Available Liquidity so the graph matches the newer market terminology.
- Open the Performance accordion by default so its history panel starts loading immediately.

## Changes
- Updates the existing cash metric label in both metric option sets without changing the underlying data key or chart behavior.
- Sets the vault overview Performance section to default open at the overview call site, without changing the shared accordion component API.

## Test plan
- [x] npx eslint components/entities/vault/overview/VaultOverview.vue components/entities/vault/overview/VaultOverviewAccordionSection.vue components/entities/vault/overview/VaultOverviewBlockHistory.vue
- [x] npm run typecheck
- [x] git diff --check