### PR TITLE
fix: template request paths in middleware logs to avoid logging wallet addresses

### DIFF
--- a/docs/geo-blocking.md
+++ b/docs/geo-blocking.md
@@ -90,6 +90,8 @@ Request → cors.ts (strip client x-country-code, set response x-country-code fr
                 └─ prod env → HTTP 451 (fail-closed)
 ```
 
+When the gate blocks a request or flags VPN/proxy usage it logs the request path. Because some `/api/*` routes embed a wallet address in the path (e.g. `/api/proxy/merkl/users/0x.../rewards`), the path is first run through `safePathTemplate` (`server/utils/observability.ts`), which replaces address and numeric segments with `:address`/`:number` placeholders. This keeps wallet addresses (PII) out of the log sink while preserving the route shape for observability. Routing and matching still operate on the real path.
+
 ## Blocking Rules
 
 **File**: `composables/useGeoBlock.ts`

--- a/server/middleware/geo-gate.ts
+++ b/server/middleware/geo-gate.ts
@@ -2,6 +2,7 @@ import { createError, getRequestURL } from 'h3'
 import { SANCTIONED_COUNTRIES } from '~/entities/country-constants'
 import { isInternalRequest } from '~/server/utils/internal-headers'
 import { logger } from '~/server/utils/logger'
+import { safePathTemplate } from '~/server/utils/observability'
 
 export default defineEventHandler((event) => {
   // Only gate API routes
@@ -42,7 +43,7 @@ export default defineEventHandler((event) => {
   // In dev (DOPPLER_ENVIRONMENT=dev) without DEV_GEO_COUNTRY set, allow through.
   if (!country && process.env.DOPPLER_ENVIRONMENT !== 'dev') {
     logger.warn(
-      { ctx: 'geo-gate', cfCountry: cfCountry || 'absent', path: url.pathname },
+      { ctx: 'geo-gate', cfCountry: cfCountry || 'absent', pathTemplate: safePathTemplate(url.pathname) },
       'blocked: country undetermined',
     )
     throw createError({
@@ -57,7 +58,7 @@ export default defineEventHandler((event) => {
   // Log VPN/proxy usage for monitoring (do not block -- too many false positives)
   if (isVpn === 'true' || isProxyOrVpn === 'true') {
     logger.warn(
-      { ctx: 'geo-gate', country, isVpn, isProxyOrVpn, path: url.pathname },
+      { ctx: 'geo-gate', country, isVpn, isProxyOrVpn, pathTemplate: safePathTemplate(url.pathname) },
       'VPN/proxy detected',
     )
   }
@@ -65,7 +66,7 @@ export default defineEventHandler((event) => {
   // Block sanctioned countries
   if (country && SANCTIONED_COUNTRIES.includes(country)) {
     logger.warn(
-      { ctx: 'geo-gate', country, path: url.pathname },
+      { ctx: 'geo-gate', country, pathTemplate: safePathTemplate(url.pathname) },
       'blocked sanctioned country',
     )
     throw createError({

--- a/tests/server/geo-gate.test.ts
+++ b/tests/server/geo-gate.test.ts
@@ -36,17 +36,28 @@ const makeEvent = (url: string, headers: Record<string, string | undefined> = {}
 
 const runHandler = (event: TestEvent) => (handler as (e: TestEvent) => unknown)(event)
 
-let originalEnv: string | undefined
+// The only environment knobs the middleware consults. Snapshot and clear
+// every one of them per test so the suite is deterministic regardless of the
+// caller's shell — a stray DEV_GEO_COUNTRY, for example, would otherwise take
+// the dev-country fallback and defeat the fail-closed (undetermined-country)
+// path under test.
+const ENV_KNOBS = ['DOPPLER_ENVIRONMENT', 'DEV_GEO_COUNTRY'] as const
+
+const envSnapshot: Record<string, string | undefined> = {}
 
 beforeEach(() => {
   warn.mockClear()
-  originalEnv = process.env.DOPPLER_ENVIRONMENT
+  for (const key of ENV_KNOBS) {
+    envSnapshot[key] = process.env[key]
+    Reflect.deleteProperty(process.env, key)
+  }
 })
 
 afterEach(() => {
-  if (originalEnv === undefined) delete process.env.DOPPLER_ENVIRONMENT
-  else process.env.DOPPLER_ENVIRONMENT = originalEnv
-  delete process.env.DEV_GEO_COUNTRY
+  for (const key of ENV_KNOBS) {
+    if (envSnapshot[key] === undefined) Reflect.deleteProperty(process.env, key)
+    else process.env[key] = envSnapshot[key]
+  }
 })
 
 describe('geo-gate log hygiene', () => {

--- a/tests/server/geo-gate.test.ts
+++ b/tests/server/geo-gate.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Regression tests for the geo-gate middleware log hygiene.
+ *
+ * Some `/api/*` routes embed a wallet address in the path
+ * (e.g. /api/proxy/merkl/users/0x.../rewards). When geo-gate blocks a
+ * request or flags VPN/proxy usage it logs the request path. The path
+ * MUST be run through safePathTemplate so a raw wallet address (PII)
+ * never reaches the log sink. These tests lock that in.
+ */
+import type { H3Event } from 'h3'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('h3', () => ({
+  createError: (error: unknown) => error,
+  getRequestURL: (event: TestEvent) => new URL(event.url),
+}))
+
+const warn = vi.fn()
+vi.mock('~/server/utils/logger', () => ({
+  logger: { warn: (...args: unknown[]) => warn(...args) },
+}))
+
+type TestEvent = H3Event & {
+  url: string
+  node: { req: { headers: Record<string, string | undefined> } }
+}
+
+const ADDRESS = '0x0000000000000000000000000000000000000001'
+
+const handler = (await import('~/server/middleware/geo-gate')).default
+
+const makeEvent = (url: string, headers: Record<string, string | undefined> = {}): TestEvent => ({
+  url,
+  node: { req: { headers } },
+} as unknown as TestEvent)
+
+const runHandler = (event: TestEvent) => (handler as (e: TestEvent) => unknown)(event)
+
+let originalEnv: string | undefined
+
+beforeEach(() => {
+  warn.mockClear()
+  originalEnv = process.env.DOPPLER_ENVIRONMENT
+})
+
+afterEach(() => {
+  if (originalEnv === undefined) delete process.env.DOPPLER_ENVIRONMENT
+  else process.env.DOPPLER_ENVIRONMENT = originalEnv
+  delete process.env.DEV_GEO_COUNTRY
+})
+
+describe('geo-gate log hygiene', () => {
+  it('templates the wallet address when blocking undetermined country', () => {
+    process.env.DOPPLER_ENVIRONMENT = 'prd'
+
+    expect(() =>
+      runHandler(makeEvent(`https://app.example/api/proxy/merkl/users/${ADDRESS}/rewards`)),
+    ).toThrow()
+
+    expect(warn).toHaveBeenCalledTimes(1)
+    const [payload] = warn.mock.calls[0]
+    expect(payload.pathTemplate).toBe('/api/proxy/merkl/users/:address/rewards')
+    expect(JSON.stringify(payload)).not.toContain(ADDRESS)
+    expect(payload).not.toHaveProperty('path')
+  })
+
+  it('templates the wallet address when flagging VPN/proxy usage', () => {
+    process.env.DOPPLER_ENVIRONMENT = 'prd'
+
+    runHandler(makeEvent(`https://app.example/api/proxy/merkl/users/${ADDRESS}/rewards`, {
+      'cf-ipcountry': 'US',
+      'x-is-vpn': 'true',
+    }))
+
+    expect(warn).toHaveBeenCalledTimes(1)
+    const [payload] = warn.mock.calls[0]
+    expect(payload.pathTemplate).toBe('/api/proxy/merkl/users/:address/rewards')
+    expect(JSON.stringify(payload)).not.toContain(ADDRESS)
+  })
+
+  it('templates the wallet address when blocking a sanctioned country', () => {
+    process.env.DOPPLER_ENVIRONMENT = 'prd'
+
+    expect(() =>
+      runHandler(makeEvent(`https://app.example/api/proxy/merkl/users/${ADDRESS}/rewards`, {
+        'cf-ipcountry': 'KP',
+      })),
+    ).toThrow()
+
+    expect(warn).toHaveBeenCalledTimes(1)
+    const [payload] = warn.mock.calls[0]
+    expect(payload.pathTemplate).toBe('/api/proxy/merkl/users/:address/rewards')
+    expect(JSON.stringify(payload)).not.toContain(ADDRESS)
+  })
+
+  it('does not gate or log internal server-to-server requests', () => {
+    process.env.DOPPLER_ENVIRONMENT = 'prd'
+
+    expect(() =>
+      runHandler(makeEvent(`https://app.example/api/proxy/merkl/users/${ADDRESS}/rewards`, {
+        'cf-connecting-ip': '127.0.0.1',
+      })),
+    ).not.toThrow()
+
+    expect(warn).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Some `/api/*` proxy routes embed a wallet address directly in the request path (e.g. `/api/proxy/merkl/users/0x.../rewards`). The geo-gate middleware logged the raw `url.pathname` in three places — when blocking on an undetermined country, when flagging VPN/proxy usage, and when blocking a sanctioned country. As a result, wallet addresses (PII) reached the log sink whenever one of those conditions fired.

## Fix

Run the logged path through `safePathTemplate` (`server/utils/observability.ts`) before logging, replacing the field name `path` with `pathTemplate`. This matches the log hygiene already used elsewhere in the server layer (the body-limit middleware and the proxy routes). Address and numeric path segments are replaced with `:address` / `:number` placeholders, so the route shape is preserved for observability while PII is not.

Gating and routing logic are unchanged and continue to operate on the real path — only what is written to logs is templated.

## Tests

- New `tests/server/geo-gate.test.ts` invokes the middleware directly and asserts that an address-bearing path is templated to `:address` in the log payload for all three log sites, that the raw address never appears in the serialized payload, and that internal server-to-server requests are neither gated nor logged.
- Existing `tests/server/observability.test.ts` already covers `safePathTemplate` behaviour.
- All 9 tests pass; eslint is clean on the changed files.

## Docs

`docs/geo-blocking.md` now documents that the geo-gate templates request paths before logging to keep wallet addresses out of the log sink.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Geo-blocking logs now use sanitized request paths, preventing wallet addresses and other sensitive path values from appearing in logs.
  * Warning messages still include route shape and relevant geo/VPN details, while keeping the original blocking behavior unchanged.

* **Tests**
  * Added regression coverage to verify sanitized logging for blocked requests and to ensure internal requests remain exempt from geo checks.

* **Documentation**
  * Updated geo-blocking docs to reflect the new sanitized logging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->