### PR TITLE
fix: zero-pad fractional part of securitize supply cap percentage

### DIFF
--- a/components/entities/vault/overview/SecuritizeVaultOverview.vue
+++ b/components/entities/vault/overview/SecuritizeVaultOverview.vue
@@ -119,10 +119,13 @@ watchEffect(async () => {
 
 const supplyCapPercentageDisplay = computed(() => {
   if (!vault.supplyCap || vault.supplyCap >= maxUint256 || vault.supplyCap === 0n) return 0
-  const scale = 10n ** 2n
+  const decimals = 2
+  const scale = 10n ** BigInt(decimals)
   // Compare totalShares to supplyCap (both in shares denomination)
   const fraction = (vault.totalShares * scale * 100n) / vault.supplyCap
-  return parseFloat(`${fraction / scale}.${fraction % scale}`)
+  // Zero-pad the fractional part so e.g. a remainder of 5 renders as ".05" not ".5"
+  const fractional = String(fraction % scale).padStart(decimals, '0')
+  return parseFloat(`${fraction / scale}.${fractional}`)
 })
 </script>
 


### PR DESCRIPTION
## Problem

The supply cap percentage on the Securitize vault overview was computed by string-interpolating a bigint quotient and remainder without zero-padding the fractional part:

```
return parseFloat(`${fraction / scale}.${fraction % scale}`)  // scale = 100
```

Because the remainder is not zero-padded to 2 digits, any fractional remainder below 10 was rendered an order of magnitude too large. For example, a value that should display as `12.05%` was rendered as `12.5%`, and `3.09%` as `3.9%`. Remainders of 10 or more (e.g. `12.50`) happened to display correctly, masking the bug.

## Solution

Zero-pad the remainder to the scale's decimal width (2) before interpolation:

```
const decimals = 2
const scale = 10n ** BigInt(decimals)
const fraction = (vault.totalShares * scale * 100n) / vault.supplyCap
const fractional = String(fraction % scale).padStart(decimals, '0')
return parseFloat(`${fraction / scale}.${fractional}`)
```

This matches the padding approach already used elsewhere in the codebase for bigint fixed-point-to-string formatting.

Edge cases confirmed:
- remainder `0` -> `12.00` -> `12`
- remainder `5` -> `12.05` (previously `12.5`)
- remainder `50` -> `12.50` -> `12.5`
- full cap -> `100.00` -> `100`
