### PR TITLE
fix: exclude dev-only /ui and /_icons routes from production builds

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -416,6 +416,10 @@ export default defineNuxtConfig({
     // The /ui component playground is a dev-only UI kit; it must not ship as
     // a routable page in production builds. Drop the route (and its bundle)
     // outside dev so it is neither reachable nor included in the output.
+    // (The /_icons svg-sprite gallery is disabled separately via svgSprite
+    // .iconsPath below, because it is registered by the module's own
+    // pages:extend hook which runs after this one — filtering here can't
+    // remove it reliably.)
     'pages:extend': (pages) => {
       if (import.meta.dev) return
       const index = pages.findIndex(page => page.path === '/ui')
@@ -426,5 +430,10 @@ export default defineNuxtConfig({
 
   svgSprite: {
     elementClass: 'icon',
+    // The module registers a dev-only /_icons sprite-gallery page from
+    // iconsPath. It is not linked anywhere in the app, so disable the route
+    // outside dev (empty iconsPath is falsy and skips the module's page
+    // registration, matching the module's `if (options.iconsPath)` guard).
+    ...(process.env.NODE_ENV === 'development' ? {} : { iconsPath: '' }),
   },
 })

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -411,6 +411,17 @@ export default defineNuxtConfig({
   },
 
   telemetry: false,
+
+  hooks: {
+    // The /ui component playground is a dev-only UI kit; it must not ship as
+    // a routable page in production builds. Drop the route (and its bundle)
+    // outside dev so it is neither reachable nor included in the output.
+    'pages:extend': (pages) => {
+      if (import.meta.dev) return
+      const index = pages.findIndex(page => page.path === '/ui')
+      if (index !== -1) pages.splice(index, 1)
+    },
+  },
   eslint: { config: { stylistic: true } },
 
   svgSprite: {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -420,8 +420,10 @@ export default defineNuxtConfig({
     // .iconsPath below, because it is registered by the module's own
     // pages:extend hook which runs after this one — filtering here can't
     // remove it reliably.)
+    // NODE_ENV, not import.meta.dev: nuxt.config runs under jiti, where
+    // import.meta.dev is undefined — it would remove the route in dev too.
     'pages:extend': (pages) => {
-      if (import.meta.dev) return
+      if (process.env.NODE_ENV === 'development') return
       const index = pages.findIndex(page => page.path === '/ui')
       if (index !== -1) pages.splice(index, 1)
     },


### PR DESCRIPTION
## Problem

Two developer-only routes shipped as routable pages in production builds:

- `/ui` — a component playground / UI kit (`pages/ui.vue`) with modals, inputs, toasts and alerts. It has no route guard, so its code was included in the client bundle and the route was reachable by anyone.
- `/_icons` — an svg-sprite icon gallery injected by the `@gvade/nuxt3-svg-sprite` module via its `iconsPath` option. Neither the route nor the gallery is linked or navigated to anywhere in the app; it is purely a dev preview tool.

Neither is referenced from any component or page.

## Solution

Both routes are excluded from production builds so they are neither reachable nor included in the output, while remaining available in dev:

- `/ui`: a `pages:extend` hook in `nuxt.config.ts` removes the route from the page manifest when the build is not a dev build. The page is dropped before route generation, so its chunk is never emitted.
- `/_icons`: the module registers this page from its own `pages:extend` hook, which runs after the config hook — so filtering it there is not reliable. Instead the route is disabled at its source by setting `svgSprite.iconsPath` to an empty (falsy) value outside dev, which skips the module's page registration entirely.

In dev both routes are left untouched.

## Verification

- `npm run build` succeeds.
- The compiled client route table lists every real route (`/`, `/lend`, `/earn`, `/borrow`, `/explore`, `/portfolio`, `/batch`, …) but no longer contains `path:"/ui"` or `path:"/_icons"`.
- The `icons-page` route name and its component chunk are absent from the production output; no bundle references `pages/ui` or the playground's unique template text.
- ESLint passes on the changed file.
