### PR TITLE
refactor: dedupe oracle-checks handlers and drop pass-through chain wrappers

### DIFF
--- a/composables/useChainConfig.ts
+++ b/composables/useChainConfig.ts
@@ -77,8 +77,8 @@ function scanEnv(): ChainConfig {
 
   const enabledChainIds = getEnabledChainIds()
   const enabledSet = new Set(enabledChainIds)
-  const deprecatedChainIds = parseDeprecatedChains(process.env.DEPRECATED_CHAINS, enabledSet)
-  const onchainSdkChainIds = parseOnchainSdkChains(process.env.ONCHAIN_SDK_CHAINS, enabledSet)
+  const deprecatedChainIds = parseChainIds(process.env.DEPRECATED_CHAINS, enabledSet)
+  const onchainSdkChainIds = parseChainIds(process.env.ONCHAIN_SDK_CHAINS, enabledSet)
   const eVaultFetchChunkChainIds = parseEVaultFetchChunkChainIds(process.env, enabledSet)
 
   return { enabledChainIds, deprecatedChainIds, onchainSdkChainIds, eVaultFetchChunkChainIds, unsupportedChainIds, chainEnvIssues }

--- a/server/api/oracle-adapter.get.ts
+++ b/server/api/oracle-adapter.get.ts
@@ -4,6 +4,8 @@ import { createTtlCache } from '~/server/utils/cache'
 import { fetchWithTimeout } from '~/server/utils/fetchWithTimeout'
 import { logger } from '~/server/utils/logger'
 import { hashIdentifier } from '~/server/utils/observability'
+import { oracleChecksUrl } from '~/server/utils/oracle-checks'
+import { resolveChainId } from '~/server/utils/resolve-chain-id'
 
 const CACHE_TTL_MS = 300_000
 const ADDRESS_RE = /^0x[0-9a-fA-F]{40}$/
@@ -16,25 +18,12 @@ const rateLimiter = createRateLimiter({
 
 const cache = createTtlCache<unknown>({ ttlMs: CACHE_TTL_MS, maxEntries: 500 })
 
-function getUpstreamUrl(chainId: number, address: string): string {
-  const baseUrl = (process.env.NUXT_PUBLIC_CONFIG_ORACLE_CHECKS_BASE_URL || '').trim().replace(/\/+$/, '')
-  if (baseUrl) {
-    return `${baseUrl}/${chainId}/adapters/${address}.json`
-  }
-
-  const repo = process.env.NUXT_PUBLIC_CONFIG_ORACLE_CHECKS_REPO || 'euler-xyz/oracle-checks'
-  return `https://raw.githubusercontent.com/${repo}/refs/heads/master/data/${chainId}/adapters/${address}.json`
-}
-
 export default defineEventHandler(async (event) => {
   rateLimiter.consume(event)
 
-  const query = getQuery(event)
-  const chainId = Number(query.chainId)
-  if (!Number.isInteger(chainId) || chainId <= 0) {
-    throw createError({ statusCode: 400, statusMessage: 'Invalid chainId' })
-  }
+  const chainId = resolveChainId(event, { requireEnabled: false })
 
+  const query = getQuery(event)
   const address = String(query.address || '')
   if (!ADDRESS_RE.test(address)) {
     throw createError({ statusCode: 400, statusMessage: 'Invalid address' })
@@ -50,7 +39,7 @@ export default defineEventHandler(async (event) => {
   if (cached !== undefined) return cached
 
   try {
-    const resp = await fetchWithTimeout(getUpstreamUrl(chainId, address))
+    const resp = await fetchWithTimeout(oracleChecksUrl(chainId, 'adapters', address))
     if (!resp.ok) {
       if (resp.status === 404) {
         cache.set(key, null)

--- a/server/api/oracle-adapters.get.ts
+++ b/server/api/oracle-adapters.get.ts
@@ -1,66 +1,8 @@
-import { createError, getQuery } from 'h3'
-import { createRateLimiter } from '~/server/utils/rate-limit'
-import { createTtlCache } from '~/server/utils/cache'
-import { fetchWithTimeout } from '~/server/utils/fetchWithTimeout'
-import { logger } from '~/server/utils/logger'
+import { createOracleChecksHandler } from '~/server/utils/oracle-checks'
 
-const CACHE_TTL_MS = 300_000
-
-const rateLimiter = createRateLimiter({
-  max: 60,
-  windowMs: 60_000,
+export default createOracleChecksHandler({
+  resource: 'adapters',
   label: 'oracle-adapters',
-})
-
-const cache = createTtlCache<unknown>({ ttlMs: CACHE_TTL_MS, maxEntries: 50 })
-
-function getUpstreamUrl(chainId: number): string {
-  const baseUrl = (process.env.NUXT_PUBLIC_CONFIG_ORACLE_CHECKS_BASE_URL || '').trim().replace(/\/+$/, '')
-  if (baseUrl) {
-    return `${baseUrl}/${chainId}/adapters/all.json`
-  }
-
-  const repo = process.env.NUXT_PUBLIC_CONFIG_ORACLE_CHECKS_REPO || 'euler-xyz/oracle-checks'
-  return `https://raw.githubusercontent.com/${repo}/refs/heads/master/data/${chainId}/adapters/all.json`
-}
-
-export default defineEventHandler(async (event) => {
-  rateLimiter.consume(event)
-
-  const query = getQuery(event)
-  const chainId = Number(query.chainId)
-  if (!Number.isInteger(chainId) || chainId <= 0) {
-    throw createError({ statusCode: 400, statusMessage: 'Invalid chainId' })
-  }
-
-  const key = `${chainId}`
-
-  const cached = cache.get(key)
-  if (cached !== undefined) return cached
-
-  try {
-    const resp = await fetchWithTimeout(getUpstreamUrl(chainId))
-    if (!resp.ok) {
-      // Don't cache the empty fallback for 404 (or any non-OK status). A
-      // missing/transient upstream response would otherwise pin every client
-      // to the empty array for the full TTL window — better to let the next
-      // request retry quickly.
-      if (resp.status === 404) return []
-      throw new Error(`Upstream returned ${resp.status}`)
-    }
-
-    const data: unknown = await resp.json()
-    cache.set(key, data)
-    return data
-  }
-  catch (err) {
-    logger.warn({ ctx: 'oracle-adapters', chainId, err }, 'fetch all.json failed')
-
-    const stale = cache.getStale(key)
-    if (stale !== undefined) return stale
-
-    // Same reasoning as the 404 branch: don't pollute the cache with an empty
-    // array on transient failures.
-    return []
-  }
+  max: 60,
+  logMessage: 'fetch all.json failed',
 })

--- a/server/api/oracle-routers.get.ts
+++ b/server/api/oracle-routers.get.ts
@@ -1,66 +1,8 @@
-import { createError, getQuery } from 'h3'
-import { createRateLimiter } from '~/server/utils/rate-limit'
-import { createTtlCache } from '~/server/utils/cache'
-import { fetchWithTimeout } from '~/server/utils/fetchWithTimeout'
-import { logger } from '~/server/utils/logger'
+import { createOracleChecksHandler } from '~/server/utils/oracle-checks'
 
-const CACHE_TTL_MS = 300_000
-
-const rateLimiter = createRateLimiter({
-  max: 60,
-  windowMs: 60_000,
+export default createOracleChecksHandler({
+  resource: 'routers',
   label: 'oracle-routers',
-})
-
-const cache = createTtlCache<unknown>({ ttlMs: CACHE_TTL_MS, maxEntries: 50 })
-
-function getUpstreamUrl(chainId: number): string {
-  const baseUrl = (process.env.NUXT_PUBLIC_CONFIG_ORACLE_CHECKS_BASE_URL || '').trim().replace(/\/+$/, '')
-  if (baseUrl) {
-    return `${baseUrl}/${chainId}/routers/all.json`
-  }
-
-  const repo = process.env.NUXT_PUBLIC_CONFIG_ORACLE_CHECKS_REPO || 'euler-xyz/oracle-checks'
-  return `https://raw.githubusercontent.com/${repo}/refs/heads/master/data/${chainId}/routers/all.json`
-}
-
-export default defineEventHandler(async (event) => {
-  rateLimiter.consume(event)
-
-  const query = getQuery(event)
-  const chainId = Number(query.chainId)
-  if (!Number.isInteger(chainId) || chainId <= 0) {
-    throw createError({ statusCode: 400, statusMessage: 'Invalid chainId' })
-  }
-
-  const key = `${chainId}`
-
-  const cached = cache.get(key)
-  if (cached !== undefined) return cached
-
-  try {
-    const resp = await fetchWithTimeout(getUpstreamUrl(chainId))
-    if (!resp.ok) {
-      // Don't cache the empty fallback for 404 (or any non-OK status). A
-      // missing/transient upstream response would otherwise pin every client
-      // to the empty array for the full TTL window — better to let the next
-      // request retry quickly.
-      if (resp.status === 404) return []
-      throw new Error(`Upstream returned ${resp.status}`)
-    }
-
-    const data: unknown = await resp.json()
-    cache.set(key, data)
-    return data
-  }
-  catch (err) {
-    logger.warn({ ctx: 'oracle-routers', chainId, err }, 'fetch routers all.json failed')
-
-    const stale = cache.getStale(key)
-    if (stale !== undefined) return stale
-
-    // Same reasoning as the 404 branch: don't pollute the cache with an empty
-    // array on transient failures.
-    return []
-  }
+  max: 60,
+  logMessage: 'fetch routers all.json failed',
 })

--- a/server/plugins/chain-config.ts
+++ b/server/plugins/chain-config.ts
@@ -6,8 +6,7 @@
  * The config is embedded as a <script> tag in the HTML head, making it
  * accessible to the client synchronously via window.__CHAIN_CONFIG__.
  */
-import { parseDeprecatedChains } from '../../utils/parseDeprecatedChains'
-import { parseOnchainSdkChains } from '../../utils/parseOnchainSdkChains'
+import { parseChainIds } from '../../utils/parseChainIds'
 import { getChainEnvIssues, getConfiguredChainIds, getEnabledChainIds } from '~/utils/chain-env'
 import { getUnknownChainIds } from '~/entities/chainRegistry'
 import { logger } from '~/server/utils/logger'
@@ -39,8 +38,8 @@ export default defineNitroPlugin((nitroApp) => {
   const enabledChainIds = getEnabledChainIds()
 
   const enabledSet = new Set(enabledChainIds)
-  const deprecatedChainIds = parseDeprecatedChains(process.env.DEPRECATED_CHAINS, enabledSet)
-  const onchainSdkChainIds = parseOnchainSdkChains(process.env.ONCHAIN_SDK_CHAINS, enabledSet)
+  const deprecatedChainIds = parseChainIds(process.env.DEPRECATED_CHAINS, enabledSet)
+  const onchainSdkChainIds = parseChainIds(process.env.ONCHAIN_SDK_CHAINS, enabledSet)
   const eVaultFetchChunkChainIds = parseEVaultFetchChunkChainIds(process.env, enabledSet)
 
   const scriptTag = `<script>window.__CHAIN_CONFIG__=${JSON.stringify({ enabledChainIds, deprecatedChainIds, onchainSdkChainIds, eVaultFetchChunkChainIds, unsupportedChainIds: unknownChainIds, chainEnvIssues })}</script>`

--- a/server/plugins/warm-cache.ts
+++ b/server/plugins/warm-cache.ts
@@ -45,7 +45,7 @@ import {
   warnIfVaultSourceNeedsV3,
 } from '~/utils/api-url-env'
 import { getEnabledChainIds } from '~/utils/chain-env'
-import { parseDeprecatedChains } from '~/utils/parseDeprecatedChains'
+import { parseChainIds } from '~/utils/parseChainIds'
 import { reportStatus } from '../utils/log'
 import { logger } from '~/server/utils/logger'
 
@@ -143,7 +143,7 @@ export default defineNitroPlugin(() => {
 
   const enabledChainIds = getEnabledChainIds()
   const deprecatedChainIds = new Set(
-    parseDeprecatedChains(process.env.DEPRECATED_CHAINS, new Set(enabledChainIds)),
+    parseChainIds(process.env.DEPRECATED_CHAINS, new Set(enabledChainIds)),
   )
   const chainIds = enabledChainIds.filter(id => !deprecatedChainIds.has(id))
   if (chainIds.length === 0) return

--- a/server/utils/oracle-checks.ts
+++ b/server/utils/oracle-checks.ts
@@ -1,0 +1,86 @@
+import { defineEventHandler } from 'h3'
+import { createRateLimiter } from '~/server/utils/rate-limit'
+import { createTtlCache } from '~/server/utils/cache'
+import { fetchWithTimeout } from '~/server/utils/fetchWithTimeout'
+import { logger } from '~/server/utils/logger'
+import { resolveChainId } from '~/server/utils/resolve-chain-id'
+
+const CACHE_TTL_MS = 300_000
+
+/**
+ * Builds the upstream oracle-checks URL for a chain's resource. When
+ * `address` is omitted, targets the warm-cached `all.json` list; otherwise
+ * targets a single `<address>.json` entry. Honours the base-URL / repo env
+ * overrides shared by every oracle-checks endpoint.
+ */
+export function oracleChecksUrl(chainId: number, resource: string, address?: string): string {
+  const leaf = address ? `${address}.json` : 'all.json'
+  const baseUrl = (process.env.NUXT_PUBLIC_CONFIG_ORACLE_CHECKS_BASE_URL || '').trim().replace(/\/+$/, '')
+  if (baseUrl) {
+    return `${baseUrl}/${chainId}/${resource}/${leaf}`
+  }
+
+  const repo = process.env.NUXT_PUBLIC_CONFIG_ORACLE_CHECKS_REPO || 'euler-xyz/oracle-checks'
+  return `https://raw.githubusercontent.com/${repo}/refs/heads/master/data/${chainId}/${resource}/${leaf}`
+}
+
+/**
+ * Builds a warm-cached oracle-checks list handler for a resource
+ * (`routers` / `adapters`). Fetches `<chainId>/<resource>/all.json`, caches
+ * successful responses, and falls back to a stale cache entry or empty array
+ * on transient failures. 404s return an empty array without polluting the
+ * cache.
+ */
+export function createOracleChecksHandler(options: {
+  resource: string
+  label: string
+  max: number
+  logMessage: string
+}) {
+  const { resource, label, max, logMessage } = options
+
+  const rateLimiter = createRateLimiter({
+    max,
+    windowMs: 60_000,
+    label,
+  })
+
+  const cache = createTtlCache<unknown>({ ttlMs: CACHE_TTL_MS, maxEntries: 50 })
+
+  return defineEventHandler(async (event) => {
+    rateLimiter.consume(event)
+
+    const chainId = resolveChainId(event, { requireEnabled: false })
+
+    const key = `${chainId}`
+
+    const cached = cache.get(key)
+    if (cached !== undefined) return cached
+
+    try {
+      const resp = await fetchWithTimeout(oracleChecksUrl(chainId, resource))
+      if (!resp.ok) {
+        // Don't cache the empty fallback for 404 (or any non-OK status). A
+        // missing/transient upstream response would otherwise pin every client
+        // to the empty array for the full TTL window — better to let the next
+        // request retry quickly.
+        if (resp.status === 404) return []
+        throw new Error(`Upstream returned ${resp.status}`)
+      }
+
+      const data: unknown = await resp.json()
+      cache.set(key, data)
+      return data
+    }
+    catch (err) {
+      logger.warn({ ctx: label, chainId, err }, logMessage)
+
+      const stale = cache.getStale(key)
+      if (stale !== undefined) return stale
+
+      // Same reasoning as the 404 branch: don't pollute the cache with an empty
+      // array on transient failures.
+      return []
+    }
+  })
+}

--- a/server/utils/sdk-server.ts
+++ b/server/utils/sdk-server.ts
@@ -31,7 +31,7 @@ import {
   readV3ApiUrl,
   type VaultDataSource,
 } from '~/utils/api-url-env'
-import { parseOnchainSdkChains } from '~/utils/parseOnchainSdkChains'
+import { parseChainIds } from '~/utils/parseChainIds'
 import { resolveRpcUrl } from './rpc'
 import { resolveLabelsBaseUrl } from './labels-base-url'
 
@@ -67,7 +67,7 @@ const adapterConfigForSource = (source: VaultDataSource): Partial<EulerSDKConfig
 }
 
 const isOnchainSdkChain = (chainId: number): boolean =>
-  parseOnchainSdkChains(process.env.ONCHAIN_SDK_CHAINS, new Set([chainId])).includes(chainId)
+  parseChainIds(process.env.ONCHAIN_SDK_CHAINS, new Set([chainId])).includes(chainId)
 
 const buildServerSdkConfig = (chainId: number): EulerSDKConfig => {
   const rpcUrl = resolveRpcUrl(chainId)

--- a/utils/parseDeprecatedChains.ts
+++ b/utils/parseDeprecatedChains.ts
@@ -1,5 +1,0 @@
-import { parseChainIds } from './parseChainIds'
-
-export function parseDeprecatedChains(rawEnv: string | undefined, enabledSet: Set<number>): number[] {
-  return parseChainIds(rawEnv, enabledSet)
-}

--- a/utils/parseOnchainSdkChains.ts
+++ b/utils/parseOnchainSdkChains.ts
@@ -1,5 +1,0 @@
-import { parseChainIds } from './parseChainIds'
-
-export function parseOnchainSdkChains(rawEnv: string | undefined, enabledSet: Set<number>): number[] {
-  return parseChainIds(rawEnv, enabledSet)
-}


### PR DESCRIPTION
## Summary

Deduplicates the server oracle-checks handlers and removes two zero-behavior utility wrappers. External behavior is preserved exactly: response shapes, cache headers, rate limits, error messages, and log labels are unchanged.

## Changes

### Oracle-checks handlers
- Add `server/utils/oracle-checks.ts` exposing:
  - `oracleChecksUrl(chainId, resource, address?)` — the shared base-URL / repo env resolution and path builder (`all.json` for lists, `<address>.json` for single lookups).
  - `createOracleChecksHandler({ resource, label, max, logMessage })` — the shared warm-cached list handler (rate limit, TTL cache, 404/transient-failure fallbacks).
- `server/api/oracle-routers.get.ts` and `server/api/oracle-adapters.get.ts` collapse from 66 lines each to ~7-line factory calls. The pre-existing per-endpoint log messages (`fetch routers all.json failed` vs `fetch all.json failed`) are preserved verbatim via `logMessage`.
- `server/api/oracle-adapter.get.ts` reuses `oracleChecksUrl` for its single-adapter lookup and drops its local copy of the URL builder.

### chainId validation
- The three oracle-checks handlers now validate `chainId` via the canonical `resolveChainId` helper instead of a hand-rolled `Number()` + integer/positive check. `{ requireEnabled: false }` is passed to preserve the prior behavior of accepting any positive-integer chain (the hand-rolled versions did not restrict to the enabled set).

### Pass-through wrappers
- Delete `utils/parseDeprecatedChains.ts` and `utils/parseOnchainSdkChains.ts`. Both were one-line forwards to `parseChainIds` with identical arguments and typing, adding no narrowing or validation.
- All callers (`composables/useChainConfig.ts`, `server/plugins/chain-config.ts`, `server/plugins/warm-cache.ts`, `server/utils/sdk-server.ts`) now call `parseChainIds` directly.

## Behavior note
- `server/api/token-list.get.ts` also hand-rolls chainId validation, but its error message (`chainId is required and must be a positive integer`) differs from `resolveChainId`'s (`Invalid chainId`). To avoid changing that endpoint's external response, it is left untouched.

## Validation
- `eslint` clean on all changed files.
- Relevant server/util tests pass (`sdk-server`, `useVaults`, `oracle-adapter-views`, `oracle-label`).