### PR TITLE
fix: escape "<" in inline __APP_CONFIG__ script payload

### DIFF
--- a/server/plugins/app-config.ts
+++ b/server/plugins/app-config.ts
@@ -28,6 +28,18 @@ function escapeHtml(str: string): string {
     .replace(/'/g, '&#39;')
 }
 
+// JSON.stringify does not escape `<`, so a config value containing `</script>`
+// would break out of the inline script context. Escaping `<` (and the U+2028 /
+// U+2029 line separators, which are invalid in JS string literals) as unicode
+// escapes keeps the payload inside the script tag while preserving identical
+// JSON/JS semantics — `<` parses back to `<` inside string values.
+export function escapeScriptJson(json: string): string {
+  return json
+    .replace(/</g, '\\u003c')
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029')
+}
+
 function env(key: string, ...fallbackKeys: string[]): string {
   for (const k of [key, ...fallbackKeys]) {
     if (process.env[k]) return process.env[k]!
@@ -107,7 +119,7 @@ function injectSocialImage(html: { head: string[] }, socialImageUrl: string) {
 
 export default defineNitroPlugin((nitroApp) => {
   const appConfig = readAppConfig()
-  const scriptTag = `<script>window.__APP_CONFIG__=${JSON.stringify(appConfig)}</script>`
+  const scriptTag = `<script>window.__APP_CONFIG__=${escapeScriptJson(JSON.stringify(appConfig))}</script>`
 
   nitroApp.hooks.hook('render:html', (html) => {
     html.head.push(scriptTag)

--- a/tests/server/security.test.ts
+++ b/tests/server/security.test.ts
@@ -16,6 +16,7 @@ import type { H3Event } from 'h3'
 import { buildCsp } from '~/server/plugins/csp'
 import { applySecurityHeaders } from '~/server/middleware/security-headers'
 import { ANTI_CLICKJACK_SCRIPT } from '~/server/plugins/00-anti-clickjack'
+import { escapeScriptJson } from '~/server/plugins/app-config'
 
 describe('buildCsp', () => {
   const csp = buildCsp('test-nonce', [], { connect: [] }, [])
@@ -147,5 +148,34 @@ describe('ANTI_CLICKJACK_SCRIPT', () => {
     // to use template strings — escaping inside HTML `<script>` gets
     // tricky fast. Keep it as a plain single-quoted string literal.
     expect(ANTI_CLICKJACK_SCRIPT).not.toContain('`')
+  })
+})
+
+describe('escapeScriptJson (inline __APP_CONFIG__ payload)', () => {
+  it('escapes `<` so a value cannot close the inline <script> tag', () => {
+    const payload = JSON.stringify({ appTitle: '</script><script>alert(1)</script>' })
+    const escaped = escapeScriptJson(payload)
+    const scriptTag = `<script>window.__APP_CONFIG__=${escaped}</script>`
+
+    // The only `</script>` in the emitted tag must be the closing one we added.
+    expect(escaped).not.toContain('</script>')
+    expect(escaped).not.toContain('<')
+    expect(scriptTag.match(/<\/script>/g)).toHaveLength(1)
+  })
+
+  it('escapes U+2028 / U+2029 line separators (invalid in JS string literals)', () => {
+    const escaped = escapeScriptJson(JSON.stringify({ appTitle: 'a b c' }))
+    expect(escaped).toContain('\\u2028')
+    expect(escaped).toContain('\\u2029')
+    expect(escaped).not.toContain(' ')
+    expect(escaped).not.toContain(' ')
+  })
+
+  it('preserves JSON/JS semantics — escaped payload parses back to the original', () => {
+    const original = { appTitle: 'a < b </script>', appDescription: 'x y z' }
+    const escaped = escapeScriptJson(JSON.stringify(original))
+    // The unicode escapes are interpreted by the JS/JSON parser, yielding
+    // the original characters back inside the string values.
+    expect(JSON.parse(escaped)).toEqual(original)
   })
 })


### PR DESCRIPTION
## Problem

The Nitro app-config plugin injects operator-controlled env vars into the HTML head as an inline script:

```
<script>window.__APP_CONFIG__=${JSON.stringify(appConfig)}</script>
```

`JSON.stringify` does not escape `<`, so a config value containing the literal string `</script>` would terminate the inline script element early and break out of the script context. Every value here comes from operator-controlled env vars, so the practical severity is low, but relying on well-formed env values is not a defense — the standard hardening is to make the payload structurally unable to escape the tag.

## Solution

Added a small `escapeScriptJson` helper (in the same helper-function style as the existing `escapeHtml`) that is applied to the stringified payload before it is embedded:

- Escapes `<` to `<` so no substring can form `</script>`.
- Also escapes U+2028 / U+2029 (line/paragraph separators), which are valid inside JSON strings but were invalid inside JS string literals before ES2019 — escaping them keeps the inline script robust.

These are unicode escape sequences, so JSON/JS semantics are unchanged: the values parse back to the exact original characters. The escaping is applied only to the inline-script path; the meta-patch path continues to use the existing `escapeHtml` helper.

## Verification

- Added regression tests in `tests/server/security.test.ts` covering the inline `__APP_CONFIG__` payload:
  - A value containing `</script><script>alert(1)</script>` no longer produces any `</script>` in the escaped payload, and the emitted tag contains exactly one (the real) closing tag.
  - U+2028 / U+2029 are escaped and no raw separators remain.
  - The escaped payload round-trips: `JSON.parse` yields the original object, proving semantics are preserved.
- `npx vitest run tests/server/security.test.ts` — 20 passed.
- eslint clean on both changed files.
