### PR TITLE
feat: add vault history denomination toggle

### DIFF
--- a/components/entities/vault/overview/VaultOverviewBlockHistory.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockHistory.vue
@@ -62,7 +62,7 @@ const { enableV3Backend } = useEnvConfig()
 const { getChartColors, isDark } = useThemeColors()
 
 const selectedMetric = ref<VaultHistoryMetric>('totalSupply')
-const selectedDenomination = ref<DenominationOption>('asset')
+const selectedDenomination = ref<DenominationOption>('usd')
 const selectedTimeframe = ref<VaultHistoryTimeframe>('30d')
 const fetchedHistory = shallowRef<VaultHistoryPoint[]>([])
 const fetchedHistoryEnd = ref<number | null>(null)
@@ -149,11 +149,14 @@ const hasSelectedMetricUsdData = computed(() =>
   !isPercentMetric(selectedMetric.value)
   && history.value.some(point => pointUsdValue(point, selectedMetric.value) !== null),
 )
+// While the toggle is hidden (percent metrics, missing USD data) the chart
+// falls back to asset values via the canToggleDenomination guards, but the
+// selection itself is kept so returning to a USD-capable metric restores it.
 const canToggleDenomination = computed(() =>
   !isPercentMetric(selectedMetric.value) && hasSelectedMetricUsdData.value,
 )
 const shouldShowHistoryControls = computed(() =>
-  canToggleDenomination.value || metricOptions.value.length > 1,
+  metricOptions.value.length > 1,
 )
 
 watch(
@@ -162,14 +165,6 @@ watch(
     if (!options.some(option => option.value === selectedMetric.value)) {
       selectedMetric.value = options[0]?.value ?? 'totalSupply'
     }
-  },
-  { immediate: true },
-)
-
-watch(
-  [selectedMetric, canToggleDenomination],
-  () => {
-    if (!canToggleDenomination.value) selectedDenomination.value = 'asset'
   },
   { immediate: true },
 )
@@ -441,33 +436,6 @@ const chartOptions = computed<ChartOptions<'line'>>(() => {
         class="flex flex-wrap items-center justify-end gap-8 mobile:hidden"
       >
         <div
-          v-if="canToggleDenomination"
-          class="inline-flex h-32 overflow-hidden rounded-12 border border-line-subtle bg-surface p-2 transition-colors hover:border-line focus-within:border-accent-500"
-          role="group"
-          aria-label="Chart denomination"
-        >
-          <button
-            type="button"
-            class="h-full min-w-48 cursor-pointer rounded-8 px-8 text-p3 transition-colors focus-visible:outline-none"
-            :class="selectedDenomination === 'asset' ? 'bg-accent-600 text-black hover:bg-accent-700' : 'text-content-secondary hover:bg-card-hover hover:text-content-primary'"
-            :aria-pressed="selectedDenomination === 'asset'"
-            @click="selectedDenomination = 'asset'"
-          >
-            {{ vault.asset.symbol }}
-          </button>
-          <button
-            type="button"
-            class="h-full min-w-48 cursor-pointer rounded-8 px-8 text-p3 transition-colors focus-visible:outline-none"
-            :class="selectedDenomination === 'usd' ? 'bg-accent-600 text-black hover:bg-accent-700' : 'text-content-secondary hover:bg-card-hover hover:text-content-primary'"
-            :aria-pressed="selectedDenomination === 'usd'"
-            @click="selectedDenomination = 'usd'"
-          >
-            USD
-          </button>
-        </div>
-
-        <div
-          v-if="metricOptions.length > 1"
           class="relative inline-flex h-32 rounded-8 border border-line-subtle bg-surface transition-colors hover:border-line focus-within:border-accent-500"
         >
           <select
@@ -499,33 +467,6 @@ const chartOptions = computed<ChartOptions<'line'>>(() => {
       class="hidden flex-wrap items-center gap-8 mobile:flex"
     >
       <div
-        v-if="canToggleDenomination"
-        class="inline-flex h-32 overflow-hidden rounded-12 border border-line-subtle bg-surface p-2 transition-colors hover:border-line focus-within:border-accent-500"
-        role="group"
-        aria-label="Chart denomination"
-      >
-        <button
-          type="button"
-          class="h-full min-w-48 cursor-pointer rounded-8 px-8 text-p3 transition-colors focus-visible:outline-none"
-          :class="selectedDenomination === 'asset' ? 'bg-accent-600 text-black hover:bg-accent-700' : 'text-content-secondary hover:bg-card-hover hover:text-content-primary'"
-          :aria-pressed="selectedDenomination === 'asset'"
-          @click="selectedDenomination = 'asset'"
-        >
-          {{ vault.asset.symbol }}
-        </button>
-        <button
-          type="button"
-          class="h-full min-w-48 cursor-pointer rounded-8 px-8 text-p3 transition-colors focus-visible:outline-none"
-          :class="selectedDenomination === 'usd' ? 'bg-accent-600 text-black hover:bg-accent-700' : 'text-content-secondary hover:bg-card-hover hover:text-content-primary'"
-          :aria-pressed="selectedDenomination === 'usd'"
-          @click="selectedDenomination = 'usd'"
-        >
-          USD
-        </button>
-      </div>
-
-      <div
-        v-if="metricOptions.length > 1"
         class="relative inline-flex h-32 rounded-8 border border-line-subtle bg-surface transition-colors hover:border-line focus-within:border-accent-500"
       >
         <select
@@ -598,6 +539,38 @@ const chartOptions = computed<ChartOptions<'line'>>(() => {
         >
           {{ timeframe.label }}
         </button>
+
+        <div
+          v-if="canToggleDenomination"
+          class="h-20 w-[1px] shrink-0 bg-line-subtle"
+          aria-hidden="true"
+        />
+
+        <div
+          v-if="canToggleDenomination"
+          class="contents"
+          role="group"
+          aria-label="Chart denomination"
+        >
+          <button
+            type="button"
+            class="h-32 min-w-48 rounded-8 px-10 text-p3 transition-colors"
+            :class="selectedDenomination === 'usd' ? 'bg-accent-600 text-black hover:bg-accent-700' : 'bg-surface text-content-secondary hover:text-content-primary'"
+            :aria-pressed="selectedDenomination === 'usd'"
+            @click="selectedDenomination = 'usd'"
+          >
+            USD
+          </button>
+          <button
+            type="button"
+            class="h-32 min-w-48 rounded-8 px-10 text-p3 transition-colors"
+            :class="selectedDenomination === 'asset' ? 'bg-accent-600 text-black hover:bg-accent-700' : 'bg-surface text-content-secondary hover:text-content-primary'"
+            :aria-pressed="selectedDenomination === 'asset'"
+            @click="selectedDenomination = 'asset'"
+          >
+            {{ vault.asset.symbol }}
+          </button>
+        </div>
       </div>
     </template>
   </VaultOverviewAccordionSection>

--- a/components/entities/vault/overview/VaultOverviewBlockHistory.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockHistory.vue
@@ -14,7 +14,7 @@ import {
 } from 'chart.js'
 import { Line } from 'vue-chartjs'
 import { logWarn } from '~/utils/errorHandling'
-import { compactNumber } from '~/utils/string-utils'
+import { compactNumber, formatCompactUsdValue } from '~/utils/string-utils'
 import { isVaultBorrowable } from '~/utils/vault/classification'
 import {
   buildVaultTotalsHistoryPath,
@@ -42,6 +42,7 @@ type MetricOption = {
   value: VaultHistoryMetric
   label: string
 }
+type DenominationOption = 'asset' | 'usd'
 type FetchErrorLike = {
   status?: number
   statusCode?: number
@@ -61,6 +62,7 @@ const { enableV3Backend } = useEnvConfig()
 const { getChartColors, isDark } = useThemeColors()
 
 const selectedMetric = ref<VaultHistoryMetric>('totalSupply')
+const selectedDenomination = ref<DenominationOption>('asset')
 const selectedTimeframe = ref<VaultHistoryTimeframe>('30d')
 const fetchedHistory = shallowRef<VaultHistoryPoint[]>([])
 const fetchedHistoryEnd = ref<number | null>(null)
@@ -109,11 +111,11 @@ const shouldShowBorrowMetrics = computed(() =>
 const metricOptions = computed<MetricOption[]>(() => {
   if (shouldShowBorrowMetrics.value) {
     return [
-      { value: 'apy', label: 'APY' },
       { value: 'totalSupply', label: 'Total supply' },
       { value: 'totalBorrows', label: 'Total borrowed' },
-      { value: 'utilization', label: 'Utilization' },
       { value: 'cash', label: 'Available Liquidity' },
+      { value: 'utilization', label: 'Utilization' },
+      { value: 'apy', label: 'APY' },
     ]
   }
 
@@ -127,12 +129,44 @@ const selectedMetricLabel = computed(() =>
   metricOptions.value.find(option => option.value === selectedMetric.value)?.label ?? 'Metric',
 )
 
+const isPercentMetric = (metric: VaultHistoryMetric) =>
+  metric === 'apy' || metric === 'utilization'
+
+const pointUsdValue = (point: VaultHistoryPoint, metric: VaultHistoryMetric): number | null => {
+  switch (metric) {
+    case 'totalSupply':
+      return point.totalAssetsUsd
+    case 'totalBorrows':
+      return point.totalBorrowsUsd
+    case 'cash':
+      return point.cashUsd
+    default:
+      return null
+  }
+}
+
+const hasSelectedMetricUsdData = computed(() =>
+  !isPercentMetric(selectedMetric.value)
+  && history.value.some(point => pointUsdValue(point, selectedMetric.value) !== null),
+)
+const canToggleDenomination = computed(() =>
+  !isPercentMetric(selectedMetric.value) && hasSelectedMetricUsdData.value,
+)
+
 watch(
   metricOptions,
   (options) => {
     if (!options.some(option => option.value === selectedMetric.value)) {
       selectedMetric.value = options[0]?.value ?? 'totalSupply'
     }
+  },
+  { immediate: true },
+)
+
+watch(
+  [selectedMetric, canToggleDenomination],
+  () => {
+    if (!canToggleDenomination.value) selectedDenomination.value = 'asset'
   },
   { immediate: true },
 )
@@ -267,8 +301,13 @@ const pointValue = (point: VaultHistoryPoint, metric: VaultHistoryMetric): numbe
   }
 }
 
+const pointChartValue = (point: VaultHistoryPoint, metric: VaultHistoryMetric): number | null =>
+  selectedDenomination.value === 'usd' && canToggleDenomination.value
+    ? pointUsdValue(point, metric)
+    : pointValue(point, metric)
+
 const visiblePoints = computed(() =>
-  history.value.filter(point => pointValue(point, selectedMetric.value) !== null),
+  history.value.filter(point => pointChartValue(point, selectedMetric.value) !== null),
 )
 const hasChartData = computed(() => visiblePoints.value.length > 1)
 
@@ -276,7 +315,7 @@ const chartData = computed<ChartData<'line', number[], string>>(() => {
   void isDark.value
   const colors = getChartColors()
   const labels = visiblePoints.value.map(point => formatDate(point.timestamp))
-  const primaryValues = visiblePoints.value.map(point => pointValue(point, selectedMetric.value) ?? 0)
+  const primaryValues = visiblePoints.value.map(point => pointChartValue(point, selectedMetric.value) ?? 0)
 
   const datasets: ChartData<'line', number[], string>['datasets'] = [
     {
@@ -309,10 +348,11 @@ const chartData = computed<ChartData<'line', number[], string>>(() => {
   return { labels, datasets }
 })
 
-const formatValue = (value: number) =>
-  selectedMetric.value === 'apy' || selectedMetric.value === 'utilization'
-    ? `${compactNumber(value, 2, 0)}%`
-    : `${compactNumber(value, 2, 0)} ${vault.asset.symbol}`
+const formatValue = (value: number, metric: VaultHistoryMetric = selectedMetric.value) => {
+  if (isPercentMetric(metric)) return `${compactNumber(value, 2, 0)}%`
+  if (selectedDenomination.value === 'usd' && canToggleDenomination.value) return formatCompactUsdValue(value)
+  return `${compactNumber(value, 2, 0)} ${vault.asset.symbol}`
+}
 
 const chartOptions = computed<ChartOptions<'line'>>(() => {
   void isDark.value
@@ -343,7 +383,12 @@ const chartOptions = computed<ChartOptions<'line'>>(() => {
         bodyColor: colors.tooltip.textMuted,
         displayColors: true,
         callbacks: {
-          label: context => `${context.dataset.label}: ${formatValue(Number(context.parsed.y))}`,
+          label: (context) => {
+            const metric = selectedMetric.value === 'apy' && context.dataset.label === 'Borrow APY'
+              ? 'apy'
+              : selectedMetric.value
+            return `${context.dataset.label}: ${formatValue(Number(context.parsed.y), metric)}`
+          },
         },
       },
     },
@@ -389,28 +434,59 @@ const chartOptions = computed<ChartOptions<'line'>>(() => {
   >
     <template #actions="{ isOpen }">
       <div
-        v-if="isOpen && metricOptions.length > 1"
-        class="relative inline-flex h-32 rounded-8 border border-line-subtle bg-surface transition-colors hover:border-line focus-within:border-accent-500"
+        v-if="isOpen"
+        class="flex flex-wrap items-center justify-end gap-8"
       >
-        <select
-          v-model="selectedMetric"
-          class="absolute inset-0 h-full w-full cursor-pointer appearance-none opacity-0"
-          aria-label="Performance metric"
+        <div
+          v-if="canToggleDenomination"
+          class="inline-flex h-32 overflow-hidden rounded-12 border border-line-subtle bg-surface p-2 transition-colors hover:border-line focus-within:border-accent-500"
+          role="group"
+          aria-label="Chart denomination"
         >
-          <option
-            v-for="option in metricOptions"
-            :key="option.value"
-            :value="option.value"
+          <button
+            type="button"
+            class="h-full min-w-48 cursor-pointer rounded-8 px-8 text-p3 transition-colors focus-visible:outline-none"
+            :class="selectedDenomination === 'asset' ? 'bg-accent-600 text-black hover:bg-accent-700' : 'text-content-secondary hover:bg-card-hover hover:text-content-primary'"
+            :aria-pressed="selectedDenomination === 'asset'"
+            @click="selectedDenomination = 'asset'"
           >
-            {{ option.label }}
-          </option>
-        </select>
-        <div class="pointer-events-none flex h-full items-center gap-8 px-10 text-p3 text-content-primary">
-          <span class="whitespace-nowrap">{{ selectedMetricLabel }}</span>
-          <UiIcon
-            name="arrow-down"
-            class="h-16 w-16 shrink-0 text-content-secondary"
-          />
+            {{ vault.asset.symbol }}
+          </button>
+          <button
+            type="button"
+            class="h-full min-w-48 cursor-pointer rounded-8 px-8 text-p3 transition-colors focus-visible:outline-none"
+            :class="selectedDenomination === 'usd' ? 'bg-accent-600 text-black hover:bg-accent-700' : 'text-content-secondary hover:bg-card-hover hover:text-content-primary'"
+            :aria-pressed="selectedDenomination === 'usd'"
+            @click="selectedDenomination = 'usd'"
+          >
+            USD
+          </button>
+        </div>
+
+        <div
+          v-if="metricOptions.length > 1"
+          class="relative inline-flex h-32 rounded-8 border border-line-subtle bg-surface transition-colors hover:border-line focus-within:border-accent-500"
+        >
+          <select
+            v-model="selectedMetric"
+            class="absolute inset-0 h-full w-full cursor-pointer appearance-none opacity-0"
+            aria-label="Performance metric"
+          >
+            <option
+              v-for="option in metricOptions"
+              :key="option.value"
+              :value="option.value"
+            >
+              {{ option.label }}
+            </option>
+          </select>
+          <div class="pointer-events-none flex h-full items-center gap-8 px-10 text-p3 text-content-primary">
+            <span class="whitespace-nowrap">{{ selectedMetricLabel }}</span>
+            <UiIcon
+              name="arrow-down"
+              class="h-16 w-16 shrink-0 text-content-secondary"
+            />
+          </div>
         </div>
       </div>
     </template>

--- a/components/entities/vault/overview/VaultOverviewBlockHistory.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockHistory.vue
@@ -152,6 +152,9 @@ const hasSelectedMetricUsdData = computed(() =>
 const canToggleDenomination = computed(() =>
   !isPercentMetric(selectedMetric.value) && hasSelectedMetricUsdData.value,
 )
+const shouldShowHistoryControls = computed(() =>
+  canToggleDenomination.value || metricOptions.value.length > 1,
+)
 
 watch(
   metricOptions,
@@ -434,8 +437,8 @@ const chartOptions = computed<ChartOptions<'line'>>(() => {
   >
     <template #actions="{ isOpen }">
       <div
-        v-if="isOpen"
-        class="flex flex-wrap items-center justify-end gap-8"
+        v-if="isOpen && shouldShowHistoryControls"
+        class="flex flex-wrap items-center justify-end gap-8 mobile:hidden"
       >
         <div
           v-if="canToggleDenomination"
@@ -490,6 +493,63 @@ const chartOptions = computed<ChartOptions<'line'>>(() => {
         </div>
       </div>
     </template>
+
+    <div
+      v-if="shouldShowHistoryControls"
+      class="hidden flex-wrap items-center gap-8 mobile:flex"
+    >
+      <div
+        v-if="canToggleDenomination"
+        class="inline-flex h-32 overflow-hidden rounded-12 border border-line-subtle bg-surface p-2 transition-colors hover:border-line focus-within:border-accent-500"
+        role="group"
+        aria-label="Chart denomination"
+      >
+        <button
+          type="button"
+          class="h-full min-w-48 cursor-pointer rounded-8 px-8 text-p3 transition-colors focus-visible:outline-none"
+          :class="selectedDenomination === 'asset' ? 'bg-accent-600 text-black hover:bg-accent-700' : 'text-content-secondary hover:bg-card-hover hover:text-content-primary'"
+          :aria-pressed="selectedDenomination === 'asset'"
+          @click="selectedDenomination = 'asset'"
+        >
+          {{ vault.asset.symbol }}
+        </button>
+        <button
+          type="button"
+          class="h-full min-w-48 cursor-pointer rounded-8 px-8 text-p3 transition-colors focus-visible:outline-none"
+          :class="selectedDenomination === 'usd' ? 'bg-accent-600 text-black hover:bg-accent-700' : 'text-content-secondary hover:bg-card-hover hover:text-content-primary'"
+          :aria-pressed="selectedDenomination === 'usd'"
+          @click="selectedDenomination = 'usd'"
+        >
+          USD
+        </button>
+      </div>
+
+      <div
+        v-if="metricOptions.length > 1"
+        class="relative inline-flex h-32 rounded-8 border border-line-subtle bg-surface transition-colors hover:border-line focus-within:border-accent-500"
+      >
+        <select
+          v-model="selectedMetric"
+          class="absolute inset-0 h-full w-full cursor-pointer appearance-none opacity-0"
+          aria-label="Performance metric"
+        >
+          <option
+            v-for="option in metricOptions"
+            :key="option.value"
+            :value="option.value"
+          >
+            {{ option.label }}
+          </option>
+        </select>
+        <div class="pointer-events-none flex h-full items-center gap-8 px-10 text-p3 text-content-primary">
+          <span class="whitespace-nowrap">{{ selectedMetricLabel }}</span>
+          <UiIcon
+            name="arrow-down"
+            class="h-16 w-16 shrink-0 text-content-secondary"
+          />
+        </div>
+      </div>
+    </div>
 
     <div
       v-if="isLoading && !hasChartData"

--- a/tests/utils/vault-history.test.ts
+++ b/tests/utils/vault-history.test.ts
@@ -16,11 +16,15 @@ describe('vault history utilities', () => {
           {
             timestamp: '2026-07-01T00:00:00.000Z',
             totalAssets: '123450000',
+            totalAssetsUsd: 123.45,
             totalBorrows: '1000000',
+            totalBorrowsUsd: 1,
             cash: '122450000',
+            cashUsd: 122.45,
             utilization: 0.25,
             supplyApy: 4.5,
             borrowApy: 6.75,
+            sharePrice: 1.01,
           },
         ],
       },
@@ -30,11 +34,15 @@ describe('vault history utilities', () => {
       {
         timestamp: '2026-07-01T00:00:00.000Z',
         totalAssets: 123.45,
+        totalAssetsUsd: 123.45,
         totalBorrows: 1,
+        totalBorrowsUsd: 1,
         cash: 122.45,
+        cashUsd: 122.45,
         utilization: 0.25,
         supplyApy: 4.5,
         borrowApy: 6.75,
+        sharePrice: 1.01,
       },
     ])
   })
@@ -60,11 +68,15 @@ describe('vault history utilities', () => {
       {
         timestamp: '2026-07-01T00:00:00.000Z',
         totalAssets: 123.45,
+        totalAssetsUsd: null,
         totalBorrows: 1,
+        totalBorrowsUsd: null,
         cash: 122.45,
+        cashUsd: null,
         utilization: null,
         supplyApy: null,
         borrowApy: null,
+        sharePrice: null,
       },
     ])
   })

--- a/utils/vault-history.ts
+++ b/utils/vault-history.ts
@@ -8,25 +8,40 @@ export const VAULT_HISTORY_TIMEFRAMES = [
 
 export type VaultHistoryTimeframe = typeof VAULT_HISTORY_TIMEFRAMES[number]['value']
 export const VAULT_HISTORY_FETCH_TIMEFRAME: VaultHistoryTimeframe = '90d'
-export type VaultHistoryMetric = 'apy' | 'totalSupply' | 'totalBorrows' | 'utilization' | 'cash'
+export type VaultHistoryMetric
+  = | 'apy'
+    | 'totalSupply'
+    | 'totalBorrows'
+    | 'utilization'
+    | 'cash'
 export type VaultHistoryPoint = {
   timestamp: string
   totalAssets: number | null
+  totalAssetsUsd: number | null
   totalBorrows: number | null
+  totalBorrowsUsd: number | null
   cash: number | null
+  cashUsd: number | null
   utilization: number | null
   supplyApy: number | null
   borrowApy: number | null
+  sharePrice: number | null
 }
 
 type RawVaultHistoryPoint = {
   timestamp?: unknown
   totalAssets?: unknown
+  totalAssetsUsd?: unknown
+  totalSupplyUsd?: unknown
   totalBorrows?: unknown
+  totalBorrowsUsd?: unknown
   cash?: unknown
+  cashUsd?: unknown
   utilization?: unknown
   supplyApy?: unknown
   borrowApy?: unknown
+  apy?: unknown
+  sharePrice?: unknown
 }
 
 export type VaultTotalsHistoryResponse = {
@@ -68,11 +83,15 @@ export const parseVaultTotalsHistory = (
       return {
         timestamp: point.timestamp,
         totalAssets: parseAmount(point.totalAssets, decimals),
+        totalAssetsUsd: parseNumber(point.totalAssetsUsd ?? point.totalSupplyUsd),
         totalBorrows: parseAmount(point.totalBorrows, decimals),
+        totalBorrowsUsd: parseNumber(point.totalBorrowsUsd),
         cash: parseAmount(point.cash, decimals),
+        cashUsd: parseNumber(point.cashUsd),
         utilization: parseNumber(point.utilization),
-        supplyApy: parseNumber(point.supplyApy),
+        supplyApy: parseNumber(point.supplyApy ?? point.apy),
         borrowApy: parseNumber(point.borrowApy),
+        sharePrice: parseNumber(point.sharePrice),
       }
     })
     .filter((point): point is VaultHistoryPoint => point !== null)


### PR DESCRIPTION
## Summary
- Add an asset/USD denomination toggle to the existing EVK Performance graph so USD values are selected explicitly instead of shown as separate metrics or parenthetical tooltip text.
- Parse USD totals from the V3 vault totals history response for supply, borrowed, and available liquidity values.

## Changes
- Keeps the graph metric dropdown focused on the original metric choices while showing the denomination toggle only for amount metrics with USD data.
- Uses the selected denomination for chart values, axis labels, and tooltip labels.
- Preserves asset-denominated display for percentage metrics and whenever USD data is unavailable.

## Test plan
- [x] npm run test:run -- tests/utils/vault-history.test.ts
- [x] npx eslint components/entities/vault/overview/VaultOverviewBlockHistory.vue
- [x] npm run typecheck
- [x] Manually checked the Performance graph locally at http://127.0.0.1:3001/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a denomination toggle in vault history charts, letting users switch between asset and USD views when USD data is available.
  * Expanded chart and tooltip formatting to better display percent-based metrics, USD values, and asset-denominated values.

* **Bug Fixes**
  * Improved control visibility so chart options only appear when relevant.
  * Ensured the denomination selector automatically resets to asset view if USD switching is no longer available.
  * Updated vault history handling to include additional USD metrics and share price data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->