### PR TITLE
refactor: consolidate vault metadata badges and info modals

### DIFF
--- a/components/entities/vault/AccessControlBadge.vue
+++ b/components/entities/vault/AccessControlBadge.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { useModal } from '~/components/ui/composables/useModal'
 import { AccessControlInfoModal } from '#components'
 
 const { size = 'small', block = false, as = 'span', nudge = false } = defineProps<{
@@ -8,26 +7,17 @@ const { size = 'small', block = false, as = 'span', nudge = false } = defineProp
   as?: 'button' | 'span'
   nudge?: boolean
 }>()
-
-const modal = useModal()
-
-const openInfoModal = (event: MouseEvent | KeyboardEvent) => {
-  event.preventDefault()
-  event.stopPropagation()
-  modal.open(AccessControlInfoModal)
-}
 </script>
 
 <template>
-  <VaultMetadataTag
-    :as="as"
+  <VaultMetadataBadge
     icon="search-user"
     label="Access control"
-    tone="accent"
+    title="This vault restricts operations to allowlisted addresses"
+    :modal="AccessControlInfoModal"
     :size="size"
     :block="block"
+    :as="as"
     :nudge="nudge"
-    title="This vault restricts operations to allowlisted addresses"
-    @click="openInfoModal"
   />
 </template>

--- a/components/entities/vault/AccessControlInfoModal.vue
+++ b/components/entities/vault/AccessControlInfoModal.vue
@@ -1,68 +1,20 @@
 <script setup lang="ts">
-defineEmits(['close'])
+defineEmits<{ close: [] }>()
+
+const bullets = [
+  'Access is granted by the vault manager — there is no self-service verification',
+  'If your address is not whitelisted, the gated operations will revert',
+  'Which operations are gated depends on the vault\'s hook configuration',
+]
 </script>
 
 <template>
-  <BaseModalWrapper
+  <UiInfoModal
     title="Access-controlled Vault"
+    icon="search-user"
+    headline="Permissioned Operations"
+    body="This vault routes operations through an access-control hook. Only addresses on an on-chain allowlist can perform the gated operations."
+    :bullets="bullets"
     @close="$emit('close')"
-  >
-    <div class="flex flex-col gap-16 pt-8">
-      <div class="flex items-center justify-center">
-        <div class="flex items-center justify-center w-48 h-48 rounded-12 bg-accent-100">
-          <SvgIcon
-            name="search-user"
-            class="!w-24 !h-24 text-accent-600"
-          />
-        </div>
-      </div>
-
-      <div class="flex flex-col gap-8">
-        <p class="text-p2 text-content-primary text-center font-medium">
-          Permissioned Operations
-        </p>
-        <p class="text-p3 text-content-secondary text-center">
-          This vault routes operations through an access-control hook. Only addresses on an on-chain allowlist can perform the gated operations.
-        </p>
-      </div>
-
-      <div class="flex flex-col gap-8 p-12 rounded-12 bg-surface-secondary">
-        <div class="flex items-start gap-8">
-          <SvgIcon
-            name="check-circle"
-            class="!w-16 !h-16 text-accent-600 mt-2 shrink-0"
-          />
-          <p class="text-p3 text-content-secondary">
-            Access is granted by the vault manager — there is no self-service verification
-          </p>
-        </div>
-        <div class="flex items-start gap-8">
-          <SvgIcon
-            name="check-circle"
-            class="!w-16 !h-16 text-accent-600 mt-2 shrink-0"
-          />
-          <p class="text-p3 text-content-secondary">
-            If your address is not whitelisted, the gated operations will revert
-          </p>
-        </div>
-        <div class="flex items-start gap-8">
-          <SvgIcon
-            name="check-circle"
-            class="!w-16 !h-16 text-accent-600 mt-2 shrink-0"
-          />
-          <p class="text-p3 text-content-secondary">
-            Which operations are gated depends on the vault's hook configuration
-          </p>
-        </div>
-      </div>
-
-      <UiButton
-        variant="primary"
-        size="large"
-        @click="$emit('close')"
-      >
-        Got it
-      </UiButton>
-    </div>
-  </BaseModalWrapper>
+  />
 </template>

--- a/components/entities/vault/CyclicalNoteBadge.vue
+++ b/components/entities/vault/CyclicalNoteBadge.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { useModal } from '~/components/ui/composables/useModal'
 import { CyclicalNoteInfoModal } from '#components'
 
 const { size = 'small', block = false, as = 'span', nudge = false } = defineProps<{
@@ -8,26 +7,17 @@ const { size = 'small', block = false, as = 'span', nudge = false } = defineProp
   as?: 'button' | 'span'
   nudge?: boolean
 }>()
-
-const modal = useModal()
-
-const openInfoModal = (event: MouseEvent | KeyboardEvent) => {
-  event.preventDefault()
-  event.stopPropagation()
-  modal.open(CyclicalNoteInfoModal)
-}
 </script>
 
 <template>
-  <VaultMetadataTag
-    :as="as"
+  <VaultMetadataBadge
     icon="refresh"
     label="Cyclical note"
-    tone="accent"
+    title="Fixed-rate vault with recurring cycles"
+    :modal="CyclicalNoteInfoModal"
     :size="size"
     :block="block"
+    :as="as"
     :nudge="nudge"
-    title="Fixed-rate vault with recurring cycles"
-    @click="openInfoModal"
   />
 </template>

--- a/components/entities/vault/CyclicalNoteInfoModal.vue
+++ b/components/entities/vault/CyclicalNoteInfoModal.vue
@@ -1,77 +1,21 @@
 <script setup lang="ts">
 defineEmits<{ close: [] }>()
+
+const bullets = [
+  'Borrowers pay a fixed rate during the cycle and can repay at any time without penalty',
+  'Lenders can only withdraw when liquidity is available, typically at the end of each cycle',
+  'The rate rises sharply during the repayment window, creating an incentive to repay and a structured exit point for lenders',
+  'Cycles repeat indefinitely — no manual rollover is required',
+]
 </script>
 
 <template>
-  <BaseModalWrapper
+  <UiInfoModal
     title="Cyclical Note"
+    icon="refresh"
+    headline="Fixed rates with recurring cycles"
+    body="Cyclical Notes offer borrowers a fixed interest rate for most of the cycle, followed by a short repayment window with a sharply higher rate to incentivise repayment. For lenders, withdrawals may be limited during the cycle."
+    :bullets="bullets"
     @close="$emit('close')"
-  >
-    <div class="flex flex-col gap-16 pt-8">
-      <div class="flex items-center justify-center">
-        <div class="flex items-center justify-center w-48 h-48 rounded-12 bg-accent-100">
-          <SvgIcon
-            name="refresh"
-            class="!w-24 !h-24 text-accent-600"
-          />
-        </div>
-      </div>
-
-      <div class="flex flex-col gap-8">
-        <p class="text-p2 text-content-primary text-center font-medium">
-          Fixed rates with recurring cycles
-        </p>
-        <p class="text-p3 text-content-secondary text-center">
-          Cyclical Notes offer borrowers a fixed interest rate for most of the cycle, followed by a short repayment window with a sharply higher rate to incentivise repayment. For lenders, withdrawals may be limited during the cycle.
-        </p>
-      </div>
-
-      <div class="flex flex-col gap-8 p-12 rounded-12 bg-surface-secondary">
-        <div class="flex items-start gap-8">
-          <SvgIcon
-            name="check-circle"
-            class="!w-16 !h-16 text-accent-600 mt-2 shrink-0"
-          />
-          <p class="text-p3 text-content-secondary">
-            Borrowers pay a fixed rate during the cycle and can repay at any time without penalty
-          </p>
-        </div>
-        <div class="flex items-start gap-8">
-          <SvgIcon
-            name="check-circle"
-            class="!w-16 !h-16 text-accent-600 mt-2 shrink-0"
-          />
-          <p class="text-p3 text-content-secondary">
-            Lenders can only withdraw when liquidity is available, typically at the end of each cycle
-          </p>
-        </div>
-        <div class="flex items-start gap-8">
-          <SvgIcon
-            name="check-circle"
-            class="!w-16 !h-16 text-accent-600 mt-2 shrink-0"
-          />
-          <p class="text-p3 text-content-secondary">
-            The rate rises sharply during the repayment window, creating an incentive to repay and a structured exit point for lenders
-          </p>
-        </div>
-        <div class="flex items-start gap-8">
-          <SvgIcon
-            name="check-circle"
-            class="!w-16 !h-16 text-accent-600 mt-2 shrink-0"
-          />
-          <p class="text-p3 text-content-secondary">
-            Cycles repeat indefinitely — no manual rollover is required
-          </p>
-        </div>
-      </div>
-
-      <UiButton
-        variant="primary"
-        size="large"
-        @click="$emit('close')"
-      >
-        Got it
-      </UiButton>
-    </div>
-  </BaseModalWrapper>
+  />
 </template>

--- a/components/entities/vault/GovernanceLimitedBadge.vue
+++ b/components/entities/vault/GovernanceLimitedBadge.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { useModal } from '~/components/ui/composables/useModal'
 import { GovernanceLimitedInfoModal } from '#components'
 
 const { size = 'small', block = false, as = 'span', nudge = false } = defineProps<{
@@ -8,26 +7,17 @@ const { size = 'small', block = false, as = 'span', nudge = false } = defineProp
   as?: 'button' | 'span'
   nudge?: boolean
 }>()
-
-const modal = useModal()
-
-const openInfoModal = (event: MouseEvent | KeyboardEvent) => {
-  event.preventDefault()
-  event.stopPropagation()
-  modal.open(GovernanceLimitedInfoModal)
-}
 </script>
 
 <template>
-  <VaultMetadataTag
-    :as="as"
+  <VaultMetadataBadge
     icon="pulse"
     label="Limited"
-    tone="accent"
+    title="This vault has limited risk management"
+    :modal="GovernanceLimitedInfoModal"
     :size="size"
     :block="block"
+    :as="as"
     :nudge="nudge"
-    title="This vault has limited risk management"
-    @click="openInfoModal"
   />
 </template>

--- a/components/entities/vault/GovernanceLimitedInfoModal.vue
+++ b/components/entities/vault/GovernanceLimitedInfoModal.vue
@@ -1,40 +1,15 @@
 <script setup lang="ts">
 import { vaultTypeDescriptions } from '~/utils/vault/descriptions'
 
-defineEmits(['close'])
+defineEmits<{ close: [] }>()
 </script>
 
 <template>
-  <BaseModalWrapper
+  <UiInfoModal
     title="Limited Risk Management"
+    icon="pulse"
+    headline="Limited Risk Management"
+    :body="vaultTypeDescriptions.governanceLimited"
     @close="$emit('close')"
-  >
-    <div class="flex flex-col gap-16 pt-8">
-      <div class="flex items-center justify-center">
-        <div class="flex items-center justify-center w-48 h-48 rounded-12 bg-accent-100">
-          <SvgIcon
-            name="pulse"
-            class="!w-24 !h-24 text-accent-600"
-          />
-        </div>
-      </div>
-
-      <div class="flex flex-col gap-8">
-        <p class="text-p2 text-content-primary text-center font-medium">
-          Limited Risk Management
-        </p>
-        <p class="text-p3 text-content-secondary text-center">
-          {{ vaultTypeDescriptions.governanceLimited }}
-        </p>
-      </div>
-
-      <UiButton
-        variant="primary"
-        size="large"
-        @click="$emit('close')"
-      >
-        Got it
-      </UiButton>
-    </div>
-  </BaseModalWrapper>
+  />
 </template>

--- a/components/entities/vault/RestrictedInfoModal.vue
+++ b/components/entities/vault/RestrictedInfoModal.vue
@@ -3,7 +3,7 @@ type Variant = 'blocked' | 'restricted'
 
 const { variant = 'blocked' } = defineProps<{ variant?: Variant }>()
 
-defineEmits(['close'])
+defineEmits<{ close: [] }>()
 
 const title = computed(() => variant === 'restricted' ? 'Asset Restricted' : 'Region Restricted')
 const headline = computed(() => variant === 'restricted' ? 'Asset restricted in your region' : 'Not available in your region')
@@ -15,36 +15,12 @@ const body = computed(() =>
 </script>
 
 <template>
-  <BaseModalWrapper
+  <UiInfoModal
     :title="title"
+    icon="warning"
+    icon-tone="warning"
+    :headline="headline"
+    :body="body"
     @close="$emit('close')"
-  >
-    <div class="flex flex-col gap-16 pt-8">
-      <div class="flex items-center justify-center">
-        <div class="flex items-center justify-center w-48 h-48 rounded-12 bg-warning-100">
-          <SvgIcon
-            name="warning"
-            class="!w-24 !h-24 text-warning-500"
-          />
-        </div>
-      </div>
-
-      <div class="flex flex-col gap-8">
-        <p class="text-p2 text-content-primary text-center font-medium">
-          {{ headline }}
-        </p>
-        <p class="text-p3 text-content-secondary text-center">
-          {{ body }}
-        </p>
-      </div>
-
-      <UiButton
-        variant="primary"
-        size="large"
-        @click="$emit('close')"
-      >
-        Got it
-      </UiButton>
-    </div>
-  </BaseModalWrapper>
+  />
 </template>

--- a/components/entities/vault/VaultMetadataBadge.vue
+++ b/components/entities/vault/VaultMetadataBadge.vue
@@ -2,7 +2,7 @@
 import type { Component } from 'vue'
 import { useModal } from '~/components/ui/composables/useModal'
 
-const { size = 'small', block = false, as = 'span', nudge = false } = defineProps<{
+const { modal, size = 'small', block = false, as = 'span', nudge = false } = defineProps<{
   icon: string
   label: string
   title: string

--- a/components/entities/vault/VaultMetadataBadge.vue
+++ b/components/entities/vault/VaultMetadataBadge.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import type { Component } from 'vue'
+import { useModal } from '~/components/ui/composables/useModal'
+
+const { size = 'small', block = false, as = 'span', nudge = false } = defineProps<{
+  icon: string
+  label: string
+  title: string
+  modal: Component
+  size?: 'small' | 'large'
+  block?: boolean
+  as?: 'button' | 'span'
+  nudge?: boolean
+}>()
+
+const modalManager = useModal()
+
+const openInfoModal = (event: MouseEvent | KeyboardEvent) => {
+  event.preventDefault()
+  event.stopPropagation()
+  modalManager.open(modal)
+}
+</script>
+
+<template>
+  <VaultMetadataTag
+    :as="as"
+    :icon="icon"
+    :label="label"
+    tone="accent"
+    :size="size"
+    :block="block"
+    :nudge="nudge"
+    :title="title"
+    @click="openInfoModal"
+  />
+</template>

--- a/components/keyring/KeyringBadge.vue
+++ b/components/keyring/KeyringBadge.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { useModal } from '~/components/ui/composables/useModal'
 import { KeyringInfoModal } from '#components'
 
 const { size = 'small', block = false, as = 'span', nudge = false } = defineProps<{
@@ -8,26 +7,17 @@ const { size = 'small', block = false, as = 'span', nudge = false } = defineProp
   as?: 'button' | 'span'
   nudge?: boolean
 }>()
-
-const modal = useModal()
-
-const openKeyringInfoModal = (event: MouseEvent | KeyboardEvent) => {
-  event.preventDefault()
-  event.stopPropagation()
-  modal.open(KeyringInfoModal)
-}
 </script>
 
 <template>
-  <VaultMetadataTag
-    :as="as"
+  <VaultMetadataBadge
     icon="shield"
     label="Private"
-    tone="accent"
+    title="This vault requires identity verification"
+    :modal="KeyringInfoModal"
     :size="size"
     :block="block"
+    :as="as"
     :nudge="nudge"
-    title="This vault requires identity verification"
-    @click="openKeyringInfoModal"
   />
 </template>

--- a/components/keyring/KeyringInfoModal.vue
+++ b/components/keyring/KeyringInfoModal.vue
@@ -1,68 +1,20 @@
 <script setup lang="ts">
-defineEmits(['close'])
+defineEmits<{ close: [] }>()
+
+const bullets = [
+  'Install the Keyring browser extension to complete verification',
+  'Credentials expire after a limited time and may need periodic renewal',
+  'A small on-chain fee is paid during credential registration',
+]
 </script>
 
 <template>
-  <BaseModalWrapper
+  <UiInfoModal
     title="Private Vault"
+    icon="shield"
+    headline="Identity Verification Required"
+    body="This vault requires identity verification through Keyring Network before you can interact with it."
+    :bullets="bullets"
     @close="$emit('close')"
-  >
-    <div class="flex flex-col gap-16 pt-8">
-      <div class="flex items-center justify-center">
-        <div class="flex items-center justify-center w-48 h-48 rounded-12 bg-accent-100">
-          <SvgIcon
-            name="shield"
-            class="!w-24 !h-24 text-accent-600"
-          />
-        </div>
-      </div>
-
-      <div class="flex flex-col gap-8">
-        <p class="text-p2 text-content-primary text-center font-medium">
-          Identity Verification Required
-        </p>
-        <p class="text-p3 text-content-secondary text-center">
-          This vault requires identity verification through Keyring Network before you can interact with it.
-        </p>
-      </div>
-
-      <div class="flex flex-col gap-8 p-12 rounded-12 bg-surface-secondary">
-        <div class="flex items-start gap-8">
-          <SvgIcon
-            name="check-circle"
-            class="!w-16 !h-16 text-accent-600 mt-2 shrink-0"
-          />
-          <p class="text-p3 text-content-secondary">
-            Install the Keyring browser extension to complete verification
-          </p>
-        </div>
-        <div class="flex items-start gap-8">
-          <SvgIcon
-            name="check-circle"
-            class="!w-16 !h-16 text-accent-600 mt-2 shrink-0"
-          />
-          <p class="text-p3 text-content-secondary">
-            Credentials expire after a limited time and may need periodic renewal
-          </p>
-        </div>
-        <div class="flex items-start gap-8">
-          <SvgIcon
-            name="check-circle"
-            class="!w-16 !h-16 text-accent-600 mt-2 shrink-0"
-          />
-          <p class="text-p3 text-content-secondary">
-            A small on-chain fee is paid during credential registration
-          </p>
-        </div>
-      </div>
-
-      <UiButton
-        variant="primary"
-        size="large"
-        @click="$emit('close')"
-      >
-        Got it
-      </UiButton>
-    </div>
-  </BaseModalWrapper>
+  />
 </template>

--- a/components/ui/UiInfoModal.vue
+++ b/components/ui/UiInfoModal.vue
@@ -1,0 +1,73 @@
+<script setup lang="ts">
+const {
+  iconTone = 'accent',
+  bullets = [],
+} = defineProps<{
+  title: string
+  icon: string
+  iconTone?: 'accent' | 'warning'
+  headline: string
+  body: string
+  bullets?: string[]
+}>()
+
+defineEmits<{ close: [] }>()
+</script>
+
+<template>
+  <BaseModalWrapper
+    :title="title"
+    @close="$emit('close')"
+  >
+    <div class="flex flex-col gap-16 pt-8">
+      <div class="flex items-center justify-center">
+        <div
+          class="flex items-center justify-center w-48 h-48 rounded-12"
+          :class="iconTone === 'warning' ? 'bg-warning-100' : 'bg-accent-100'"
+        >
+          <SvgIcon
+            :name="icon"
+            class="!w-24 !h-24"
+            :class="iconTone === 'warning' ? 'text-warning-500' : 'text-accent-600'"
+          />
+        </div>
+      </div>
+
+      <div class="flex flex-col gap-8">
+        <p class="text-p2 text-content-primary text-center font-medium">
+          {{ headline }}
+        </p>
+        <p class="text-p3 text-content-secondary text-center">
+          {{ body }}
+        </p>
+      </div>
+
+      <div
+        v-if="bullets.length"
+        class="flex flex-col gap-8 p-12 rounded-12 bg-surface-secondary"
+      >
+        <div
+          v-for="(bullet, index) in bullets"
+          :key="index"
+          class="flex items-start gap-8"
+        >
+          <SvgIcon
+            name="check-circle"
+            class="!w-16 !h-16 text-accent-600 mt-2 shrink-0"
+          />
+          <p class="text-p3 text-content-secondary">
+            {{ bullet }}
+          </p>
+        </div>
+      </div>
+
+      <UiButton
+        variant="primary"
+        size="large"
+        @click="$emit('close')"
+      >
+        Got it
+      </UiButton>
+    </div>
+  </BaseModalWrapper>
+</template>


### PR DESCRIPTION
## What

Two related consolidations of duplicated components in one PR.

### Vault metadata badges (4 files → 1 shared)

`AccessControlBadge`, `CyclicalNoteBadge`, `GovernanceLimitedBadge`, and `KeyringBadge` were near-identical: same props block, same `openInfoModal` handler, same `<VaultMetadataTag>` template. They differed only in `icon`, `label`, `title`, and which info modal `useModal().open()` received.

- Added `VaultMetadataBadge.vue`, parameterised by `{ icon, label, title, modal }` (with `modal` passed as a component prop) plus the forwarded layout props (`size`, `block`, `as`, `nudge`).
- Reduced the four badges to thin wrappers that supply their specific values. Their public component names are unchanged, so every call site works untouched.
- `RestrictedBadge` is intentionally left alone — it is a different variant built on `UiHoverPreviewTooltip`.

### Info modals (5 files sharing one skeleton)

`AccessControlInfoModal`, `CyclicalNoteInfoModal`, `GovernanceLimitedInfoModal`, `RestrictedInfoModal`, and `KeyringInfoModal` all shared the same layout: `BaseModalWrapper` → centred `w-48 h-48 rounded-12` icon badge → centred headline + body → "Got it" button, with an optional `check-circle` bullet list in a `bg-surface-secondary` box.

- Added `UiInfoModal.vue` with props `title`, `icon`, `iconTone` (`accent` | `warning`), `headline`, `body`, optional `bullets`, and a `close` emit.
- Reduced the five modals to props-only usages of `UiInfoModal`. Their public component names are preserved, so the badge components and `RestrictedBadge`'s `modal.open(..., { props: { variant } })` call keep their existing API.

## Notes

- Rendered output is byte-for-byte equivalent: classes, spacing, icons, tones, and copy are all preserved. `RestrictedInfoModal` keeps its warning tone via `iconTone="warning"`.
- No `data-*` attributes existed on any of the affected components.

## Net LOC

11 files changed, +178 / -309 (net -131).

## Validation

- `npx eslint` on all 11 changed files: clean.
- `npx vitest run tests/composables/useVaultTypeBadges.test.ts`: 9 passed.