### PR TITLE
fix: resolve eslint errors to unblock blocking lint CI gate

### DIFF
--- a/components/ui/directives/text-fit.ts
+++ b/components/ui/directives/text-fit.ts
@@ -18,7 +18,6 @@ const updateSize = (el: HTMLElement) => {
       currentFontSize++
       if (isOverflowed(el)) {
         el.style.fontSize = (currentFontSize - 1) + 'px'
-        currentFontSize--
         return
       }
     }

--- a/middleware/ensure-vault.global.ts
+++ b/middleware/ensure-vault.global.ts
@@ -92,7 +92,7 @@ export default defineNuxtRouteMiddleware(async (to, from) => {
     return
   }
 
-  let vaultAddress: string | null = null
+  let vaultAddress: string
   try {
     vaultAddress = getAddress(String(normalizeParam(rawVault)))
   }

--- a/scripts/parity-compare.mjs
+++ b/scripts/parity-compare.mjs
@@ -295,7 +295,7 @@ async function loadLocalEnvFiles() {
   const loaded = []
   for (const envFile of envFiles) {
     const filePath = path.resolve(ROOT_DIR, envFile)
-    let content = ''
+    let content
 
     try {
       content = await fs.readFile(filePath, 'utf8')
@@ -1236,7 +1236,7 @@ async function capturePlanAndFollowPlans({ appDefinition, app: startedApp = null
   if (ownsApp) state.apps = [app]
   const ownsRuntime = !runtime
   const activeRuntime = runtime || await createAppPhaseRuntime(browser, plan.scenario)
-  let pageResult = null
+  let pageResult
 
   try {
     await prepareRuntimeForScenario(activeRuntime, plan.scenario)
@@ -1331,7 +1331,7 @@ async function capturePlanWithModalsSequential({ appDefinition, app: startedApp 
   if (ownsApp) state.apps = [app]
   const ownsRuntime = !runtime
   const activeRuntime = runtime || await createAppPhaseRuntime(browser, plan.scenario)
-  let pageResult = null
+  let pageResult
 
   try {
     await prepareRuntimeForScenario(activeRuntime, plan.scenario)
@@ -1449,7 +1449,7 @@ async function captureModalPlanSequential({ appDefinition, app: startedApp = nul
   if (ownsApp) state.apps = [app]
   const ownsRuntime = !runtime
   const activeRuntime = runtime || await createAppPhaseRuntime(browser, plan.scenario)
-  let pageResult = null
+  let pageResult
 
   try {
     await prepareRuntimeForScenario(activeRuntime, plan.scenario)
@@ -2090,7 +2090,7 @@ async function waitForSelectors(page, selectors = [], timeout = 45_000) {
       await page.waitForSelector(selector, { state: 'attached', timeout })
     }
     catch (error) {
-      throw new Error('Timed out waiting for selector "' + selector + '": ' + (error?.message || String(error)))
+      throw new Error('Timed out waiting for selector "' + selector + '": ' + (error?.message || String(error)), { cause: error })
     }
   }
 }
@@ -2195,7 +2195,7 @@ async function hydrateListPageBeforeScrape(page, pathName) {
   let stableRounds = 0
   let fullRenderRounds = 0
   let previousSignature = ''
-  let lastState = null
+  let lastState
 
   do {
     await scrollListPage(page)

--- a/scripts/parity-overlay.mjs
+++ b/scripts/parity-overlay.mjs
@@ -1075,6 +1075,7 @@ async function launchBrowser() {
     throw new Error(
       'Could not launch a browser. Install Playwright Chromium with "npx playwright install chromium" or set PARITY_BROWSER_CHANNEL to an installed channel. Original error: '
       + error.message,
+      { cause: error },
     )
   }
 }

--- a/scripts/public-endpoint-parity.mjs
+++ b/scripts/public-endpoint-parity.mjs
@@ -511,7 +511,7 @@ async function loadLocalEnvFiles() {
   const loaded = []
   for (const envFile of envFiles) {
     const filePath = path.resolve(ROOT_DIR, envFile)
-    let content = ''
+    let content
     try {
       content = await fs.readFile(filePath, 'utf8')
     }

--- a/utils/pyth.ts
+++ b/utils/pyth.ts
@@ -374,7 +374,7 @@ export const buildPythBatchItemsFromFeeds = async (
     const updateData = await fetchPythUpdateData([...feedSet], hermesEndpoint)
     if (!updateData.length) continue
 
-    let fee = 0n
+    let fee: bigint
     try {
       // The SDK is linked from a workspace and ships its own viem (2.43.x), so
       // its PublicClient is structurally similar but not identical to the app's


### PR DESCRIPTION
## Problem

`npm run lint` failed on `development` with 11 pre-existing eslint errors, spread across scripts, middleware and utils. Because lint was red, the new CI workflow had to run its lint job with `continue-on-error`, so lint could not act as a blocking gate.

This change fixes every error so `npm run lint` exits clean (0 errors, no new warnings), unblocking the move to make the CI lint job a blocking gate.

## Fixes

Errors were `no-useless-assignment` (dead initializers overwritten before any read) and `preserve-caught-error` (rethrown errors dropping their cause). Changes are behavior-preserving.

- **components/ui/directives/text-fit.ts** — dropped a `currentFontSize--` immediately followed by `return`; the value is never read again (the preceding `el.style.fontSize` write is the meaningful effect).
- **middleware/ensure-vault.global.ts** — removed the `= null` initializer on `vaultAddress`; the `try` assigns it before use and the `catch` returns, so the initial value was never observed.
- **utils/pyth.ts** — removed the `= 0n` initializer on `fee`; assigned in the `try` before use, and the `catch` `continue`s past the read.
- **scripts/parity-compare.mjs** — removed dead initializers on `content`, three `pageResult` declarations and `lastState` (each assigned before any read within the enclosing `try`/`do` body); attached `{ cause }` to the selector-timeout error so the original error is preserved.
- **scripts/parity-overlay.mjs** — attached `{ cause }` to the browser-launch failure error.
- **scripts/public-endpoint-parity.mjs** — removed the dead `content = ''` initializer (assigned in `try` before use).

No dead assignment was masking a real bug; in every case the value was unconditionally overwritten before it could be read.

## Verification

- `npm run lint` exits 0 — 0 errors, 6 warnings (all pre-existing `no-explicit-any`, none new).
- `npm run test:run` — 1083 passed, 1 skipped.
