### PR TITLE
refactor: extract shared position form summary/alert/footer blocks

### DIFF
--- a/components/entities/vault/form/FormAlertStack.vue
+++ b/components/entities/vault/form/FormAlertStack.vue
@@ -1,0 +1,54 @@
+<script setup lang="ts">
+// Shared warning stack for the collateral supply/withdraw forms: region /
+// asset / swap restriction alerts followed by the estimate and simulation
+// error alerts. The restriction alerts differ only in their (already
+// composed) visibility condition and their copy, so those are passed as
+// props to keep the rendered DOM byte-identical per page.
+defineProps<{
+  isGeoBlocked?: boolean
+  assetRestricted?: boolean
+  assetRestrictedDescription?: string
+  swapRestricted?: boolean
+  swapRestrictedDescription?: string
+  estimatesError?: string
+  simulationError?: string
+}>()
+</script>
+
+<template>
+  <UiAlert
+    v-if="isGeoBlocked"
+    title="Region restricted"
+    description="This operation is not available in your region. You can still repay existing debt."
+    variant="warning"
+    size="compact"
+  />
+  <UiAlert
+    v-if="assetRestricted"
+    title="Asset restricted"
+    :description="assetRestrictedDescription"
+    variant="warning"
+    size="compact"
+  />
+  <UiAlert
+    v-if="swapRestricted"
+    title="Swap restricted"
+    :description="swapRestrictedDescription"
+    variant="warning"
+    size="compact"
+  />
+  <UiAlert
+    v-show="estimatesError"
+    title="Error"
+    variant="error"
+    :description="estimatesError"
+    size="compact"
+  />
+  <UiAlert
+    v-if="simulationError"
+    title="Error"
+    variant="error"
+    :description="simulationError"
+    size="compact"
+  />
+</template>

--- a/components/entities/vault/form/FormSubmitFooter.vue
+++ b/components/entities/vault/form/FormSubmitFooter.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+import type { BorrowVaultPair } from '~/types/borrow-pair'
+import type { EVault, SecuritizeCollateralVault, PortfolioBorrowPosition, VaultEntity } from '@eulerxyz/euler-v2-sdk'
+import type { DisabledReasonVariant } from '~/components/entities/vault/form/types'
+
+// Shared submit footer used by the position action forms: an optional
+// "Vault/Pair information" button stacked above the primary submit button,
+// inside the grid-positioned wrapper `laptop:col-start-1 laptop:row-start-2`.
+//
+// The info button renders only when `infoVault` or `infoPair` is provided; the
+// submit label is passed via the default slot.
+defineProps<{
+  // VaultFormInfoButton bindings (info button omitted when neither is set)
+  infoVault?: EVault | SecuritizeCollateralVault
+  infoPair?: BorrowVaultPair | PortfolioBorrowPosition<VaultEntity>
+  infoDisabled?: boolean
+  // VaultFormSubmit bindings
+  submitDisabled?: boolean
+  submitLoading?: boolean
+  disabledReason?: string
+  disabledReasonVariant?: DisabledReasonVariant
+  canAddToBatch?: boolean
+}>()
+defineEmits<{ (e: 'add-to-batch'): void }>()
+</script>
+
+<template>
+  <div class="flex flex-col gap-8 laptop:col-start-1 laptop:row-start-2">
+    <VaultFormInfoButton
+      v-if="infoVault || infoPair"
+      :vault="infoVault"
+      :pair="infoPair"
+      :disabled="infoDisabled"
+    />
+    <VaultFormSubmit
+      :disabled="submitDisabled"
+      :loading="submitLoading"
+      :disabled-reason="disabledReason"
+      :disabled-reason-variant="disabledReasonVariant"
+      :can-add-to-batch="canAddToBatch"
+      @add-to-batch="$emit('add-to-batch')"
+    >
+      <slot />
+    </VaultFormSubmit>
+  </div>
+</template>

--- a/components/entities/vault/form/PositionSummaryBlock.vue
+++ b/components/entities/vault/form/PositionSummaryBlock.vue
@@ -1,0 +1,75 @@
+<script setup lang="ts">
+import { formatNumber, formatSmartAmount, formatHealthScore } from '~/utils/string-utils'
+import { formatLiquidationBuffer as formatLiqBuffer } from '~/utils/repayUtils'
+import { nanoToValue } from '~/utils/crypto-utils'
+import type { useCollateralForm } from '~/composables/position/useCollateralForm'
+
+// Shared position summary card used by the collateral supply/withdraw forms.
+// Both drive off the same `useCollateralForm` shape, so the whole form object
+// is passed through. The two per-page differences are exposed as props:
+//  - `visible`: the wrapping `v-if` (supply gates on position only, withdraw
+//    additionally requires a borrow vault).
+//  - `excludeInfiniteLiqPrice`: supply hides the current liq. price when it is
+//    `Infinity`; withdraw shows it whenever it is non-null.
+const props = defineProps<{
+  form: ReturnType<typeof useCollateralForm>
+  visible: boolean
+  excludeInfiniteLiqPrice?: boolean
+}>()
+
+const form = props.form
+</script>
+
+<template>
+  <VaultFormInfoBlock
+    v-if="visible"
+    :loading="form.isEstimatesLoading.value"
+    variant="card"
+    class="w-full laptop:max-w-[360px]"
+  >
+    <SummaryRow label="Net APY">
+      <SummaryValue
+        :before="formatNumber(form.netAPY.value)"
+        :after="formatNumber(form.estimateNetAPY.value)"
+        suffix="%"
+      />
+    </SummaryRow>
+    <SummaryRow label="Oracle price">
+      <SummaryPriceValue
+        :value="!form.priceFixed.value.isZero() ? formatSmartAmount(form.priceInvert.invertValue(form.priceFixed.value.toUnsafeFloat())) : undefined"
+        :symbol="form.priceInvert.displaySymbol"
+        invertible
+        @invert="form.priceInvert.toggle"
+      />
+    </SummaryRow>
+    <SummaryRow label="Liq. price">
+      <SummaryPriceValue
+        :before="form.liquidationPrice.value != null && (!excludeInfiniteLiqPrice || form.liquidationPrice.value !== Infinity) ? formatSmartAmount(form.priceInvert.invertValue(form.liquidationPrice.value)!) : undefined"
+        :after="form.estimateLiquidationPrice.value != null ? formatSmartAmount(form.priceInvert.invertValue(form.estimateLiquidationPrice.value)!) : undefined"
+        :symbol="form.priceInvert.displaySymbol"
+        invertible
+        @invert="form.priceInvert.toggle"
+      />
+    </SummaryRow>
+    <SummaryRow label="Liq. buffer">
+      <SummaryValue
+        :before="formatLiqBuffer(form.priceInvert.invertValue(form.priceFixed.value.toUnsafeFloat()), form.priceInvert.invertValue(form.liquidationPrice.value))"
+        :after="formatLiqBuffer(form.priceInvert.invertValue(form.priceFixed.value.toUnsafeFloat()), form.priceInvert.invertValue(form.estimateLiquidationPrice.value))"
+        suffix="%"
+      />
+    </SummaryRow>
+    <SummaryRow label="LTV">
+      <SummaryValue
+        :before="formatNumber(ltvToPercent(nanoToValue(form.position.value.userLTV ?? form.position.value.currentLTV ?? 0n, 18)))"
+        :after="formatNumber(nanoToValue(form.estimateUserLTV.value, 18))"
+        suffix="%"
+      />
+    </SummaryRow>
+    <SummaryRow label="Health score">
+      <SummaryValue
+        :before="formatHealthScore(nanoToValue(form.position.value.healthFactor ?? 0n, 18))"
+        :after="formatHealthScore(nanoToValue(form.estimateHealth.value, 18))"
+      />
+    </SummaryRow>
+  </VaultFormInfoBlock>
+</template>

--- a/pages/position/[number]/borrow/index.vue
+++ b/pages/position/[number]/borrow/index.vue
@@ -644,18 +644,16 @@ watch([collateralAmount, borrowAmount], async () => {
             </SummaryRow>
           </VaultFormInfoBlock>
 
-          <div class="flex flex-col gap-8 laptop:col-start-1 laptop:row-start-2">
-            <VaultFormSubmit
-              :disabled="reviewBorrowDisabled"
-              :loading="isSubmitting || isPreparing"
-              :disabled-reason="disabledReasonInfo?.message"
-              :disabled-reason-variant="disabledReasonInfo?.variant"
-              :can-add-to-batch="canAddToBatch"
-              @add-to-batch="addToBatch"
-            >
-              Review Borrow
-            </VaultFormSubmit>
-          </div>
+          <FormSubmitFooter
+            :submit-disabled="reviewBorrowDisabled"
+            :submit-loading="isSubmitting || isPreparing"
+            :disabled-reason="disabledReasonInfo?.message"
+            :disabled-reason-variant="disabledReasonInfo?.variant"
+            :can-add-to-batch="canAddToBatch"
+            @add-to-batch="addToBatch"
+          >
+            Review Borrow
+          </FormSubmitFooter>
         </div>
       </template>
     </VaultForm>

--- a/pages/position/[number]/borrow/swap.vue
+++ b/pages/position/[number]/borrow/swap.vue
@@ -1867,18 +1867,16 @@ function getOperationVaultAddresses(): string[] {
               size="compact"
             />
 
-            <div class="flex flex-col gap-8 laptop:col-start-1 laptop:row-start-2">
-              <VaultFormSubmit
-                :disabled="reviewRefinanceDisabled"
-                :loading="isSubmitting || isPreparing"
-                :disabled-reason="disabledReasonInfo?.message"
-                :disabled-reason-variant="disabledReasonInfo?.variant"
-                :can-add-to-batch="canAddToBatch"
-                @add-to-batch="addToBatch"
-              >
-                {{ reviewRefinanceLabel }}
-              </VaultFormSubmit>
-            </div>
+            <FormSubmitFooter
+              :submit-disabled="reviewRefinanceDisabled"
+              :submit-loading="isSubmitting || isPreparing"
+              :disabled-reason="disabledReasonInfo?.message"
+              :disabled-reason-variant="disabledReasonInfo?.variant"
+              :can-add-to-batch="canAddToBatch"
+              @add-to-batch="addToBatch"
+            >
+              {{ reviewRefinanceLabel }}
+            </FormSubmitFooter>
           </div>
 
           <VaultFormInfoBlock

--- a/pages/position/[number]/repay.vue
+++ b/pages/position/[number]/repay.vue
@@ -849,24 +849,18 @@ watch(formTab, () => {
               />
             </VaultFormInfoBlock>
 
-            <div class="flex flex-col gap-8 laptop:col-start-1 laptop:row-start-2">
-              <VaultFormInfoButton
-                :pair="position"
-                :disabled="isLoading || isSubmitting"
-              >
-                Pair information
-              </VaultFormInfoButton>
-              <VaultFormSubmit
-                :disabled="reviewRepayDisabled"
-                :loading="isSubmitting || isPreparing"
-                :disabled-reason="disabledReasonInfo?.message"
-                :disabled-reason-variant="disabledReasonInfo?.variant"
-                :can-add-to-batch="canAddToBatch"
-                @add-to-batch="addToBatch"
-              >
-                {{ reviewRepayLabel }}
-              </VaultFormSubmit>
-            </div>
+            <FormSubmitFooter
+              :info-pair="position"
+              :info-disabled="isLoading || isSubmitting"
+              :submit-disabled="reviewRepayDisabled"
+              :submit-loading="isSubmitting || isPreparing"
+              :disabled-reason="disabledReasonInfo?.message"
+              :disabled-reason-variant="disabledReasonInfo?.variant"
+              :can-add-to-batch="canAddToBatch"
+              @add-to-batch="addToBatch"
+            >
+              {{ reviewRepayLabel }}
+            </FormSubmitFooter>
           </div>
         </template>
 
@@ -1039,24 +1033,18 @@ watch(formTab, () => {
               />
             </VaultFormInfoBlock>
 
-            <div class="flex flex-col gap-8 laptop:col-start-1 laptop:row-start-2">
-              <VaultFormInfoButton
-                :pair="position"
-                :disabled="isLoading || isSubmitting"
-              >
-                Pair information
-              </VaultFormInfoButton>
-              <VaultFormSubmit
-                :disabled="reviewRepayDisabled"
-                :loading="isSubmitting || isPreparing"
-                :disabled-reason="disabledReasonInfo?.message"
-                :disabled-reason-variant="disabledReasonInfo?.variant"
-                :can-add-to-batch="canAddToBatch"
-                @add-to-batch="addToBatch"
-              >
-                {{ reviewRepayLabel }}
-              </VaultFormSubmit>
-            </div>
+            <FormSubmitFooter
+              :info-pair="position"
+              :info-disabled="isLoading || isSubmitting"
+              :submit-disabled="reviewRepayDisabled"
+              :submit-loading="isSubmitting || isPreparing"
+              :disabled-reason="disabledReasonInfo?.message"
+              :disabled-reason-variant="disabledReasonInfo?.variant"
+              :can-add-to-batch="canAddToBatch"
+              @add-to-batch="addToBatch"
+            >
+              {{ reviewRepayLabel }}
+            </FormSubmitFooter>
           </div>
         </template>
 
@@ -1225,24 +1213,18 @@ watch(formTab, () => {
               />
             </VaultFormInfoBlock>
 
-            <div class="flex flex-col gap-8 laptop:col-start-1 laptop:row-start-2">
-              <VaultFormInfoButton
-                :pair="position"
-                :disabled="isLoading || isSubmitting"
-              >
-                Pair information
-              </VaultFormInfoButton>
-              <VaultFormSubmit
-                :disabled="reviewRepayDisabled"
-                :loading="isSubmitting || isPreparing"
-                :disabled-reason="disabledReasonInfo?.message"
-                :disabled-reason-variant="disabledReasonInfo?.variant"
-                :can-add-to-batch="canAddToBatch"
-                @add-to-batch="addToBatch"
-              >
-                {{ reviewRepayLabel }}
-              </VaultFormSubmit>
-            </div>
+            <FormSubmitFooter
+              :info-pair="position"
+              :info-disabled="isLoading || isSubmitting"
+              :submit-disabled="reviewRepayDisabled"
+              :submit-loading="isSubmitting || isPreparing"
+              :disabled-reason="disabledReasonInfo?.message"
+              :disabled-reason-variant="disabledReasonInfo?.variant"
+              :can-add-to-batch="canAddToBatch"
+              @add-to-batch="addToBatch"
+            >
+              {{ reviewRepayLabel }}
+            </FormSubmitFooter>
           </div>
         </template>
       </template>

--- a/pages/position/[number]/supply.vue
+++ b/pages/position/[number]/supply.vue
@@ -4,8 +4,6 @@ import type { SwapTokenSelectMeta } from '~/components/entities/asset/SwapTokenS
 import { getCollateralOraclePrice, getAssetOraclePrice, conservativePriceRatio, getTokenUsdPrice } from '~/utils/sdk-prices'
 import type { SwapQuote, EVault } from '@eulerxyz/euler-v2-sdk'
 import { SwapperMode } from '@eulerxyz/euler-v2-sdk'
-import { formatNumber, formatSmartAmount, formatHealthScore } from '~/utils/string-utils'
-import { formatLiquidationBuffer as formatLiqBuffer } from '~/utils/repayUtils'
 import { nanoToValue } from '~/utils/crypto-utils'
 import { useCollateralForm } from '~/composables/position/useCollateralForm'
 import { usePriceImpactGate } from '~/composables/usePriceImpactGate'
@@ -384,112 +382,36 @@ watch(selectedAsset, async () => {
               size="compact"
             />
 
-            <UiAlert
-              v-if="form.isGeoBlocked.value"
-              title="Region restricted"
-              description="This operation is not available in your region. You can still repay existing debt."
-              variant="warning"
-              size="compact"
-            />
-            <UiAlert
-              v-if="!form.isGeoBlocked.value && form.isInputAssetBlocked.value"
-              title="Asset restricted"
-              description="Paying with this asset is not available in your region. Pick a different token."
-              variant="warning"
-              size="compact"
-            />
-            <UiAlert
-              v-if="!form.isGeoBlocked.value && !form.isInputAssetBlocked.value && form.isSwapRestricted.value"
-              title="Swap restricted"
-              description="Swapping into this vault is not available in your region. You can deposit the vault's underlying asset directly."
-              variant="warning"
-              size="compact"
-            />
-            <UiAlert
-              v-show="form.estimatesError.value"
-              title="Error"
-              variant="error"
-              :description="form.estimatesError.value"
-              size="compact"
-            />
-            <UiAlert
-              v-if="form.simulationError.value"
-              title="Error"
-              variant="error"
-              :description="form.simulationError.value"
-              size="compact"
+            <FormAlertStack
+              :is-geo-blocked="form.isGeoBlocked.value"
+              :asset-restricted="!form.isGeoBlocked.value && form.isInputAssetBlocked.value"
+              asset-restricted-description="Paying with this asset is not available in your region. Pick a different token."
+              :swap-restricted="!form.isGeoBlocked.value && !form.isInputAssetBlocked.value && form.isSwapRestricted.value"
+              swap-restricted-description="Swapping into this vault is not available in your region. You can deposit the vault's underlying asset directly."
+              :estimates-error="form.estimatesError.value"
+              :simulation-error="form.simulationError.value"
             />
             <VaultWarningBanner :warnings="[form.hookWarning.value]" />
           </div>
 
-          <VaultFormInfoBlock
-            v-if="form.position.value"
-            :loading="form.isEstimatesLoading.value"
-            variant="card"
-            class="w-full laptop:max-w-[360px]"
-          >
-            <SummaryRow label="Net APY">
-              <SummaryValue
-                :before="formatNumber(form.netAPY.value)"
-                :after="formatNumber(form.estimateNetAPY.value)"
-                suffix="%"
-              />
-            </SummaryRow>
-            <SummaryRow label="Oracle price">
-              <SummaryPriceValue
-                :value="!form.priceFixed.value.isZero() ? formatSmartAmount(form.priceInvert.invertValue(form.priceFixed.value.toUnsafeFloat())) : undefined"
-                :symbol="form.priceInvert.displaySymbol"
-                invertible
-                @invert="form.priceInvert.toggle"
-              />
-            </SummaryRow>
-            <SummaryRow label="Liq. price">
-              <SummaryPriceValue
-                :before="form.liquidationPrice.value != null && form.liquidationPrice.value !== Infinity ? formatSmartAmount(form.priceInvert.invertValue(form.liquidationPrice.value)!) : undefined"
-                :after="form.estimateLiquidationPrice.value != null ? formatSmartAmount(form.priceInvert.invertValue(form.estimateLiquidationPrice.value)!) : undefined"
-                :symbol="form.priceInvert.displaySymbol"
-                invertible
-                @invert="form.priceInvert.toggle"
-              />
-            </SummaryRow>
-            <SummaryRow label="Liq. buffer">
-              <SummaryValue
-                :before="formatLiqBuffer(form.priceInvert.invertValue(form.priceFixed.value.toUnsafeFloat()), form.priceInvert.invertValue(form.liquidationPrice.value))"
-                :after="formatLiqBuffer(form.priceInvert.invertValue(form.priceFixed.value.toUnsafeFloat()), form.priceInvert.invertValue(form.estimateLiquidationPrice.value))"
-                suffix="%"
-              />
-            </SummaryRow>
-            <SummaryRow label="LTV">
-              <SummaryValue
-                :before="formatNumber(ltvToPercent(nanoToValue(form.position.value.userLTV ?? form.position.value.currentLTV ?? 0n, 18)))"
-                :after="formatNumber(nanoToValue(form.estimateUserLTV.value, 18))"
-                suffix="%"
-              />
-            </SummaryRow>
-            <SummaryRow label="Health score">
-              <SummaryValue
-                :before="formatHealthScore(nanoToValue(form.position.value.healthFactor ?? 0n, 18))"
-                :after="formatHealthScore(nanoToValue(form.estimateHealth.value, 18))"
-              />
-            </SummaryRow>
-          </VaultFormInfoBlock>
+          <PositionSummaryBlock
+            :form="form"
+            :visible="!!form.position.value"
+            exclude-infinite-liq-price
+          />
 
-          <div class="flex flex-col gap-8 laptop:col-start-1 laptop:row-start-2">
-            <VaultFormInfoButton
-              :disabled="form.isLoading.value || form.isSubmitting.value"
-              :vault="form.collateralVault.value"
-            />
-            <VaultFormSubmit
-              :disabled="form.submitDisabled.value"
-              :loading="form.isSubmitting.value || form.isPreparing.value"
-              :disabled-reason="disabledReasonInfo?.message"
-              :disabled-reason-variant="disabledReasonInfo?.variant"
-              :can-add-to-batch="canAddToBatch"
-              @add-to-batch="addToBatch"
-            >
-              {{ form.submitLabel }}
-            </VaultFormSubmit>
-          </div>
+          <FormSubmitFooter
+            :info-vault="form.collateralVault.value"
+            :info-disabled="form.isLoading.value || form.isSubmitting.value"
+            :submit-disabled="form.submitDisabled.value"
+            :submit-loading="form.isSubmitting.value || form.isPreparing.value"
+            :disabled-reason="disabledReasonInfo?.message"
+            :disabled-reason-variant="disabledReasonInfo?.variant"
+            :can-add-to-batch="canAddToBatch"
+            @add-to-batch="addToBatch"
+          >
+            {{ form.submitLabel }}
+          </FormSubmitFooter>
         </div>
       </template>
     </VaultForm>

--- a/pages/position/[number]/withdraw.vue
+++ b/pages/position/[number]/withdraw.vue
@@ -5,8 +5,6 @@ import { getUtilisationWarning } from '~/composables/useVaultWarnings'
 import { getAssetOraclePrice, getCollateralOraclePrice, conservativePriceRatio } from '~/utils/sdk-prices'
 import type { SwapQuote, EVault } from '@eulerxyz/euler-v2-sdk'
 import { SwapperMode } from '@eulerxyz/euler-v2-sdk'
-import { formatNumber, formatSmartAmount, formatHealthScore } from '~/utils/string-utils'
-import { formatLiquidationBuffer as formatLiqBuffer } from '~/utils/repayUtils'
 import { nanoToValue } from '~/utils/crypto-utils'
 import { useCollateralForm } from '~/composables/position/useCollateralForm'
 import { usePriceImpactGate } from '~/composables/usePriceImpactGate'
@@ -375,113 +373,36 @@ watch(selectedOutputAsset, () => {
               size="compact"
             />
 
-            <UiAlert
-              v-if="form.isGeoBlocked.value"
-              title="Region restricted"
-              description="This operation is not available in your region. You can still repay existing debt."
-              variant="warning"
-              size="compact"
-            />
-            <UiAlert
-              v-if="!form.isGeoBlocked.value && (form.isOutputAssetBlocked.value || form.isOutputAssetRestricted.value)"
-              title="Asset restricted"
-              description="Receiving this asset is not available in your region. Pick a different token."
-              variant="warning"
-              size="compact"
-            />
-            <UiAlert
-              v-if="!form.isGeoBlocked.value && !form.isOutputAssetBlocked.value && !form.isOutputAssetRestricted.value && form.isSwapRestricted.value"
-              title="Swap restricted"
-              description="Swapping from this vault is not available in your region. You can withdraw the vault's underlying asset directly."
-              variant="warning"
-              size="compact"
-            />
-            <UiAlert
-              v-show="form.estimatesError.value"
-              title="Error"
-              variant="error"
-              :description="form.estimatesError.value"
-              size="compact"
-            />
-            <UiAlert
-              v-if="form.simulationError.value"
-              title="Error"
-              variant="error"
-              :description="form.simulationError.value"
-              size="compact"
+            <FormAlertStack
+              :is-geo-blocked="form.isGeoBlocked.value"
+              :asset-restricted="!form.isGeoBlocked.value && (form.isOutputAssetBlocked.value || form.isOutputAssetRestricted.value)"
+              asset-restricted-description="Receiving this asset is not available in your region. Pick a different token."
+              :swap-restricted="!form.isGeoBlocked.value && !form.isOutputAssetBlocked.value && !form.isOutputAssetRestricted.value && form.isSwapRestricted.value"
+              swap-restricted-description="Swapping from this vault is not available in your region. You can withdraw the vault's underlying asset directly."
+              :estimates-error="form.estimatesError.value"
+              :simulation-error="form.simulationError.value"
             />
 
             <VaultWarningBanner :warnings="withdrawWarnings" />
           </div>
 
-          <VaultFormInfoBlock
-            v-if="form.position.value && form.borrowVault.value"
-            :loading="form.isEstimatesLoading.value"
-            variant="card"
-            class="w-full laptop:max-w-[360px]"
-          >
-            <SummaryRow label="Net APY">
-              <SummaryValue
-                :before="formatNumber(form.netAPY.value)"
-                :after="formatNumber(form.estimateNetAPY.value)"
-                suffix="%"
-              />
-            </SummaryRow>
-            <SummaryRow label="Oracle price">
-              <SummaryPriceValue
-                :value="!form.priceFixed.value.isZero() ? formatSmartAmount(form.priceInvert.invertValue(form.priceFixed.value.toUnsafeFloat())) : undefined"
-                :symbol="form.priceInvert.displaySymbol"
-                invertible
-                @invert="form.priceInvert.toggle"
-              />
-            </SummaryRow>
-            <SummaryRow label="Liq. price">
-              <SummaryPriceValue
-                :before="form.liquidationPrice.value != null ? formatSmartAmount(form.priceInvert.invertValue(form.liquidationPrice.value)!) : undefined"
-                :after="form.estimateLiquidationPrice.value != null ? formatSmartAmount(form.priceInvert.invertValue(form.estimateLiquidationPrice.value)!) : undefined"
-                :symbol="form.priceInvert.displaySymbol"
-                invertible
-                @invert="form.priceInvert.toggle"
-              />
-            </SummaryRow>
-            <SummaryRow label="Liq. buffer">
-              <SummaryValue
-                :before="formatLiqBuffer(form.priceInvert.invertValue(form.priceFixed.value.toUnsafeFloat()), form.priceInvert.invertValue(form.liquidationPrice.value))"
-                :after="formatLiqBuffer(form.priceInvert.invertValue(form.priceFixed.value.toUnsafeFloat()), form.priceInvert.invertValue(form.estimateLiquidationPrice.value))"
-                suffix="%"
-              />
-            </SummaryRow>
-            <SummaryRow label="LTV">
-              <SummaryValue
-                :before="formatNumber(ltvToPercent(nanoToValue(form.position.value.userLTV ?? form.position.value.currentLTV ?? 0n, 18)))"
-                :after="formatNumber(nanoToValue(form.estimateUserLTV.value, 18))"
-                suffix="%"
-              />
-            </SummaryRow>
-            <SummaryRow label="Health score">
-              <SummaryValue
-                :before="formatHealthScore(nanoToValue(form.position.value.healthFactor ?? 0n, 18))"
-                :after="formatHealthScore(nanoToValue(form.estimateHealth.value, 18))"
-              />
-            </SummaryRow>
-          </VaultFormInfoBlock>
+          <PositionSummaryBlock
+            :form="form"
+            :visible="!!(form.position.value && form.borrowVault.value)"
+          />
 
-          <div class="flex flex-col gap-8 laptop:col-start-1 laptop:row-start-2">
-            <VaultFormInfoButton
-              :disabled="form.isLoading.value || form.isSubmitting.value"
-              :vault="form.collateralVault.value"
-            />
-            <VaultFormSubmit
-              :disabled="form.submitDisabled.value"
-              :loading="form.isSubmitting.value || form.isPreparing.value"
-              :disabled-reason="disabledReasonInfo?.message"
-              :disabled-reason-variant="disabledReasonInfo?.variant"
-              :can-add-to-batch="canAddToBatch"
-              @add-to-batch="addToBatch"
-            >
-              {{ form.submitLabel }}
-            </VaultFormSubmit>
-          </div>
+          <FormSubmitFooter
+            :info-vault="form.collateralVault.value"
+            :info-disabled="form.isLoading.value || form.isSubmitting.value"
+            :submit-disabled="form.submitDisabled.value"
+            :submit-loading="form.isSubmitting.value || form.isPreparing.value"
+            :disabled-reason="disabledReasonInfo?.message"
+            :disabled-reason-variant="disabledReasonInfo?.variant"
+            :can-add-to-batch="canAddToBatch"
+            @add-to-batch="addToBatch"
+          >
+            {{ form.submitLabel }}
+          </FormSubmitFooter>
         </div>
       </template>
     </VaultForm>


### PR DESCRIPTION
## What

The position action forms each copy-pasted up to three near-identical template blocks — a position summary card, a warning alert stack, and a submit footer. This extracts the shared shapes into reusable components under `components/entities/vault/form/`, keeping the rendered DOM byte-for-byte identical on every page.

## New components

**`PositionSummaryBlock.vue`** — the summary card (Net APY / Oracle price / Liq. price / Liq. buffer / LTV / Health score). Both consumers drive off the same `useCollateralForm` shape, so the whole `form` object is passed through. Per-page variance is exposed as props:
- `visible` — the wrapping `v-if` (supply gates on the position; withdraw additionally requires a borrow vault).
- `excludeInfiniteLiqPrice` — supply hides an `Infinity` current liq. price; withdraw shows any non-null value.

Used by: `supply`, `withdraw`.

**`FormAlertStack.vue`** — the region / asset / swap restriction alerts followed by the estimate and simulation error alerts. The restriction alerts differ only in their (already composed) visibility condition and copy, so those are passed as props (`isGeoBlocked`, `assetRestricted` + `assetRestrictedDescription`, `swapRestricted` + `swapRestrictedDescription`, `estimatesError`, `simulationError`).

Used by: `supply`, `withdraw`.

**`FormSubmitFooter.vue`** — the grid-positioned `laptop:col-start-1 laptop:row-start-2` footer wrapping an optional info button above the primary submit. The info button renders only when `infoVault` or `infoPair` is set; submit bindings (`submitDisabled`, `submitLoading`, `disabledReason`, `disabledReasonVariant`, `canAddToBatch`, `add-to-batch`) and the label slot cover the rest.

Used by: `supply`, `withdraw` (info button by vault), the three `repay` tabs (info button by pair), `borrow` and `borrow/swap` (submit only).

## Left inline (too divergent to share)

- **ROE-style summary cards** in the repay collateral/savings tabs, `multiply`, and `borrow/swap` — different composables and prefixes, extra/conditional rows (ROE, Swap price vs Transfer, Borrow LTV, per-leg swap rows) and custom inline markup.
- **`borrow` landing page footer** (`pages/borrow/[collateral]/[borrow]`) — uses a `#buttons` slot with two conditional submits and `extra-vault`, with no grid wrapper.
- **`multiply` footer** — its submit sits directly in the input column with no `col-start`/`row-start` wrapper, so wrapping it would alter layout.
- Alert stacks on repay / borrow / multiply / swap — divergent conditions and copy.

## Net LOC

Pages: 105 insertions, 284 deletions. New shared components: 175 lines.

## Validation

- `eslint` clean on all changed files and new components.
- `nuxt typecheck` passes (exit 0, no errors).
- `vitest run` — 1083 passed, 1 skipped. (Golden suite not run: it requires the `../euler-lite-sdk-exec-legacy` sibling worktree, which is not present here; these changes are template-only and do not touch tx-plan builders.)
