### PR TITLE
fix: remove IRM config tooltip

### DIFF
--- a/tests/utils/discovery-calculations.test.ts
+++ b/tests/utils/discovery-calculations.test.ts
@@ -17,6 +17,7 @@ import type { VaultBadDebtCacheEntry } from '~/utils/vault-bad-debt'
 import type { MarketGroup } from '~/entities/lend-discovery'
 import type { EVault, EVaultCollateral, SecuritizeCollateralVault } from '@eulerxyz/euler-v2-sdk'
 import { VaultRewardInfo } from '@eulerxyz/euler-v2-sdk'
+import { INTEREST_RATE_MODEL_TYPE } from '~/entities/constants'
 
 vi.mock('~/entities/euler/labels', () => ({
   getEulerLabelEntityLogo: (logo: string) => `/entities/${logo}`,
@@ -409,7 +410,7 @@ describe('attribute config matrix', () => {
         socializeDebt: true,
       },
       interestRateModel: {
-        type: 0,
+        type: INTEREST_RATE_MODEL_TYPE.KINK,
         address: '0xIrm',
       },
     } as unknown as EVault
@@ -422,6 +423,8 @@ describe('attribute config matrix', () => {
 
     expect(byRow.get('interestFee')!.display).toBe('10.00%')
     expect(byRow.get('maxLiqDiscount')!.display).toBe('15%')
+    expect(byRow.get('irmType')!.display).toBe('Kink')
+    expect(byRow.get('irmType')!.hint).toBeUndefined()
   })
 })
 

--- a/utils/discoveryCalculations.ts
+++ b/utils/discoveryCalculations.ts
@@ -799,7 +799,7 @@ export const CONFIG_ROWS: AttributeRow[] = [
       const label = isVaultCyclicalNote(vault.address)
         ? 'Cyclical note'
         : getIrmTypeLabel(typeof t === 'number' ? t : undefined)
-      return { display: label, kind: 'text', hint: vault.interestRateModel.address }
+      return { display: label, kind: 'text' }
     },
   },
   {


### PR DESCRIPTION
## Summary
- Remove the interest-rate-model address tooltip from the Configuration matrix while keeping the visible IRM type label.
- Avoid exposing placeholder or low-value IRM address text in Config rows.

## Changes
- Stop returning the IRM address as the Config matrix cell hint for the Interest rate model row.
- Add focused coverage that the IRM type still renders and the tooltip hint is absent.

## Test plan
- [x] npm run test:run -- tests/utils/discovery-calculations.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the display of interest rate model information so it now shows only the model label, without extra hint text.
  * Updated related checks to ensure the model type is shown correctly and no hint appears where it shouldn’t.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->