### PR TITLE
fix: stop oracle adapter reloads from freezing explore matrix

### DIFF
--- a/composables/useEulerOracleAdapters.ts
+++ b/composables/useEulerOracleAdapters.ts
@@ -37,6 +37,13 @@ const normalizeOracleAdapterMap = (
 const loadAllOracleAdapters = async (chainId: number): Promise<void> => {
   if (!Number.isInteger(chainId) || chainId <= 0) return
 
+  // The dataset is fetched whole per chain, so once it's loaded a lookup miss
+  // means the adapter genuinely isn't in it — reloading cannot surface it and
+  // would replace oracleAdaptersRef with a fresh object, re-triggering every
+  // subscriber (see the loadOracleAdapter miss path, which lands here on each
+  // call for an unlisted adapter).
+  if (oracleAdaptersChainId.value === chainId) return
+
   const inflight = pendingOracleAdapterLoads.get(chainId)
   if (inflight) {
     await inflight
@@ -78,8 +85,17 @@ const loadOracleAdapters = async (chainId: number, addresses?: string[]) => {
   await Promise.all(addresses.map(addr => loadOracleAdapter(chainId, addr)))
 }
 
+// Module-level singleton: toReactive() wraps the computed in reactive(), whose
+// isReadonly() probe reads a property through the proxy — a reactive read of
+// the computed at construction time. Built per-call inside useEulerOracleAdapters,
+// that read would subscribe whatever effect is currently running (e.g. a computed
+// that reaches useEulerLabels() mid-evaluation) to oracleAdaptersRef, coupling
+// unrelated reactive state to oracle-adapter loads. Constructing it once at
+// module init (no active effect) keeps the subscription surface to actual readers.
+const oracleAdapters = toReactive(computed(() => oracleAdaptersRef.value))
+
 export const useEulerOracleAdapters = () => ({
-  oracleAdapters: toReactive(computed(() => oracleAdaptersRef.value)),
+  oracleAdapters,
   loadOracleAdapter,
   loadOracleAdapters,
   loadAllOracleAdapters,

--- a/tests/composables/useEulerOracleAdapters.test.ts
+++ b/tests/composables/useEulerOracleAdapters.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { computed } from 'vue'
+
+const { fetchOracleAdapterMap } = vi.hoisted(() => ({
+  fetchOracleAdapterMap: vi.fn(),
+}))
+
+vi.mock('~/composables/useEulerSdk', () => ({
+  getEulerSdk: async () => ({ oracleAdapterService: { fetchOracleAdapterMap } }),
+}))
+
+const KNOWN_ADAPTER = '0x0000000000000000000000000000000000000001'
+const UNLISTED_ADAPTER = '0x0000000000000000000000000000000000000002'
+
+describe('useEulerOracleAdapters', () => {
+  afterEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+  })
+
+  it('loads the adapter map once per chain and serves later misses from the loaded map', async () => {
+    fetchOracleAdapterMap.mockResolvedValue({
+      [KNOWN_ADAPTER]: { oracle: KNOWN_ADAPTER, name: 'Known' },
+    })
+    const { useEulerOracleAdapters } = await import('~/composables/useEulerOracleAdapters')
+    const { loadOracleAdapter } = useEulerOracleAdapters()
+
+    const known = await loadOracleAdapter(1, KNOWN_ADAPTER)
+    expect(known?.name).toBe('Known')
+    expect(fetchOracleAdapterMap).toHaveBeenCalledTimes(1)
+
+    // A miss on an already-loaded chain must not refetch: the dataset is
+    // fetched whole per chain, so reloading cannot surface an unlisted
+    // adapter — and the rewrite of the store would re-trigger every
+    // subscriber (regression: infinite update loop freezing the explore page
+    // for markets whose custom adapters are absent from the dataset).
+    const missing = await loadOracleAdapter(1, UNLISTED_ADAPTER)
+    expect(missing).toBeUndefined()
+    expect(fetchOracleAdapterMap).toHaveBeenCalledTimes(1)
+  })
+
+  it('reloads when the chain changes', async () => {
+    fetchOracleAdapterMap.mockResolvedValue({})
+    const { useEulerOracleAdapters } = await import('~/composables/useEulerOracleAdapters')
+    const { loadAllOracleAdapters } = useEulerOracleAdapters()
+
+    await loadAllOracleAdapters(1)
+    await loadAllOracleAdapters(1)
+    expect(fetchOracleAdapterMap).toHaveBeenCalledTimes(1)
+
+    await loadAllOracleAdapters(2)
+    expect(fetchOracleAdapterMap).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not subscribe the calling effect to adapter loads', async () => {
+    // Calling useEulerOracleAdapters() inside a computed (e.g. via
+    // useEulerLabels() deep in the market-groups pipeline) must not make that
+    // computed a subscriber of the adapter store. The shared reactive view is
+    // built once at module scope because toReactive()'s reactive() wrapper
+    // performs a property read through the proxy at construction time, which
+    // would otherwise register the currently-running effect as a dependent.
+    fetchOracleAdapterMap.mockResolvedValue({
+      [KNOWN_ADAPTER]: { oracle: KNOWN_ADAPTER, name: 'Known' },
+    })
+    const { useEulerOracleAdapters } = await import('~/composables/useEulerOracleAdapters')
+
+    let evaluations = 0
+    const bystander = computed(() => {
+      useEulerOracleAdapters()
+      return ++evaluations
+    })
+    expect(bystander.value).toBe(1)
+
+    await useEulerOracleAdapters().loadAllOracleAdapters(1)
+    expect(bystander.value).toBe(1)
+
+    // Actual readers of the map still react to the load.
+    const { oracleAdapters } = useEulerOracleAdapters()
+    expect(oracleAdapters[KNOWN_ADAPTER]?.name).toBe('Known')
+  })
+})


### PR DESCRIPTION
## Problem

Selecting a cell in the explore matrix **Oracles** view froze the whole page — no error logged — for markets whose oracle adapters are not present in the oracle-checks dataset (e.g. Poppie Ondo Markets on BSC, whose pairs are priced by custom adapters).

Reproduced and traced with an instrumented dev build; it is an infinite reactive update loop cycling every ~7 ms:

1. The mounted oracle-details block calls `loadOracleAdapter` for each route step. For an adapter missing from the dataset the lookup misses, so it fell through to `loadAllOracleAdapters`, which re-fetched the chain's adapter map (served from the SDK's in-memory cache) and **replaced `oracleAdaptersRef` with a fresh object on every call**.
2. `useEulerOracleAdapters()` built its `toReactive(computed(...))` view **per call**. `toReactive` wraps the proxy in `reactive()`, whose `isReadonly` probe reads a property through the proxy — a reactive read of the underlying computed at construction time. That subscribes whatever effect is currently running. Market-group computation reaches `useEulerLabels()` (→ `useEulerOracleAdapters()`) mid-evaluation via governor verification, so `marketGroupsSync` became a subscriber of the adapter store.
3. Store rewrite → market groups recompute → new `markets` array → accordion re-renders → the oracle block's `routeSteps` watch refires (its `collateral-vaults` prop is a fresh array per render) → another lookup miss → back to 1.

Vue's "Maximum recursive updates" guard is dev-only, so production builds spin silently — the tab just hangs.

## Fix

Both legs of the loop are removed in `composables/useEulerOracleAdapters.ts`:

- `loadAllOracleAdapters` returns early when the chain's map is already loaded. The dataset is fetched whole per chain, so a lookup miss can never be resolved by reloading; the refetch only churned every subscriber. Chain switches still reload, and a failed load leaves the chain id unset so it retries.
- The `toReactive(computed(...))` view is now a module-level singleton, so calling the composable inside a running effect no longer registers that effect as a dependent of the store.

Either change alone breaks the cycle; together they remove both the redundant trigger and the accidental coupling.

## Verification

- Playwright repro against a local dev build: before the fix, clicking an oracle cell on the Poppie Ondo matrix left the main thread permanently unresponsive (even `page.evaluate(() => 1 + 1)` never ran); after the fix the page stays responsive and the oracle details section renders both custom adapters with live prices.
- New unit tests in `tests/composables/useEulerOracleAdapters.test.ts` cover: no refetch on a miss for an already-loaded chain, reload on chain change, and no subscription leak into a calling effect.
- `eslint` and `nuxt typecheck` pass.

## Notes

Same latent pattern exists elsewhere but is out of scope here: the per-call `toReactive(computed(...))` factories in `useEulerLabels.ts` (`useEulerProductOfVault` etc.) subscribe callers to `labelsData` at construction the same way, but their target rarely changes and no feedback cycle exists today.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unnecessary reloads of oracle adapter data when the requested chain has already been loaded.
  * Kept loaded adapter data stable to avoid replacing the current values on repeat requests.
  * Improved shared reactive behavior so adapter updates are reflected consistently across the app without extra recalculations.

* **Tests**
  * Added coverage for chain-based loading, cached reuse, chain switching, and reactive update behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->