### PR TITLE
Render Earn detail from cached vault

### DIFF
--- a/composables/useVaults.ts
+++ b/composables/useVaults.ts
@@ -71,6 +71,7 @@ const isMarketDataResolved = ref(false)
 // Incremented in resetVaultsState(); any async operation capturing an older generation
 // must stop registering vaults.
 const loadGeneration = ref(0)
+const EARN_VAULT_REGISTRY_WAIT_MS = 10_000
 
 interface UpdateEVaultsOptions {
   verifiedAddresses?: ReadonlySet<string>
@@ -979,16 +980,22 @@ const getEarnVault = async (address: string): Promise<EulerEarn> => {
   const normalizedAddress = getAddress(address)
   const { earnVaults } = useEulerLabels()
 
-  if (earnVaults.value.includes(normalizedAddress) && !isEarnVaultNotExplorable(normalizedAddress)) {
-    await until(computed(() => Boolean(registryGetVault(normalizedAddress)))).toMatch(Boolean)
-  }
-  else {
+  const fetchAndStoreEarnVault = async () => {
     const vault = await useVaultRegistry().fetchVaultByType(normalizedAddress, 'earn') as EulerEarn
     registrySet(normalizedAddress, vault, 'earn')
     return vault
   }
 
-  return registryGetVault(normalizedAddress) as EulerEarn
+  if (earnVaults.value.includes(normalizedAddress) && !isEarnVaultNotExplorable(normalizedAddress)) {
+    await Promise.race([
+      until(computed(() => Boolean(registryGetVault(normalizedAddress)))).toMatch(Boolean),
+      new Promise<void>(resolve => setTimeout(resolve, EARN_VAULT_REGISTRY_WAIT_MS)),
+    ])
+    const cachedVault = registryGetVault(normalizedAddress)
+    return cachedVault ? cachedVault as EulerEarn : await fetchAndStoreEarnVault()
+  }
+
+  return await fetchAndStoreEarnVault()
 }
 const updateVault = async (vaultAddress: string): Promise<EVault | SecuritizeCollateralVault> => {
   const { set: registrySet, isKnownEscrowAddress, getType } = useVaultRegistry()

--- a/pages/earn/[vault]/index.vue
+++ b/pages/earn/[vault]/index.vue
@@ -22,7 +22,7 @@ const { planDeposit, executePlan } = useEulerTx()
 const { addEntry: addBatchEntry } = useTxBatch()
 const { redirectAfterAdd } = useBatchRedirect()
 const { account: planAccount } = usePlanAccount()
-const { updateEarnVault } = useVaults()
+const { getEarnVault, updateEarnVault } = useVaults()
 const { isReady: isLabelsReady } = useEulerLabels()
 const { isConnected, address } = useWagmi()
 const { isSpyMode } = useSpyMode()
@@ -63,6 +63,22 @@ const supplyApyBreakdown = computed(() => vault.value ? computeSupplyApyBreakdow
 const visibleApyBreakdown = computed(() => visibleBreakdown(supplyApyBreakdown.value))
 const supplyApyTotal = computed(() => visibleTotal(supplyApyBreakdown.value) ?? 0)
 
+const applyLoadedVault = (loadedVault: EulerEarn) => {
+  vault.value = loadedVault
+  asset.value = loadedVault.asset
+  estimateSupplyAPY.value = supplyApyTotal.value
+}
+
+const refreshEarnVault = async (address: string, silent = false) => {
+  try {
+    applyLoadedVault(await updateEarnVault(address))
+  }
+  catch (e) {
+    if (!silent) throw e
+    logWarn('[earn] failed to refresh vault', e)
+  }
+}
+
 // Non-blocking to avoid Suspense + pageTransition crash on direct navigation
 ;(async () => {
   try {
@@ -72,9 +88,7 @@ const supplyApyTotal = computed(() => visibleTotal(supplyApyBreakdown.value) ?? 
     if (!isLabelsReady.value) {
       await until(isLabelsReady).toBe(true)
     }
-    vault.value = await updateEarnVault(vaultAddress)
-    asset.value = vault.value?.asset
-    estimateSupplyAPY.value = supplyApyTotal.value
+    applyLoadedVault(await getEarnVault(vaultAddress))
 
     if (!useVaultRegistry().isVerifiedVault(vault.value.address)) {
       modal.open(VaultUnverifiedDisclaimerModal, {
@@ -86,6 +100,8 @@ const supplyApyTotal = computed(() => visibleTotal(supplyApyBreakdown.value) ?? 
         },
       })
     }
+
+    void refreshEarnVault(vault.value.address, true)
   }
   catch (e) {
     showError('Unable to load Vault')
@@ -210,9 +226,7 @@ const send = async () => {
 const updateEstimates = async () => {
   if (!vault.value) return
   try {
-    vault.value = await updateEarnVault(vault.value.address)
-    if (!asset.value?.address) return
-    estimateSupplyAPY.value = supplyApyTotal.value
+    await refreshEarnVault(vault.value.address)
   }
   catch (e) {
     logWarn('earn-supply/estimates', e)

--- a/tests/composables/useVaults.test.ts
+++ b/tests/composables/useVaults.test.ts
@@ -1,4 +1,4 @@
-import type { EVault } from '@eulerxyz/euler-v2-sdk'
+import type { EVault, EulerEarn } from '@eulerxyz/euler-v2-sdk'
 import { getAddress, type Address } from 'viem'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
@@ -20,8 +20,13 @@ const makeVault = (address: string): EVault => ({
   collaterals: [],
 }) as unknown as EVault
 
+const makeEarnVault = (address: string): EulerEarn => ({
+  address: getAddress(address),
+}) as unknown as EulerEarn
+
 const fetchVaults = vi.fn()
 const fetchEarnVaults = vi.fn()
+const fetchEarnVault = vi.fn()
 const fetchVerifiedVaultAddresses = vi.fn()
 const fetchVaultTypes = vi.fn()
 const chainId = ref(1)
@@ -30,6 +35,7 @@ describe('useVaults EVault verification metadata', () => {
   beforeEach(() => {
     fetchVaults.mockReset()
     fetchEarnVaults.mockReset()
+    fetchEarnVault.mockReset()
     fetchVerifiedVaultAddresses.mockReset()
     fetchVaultTypes.mockReset()
 
@@ -38,6 +44,10 @@ describe('useVaults EVault verification metadata', () => {
       result: addresses.map(address => makeVault(address)),
     }))
     fetchEarnVaults.mockResolvedValue({ errors: [], result: [] })
+    fetchEarnVault.mockImplementation(async (_chainId: number, address: Address) => ({
+      errors: [],
+      result: makeEarnVault(address),
+    }))
     fetchVerifiedVaultAddresses.mockResolvedValue([])
     fetchVaultTypes.mockResolvedValue({})
     chainId.value = 1
@@ -52,7 +62,7 @@ describe('useVaults EVault verification metadata', () => {
     vi.stubGlobal('useEulerLabels', useEulerLabels)
     const sdk = {
       eVaultService: { fetchVaults, fetchVerifiedVaultAddresses },
-      eulerEarnService: { fetchVaults: fetchEarnVaults },
+      eulerEarnService: { fetchVaults: fetchEarnVaults, fetchVault: fetchEarnVault },
       vaultMetaService: { fetchVaultTypes },
     }
     vi.stubGlobal('useEulerSdk', () => ({
@@ -67,6 +77,7 @@ describe('useVaults EVault verification metadata', () => {
   })
 
   afterEach(() => {
+    vi.useRealTimers()
     useVaultRegistry().clear()
     vi.unstubAllGlobals()
   })
@@ -209,6 +220,31 @@ describe('useVaults EVault verification metadata', () => {
     await useVaults().loadVaults()
 
     expect(fetchEarnVaults).not.toHaveBeenCalled()
+  })
+
+  it('falls back to direct fetch when a known Earn vault never reaches the registry', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('until', () => ({
+      toMatch: vi.fn(() => new Promise<void>(() => undefined)),
+    }))
+    __setEulerLabelsDataForTest({
+      earnVaults: [getAddress(BASE_EARN_VAULT)],
+    })
+
+    const promise = useVaults().getEarnVault(BASE_EARN_VAULT)
+    await vi.advanceTimersByTimeAsync(10_000)
+    const vault = await promise
+
+    expect(vault.address).toBe(getAddress(BASE_EARN_VAULT))
+    expect(fetchEarnVault).toHaveBeenCalledWith(
+      1,
+      getAddress(BASE_EARN_VAULT),
+      expect.objectContaining({
+        populateMarketPrices: true,
+        populateStrategyVaults: true,
+      }),
+    )
+    expect(useVaultRegistry().get(BASE_EARN_VAULT)?.type).toBe('earn')
   })
 
   it('keeps dynamically resolved off-label EVaults out of verified EVault lists', async () => {


### PR DESCRIPTION
## Summary
- Render Earn vault detail pages from the hydrated registry/cache before starting the SDK refresh.
- Avoid blocking Monad Earn detail first paint on a single onchain vault fetch after the Earn list has already loaded.

## Changes
- Use getEarnVault for the initial detail load so cached /api/vaults data can satisfy navigation from the list.
- Keep updateEarnVault as a background refresh and reuse it for post-submit estimate refreshes.

## Test plan
- [x] npx eslint pages/earn/[vault]/index.vue
- [x] git diff --check
- [x] npm run typecheck
- [x] Local HTTP 200 for /earn?network=monad
- [x] Local HTTP 200 for /api/vaults?chainId=143 with cached Earn vaults
- [x] Local HTTP 200 for a Monad Earn detail URL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Vault pages now refresh estimates more reliably, reducing stale APY values.
  * Background updates are handled more quietly, avoiding unnecessary error interruptions.
* **Refactor**
  * Improved vault data loading so the page updates vault details and asset information more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->