### PR TITLE
fix: update discovery matrix row labels

### DIFF
--- a/components/entities/vault/discovery/DiscoveryMarketAttributeMatrix.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketAttributeMatrix.vue
@@ -183,7 +183,7 @@ const cellDataValue = (cell: AttributeCell, vault: AttributeMatrixColumn): strin
               data-list="attribute-matrix-column"
               :data-key="col.attribute.id"
               :data-field="col.attribute.id"
-              :class="isAttributeColumnHighlighted(col.attribute.id) ? '!bg-white/[0.06] text-content-primary' : ''"
+              :class="isAttributeColumnHighlighted(col.attribute.id) ? 'text-content-primary shadow-[inset_0_0_0_9999px_rgba(255,255,255,0.06)]' : ''"
             >
               <span class="inline-flex items-center justify-center gap-4">
                 <span>{{ col.attribute.label }}</span>
@@ -215,12 +215,12 @@ const cellDataValue = (cell: AttributeCell, vault: AttributeMatrixColumn): strin
               :class="
                 selectedHeader?.address === vault.address
                   && selectedHeader?.axis === 'row'
-                  ? 'text-accent-500 !bg-accent-500/10'
+                  ? 'text-accent-500 shadow-[inset_0_0_0_9999px_rgba(var(--accent-rgb),0.10)]'
                   : isVaultRowHighlighted(vault.address)
-                    ? (vault.isExternal ? 'text-content-tertiary !bg-white/[0.06]' : 'text-content-primary !bg-white/[0.06]')
+                    ? (vault.isExternal ? 'text-content-tertiary shadow-[inset_0_0_0_9999px_rgba(255,255,255,0.06)]' : 'text-content-primary shadow-[inset_0_0_0_9999px_rgba(255,255,255,0.06)]')
                     : (vault.isExternal
-                      ? 'text-content-tertiary hover:bg-white/[0.04]'
-                      : 'text-content-primary hover:bg-white/[0.04]')
+                      ? 'text-content-tertiary hover:shadow-[inset_0_0_0_9999px_rgba(255,255,255,0.04)]'
+                      : 'text-content-primary hover:shadow-[inset_0_0_0_9999px_rgba(255,255,255,0.04)]')
               "
               @click.stop="$emit('selectHeader', vault.address, 'row')"
             >

--- a/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
@@ -303,10 +303,10 @@ watch(
               :class="
                 selectedHeader?.address === col.address
                   && selectedHeader?.axis === 'column'
-                  ? 'text-accent-500 !bg-accent-500/10'
+                  ? 'text-accent-500 shadow-[inset_0_0_0_9999px_rgba(var(--accent-rgb),0.10)]'
                   : isColumnHighlighted(col.address)
-                    ? 'text-content-primary !bg-white/[0.06]'
-                    : 'text-content-primary hover:bg-white/[0.04]'
+                    ? 'text-content-primary shadow-[inset_0_0_0_9999px_rgba(255,255,255,0.06)]'
+                    : 'text-content-primary hover:shadow-[inset_0_0_0_9999px_rgba(255,255,255,0.04)]'
               "
               @click.stop="$emit('selectHeader', col.address, 'column')"
             >
@@ -340,12 +340,12 @@ watch(
               :class="
                 selectedHeader?.address === row.address
                   && selectedHeader?.axis === 'row'
-                  ? 'text-accent-500 !bg-accent-500/10'
+                  ? 'text-accent-500 shadow-[inset_0_0_0_9999px_rgba(var(--accent-rgb),0.10)]'
                   : isRowHighlighted(row.address)
-                    ? (row.category !== 'borrowable' ? 'text-content-tertiary !bg-white/[0.06]' : 'text-content-primary !bg-white/[0.06]')
+                    ? (row.category !== 'borrowable' ? 'text-content-tertiary shadow-[inset_0_0_0_9999px_rgba(255,255,255,0.06)]' : 'text-content-primary shadow-[inset_0_0_0_9999px_rgba(255,255,255,0.06)]')
                     : (row.category !== 'borrowable'
-                      ? 'text-content-tertiary hover:bg-white/[0.04]'
-                      : 'text-content-primary hover:bg-white/[0.04]')
+                      ? 'text-content-tertiary hover:shadow-[inset_0_0_0_9999px_rgba(255,255,255,0.04)]'
+                      : 'text-content-primary hover:shadow-[inset_0_0_0_9999px_rgba(255,255,255,0.04)]')
               "
               @click.stop="$emit('selectHeader', row.address, 'row')"
             >

--- a/utils/discoveryCalculations.ts
+++ b/utils/discoveryCalculations.ts
@@ -903,16 +903,16 @@ export const STATS_ROWS: AttributeRow[] = [
   },
   {
     id: 'exposure',
-    label: 'Exposure',
+    label: 'Current exposure',
     getValue: (vault) => {
       if (!isEVault(vault) || isEscrow(vault)) return NA_CELL
       if (!isVaultBorrowable(vault)) return NA_CELL
-      return { display: 'Exposure', kind: 'exposure' }
+      return { display: 'Current exposure', kind: 'exposure' }
     },
   },
   {
     id: 'badDebt',
-    label: 'Bad debt',
+    label: 'Pending bad debt',
     getValue: (vault, usd, _apy, badDebt, isBadDebtLoaded) => {
       if (!isEVault(vault) || isEscrow(vault)) return NA_CELL
       if (!badDebt) {


### PR DESCRIPTION
## Summary
- Rename the discovery matrix exposure row to clarify it shows current exposure.
- Rename the bad debt row to clarify it shows pending bad debt.
- Keep highlighted sticky matrix headers opaque so scrolled values cannot bleed underneath them.

## Changes
- Updates the discovery stats row labels and exposure display copy.
- Uses inset highlight shadows on sticky matrix row/column headers instead of replacing their opaque surface background with translucent background colors.

## Test plan
- [x] Ran git diff --check.
- [x] Ran npx eslint components/entities/vault/discovery/DiscoveryMarketAttributeMatrix.vue components/entities/vault/discovery/DiscoveryMarketMatrix.vue utils/discoveryCalculations.ts.
- [x] Committed with the repo staged-file eslint hook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated display labels for two stats rows to better match the information shown to users.
  * Renamed **“Exposure”** to **“Current exposure”** and **“Bad debt”** to **“Pending bad debt”** in the relevant views.
* **Style**
  * Improved header highlighting in the discovery market matrices by switching selection/hover visuals to inset shadow effects (including accent styling).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->