### PR TITLE
fix: skip Morpho migration discovery on unindexed chains

### DIFF
--- a/composables/useExternalMigrationPositions.ts
+++ b/composables/useExternalMigrationPositions.ts
@@ -1,7 +1,7 @@
 import { readonly, ref, type Ref } from 'vue'
 import { erc20Abi, getAddress, type Address } from 'viem'
 import { getEulerSdk } from '~/composables/useEulerSdk'
-import { AAVE_CONNECTOR_ID, METAMORPHO_CONNECTOR_ID, MORPHO_CONNECTOR_ID } from '~/entities/migration/constants'
+import { AAVE_CONNECTOR_ID, METAMORPHO_CONNECTOR_ID, MORPHO_CONNECTOR_ID, MORPHO_MIGRATION_SUPPORTED_CHAIN_IDS } from '~/entities/migration/constants'
 import { nanoToValue } from '~/utils/crypto-utils'
 import { logWarn } from '~/utils/errorHandling'
 
@@ -838,6 +838,10 @@ export const useExternalMigrationPositions = (options: {
   }
 
   const fetchMorphoMigrationPositions = async (targetChainId: number, targetOwner: Address): Promise<(MorphoMigrationCandidate | MetamorphoMigrationCandidate)[]> => {
+    // Morpho's indexer only covers a fixed set of chains. Querying an unindexed
+    // chain (e.g. BSC) returns an "unsupported chainId" error that would surface
+    // as a scan failure, so treat those chains as "nothing to migrate" instead.
+    if (!MORPHO_MIGRATION_SUPPORTED_CHAIN_IDS.has(targetChainId)) return []
     try {
       const res = await fetch('/api/internal/proxy/morpho', {
         method: 'POST',

--- a/entities/migration/constants.ts
+++ b/entities/migration/constants.ts
@@ -1,3 +1,17 @@
 export const AAVE_CONNECTOR_ID = 'aave'
 export const MORPHO_CONNECTOR_ID = 'morpho'
 export const METAMORPHO_CONNECTOR_ID = 'metamorpho'
+
+/**
+ * Chains whose positions Morpho's hosted GraphQL indexer (api.morpho.org) can
+ * return. Discovery must skip every other chain: querying an unindexed chain
+ * (e.g. BNB Smart Chain, 56) makes the API reject the request with an
+ * "unsupported chainId" error, which would otherwise surface as a "could not
+ * scan external positions" failure even when the user simply has nothing to
+ * migrate. Aave discovery self-gates on connector pool presence, so it needs no
+ * equivalent list.
+ */
+export const MORPHO_MIGRATION_SUPPORTED_CHAIN_IDS: ReadonlySet<number> = new Set([
+  1, // Ethereum
+  8453, // Base
+])

--- a/tests/composables/useExternalMigrationPositions.test.ts
+++ b/tests/composables/useExternalMigrationPositions.test.ts
@@ -243,6 +243,25 @@ describe('useExternalMigrationPositions', () => {
     expect(result.isLoading.value).toBe(false)
   })
 
+  it('skips Morpho discovery on chains its indexer does not support', async () => {
+    // BNB Smart Chain (56) is not indexed by api.morpho.org, and no Aave pool is
+    // registered there either — so the scan must resolve to an empty list rather
+    // than surfacing the API's "unsupported chainId" error.
+    vi.stubGlobal('useEulerAddresses', () => ({ chainId: ref(56) }))
+
+    const result = useExternalMigrationPositions()
+
+    await flushPromises()
+    await nextTick()
+
+    const morphoQueried = fetchMock.mock.calls.some(([, init]) =>
+      String((init as RequestInit | undefined)?.body ?? '').includes('LiteMorphoMigrationPositions'),
+    )
+    expect(morphoQueried).toBe(false)
+    expect(result.positions.value).toEqual([])
+    expect(result.error.value).toBe('')
+  })
+
   it('discovers Morpho positions from indexed market positions', async () => {
     fetchMock.mockResolvedValue(new Response(JSON.stringify({
       data: {


### PR DESCRIPTION
## Problem

On a chain Morpho's hosted indexer (`api.morpho.org`) doesn't cover — e.g. **BNB Smart Chain (56)** — the migrate page fails with:

> Could not scan external positions — unsupported chainId 56

External-position scanning (`useExternalMigrationPositions.load()`) runs for **whatever chain is active**, with no supported-chain gate. It fires two discovery sources in parallel:

- **Aave** — self-gates: `if (!client || !pool) return []`, so it quietly finds nothing.
- **Morpho** — **no gate**: it always POSTs `{ chainId, address }` to the Morpho GraphQL proxy. On an unindexed chain the API rejects the request, `fetchMorphoMigrationPositions` throws, and because Aave found nothing, `load()` rethrows the error (`if (firstError && nextPositions.length === 0) throw firstError`).

Net effect: a user with **nothing to migrate** on such a chain sees a hard error instead of an empty list. The message text is Morpho's API response, not an app/SDK check.

## Fix

Mirror the Aave path's self-gate on the Morpho side: gate `fetchMorphoMigrationPositions` on a new `MORPHO_MIGRATION_SUPPORTED_CHAIN_IDS` set (Ethereum, Base) in `entities/migration/constants.ts`, returning `[]` for other chains. Unsupported chains now resolve to "no external positions" and skip a pointless proxy round-trip.

The set matches the chains the app already treats as Morpho-capable (`MORPHO_APP_CHAIN_SLUGS` = `{1, 8453}`).

## Test

Adds a regression case: on chain 56 the Morpho query is never issued, positions resolve to `[]`, and no error surfaces. `useExternalMigrationPositions` suite: 9/9 pass. Lint + typecheck clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented migration position lookups on unsupported networks, avoiding unnecessary errors and emptying results when the chain isn’t available.
  * Improved stability for migration discovery by skipping unsupported chain requests instead of attempting them.
  
* **Tests**
  * Added coverage for unsupported network behavior to ensure no migration lookup is triggered and results stay empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->