### PR TITLE
fix: restore asset selector labels

### DIFF
--- a/components/entities/asset/AssetInput.vue
+++ b/components/entities/asset/AssetInput.vue
@@ -9,7 +9,7 @@ import { ChooseCollateralModal } from '#components'
 import { useModal } from '~/components/ui/composables/useModal'
 import { formatUnits } from 'viem'
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
   label?: string
   desc?: string
   maxable?: boolean
@@ -35,7 +35,9 @@ const props = defineProps<{
   selectedSubAccount?: string // Disambiguates between multiple savings positions on different sub-accounts
   selectedVaultAddress?: string // Disambiguates same sub-account positions across different vaults (e.g. wallet rows)
   maxHandler?: () => void // When provided, replaces the default "Max" button behavior
-}>()
+}>(), {
+  assetSelectorSelected: true,
+})
 const emits = defineEmits(['input', 'change-collateral', 'click-asset'])
 const model = defineModel<string>({ default: '' })
 
@@ -178,9 +180,10 @@ const canOpenCollateralModal = computed(() => {
   const optionsCount = props.collateralOptions?.length ?? 0
   return props.collateralModalForceOpen ? optionsCount > 0 : optionsCount >= 2
 })
+const canSelectAsset = computed(() => props.swappable || canOpenCollateralModal.value)
 // The arrow must mirror canOpenCollateralModal, or the pill looks clickable
 // while openChooseCollateralModal() immediately returns.
-const showAssetSelectorArrow = computed(() => props.swappable || canOpenCollateralModal.value)
+const showAssetSelectorArrow = computed(() => canSelectAsset.value)
 
 onBeforeUnmount(() => {
   if (emitInputTimeout.value) {
@@ -211,6 +214,14 @@ const openChooseCollateralModal = () => {
       },
     },
   })
+}
+const onAssetSelectorClick = () => {
+  if (!canSelectAsset.value) return
+  if (props.swappable) {
+    emits('click-asset')
+    return
+  }
+  openChooseCollateralModal()
 }
 </script>
 
@@ -279,8 +290,10 @@ const openChooseCollateralModal = () => {
         :data-asset-symbol="asset.symbol"
         :data-asset-address="asset.address"
         :data-swappable="swappable ? 'true' : 'false'"
-        class="bg-card text-p3 font-semibold gap-8 flex items-center justify-center px-12 min-h-36 py-6 rounded-[40px] whitespace-nowrap cursor-pointer shrink-0"
-        @click="swappable ? emits('click-asset') : openChooseCollateralModal()"
+        :data-selectable="canSelectAsset ? 'true' : 'false'"
+        class="bg-card text-p3 font-semibold gap-8 flex items-center justify-center px-12 min-h-36 py-6 rounded-[40px] whitespace-nowrap shrink-0"
+        :class="canSelectAsset ? 'cursor-pointer' : 'cursor-default'"
+        @click="onAssetSelectorClick"
       >
         <template v-if="showAssetSelectorAsset">
           <AssetAvatar

--- a/components/entities/asset/SwapTokenSelector.vue
+++ b/components/entities/asset/SwapTokenSelector.vue
@@ -138,9 +138,14 @@ const isUnknownAddress = computed(() => {
   return isAddress(q) && !knownAddresses.value.has(q.toLowerCase())
 })
 
-// Show the full list with relevant tokens bubbled to the top (see
-// sortSelectableTokens). Picker mode still controls geo restriction semantics.
+// In input mode, the default list narrows to held tokens. Search still reaches
+// the full list when a user wants to pick an unheld token explicitly.
 const filteredOptions = computed(() => filterSelectableTokens(tokenOptions.value, mode, searchQuery.value))
+const emptyMessage = computed(() => {
+  if (searchQuery.value.trim()) return 'No results found'
+  if (mode === 'input') return 'No wallet balances found. Search to select another token.'
+  return 'No tokens found'
+})
 
 // Incrementally render rows — and therefore token-icon requests — instead of
 // mounting the whole list at once: start with a capped batch and grow on scroll.
@@ -471,10 +476,11 @@ const handleSelectCustomToken = () => {
 
         <!-- No results (only when NOT resolving a custom address) -->
         <div
-          v-if="!filteredOptions.length && searchQuery && !isUnknownAddress"
-          class="py-24 text-center text-content-tertiary text-p3"
+          v-if="!filteredOptions.length && !isUnknownAddress"
+          data-id="swap-token-empty"
+          class="px-24 py-32 text-center text-content-tertiary text-p3"
         >
-          No results found
+          {{ emptyMessage }}
         </div>
       </div>
     </div>

--- a/components/entities/asset/SwapTokenSelector.vue
+++ b/components/entities/asset/SwapTokenSelector.vue
@@ -138,8 +138,8 @@ const isUnknownAddress = computed(() => {
   return isAddress(q) && !knownAddresses.value.has(q.toLowerCase())
 })
 
-// Output ("Receive as") shows the full list with relevant tokens bubbled to the
-// top (see sortSelectableTokens); input ("Pay with") narrows to held tokens.
+// Show the full list with relevant tokens bubbled to the top (see
+// sortSelectableTokens). Picker mode still controls geo restriction semantics.
 const filteredOptions = computed(() => filterSelectableTokens(tokenOptions.value, mode, searchQuery.value))
 
 // Incrementally render rows — and therefore token-icon requests — instead of

--- a/pages/borrow/[collateral]/[borrow]/index.vue
+++ b/pages/borrow/[collateral]/[borrow]/index.vue
@@ -529,6 +529,18 @@ watch(effectiveOwner, () => {
 watch(formTab, () => {
   borrow.resetOnTabSwitch()
   multiply.resetOnTabSwitch()
+
+  const currentRouteTab = formTabFromQuery(route.query.tab) ?? 'borrow'
+  if (formTab.value === currentRouteTab) return
+
+  const query = { ...route.query }
+  if (formTab.value === 'borrow') {
+    delete query.tab
+  }
+  else {
+    query.tab = formTab.value
+  }
+  void router.replace({ query })
 })
 
 watch(

--- a/tests/utils/token-selector.test.ts
+++ b/tests/utils/token-selector.test.ts
@@ -21,8 +21,8 @@ const spam = tok({ source: 'tokenList', asset: { symbol: 'SPROUT', name: 'Sprout
 const all = [vaultAsset, held, spam]
 
 describe('filterSelectableTokens', () => {
-  it('input mode without search shows only tokens the user holds', () => {
-    expect(filterSelectableTokens(all, 'input', '')).toEqual([held])
+  it('input mode without search shows the full list (nothing hidden)', () => {
+    expect(filterSelectableTokens(all, 'input', '')).toEqual(all)
   })
 
   it('output mode without search shows the full list (nothing hidden)', () => {

--- a/tests/utils/token-selector.test.ts
+++ b/tests/utils/token-selector.test.ts
@@ -21,8 +21,8 @@ const spam = tok({ source: 'tokenList', asset: { symbol: 'SPROUT', name: 'Sprout
 const all = [vaultAsset, held, spam]
 
 describe('filterSelectableTokens', () => {
-  it('input mode without search shows the full list (nothing hidden)', () => {
-    expect(filterSelectableTokens(all, 'input', '')).toEqual(all)
+  it('input mode without search shows only tokens the user holds', () => {
+    expect(filterSelectableTokens(all, 'input', '')).toEqual([held])
   })
 
   it('output mode without search shows the full list (nothing hidden)', () => {

--- a/utils/token-selector.ts
+++ b/utils/token-selector.ts
@@ -37,14 +37,14 @@ export function sortSelectableTokens<T extends SelectableToken>(options: T[]): T
 
 // Narrows the list for the picker:
 // - any mode + search: match symbol / name / address.
-// - no search: the full sorted list, unchanged — relevant tokens are bubbled to
-//   the top by sortSelectableTokens, nothing is hidden.
+// - input ("Pay with") + no search: only tokens the user holds.
+// - output ("Receive as") + no search: the full list, unchanged — relevant
+//   tokens are bubbled to the top by sortSelectableTokens, nothing is hidden.
 export function filterSelectableTokens<T extends SelectableToken>(
   options: T[],
   mode: 'input' | 'output',
   searchQuery: string,
 ): T[] {
-  void mode
   const query = searchQuery.trim().toLowerCase()
   if (query) {
     return options.filter(opt =>
@@ -52,6 +52,9 @@ export function filterSelectableTokens<T extends SelectableToken>(
       || opt.asset.name.toLowerCase().includes(query)
       || opt.asset.address.toLowerCase().includes(query),
     )
+  }
+  if (mode === 'input') {
+    return options.filter(opt => opt.balance > 0n)
   }
   return options
 }

--- a/utils/token-selector.ts
+++ b/utils/token-selector.ts
@@ -37,15 +37,14 @@ export function sortSelectableTokens<T extends SelectableToken>(options: T[]): T
 
 // Narrows the list for the picker:
 // - any mode + search: match symbol / name / address.
-// - input ("Pay with") + no search: only tokens the user holds (you can only pay
-//   with what you have).
-// - output ("Receive as") + no search: the full list, unchanged — relevant
-//   tokens are bubbled to the top by sortSelectableTokens, nothing is hidden.
+// - no search: the full sorted list, unchanged — relevant tokens are bubbled to
+//   the top by sortSelectableTokens, nothing is hidden.
 export function filterSelectableTokens<T extends SelectableToken>(
   options: T[],
   mode: 'input' | 'output',
   searchQuery: string,
 ): T[] {
+  void mode
   const query = searchQuery.trim().toLowerCase()
   if (query) {
     return options.filter(opt =>
@@ -53,9 +52,6 @@ export function filterSelectableTokens<T extends SelectableToken>(
       || opt.asset.name.toLowerCase().includes(query)
       || opt.asset.address.toLowerCase().includes(query),
     )
-  }
-  if (mode === 'input') {
-    return options.filter(opt => opt.balance > 0n)
   }
   return options
 }


### PR DESCRIPTION
## Summary
- Restore default AssetInput rendering so existing forms show selected asset symbols unless a caller explicitly opts into placeholder mode.
- Keep Pay with pickers focused on wallet balances by default, but show an empty state when no held tokens are available.
- Keep the borrow/multiply form tab synchronized with the URL so modal history cannot restore a stale tab after selecting an asset.

## Changes
- Set assetSelectorSelected to true by default with withDefaults.
- Add a shared canSelectAsset computed and click handler so non-selectable pills do nothing without advertising clickability.
- Add Pay with empty-state copy for zero-balance/disconnected wallets while preserving search access to the full token list.
- Update the borrow page tab watcher to remove tab on Borrow and set tab=multiply on Multiply.

## Test plan
- [x] npx eslint components/entities/asset/AssetInput.vue
- [x] npx eslint utils/token-selector.ts tests/utils/token-selector.test.ts components/entities/asset/SwapTokenSelector.vue pages/borrow/[collateral]/[borrow]/index.vue
- [x] npx vitest run tests/utils/token-selector.test.ts
- [x] npm run typecheck
- [x] Local smoke on http://127.0.0.1:3012/borrow/0xCf4846E0d8A8667c516B844EB72A4d6e7430101D/0x2Ff596321782FE034102f55af5ad707A4Ce0d6a7?network=1&tab=multiply shows VBILL/VBILL/USDC instead of Select asset.
- [x] Local smoke on http://127.0.0.1:3012/borrow/0x797DD80692c3b2dAdabCe8e30C07fDE5307D48a9/0x313603FA690301b0CaeEf8069c065862f9162162?network=1&tab=multiply: click Borrow, open Pay with, see No wallet balances found. Search to select another token., and remain on Borrow.