### PR TITLE
fix: stabilize chart rendering

### DIFF
--- a/components/entities/vault/overview/VaultOverviewBlockHistory.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockHistory.vue
@@ -325,8 +325,11 @@ const pointChartValue = (point: VaultHistoryPoint, metric: VaultHistoryMetric): 
     ? pointUsdValue(point, metric)
     : pointValue(point, metric)
 
+const isChartableValue = (value: number | null): value is number =>
+  typeof value === 'number' && Number.isFinite(value)
+
 const visiblePoints = computed(() =>
-  history.value.filter(point => pointChartValue(point, selectedMetric.value) !== null),
+  history.value.filter(point => isChartableValue(pointChartValue(point, selectedMetric.value))),
 )
 const hasChartData = computed(() => visiblePoints.value.length > 1)
 

--- a/components/entities/vault/overview/VaultOverviewBlockIRM.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockIRM.vue
@@ -10,7 +10,6 @@ import {
 import { hasCollateralExposure } from '~/utils/vault/collateral-exposure'
 import { useVaultRegistry } from '~/composables/useVaultRegistry'
 import { eulerUtilsLensABI, eulerVaultLensABI } from '~/entities/euler/abis'
-import annotationPlugin from 'chartjs-plugin-annotation'
 import { Chart as ChartJS, CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend, Filler, type ChartData, type ChartOptions } from 'chart.js'
 import { zeroAddress, formatUnits, type Address, type Abi } from 'viem'
 import { INTEREST_RATE_MODEL_TYPE, SECONDS_IN_YEAR } from '~/entities/constants'
@@ -29,7 +28,6 @@ ChartJS.register(
   Tooltip,
   Legend,
   Filler,
-  annotationPlugin,
 )
 
 const { vault, defaultOpen = true } = defineProps<{ vault: EVault, defaultOpen?: boolean }>()

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -5,6 +5,7 @@ import { resolve } from 'node:path'
 
 const themeBootstrapScript = '(function(){var theme="dark";try{theme=localStorage.getItem("theme")==="light"?"light":"dark"}catch(e){}document.documentElement.setAttribute("data-theme",theme);document.documentElement.style.colorScheme=theme})()'
 const eulerSdkPackage = '@eulerxyz/euler-v2-sdk'
+const chartPackages = ['chart.js', 'chartjs-plugin-annotation']
 const isLinkedEulerSdk = (() => {
   try {
     return lstatSync(resolve(process.cwd(), 'node_modules', ...eulerSdkPackage.split('/'))).isSymbolicLink()
@@ -396,7 +397,7 @@ export default defineNuxtConfig({
     optimizeDeps: {
       // Linked SDK builds should be loaded directly so Vite does not keep
       // serving stale optimized bundles after rebuilding the sibling package.
-      include: isLinkedEulerSdk ? [] : [eulerSdkPackage],
+      include: isLinkedEulerSdk ? chartPackages : [eulerSdkPackage, ...chartPackages],
       exclude: isLinkedEulerSdk ? [eulerSdkPackage] : [],
       esbuildOptions: { target: 'esnext' },
     },

--- a/plugins/00.chartjs.client.ts
+++ b/plugins/00.chartjs.client.ts
@@ -1,0 +1,6 @@
+import annotationPlugin from 'chartjs-plugin-annotation'
+import { Chart as ChartJS } from 'chart.js'
+
+export default defineNuxtPlugin(() => {
+  ChartJS.register(annotationPlugin)
+})

--- a/tests/utils/vault-history.test.ts
+++ b/tests/utils/vault-history.test.ts
@@ -82,6 +82,43 @@ describe('vault history utilities', () => {
     ])
   })
 
+  it('preserves zero totals as chartable values', () => {
+    const points = parseVaultTotalsHistory({
+      data: {
+        history: [
+          {
+            timestamp: '2026-07-01T00:00:00.000Z',
+            totalAssets: '0',
+            totalAssetsUsd: 0,
+            totalBorrows: '0',
+            totalBorrowsUsd: 0,
+            cash: '0',
+            cashUsd: 0,
+            utilization: 0,
+            supplyApy: 0,
+            borrowApy: 0,
+          },
+        ],
+      },
+    }, 6)
+
+    expect(points).toEqual([
+      {
+        timestamp: '2026-07-01T00:00:00.000Z',
+        totalAssets: 0,
+        totalAssetsUsd: 0,
+        totalBorrows: 0,
+        totalBorrowsUsd: 0,
+        cash: 0,
+        cashUsd: 0,
+        utilization: 0,
+        supplyApy: 0,
+        borrowApy: 0,
+        sharePrice: null,
+      },
+    ])
+  })
+
   it('parses earn totals history points into display units', () => {
     const points = parseVaultTotalsHistory({
       data: {


### PR DESCRIPTION
## Summary
- Fix intermittent Chart.js annotation plugin crashes on graph pages by registering the annotation plugin during client startup before chart instances mount.
- Keep zero totals history points chartable so flat zero series do not fall through to the no-data state.

## Changes
- Added an early client Chart.js plugin registration and Vite pre-bundling for the chart packages.
- Removed late annotation plugin registration from the IRM component.
- Filter Performance chart points by finite numeric values instead of null-only checks.
- Added zero totals parser regression coverage.

## Test plan
- [x] npm run test:run -- tests/utils/vault-history.test.ts
- [x] npm run typecheck
- [x] npx eslint nuxt.config.ts components/entities/vault/overview/VaultOverviewBlockIRM.vue components/entities/vault/overview/VaultOverviewBlockHistory.vue plugins/00.chartjs.client.ts tests/utils/vault-history.test.ts
- [x] Local headless smoke on the reported borrow route after Vite warmup confirmed no Chart.js annotations or visibleElements console errors