### PR TITLE
fix: harden announcement relative links

### DIFF
--- a/tests/utils/announcement-config.test.ts
+++ b/tests/utils/announcement-config.test.ts
@@ -29,6 +29,8 @@ describe('announcement-config', () => {
     expect(parseAnnouncementUrl('javascript:alert(1)')).toBe('')
     expect(parseAnnouncementUrl('data:text/html,<script>alert(1)</script>')).toBe('')
     expect(parseAnnouncementUrl('//example.com/docs')).toBe('')
+    expect(parseAnnouncementUrl('/\\evil.com')).toBe('')
+    expect(parseAnnouncementUrl('/\\\\evil.com')).toBe('')
     expect(parseAnnouncementUrl('docs')).toBe('')
     expect(parseAnnouncementUrl('not a url')).toBe('')
   })

--- a/utils/announcement-config.ts
+++ b/utils/announcement-config.ts
@@ -60,7 +60,7 @@ export const parseAnnouncementUrl = (value: unknown): string => {
   if (!raw) return ''
 
   if (raw.startsWith('/')) {
-    return raw.startsWith('//') ? '' : raw
+    return /^\/[\\/]/.test(raw) ? '' : raw
   }
 
   try {


### PR DESCRIPTION
## Summary
- Harden configured announcement CTA links against slash-backslash URL forms that browsers can resolve as external origins.
- Keep the announcement URL parser fail-closed for ambiguous root-relative input.

## Changes
- Reject root-relative URLs that start with `/\` or `/\\` in addition to protocol-relative `//`.
- Add regression coverage for both slash-backslash forms.

## Test plan
- [x] `npm run test:run -- tests/utils/announcement-config.test.ts`
- [x] `npx eslint utils/announcement-config.ts tests/utils/announcement-config.test.ts`
- [x] `npm run typecheck`
