### PR TITLE
fix: restore migration batch prewarm fast path + clarify Aave E-Mode revert

### DIFF
--- a/entities/constants.ts
+++ b/entities/constants.ts
@@ -18,6 +18,7 @@ export const ERROR_MESSAGE_MAP: Record<string, string> = {
   ERC4626ExceededMaxRedeem: 'Redeem exceeds vault limits.',
   SlippageExceeded: 'Slippage exceeded your tolerance. Increase slippage tolerance or refresh the quote.',
   HealthFactorLowerThanLiquidationThreshold: 'Aave account health factor would be below the liquidation threshold.',
+  NotBorrowableInEMode: 'This Aave account is in an E-Mode that is incompatible with this position\'s assets. Exit the E-Mode in the Aave app before migrating.',
   Swapper_SwapError: 'Swap failed. Try increasing slippage tolerance, refreshing the quote, or selecting a different swap provider.',
   Swapper_UnknownHandler: 'Swap provider is not registered. Try selecting a different swap provider.',
   SwapVerifier_skimMin: 'Swap received less than the minimum amount. Increase slippage tolerance or refresh the quote.',
@@ -36,6 +37,7 @@ export const ERROR_MESSAGE_MAP: Record<string, string> = {
 export const ERROR_SIGNATURE_MAP: Record<string, string> = {
   ...EVC_ERROR_SIGNATURES,
   '0x6679996d': 'HealthFactorLowerThanLiquidationThreshold',
+  '0x57db5bba': 'NotBorrowableInEMode', // Aave V3 borrow rejected: asset not borrowable in the account's active E-Mode
 }
 
 export const TTL_INFINITY = BigInt(

--- a/pages/position/[number]/borrow/swap.vue
+++ b/pages/position/[number]/borrow/swap.vue
@@ -2874,6 +2874,17 @@ const addInboundExternalMigrationToBatch = async () => {
     await addBatchEntry({
       ...batchEntry,
       buildPlan: async (account: Account<IHasVaultAddress>) => {
+        // The preview was warmed against the fresh owner account. For the first
+        // batch entry the planning account is that same account, so reuse the
+        // prewarmed plan instead of re-running the full cross-protocol migration
+        // simulation. Only re-simulate when the batch already has entries, where
+        // the planning account is a later layer the prewarm didn't account for.
+        if (!isBatchActive.value) {
+          return {
+            plan: preview.tenderlySimulation.plan,
+            stateOverrides: preview.tenderlySimulation.stateOverrides,
+          }
+        }
         const simulationResult = await buildInboundExternalMigrationSimulationResult(input, preview.authorizationRequest, account)
         return {
           plan: simulationResult.plan,

--- a/pages/position/[number]/migrate.vue
+++ b/pages/position/[number]/migrate.vue
@@ -906,6 +906,18 @@ async function addPreparedMigrationToBatch(preview: OutgoingMigrationPreview) {
   await addBatchEntry({
     ...batchEntry,
     buildPlan: async (account: Account<IHasVaultAddress>) => {
+      // The preview was warmed against the fresh owner account. For the first
+      // batch entry the planning account is that same account, so reuse the
+      // prewarmed plan instead of re-running the full cross-protocol migration
+      // simulation (position resolve → plan build). Only re-simulate when the
+      // batch already has entries, where the planning account is a later layer
+      // the prewarm didn't account for.
+      if (!isBatchActive.value) {
+        return {
+          plan: preview.tenderlySimulation.plan,
+          stateOverrides: preview.tenderlySimulation.stateOverrides,
+        }
+      }
       const simulationResult = await buildMigrationSimulation(input, migrationPosition, account)
       return {
         plan: simulationResult.plan,


### PR DESCRIPTION
## Summary

Two migration fixes.

### 1. Regression: adding a migration to the batch re-simulates instead of using the prewarmed plan

The background prewarm still builds the full cross-protocol migration simulation as soon as targets settle, but since `298fe8a5` ("fix: preserve reviewed migration batches") the batch entry's `buildPlan` re-ran that entire simulation again at click time (position resolve → plan build), discarding the warmed plan. That restored the latency the prewarm (`abe4402a`) was meant to remove.

`298fe8a5` did this to simulate against the batch's *planning account* rather than the owner. But for the **first** batch entry the planning account is the fresh owner account the preview was already warmed against (`usePlanAccount` returns the fresh account when no batch layer is active; the batch's empty-case planning account is the same fresh owner snapshot). So we can reuse the prewarmed plan there and only re-simulate when the batch already has entries — whose planning account is a later layer the prewarm didn't cover.

Applied to both:
- Inbound (external → Euler): `pages/position/[number]/borrow/swap.vue`
- Outbound (Euler → Aave): `pages/position/[number]/migrate.vue`

### 2. Clearer Aave E-Mode revert message

Migrating a position into an Aave account that already sits in an incompatible **E-Mode** reverts with Aave V3's `NotBorrowableInEMode()` (`0x57db5bba`), which surfaced as the raw error name in the batch simulation. Mapped it through the existing error-copy pattern (`ERROR_SIGNATURE_MAP` + `ERROR_MESSAGE_MAP`, mirroring `HealthFactorLowerThanLiquidationThreshold`) to explain the cause.

Repro that motivated this: position 3 on Base, owner in Aave E-Mode 4 ("LBTC_cbBTC") — supplying cbBTC / borrowing USDC is not permitted in that E-Mode, so the borrow reverts.

## Testing
- `npm run typecheck` — passes
- `npm run lint` (changed files) — passes
- Selector `0x57db5bba` confirmed on Base as `NotBorrowableInEMode()` by reproducing the borrow revert on-chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added support for a new borrow rejection reason so users now see a clearer message when an asset can’t be borrowed in E-Mode.
  * Improved batch migration and borrow swap handling to reuse existing preview results when possible, reducing unnecessary reprocessing and making the flow smoother.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->