### PR TITLE
[DO NOT MERGE] feat: pure-RPC on-chain position discovery (no subgraph)

### DIFF
--- a/composables/useEulerSdk.ts
+++ b/composables/useEulerSdk.ts
@@ -133,6 +133,11 @@ const v3AdapterConfig: Partial<EulerSDKConfig> = {
 
 const onchainAdapterConfig: Partial<EulerSDKConfig> = {
   accountServiceAdapter: 'onchain',
+  // Discover sub-accounts/positions purely over RPC (deployless brute-force
+  // lens) instead of the subgraph. Applies to the plan-time/fresh instance and
+  // to fast reads pinned onchain. Set EULER_SDK_ACCOUNT_POSITION_DISCOVERY (or
+  // this flag) back to 'subgraph' to restore the subgraph discovery path.
+  accountPositionDiscovery: 'onchain',
   eVaultServiceAdapter: 'onchain',
   eulerEarnServiceAdapter: 'onchain',
   vaultTypeAdapter: 'subgraph',


### PR DESCRIPTION
> ⚠️ **DO NOT MERGE** — depends on an unmerged SDK branch and is up for review/discussion only.

## Summary

Adds a pure-RPC alternative to **subgraph-based sub-account & position discovery**. Previously the SDK's "onchain" account adapter still relied on a subgraph (`trackingActiveAccounts`) to learn *which* sub-accounts and vaults an owner touches. This flips the `onchain` account path to discover positions entirely over RPC.

This lite change is a one-line config: the `onchain` adapter now sets `accountPositionDiscovery: 'onchain'`, so the plan-time/fresh SDK instance (which the portfolio loads through) uses the new discovery path.

## How it works (SDK side)

The heavy lifting lives in the SDK — **branch [`feat/onchain-account-discovery`](https://github.com/euler-xyz/euler-sdks/tree/feat/onchain-account-discovery) in `euler-xyz/euler-sdks`** (must be linked/published for this to run):

- A **deployless discovery lens** (`AccountDiscoveryLens.sol`) called via `eth_call` with no `to` and `data = creationCode ++ abi.encode(owner, subAccountIds, vaults, evc)`; the constructor brute-forces `vault.balanceOf(subAccount)` for deposits and `EVC.getControllers`/`debtOf` for borrows, returning `(address[][] deposits, address[][] borrows)`.
- The `subAccounts × vaults` workload is split into chunks and fired as **parallel unbatched eth_calls** so the RPC provider spreads them; no single call approaches the eth_call gas ceiling.
- Vault set defaults to a **labels-based resolver** (product + earn vaults, **including deprecated**); borrows are 100% complete via `getControllers` regardless of the vault set.

## Validation (`0x8A54C278D117854486db0F6460D901a180Fff517`, mainnet, 21 active sub-accounts)

- Discovery **~0.7 s** (labels warm) + ~0.3 s one-time labels fetch (cached in-app) — well under the 5 s target
- **21/21 sub-accounts**, **19/19 borrows** vs the subgraph baseline; verified live in the app (spy mode) — full portfolio rendered, **no `trackingActiveAccounts` subgraph query**
- 405 SDK tests pass, incl. new adapter unit tests

## Notes

- Requires the linked SDK build (`feat/onchain-account-discovery`); not mergeable until that lands and is versioned.
- Vault-type classification still uses the subgraph (`vaultTypeAdapter: 'subgraph'`), unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)