### PR TITLE
fix: denominate swap-supply estimates in quoted collateral output

### DIFF
--- a/composables/position/useCollateralForm.ts
+++ b/composables/position/useCollateralForm.ts
@@ -262,8 +262,20 @@ export const useCollateralForm = (options: UseCollateralFormOptions) => {
   })
 
   // --- FixedPoint computeds ---
+  // In swap-supply mode `amount` is denominated in the user-selected "pay
+  // with" token, so parsing it with collateral decimals would treat e.g.
+  // "100" (USDC) as 100 WETH. The collateral delta is the quoted swap output
+  // instead — 0 while no quote is available, so estimates show no change
+  // until quotes arrive. `null` means "amount is collateral-denominated"
+  // (direct supply, native wrap, all withdraw flows).
+  const swapCollateralDeltaNano = computed<bigint | null>(() => {
+    if (options.mode !== 'supply' || !options.needsSwap.value) return null
+    if (!swapEffectiveQuote.value) return 0n
+    const amountOut = BigInt(swapEffectiveQuote.value.amountOut || 0)
+    return amountOut > 0n ? amountOut : 0n
+  })
   const amountFixed = computed(() => FixedPoint.fromValue(
-    valueToNano(amount.value || '0', collateralVault.value?.asset.decimals),
+    swapCollateralDeltaNano.value ?? valueToNano(amount.value || '0', collateralVault.value?.asset.decimals),
     Number(collateralVault.value?.asset.decimals),
   ))
   const borrowedFixed = computed(() => FixedPoint.fromValue(position.value?.borrowed || 0n, borrowVault.value?.shares.decimals || 18))
@@ -414,7 +426,9 @@ export const useCollateralForm = (options: UseCollateralFormOptions) => {
       return
     }
 
-    const inputAmountNano = valueToNano(amount.value || '0', asset.value.decimals)
+    // `amount` is denominated in `effectiveAsset` (the pay-with token in
+    // swap-supply mode) — parse with its decimals, not the collateral's.
+    const inputAmountNano = valueToNano(amount.value || '0', options.effectiveAsset.value?.decimals ?? asset.value.decimals)
     if (inputAmountNano <= 0n) {
       resetSwapQuoteState()
       return
@@ -607,7 +621,7 @@ export const useCollateralForm = (options: UseCollateralFormOptions) => {
     try {
       if (!isEVault(collateralVault.value)) return
       const evault = collateralVault.value
-      const amountNano = valueToNano(amount.value, evault.asset.decimals)
+      const amountNano = swapCollateralDeltaNano.value ?? valueToNano(amount.value, evault.asset.decimals)
       const cashDelta = options.mode === 'supply' ? amountNano : -amountNano
 
       const [projected, collateralUsd, borrowedUsd] = await Promise.all([
@@ -889,15 +903,31 @@ export const useCollateralForm = (options: UseCollateralFormOptions) => {
 
   watch(amount, async () => {
     if (!collateralVault.value) return
+    // Reset quotes before computing estimates: in swap-supply mode the
+    // collateral delta derives from the effective quote, and the previous
+    // amount's quote must not leak into the new amount's estimates.
+    if (options.needsSwap.value) {
+      resetSwapQuoteState()
+      requestSwapQuote()
+    }
     updateSyncEstimates()
     if (!isEstimatesLoading.value) {
       isEstimatesLoading.value = true
     }
     updateAsyncEstimates()
-    if (options.needsSwap.value) {
-      resetSwapQuoteState()
-      requestSwapQuote()
+  })
+
+  // Swap-supply estimates derive from the quoted output — recompute when the
+  // effective quote (and thus the collateral delta) changes, e.g. when quotes
+  // arrive after the debounced fetch or the user picks a different provider.
+  watch(swapCollateralDeltaNano, (val, old) => {
+    if (val === null || old === null || val === old) return
+    if (!collateralVault.value) return
+    updateSyncEstimates()
+    if (!isEstimatesLoading.value) {
+      isEstimatesLoading.value = true
     }
+    updateAsyncEstimates()
   })
 
   watch(swapSlippage, () => {

--- a/tests/composables/useCollateralForm.test.ts
+++ b/tests/composables/useCollateralForm.test.ts
@@ -1,0 +1,385 @@
+import { computed, nextTick, ref, shallowRef, getCurrentScope, type Ref } from 'vue'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { EVault, SwapQuote } from '@eulerxyz/euler-v2-sdk'
+import type { VaultAsset } from '~/types/asset'
+import { FixedPoint } from '~/utils/fixed-point'
+import { useCollateralForm, type UseCollateralFormOptions } from '~/composables/position/useCollateralForm'
+
+const { COLLATERAL_VAULT, wethAsset, usdcAsset, collateralVault, borrowVault, mocks } = vi.hoisted(() => {
+  const COLLATERAL_VAULT = '0x0000000000000000000000000000000000000002'
+  const BORROW_VAULT = '0x0000000000000000000000000000000000000004'
+  const wethAsset = {
+    address: '0x0000000000000000000000000000000000000003',
+    symbol: 'WETH',
+    decimals: 18,
+  }
+  const usdcAsset = {
+    address: '0x0000000000000000000000000000000000000005',
+    symbol: 'USDC',
+    decimals: 6,
+  }
+  const collateralVault = {
+    address: COLLATERAL_VAULT,
+    asset: wethAsset,
+    shares: { address: COLLATERAL_VAULT, symbol: 'eWETH', decimals: 18 },
+    totalCash: 100n * 10n ** 18n,
+    totalBorrowed: 0n,
+    collaterals: [],
+  } as unknown as EVault
+  const borrowVault = {
+    address: BORROW_VAULT,
+    asset: usdcAsset,
+    shares: { address: BORROW_VAULT, symbol: 'eUSDC', decimals: 6 },
+    totalCash: 1_000_000n * 10n ** 6n,
+    totalBorrowed: 0n,
+    collaterals: [{ address: COLLATERAL_VAULT, borrowLTV: 8000, liquidationLTV: 8600 }],
+  } as unknown as EVault
+  return {
+    COLLATERAL_VAULT,
+    wethAsset,
+    usdcAsset,
+    collateralVault,
+    borrowVault,
+    mocks: {
+      getProjectedRates: vi.fn(async () => null),
+      getNetAPY: vi.fn(() => 0),
+    },
+  }
+})
+
+vi.mock('#components', () => ({
+  OperationReviewModal: {},
+  SwapTokenSelector: {},
+  SlippageSettingsModal: {},
+}))
+
+vi.mock('@eulerxyz/euler-v2-sdk', () => ({
+  isEVault: () => true,
+  SwapperMode: { EXACT_IN: 0, TARGET_DEBT: 2 },
+}))
+
+vi.mock('~/components/ui/composables/useModal', () => ({
+  useModal: () => ({ open: vi.fn(), close: vi.fn() }),
+}))
+
+vi.mock('~/components/ui/composables/useToast', () => ({
+  useToast: () => ({ error: vi.fn() }),
+}))
+
+vi.mock('~/utils/vault/apy', () => ({
+  getProjectedRates: mocks.getProjectedRates,
+  getNetAPY: mocks.getNetAPY,
+}))
+
+vi.mock('~/utils/sdk-prices', () => ({
+  getAssetUsdValueOrZero: vi.fn(async () => 0),
+  getCollateralUsdValueOrZero: vi.fn(async () => 0),
+}))
+
+vi.mock('~/composables/useGeoBlock', () => ({
+  isAnyVaultBlockedByCountry: vi.fn(() => false),
+  isVaultRestrictedByCountry: vi.fn(() => false),
+  isAssetBlockedByCountry: vi.fn(() => false),
+  isAssetRestrictedByCountry: vi.fn(() => false),
+}))
+
+vi.mock('~/utils/operationGuardRegistry', async () => {
+  const { ref } = await import('vue')
+  return { isOperationBlocked: ref(false) }
+})
+
+vi.mock('~/composables/useVaultRegistry', () => ({
+  useVaultRegistry: () => ({ getOrFetch: vi.fn(async () => collateralVault) }),
+}))
+
+vi.mock('~/utils/vault-intrinsic-apy', () => ({
+  withVaultIntrinsicApy: (apy: number) => apy,
+}))
+
+// Mutable quote state shared with the composable — tests drive
+// `effectiveQuote` to simulate quotes arriving/being cleared.
+vi.mock('~/composables/useSwapQuotesParallel', async () => {
+  const { ref } = await import('vue')
+  const effectiveQuote = ref<SwapQuote | null>(null)
+  const selectedQuote = ref<SwapQuote | null>(null)
+  const api = {
+    sortedQuoteCards: ref([]),
+    selectedProvider: ref(null),
+    selectedQuote,
+    selectedQuoteCard: ref(null),
+    effectiveQuote,
+    effectiveQuoteFetchedAt: ref(null),
+    providersCount: ref(0),
+    isLoading: ref(false),
+    quoteError: ref(null),
+    statusLabel: ref(''),
+    getQuoteDiffPct: vi.fn(() => null),
+    reset: vi.fn(() => {
+      effectiveQuote.value = null
+      selectedQuote.value = null
+    }),
+    requestQuotes: vi.fn(async () => {}),
+    selectProvider: vi.fn(),
+  }
+  return { useSwapQuotesParallel: () => api, __swapApi: api }
+})
+
+vi.mock('~/composables/useStateOverrideOptions', () => ({
+  useStateOverrideOptions: () => ({
+    primeSlotHintsFor: vi.fn(),
+    buildStateOverrideOptions: vi.fn(() => ({})),
+  }),
+}))
+
+vi.mock('~/utils/swapRouteItems', () => ({
+  buildSwapRouteItems: vi.fn(() => []),
+}))
+
+vi.mock('~/composables/useSwapPriceImpact', async () => {
+  const { ref } = await import('vue')
+  return { useSwapPriceImpact: () => ({ priceImpact: ref(null) }) }
+})
+
+vi.mock('~/composables/usePriceImpactGate', () => ({
+  usePriceImpactGate: () => ({
+    guardWithPriceImpact: (cb: () => Promise<void>) => cb(),
+  }),
+}))
+
+vi.mock('~/utils/string-utils', () => ({
+  formatSmartAmount: (v: string) => v,
+}))
+
+vi.mock('~/utils/crypto-utils', () => ({
+  nanoToValue: (v: bigint, decimals: number) => Number(v) / 10 ** decimals,
+}))
+
+vi.mock('~/utils/accountPositionHelpers', () => ({
+  normalizeAddressOrEmpty: (a?: string) => (a || '').toLowerCase(),
+}))
+
+vi.mock('~/utils/vault-hooks', () => ({
+  OP_DEPOSIT: 'deposit',
+  OP_WITHDRAW: 'withdraw',
+  isOpDisabled: vi.fn(() => false),
+}))
+
+vi.mock('~/composables/useVaultWarnings', () => ({
+  getHookDisabledWarning: vi.fn(() => null),
+}))
+
+vi.mock('~/utils/ltv', () => ({
+  decimalLtvToBps: (v: number) => BigInt(Math.round(v * 10000)),
+  getBorrowPositionEffectiveLiquidationLTV: vi.fn(() => 0.86),
+}))
+
+vi.mock('~/utils/errorHandling', () => ({
+  logWarn: vi.fn(),
+}))
+
+vi.mock('~/utils/race-guard', () => ({
+  createRaceGuard: () => ({ next: () => 0, isStale: () => false }),
+}))
+
+vi.mock('~/utils/position-estimates', () => ({
+  getTotalCollateralValue: vi.fn(() => null),
+}))
+
+vi.mock('~/utils/tx-errors', () => ({
+  getTxErrorMessage: vi.fn(async () => ''),
+}))
+
+const getSwapApi = async () => {
+  const mod = await import('~/composables/useSwapQuotesParallel') as unknown as {
+    __swapApi: {
+      effectiveQuote: Ref<SwapQuote | null>
+      selectedQuote: Ref<SwapQuote | null>
+      reset: () => void
+    }
+  }
+  return mod.__swapApi
+}
+
+const makePosition = () => ({
+  subAccount: '0x0000000000000000000000000000000000000011',
+  collateralVault,
+  borrowVault,
+  supplied: 10n * 10n ** 18n,
+  borrowed: 5000n * 10n ** 6n,
+  collaterals: [{ vaultAddress: COLLATERAL_VAULT, assets: 10n * 10n ** 18n }],
+  healthFactor: 2n * 10n ** 18n,
+  userLTV: 4000n,
+  currentLTV: 4000n,
+})
+
+const flush = async () => {
+  await nextTick()
+  await new Promise(resolve => setTimeout(resolve, 0))
+}
+
+const makeForm = (overrides: Partial<UseCollateralFormOptions> = {}) => useCollateralForm({
+  mode: 'supply',
+  needsSwap: computed(() => true),
+  effectiveBalance: computed(() => 1_000_000n * 10n ** 6n),
+  effectiveAsset: computed(() => usdcAsset as VaultAsset),
+  computePriceFixed: () => FixedPoint.fromValue(10n ** 18n, 18),
+  computeLiquidationPrice: () => undefined,
+  validateEstimate: () => {},
+  buildDirectPlan: async () => ({}) as never,
+  buildSwapPlan: async () => ({}) as never,
+  requestSwapQuoteParams: () => null,
+  getSwapOutputAsset: () => wethAsset as VaultAsset,
+  reviewLabel: 'Review Supply',
+  reviewType: 'supply',
+  swapReviewType: 'swap-supply',
+  getReviewAsset: () => wethAsset as VaultAsset,
+  getSwapToAsset: () => wethAsset as VaultAsset,
+  ...overrides,
+})
+
+describe('useCollateralForm amount denomination', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    const swapApi = await getSwapApi()
+    swapApi.effectiveQuote.value = null
+    swapApi.selectedQuote.value = null
+    vi.stubGlobal('getCurrentScope', getCurrentScope)
+    vi.stubGlobal('useDebounceFn', (fn: unknown) => fn)
+    vi.stubGlobal('until', () => ({ toBe: async () => {} }))
+    vi.stubGlobal('useRoute', () => ({ query: {} }))
+    vi.stubGlobal('showError', vi.fn())
+    vi.stubGlobal('usePositionIndex', () => '0')
+    vi.stubGlobal('useEulerTx', () => ({
+      executePlan: vi.fn(),
+      executePreparedPlan: vi.fn(),
+      prepareTransactionPlan: vi.fn(),
+      prefetchPluginData: vi.fn(),
+    }))
+    vi.stubGlobal('useEffectiveAddress', () => ({
+      isConnected: ref(true),
+      isSpyMode: ref(false),
+      effectiveAddress: ref('0x0000000000000000000000000000000000000001'),
+    }))
+    vi.stubGlobal('usePlanAccount', () => ({ account: shallowRef(null) }))
+    vi.stubGlobal('useTxFinalization', () => ({ finalizeTxAndRedirect: vi.fn() }))
+    vi.stubGlobal('useEulerAccount', () => ({
+      isPositionsLoaded: ref(true),
+      getPositionBySubAccountIndex: () => makePosition(),
+    }))
+    vi.stubGlobal('useRewardsApy', () => ({
+      getSupplyRewardApy: () => 0,
+      getBorrowRewardApy: () => 0,
+    }))
+    vi.stubGlobal('useUserSettings', () => ({ settings: ref({ enableIntrinsicApy: false }) }))
+    vi.stubGlobal('useTransactionPlanSimulation', () => ({
+      runSimulation: vi.fn(),
+      runPreparedSimulation: vi.fn(),
+      simulationError: ref(null),
+      clearSimulationError: vi.fn(),
+    }))
+    vi.stubGlobal('useVaults', () => ({ isReady: ref(true) }))
+    vi.stubGlobal('useEulerAddresses', () => ({
+      isReady: ref(true),
+      loadEulerConfig: vi.fn(),
+      chainId: ref(1),
+    }))
+    vi.stubGlobal('useSlippage', () => ({ slippage: ref(0.5) }))
+    vi.stubGlobal('usePriceInvert', () => ({
+      invertValue: (v: number | null) => v,
+      displaySymbol: 'WETH',
+      toggle: vi.fn(),
+    }))
+    vi.stubGlobal('valueToNano', (value: string | number, decimals = 0) =>
+      BigInt(Math.round(Number(value || 0) * 10 ** Number(decimals))))
+    vi.stubGlobal('getVaultSupplyApy', () => 0)
+    vi.stubGlobal('getVaultBorrowApy', () => 0)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('swap-supply: collateral delta comes from the quoted output, not the raw amount', async () => {
+    const swapApi = await getSwapApi()
+    const form = makeForm()
+    await flush()
+
+    // User enters 100 (USDC, the pay-with token). No quote yet: the
+    // collateral delta must be 0, not "100 WETH".
+    form.amount.value = '100'
+    await flush()
+    expect(form.amountFixed.value.value).toBe(0n)
+
+    // Quote arrives: 100 USDC -> 0.03 WETH.
+    const amountOut = 3n * 10n ** 16n
+    swapApi.effectiveQuote.value = {
+      amountIn: (100n * 10n ** 6n).toString(),
+      amountOut: amountOut.toString(),
+      tokenIn: usdcAsset,
+    } as unknown as SwapQuote
+    await flush()
+
+    expect(form.amountFixed.value.value).toBe(amountOut)
+
+    // Async estimates (projected rates / net APY) must also use the quoted
+    // output as the collateral cash delta.
+    const lastCall = mocks.getProjectedRates.mock.calls.at(-1) as unknown[]
+    expect(lastCall?.[3]).toBe(amountOut)
+  })
+
+  it('swap-supply: clearing quotes resets the collateral delta to zero', async () => {
+    const swapApi = await getSwapApi()
+    const form = makeForm()
+    await flush()
+
+    form.amount.value = '100'
+    await flush()
+    swapApi.effectiveQuote.value = {
+      amountIn: (100n * 10n ** 6n).toString(),
+      amountOut: (3n * 10n ** 16n).toString(),
+      tokenIn: usdcAsset,
+    } as unknown as SwapQuote
+    await flush()
+    expect(form.amountFixed.value.value).toBe(3n * 10n ** 16n)
+
+    swapApi.reset()
+    await flush()
+    expect(form.amountFixed.value.value).toBe(0n)
+  })
+
+  it('direct supply: amount is parsed with collateral decimals', async () => {
+    const form = makeForm({
+      needsSwap: computed(() => false),
+      effectiveAsset: computed(() => wethAsset as VaultAsset),
+    })
+    await flush()
+
+    form.amount.value = '2'
+    await flush()
+    expect(form.amountFixed.value.value).toBe(2n * 10n ** 18n)
+  })
+
+  it('withdraw with swap-out: amount stays collateral-denominated, quote is ignored', async () => {
+    const swapApi = await getSwapApi()
+    const form = makeForm({
+      mode: 'withdraw',
+      needsSwap: computed(() => true),
+      effectiveAsset: computed(() => wethAsset as VaultAsset),
+      getSwapOutputAsset: () => usdcAsset as VaultAsset,
+    })
+    await flush()
+
+    form.amount.value = '2'
+    await flush()
+    expect(form.amountFixed.value.value).toBe(2n * 10n ** 18n)
+
+    swapApi.effectiveQuote.value = {
+      amountIn: (2n * 10n ** 18n).toString(),
+      amountOut: (6600n * 10n ** 6n).toString(),
+      tokenIn: wethAsset,
+    } as unknown as SwapQuote
+    await flush()
+    expect(form.amountFixed.value.value).toBe(2n * 10n ** 18n)
+  })
+})


### PR DESCRIPTION
## Problem

On `/position/<n>/supply`, when the user pays with a token that differs from the collateral vault's asset, the amount input is denominated in the pay-with token. The position summary estimates, however, parsed that same string with the collateral vault's asset decimals:

- `amountFixed` fed the sync estimates (LTV, health score, liquidation price/buffer) treating the raw input as collateral units.
- `updateAsyncEstimates` did the same for the projected Net APY and collateral USD value.

Entering 100 USDC to swap into a WETH collateral vault made the summary project a deposit of **100 WETH** instead of the quoted ~0.03 WETH, so all after-values (Net APY, LTV, liquidation price/buffer, health score) were wildly wrong.

## Fix

- Added `swapCollateralDeltaNano`: in swap-supply mode the collateral delta is the effective quote's `amountOut` (already denominated in the collateral asset), and 0 while quotes are loading. `null` in every other flow (direct supply, native wrap, all withdraw modes), which keeps the existing collateral-decimals parsing there.
- `amountFixed` and the async estimate deltas now use it.
- Estimates recompute when the effective quote changes (quotes arriving after the debounced fetch, provider selection, refresh), since the delta now derives from the quote rather than only the typed amount.
- The amount watcher resets quote state before computing estimates so a stale quote's output can't leak into the new amount's estimates.
- The swap-quote zero-check now parses the amount with the pay-with token's decimals instead of the collateral's.

## Testing

- New regression tests in `tests/composables/useCollateralForm.test.ts` covering: swap-supply delta from quoted output, delta reset when quotes clear, direct supply unchanged, withdraw-with-swap unchanged. The two swap-supply cases fail on the previous implementation.
- Full vitest suite passes (1196 tests), `nuxt typecheck` and eslint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved collateral amount handling for swap-based supply flows so displayed and calculated values now follow the quoted output amount instead of the raw input.
  - Quote updates now refresh estimates more reliably when pricing or provider selection changes, and reset cleanly when quotes are cleared.
  - Direct supply and withdraw flows continue to use the expected collateral-based amount formatting.

- **Tests**
  - Added coverage for swap-supply, direct supply, quote reset, and withdraw-with-swap behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->