### PR TITLE
fix: log v3 proxy failure context

### DIFF
--- a/server/api/internal/v3/[...path].ts
+++ b/server/api/internal/v3/[...path].ts
@@ -21,6 +21,7 @@ import {
 import {
   buildV3ProxyRequestHeaders,
   buildV3ProxyTarget,
+  buildV3ProxyLogFields,
   getV3ProxyPath,
   readForwardedV3ResponseHeaders,
   validateV3ProxyUrl,
@@ -44,6 +45,7 @@ export default defineEventHandler(async (event) => {
   const requestUrl = getRequestURL(event)
   const proxyPath = getV3ProxyPath(requestUrl)
   const pathTemplate = safePathTemplate(proxyPath)
+  const logFields = buildV3ProxyLogFields(requestUrl)
   const urlValidation = validateV3ProxyUrl(method, requestUrl)
   if (urlValidation.ok === false) {
     logger.warn(
@@ -81,6 +83,7 @@ export default defineEventHandler(async (event) => {
         ctx: 'v3-proxy',
         method,
         pathTemplate,
+        ...logFields,
         upstreamHost,
         bodyBytes: body?.length,
         durationMs: Date.now() - startedAt,
@@ -112,6 +115,7 @@ export default defineEventHandler(async (event) => {
         ctx: 'v3-proxy',
         method,
         pathTemplate,
+        ...logFields,
         upstreamHost,
         bodyBytes: body?.length,
         status: upstream.status,

--- a/server/utils/v3-proxy.ts
+++ b/server/utils/v3-proxy.ts
@@ -33,6 +33,18 @@ const POST_ONLY_PATHS = new Set([
   '/v3/resolve/vaults',
 ])
 
+const ADDRESS_RE = /^0x[a-fA-F0-9]{40}$/
+const INTEGER_RE = /^[0-9]+$/
+const DECIMAL_RE = /^[0-9]+(?:\.[0-9]+)?$/
+const SAFE_QUERY_FIELDS = {
+  from: INTEGER_RE,
+  limit: INTEGER_RE,
+  minBadDebtUsd: DECIMAL_RE,
+  offset: INTEGER_RE,
+  resolution: /^[A-Za-z0-9_-]{1,16}$/,
+  to: INTEGER_RE,
+} as const
+
 type V3ProxyValidationResult
   = | { ok: true }
     | { ok: false, statusCode: number, statusMessage: string }
@@ -107,6 +119,69 @@ export function buildV3ProxyRequestHeaders(
   if (apiKey) headers.set('X-API-Key', apiKey)
 
   return headers
+}
+
+const cleanParam = (value: string | null, pattern: RegExp): string | undefined =>
+  value != null && pattern.test(value) ? value : undefined
+
+const readSafeQueryFields = (params: URLSearchParams): Record<string, string> => {
+  const fields: Record<string, string> = {}
+  for (const [name, pattern] of Object.entries(SAFE_QUERY_FIELDS)) {
+    const value = cleanParam(params.get(name), pattern)
+    if (value != null) fields[`v3${name[0].toUpperCase()}${name.slice(1)}`] = value
+  }
+  return fields
+}
+
+export function buildV3ProxyLogFields(requestUrl: URL): Record<string, string> {
+  const pathname = getV3ProxyPath(requestUrl)
+  const parts = pathname.split('/').filter(Boolean)
+  const fields: Record<string, string> = {}
+  const chainId = cleanParam(requestUrl.searchParams.get('chainId'), INTEGER_RE)
+  if (chainId != null) fields.v3ChainId = chainId
+
+  if (
+    parts.length === 5
+    && parts[0] === 'v3'
+    && (parts[1] === 'evk' || parts[1] === 'earn')
+    && parts[2] === 'vaults'
+    && INTEGER_RE.test(parts[3])
+    && ADDRESS_RE.test(parts[4])
+  ) {
+    fields.v3VaultKind = parts[1]
+    fields.v3ChainId = parts[3]
+    fields.v3VaultAddress = parts[4]
+  }
+
+  if (
+    parts.length === 6
+    && parts[0] === 'v3'
+    && (parts[1] === 'evk' || parts[1] === 'earn')
+    && parts[2] === 'vaults'
+    && INTEGER_RE.test(parts[3])
+    && ADDRESS_RE.test(parts[4])
+    && parts[5] === 'totals'
+  ) {
+    fields.v3VaultKind = parts[1]
+    fields.v3ChainId = parts[3]
+    fields.v3VaultAddress = parts[4]
+  }
+
+  if (
+    parts.length === 4
+    && parts[0] === 'v3'
+    && parts[1] === 'evk'
+    && parts[2] === 'vaults'
+    && parts[3] === 'open-interest'
+  ) {
+    const vaultAddress = cleanParam(requestUrl.searchParams.get('vault'), ADDRESS_RE)
+    if (vaultAddress != null) fields.v3VaultAddress = vaultAddress
+  }
+
+  return {
+    ...fields,
+    ...readSafeQueryFields(requestUrl.searchParams),
+  }
 }
 
 export function readForwardedV3ResponseHeaders(headers: Headers): Record<string, string> {

--- a/tests/server/v3-proxy.test.ts
+++ b/tests/server/v3-proxy.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  buildV3ProxyLogFields,
   buildV3ProxyRequestHeaders,
   buildV3ProxyTarget,
   isV3ProxyPathAllowed,
@@ -99,6 +100,48 @@ describe('v3 proxy utilities', () => {
       'POST',
       new URL('https://app.example/api/internal/v3/prices'),
     )).toMatchObject({ ok: false, statusCode: 405 })
+  })
+
+  it('extracts public vault totals failure context without raw paths', () => {
+    expect(buildV3ProxyLogFields(
+      new URL(`https://app.example/api/internal/v3/evk/vaults/1/${VAULT}/totals?resolution=1d&from=1782380000&to=1782984800`),
+    )).toEqual({
+      v3ChainId: '1',
+      v3From: '1782380000',
+      v3Resolution: '1d',
+      v3To: '1782984800',
+      v3VaultAddress: VAULT,
+      v3VaultKind: 'evk',
+    })
+  })
+
+  it('extracts public open-interest and bad-debt failure context', () => {
+    expect(buildV3ProxyLogFields(
+      new URL(`https://app.example/api/internal/v3/evk/vaults/open-interest?chainId=1&vault=${VAULT}&limit=10`),
+    )).toEqual({
+      v3ChainId: '1',
+      v3Limit: '10',
+      v3VaultAddress: VAULT,
+    })
+
+    expect(buildV3ProxyLogFields(
+      new URL('https://app.example/api/internal/v3/evk/vaults/bad-debt?chainId=1&minBadDebtUsd=0&offset=100&limit=100'),
+    )).toEqual({
+      v3ChainId: '1',
+      v3Limit: '100',
+      v3MinBadDebtUsd: '0',
+      v3Offset: '100',
+    })
+  })
+
+  it('does not log dynamic account addresses from account-position requests', () => {
+    expect(buildV3ProxyLogFields(
+      new URL(`https://app.example/api/internal/v3/accounts/${ACCOUNT}/positions?chainId=1&offset=0&limit=100`),
+    )).toEqual({
+      v3ChainId: '1',
+      v3Limit: '100',
+      v3Offset: '0',
+    })
   })
 
   it('injects only fixed SDK headers and the server-side API key', () => {


### PR DESCRIPTION
## Summary
- Add structured V3 proxy failure context so timeout/non-ok alerts identify the public vault endpoint that failed.
- Keep logs bounded to allowlisted fields instead of raw request paths or account addresses.

## Changes
- Include `v3ChainId`, `v3VaultAddress`, `v3VaultKind`, and safe range/pagination fields on V3 upstream failure logs.
- Cover vault totals graphs, open-interest, and bad-debt request shapes while omitting dynamic account addresses.
- Add V3 proxy utility coverage for the new log-field extraction.

## Test plan
- [x] `./node_modules/.bin/vitest run tests/server/v3-proxy.test.ts tests/server/v3-proxy-route.test.ts`
- [x] `npx eslint server/utils/v3-proxy.ts 'server/api/internal/v3/[...path].ts' tests/server/v3-proxy.test.ts`
- [x] `npm run typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of V3 proxy requests so failures are logged with more consistent request details.
  * Enhanced safe request metadata capture for proxy-related errors, helping support troubleshooting without exposing sensitive values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->