### PR TITLE
fix: expose the connector address in EIP-55 checksummed form

### DIFF
--- a/composables/useKeyring/index.ts
+++ b/composables/useKeyring/index.ts
@@ -160,9 +160,11 @@ export const useKeyring = (vaultAddress: string | Ref<string>) => {
 
       const state = await KeyringConnect.getExtensionState()
       const cred = state?.credentialData
+      // The extension echoes the trader address in its own casing — compare
+      // case-insensitively so a casing difference doesn't force a re-auth.
       if (
         cred
-        && cred.trader === userAddress.value
+        && cred.trader?.toLowerCase() === userAddress.value?.toLowerCase()
         && cred.policyId === policyId.value
         && cred.chainId === chainId.value
       ) {

--- a/composables/useWagmi.ts
+++ b/composables/useWagmi.ts
@@ -1,7 +1,8 @@
 import { useAccount, useDisconnect, useSwitchChain, useEnsName, useConfig } from '@wagmi/vue'
 import { connect as connectWallet, getConnectors } from '@wagmi/vue/actions'
-import { getAddress, isAddress, type Address } from 'viem'
+import type { Address } from 'viem'
 import { logWarn } from '~/utils/errorHandling'
+import { normalizeAddress } from '~/utils/normalizeAddress'
 import { truncate } from '~/utils/string-utils'
 import { useAddressScreen } from '~/composables/useAddressScreen'
 import { parseChainId } from '~/entities/chainRegistry'
@@ -122,21 +123,22 @@ export const useWagmi = () => {
   // Fail closed: a connected address only becomes user-visible once screening
   // returns a non-restricted verdict. Consumers that read `address`/`isConnected`
   // automatically see the gated state without each having to import useAddressScreen.
-  const address: ComputedRef<Address | undefined> = computed(() =>
-    isAddressScreened(wagmiAddress.value) ? (wagmiAddress.value || undefined) : undefined,
-  )
+  //
+  // Always exposed in EIP-55 checksummed form: connectors are not guaranteed
+  // to report checksummed casing (AppKit's WalletConnect connector passes the
+  // wallet's session string through verbatim, and wallets may emit lowercase),
+  // while consumers key caches and compare against this value. Normalizing at
+  // this single choke point gives every consumer canonical casing.
+  const address: ComputedRef<Address | undefined> = computed(() => {
+    const raw = wagmiAddress.value
+    if (!raw || !isAddressScreened(raw)) return undefined
+    return normalizeAddress(raw)
+  })
   const isConnected = computed(() => Boolean(wagmiIsConnected.value && isAddressScreened(wagmiAddress.value)))
   const chain = computed(() => wagmiChain.value)
   const chainId = computed(() => wagmiChain.value?.id)
 
-  const checksummedAddress = computed(() => {
-    try {
-      return address.value && isAddress(address.value) ? getAddress(address.value) : ''
-    }
-    catch {
-      return address.value
-    }
-  })
+  const checksummedAddress = computed(() => address.value ?? '')
 
   const friendlyAddress = computed(() => checksummedAddress.value)
   const shortAddress = computed(() => address.value ? truncate(address.value) : '')

--- a/docs/portfolio-logic.md
+++ b/docs/portfolio-logic.md
@@ -341,7 +341,7 @@ The poll interval awaits `updateBalances()` before `refreshVaults()` to ensure w
 
 After each fetch, `updateBalances()` schedules a follow-up run if its inputs (chain, address, registry readiness) changed mid-flight. Two safeguards keep this from looping:
 
-- Address identity is compared **case-insensitively**. Connector-reported addresses are not guaranteed to be EIP-55 checksummed (WalletConnect wallets commonly report lowercase, injected wallets checksum), while the last-fetched address is stored checksummed. A cased compare here once kept the follow-up condition true forever, refetching in an unbounded loop that hung the tab.
+- Address identity is compared **case-insensitively**. Connector-reported addresses are not guaranteed to be EIP-55 checksummed (WalletConnect wallets commonly report lowercase, injected wallets checksum), while the last-fetched address is stored checksummed. A cased compare here once kept the follow-up condition true forever, refetching in an unbounded loop that hung the tab. `useWagmi().address` now normalizes the connector value to checksummed form at the source, so consumers always see canonical casing — the case-insensitive compare stays as defense-in-depth.
 - Consecutive follow-up runs are capped (`MAX_CONSECUTIVE_AUTO_REFETCHES`); hitting the cap logs a warning instead of spinning, since legitimate mid-flight changes settle within a couple of rounds.
 
 ## Related Documentation

--- a/tests/composables/useWagmi.test.ts
+++ b/tests/composables/useWagmi.test.ts
@@ -1,0 +1,88 @@
+import { computed, ref } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Address } from 'viem'
+
+/**
+ * useWagmi exposes the connector address in EIP-55 checksummed form.
+ *
+ * Connectors are not guaranteed to report checksummed casing — AppKit's
+ * WalletConnect connector passes the wallet's session string through
+ * verbatim, and wallets may emit lowercase. Normalizing at this choke point
+ * gives every consumer canonical casing (raw-casing comparisons against this
+ * value previously caused the balance refetch loop fixed in useWallets).
+ */
+
+const CHECKSUMMED = '0x904788be730704B53B55E0654A9D659B3A9ce0a7'
+const LOWERCASE = CHECKSUMMED.toLowerCase() as Address
+
+const wagmiAddress = ref<Address | undefined>(undefined)
+const wagmiIsConnected = ref(false)
+const wagmiChain = ref<{ id: number } | undefined>(undefined)
+
+vi.mock('@wagmi/vue', () => ({
+  useAccount: () => ({
+    address: wagmiAddress,
+    isConnected: wagmiIsConnected,
+    connector: ref(undefined),
+    chain: wagmiChain,
+    status: ref('disconnected'),
+  }),
+  useDisconnect: () => ({ disconnect: vi.fn() }),
+  useSwitchChain: () => ({ switchChain: vi.fn() }),
+  useEnsName: () => ({ data: ref(undefined) }),
+  useConfig: () => ({}),
+}))
+vi.mock('@wagmi/vue/actions', () => ({
+  connect: vi.fn(),
+  getConnectors: () => [],
+}))
+vi.mock('~/composables/useAddressScreen', () => ({
+  useAddressScreen: () => ({
+    screenConnectedAddress: vi.fn(async () => false),
+    resetScreeningCache: vi.fn(),
+    isAddressScreened: (address?: string | null) => Boolean(address),
+  }),
+}))
+
+describe('useWagmi address casing', () => {
+  beforeEach(() => {
+    vi.stubGlobal('useRoute', () => ({ path: '/', query: {}, hash: '' }))
+    vi.stubGlobal('useRouter', () => ({ replace: vi.fn(async () => {}), push: vi.fn(async () => {}) }))
+    vi.stubGlobal('useEulerAddresses', () => ({
+      changeCurrentChainId: vi.fn(),
+      chainId: ref(1),
+      allowedChainIds: computed(() => [1]),
+    }))
+    vi.stubGlobal('useNuxtApp', () => ({}))
+  })
+
+  it('exposes a lowercase connector address in checksummed form', async () => {
+    const { useWagmi } = await import('~/composables/useWagmi')
+    const { address, checksummedAddress } = useWagmi()
+
+    wagmiAddress.value = LOWERCASE
+    wagmiIsConnected.value = true
+
+    expect(address.value).toBe(CHECKSUMMED)
+    expect(checksummedAddress.value).toBe(CHECKSUMMED)
+  })
+
+  it('leaves an already-checksummed connector address unchanged', async () => {
+    const { useWagmi } = await import('~/composables/useWagmi')
+    const { address } = useWagmi()
+
+    wagmiAddress.value = CHECKSUMMED as Address
+
+    expect(address.value).toBe(CHECKSUMMED)
+  })
+
+  it('stays undefined when no address is connected', async () => {
+    const { useWagmi } = await import('~/composables/useWagmi')
+    const { address, checksummedAddress } = useWagmi()
+
+    wagmiAddress.value = undefined
+
+    expect(address.value).toBeUndefined()
+    expect(checksummedAddress.value).toBe('')
+  })
+})


### PR DESCRIPTION
Follow-up to #713. That PR fixed the concrete tab-hang by making one comparison casing-proof; this one removes the bug class at the source so raw-casing comparisons against the connector address become structurally impossible.

## Change

- `useWagmi().address` now returns the EIP-55 checksummed form via `normalizeAddress` (single choke point). Connectors are not guaranteed to report checksummed casing — AppKit's WalletConnect connector returns the wallet's session account string verbatim, and wallets may emit lowercase (spec-legal per CAIP-10 / the eip155 namespace profile). `checksummedAddress` simplifies to an alias. `useEffectiveAddress().effectiveAddress` becomes uniformly checksummed since the spy branch already was.
- Normalization runs once per address change in a computed — a single keccak hash at the boundary, mirroring what upstream wagmi's own WalletConnect connector does (`provider.accounts.map(x => getAddress(x))`); AppKit's replacement connector dropped it.

## Consumer sweep

Audited every consumer of `address` / `checksummedAddress` / `friendlyAddress` / `effectiveAddress` across composables, components, pages, utils, and services for case-sensitive comparisons, address-derived cache/storage keys, and strict compares against wagmi-internal values. All but one already normalize (`getAddress`/`toLowerCase`/`isSameAddress`) or only pass the value to SDK/API calls; no localStorage/useState keys are built from the wallet address.

The one behavioral dependency found: the Keyring credential check compared `cred.trader` (echoed by the Keyring browser extension in its own casing) strictly against the exposed address — now compared case-insensitively so a casing difference can't force a spurious re-auth.

## Verification

- New `tests/composables/useWagmi.test.ts` feeds a lowercase connector address through mocked wagmi and asserts the exposed values are checksummed; mutation-checked (reverting the normalization fails it).
- The #713 regression tests (refetch loop, auto-refetch cap) still pass — the case-insensitive compare and cap remain as defense-in-depth.
- Full unit suite passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wallet address handling so addresses are compared and displayed consistently, even when casing differs.
  * Reduced the chance of repeated balance refresh loops caused by address formatting mismatches.

* **Tests**
  * Added coverage for address normalization, preserving existing checksummed addresses, and handling missing addresses.

* **Documentation**
  * Clarified address casing behavior in balance refresh guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->