### PR TITLE
fix(portfolio): show an error state instead of $0.00 when the portfolio fetch fails

### DIFF
--- a/composables/useEulerAccount.ts
+++ b/composables/useEulerAccount.ts
@@ -28,6 +28,10 @@ const isPositionsLoaded = ref(false)
 const isDepositsLoading = ref(true)
 const isDepositsLoaded = ref(false)
 const isShowAllPositions = ref(false)
+// True when the most recent portfolio fetch threw, as opposed to succeeding
+// with partial per-asset pricing issues. Surfaced to the UI so a failed load
+// renders an error state instead of formatted zeros — see `hasPortfolioLoadError`.
+const hasPositionsFetchError = ref(false)
 
 // Transparent layer overlay: when a non-zero batch layer is active, the
 // simulated portfolio is served for both the visible and all-positions views,
@@ -101,6 +105,7 @@ export const useEulerAccount = () => {
     visiblePortfolio.value = undefined
     allPortfolio.value = undefined
     portfolioDiagnostics.value = []
+    hasPositionsFetchError.value = false
     isPositionsLoaded.value = false
     isPositionsLoading.value = true
     isDepositsLoaded.value = false
@@ -121,6 +126,7 @@ export const useEulerAccount = () => {
     const gen = positionGuard.current()
 
     try {
+      hasPositionsFetchError.value = false
       if (!walletAddress) {
         visiblePortfolio.value = undefined
         allPortfolio.value = undefined
@@ -162,6 +168,7 @@ export const useEulerAccount = () => {
     catch (error) {
       if (positionGuard.isStale(gen)) return
       logWarn('useEulerAccount/fetchAndUpdatePortfolio', error)
+      hasPositionsFetchError.value = true
       portfolioDiagnostics.value = [{
         code: 'SOURCE_UNAVAILABLE',
         severity: 'error',
@@ -227,6 +234,12 @@ export const useEulerAccount = () => {
   startWatchers()
   onScopeDispose(releaseWatchers)
 
+  // A portfolio fetch failed AND we have no (stale) portfolio to fall back on.
+  // Gating on the absence of data means a transient background-refresh failure
+  // keeps the last-good figures on screen, while a genuine cold-load failure
+  // lets the UI show an error instead of misleading $0.00 totals.
+  const hasPortfolioLoadError = computed(() => hasPositionsFetchError.value && !portfolio.value)
+
   const portfolioRoe = computed(() => portfolio.value?.roe ?? 0)
   const portfolioNetApy = computed(() => portfolio.value?.netApy ?? 0)
   const totalSuppliedValue = computed(() => usdWadToNumber(portfolio.value?.totalSuppliedValueUsd))
@@ -276,6 +289,7 @@ export const useEulerAccount = () => {
   return {
     portfolio,
     portfolioDiagnostics,
+    hasPortfolioLoadError,
     borrowPositions,
     depositPositions,
     removedBorrowPositions,

--- a/composables/useEulerAccount.ts
+++ b/composables/useEulerAccount.ts
@@ -126,11 +126,11 @@ export const useEulerAccount = () => {
     const gen = positionGuard.current()
 
     try {
-      hasPositionsFetchError.value = false
       if (!walletAddress) {
         visiblePortfolio.value = undefined
         allPortfolio.value = undefined
         portfolioDiagnostics.value = []
+        hasPositionsFetchError.value = false
         markLoaded()
         return
       }
@@ -163,6 +163,7 @@ export const useEulerAccount = () => {
       allPortfolio.value = nextAllPortfolio
       visiblePortfolio.value = nextVisiblePortfolio
       portfolioDiagnostics.value = fetched.errors
+      hasPositionsFetchError.value = false
       markLoaded()
     }
     catch (error) {

--- a/pages/portfolio.vue
+++ b/pages/portfolio.vue
@@ -20,6 +20,7 @@ const {
   isPositionsLoaded,
   isShowAllPositions,
   refreshAllPositions,
+  hasPortfolioLoadError,
 } = useEulerAccount()
 const { refresh: refreshFreshAccount } = useFreshAccount()
 const { rewards } = useSdkRewards()
@@ -134,17 +135,23 @@ watch([() => route.name, showMigrationTab, hasMigrationLoaded, isMigrationLoadin
 })
 
 const portfolioNetApyDisplay = computed(() =>
-  Number.isFinite(portfolioNetApy.value) ? `${formatNumber(portfolioNetApy.value)}%` : '-',
+  !hasPortfolioLoadError.value && Number.isFinite(portfolioNetApy.value)
+    ? `${formatNumber(portfolioNetApy.value)}%`
+    : '-',
 )
 const portfolioRoeDisplay = computed(() =>
-  Number.isFinite(portfolioRoe.value) ? `${formatNumber(portfolioRoe.value)}%` : '-',
+  !hasPortfolioLoadError.value && Number.isFinite(portfolioRoe.value)
+    ? `${formatNumber(portfolioRoe.value)}%`
+    : '-',
 )
 const totalSuppliedDisplay = computed(() => {
+  if (hasPortfolioLoadError.value) return '—'
   const { total, hasMissingPrices } = totalSuppliedValueInfo.value
   if (total === 0 && hasMissingPrices) return '—'
   return formatCompactUsdValue(total)
 })
 const totalBorrowedDisplay = computed(() => {
+  if (hasPortfolioLoadError.value) return '—'
   const { total, hasMissingPrices } = totalBorrowedValueInfo.value
   if (total === 0 && hasMissingPrices) return '—'
   return formatCompactUsdValue(total)
@@ -153,6 +160,7 @@ const netAssetValueInfo = computed(() => {
   return netAssetMarketValueInfo.value
 })
 const netAssetValueDisplay = computed(() => {
+  if (hasPortfolioLoadError.value) return '—'
   const { total, hasMissingPrices } = netAssetValueInfo.value
   if (total === 0 && hasMissingPrices) return '—'
   return formatCompactUsdValue(total)
@@ -171,6 +179,10 @@ const updatePositions = async (
     source: options.portfolioSource,
     preempt: options.preemptPortfolio,
   })
+}
+
+const retryPortfolioLoad = () => {
+  void updatePositions({ portfolioSource: 'fresh', preemptPortfolio: true })
 }
 
 onActivated(async () => {
@@ -218,6 +230,26 @@ watch(showAllLabelEntries, (showAll) => {
 
     <PortfolioRampingBanner />
 
+    <div
+      v-if="hasPortfolioLoadError"
+      class="flex items-center gap-8 rounded-12 p-12 mx-16 bg-error-100"
+    >
+      <SvgIcon
+        name="warning"
+        class="!w-20 !h-20 text-error-500 shrink-0"
+      />
+      <span class="text-p4 flex-1 text-error-500">
+        We couldn't load your portfolio. Your funds are safe on-chain — this is usually temporary.
+      </span>
+      <button
+        type="button"
+        class="shrink-0 text-p4 font-medium text-error-500 hover:text-error-500/70 transition-colors"
+        @click="retryPortfolioLoad"
+      >
+        Retry
+      </button>
+    </div>
+
     <div class="flex flex-col gap-16 mx-16 laptop:flex-row laptop:items-stretch">
       <div class="flex flex-col gap-16 p-16 rounded-12 border border-line-default bg-card shadow-card laptop:flex-1">
         <div class="text-h4 text-content-primary">
@@ -240,7 +272,7 @@ watch(showAllLabelEntries, (showAll) => {
               data-id="data-point"
               :data-key="spyAddress || address"
               data-field="portfolio-net-apy"
-              :data-value="Number.isFinite(portfolioNetApy) ? portfolioNetApy : '-'"
+              :data-value="hasPortfolioLoadError ? '-' : (Number.isFinite(portfolioNetApy) ? portfolioNetApy : '-')"
             >
               {{ portfolioNetApyDisplay }}
             </div>
@@ -263,7 +295,7 @@ watch(showAllLabelEntries, (showAll) => {
               data-id="data-point"
               :data-key="spyAddress || address"
               data-field="portfolio-roe"
-              :data-value="Number.isFinite(portfolioRoe) ? portfolioRoe : '-'"
+              :data-value="hasPortfolioLoadError ? '-' : (Number.isFinite(portfolioRoe) ? portfolioRoe : '-')"
             >
               {{ portfolioRoeDisplay }}
             </div>
@@ -291,7 +323,7 @@ watch(showAllLabelEntries, (showAll) => {
               data-id="data-point"
               :data-key="spyAddress || address"
               data-field="portfolio-total-supplied"
-              :data-value="totalSuppliedValueInfo.hasMissingPrices ? totalSuppliedDisplay : totalSuppliedValueInfo.total"
+              :data-value="hasPortfolioLoadError ? '—' : (totalSuppliedValueInfo.hasMissingPrices ? totalSuppliedDisplay : totalSuppliedValueInfo.total)"
             >
               {{ totalSuppliedDisplay }}
             </div>
@@ -314,7 +346,7 @@ watch(showAllLabelEntries, (showAll) => {
               data-id="data-point"
               :data-key="spyAddress || address"
               data-field="portfolio-total-borrowed"
-              :data-value="totalBorrowedValueInfo.hasMissingPrices ? totalBorrowedDisplay : totalBorrowedValueInfo.total"
+              :data-value="hasPortfolioLoadError ? '—' : (totalBorrowedValueInfo.hasMissingPrices ? totalBorrowedDisplay : totalBorrowedValueInfo.total)"
             >
               {{ totalBorrowedDisplay }}
             </div>
@@ -337,7 +369,7 @@ watch(showAllLabelEntries, (showAll) => {
               data-id="data-point"
               :data-key="spyAddress || address"
               data-field="portfolio-net-asset-value"
-              :data-value="netAssetValueInfo.hasMissingPrices ? netAssetValueDisplay : netAssetValueInfo.total"
+              :data-value="hasPortfolioLoadError ? '—' : (netAssetValueInfo.hasMissingPrices ? netAssetValueDisplay : netAssetValueInfo.total)"
             >
               {{ netAssetValueDisplay }}
             </div>

--- a/tests/composables/useEulerAccount.test.ts
+++ b/tests/composables/useEulerAccount.test.ts
@@ -3,35 +3,47 @@ import { effectScope, nextTick, ref, type EffectScope } from 'vue'
 
 const owner = '0x1000000000000000000000000000000000000000'
 
-const importUseEulerAccount = async ({ failFetch = false }: { failFetch?: boolean } = {}) => {
+const fetchedPortfolio = {
+  account: { owner },
+  borrows: ['all-borrow'],
+  savings: ['all-saving'],
+  totalSuppliedValueUsd: 100,
+  totalBorrowedValueUsd: 25,
+  netAssetValueUsd: 75,
+  roe: 3,
+  netApy: 2,
+}
+
+const visiblePortfolio = {
+  account: { owner },
+  borrows: ['visible-borrow'],
+  savings: [],
+  totalSuppliedValueUsd: 40,
+  totalBorrowedValueUsd: 10,
+  netAssetValueUsd: 30,
+  roe: 1,
+  netApy: 0.5,
+}
+
+const portfolioResponse = () => ({
+  errors: [],
+  result: fetchedPortfolio,
+})
+
+const importUseEulerAccount = async (
+  { failFetch = false, fetchPortfolioImpl }: {
+    failFetch?: boolean
+    fetchPortfolioImpl?: () => Promise<ReturnType<typeof portfolioResponse>>
+  } = {},
+) => {
   vi.resetModules()
 
   const fetchPortfolio = vi.fn(async () => {
+    if (fetchPortfolioImpl) return fetchPortfolioImpl()
     if (failFetch) throw new Error('portfolio source unavailable')
-    return {
-      errors: [],
-      result: {
-        account: { owner },
-        borrows: ['all-borrow'],
-        savings: ['all-saving'],
-        totalSuppliedValueUsd: 100,
-        totalBorrowedValueUsd: 25,
-        netAssetValueUsd: 75,
-        roe: 3,
-        netApy: 2,
-      },
-    }
+    return portfolioResponse()
   })
-  const buildPortfolio = vi.fn(() => ({
-    account: { owner },
-    borrows: ['visible-borrow'],
-    savings: [],
-    totalSuppliedValueUsd: 40,
-    totalBorrowedValueUsd: 10,
-    netAssetValueUsd: 30,
-    roe: 1,
-    netApy: 0.5,
-  }))
+  const buildPortfolio = vi.fn(() => visiblePortfolio)
   const sdk = {
     portfolioService: {
       fetchPortfolio,
@@ -143,5 +155,37 @@ describe('useEulerAccount', () => {
     expect(account?.portfolio.value).toBeUndefined()
     expect(account?.totalSuppliedValue.value).toBe(0)
     expect(account?.portfolioDiagnostics.value.some(issue => issue.severity === 'error')).toBe(true)
+  })
+
+  it('keeps the load error visible until a retry confirms new data', async () => {
+    let resolveRetry: ((value: ReturnType<typeof portfolioResponse>) => void) | undefined
+    const fetchPortfolioImpl = vi.fn()
+      .mockRejectedValueOnce(new Error('portfolio source unavailable'))
+      .mockImplementationOnce(() => new Promise<ReturnType<typeof portfolioResponse>>((resolve) => {
+        resolveRetry = resolve
+      }))
+
+    const { useEulerAccount, fetchPortfolio } = await importUseEulerAccount({ fetchPortfolioImpl })
+
+    let account: ReturnType<typeof useEulerAccount> | undefined
+    scope = effectScope()
+    scope.run(() => {
+      account = useEulerAccount()
+    })
+
+    await vi.waitFor(() => expect(fetchPortfolio).toHaveBeenCalledTimes(1))
+    await vi.waitFor(() => expect(account?.hasPortfolioLoadError.value).toBe(true))
+
+    const retry = account!.refreshAllPositions(undefined, owner, { preempt: true })
+    await vi.waitFor(() => expect(fetchPortfolio).toHaveBeenCalledTimes(2))
+
+    expect(account?.portfolio.value).toBeUndefined()
+    expect(account?.hasPortfolioLoadError.value).toBe(true)
+
+    resolveRetry?.(portfolioResponse())
+    await retry
+
+    expect(account?.portfolio.value).toEqual(visiblePortfolio)
+    expect(account?.hasPortfolioLoadError.value).toBe(false)
   })
 })

--- a/tests/composables/useEulerAccount.test.ts
+++ b/tests/composables/useEulerAccount.test.ts
@@ -3,22 +3,25 @@ import { effectScope, nextTick, ref, type EffectScope } from 'vue'
 
 const owner = '0x1000000000000000000000000000000000000000'
 
-const importUseEulerAccount = async () => {
+const importUseEulerAccount = async ({ failFetch = false }: { failFetch?: boolean } = {}) => {
   vi.resetModules()
 
-  const fetchPortfolio = vi.fn(async () => ({
-    errors: [],
-    result: {
-      account: { owner },
-      borrows: ['all-borrow'],
-      savings: ['all-saving'],
-      totalSuppliedValueUsd: 100,
-      totalBorrowedValueUsd: 25,
-      netAssetValueUsd: 75,
-      roe: 3,
-      netApy: 2,
-    },
-  }))
+  const fetchPortfolio = vi.fn(async () => {
+    if (failFetch) throw new Error('portfolio source unavailable')
+    return {
+      errors: [],
+      result: {
+        account: { owner },
+        borrows: ['all-borrow'],
+        savings: ['all-saving'],
+        totalSuppliedValueUsd: 100,
+        totalBorrowedValueUsd: 25,
+        netAssetValueUsd: 75,
+        roe: 3,
+        netApy: 2,
+      },
+    }
+  })
   const buildPortfolio = vi.fn(() => ({
     account: { owner },
     borrows: ['visible-borrow'],
@@ -121,5 +124,24 @@ describe('useEulerAccount', () => {
     expect(account?.borrowPositions.value).toEqual(['all-borrow'])
     expect(account?.depositPositions.value).toEqual(['all-saving'])
     expect(account?.totalSuppliedValue.value).toBe(100)
+  })
+
+  it('flags a load error (rather than showing zeros) when the fetch fails with no data to fall back on', async () => {
+    const { useEulerAccount, fetchPortfolio } = await importUseEulerAccount({ failFetch: true })
+
+    let account: ReturnType<typeof useEulerAccount> | undefined
+    scope = effectScope()
+    scope.run(() => {
+      account = useEulerAccount()
+    })
+
+    await vi.waitFor(() => expect(fetchPortfolio).toHaveBeenCalled())
+    await vi.waitFor(() => expect(account?.hasPortfolioLoadError.value).toBe(true))
+
+    // No portfolio is present, so the totals are zero — the error flag is what
+    // lets the page render an error state instead of a misleading $0.00.
+    expect(account?.portfolio.value).toBeUndefined()
+    expect(account?.totalSuppliedValue.value).toBe(0)
+    expect(account?.portfolioDiagnostics.value.some(issue => issue.severity === 'error')).toBe(true)
   })
 })


### PR DESCRIPTION
## Problem

When `fetchAndUpdatePortfolio` in `useEulerAccount` throws, the catch block records a diagnostic but still calls `markLoaded()`, leaving `visiblePortfolio`/`allPortfolio` `undefined`. The portfolio page only substitutes "—" when positions exist with missing prices, so an outright load failure falls through to formatted zeros:

> $0.00 Supplied · $0.00 Borrowed · $0.00 Net Worth

For an account with real deposits and borrows this is indistinguishable from an empty account, and the recorded `portfolioDiagnostics` are consumed nowhere in the UI — the failure is fully swallowed. In a lending context, showing a confident $0.00 where a user has funds can drive wrong decisions.

## Fix

- Add an explicit `hasPositionsFetchError` flag in `useEulerAccount`, set when a fetch throws and cleared at the start of every fresh attempt.
- Expose `hasPortfolioLoadError`, computed as "a fetch failed **and** there is no portfolio to fall back on". Gating on the absence of data means a transient background-refresh failure keeps the last-good figures on screen, while a genuine cold-load failure lets the UI show an error.
- On the portfolio page, render an error banner with a **Retry** action and show `—`/`-` for the value and performance figures instead of zeros. The `data-value` capture attributes reflect the error too, so parity/e2e captures don't record misleading zeros.

This mirrors the existing `hasQueryFailure` → "Position data is incomplete" handling already used on the per-position page.

## Testing

- Added a unit test in `tests/composables/useEulerAccount.test.ts` covering the failed-fetch path (asserts `hasPortfolioLoadError` is set, totals stay zero, and an error-severity diagnostic is present).
- `npx vitest run tests/composables/useEulerAccount.test.ts` — passes.
- ESLint clean on the changed files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added clearer handling for portfolio load failures, so the app can distinguish between first-time load errors and temporary refresh issues.
  * Portfolio stats now show placeholders when data can’t be loaded, instead of displaying misleading values.
  * An error banner with a retry option now appears when the portfolio fails to load, making recovery easier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->