### PR TITLE
fix: bind prepared plans to wallet context

### DIFF
--- a/composables/useEulerTx.ts
+++ b/composables/useEulerTx.ts
@@ -1268,12 +1268,11 @@ export const useEulerTx = () => {
       ? prepared.account
       : prepared.account.owner
     const assertPreparedWalletContext = () => {
-      const currentOwner = requireOwner()
-      const currentChainId = requireChainId()
-      if (getAddress(currentOwner) !== getAddress(preparedOwner)) {
+      const currentWallet = getAccount(config)
+      if (!currentWallet.address || getAddress(currentWallet.address) !== getAddress(preparedOwner)) {
         throw new Error('Wallet account changed since this transaction was prepared. Review the transaction again.')
       }
-      if (currentChainId !== prepared.chainId) {
+      if (currentWallet.chainId === undefined || currentWallet.chainId !== prepared.chainId) {
         throw new Error('Wallet network changed since this transaction was prepared. Review the transaction again.')
       }
     }

--- a/composables/useEulerTx.ts
+++ b/composables/useEulerTx.ts
@@ -58,6 +58,11 @@ const SUB_ACCOUNT_SNAPSHOT_FETCH_OPTIONS = {
   populateUserRewards: false,
 } as const
 type PrefetchPluginAccount = Account<IHasVaultAddress> | Address
+type PreparedWalletContext = {
+  account: Address
+  chainId: number
+  assertCurrent: () => void
+}
 
 const isOkxWallet = async (connector?: { id?: string, name?: string, getProvider?: () => Promise<unknown> }) => {
   if (!connector) return false
@@ -1164,18 +1169,27 @@ export const useEulerTx = () => {
     })
   }
 
-  const buildSendTransaction = (isOkx: boolean) => {
+  const buildSendTransaction = (isOkx: boolean, preparedContext?: PreparedWalletContext) => {
     let okxDelayPending = false
     const send = async ({ to, data, value }: { to: Address, data: Hex, value?: bigint }) => {
       if (okxDelayPending) {
         await new Promise(r => setTimeout(r, OKX_POST_APPROVE_DELAY_MS))
         okxDelayPending = false
       }
-      const hash = await sendTransactionAsync({
-        to,
-        data: data as Hex,
-        value: value ?? 0n,
-      })
+      preparedContext?.assertCurrent()
+      const hash = preparedContext
+        ? await sendTransactionAsync({
+            account: preparedContext.account,
+            chainId: preparedContext.chainId,
+            to,
+            data: data as Hex,
+            value: value ?? 0n,
+          })
+        : await sendTransactionAsync({
+            to,
+            data: data as Hex,
+            value: value ?? 0n,
+          })
       if (isOkx && (data as Hex).toLowerCase().startsWith(ERC20_APPROVE_SELECTOR)) {
         okxDelayPending = true
       }
@@ -1250,15 +1264,38 @@ export const useEulerTx = () => {
     if (isSpyMode.value) {
       throw new Error('Transactions are disabled in spy mode')
     }
+    const preparedOwner = typeof prepared.account === 'string'
+      ? prepared.account
+      : prepared.account.owner
+    const assertPreparedWalletContext = () => {
+      const currentOwner = requireOwner()
+      const currentChainId = requireChainId()
+      if (getAddress(currentOwner) !== getAddress(preparedOwner)) {
+        throw new Error('Wallet account changed since this transaction was prepared. Review the transaction again.')
+      }
+      if (currentChainId !== prepared.chainId) {
+        throw new Error('Wallet network changed since this transaction was prepared. Review the transaction again.')
+      }
+    }
+
+    assertPreparedWalletContext()
     const sdk = await getEulerSdkFresh()
     const isOkx = await isOkxWallet(getAccount(config).connector)
-    const sendTransaction = buildSendTransaction(isOkx)
+    const sendTransaction = buildSendTransaction(isOkx, {
+      account: preparedOwner,
+      chainId: prepared.chainId,
+      assertCurrent: assertPreparedWalletContext,
+    })
 
     const result = await sdk.executionService.executePreparedTransactionPlan({
       prepared,
       sendTransaction,
       signTypedData: async (typedData) => {
-        const signature = await signTypedDataAsync(typedData as unknown as Parameters<typeof signTypedDataAsync>[0])
+        assertPreparedWalletContext()
+        const signature = await signTypedDataAsync({
+          ...typedData,
+          account: preparedOwner,
+        } as unknown as Parameters<typeof signTypedDataAsync>[0])
         return signature as Hex
       },
       onProgress: (_progress: TransactionPlanExecutionProgress) => {},

--- a/tests/composables/useEulerTx.test.ts
+++ b/tests/composables/useEulerTx.test.ts
@@ -1,0 +1,168 @@
+import { ref, type Ref } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Account, IHasVaultAddress, TransactionPlanPrepared } from '@eulerxyz/euler-v2-sdk'
+import type { Address, Hex } from 'viem'
+import { useEulerTx } from '~/composables/useEulerTx'
+
+const { mocks } = vi.hoisted(() => ({
+  mocks: {
+    executePreparedTransactionPlan: vi.fn(),
+    getAccount: vi.fn(),
+    getEulerSdkFresh: vi.fn(),
+    invalidateSdkQueries: vi.fn(),
+    sendTransactionAsync: vi.fn(),
+    signTypedDataAsync: vi.fn(),
+    triggerPortfolioRefresh: vi.fn(),
+  },
+}))
+
+vi.mock('@wagmi/vue', () => ({
+  useConfig: () => ({}),
+  useSendTransaction: () => ({ sendTransactionAsync: mocks.sendTransactionAsync }),
+  useSignTypedData: () => ({ signTypedDataAsync: mocks.signTypedDataAsync }),
+}))
+
+vi.mock('@wagmi/vue/actions', () => ({
+  getAccount: mocks.getAccount,
+}))
+
+vi.mock('~/composables/useEulerSdk', () => ({
+  buildSubgraphProxyApiPath: vi.fn(),
+  getEulerSdkForChain: vi.fn(),
+  getEulerSdkFresh: mocks.getEulerSdkFresh,
+}))
+
+vi.mock('~/utils/errorHandling', () => ({
+  logWarn: vi.fn(),
+}))
+
+vi.mock('~/utils/sdk-query-cache', () => ({
+  invalidateSdkQueries: mocks.invalidateSdkQueries,
+}))
+
+vi.mock('~/utils/sdk-query-policy', () => ({
+  INVALIDATE_AFTER_TX: [],
+}))
+
+vi.mock('~/utils/subgraph', () => ({
+  waitForSubgraphBlock: vi.fn(),
+}))
+
+vi.mock('~/utils/profiler', () => ({
+  profAsync: (_group: string, _operation: string, fn: () => unknown) => fn(),
+}))
+
+const OWNER = '0x0000000000000000000000000000000000000001' as Address
+const OTHER_OWNER = '0x0000000000000000000000000000000000000002' as Address
+const TARGET = '0x0000000000000000000000000000000000000003' as Address
+const CHAIN_ID = 1
+const OTHER_CHAIN_ID = 8453
+const TX_HASH = `0x${'1'.repeat(64)}` as Hex
+const SIGNATURE = `0x${'2'.repeat(130)}` as Hex
+
+type PreparedExecutionCallbacks = {
+  sendTransaction: (transaction: { to: Address, data: Hex, value?: bigint }) => Promise<Hex>
+  signTypedData: (typedData: {
+    domain: Record<string, unknown>
+    types: Record<string, unknown>
+    primaryType: string
+    message: Record<string, unknown>
+  }) => Promise<Hex>
+}
+
+const typedData = {
+  domain: { chainId: CHAIN_ID },
+  types: { Permit: [{ name: 'owner', type: 'address' }] },
+  primaryType: 'Permit',
+  message: { owner: OWNER },
+}
+
+const preparedPlan = (account: TransactionPlanPrepared['account'] = OWNER): TransactionPlanPrepared => ({
+  __prepared: true,
+  plan: [],
+  chainId: CHAIN_ID,
+  account,
+  usePermit2: true,
+  unlimitedApproval: false,
+})
+
+describe('useEulerTx executePreparedPlan', () => {
+  let walletAddress: Ref<Address | undefined>
+  let walletChainId: Ref<number | undefined>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    walletAddress = ref(OWNER)
+    walletChainId = ref(CHAIN_ID)
+
+    vi.stubGlobal('useWagmi', () => ({
+      address: walletAddress,
+      chainId: walletChainId,
+    }))
+    vi.stubGlobal('useSpyMode', () => ({
+      isSpyMode: ref(false),
+      spyAddress: ref(undefined),
+    }))
+    vi.stubGlobal('usePermit2Preference', () => ({ permit2Enabled: ref(true) }))
+    vi.stubGlobal('usePortfolioRefresh', () => ({ triggerPortfolioRefresh: mocks.triggerPortfolioRefresh }))
+    vi.stubGlobal('useEulerAddresses', () => ({ chainId: ref(CHAIN_ID) }))
+
+    mocks.getAccount.mockReturnValue({ connector: undefined })
+    mocks.getEulerSdkFresh.mockResolvedValue({
+      executionService: {
+        executePreparedTransactionPlan: mocks.executePreparedTransactionPlan,
+      },
+    })
+    mocks.sendTransactionAsync.mockResolvedValue(TX_HASH)
+    mocks.signTypedDataAsync.mockResolvedValue(SIGNATURE)
+  })
+
+  it('rejects account drift immediately before a prepared signature', async () => {
+    mocks.executePreparedTransactionPlan.mockImplementation(async ({ signTypedData }: PreparedExecutionCallbacks) => {
+      walletAddress.value = OTHER_OWNER
+      await signTypedData(typedData)
+      return { receipts: [] }
+    })
+
+    await expect(useEulerTx().executePreparedPlan(preparedPlan())).rejects.toThrow(
+      'Wallet account changed since this transaction was prepared. Review the transaction again.',
+    )
+    expect(mocks.signTypedDataAsync).not.toHaveBeenCalled()
+  })
+
+  it('rejects chain drift immediately before a prepared transaction', async () => {
+    mocks.executePreparedTransactionPlan.mockImplementation(async ({ sendTransaction }: PreparedExecutionCallbacks) => {
+      walletChainId.value = OTHER_CHAIN_ID
+      await sendTransaction({ to: TARGET, data: '0x' })
+      return { receipts: [] }
+    })
+
+    await expect(useEulerTx().executePreparedPlan(preparedPlan())).rejects.toThrow(
+      'Wallet network changed since this transaction was prepared. Review the transaction again.',
+    )
+    expect(mocks.sendTransactionAsync).not.toHaveBeenCalled()
+  })
+
+  it('binds prepared sends and signatures to the prepared wallet context', async () => {
+    mocks.executePreparedTransactionPlan.mockImplementation(async ({ sendTransaction, signTypedData }: PreparedExecutionCallbacks) => {
+      await signTypedData(typedData)
+      await sendTransaction({ to: TARGET, data: '0x' })
+      return { receipts: [] }
+    })
+    const preparedAccount = { owner: OWNER } as Account<IHasVaultAddress>
+
+    await useEulerTx().executePreparedPlan(preparedPlan(preparedAccount))
+
+    expect(mocks.signTypedDataAsync).toHaveBeenCalledWith({
+      ...typedData,
+      account: OWNER,
+    })
+    expect(mocks.sendTransactionAsync).toHaveBeenCalledWith({
+      account: OWNER,
+      chainId: CHAIN_ID,
+      to: TARGET,
+      data: '0x',
+      value: 0n,
+    })
+  })
+})

--- a/tests/composables/useEulerTx.test.ts
+++ b/tests/composables/useEulerTx.test.ts
@@ -89,11 +89,13 @@ const preparedPlan = (account: TransactionPlanPrepared['account'] = OWNER): Tran
 describe('useEulerTx executePreparedPlan', () => {
   let walletAddress: Ref<Address | undefined>
   let walletChainId: Ref<number | undefined>
+  let walletConnector: { id: string } | undefined
 
   beforeEach(() => {
     vi.clearAllMocks()
     walletAddress = ref(OWNER)
     walletChainId = ref(CHAIN_ID)
+    walletConnector = undefined
 
     vi.stubGlobal('useWagmi', () => ({
       address: walletAddress,
@@ -107,7 +109,11 @@ describe('useEulerTx executePreparedPlan', () => {
     vi.stubGlobal('usePortfolioRefresh', () => ({ triggerPortfolioRefresh: mocks.triggerPortfolioRefresh }))
     vi.stubGlobal('useEulerAddresses', () => ({ chainId: ref(CHAIN_ID) }))
 
-    mocks.getAccount.mockReturnValue({ connector: undefined })
+    mocks.getAccount.mockImplementation(() => ({
+      address: walletAddress.value,
+      chainId: walletChainId.value,
+      connector: walletConnector,
+    }))
     mocks.getEulerSdkFresh.mockResolvedValue({
       executionService: {
         executePreparedTransactionPlan: mocks.executePreparedTransactionPlan,
@@ -126,6 +132,19 @@ describe('useEulerTx executePreparedPlan', () => {
 
     await expect(useEulerTx().executePreparedPlan(preparedPlan())).rejects.toThrow(
       'Wallet account changed since this transaction was prepared. Review the transaction again.',
+    )
+    expect(mocks.signTypedDataAsync).not.toHaveBeenCalled()
+  })
+
+  it('rejects a missing wallet chain immediately before a prepared signature', async () => {
+    mocks.executePreparedTransactionPlan.mockImplementation(async ({ signTypedData }: PreparedExecutionCallbacks) => {
+      walletChainId.value = undefined
+      await signTypedData(typedData)
+      return { receipts: [] }
+    })
+
+    await expect(useEulerTx().executePreparedPlan(preparedPlan())).rejects.toThrow(
+      'Wallet network changed since this transaction was prepared. Review the transaction again.',
     )
     expect(mocks.signTypedDataAsync).not.toHaveBeenCalled()
   })


### PR DESCRIPTION
## Summary
- Prepared-plan execution proceeds only while the connected wallet account and network match the reviewed envelope.
- Signing and transaction callbacks remain bound to the prepared account and chain throughout execution.

## Changes
- Read the current wallet snapshot at execution entry and immediately before every prepared signature or transaction send.
- Reject missing or mismatched wallet account and chain data without substituting the browsed network.
- Keep raw-plan execution unchanged and cover account drift, chain drift, unavailable wallet-chain state, and matching-context execution.

## Test plan
- [x] npm run test:run -- tests/composables/useEulerTx.test.ts
- [x] npm run test:run
- [x] npm run typecheck
- [x] npm run lint
- [x] git diff --check origin/development...HEAD