### PR TITLE
fix: isolate lazy vault resolution by chain

### DIFF
--- a/composables/useVaultRegistry.ts
+++ b/composables/useVaultRegistry.ts
@@ -40,12 +40,18 @@ interface VaultEntryMetadata {
   vaultCategory?: 'standard' | 'escrow'
 }
 
+interface VaultResolutionContext {
+  targetChainId: number
+  generation: number
+}
+
 // Registry state
 const registry: Ref<Map<string, VaultEntry>> = shallowRef(new Map())
 const isLoading = ref(false)
 const registryVersion = ref(0)
+let registryGeneration = 0
 
-// In-flight resolution promises — deduplicates concurrent getOrFetch() calls for the same vault
+// In-flight resolution promises — deduplicates concurrent getOrFetch() calls for the same vault on the same chain.
 const pendingResolutions = new Map<string, Promise<VaultEntity | undefined>>()
 
 // Escrow address set - populated early, before full vault info is loaded
@@ -115,6 +121,7 @@ const setMany = (entries: Array<{ address: string, vault: AnyVault, type: VaultT
 
 // Clear registry (for chain switching)
 const clear = (): void => {
+  registryGeneration++
   registry.value = new Map()
   escrowAddresses.value = new Set()
   pendingResolutions.clear()
@@ -210,32 +217,45 @@ const getVaultCategory = (address: string): 'standard' | 'escrow' | undefined =>
 // Reactive size for watchers
 const size = computed(() => registry.value.size)
 
+const createResolutionContext = (targetChainId?: number): VaultResolutionContext | undefined => {
+  const resolvedChainId = targetChainId ?? useEulerAddresses().chainId.value
+  if (!resolvedChainId) return undefined
+  return { targetChainId: resolvedChainId, generation: registryGeneration }
+}
+
+const isResolutionContextCurrent = (context: VaultResolutionContext): boolean => {
+  return context.generation === registryGeneration
+    && useEulerAddresses().chainId.value === context.targetChainId
+}
+
+const resolutionKey = (targetChainId: number, address: string): string => {
+  return `${targetChainId}:${normalizeAddress(address)}`
+}
+
 /**
  * Fetch vault using the appropriate SDK service based on type.
  * Escrow vaults are an EVault category, so they use the EVault service.
  */
-const fetchVaultByType = async (address: string, type: VaultType): Promise<VaultEntity> => {
-  const { chainId } = useEulerAddresses()
+const fetchVaultByType = async (address: string, type: VaultType, targetChainId?: number): Promise<VaultEntity> => {
   const { getEulerSdkForChain } = useEulerSdk()
-  // Capture the chain id once so the SDK backend selection and the fetches
-  // can't diverge if the user switches chains mid-await.
-  const targetChainId = chainId.value
-  const sdk = await getEulerSdkForChain(targetChainId)
+  const resolvedChainId = targetChainId ?? useEulerAddresses().chainId.value
+  if (!resolvedChainId) throw new Error('Cannot fetch vault without a target chain')
+  const sdk = await getEulerSdkForChain(resolvedChainId)
   const vaultAddress = getAddress(address) as Address
   switch (type) {
     case 'earn': {
-      const { result } = await sdk.eulerEarnService.fetchVault(targetChainId, vaultAddress, liteVaultFetchOptions)
+      const { result } = await sdk.eulerEarnService.fetchVault(resolvedChainId, vaultAddress, liteVaultFetchOptions)
       if (!result) throw new Error(`Earn vault not found for ${address}`)
       return result
     }
     case 'securitize': {
-      const { result } = await sdk.securitizeVaultService.fetchVault(targetChainId, vaultAddress, liteSecuritizeVaultFetchOptions)
+      const { result } = await sdk.securitizeVaultService.fetchVault(resolvedChainId, vaultAddress, liteSecuritizeVaultFetchOptions)
       if (!result) throw new Error(`Securitize vault not found for ${address}`)
       return result
     }
     case 'evk':
     default: {
-      const { result } = await sdk.eVaultService.fetchVault(targetChainId, vaultAddress, liteVaultFetchOptions)
+      const { result } = await sdk.eVaultService.fetchVault(resolvedChainId, vaultAddress, liteVaultFetchOptions)
       if (!result) throw new Error(`EVault not found for ${address}`)
       return result
     }
@@ -247,9 +267,12 @@ const fetchVaultByType = async (address: string, type: VaultType): Promise<Vault
  * SDK service, and cache in the registry. Escrow category comes from the SDK
  * verified-array read, so no separate local perspective probe is needed.
  */
-const resolveUnknown = async (address: string): Promise<VaultEntry> => {
+const resolveUnknownForContext = async (address: string, context: VaultResolutionContext): Promise<VaultEntry | undefined> => {
   const normalized = normalizeAddress(address)
-  const category = await fetchVaultCategory(normalized)
+  if (!isResolutionContextCurrent(context)) return undefined
+
+  const category = await fetchVaultCategory(normalized, context.targetChainId)
+  if (!isResolutionContextCurrent(context)) return undefined
 
   let type: VaultType
   if (category === 'earn') {
@@ -267,24 +290,34 @@ const resolveUnknown = async (address: string): Promise<VaultEntry> => {
     // EVault.
     logWarn('resolveUnknown', `Category not found for ${address}, trying fetch methods`)
     try {
-      const vault = await fetchVaultByType(normalized, 'securitize')
+      const vault = await fetchVaultByType(normalized, 'securitize', context.targetChainId)
+      if (!isResolutionContextCurrent(context)) return undefined
       set(normalized, vault, 'securitize')
       return get(normalized)!
     }
     catch {
+      if (!isResolutionContextCurrent(context)) return undefined
       type = 'evk'
     }
   }
 
   if (type === 'evk' && category === 'escrow') {
-    const vault = await fetchVaultByType(normalized, 'evk')
+    const vault = await fetchVaultByType(normalized, 'evk', context.targetChainId)
+    if (!isResolutionContextCurrent(context)) return undefined
     set(normalized, vault, 'evk', { verified: true, vaultCategory: 'escrow' })
     return get(normalized)!
   }
 
-  const vault = await fetchVaultByType(normalized, type)
+  const vault = await fetchVaultByType(normalized, type, context.targetChainId)
+  if (!isResolutionContextCurrent(context)) return undefined
   set(normalized, vault, type)
   return get(normalized)!
+}
+
+const resolveUnknown = async (address: string, targetChainId?: number): Promise<VaultEntry | undefined> => {
+  const context = createResolutionContext(targetChainId)
+  if (!context) return undefined
+  return resolveUnknownForContext(address, context)
 }
 
 /**
@@ -292,32 +325,38 @@ const resolveUnknown = async (address: string): Promise<VaultEntry> => {
  * Primary method for vault resolution. After calling, use getType(address) if you need the type.
  */
 const getOrFetch = async (address: string): Promise<VaultEntity | undefined> => {
+  const context = createResolutionContext()
+  if (!context) return undefined
+
   // Check registry first
   const existing = get(address)
-  if (existing) {
+  if (existing?.vault.chainId === context.targetChainId) {
     return existing.vault as VaultEntity
   }
 
   const normalized = normalizeAddress(address)
+  const key = resolutionKey(context.targetChainId, normalized)
 
   // Return existing in-flight promise if one exists (deduplicates concurrent calls)
-  const pending = pendingResolutions.get(normalized)
+  const pending = pendingResolutions.get(key)
   if (pending) {
     return pending
   }
 
   // Create and track new resolution promise
-  const resolution = resolveUnknown(address)
-    .then(entry => entry.vault as VaultEntity)
+  const resolution = resolveUnknownForContext(address, context)
+    .then(entry => entry?.vault as VaultEntity | undefined)
     .catch((e) => {
       logWarn('vaultRegistry/resolve', e)
       return undefined
     })
     .finally(() => {
-      pendingResolutions.delete(normalized)
+      if (pendingResolutions.get(key) === resolution) {
+        pendingResolutions.delete(key)
+      }
     })
 
-  pendingResolutions.set(normalized, resolution)
+  pendingResolutions.set(key, resolution)
   return resolution
 }
 

--- a/tests/composables/useVaultRegistry.test.ts
+++ b/tests/composables/useVaultRegistry.test.ts
@@ -1,0 +1,121 @@
+import type { EVault } from '@eulerxyz/euler-v2-sdk'
+import { VaultType } from '@eulerxyz/euler-v2-sdk'
+import { getAddress, type Address } from 'viem'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import { useVaultRegistry } from '~/composables/useVaultRegistry'
+import { resetVaultCategoryCache } from '~/utils/vault/categories'
+
+const VAULT_ADDRESS = getAddress('0x0000000000000000000000000000000000000101')
+
+const mocks = vi.hoisted(() => ({
+  fetchVault: vi.fn(),
+  fetchVaultType: vi.fn(),
+  fetchVerifiedVaultAddresses: vi.fn(),
+  getEulerSdkForChain: vi.fn(),
+}))
+
+const chainId = ref(1)
+
+const deferred = <T>() => {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, reject, resolve }
+}
+
+const makeVault = (vaultChainId: number, totalAssets = 0n): EVault => ({
+  address: VAULT_ADDRESS,
+  chainId: vaultChainId,
+  totalAssets,
+}) as unknown as EVault
+
+describe('useVaultRegistry lazy resolution', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetVaultCategoryCache()
+    chainId.value = 1
+
+    mocks.fetchVaultType.mockResolvedValue(VaultType.EVault)
+    mocks.fetchVerifiedVaultAddresses.mockResolvedValue([])
+    const sdk = {
+      eVaultService: {
+        fetchVault: mocks.fetchVault,
+        fetchVerifiedVaultAddresses: mocks.fetchVerifiedVaultAddresses,
+      },
+      eulerEarnService: { fetchVault: vi.fn() },
+      securitizeVaultService: { fetchVault: vi.fn() },
+      vaultMetaService: { fetchVaultType: mocks.fetchVaultType },
+    }
+    mocks.getEulerSdkForChain.mockResolvedValue(sdk)
+
+    vi.stubGlobal('useEulerAddresses', () => ({ chainId }))
+    vi.stubGlobal('useEulerSdk', () => ({ getEulerSdkForChain: mocks.getEulerSdkForChain }))
+    useVaultRegistry().clear()
+  })
+
+  afterEach(() => {
+    useVaultRegistry().clear()
+    resetVaultCategoryCache()
+    vi.unstubAllGlobals()
+  })
+
+  it('does not commit an old-chain resolution that finishes after replacement', async () => {
+    const oldFetch = deferred<{ result: EVault }>()
+    const currentVault = makeVault(8453, 2n)
+    mocks.fetchVault.mockImplementation(async (targetChainId: number) => {
+      if (targetChainId === 1) return oldFetch.promise
+      return { result: currentVault }
+    })
+
+    const registry = useVaultRegistry()
+    const oldResolution = registry.getOrFetch(VAULT_ADDRESS)
+    await vi.waitFor(() => expect(mocks.fetchVault).toHaveBeenCalledWith(
+      1,
+      VAULT_ADDRESS as Address,
+      expect.any(Object),
+    ))
+
+    chainId.value = 8453
+    registry.clear()
+    await expect(registry.getOrFetch(VAULT_ADDRESS)).resolves.toBe(currentVault)
+    expect(registry.getVault(VAULT_ADDRESS)).toBe(currentVault)
+
+    oldFetch.resolve({ result: makeVault(1, 1n) })
+    await expect(oldResolution).resolves.toBeUndefined()
+    expect(registry.getVault(VAULT_ADDRESS)).toBe(currentVault)
+  })
+
+  it('keeps a same-address replacement pending when the stale promise settles', async () => {
+    const staleFetch = deferred<{ result: EVault }>()
+    const replacementFetch = deferred<{ result: EVault }>()
+    const replacementVault = makeVault(1, 2n)
+    mocks.fetchVault
+      .mockImplementationOnce(() => staleFetch.promise)
+      .mockImplementationOnce(() => replacementFetch.promise)
+      .mockResolvedValue({ result: makeVault(1, 3n) })
+
+    const registry = useVaultRegistry()
+    const staleResolution = registry.getOrFetch(VAULT_ADDRESS)
+    await vi.waitFor(() => expect(mocks.fetchVault).toHaveBeenCalledTimes(1))
+
+    registry.clear()
+    const replacementResolution = registry.getOrFetch(VAULT_ADDRESS)
+    await vi.waitFor(() => expect(mocks.fetchVault).toHaveBeenCalledTimes(2))
+
+    staleFetch.resolve({ result: makeVault(1, 1n) })
+    await expect(staleResolution).resolves.toBeUndefined()
+
+    const deduplicatedResolution = registry.getOrFetch(VAULT_ADDRESS)
+    await Promise.resolve()
+    expect(mocks.fetchVault).toHaveBeenCalledTimes(2)
+
+    replacementFetch.resolve({ result: replacementVault })
+    await expect(replacementResolution).resolves.toBe(replacementVault)
+    await expect(deduplicatedResolution).resolves.toBe(replacementVault)
+    expect(registry.getVault(VAULT_ADDRESS)).toBe(replacementVault)
+  })
+})

--- a/utils/vault/categories.ts
+++ b/utils/vault/categories.ts
@@ -198,8 +198,8 @@ export const fetchChainVaultCategories = async (): Promise<VaultCategories> => {
  * Resolve the category of a single vault address from SDK metadata. Escrow
  * membership is checked first because escrow is a more specific EVault label.
  */
-export const fetchVaultCategory = async (address: string): Promise<VaultCategory | null> => {
-  const chainId = getChainId()
+export const fetchVaultCategory = async (address: string, targetChainId?: number): Promise<VaultCategory | null> => {
+  const chainId = targetChainId ?? getChainId()
   if (!chainId || !isAddress(address)) return null
 
   const normalized = normalize(address)


### PR DESCRIPTION
## Summary

- Lazy vault resolution is bound to the chain and registry generation that started it.
- Results from cleared or switched registry contexts return without updating current-chain state.

## Changes

- Carry the target chain through category classification and typed SDK fetches, and validate the generation before every registry write.
- Deduplicate pending resolutions by chain and address, with identity-safe cleanup when a replacement is active.
- Cover old-chain late completion and same-address replacement races.

## Test plan

- [x] npm run test:run -- tests/composables/useVaultRegistry.test.ts tests/composables/useVaults.test.ts
- [x] npm run test:run
- [x] npm run typecheck
- [x] npm run lint (0 errors; 6 existing warnings)
- [x] git diff --check