### PR TITLE
fix: isolate label loading by chain

### DIFF
--- a/composables/useEulerLabels.ts
+++ b/composables/useEulerLabels.ts
@@ -52,7 +52,8 @@ const labelsChainId = ref<number | null>(null)
 const labelsVersion = ref(0)
 const isLoading = ref(false)
 const isReady = ref(false)
-let pendingLabelsLoad: Promise<void> | undefined
+const pendingLabelsFetches = new Map<number, Promise<EulerLabelsData>>()
+let labelsLoadGeneration = 0
 let wrapPairProbeGeneration = 0
 const wrapPairs = shallowReactive<Record<string, string>>({})
 
@@ -69,6 +70,10 @@ export const getEulerLabelsVersion = (): number => labelsVersion.value
 export const getEulerLabelWrapPairs = (): Record<string, string> => wrapPairs
 
 export const __setEulerLabelsDataForTest = (data: Partial<EulerLabelsData> = {}) => {
+  labelsLoadGeneration += 1
+  wrapPairProbeGeneration += 1
+  pendingLabelsFetches.clear()
+  Object.keys(wrapPairs).forEach(key => Reflect.deleteProperty(wrapPairs, key))
   setLabelsData({
     ...createEmptyEulerLabelsData(),
     ...data,
@@ -82,9 +87,9 @@ export const __setEulerLabelsDataForTest = (data: Partial<EulerLabelsData> = {})
 const resolveChainId = async (): Promise<number> => {
   const { getCurrentChainConfig, loadEulerConfig } = useEulerAddresses()
 
-  if (!getCurrentChainConfig.value) {
-    void loadEulerConfig()
-  }
+  if (getCurrentChainConfig.value) return getCurrentChainConfig.value.chainId
+
+  void loadEulerConfig()
   await until(getCurrentChainConfig).toBeTruthy()
 
   return getCurrentChainConfig.value!.chainId
@@ -96,70 +101,99 @@ const points = toReactive(computed(() => labelsData.value.points as Record<strin
 const verifiedVaultAddresses = computed(() => labelsData.value.verifiedVaultAddresses)
 const earnVaults = computed(() => labelsData.value.earnVaults)
 
-const loadLabels = async (forceRefresh = false) => {
-  if (pendingLabelsLoad && !forceRefresh) return pendingLabelsLoad
+const isCurrentLabelsLoad = (chainId: number, generation: number) => {
+  const { getCurrentChainConfig } = useEulerAddresses()
+  return generation === labelsLoadGeneration && getCurrentChainConfig.value?.chainId === chainId
+}
 
-  const promise = (async () => {
-    const chainId = await resolveChainId()
+const getLabelsFetch = (chainId: number, forceRefresh: boolean) => {
+  const pendingFetch = pendingLabelsFetches.get(chainId)
+  if (pendingFetch && !forceRefresh) return pendingFetch
 
-    if (!forceRefresh && labelsChainId.value === chainId && isReady.value) return
-
-    try {
-      isReady.value = false
-      isLoading.value = true
-      const probeGeneration = ++wrapPairProbeGeneration
-      Object.keys(wrapPairs).forEach(key => Reflect.deleteProperty(wrapPairs, key))
-
-      if (labelsChainId.value !== chainId) {
-        setLabelsData(createEmptyEulerLabelsData(), chainId)
-      }
-
-      if (forceRefresh) {
-        await invalidateSdkQueries([...LABEL_QUERY_NAMES])
-      }
-
-      const sdk = await getEulerSdk()
-      setLabelsData(await sdk.eulerLabelsService.fetchEulerLabelsData(chainId), chainId)
-      void probeWrapPairs(chainId, probeGeneration)
+  const fetchPromise = (async () => {
+    if (forceRefresh) {
+      await invalidateSdkQueries([...LABEL_QUERY_NAMES])
     }
-    catch (e) {
-      logWarn('labels/load', e)
+
+    const sdk = await getEulerSdk()
+    return sdk.eulerLabelsService.fetchEulerLabelsData(chainId)
+  })()
+
+  pendingLabelsFetches.set(chainId, fetchPromise)
+  return fetchPromise
+}
+
+const loadLabels = async (forceRefresh = false): Promise<void> => {
+  const chainId = await resolveChainId()
+
+  const { getCurrentChainConfig } = useEulerAddresses()
+  if (getCurrentChainConfig.value?.chainId !== chainId) return
+  if (!forceRefresh && labelsChainId.value === chainId && isReady.value) return
+
+  const generation = ++labelsLoadGeneration
+  const isCurrentLoad = () => isCurrentLabelsLoad(chainId, generation)
+  if (!isCurrentLoad()) return
+
+  isReady.value = false
+  isLoading.value = true
+  const probeGeneration = ++wrapPairProbeGeneration
+  Object.keys(wrapPairs).forEach(key => Reflect.deleteProperty(wrapPairs, key))
+
+  if (labelsChainId.value !== chainId && isCurrentLoad()) {
+    setLabelsData(createEmptyEulerLabelsData(), chainId)
+  }
+
+  const fetchPromise = getLabelsFetch(chainId, forceRefresh)
+
+  try {
+    const data = await fetchPromise
+    if (isCurrentLoad()) {
+      setLabelsData(data, chainId)
     }
-    finally {
+    if (isCurrentLoad()) {
+      void probeWrapPairs(chainId, generation, probeGeneration)
+    }
+  }
+  catch (e) {
+    logWarn('labels/load', e)
+  }
+  finally {
+    if (pendingLabelsFetches.get(chainId) === fetchPromise) {
+      pendingLabelsFetches.delete(chainId)
+    }
+    if (isCurrentLoad()) {
       isLoading.value = false
       isReady.value = true
     }
-  })()
-
-  pendingLabelsLoad = promise
-  try {
-    await promise
-  }
-  finally {
-    if (pendingLabelsLoad === promise) pendingLabelsLoad = undefined
   }
 }
 
 const WRAP_PAIR_PROBE_BATCH_SIZE = 25
 
-const probeWrapPairs = async (startChainId: number, generation: number) => {
+const probeWrapPairs = async (startChainId: number, loadGeneration: number, probeGeneration: number) => {
+  const { getCurrentChainConfig } = useEulerAddresses()
   const isCurrentProbe = () =>
-    generation === wrapPairProbeGeneration && labelsChainId.value === startChainId
+    loadGeneration === labelsLoadGeneration
+    && probeGeneration === wrapPairProbeGeneration
+    && labelsChainId.value === startChainId
+    && getCurrentChainConfig.value?.chainId === startChainId
 
   try {
-    const { getCurrentChainConfig } = useEulerAddresses()
     const config = getCurrentChainConfig.value
     if (!config || config.chainId !== startChainId || !isCurrentProbe()) return
 
     const evcAddress = config.addresses.coreAddrs.evc
     const sdk = await getEulerSdk()
+    if (!isCurrentProbe()) return
     // The SDK is linked from a workspace and ships its own viem (2.43.x), so
     // its PublicClient is structurally similar but not identical to the app's
     // viem (2.48.x) — cast once at the boundary.
     const provider = sdk.providerService.getProvider(startChainId) as unknown as PublicClient
 
     const { useVaults } = await import('~/composables/useVaults')
+    if (!isCurrentProbe()) return
     const { useVaultRegistry } = await import('~/composables/useVaultRegistry')
+    if (!isCurrentProbe()) return
     const { isReady: isVaultsReady } = useVaults()
     if (!isVaultsReady.value) await until(isVaultsReady).toBe(true)
     if (!isCurrentProbe()) return

--- a/tests/composables/useEulerLabels.test.ts
+++ b/tests/composables/useEulerLabels.test.ts
@@ -1,0 +1,258 @@
+import type { EulerLabelsData } from '@eulerxyz/euler-v2-sdk'
+import { computed, ref } from 'vue'
+import { encodeAbiParameters } from 'viem'
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  __setEulerLabelsDataForTest,
+  getCurrentEulerLabelsData,
+  getEulerLabelsVersion,
+  getEulerLabelWrapPairs,
+  useEulerLabels,
+} from '~/composables/useEulerLabels'
+
+type Deferred<T> = {
+  promise: Promise<T>
+  resolve: (value: T) => void
+  reject: (reason?: unknown) => void
+}
+
+const deferred = <T>(): Deferred<T> => {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+
+  return { promise, resolve, reject }
+}
+
+const mocks = vi.hoisted(() => ({
+  evcBatchCall: vi.fn(),
+  fetchEulerLabelsData: vi.fn(),
+  getProvider: vi.fn(),
+  invalidateSdkQueries: vi.fn(),
+  vaults: [] as Array<{ asset: { address: string } }>,
+}))
+
+vi.mock('~/composables/useEulerSdk', () => ({
+  getEulerSdk: vi.fn(async () => ({
+    eulerLabelsService: {
+      fetchEulerLabelsData: mocks.fetchEulerLabelsData,
+    },
+    providerService: {
+      getProvider: mocks.getProvider,
+    },
+  })),
+}))
+
+vi.mock('~/composables/useEulerOracleAdapters', () => ({
+  useEulerOracleAdapters: () => ({
+    oracleAdapters: {},
+    loadOracleAdapter: vi.fn(),
+    loadOracleAdapters: vi.fn(),
+    loadAllOracleAdapters: vi.fn(),
+  }),
+}))
+
+vi.mock('~/composables/useVaults', () => ({
+  useVaults: () => ({ isReady: { value: true } }),
+}))
+
+vi.mock('~/composables/useVaultRegistry', () => ({
+  useVaultRegistry: () => ({
+    getEVaults: () => mocks.vaults,
+    getEarnVaults: () => [],
+    getSecuritizeVaults: () => [],
+  }),
+}))
+
+vi.mock('~/utils/multicall', () => ({
+  buildBatchItem: vi.fn((target: string, data: string) => ({ target, data })),
+  evcBatchCall: mocks.evcBatchCall,
+}))
+
+vi.mock('~/utils/sdk-query-cache', () => ({
+  invalidateSdkQueries: mocks.invalidateSdkQueries,
+}))
+
+const currentChainId = ref(1)
+const getCurrentChainConfig = computed(() => ({
+  chainId: currentChainId.value,
+  addresses: {
+    coreAddrs: {
+      evc: '0x0000000000000000000000000000000000000001',
+    },
+  },
+}))
+
+const labelsFor = (marker: string) => ({
+  products: {
+    [marker]: { name: marker },
+  },
+}) as unknown as EulerLabelsData
+
+const currentProductKeys = () => Object.keys(getCurrentEulerLabelsData().products)
+
+describe('useEulerLabels chain-scoped loading', () => {
+  beforeEach(() => {
+    currentChainId.value = 1
+    mocks.evcBatchCall.mockReset().mockResolvedValue([])
+    mocks.fetchEulerLabelsData.mockReset()
+    mocks.getProvider.mockReset().mockReturnValue({})
+    mocks.invalidateSdkQueries.mockReset().mockResolvedValue(undefined)
+    mocks.vaults.length = 0
+    vi.stubGlobal('useEulerAddresses', () => ({
+      getCurrentChainConfig,
+      loadEulerConfig: vi.fn(),
+    }))
+    __setEulerLabelsDataForTest()
+  })
+
+  afterAll(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('starts a separate fetch for a new chain and ignores the stale response', async () => {
+    const chainOne = deferred<EulerLabelsData>()
+    const chainTwo = deferred<EulerLabelsData>()
+    mocks.fetchEulerLabelsData.mockImplementation((chainId: number) => {
+      if (chainId === 1) return chainOne.promise
+      if (chainId === 2) return chainTwo.promise
+      throw new Error(`unexpected chain ${chainId}`)
+    })
+
+    const labels = useEulerLabels()
+    const firstLoad = labels.loadLabels()
+    await vi.waitFor(() => expect(mocks.fetchEulerLabelsData).toHaveBeenCalledWith(1))
+
+    currentChainId.value = 2
+    const secondLoad = labels.loadLabels()
+    await vi.waitFor(() => expect(mocks.fetchEulerLabelsData).toHaveBeenCalledWith(2))
+
+    expect(labels.isLoading.value).toBe(true)
+    expect(labels.isReady.value).toBe(false)
+
+    chainTwo.resolve(labelsFor('chain-two'))
+    await secondLoad
+
+    expect(currentProductKeys()).toEqual(['chain-two'])
+    expect(labels.isLoading.value).toBe(false)
+    expect(labels.isReady.value).toBe(true)
+
+    chainOne.resolve(labelsFor('stale-chain-one'))
+    await firstLoad
+
+    expect(mocks.fetchEulerLabelsData).toHaveBeenCalledTimes(2)
+    expect(currentProductKeys()).toEqual(['chain-two'])
+    expect(labels.isLoading.value).toBe(false)
+    expect(labels.isReady.value).toBe(true)
+  })
+
+  it('reuses only the chain fetch while the latest wrapper controls publication', async () => {
+    const chainOne = deferred<EulerLabelsData>()
+    const chainTwo = deferred<EulerLabelsData>()
+    mocks.fetchEulerLabelsData.mockImplementation((chainId: number) => {
+      if (chainId === 1) return chainOne.promise
+      if (chainId === 2) return chainTwo.promise
+      throw new Error(`unexpected chain ${chainId}`)
+    })
+    const initialVersion = getEulerLabelsVersion()
+
+    const labels = useEulerLabels()
+    const firstChainOneLoad = labels.loadLabels()
+    await vi.waitFor(() => expect(mocks.fetchEulerLabelsData).toHaveBeenCalledWith(1))
+
+    currentChainId.value = 2
+    const chainTwoLoad = labels.loadLabels()
+    await vi.waitFor(() => expect(mocks.fetchEulerLabelsData).toHaveBeenCalledWith(2))
+
+    currentChainId.value = 1
+    const latestChainOneLoad = labels.loadLabels()
+    await vi.waitFor(() => expect(mocks.fetchEulerLabelsData).toHaveBeenCalledTimes(2))
+
+    chainOne.resolve(labelsFor('latest-chain-one'))
+    await Promise.all([firstChainOneLoad, latestChainOneLoad])
+
+    expect(mocks.fetchEulerLabelsData.mock.calls.filter(([chainId]) => chainId === 1)).toHaveLength(1)
+    expect(currentProductKeys()).toEqual(['latest-chain-one'])
+    expect(getEulerLabelsVersion()).toBe(initialVersion + 4)
+    expect(labels.isLoading.value).toBe(false)
+    expect(labels.isReady.value).toBe(true)
+
+    chainTwo.resolve(labelsFor('stale-chain-two'))
+    await chainTwoLoad
+
+    expect(currentProductKeys()).toEqual(['latest-chain-one'])
+    expect(getEulerLabelsVersion()).toBe(initialVersion + 4)
+  })
+
+  it('keeps a force-refresh replacement available when the older fetch settles first', async () => {
+    const original = deferred<EulerLabelsData>()
+    const refreshed = deferred<EulerLabelsData>()
+    mocks.fetchEulerLabelsData
+      .mockReturnValueOnce(original.promise)
+      .mockReturnValueOnce(refreshed.promise)
+
+    const labels = useEulerLabels()
+    const originalLoad = labels.loadLabels()
+    await vi.waitFor(() => expect(mocks.fetchEulerLabelsData).toHaveBeenCalledTimes(1))
+
+    const refreshLoad = labels.loadLabels(true)
+    await vi.waitFor(() => {
+      expect(mocks.invalidateSdkQueries).toHaveBeenCalledTimes(1)
+      expect(mocks.fetchEulerLabelsData).toHaveBeenCalledTimes(2)
+    })
+
+    original.resolve(labelsFor('original'))
+    await originalLoad
+
+    const joinedRefreshLoad = labels.loadLabels()
+    await Promise.resolve()
+    expect(mocks.fetchEulerLabelsData).toHaveBeenCalledTimes(2)
+
+    refreshed.resolve(labelsFor('refreshed'))
+    await Promise.all([refreshLoad, joinedRefreshLoad])
+
+    expect(currentProductKeys()).toEqual(['refreshed'])
+    expect(labels.isLoading.value).toBe(false)
+    expect(labels.isReady.value).toBe(true)
+  })
+
+  it('does not publish wrap pairs from a probe invalidated by a chain change', async () => {
+    const wrapper = '0x0000000000000000000000000000000000000011'
+    const underlying = '0x0000000000000000000000000000000000000022'
+    const staleProbe = deferred<Array<{ success: boolean, result: string }>>()
+    const chainTwo = deferred<EulerLabelsData>()
+    mocks.vaults.push({ asset: { address: wrapper } })
+    mocks.evcBatchCall.mockReturnValueOnce(staleProbe.promise)
+    mocks.fetchEulerLabelsData.mockImplementation((chainId: number) => {
+      if (chainId === 1) return Promise.resolve(labelsFor('chain-one'))
+      if (chainId === 2) return chainTwo.promise
+      throw new Error(`unexpected chain ${chainId}`)
+    })
+
+    const labels = useEulerLabels()
+    await labels.loadLabels()
+    await vi.waitFor(() => expect(mocks.evcBatchCall).toHaveBeenCalledTimes(1))
+
+    currentChainId.value = 2
+    mocks.vaults.length = 0
+    const chainTwoLoad = labels.loadLabels()
+    await vi.waitFor(() => expect(mocks.fetchEulerLabelsData).toHaveBeenCalledWith(2))
+
+    staleProbe.resolve([{
+      success: true,
+      result: encodeAbiParameters([{ type: 'address' }], [underlying]),
+    }])
+    await staleProbe.promise
+    await Promise.resolve()
+
+    expect(getEulerLabelWrapPairs()).toEqual({})
+
+    chainTwo.resolve(labelsFor('chain-two'))
+    await chainTwoLoad
+    expect(currentProductKeys()).toEqual(['chain-two'])
+    expect(getEulerLabelWrapPairs()).toEqual({})
+  })
+})


### PR DESCRIPTION
## Summary
- Scope in-flight label fetches by target chain so rapid network switches cannot share or publish wrong-chain results.
- Keep label readiness, loading, snapshot, and wrap-pair state aligned with the latest active chain load.

## Changes
- Reuse only the underlying fetch for the same target chain while per-call generations control publication.
- Guard state writes and asynchronous wrap-pair probes with load generation, probe generation, loaded-label chain, and current-chain checks.
- Cover A to B, A to B to A, force-refresh replacement, and stale-probe races with deterministic composable tests.

## Test plan
- [x] npm run test:run -- tests/composables/useEulerLabels.test.ts tests/composables/useEulerAccount.test.ts
- [x] npm run typecheck
- [x] npx eslint composables/useEulerLabels.ts tests/composables/useEulerLabels.test.ts
- [x] git diff --check

## Residual
- PR #619 also changes useEulerLabels and currently has a conflicting merge state; whichever change lands second must preserve these request-scoping guards during conflict resolution.