### PR TITLE
chore: bump Euler SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@eulerxyz/euler-v2-sdk": "1.1.2",
+        "@eulerxyz/euler-v2-sdk": "1.1.3",
         "@floating-ui/vue": "2.0.0",
         "@gvade/nuxt3-svg-sprite": "1.0.3",
         "@keyringnetwork/keyring-connect-sdk": "3.2.0",
@@ -1469,9 +1469,9 @@
       }
     },
     "node_modules/@eulerxyz/euler-v2-sdk": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@eulerxyz/euler-v2-sdk/-/euler-v2-sdk-1.1.2.tgz",
-      "integrity": "sha512-sGW9h5z0t4JtdsnZm88vMQXFDdTX8JPErjFCVITb/aqaE0g8BJhWzlxxSwQfGmaWY01tM/OEOjNVy0FnH3T+xQ==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@eulerxyz/euler-v2-sdk/-/euler-v2-sdk-1.1.3.tgz",
+      "integrity": "sha512-MBIDBsN294KMI4OfHwrCHdpJZs8Mj7nYIAaqgvKlibaWmuUlcl1+NL7emOu+gnjtCBHjJroXkPBJDZOG8hX4PQ==",
       "license": "MIT",
       "dependencies": {
         "viem": "2.48.8"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     ]
   },
   "dependencies": {
-    "@eulerxyz/euler-v2-sdk": "1.1.2",
+    "@eulerxyz/euler-v2-sdk": "1.1.3",
     "@floating-ui/vue": "2.0.0",
     "@gvade/nuxt3-svg-sprite": "1.0.3",
     "@keyringnetwork/keyring-connect-sdk": "3.2.0",


### PR DESCRIPTION
## Summary
- Use @eulerxyz/euler-v2-sdk 1.1.3 for position migration query caching and full-balance same-asset collateral migrations.
- Keep the npm lockfile aligned with the published package tarball and integrity.

## Changes
- Pin the Euler SDK dependency to 1.1.3.
- Resolve the lockfile to the 1.1.3 npm artifact while preserving its nested viem 2.48.8 dependency.

## SDK release notes
[euler-v2-sdk v1.1.3](https://github.com/euler-xyz/euler-sdks/releases/tag/euler-v2-sdk-v1.1.3)

- Route position migration reads through buildQuery for caching and deduplication ([euler-sdks#72](https://github.com/euler-xyz/euler-sdks/pull/72)) @dglowinski
- Document position migration flows and refresh SDK integration guidance ([euler-sdks#73](https://github.com/euler-xyz/euler-sdks/pull/73)) @dglowinski
- Fix max same-asset collateral migrations to skim the full redeemed balance ([euler-sdks#74](https://github.com/euler-xyz/euler-sdks/pull/74)) @Seranged

## Test plan
- [x] npm ci
- [x] npm ls @eulerxyz/euler-v2-sdk viem
- [x] npm run typecheck
- [x] npm run test:golden
- [x] npm run test:run -- tests/composables/useEulerSdk.test.ts tests/server/sdk-server.test.ts tests/composables/useExternalMigrationPositions.test.ts
- [x] git diff --check