### PR TITLE
fix: classify SDK 1.1.4 migration and rewards queries in the cache policy

### DIFF
--- a/composables/useSdkRewards.ts
+++ b/composables/useSdkRewards.ts
@@ -7,8 +7,9 @@ const USER_REWARD_QUERY_NAMES: EulerSDKQueryName[] = [
   'queryMerklUserRewards',
   'queryBrevisCampaigns',
   'queryBrevisUserProofs',
-  'queryFuulClaimableRewards' as EulerSDKQueryName,
-  'queryTurtleMerkleProofs' as EulerSDKQueryName,
+  'queryFuulClaimChecks',
+  'queryFuulClaimableRewards',
+  'queryTurtleMerkleProofs',
 ]
 const REWARD_CLAIM_REFRESH_RETRY_DELAYS_MS = [5_000, 30_000] as const
 

--- a/docs/sdk-integration.md
+++ b/docs/sdk-integration.md
@@ -105,7 +105,11 @@ The full object is serialized into `staticCacheKey`, so any change produces a ne
 
 ## Query Policy (single source of truth)
 
-`utils/sdk-query-policy.ts` owns the per-query policy. One row per `query*` name:
+`utils/sdk-query-policy.ts` owns the per-query policy. One row per `query*` name.
+Completeness is test-enforced: `tests/utils/sdk-query-policy.test.ts` builds the
+real SDK with a recording `buildQuery` and fails when a wrapped query name has
+no policy row (or when a row no longer matches any wrapped name), so an SDK bump
+cannot introduce a query that silently inherits `DEFAULT_STALE_TIME_MS`.
 
 ```ts
 interface SdkQueryPolicyEntry {
@@ -134,6 +138,12 @@ export const SDK_QUERY_POLICY = {
 
   // Balances
   queryBalanceOf:      { staleTimeMs: MINUTE, formStaleTimeMs: 15 * SECOND },
+
+  // Position migration: external position balances and authorization state
+  // are balance-like (debt accrues per block; the user can sign or revoke
+  // authorization mid-flow), so they take short windows + post-tx eviction.
+  queryGetPosition:      { staleTimeMs: MINUTE, formStaleTimeMs: 15 * SECOND, invalidateAfterTx: true },
+  queryGetAuthorization: { staleTimeMs: MINUTE, formStaleTimeMs: 15 * SECOND, invalidateAfterTx: true },
 }
 ```
 
@@ -170,7 +180,7 @@ export const sdkFreshBuildQuery = buildSdkQuery(FORM_STALE_TIMES)
 export const invalidateSdkQueries = (queryNames: EulerSDKQueryName[]) => { … }
 ```
 
-`buildSdkQuery(staleTimes)` returns a `BuildQueryFn` that wraps each SDK `query*` method with a `QueryClient.fetchQuery({ queryKey: ['sdk', queryName, serializedArgs], queryFn, staleTime: staleTimes[queryName] ?? DEFAULT_STALE_TIME_MS })` call. Non-listed queries fall through to `DEFAULT_STALE_TIME_MS`.
+`buildSdkQuery(staleTimes)` returns a `BuildQueryFn` that wraps each SDK `query*` method with a `QueryClient.fetchQuery({ queryKey: ['sdk', queryName, serializedArgs], queryFn, staleTime: staleTimes[queryName] ?? DEFAULT_STALE_TIME_MS })` call. The `DEFAULT_STALE_TIME_MS` fall-through is a runtime backstop only — the completeness test keeps the policy table exhaustive, so no shipped query name actually relies on it.
 
 Key properties:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@eulerxyz/euler-v2-sdk": "1.1.2",
+        "@eulerxyz/euler-v2-sdk": "1.1.3",
         "@floating-ui/vue": "2.0.0",
         "@gvade/nuxt3-svg-sprite": "1.0.3",
         "@keyringnetwork/keyring-connect-sdk": "3.2.0",
@@ -1469,9 +1469,9 @@
       }
     },
     "node_modules/@eulerxyz/euler-v2-sdk": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@eulerxyz/euler-v2-sdk/-/euler-v2-sdk-1.1.2.tgz",
-      "integrity": "sha512-sGW9h5z0t4JtdsnZm88vMQXFDdTX8JPErjFCVITb/aqaE0g8BJhWzlxxSwQfGmaWY01tM/OEOjNVy0FnH3T+xQ==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@eulerxyz/euler-v2-sdk/-/euler-v2-sdk-1.1.3.tgz",
+      "integrity": "sha512-MBIDBsN294KMI4OfHwrCHdpJZs8Mj7nYIAaqgvKlibaWmuUlcl1+NL7emOu+gnjtCBHjJroXkPBJDZOG8hX4PQ==",
       "license": "MIT",
       "dependencies": {
         "viem": "2.48.8"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@eulerxyz/euler-v2-sdk": "1.1.3",
+        "@eulerxyz/euler-v2-sdk": "1.1.4",
         "@floating-ui/vue": "2.0.0",
         "@gvade/nuxt3-svg-sprite": "1.0.3",
         "@keyringnetwork/keyring-connect-sdk": "3.2.0",
@@ -1469,9 +1469,9 @@
       }
     },
     "node_modules/@eulerxyz/euler-v2-sdk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@eulerxyz/euler-v2-sdk/-/euler-v2-sdk-1.1.3.tgz",
-      "integrity": "sha512-MBIDBsN294KMI4OfHwrCHdpJZs8Mj7nYIAaqgvKlibaWmuUlcl1+NL7emOu+gnjtCBHjJroXkPBJDZOG8hX4PQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@eulerxyz/euler-v2-sdk/-/euler-v2-sdk-1.1.4.tgz",
+      "integrity": "sha512-qdu422qw0GzO6hB4cGspqK6IZ4KUv8RaQraHrmez9rqBm1pRbSum1e1DysyeC7X/OEKfjmIi6+psNky2aMa2uw==",
       "license": "MIT",
       "dependencies": {
         "viem": "2.48.8"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     ]
   },
   "dependencies": {
-    "@eulerxyz/euler-v2-sdk": "1.1.3",
+    "@eulerxyz/euler-v2-sdk": "1.1.4",
     "@floating-ui/vue": "2.0.0",
     "@gvade/nuxt3-svg-sprite": "1.0.3",
     "@keyringnetwork/keyring-connect-sdk": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     ]
   },
   "dependencies": {
-    "@eulerxyz/euler-v2-sdk": "1.1.2",
+    "@eulerxyz/euler-v2-sdk": "1.1.3",
     "@floating-ui/vue": "2.0.0",
     "@gvade/nuxt3-svg-sprite": "1.0.3",
     "@keyringnetwork/keyring-connect-sdk": "3.2.0",

--- a/tests/composables/useSdkRewards.test.ts
+++ b/tests/composables/useSdkRewards.test.ts
@@ -210,6 +210,7 @@ describe('useSdkRewards', () => {
       'queryMerklUserRewards',
       'queryBrevisCampaigns',
       'queryBrevisUserProofs',
+      'queryFuulClaimChecks',
       'queryFuulClaimableRewards',
       'queryTurtleMerkleProofs',
     ])
@@ -237,6 +238,7 @@ describe('useSdkRewards', () => {
       'queryMerklUserRewards',
       'queryBrevisCampaigns',
       'queryBrevisUserProofs',
+      'queryFuulClaimChecks',
       'queryFuulClaimableRewards',
       'queryTurtleMerkleProofs',
     ])

--- a/tests/utils/sdk-query-policy.test.ts
+++ b/tests/utils/sdk-query-policy.test.ts
@@ -13,6 +13,8 @@
  * exports.
  */
 import { describe, expect, it } from 'vitest'
+import { buildEulerSDK, createKeyringPlugin, createPythPlugin } from '@eulerxyz/euler-v2-sdk'
+import type { BuildQueryFn } from '@eulerxyz/euler-v2-sdk'
 import {
   FORM_STALE_TIMES,
   INVALIDATE_AFTER_TX,
@@ -78,4 +80,57 @@ describe('SDK_QUERY_POLICY derived lists', () => {
       expect(form, `${name}: form-time stale must be <= browsing stale`).toBeLessThanOrEqual(browse)
     }
   })
+})
+
+describe('SDK_QUERY_POLICY completeness', () => {
+  // Builds the real SDK with a buildQuery that records every query name it is
+  // asked to wrap. Every wrapped name must have an explicit policy row —
+  // otherwise a query added by an SDK bump silently inherits
+  // DEFAULT_STALE_TIME_MS on both the browsing and the plan-time instance
+  // (the regression that shipped the position-migration queries with a
+  // 5-minute plan-time cache).
+  it('classifies every query name the SDK routes through buildQuery', async () => {
+    const recorded = new Set<string>()
+    const recordingBuildQuery: BuildQueryFn = ((name: string, fn: unknown) => {
+      recorded.add(name)
+      // buildEulerSDK resolves deployments through buildQuery at build time;
+      // stub it so the build needs no network. Every URL below points at a
+      // closed port so any other build-time fetch fails the test loudly.
+      if (name === 'queryDeployments') return async () => []
+      return fn
+    }) as BuildQueryFn
+
+    const sdk = await buildEulerSDK({
+      config: {
+        rpcUrls: { 1: 'http://127.0.0.1:9/rpc' },
+        deploymentsUrl: 'http://127.0.0.1:9/deployments',
+        // V3 keeps the v3 adapters in the build so their query names are
+        // covered as well.
+        v3ApiUrl: 'http://127.0.0.1:9/v3',
+      },
+      buildQuery: recordingBuildQuery,
+      plugins: [
+        createPythPlugin({ buildQuery: recordingBuildQuery }),
+        createKeyringPlugin({
+          hookTargets: {},
+          getCredentialData: async () => undefined,
+          buildQuery: recordingBuildQuery,
+        }),
+      ],
+    })
+    expect(sdk).toBeTruthy()
+    expect(recorded.size).toBeGreaterThan(0)
+
+    const unclassified = [...recorded].filter(name => !(name in SDK_QUERY_POLICY)).sort()
+    expect(
+      unclassified,
+      'SDK query names without an SDK_QUERY_POLICY row — classify them so they do not silently inherit DEFAULT_STALE_TIME_MS',
+    ).toEqual([])
+
+    const unwrapped = Object.keys(SDK_QUERY_POLICY).filter(name => !recorded.has(name)).sort()
+    expect(
+      unwrapped,
+      'policy rows whose query name the SDK build never wrapped — likely a typo or a query removed upstream',
+    ).toEqual([])
+  }, 30_000)
 })

--- a/utils/sdk-query-policy.ts
+++ b/utils/sdk-query-policy.ts
@@ -9,8 +9,11 @@ import type { EulerSDKQueryName } from '@eulerxyz/euler-v2-sdk'
  *   - `staleTimeMs` (required): the QueryClient stale time used by the
  *     browsing SDK instance (`getEulerSdk()`). Entries younger than this are
  *     served from cache; older ones trigger a re-fetch. Matches TanStack
- *     Query's `staleTime` semantics. Current SDK query names are listed here;
- *     future unlisted names fall through to `DEFAULT_STALE_TIME_MS`.
+ *     Query's `staleTime` semantics. Every query name the SDK routes through
+ *     `buildQuery` must have an explicit row — the completeness test in
+ *     `tests/utils/sdk-query-policy.test.ts` builds the SDK with a recording
+ *     `buildQuery` and fails on unclassified names, so a new SDK query cannot
+ *     silently inherit `DEFAULT_STALE_TIME_MS`.
  *
  *   - `formStaleTimeMs` (optional): override on the plan-time/form SDK
  *     instance (`getEulerSdkFresh()`). When forms construct a transaction
@@ -73,8 +76,10 @@ export const SDK_QUERY_POLICY: Partial<Record<EulerSDKQueryName, SdkQueryPolicyE
   queryEVaultVerifiedArray: { staleTimeMs: DEFAULT_STALE_TIME_MS },
   queryEulerEarnConvertToAssets: { staleTimeMs: DEFAULT_STALE_TIME_MS },
   queryEulerEarnVerifiedArray: { staleTimeMs: DEFAULT_STALE_TIME_MS },
+  queryFuulClaimChecks: { staleTimeMs: DEFAULT_STALE_TIME_MS },
   queryFuulClaimableRewards: { staleTimeMs: DEFAULT_STALE_TIME_MS },
   queryFuulIncentives: { staleTimeMs: DEFAULT_STALE_TIME_MS },
+  queryFuulTotals: { staleTimeMs: DEFAULT_STALE_TIME_MS },
   queryKeyringAddress: { staleTimeMs: DEFAULT_STALE_TIME_MS },
   queryKeyringCheckCredential: { staleTimeMs: DEFAULT_STALE_TIME_MS },
   queryKeyringPolicyId: { staleTimeMs: DEFAULT_STALE_TIME_MS },
@@ -83,6 +88,8 @@ export const SDK_QUERY_POLICY: Partial<Record<EulerSDKQueryName, SdkQueryPolicyE
   querySecuritizeVaultGovernorAdmin: { staleTimeMs: DEFAULT_STALE_TIME_MS },
   querySecuritizeVaultSupplyCapResolved: { staleTimeMs: DEFAULT_STALE_TIME_MS },
   querySwapProviders: { staleTimeMs: DEFAULT_STALE_TIME_MS },
+  queryTurtleMerkleProofs: { staleTimeMs: DEFAULT_STALE_TIME_MS },
+  queryTurtleStreams: { staleTimeMs: DEFAULT_STALE_TIME_MS },
   queryV3EVaultList: { staleTimeMs: DEFAULT_STALE_TIME_MS },
   queryV3EulerEarnList: { staleTimeMs: DEFAULT_STALE_TIME_MS },
   queryV3IntrinsicApysPage: { staleTimeMs: DEFAULT_STALE_TIME_MS },
@@ -99,6 +106,22 @@ export const SDK_QUERY_POLICY: Partial<Record<EulerSDKQueryName, SdkQueryPolicyE
   queryEVCAccountInfo: { staleTimeMs: 5 * MINUTE, formStaleTimeMs: MINUTE, invalidateAfterTx: true },
   queryVaultAccountInfo: { staleTimeMs: 5 * MINUTE, formStaleTimeMs: MINUTE, invalidateAfterTx: true },
   queryVaultFactories: { staleTimeMs: 5 * MINUTE, invalidateAfterTx: true },
+
+  // === Position migration (SDK 1.1.3) ===
+  // Discovery lists are heavier connector reads (GraphQL + balance
+  // multicalls). External position balances and authorization state back
+  // plan sizing and signature prompts — debt accrues per block and the user
+  // can grant/revoke authorization mid-flow — so they get the balance-class
+  // short windows plus post-tx eviction (a completed migration must not
+  // serve the pre-migration position for 5 minutes). Euler-side target
+  // vault data (assets + borrow LTV) is governance config; source vault
+  // asset addresses are immutable in practice.
+  queryListPositions: { staleTimeMs: DEFAULT_STALE_TIME_MS, formStaleTimeMs: MINUTE, invalidateAfterTx: true },
+  queryListTargets: { staleTimeMs: DEFAULT_STALE_TIME_MS, formStaleTimeMs: MINUTE, invalidateAfterTx: true },
+  queryGetPosition: { staleTimeMs: MINUTE, formStaleTimeMs: 15 * SECOND, invalidateAfterTx: true },
+  queryGetAuthorization: { staleTimeMs: MINUTE, formStaleTimeMs: 15 * SECOND, invalidateAfterTx: true },
+  queryEulerTargetVaultData: { staleTimeMs: 5 * MINUTE, formStaleTimeMs: MINUTE },
+  queryEulerSourceVaultAssets: { staleTimeMs: 5 * MINUTE },
 
   // === Pricing / APY: display-side, 1-min cache ===
   queryAssetPriceInfo: { staleTimeMs: MINUTE },


### PR DESCRIPTION
Supersedes #729: bumps `@eulerxyz/euler-v2-sdk` 1.1.2 → 1.1.4 directly and classifies the queries the bump introduces, addressing the blocking review on #729 (the position-migration queries had no `SDK_QUERY_POLICY` classification).

## Problem

SDK 1.1.3 routes six new `PositionMigrationService` queries (`queryListPositions`, `queryListTargets`, `queryGetPosition`, `queryGetAuthorization`, `queryEulerTargetVaultData`, `queryEulerSourceVaultAssets`) through Lite's `buildQuery`. With no policy row, both `getEulerSdk()` and `getEulerSdkFresh()` fell back to `DEFAULT_STALE_TIME_MS` (5 min) on the shared query client, and no post-tx eviction applied. Reproduced locally: two fresh-wrapper calls with identical inputs ran the underlying read once, and a browsing-SDK read seeded the cache the plan-time SDK then reused. Migration planning could therefore reuse stale external position balances (debt accrues per block) and authorization state, and a completed migration kept serving the pre-migration position for up to 5 minutes.

A completeness sweep also found four rewards queries silently defaulting since SDK 1.1.2: `queryFuulClaimChecks`, `queryFuulTotals`, `queryTurtleMerkleProofs`, `queryTurtleStreams`.

## Fix

- **Policy rows for all ten queries.** Position/authorization reads take balance-class windows (1 min browse / 15 s plan-time) with `invalidateAfterTx`; discovery lists take 5 min / 1 min with `invalidateAfterTx`; Euler-side target vault data takes the governance-config class (5 min / 1 min); source vault assets (immutable) 5 min flat. Fuul/Turtle rewards take the existing rewards default, and `queryFuulClaimChecks` joins the post-claim invalidation list in `useSdkRewards`.
- **Completeness test.** `tests/utils/sdk-query-policy.test.ts` now builds the real SDK offline with a recording `buildQuery` and fails when any wrapped query name lacks a policy row, or when a row matches no wrapped name. A future SDK bump adding queries fails CI until they are classified.
- **SDK 1.1.4** adds `PositionMigrationService` to the `EulerSDKQueryName` union (euler-xyz/euler-sdks#75), so the new rows typecheck without a local type widening. The obsolete `as EulerSDKQueryName` casts in `useSdkRewards` are dropped.

Note on the lockfile: 1.1.4 was published today, inside the project's `min-release-age=7` window, so it was resolved with a one-off `--min-release-age=0` install. `npm ci` installs from the lockfile and is unaffected.

Verified: full `tests/utils` + affected composable suites pass (793 tests), `nuxt typecheck` clean against 1.1.4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for newly available rewards, incentives, Turtle, and position-migration data queries.
  * Improved cache refresh behavior so reward updates reflect more completely after actions.
  * Added tailored caching and refresh policies for migration-related account and position information.

* **Bug Fixes**
  * Updated the SDK integration to ensure newly supported queries use explicit caching policies instead of fallback defaults.

* **Documentation**
  * Clarified SDK query caching requirements and policy coverage in the integration documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->