### PR TITLE
fix(discovery): show bounded external vault relationships

### DIFF
--- a/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketMatrix.vue
@@ -305,8 +305,10 @@ watch(
                   && selectedHeader?.axis === 'column'
                   ? 'text-accent-500 shadow-[inset_0_0_0_9999px_rgba(var(--accent-rgb),0.10)]'
                   : isColumnHighlighted(col.address)
-                    ? 'text-content-primary shadow-[inset_0_0_0_9999px_rgba(255,255,255,0.06)]'
-                    : 'text-content-primary hover:shadow-[inset_0_0_0_9999px_rgba(255,255,255,0.04)]'
+                    ? (col.isExternal ? 'text-content-tertiary shadow-[inset_0_0_0_9999px_rgba(255,255,255,0.06)]' : 'text-content-primary shadow-[inset_0_0_0_9999px_rgba(255,255,255,0.06)]')
+                    : (col.isExternal
+                      ? 'text-content-tertiary hover:shadow-[inset_0_0_0_9999px_rgba(255,255,255,0.04)]'
+                      : 'text-content-primary hover:shadow-[inset_0_0_0_9999px_rgba(255,255,255,0.04)]')
               "
               @click.stop="$emit('selectHeader', col.address, 'column')"
             >

--- a/tests/utils/discovery-calculations.test.ts
+++ b/tests/utils/discovery-calculations.test.ts
@@ -8,6 +8,7 @@ import {
   getActiveExternalCollateral,
   getAttributeMatrixColumns,
   getCollateralMatrix,
+  getMiniDiagram,
   getMarketEntities,
   isNodeRampingDown,
   type VaultApyCacheEntry,
@@ -102,6 +103,7 @@ const makeMarket = (
   ({
     vaults,
     externalCollateral,
+    unknownCollateral: [],
   }) as unknown as MarketGroup
 
 describe('isNodeRampingDown', () => {
@@ -111,6 +113,14 @@ describe('isNodeRampingDown', () => {
     const market = makeMarket([borrowVault, collateralVault])
 
     expect(isNodeRampingDown(market, '0xBorrow')).toBe(true)
+  })
+
+  it('marks an external liability vault whose own collateral LTV is ramping down', () => {
+    const member = makeVault('0xMember', [makeLtv({ address: '0xExternal', borrowLTV: 0.7 })])
+    const external = makeVault('0xExternal', [makeLtv({ address: '0xMember' })])
+    const market = makeMarket([member], [external])
+
+    expect(isNodeRampingDown(market, '0xExternal')).toBe(true)
   })
 
   it('does not mark a collateral vault just because another vault is ramping against it', () => {
@@ -140,6 +150,28 @@ describe('isNodeRampingDown', () => {
 })
 
 describe('getCollateralMatrix', () => {
+  it('includes bounded external-vault liabilities without pulling in their unrelated collateral', () => {
+    const usdc = makeVault('0xUsdc', [
+      makeLtv({ address: '0xCoin', borrowLTV: 0.7 }),
+      makeLtv({ address: '0xMstr', borrowLTV: 0.7 }),
+    ])
+    const coin = makeVault('0xCoin', [
+      makeLtv({ address: '0xUsdc', borrowLTV: 0.7 }),
+      makeLtv({ address: '0xMstr', borrowLTV: 0.6 }),
+      makeLtv({ address: '0xUnrelated', borrowLTV: 0.5 }),
+    ])
+    const mstr = makeVault('0xMstr', [])
+    const market = makeMarket([usdc], [coin, mstr])
+
+    const matrix = getCollateralMatrix(market)
+
+    expect(matrix).not.toBeNull()
+    expect(matrix!.columns.map(column => column.address)).toContain('0xcoin')
+    expect(matrix!.cells.get('0xusdc')?.has('0xcoin')).toBe(true)
+    expect(matrix!.cells.get('0xmstr')?.has('0xcoin')).toBe(true)
+    expect(matrix!.rows.map(row => row.address)).not.toContain('0xunrelated')
+  })
+
   it('keeps a vault as a matrix column while its liquidation LTV is still ramping down', () => {
     const borrowVault = makeVault('0xBorrow', [makeLtv({ address: '0xCollateral', borrowLTV: 0 })])
     const collateralVault = makeVault('0xCollateral', [])
@@ -184,6 +216,37 @@ describe('getCollateralMatrix', () => {
       assetAddress: '0xSecuritize',
       category: 'external',
     })
+  })
+})
+
+describe('getMiniDiagram', () => {
+  it('shows relationships among product members and their direct external collateral only', () => {
+    const usdc = makeVault('0xUsdc', [
+      makeLtv({ address: '0xCoin', borrowLTV: 0.7 }),
+      makeLtv({ address: '0xMstr', borrowLTV: 0.7 }),
+    ])
+    const coin = makeVault('0xCoin', [
+      makeLtv({ address: '0xUsdc', borrowLTV: 0.7 }),
+      makeLtv({ address: '0xMstr', borrowLTV: 0.6 }),
+      makeLtv({ address: '0xUnrelated', borrowLTV: 0.5 }),
+    ])
+    const mstr = makeVault('0xMstr', [])
+    const market = makeMarket([usdc], [coin, mstr])
+
+    const diagram = getMiniDiagram(market)
+    const edge = (from: string, to: string) => diagram.edges.find(candidate =>
+      candidate.from.address === from && candidate.to.address === to,
+    )
+
+    expect(diagram.nodes.map(node => node.address).sort()).toEqual([
+      '0xcoin',
+      '0xmstr',
+      '0xusdc',
+    ])
+    expect(edge('0xcoin', '0xusdc')).toMatchObject({ mutual: true })
+    expect(edge('0xmstr', '0xcoin')).toMatchObject({ mutual: false })
+    expect(diagram.pairCount).toBe(4)
+    expect(diagram.nodes.map(node => node.address)).not.toContain('0xunrelated')
   })
 })
 

--- a/tests/utils/discovery-calculations.test.ts
+++ b/tests/utils/discovery-calculations.test.ts
@@ -123,6 +123,14 @@ describe('isNodeRampingDown', () => {
     expect(isNodeRampingDown(market, '0xExternal')).toBe(true)
   })
 
+  it('ignores ramping relationships outside the displayed external-vault boundary', () => {
+    const member = makeVault('0xMember', [makeLtv({ address: '0xExternal', borrowLTV: 0.7 })])
+    const external = makeVault('0xExternal', [makeLtv({ address: '0xUnrelated' })])
+    const market = makeMarket([member], [external])
+
+    expect(isNodeRampingDown(market, '0xExternal')).toBe(false)
+  })
+
   it('does not mark a collateral vault just because another vault is ramping against it', () => {
     const borrowVault = makeVault('0xBorrow', [makeLtv({ address: '0xCollateral' })])
     const collateralVault = makeVault('0xCollateral', [])
@@ -167,8 +175,10 @@ describe('getCollateralMatrix', () => {
 
     expect(matrix).not.toBeNull()
     expect(matrix!.columns.map(column => column.address)).toContain('0xcoin')
+    expect(matrix!.columns.find(column => column.address === '0xcoin')).toMatchObject({ isExternal: true })
     expect(matrix!.cells.get('0xusdc')?.has('0xcoin')).toBe(true)
     expect(matrix!.cells.get('0xmstr')?.has('0xcoin')).toBe(true)
+    expect(matrix!.rows.find(row => row.address === '0xcoin')).toMatchObject({ category: 'external' })
     expect(matrix!.rows.map(row => row.address)).not.toContain('0xunrelated')
   })
 

--- a/utils/discoveryCalculations.ts
+++ b/utils/discoveryCalculations.ts
@@ -27,7 +27,7 @@ export interface MatrixCell {
 
 export interface CollateralMatrixData {
   rows: Array<{ address: string, symbol: string, assetAddress: string, category: 'escrow' | 'external' | 'borrowable' }>
-  columns: Array<{ address: string, symbol: string, assetAddress: string }>
+  columns: Array<{ address: string, symbol: string, assetAddress: string, isExternal: boolean }>
   cells: Map<string, Map<string, MatrixCell>>
   pairCount: number
 }
@@ -359,9 +359,14 @@ export const getCollateralMatrix = (market: MarketGroup): CollateralMatrixData |
   const nonBorrowable = getDiscoveryRowOnlyVaults(market)
 
   const knownAddresses = new Set<string>()
+  const externalAddresses = new Set<string>()
   for (const v of [...market.vaults, ...market.externalCollateral]) {
     const addr = getVaultAddress(v).toLowerCase()
     if (addr) knownAddresses.add(addr)
+  }
+  for (const v of market.externalCollateral) {
+    const addr = getVaultAddress(v).toLowerCase()
+    if (addr) externalAddresses.add(addr)
   }
 
   const cells = new Map<string, Map<string, MatrixCell>>()
@@ -442,13 +447,21 @@ export const getCollateralMatrix = (market: MarketGroup): CollateralMatrixData |
     rows.push({ address: addr, symbol, assetAddress, category })
   }
 
-  for (const v of sortedDiagonal) addRow(v.address.toLowerCase(), v.asset.symbol, v.asset.address, 'borrowable')
-  for (const v of sortedRowOnly) addRow(v.address.toLowerCase(), v.asset.symbol, v.asset.address, 'borrowable')
+  const getRelationshipRowCategory = (addr: string): CollateralMatrixData['rows'][0]['category'] =>
+    externalAddresses.has(addr) ? 'external' : 'borrowable'
 
-  // Escrow + external rows always render at the bottom, even when no
-  // borrowable vault references them, so curators can see same-asset escrow
-  // and external collateral at a glance. Rows without cells appear empty —
-  // the dim styling on the label conveys that they're inventory, not active.
+  for (const v of sortedDiagonal) {
+    const addr = v.address.toLowerCase()
+    addRow(addr, v.asset.symbol, v.asset.address, getRelationshipRowCategory(addr))
+  }
+  for (const v of sortedRowOnly) {
+    const addr = v.address.toLowerCase()
+    addRow(addr, v.asset.symbol, v.asset.address, getRelationshipRowCategory(addr))
+  }
+
+  // Non-liability rows render after relationship rows. External relationship
+  // rows stay aligned with their liability columns, while category metadata
+  // keeps every external label visually distinct.
   const sortedNonBorrowable = [...nonBorrowable]
     .sort((a, b) => rowAvgLTV(b.address.toLowerCase()) - rowAvgLTV(a.address.toLowerCase()))
   for (const v of sortedNonBorrowable) addRow(v.address.toLowerCase(), v.asset.symbol, v.asset.address, 'escrow')
@@ -465,8 +478,18 @@ export const getCollateralMatrix = (market: MarketGroup): CollateralMatrixData |
   for (const v of sortedExternal) addRow(getVaultAddress(v).toLowerCase(), getVaultAssetSymbol(v), getVaultAssetAddress(v), 'external')
 
   const columns: CollateralMatrixData['columns'] = [
-    ...sortedDiagonal.map(v => ({ address: v.address.toLowerCase(), symbol: v.asset.symbol, assetAddress: v.asset.address })),
-    ...sortedColOnly.map(v => ({ address: v.address.toLowerCase(), symbol: v.asset.symbol, assetAddress: v.asset.address })),
+    ...sortedDiagonal.map(v => ({
+      address: v.address.toLowerCase(),
+      symbol: v.asset.symbol,
+      assetAddress: v.asset.address,
+      isExternal: externalAddresses.has(v.address.toLowerCase()),
+    })),
+    ...sortedColOnly.map(v => ({
+      address: v.address.toLowerCase(),
+      symbol: v.asset.symbol,
+      assetAddress: v.asset.address,
+      isExternal: externalAddresses.has(v.address.toLowerCase()),
+    })),
   ]
 
   return { rows, columns, cells, pairCount }
@@ -579,7 +602,20 @@ export const isNodeRampingDown = (market: MarketGroup, address: string): boolean
     .filter(isEVault)
     .find(v => v.address.toLowerCase() === normalized)
 
-  return vault?.collaterals.some(ltv => ltv.isLiquidationLTVRamping) ?? false
+  if (!vault) return false
+
+  const isExternal = market.externalCollateral.some(v => getVaultAddress(v).toLowerCase() === normalized)
+  if (!isExternal) return vault.collaterals.some(ltv => ltv.isLiquidationLTVRamping)
+
+  const displayedAddresses = new Set([
+    ...market.vaults.map(v => getVaultAddress(v).toLowerCase()),
+    ...market.externalCollateral.map(v => getVaultAddress(v).toLowerCase()),
+    ...market.unknownCollateral.map(addr => addr.toLowerCase()),
+  ])
+
+  return vault.collaterals.some(ltv =>
+    ltv.isLiquidationLTVRamping && displayedAddresses.has(ltv.address.toLowerCase()),
+  )
 }
 
 // ============================================================

--- a/utils/discoveryCalculations.ts
+++ b/utils/discoveryCalculations.ts
@@ -7,6 +7,7 @@ import type { AnyVault } from '~/composables/useVaultRegistry'
 
 import { getEulerLabelEntityLogo } from '~/entities/euler/labels'
 import { getEntitiesByVault, isVaultCyclicalNote, isVaultDeprecated } from '~/utils/eulerLabelsUtils'
+import { ltvToPercent } from '~/utils/crypto-utils'
 import { formatNumber, compactNumber, truncate } from '~/utils/string-utils'
 import { formatHookedOpsSummary, getHookedOperationMetas, getVaultHookedOperations, hasAnyHookedOperation, isVaultEffectivelyPaused } from '~/utils/vault-hooks'
 import { INTEREST_RATE_MODEL_TYPE } from '~/entities/constants'
@@ -183,6 +184,16 @@ const hasLiveDiscoveryColumn = (vault: EVault): boolean =>
 const getDiscoveryColumnVaults = (market: MarketGroup): EVault[] =>
   market.vaults.filter(isEVault).filter(hasLiveDiscoveryColumn)
 
+// Product members define the graph boundary. External collateral is resolved
+// one hop from those members; once resolved, include its relationships only
+// when the other endpoint is already inside that bounded set. This exposes
+// member ↔ external and external ↔ external edges without recursively pulling
+// an external vault's unrelated collateral into the product graph.
+const getBoundedRelationshipVaults = (market: MarketGroup): EVault[] =>
+  [...market.vaults, ...market.externalCollateral]
+    .filter(isEVault)
+    .filter(hasLiveDiscoveryColumn)
+
 const getDiscoveryRowOnlyVaults = (market: MarketGroup): EVault[] =>
   market.vaults.filter(isEVault).filter(v => !hasLiveDiscoveryColumn(v))
 
@@ -231,8 +242,7 @@ export const getMiniDiagram = (market: MarketGroup): MiniDiagramData => {
   const connectedAddresses = new Set<string>()
   const connectedUnknownAddresses = new Set<string>()
 
-  for (const vault of market.vaults) {
-    if (!isEVault(vault)) continue
+  for (const vault of getBoundedRelationshipVaults(market)) {
     for (const ltv of vault.collaterals) {
       const colAddr = ltv.address.toLowerCase()
       const isKnown = vaultByAddr.has(colAddr)
@@ -345,7 +355,7 @@ export const getMiniDiagram = (market: MarketGroup): MiniDiagramData => {
 // ============================================================
 
 export const getCollateralMatrix = (market: MarketGroup): CollateralMatrixData | null => {
-  const borrowable = getDiscoveryColumnVaults(market)
+  const borrowable = getBoundedRelationshipVaults(market)
   const nonBorrowable = getDiscoveryRowOnlyVaults(market)
 
   const knownAddresses = new Set<string>()
@@ -565,7 +575,7 @@ export const getGraphConnectedAddresses = (diagram: MiniDiagramData, address: st
 
 export const isNodeRampingDown = (market: MarketGroup, address: string): boolean => {
   const normalized = address.toLowerCase()
-  const vault = market.vaults
+  const vault = [...market.vaults, ...market.externalCollateral]
     .filter(isEVault)
     .find(v => v.address.toLowerCase() === normalized)
 


### PR DESCRIPTION
## Summary

- include external EVaults as relationship sources once they are already part of a labelled product's direct external-collateral set
- show member ↔ external and external ↔ external relationships in both the discovery graph and collateral matrix
- keep traversal bounded: collateral referenced only by an external vault is not resolved or pulled into the product graph
- include displayed external liability vaults in ramp-down badge detection

## Boundary invariant

The displayed node universe remains:

1. labelled product members; plus
2. external collateral directly resolved from those members.

Edges are rendered only when both endpoints are already in that fixed universe. The implementation does not recurse from external nodes.

## Tests

- `npm run test:run` — 1,245 passed, 1 skipped
- `npm run test:run -- tests/utils/discovery-calculations.test.ts` — 21 passed
- `npm run typecheck`
- `npm run build`
- `npm run lint` — 0 errors; 6 pre-existing `no-explicit-any` warnings
- `git diff --check origin/development`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved discovery mini-diagrams and collateral matrices to follow the correct bounded product relationships, including external collateral links while excluding unrelated nodes.
  * Updated ramp-down detection for external liability vaults and refined relationship handling when outside the displayed boundary.
  * Corrected collateral matrix classification (external vs borrowable) and improved ordering/relationship indicators.
* **UI Improvements**
  * Refined column header styling to better distinguish external vault columns.
* **Tests**
  * Expanded coverage for bounded discovery, mini-diagram structure, and ramping/downstream detection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->