### PR TITLE
feat: add portfolio activity timeline

### DIFF
--- a/components/entities/activity/ActivityAddress.vue
+++ b/components/entities/activity/ActivityAddress.vue
@@ -1,15 +1,38 @@
 <script setup lang="ts">
+import type { ActivityVaultType } from '@eulerxyz/euler-v2-sdk'
 import { getExplorerLink } from '~/utils/block-explorer'
+import type { ActivityAddressLinkKind } from '~/utils/activity-display'
 import { shortenAddress } from '~/utils/string-utils'
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
   address: string
   chainId: number
   label?: string
-}>()
+  linkKind?: ActivityAddressLinkKind
+  vaultType?: ActivityVaultType
+}>(), {
+  linkKind: 'explorer',
+})
 
+const route = useRoute()
+const { activateSpyMode } = useSpyMode()
 const copyKey = computed(() => `activity-address-${props.address.toLowerCase()}`)
 const explorerLink = computed(() => getExplorerLink(props.address, props.chainId, true))
+const internalLink = computed(() => {
+  const query = typeof route.query.network === 'string'
+    ? { network: route.query.network }
+    : undefined
+  if (props.linkKind === 'spy') {
+    return { path: '/portfolio/activity', query: { ...query, spy: props.address } }
+  }
+  if (props.linkKind === 'vault') {
+    return {
+      path: props.vaultType === 'earn' ? `/earn/${props.address}` : `/lend/${props.address}`,
+      query,
+    }
+  }
+  return null
+})
 
 const fallbackCopy = (text: string) => {
   const textarea = document.createElement('textarea')
@@ -35,11 +58,31 @@ const { isCopied, copyToClipboard } = useClipboardCopy({ timeout: 5000, write: w
 const copyAddress = () => {
   copyToClipboard(props.address, copyKey.value).catch(() => {})
 }
+
+const handleInternalClick = (event: MouseEvent) => {
+  if (
+    props.linkKind !== 'spy'
+    || event.button !== 0
+    || event.metaKey
+    || event.ctrlKey
+    || event.shiftKey
+    || event.altKey
+  ) return
+  activateSpyMode(props.address)
+}
 </script>
 
 <template>
   <span class="inline-flex min-w-0 max-w-full items-center gap-2">
+    <NuxtLink
+      v-if="internalLink"
+      :to="internalLink"
+      class="min-w-0 truncate text-content-secondary transition-colors hover:text-accent-500 hover:underline"
+      :title="address"
+      @click="handleInternalClick"
+    >{{ label || shortenAddress(address) }}</NuxtLink>
     <a
+      v-else
       :href="explorerLink"
       target="_blank"
       rel="noopener noreferrer"

--- a/components/entities/activity/ActivityCategoryFilters.vue
+++ b/components/entities/activity/ActivityCategoryFilters.vue
@@ -2,46 +2,23 @@
 import type { ActivityFilterOption } from '~/utils/activity-display'
 
 const selected = defineModel<string[]>({ required: true })
-defineProps<{
+const props = defineProps<{
   options: readonly ActivityFilterOption[]
 }>()
 
-const selectAll = () => {
-  selected.value = []
-}
-
-const toggle = (filter: string) => {
-  selected.value = selected.value.includes(filter)
-    ? selected.value.filter(value => value !== filter)
-    : [...selected.value, filter]
-}
+const selectOptions = computed(() => props.options.map(option => ({
+  label: option.label,
+  value: option.value,
+})))
 </script>
 
 <template>
-  <div
-    class="flex max-w-full gap-8 overflow-x-auto pb-2"
-    role="group"
-    aria-label="Activity categories"
-  >
-    <button
-      type="button"
-      class="h-32 shrink-0 rounded-full px-12 text-p3 transition-colors"
-      :class="selected.length === 0 ? 'bg-accent-600 text-black hover:bg-accent-700' : 'bg-surface text-content-secondary hover:text-content-primary'"
-      :aria-pressed="selected.length === 0"
-      @click="selectAll"
-    >
-      All
-    </button>
-    <button
-      v-for="option in options"
-      :key="option.value"
-      type="button"
-      class="h-32 shrink-0 rounded-full px-12 text-p3 transition-colors"
-      :class="selected.includes(option.value) ? 'bg-accent-600 text-black hover:bg-accent-700' : 'bg-surface text-content-secondary hover:text-content-primary'"
-      :aria-pressed="selected.includes(option.value)"
-      @click="toggle(option.value)"
-    >
-      {{ option.label }}
-    </button>
-  </div>
+  <UiSelect
+    v-model="selected"
+    class="w-fit max-w-full"
+    :options="selectOptions"
+    placeholder="All activity"
+    title="Activity categories"
+    show-selected-options
+  />
 </template>

--- a/components/entities/activity/ActivityEventRow.vue
+++ b/components/entities/activity/ActivityEventRow.vue
@@ -26,8 +26,10 @@ const { event, showVault = false } = defineProps<{
 
 const route = useRoute()
 const expanded = ref(false)
-const { getVault: getRegistryVault, registryVersion } = useVaultRegistry()
+const { getVault: getRegistryVault, getVaultCategory, registryVersion } = useVaultRegistry()
 const { getTokenByAddress } = useTokenList()
+const vaultAddress = computed(() => event.vault ?? '')
+const vaultProduct = useEulerProductOfVault(vaultAddress)
 
 const tokenMetadata = (address: `0x${string}`) => {
   const token = getTokenByAddress(address)
@@ -99,7 +101,7 @@ const details = computed(() => [
 const participants = computed(() => getActivityParticipants(event).map(participant => ({
   ...participant,
   label: participant.label === 'User' && event.subAccountIndex !== undefined
-    ? `User · Account ${event.subAccountIndex}`
+    ? `Position ${event.subAccountIndex}`
     : participant.label,
 })))
 const hasExpandableMobileDetails = computed(() =>
@@ -112,7 +114,10 @@ const vaultDisplay = computed(() => {
   if (!showVault) return null
   // Re-resolve when vault metadata arrives after the activity page.
   void registryVersion.value
-  const display = resolveActivityVaultDisplay(event.vault, getRegistryVault)
+  const productName = event.vault && getVaultCategory(event.vault) === 'escrow'
+    ? 'Escrowed collateral'
+    : vaultProduct.name
+  const display = resolveActivityVaultDisplay(event.vault, getRegistryVault, productName)
   if (!display) return null
   const vault = getRegistryVault(display.address)
   const asset = vault?.asset

--- a/components/entities/activity/ActivityEventRow.vue
+++ b/components/entities/activity/ActivityEventRow.vue
@@ -24,6 +24,7 @@ const { event, showVault = false } = defineProps<{
   showVault?: boolean
 }>()
 
+const route = useRoute()
 const expanded = ref(false)
 const { getVault: getRegistryVault, registryVersion } = useVaultRegistry()
 const { getTokenByAddress } = useTokenList()
@@ -113,9 +114,15 @@ const vaultDisplay = computed(() => {
   void registryVersion.value
   const display = resolveActivityVaultDisplay(event.vault, getRegistryVault)
   if (!display) return null
+  const vault = getRegistryVault(display.address)
+  const asset = vault?.asset
   return {
     ...display,
-    link: getExplorerLink(display.address, event.chainId, true),
+    avatarAsset: asset ? { address: asset.address, symbol: asset.symbol } : null,
+    route: {
+      path: event.vaultType === 'earn' ? `/earn/${display.address}` : `/lend/${display.address}`,
+      query: { network: route.query.network },
+    },
   }
 })
 </script>
@@ -148,27 +155,27 @@ const vaultDisplay = computed(() => {
           </div>
           <div
             v-if="vaultDisplay"
-            class="mt-2 flex min-w-0 items-center gap-4 text-p4 text-content-tertiary"
+            class="mt-4 flex min-w-0 flex-wrap items-center gap-x-4 gap-y-2 text-p4"
           >
-            <span class="shrink-0">Market</span>
-            <a
-              :href="vaultDisplay.link"
-              target="_blank"
-              rel="noopener noreferrer"
-              class="flex min-w-0 items-center gap-4 text-accent-600 underline transition-colors hover:text-accent-500"
-              :title="vaultDisplay.address"
+            <span class="text-content-tertiary">Market</span>
+            <AssetAvatar
+              v-if="vaultDisplay.avatarAsset"
+              :asset="vaultDisplay.avatarAsset"
+              size="20"
+            />
+            <NuxtLink
+              v-if="vaultDisplay.name"
+              :to="vaultDisplay.route"
+              class="min-w-0 truncate text-content-secondary transition-colors hover:text-accent-500 hover:underline"
+              :title="vaultDisplay.name"
             >
-              <span
-                v-if="vaultDisplay.name"
-                class="truncate"
-              >{{ vaultDisplay.name }}</span>
-              <span
-                v-if="vaultDisplay.name"
-                class="shrink-0"
-                aria-hidden="true"
-              >&middot;</span>
-              <span class="shrink-0">{{ vaultDisplay.addressLabel }}</span>
-            </a>
+              {{ vaultDisplay.name }}
+            </NuxtLink>
+            <ActivityAddress
+              :address="vaultDisplay.address"
+              :chain-id="event.chainId"
+              :label="vaultDisplay.addressLabel"
+            />
           </div>
         </div>
       </div>

--- a/components/entities/activity/ActivityEventRow.vue
+++ b/components/entities/activity/ActivityEventRow.vue
@@ -8,7 +8,7 @@ import {
   formatActivityAssetUsd,
   formatActivityEventLabel,
   formatActivityTimestamp,
-  formatActivityValuation,
+  formatActivityValuationForAssets,
   getActivityAssetAddressLabel,
   getActivityAssetLabel,
   getActivityAssetsForDisplay,
@@ -26,7 +26,12 @@ const { event, showVault = false } = defineProps<{
 
 const route = useRoute()
 const expanded = ref(false)
-const { getVault: getRegistryVault, getVaultCategory, registryVersion } = useVaultRegistry()
+const {
+  getVault: getRegistryVault,
+  getType: getRegistryVaultType,
+  getVaultCategory,
+  registryVersion,
+} = useVaultRegistry()
 const { getTokenByAddress } = useTokenList()
 const vaultAddress = computed(() => event.vault ?? '')
 const vaultProduct = useEulerProductOfVault(vaultAddress)
@@ -39,6 +44,16 @@ const tokenMetadata = (address: `0x${string}`) => {
     name: token.name,
     symbol: token.symbol,
     decimals: token.decimals,
+  }
+}
+
+const activityVaultMetadata = (address: `0x${string}`) => {
+  const vault = getRegistryVault(address)
+  if (!vault) return undefined
+  return {
+    asset: vault.asset,
+    shares: vault.shares,
+    vaultType: getRegistryVaultType(address),
   }
 }
 
@@ -64,27 +79,33 @@ const assets = computed(() => {
       getRegistryVault,
       tokenMetadata,
     )
-    const amount = formatActivityAssetAmount(enriched)
+    const amount = formatActivityAssetAmount(enriched, event.type)
     return {
       kind: 'asset' as const,
       address: enriched.address,
       addressKind: getActivityAssetAddressLabel(enriched.kind, event.category),
       amount,
+      amountTitle: amount === 'Amount unavailable' ? `Raw units: ${enriched.amountRaw}` : undefined,
       avatarAsset: resolveAvatarAsset(enriched),
       key: `asset:${enriched.kind}:${enriched.address ?? 'unknown'}:${index}`,
-      label: getActivityAssetLabel(enriched.kind, event.category),
+      label: getActivityAssetLabel(enriched.kind, event.category, event.type),
       usd: formatActivityAssetUsd(enriched),
     }
   })
 })
-const changes = computed(() => getActivityChangeEntries(event.change).map(entry => ({
-  kind: 'change' as const,
-  key: `change:${entry.field}`,
-  label: entry.label,
-  value: entry.value,
-  valueTitle: entry.value,
-})))
-const valuation = computed(() => formatActivityValuation(event.valuation))
+const changes = computed(() => {
+  // Re-resolve human-readable vault names when registry metadata arrives.
+  void registryVersion.value
+  return getActivityChangeEntries(event, activityVaultMetadata).map(entry => ({
+    kind: 'change' as const,
+    key: `change:${entry.field}`,
+    label: entry.label,
+    value: entry.value,
+    valueTitle: entry.value,
+    addresses: entry.addresses,
+  }))
+})
+const valuation = computed(() => formatActivityValuationForAssets(event.valuation, event.assets ?? []))
 const details = computed(() => [
   ...assets.value,
   ...changes.value,
@@ -95,6 +116,7 @@ const details = computed(() => [
         label: 'USD value',
         value: valuation.value,
         valueTitle: event.valuation?.reason,
+        addresses: undefined,
       }]
     : []),
 ])
@@ -180,6 +202,8 @@ const vaultDisplay = computed(() => {
               :address="vaultDisplay.address"
               :chain-id="event.chainId"
               :label="vaultDisplay.addressLabel"
+              link-kind="vault"
+              :vault-type="event.vaultType"
             />
           </div>
         </div>
@@ -199,6 +223,7 @@ const vaultDisplay = computed(() => {
             <ActivityAddress
               :address="participant.address"
               :chain-id="event.chainId"
+              :link-kind="participant.linkKind"
             />
           </div>
           <span
@@ -250,6 +275,7 @@ const vaultDisplay = computed(() => {
             <div class="min-w-0">
               <div
                 class="break-words text-p3 font-medium text-content-primary"
+                :title="detail.amountTitle"
               >
                 {{ detail.amount }}
               </div>
@@ -273,13 +299,29 @@ const vaultDisplay = computed(() => {
           </div>
         </template>
 
-        <div
-          v-else
-          class="break-words text-p3 text-content-primary"
-          :title="detail.valueTitle"
-        >
-          {{ detail.value }}
-        </div>
+        <template v-else>
+          <div
+            v-if="detail.addresses?.length"
+            class="mt-2 flex min-w-0 flex-col items-start gap-2 text-p3"
+          >
+            <ActivityAddress
+              v-for="address in detail.addresses"
+              :key="address.address"
+              :address="address.address"
+              :chain-id="event.chainId"
+              :label="address.label"
+              :link-kind="address.linkKind"
+              :vault-type="address.vaultType"
+            />
+          </div>
+          <div
+            v-else
+            class="break-words text-p3 text-content-primary"
+            :title="detail.valueTitle"
+          >
+            {{ detail.value }}
+          </div>
+        </template>
       </div>
 
       <span

--- a/components/entities/activity/ActivityEventRow.vue
+++ b/components/entities/activity/ActivityEventRow.vue
@@ -16,9 +16,13 @@ import {
   getActivityChangeEntries,
   getActivityEventIcon,
   getActivityParticipants,
+  resolveActivityVaultDisplay,
 } from '~/utils/activity-display'
 
-const { event } = defineProps<{ event: ActivityEvent }>()
+const { event, showVault = false } = defineProps<{
+  event: ActivityEvent
+  showVault?: boolean
+}>()
 
 const expanded = ref(false)
 const { getVault: getRegistryVault, registryVersion } = useVaultRegistry()
@@ -103,6 +107,17 @@ const hasExpandableMobileDetails = computed(() =>
 const eventIcon = computed(() => getActivityEventIcon(event))
 const eventLabel = computed(() => formatActivityEventLabel(event))
 const transactionLink = computed(() => getExplorerLink(event.txHash, event.chainId))
+const vaultDisplay = computed(() => {
+  if (!showVault) return null
+  // Re-resolve when vault metadata arrives after the activity page.
+  void registryVersion.value
+  const display = resolveActivityVaultDisplay(event.vault, getRegistryVault)
+  if (!display) return null
+  return {
+    ...display,
+    link: getExplorerLink(display.address, event.chainId, true),
+  }
+})
 </script>
 
 <template>
@@ -130,6 +145,30 @@ const transactionLink = computed(() => getExplorerLink(event.txHash, event.chain
               class="whitespace-nowrap"
               :datetime="event.timestamp"
             >{{ formatActivityTimestamp(event.timestamp) }}</time>
+          </div>
+          <div
+            v-if="vaultDisplay"
+            class="mt-2 flex min-w-0 items-center gap-4 text-p4 text-content-tertiary"
+          >
+            <span class="shrink-0">Market</span>
+            <a
+              :href="vaultDisplay.link"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="flex min-w-0 items-center gap-4 text-accent-600 underline transition-colors hover:text-accent-500"
+              :title="vaultDisplay.address"
+            >
+              <span
+                v-if="vaultDisplay.name"
+                class="truncate"
+              >{{ vaultDisplay.name }}</span>
+              <span
+                v-if="vaultDisplay.name"
+                class="shrink-0"
+                aria-hidden="true"
+              >&middot;</span>
+              <span class="shrink-0">{{ vaultDisplay.addressLabel }}</span>
+            </a>
           </div>
         </div>
       </div>

--- a/components/entities/activity/ActivityFeed.vue
+++ b/components/entities/activity/ActivityFeed.vue
@@ -187,6 +187,7 @@ watch(feed.hasLoaded, (hasLoaded) => {
             v-for="event in feed.events.value"
             :key="event.id"
             :event="event"
+            :show-vault="subject === 'account'"
           />
         </ul>
       </div>

--- a/components/entities/activity/ActivityFeed.vue
+++ b/components/entities/activity/ActivityFeed.vue
@@ -10,11 +10,14 @@ import {
   type ActivityFilterOption,
 } from '~/utils/activity-display'
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
   scope: ActivityFeedScope
   enabled: boolean
   categoryOptions: readonly ActivityFilterOption[]
-}>()
+  subject?: 'account' | 'vault'
+}>(), {
+  subject: 'vault',
+})
 const emit = defineEmits<{
   'settled': []
   'update:unsupported': [unsupported: boolean]
@@ -24,6 +27,7 @@ const selectedFilters = ref<string[]>([])
 const selectedCategories = computed<ActivityCategory[]>(() =>
   resolveActivityFilterCategories(props.categoryOptions, selectedFilters.value),
 )
+const scopeLabel = computed(() => props.subject)
 const feed = useActivityFeed({
   scope: () => props.scope,
   enabled: () => props.enabled,
@@ -143,7 +147,7 @@ watch(feed.hasLoaded, (hasLoaded) => {
       v-else-if="feed.isUnsupported.value"
       class="rounded-12 border border-line-subtle bg-surface p-16 text-p3 text-content-secondary"
     >
-      {{ selectedFilters.length ? 'Activity is not available for the selected categories.' : feed.coverage.value?.reason || 'Activity is not available for this vault.' }}
+      {{ selectedFilters.length ? 'Activity is not available for the selected categories.' : feed.coverage.value?.reason || `Activity is not available for this ${scopeLabel}.` }}
     </div>
 
     <div
@@ -164,7 +168,7 @@ watch(feed.hasLoaded, (hasLoaded) => {
       v-else-if="feed.isEmpty.value"
       class="rounded-12 border border-line-subtle bg-surface p-16 text-p3 text-content-secondary"
     >
-      {{ selectedFilters.length ? 'No activity matches the selected categories.' : 'No activity has been indexed for this vault yet.' }}
+      {{ selectedFilters.length ? 'No activity matches the selected categories.' : `No activity has been indexed for this ${scopeLabel} yet.` }}
     </div>
 
     <template v-else-if="feed.events.value.length">

--- a/components/entities/activity/ActivityFeed.vue
+++ b/components/entities/activity/ActivityFeed.vue
@@ -27,7 +27,7 @@ const selectedFilters = ref<string[]>([])
 const selectedCategories = computed<ActivityCategory[]>(() =>
   resolveActivityFilterCategories(props.categoryOptions, selectedFilters.value),
 )
-const scopeLabel = computed(() => props.subject)
+const scopeLabel = computed(() => props.subject === 'account' ? 'position' : 'vault')
 const feed = useActivityFeed({
   scope: () => props.scope,
   enabled: () => props.enabled,

--- a/components/entities/activity/ActivityFeed.vue
+++ b/components/entities/activity/ActivityFeed.vue
@@ -41,7 +41,7 @@ const missingCategoryLabels = computed(() =>
 )
 const partialMessage = computed(() => {
   if (feed.coverage.value?.reason) return feed.coverage.value.reason
-  if (missingCategoryLabels.value) return `Missing categories: ${missingCategoryLabels.value}.`
+  if (missingCategoryLabels.value) return `${missingCategoryLabels.value} activity may be incomplete.`
   return 'Some activity may not be included yet.'
 })
 const scopeUnsupported = computed(() =>

--- a/components/entities/activity/ActivityFeed.vue
+++ b/components/entities/activity/ActivityFeed.vue
@@ -67,6 +67,7 @@ watch(feed.hasLoaded, (hasLoaded) => {
 <template>
   <div class="activity-feed flex flex-col gap-16">
     <ActivityCategoryFilters
+      v-if="categoryOptions.length > 1"
       v-model="selectedFilters"
       :options="categoryOptions"
     />

--- a/components/entities/vault/overview/VaultOverviewBlockActivity.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockActivity.vue
@@ -56,7 +56,7 @@ watch(feedScope, () => {
     title="Activity"
     :default-open="defaultOpen"
     :keep-mounted="true"
-    content-class="flex flex-col gap-16"
+    content-class="flex flex-col gap-16 pt-8"
     @update:open="isOpen = $event"
   >
     <div

--- a/composables/useActivityFeed.ts
+++ b/composables/useActivityFeed.ts
@@ -77,6 +77,7 @@ export const useActivityFeed = ({
   limit = 25,
 }: UseActivityFeedOptions) => {
   const events = shallowRef<ActivityEvent[]>([])
+  const rawEvents = shallowRef<ActivityEvent[]>([])
   const meta = shallowRef<ActivityEventsMeta>()
   const error = shallowRef<Error>()
   const loadMoreError = shallowRef<Error>()
@@ -109,6 +110,7 @@ export const useActivityFeed = ({
 
   const resetForContext = () => {
     events.value = []
+    rawEvents.value = []
     meta.value = undefined
     error.value = undefined
     loadMoreError.value = undefined
@@ -182,10 +184,10 @@ export const useActivityFeed = ({
         throw new Error('Activity pagination cursor did not advance')
       }
 
-      const mergedEvents = mode === 'append'
-        ? mergeActivityEvents(events.value, page.data)
+      rawEvents.value = mode === 'append'
+        ? mergeActivityEvents(rawEvents.value, page.data)
         : mergeActivityEvents([], page.data)
-      events.value = filterActivityEventsForDisplay(mergedEvents, eventTypes)
+      events.value = filterActivityEventsForDisplay(rawEvents.value, eventTypes)
       meta.value = page.meta
       error.value = undefined
       loadMoreError.value = undefined

--- a/composables/usePortfolioActivityRuntimeSupport.ts
+++ b/composables/usePortfolioActivityRuntimeSupport.ts
@@ -1,0 +1,67 @@
+import { computed, toValue, type MaybeRefOrGetter } from 'vue'
+
+interface PortfolioActivityRuntimeState {
+  contextKey?: string
+  unsupported: boolean
+}
+
+export const buildPortfolioActivityContextKey = (
+  owner: string | null | undefined,
+  chainId: number | string | null | undefined,
+): string | undefined => {
+  const resolvedChainId = Number(chainId)
+  if (!owner || !Number.isSafeInteger(resolvedChainId) || resolvedChainId <= 0) return undefined
+  return `${owner.toLowerCase()}:${resolvedChainId}`
+}
+
+export const shouldShowPortfolioActivityTab = (
+  availabilityShouldRender: boolean,
+  runtimeUnsupported: boolean,
+): boolean => availabilityShouldRender && !runtimeUnsupported
+
+export const shouldLeavePortfolioActivityRoute = ({
+  routeName,
+  isChecking,
+  shouldShow,
+}: {
+  routeName: string | symbol | null | undefined
+  isChecking: boolean
+  shouldShow: boolean
+}): boolean => routeName === 'portfolio-activity' && !isChecking && !shouldShow
+
+export const usePortfolioActivityRuntimeSupport = (
+  owner: MaybeRefOrGetter<string | null | undefined>,
+  chainId: MaybeRefOrGetter<number | string | null | undefined>,
+) => {
+  const state = useState<PortfolioActivityRuntimeState>('portfolio-activity-runtime-support', () => ({
+    unsupported: false,
+  }))
+  const contextKey = computed(() =>
+    buildPortfolioActivityContextKey(toValue(owner), toValue(chainId)),
+  )
+  const isRuntimeUnsupported = computed(() =>
+    Boolean(
+      contextKey.value
+      && state.value.contextKey === contextKey.value
+      && state.value.unsupported,
+    ),
+  )
+
+  const setRuntimeUnsupported = (unsupported: boolean) => {
+    const key = contextKey.value
+    if (!key) return
+    state.value = { contextKey: key, unsupported }
+  }
+
+  const clearRuntimeUnsupported = () => {
+    if (state.value.contextKey !== contextKey.value) return
+    state.value = { unsupported: false }
+  }
+
+  return {
+    clearRuntimeUnsupported,
+    contextKey,
+    isRuntimeUnsupported,
+    setRuntimeUnsupported,
+  }
+}

--- a/composables/useSpyMode.ts
+++ b/composables/useSpyMode.ts
@@ -30,6 +30,14 @@ export const useSpyMode = () => {
   const isSpyMode = computed(() => Boolean(spyAddress.value))
   const spyShortAddress = computed(() => spyAddress.value ? truncate(spyAddress.value) : '')
 
+  const activateSpyMode = (address: string): boolean => {
+    if (!isValidAddress(address)) return false
+    explicitlyCleared = false
+    spyAddress.value = normalizeAddress(address)
+    ownerResolved = false
+    return true
+  }
+
   // Try to pick up ?spy= — route.query may not be populated yet, so read from window.location
   if (!spyAddress.value && !explicitlyCleared && import.meta.client) {
     const spy = new URLSearchParams(window.location.search).get('spy')
@@ -105,10 +113,7 @@ export const useSpyMode = () => {
   }
 
   const setSpyMode = async (address: string) => {
-    if (!isValidAddress(address)) return
-    explicitlyCleared = false
-    spyAddress.value = normalizeAddress(address)
-    ownerResolved = false
+    if (!activateSpyMode(address)) return
 
     await router.replace({
       path: route.path,
@@ -133,6 +138,7 @@ export const useSpyMode = () => {
     spyAddress: computed(() => spyAddress.value),
     isSpyMode,
     spyShortAddress,
+    activateSpyMode,
     setSpyMode,
     clearSpyMode,
   }

--- a/pages/portfolio.vue
+++ b/pages/portfolio.vue
@@ -26,7 +26,7 @@ const { rewards } = useSdkRewards()
 const { locks, refreshLocks } = useREULLocks()
 const { isConnected, address, spyAddress, effectiveAddress, isSpyMode } = useEffectiveAddress()
 const { isLoaded: isBalancesLoaded, updateBalances } = useWallets()
-const { eulerLensAddresses } = useEulerAddresses()
+const { chainId, eulerLensAddresses } = useEulerAddresses()
 const { portfolioRefreshCounter } = usePortfolioRefresh()
 const showAllLabelEntries = useShowAllLabelEntries()
 const {
@@ -35,6 +35,12 @@ const {
   error: migrationError,
   hasLoaded: hasMigrationLoaded,
 } = useExternalMigrationPositions()
+const activityAvailability = useActivityAvailability({ kind: 'account' }, chainId)
+const activityRuntimeSupport = usePortfolioActivityRuntimeSupport(effectiveAddress, chainId)
+const showActivityTab = computed(() => shouldShowPortfolioActivityTab(
+  activityAvailability.shouldRender.value,
+  activityRuntimeSupport.isRuntimeUnsupported.value,
+))
 
 const interval: Ref<NodeJS.Timeout | null> = ref(null)
 const hasShownMigrationTab = ref(false)
@@ -107,6 +113,13 @@ const tabs = computed(() => {
     },
   ]
 
+  if (showActivityTab.value) {
+    items.push({
+      label: 'Activity',
+      value: 'portfolio-activity',
+    })
+  }
+
   if (showMigrationTab.value) {
     items.push({
       label: 'Migrate',
@@ -132,6 +145,21 @@ watch([() => route.name, showMigrationTab, hasMigrationLoaded, isMigrationLoadin
     router.replace({ name: 'portfolio', query: route.query })
   }
 })
+
+watch([
+  () => route.name,
+  showActivityTab,
+  activityAvailability.isChecking,
+  activityAvailability.reason,
+], () => {
+  if (shouldLeavePortfolioActivityRoute({
+    routeName: route.name,
+    isChecking: activityAvailability.isChecking.value,
+    shouldShow: showActivityTab.value,
+  })) {
+    router.replace({ name: 'portfolio', query: route.query })
+  }
+}, { immediate: true })
 
 const portfolioNetApyDisplay = computed(() =>
   Number.isFinite(portfolioNetApy.value) ? `${formatNumber(portfolioNetApy.value)}%` : '-',

--- a/pages/portfolio/activity.vue
+++ b/pages/portfolio/activity.vue
@@ -1,0 +1,96 @@
+<script setup lang="ts">
+import type { Address } from 'viem'
+import { getAddress, isAddress } from 'viem'
+import type { ActivityFeedScope } from '~/composables/useActivityFeed'
+import { getAccountActivityFilterOptions } from '~/utils/activity-display'
+
+defineOptions({
+  name: 'PortfolioActivityPage',
+})
+
+const route = useRoute()
+const { chainId } = useEulerAddresses()
+const { effectiveAddress } = useEffectiveAddress()
+const owner = computed<Address | undefined>(() => {
+  const value = effectiveAddress.value
+  return value && isAddress(value) ? getAddress(value) : undefined
+})
+const availability = useActivityAvailability({ kind: 'account' }, chainId)
+const runtimeSupport = usePortfolioActivityRuntimeSupport(owner, chainId)
+const categoryOptions = getAccountActivityFilterOptions()
+const isActive = computed(() => route.name === 'portfolio-activity')
+const feedScope = computed<ActivityFeedScope | undefined>(() => owner.value
+  ? {
+      kind: 'account',
+      owner: owner.value,
+      chainId: Number(chainId.value),
+    }
+  : undefined,
+)
+
+watch([owner, () => Number(chainId.value)], () => {
+  runtimeSupport.setRuntimeUnsupported(false)
+})
+</script>
+
+<template>
+  <section class="mx-16 flex flex-col gap-16">
+    <div
+      v-if="!owner"
+      class="flex flex-col items-center gap-8 rounded-12 border border-line-subtle bg-surface p-24 text-center"
+    >
+      <div class="text-p3 text-content-primary">
+        Connect a wallet to view account activity.
+      </div>
+      <div class="text-p4 text-content-secondary">
+        You can also open a portfolio in spy mode to inspect its history.
+      </div>
+    </div>
+
+    <div
+      v-else-if="availability.isChecking.value"
+      class="flex flex-col gap-8"
+      aria-label="Checking activity availability"
+    >
+      <div
+        v-for="index in 3"
+        :key="index"
+        class="h-72 animate-pulse rounded-12 bg-surface"
+      />
+    </div>
+
+    <div
+      v-else-if="availability.reason.value === 'capability-check-failed'"
+      class="flex flex-col items-center gap-12 rounded-12 border border-line-subtle bg-surface p-24 text-center"
+      role="alert"
+    >
+      <div class="text-p3 text-content-primary">
+        Activity availability could not be checked right now.
+      </div>
+      <button
+        type="button"
+        class="ui-button ui-button--medium ui-button--secondary"
+        :disabled="availability.isChecking.value"
+        @click="availability.refreshAvailability"
+      >
+        {{ availability.isChecking.value ? 'Retrying…' : 'Retry' }}
+      </button>
+    </div>
+
+    <ActivityFeed
+      v-else-if="feedScope && availability.isSupported.value"
+      :scope="feedScope"
+      :enabled="isActive"
+      :category-options="categoryOptions"
+      subject="account"
+      @update:unsupported="runtimeSupport.setRuntimeUnsupported"
+    />
+
+    <div
+      v-else
+      class="rounded-12 border border-line-subtle bg-surface p-16 text-p3 text-content-secondary"
+    >
+      Activity is not available on this network.
+    </div>
+  </section>
+</template>

--- a/pages/portfolio/activity.vue
+++ b/pages/portfolio/activity.vue
@@ -40,7 +40,7 @@ watch([owner, () => Number(chainId.value)], () => {
       class="flex flex-col items-center gap-8 rounded-12 border border-line-subtle bg-surface p-24 text-center"
     >
       <div class="text-p3 text-content-primary">
-        Connect a wallet to view account activity.
+        Connect a wallet to view position activity.
       </div>
       <div class="text-p4 text-content-secondary">
         You can also open a portfolio in spy mode to inspect its history.

--- a/tests/composables/useActivityFeed.test.ts
+++ b/tests/composables/useActivityFeed.test.ts
@@ -10,7 +10,7 @@ const TX_HASH = `0x${'1'.repeat(64)}` as const
 const event = (
   id: string,
   vault: typeof VAULT | typeof OTHER_VAULT = VAULT,
-  type = 'deposit',
+  type = 'set_caps',
   overrides: Partial<ActivityEvent> = {},
 ): ActivityEvent => ({
   id,
@@ -63,10 +63,13 @@ describe('useActivityFeed', () => {
     vi.restoreAllMocks()
   })
 
-  const setup = async (fetchVaultActivityEvents: ReturnType<typeof vi.fn>) => {
+  const setup = async (
+    fetchVaultActivityEvents: ReturnType<typeof vi.fn>,
+    fetchAccountActivityEvents: ReturnType<typeof vi.fn> = vi.fn(),
+  ) => {
     vi.stubGlobal('useEulerSdk', () => ({
       getEulerSdkForChain: vi.fn(async () => ({
-        activityService: { fetchVaultActivityEvents },
+        activityService: { fetchAccountActivityEvents, fetchVaultActivityEvents },
       })),
     }))
     return import('~/composables/useActivityFeed')
@@ -110,7 +113,14 @@ describe('useActivityFeed', () => {
       limit: 25,
     })
     const requestedEventTypes = fetchVaultActivityEvents.mock.calls[0]?.[0]?.eventTypes
-    expect(requestedEventTypes).toEqual(expect.arrayContaining(['deposit', 'withdraw', 'transfer']))
+    expect(requestedEventTypes).toEqual(expect.arrayContaining(['set_caps', 'set_ltv', 'liquidation']))
+    expect(requestedEventTypes).not.toEqual(expect.arrayContaining([
+      'deposit',
+      'withdraw',
+      'transfer',
+      'borrow',
+      'repay',
+    ]))
     expect(requestedEventTypes).not.toEqual(expect.arrayContaining([
       'interest_accrued',
       'accrue_interest',
@@ -119,23 +129,16 @@ describe('useActivityFeed', () => {
     ]))
   })
 
-  it('keeps display events while dropping interest accrual and paired share movements', async () => {
+  it('keeps risk and governance events while dropping noisy vault user flows', async () => {
     const fetchVaultActivityEvents = vi.fn(async () => page([
-      event('deposit', VAULT, 'deposit', {
-        groupId: 'paired-transaction',
-        assets: [{ kind: 'shares', address: VAULT, amountRaw: '100' }],
-      }),
+      event('set-caps', VAULT, 'set_caps'),
+      event('liquidation', VAULT, 'liquidation'),
+      event('deposit', VAULT, 'deposit'),
+      event('borrow', VAULT, 'borrow'),
       event('mint-shadow', VAULT, 'mint'),
       event('evk-interest', VAULT, 'interest_accrued'),
       event('earn-interest', VAULT, 'accrue_interest'),
-      event('transfer-shadow', VAULT, 'transfer', {
-        groupId: 'paired-transaction',
-        assets: [{ kind: 'shares', address: VAULT, amountRaw: '100' }],
-      }),
-      event('independent-transfer', VAULT, 'transfer', {
-        groupId: 'paired-transaction',
-        assets: [{ kind: 'shares', address: VAULT, amountRaw: '25' }],
-      }),
+      event('transfer', VAULT, 'transfer'),
       event('withdraw', VAULT, 'withdraw'),
       event('burn-shadow', VAULT, 'burn'),
     ]))
@@ -151,9 +154,8 @@ describe('useActivityFeed', () => {
     })
 
     await vi.waitFor(() => expect(feed?.events.value.map(item => item.id)).toEqual([
-      'deposit',
-      'independent-transfer',
-      'withdraw',
+      'set-caps',
+      'liquidation',
     ]))
   })
 
@@ -166,15 +168,15 @@ describe('useActivityFeed', () => {
       groupId: 'paired-transaction',
       assets: [{ kind: 'shares', address: VAULT, amountRaw: '100' }],
     })
-    const fetchVaultActivityEvents = vi.fn()
+    const fetchAccountActivityEvents = vi.fn()
       .mockResolvedValueOnce(page([shadowTransfer], { nextCursor: 'next' }))
       .mockResolvedValueOnce(page([deposit]))
-    const { useActivityFeed } = await setup(fetchVaultActivityEvents)
+    const { useActivityFeed } = await setup(vi.fn(), fetchAccountActivityEvents)
     let feed: ReturnType<typeof useActivityFeed> | undefined
     effect = effectScope()
     effect.run(() => {
       feed = useActivityFeed({
-        scope: { kind: 'vault', vault: VAULT, chainId: 1, vaultType: 'evk' },
+        scope: { kind: 'account', owner: VAULT, chainId: 1 },
         enabled: true,
         categories: [],
       })

--- a/tests/composables/usePortfolioActivityRuntimeSupport.test.ts
+++ b/tests/composables/usePortfolioActivityRuntimeSupport.test.ts
@@ -1,0 +1,62 @@
+import { ref } from 'vue'
+import { describe, expect, it } from 'vitest'
+import {
+  buildPortfolioActivityContextKey,
+  shouldLeavePortfolioActivityRoute,
+  shouldShowPortfolioActivityTab,
+  usePortfolioActivityRuntimeSupport,
+} from '../../composables/usePortfolioActivityRuntimeSupport'
+
+const OWNER = '0x1000000000000000000000000000000000000000'
+
+describe('portfolio activity runtime support', () => {
+  it('shares an authoritative result only within the active owner and chain', () => {
+    const owner = ref<string | undefined>(OWNER)
+    const chainId = ref(1)
+    const writer = usePortfolioActivityRuntimeSupport(owner, chainId)
+    const reader = usePortfolioActivityRuntimeSupport(owner, chainId)
+
+    writer.setRuntimeUnsupported(false)
+    expect(reader.isRuntimeUnsupported.value).toBe(false)
+
+    writer.setRuntimeUnsupported(true)
+    expect(reader.isRuntimeUnsupported.value).toBe(true)
+
+    chainId.value = 8453
+    expect(reader.isRuntimeUnsupported.value).toBe(false)
+
+    chainId.value = 1
+    expect(reader.isRuntimeUnsupported.value).toBe(true)
+
+    owner.value = '0x2000000000000000000000000000000000000000'
+    expect(reader.isRuntimeUnsupported.value).toBe(false)
+  })
+
+  it('normalizes the owner and rejects incomplete contexts', () => {
+    expect(buildPortfolioActivityContextKey(OWNER.toUpperCase(), 1)).toBe(`${OWNER}:1`)
+    expect(buildPortfolioActivityContextKey(undefined, 1)).toBeUndefined()
+    expect(buildPortfolioActivityContextKey(OWNER, 0)).toBeUndefined()
+  })
+
+  it('keeps transient failures visible and redirects only after support settles', () => {
+    expect(shouldShowPortfolioActivityTab(true, false)).toBe(true)
+    expect(shouldShowPortfolioActivityTab(true, true)).toBe(false)
+    expect(shouldShowPortfolioActivityTab(false, false)).toBe(false)
+
+    expect(shouldLeavePortfolioActivityRoute({
+      routeName: 'portfolio-activity',
+      isChecking: true,
+      shouldShow: false,
+    })).toBe(false)
+    expect(shouldLeavePortfolioActivityRoute({
+      routeName: 'portfolio-activity',
+      isChecking: false,
+      shouldShow: false,
+    })).toBe(true)
+    expect(shouldLeavePortfolioActivityRoute({
+      routeName: 'portfolio-rewards',
+      isChecking: false,
+      shouldShow: false,
+    })).toBe(false)
+  })
+})

--- a/tests/composables/useSpyMode.test.ts
+++ b/tests/composables/useSpyMode.test.ts
@@ -1,0 +1,23 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const FIRST = '0x0000000000000000000000000000000000000001'
+const SECOND = '0x0000000000000000000000000000000000000002'
+
+describe('useSpyMode', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.stubGlobal('useRoute', () => ({ path: '/portfolio/activity', query: {}, hash: '' }))
+    vi.stubGlobal('useRouter', () => ({ replace: vi.fn() }))
+  })
+
+  it('replaces the active spy address synchronously for internal account links', async () => {
+    const { useSpyMode } = await import('~/composables/useSpyMode')
+    const spy = useSpyMode()
+
+    expect(spy.activateSpyMode(FIRST)).toBe(true)
+    expect(spy.spyAddress.value.toLowerCase()).toBe(FIRST)
+
+    expect(spy.activateSpyMode(SECOND)).toBe(true)
+    expect(spy.spyAddress.value.toLowerCase()).toBe(SECOND)
+  })
+})

--- a/tests/utils/activity-display.test.ts
+++ b/tests/utils/activity-display.test.ts
@@ -8,6 +8,7 @@ import {
   formatActivityEventLabel,
   formatActivityTimestamp,
   formatActivityValuation,
+  getAccountActivityFilterOptions,
   getActivityAssetAddressLabel,
   getActivityAssetLabel,
   getActivityAssetsForDisplay,
@@ -53,6 +54,17 @@ describe('activity display helpers', () => {
       'transfer',
       'set_caps',
     ]))
+  })
+
+  it('returns the six portfolio account category filters in display order', () => {
+    expect(getAccountActivityFilterOptions()).toEqual([
+      { value: 'lending', label: 'Lending', categories: ['lending'] },
+      { value: 'borrowing', label: 'Borrowing', categories: ['borrowing'] },
+      { value: 'swaps', label: 'Swaps', categories: ['swaps'] },
+      { value: 'liquidations', label: 'Liquidations', categories: ['liquidations'] },
+      { value: 'account', label: 'Account', categories: ['account'] },
+      { value: 'rewards', label: 'Rewards', categories: ['rewards'] },
+    ])
   })
 
   it('returns vault-specific category filters with category-accurate labels', () => {

--- a/tests/utils/activity-display.test.ts
+++ b/tests/utils/activity-display.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { ActivityEvent } from '@eulerxyz/euler-v2-sdk'
+import type { Address } from 'viem'
 import {
   enrichActivityAssetForDisplay,
   filterActivityEventsForDisplay,
@@ -20,6 +21,7 @@ import {
   getVaultActivityFilterOptions,
   isActivityScopeUnsupported,
   resolveActivityFilterCategories,
+  resolveActivityVaultDisplay,
 } from '~/utils/activity-display'
 import { isVaultBorrowable } from '~/utils/vault/classification'
 
@@ -104,6 +106,39 @@ describe('activity display helpers', () => {
       'lending',
       'liquidations',
     ])
+  })
+
+  it('distinguishes same-token account activity from different markets', () => {
+    const getVaultMetadata = (address: Address) => ({
+      asset: { address: ASSET, name: 'USD Coin', symbol: 'USDC', decimals: 6 },
+      shares: {
+        address,
+        name: 'Euler USDC',
+        symbol: 'eUSDC',
+        decimals: 18,
+      },
+    })
+
+    const firstMarket = resolveActivityVaultDisplay(VAULT, getVaultMetadata)
+    const secondMarket = resolveActivityVaultDisplay(OTHER_VAULT, getVaultMetadata)
+
+    expect(firstMarket).toMatchObject({
+      name: 'Euler USDC',
+      addressLabel: '0x0000...0002',
+    })
+    expect(secondMarket).toMatchObject({
+      name: 'Euler USDC',
+      addressLabel: '0x0000...0004',
+    })
+    expect(firstMarket?.addressLabel).not.toBe(secondMarket?.addressLabel)
+  })
+
+  it('falls back to a shortened market address when registry metadata is unavailable', () => {
+    expect(resolveActivityVaultDisplay(VAULT, () => undefined)).toEqual({
+      address: VAULT,
+      addressLabel: '0x0000...0002',
+    })
+    expect(resolveActivityVaultDisplay(undefined, () => undefined)).toBeNull()
   })
 
   it('treats only explicit-All unsupported coverage as scope-wide', () => {

--- a/tests/utils/activity-display.test.ts
+++ b/tests/utils/activity-display.test.ts
@@ -46,11 +46,15 @@ describe('activity display helpers', () => {
       expect(eventTypes).not.toEqual(expect.arrayContaining(hiddenTypes))
     }
 
-    expect(getDisplayActivityEventTypes({ kind: 'account' })).toEqual(expect.arrayContaining([
+    expect(getDisplayActivityEventTypes({ kind: 'account' })).toEqual([
       'deposit',
-      'transfer',
-      'reward_transfer',
-    ]))
+      'withdraw',
+      'borrow',
+      'repay',
+      'pull_debt',
+      'liquidation',
+      'operator_status',
+    ])
     expect(getDisplayActivityEventTypes({ kind: 'vault', vaultType: 'evk' })).toEqual(expect.arrayContaining([
       'deposit',
       'transfer',
@@ -58,14 +62,12 @@ describe('activity display helpers', () => {
     ]))
   })
 
-  it('returns the six portfolio account category filters in display order', () => {
+  it('returns the focused portfolio position category filters in display order', () => {
     expect(getAccountActivityFilterOptions()).toEqual([
       { value: 'lending', label: 'Lending', categories: ['lending'] },
       { value: 'borrowing', label: 'Borrowing', categories: ['borrowing'] },
-      { value: 'swaps', label: 'Swaps', categories: ['swaps'] },
       { value: 'liquidations', label: 'Liquidations', categories: ['liquidations'] },
-      { value: 'account', label: 'Account', categories: ['account'] },
-      { value: 'rewards', label: 'Rewards', categories: ['rewards'] },
+      { value: 'account', label: 'Position', categories: ['account'] },
     ])
   })
 
@@ -119,11 +121,11 @@ describe('activity display helpers', () => {
       },
     })
 
-    const firstMarket = resolveActivityVaultDisplay(VAULT, getVaultMetadata)
+    const firstMarket = resolveActivityVaultDisplay(VAULT, getVaultMetadata, 'USDC Prime')
     const secondMarket = resolveActivityVaultDisplay(OTHER_VAULT, getVaultMetadata)
 
     expect(firstMarket).toMatchObject({
-      name: 'Euler USDC',
+      name: 'USDC Prime',
       addressLabel: '0x0000...0002',
     })
     expect(secondMarket).toMatchObject({

--- a/tests/utils/activity-display.test.ts
+++ b/tests/utils/activity-display.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import type { ActivityEvent } from '@eulerxyz/euler-v2-sdk'
-import type { Address } from 'viem'
+import { maxUint256, type Address } from 'viem'
 import {
+  decodeEvkAmountCap,
   enrichActivityAssetForDisplay,
   filterActivityEventsForDisplay,
   formatActivityAssetAmount,
@@ -9,6 +10,7 @@ import {
   formatActivityEventLabel,
   formatActivityTimestamp,
   formatActivityValuation,
+  formatActivityValuationForAssets,
   getAccountActivityFilterOptions,
   getActivityAssetAddressLabel,
   getActivityAssetLabel,
@@ -46,19 +48,25 @@ describe('activity display helpers', () => {
       expect(eventTypes).not.toEqual(expect.arrayContaining(hiddenTypes))
     }
 
-    expect(getDisplayActivityEventTypes({ kind: 'account' })).toEqual([
-      'deposit',
-      'withdraw',
-      'borrow',
-      'repay',
-      'pull_debt',
-      'liquidation',
-      'operator_status',
-    ])
-    expect(getDisplayActivityEventTypes({ kind: 'vault', vaultType: 'evk' })).toEqual(expect.arrayContaining([
+    expect(getDisplayActivityEventTypes({ kind: 'account' })).toEqual(expect.arrayContaining([
       'deposit',
       'transfer',
+      'borrow',
+      'swap',
+      'approval',
+      'reward_transfer',
+    ]))
+    expect(getDisplayActivityEventTypes({ kind: 'vault', vaultType: 'evk' })).toEqual(expect.arrayContaining([
       'set_caps',
+      'set_ltv',
+      'liquidation',
+    ]))
+    expect(getDisplayActivityEventTypes({ kind: 'vault', vaultType: 'evk' })).not.toEqual(expect.arrayContaining([
+      'deposit',
+      'withdraw',
+      'transfer',
+      'borrow',
+      'repay',
     ]))
   })
 
@@ -66,46 +74,39 @@ describe('activity display helpers', () => {
     expect(getAccountActivityFilterOptions()).toEqual([
       { value: 'lending', label: 'Lending', categories: ['lending'] },
       { value: 'borrowing', label: 'Borrowing', categories: ['borrowing'] },
+      { value: 'swaps', label: 'Swaps', categories: ['swaps'] },
       { value: 'liquidations', label: 'Liquidations', categories: ['liquidations'] },
       { value: 'account', label: 'Position', categories: ['account'] },
+      { value: 'rewards', label: 'Rewards', categories: ['rewards'] },
     ])
   })
 
   it('returns vault-specific category filters with category-accurate labels', () => {
     expect(getVaultActivityFilterOptions('evk')).toEqual([
-      { value: 'lending-borrowing', label: 'Lending and borrowing', categories: ['lending', 'borrowing'] },
       { value: 'governance', label: 'Governance', categories: ['governance'] },
       { value: 'liquidations', label: 'Liquidations', categories: ['liquidations'] },
     ])
     expect(getVaultActivityFilterOptions('earn')).toEqual([
-      { value: 'lending', label: 'Lending', categories: ['lending'] },
       { value: 'governance', label: 'Governance', categories: ['governance'] },
     ])
     expect(getVaultActivityFilterOptions('securitize')).toEqual([
-      { value: 'lending', label: 'Lending', categories: ['lending'] },
+      { value: 'controls', label: 'Controls', categories: ['account'] },
       { value: 'governance', label: 'Governance', categories: ['governance'] },
     ])
 
     const options = getVaultActivityFilterOptions('evk')
     expect(resolveActivityFilterCategories(options, [])).toEqual([
-      'borrowing',
       'governance',
-      'lending',
       'liquidations',
     ])
-    expect(resolveActivityFilterCategories(options, ['lending-borrowing'])).toEqual([
-      'borrowing',
-      'lending',
-    ])
+    expect(resolveActivityFilterCategories(options, ['liquidations'])).toEqual(['liquidations'])
   })
 
-  it('keeps historical borrowing filters for a currently non-borrowable EVK', () => {
+  it('keeps vault governance and liquidation filters independent of current borrowability', () => {
     expect(isVaultBorrowable({ isBorrowable: false, totalBorrowed: 0n })).toBe(false)
 
     expect(resolveActivityFilterCategories(getVaultActivityFilterOptions('evk'), [])).toEqual([
-      'borrowing',
       'governance',
-      'lending',
       'liquidations',
     ])
   })
@@ -300,6 +301,13 @@ describe('activity display helpers', () => {
     expect(formatActivityAssetUsd({ kind: 'assets', amountRaw: '1' })).toBeNull()
     expect(formatActivityValuation({ status: 'unavailable', reason: 'No historical price' })).toBeNull()
     expect(formatActivityValuation({ status: 'partial', amountUsd: '1234.5' })).toBe('$1.23K (partial)')
+    expect(formatActivityAssetAmount({ kind: 'assets', amountRaw: maxUint256.toString(), decimals: 18, symbol: 'USDC' }, 'approval')).toBe('Unlimited')
+    expect(formatActivityAssetAmount({ kind: 'assets', amountRaw: '0', decimals: 18, symbol: 'USDC' }, 'approval')).toBe('Revoked')
+    expect(getActivityAssetLabel('assets', 'account', 'approval')).toBe('Allowance')
+    expect(formatActivityValuationForAssets(
+      { status: 'available', amountUsd: '1234.5' },
+      [{ kind: 'assets', amountRaw: '1', amountUsd: '1234.5' }],
+    )).toBeNull()
   })
 
   it('enriches raw amounts from registry metadata without overriding source fields', () => {
@@ -357,12 +365,99 @@ describe('activity display helpers', () => {
     expect(unpriced.amountUsd).toBeUndefined()
   })
 
+  it('decodes EVK caps and formats vault configuration changes semantically', () => {
+    const getVaultMetadata = (address: Address) => address.toLowerCase() === VAULT.toLowerCase()
+      ? {
+          asset: { address: ASSET, name: 'USD Coin', symbol: 'USDC', decimals: 6 },
+          shares: { address: VAULT, name: 'Euler USDC', symbol: 'eUSDC', decimals: 18 },
+        }
+      : address.toLowerCase() === OTHER_VAULT.toLowerCase()
+        ? {
+            asset: { address: ASSET, name: 'USD Coin', symbol: 'USDC', decimals: 6 },
+            shares: { address: OTHER_VAULT, name: 'Collateral vault', symbol: 'eUSDC', decimals: 18 },
+            vaultType: 'evk' as const,
+          }
+        : undefined
+
+    expect(decodeEvkAmountCap('43213')).toBe(67_500_000_000_000n)
+    expect(decodeEvkAmountCap('65536')).toBeNull()
+    expect(getActivityChangeEntries({
+      type: 'set_caps',
+      vault: VAULT,
+      vaultType: 'evk',
+      change: {
+        fields: {
+          supply_cap: '48013',
+          borrow_cap: '43213',
+        },
+      },
+    }, getVaultMetadata)).toEqual([
+      { field: 'supply_cap', label: 'Supply cap', value: '75,000,000.00 USDC' },
+      { field: 'borrow_cap', label: 'Borrow cap', value: '67,500,000.00 USDC' },
+    ])
+
+    expect(getActivityChangeEntries({
+      type: 'set_ltv',
+      vault: VAULT,
+      vaultType: 'evk',
+      change: {
+        fields: {
+          collateral: OTHER_VAULT,
+          borrow_ltv: '8500',
+          liquidation_ltv: '9000',
+          ramp_duration: '90000',
+          target_timestamp: '1767225600',
+        },
+      },
+    }, getVaultMetadata)).toEqual([
+      {
+        field: 'collateral',
+        label: 'Collateral',
+        addresses: [{
+          address: OTHER_VAULT,
+          label: 'Collateral vault',
+          linkKind: 'vault',
+          vaultType: 'evk',
+        }],
+      },
+      { field: 'borrow_ltv', label: 'Borrow LTV', value: '85%' },
+      { field: 'liquidation_ltv', label: 'Liquidation LTV', value: '90%' },
+      { field: 'ramp_duration', label: 'Ramp duration', value: '1 day 1 hour' },
+      { field: 'target_timestamp', label: 'Target timestamp', value: expect.stringContaining('1 Jan 2026') },
+    ])
+  })
+
+  it('links protocol addresses externally and user identities through spy mode', () => {
+    expect(getActivityChangeEntries({
+      type: 'set_interest_rate_model',
+      vault: VAULT,
+      vaultType: 'evk',
+      change: { fields: { new_interest_rate_model: OTHER_VAULT } },
+    })).toEqual([{
+      field: 'new_interest_rate_model',
+      label: 'New interest rate model',
+      addresses: [{ address: OTHER_VAULT, linkKind: 'explorer' }],
+    }])
+
+    expect(getActivityParticipants({
+      category: 'lending',
+      account: VAULT,
+      actor: ASSET,
+    })).toEqual([
+      { label: 'User', address: VAULT, linkKind: 'spy' },
+      { label: 'Actor', address: ASSET, linkKind: 'explorer' },
+    ])
+  })
+
   it('formats all governance changes and category-specific liquidation details', () => {
     expect(getActivityChangeEntries({
-      fields: {
-        supply_cap: '2000',
-        is_allocator: true,
-        queue: ['one', 'two'],
+      type: 'set_config_flags',
+      change: {
+        fields: {
+          supply_cap: '2000',
+          is_allocator: true,
+          queue: ['one', 'two'],
+        },
       },
     })).toEqual([
       { field: 'supply_cap', label: 'Supply cap', value: '2000' },
@@ -379,8 +474,8 @@ describe('activity display helpers', () => {
       actor: ASSET,
       counterparty: '0x0000000000000000000000000000000000000002',
     })).toEqual([
-      { label: 'Liquidator', address: ASSET },
-      { label: 'Violator', address: '0x0000000000000000000000000000000000000002' },
+      { label: 'Liquidator', address: ASSET, linkKind: 'explorer' },
+      { label: 'Violator', address: '0x0000000000000000000000000000000000000002', linkKind: 'spy' },
     ])
   })
 

--- a/utils/activity-display.ts
+++ b/utils/activity-display.ts
@@ -10,10 +10,11 @@ import type {
   ActivityVaultType,
 } from '@eulerxyz/euler-v2-sdk'
 import { formatUnits, type Address } from 'viem'
-import { formatCompactUsdValue, formatSmartAmount } from '~/utils/string-utils'
+import { formatCompactUsdValue, formatSmartAmount, shortenAddress } from '~/utils/string-utils'
 
 interface ActivityTokenMetadata {
   address: Address
+  name?: string
   symbol: string
   decimals: number
 }
@@ -30,6 +31,32 @@ interface ActivityAssetContext {
 
 type ActivityVaultMetadataLookup = (address: Address) => ActivityVaultMetadata | undefined
 type ActivityTokenMetadataLookup = (address: Address) => ActivityTokenMetadata | undefined
+
+export interface ActivityVaultDisplay {
+  address: Address
+  addressLabel: string
+  name?: string
+}
+
+/**
+ * Resolves account-history market context from the vault registry. The address
+ * remains part of the visible label so markets with the same share-token name
+ * are still distinguishable.
+ */
+export const resolveActivityVaultDisplay = (
+  vaultAddress: Address | undefined,
+  getVaultMetadata: ActivityVaultMetadataLookup,
+): ActivityVaultDisplay | null => {
+  if (!vaultAddress) return null
+
+  const name = getVaultMetadata(vaultAddress)?.shares?.name?.trim() || undefined
+  const addressLabel = shortenAddress(vaultAddress)
+  return {
+    address: vaultAddress,
+    addressLabel,
+    ...(name ? { name } : {}),
+  }
+}
 
 const CATEGORY_LABELS: Record<ActivityCategory, string> = {
   lending: 'Lending',

--- a/utils/activity-display.ts
+++ b/utils/activity-display.ts
@@ -39,17 +39,20 @@ export interface ActivityVaultDisplay {
 }
 
 /**
- * Resolves account-history market context from the vault registry. The address
- * remains part of the visible label so markets with the same share-token name
- * are still distinguishable.
+ * Resolves position-history market context from Euler Labels and the vault
+ * registry. The address remains visible so markets with the same name are
+ * still distinguishable.
  */
 export const resolveActivityVaultDisplay = (
   vaultAddress: Address | undefined,
   getVaultMetadata: ActivityVaultMetadataLookup,
+  productName?: string,
 ): ActivityVaultDisplay | null => {
   if (!vaultAddress) return null
 
-  const name = getVaultMetadata(vaultAddress)?.shares?.name?.trim() || undefined
+  const name = productName?.trim()
+    || getVaultMetadata(vaultAddress)?.shares?.name?.trim()
+    || undefined
   const addressLabel = shortenAddress(vaultAddress)
   return {
     address: vaultAddress,
@@ -63,7 +66,7 @@ const CATEGORY_LABELS: Record<ActivityCategory, string> = {
   borrowing: 'Borrowing',
   swaps: 'Swaps',
   liquidations: 'Liquidations',
-  account: 'Account',
+  account: 'Position',
   rewards: 'Rewards',
   governance: 'Governance',
 }
@@ -71,53 +74,11 @@ const CATEGORY_LABELS: Record<ActivityCategory, string> = {
 const ACCOUNT_ACTIVITY_EVENT_TYPES = [
   'deposit',
   'withdraw',
-  'transfer',
   'borrow',
   'repay',
-  'swap',
-  'debt_socialized',
   'pull_debt',
   'liquidation',
-  'approval',
-  'balance_forwarder_status',
-  'convert_fees',
-  'reallocate_supply',
-  'reallocate_withdraw',
-  'set_fee',
-  'set_guardian',
-  'set_timelock',
-  'set_cap',
-  'set_supply_queue',
-  'set_withdraw_queue',
-  'submit_cap',
-  'submit_market_removal',
-  'revoke_pending_cap',
-  'revoke_pending_guardian',
-  'revoke_pending_timelock',
-  'revoke_pending_market_removal',
-  'frozen',
-  'unfrozen',
-  'seized',
-  'owner_registered',
-  'collateral_status',
   'operator_status',
-  'controller_status',
-  'lockdown_mode_status',
-  'nonce_status',
-  'nonce_used',
-  'permit_disabled_mode_status',
-  'reward_lock_created',
-  'reward_lock_removed',
-  'reward_transfer',
-  'reward_whitelist_status',
-  'public_reallocate_to',
-  'public_withdrawal',
-  'set_admin',
-  'set_allocation_fee',
-  'set_flow_caps',
-  'transfer_allocation_fee',
-  'buy',
-  'terms_of_use_signed',
 ] as const satisfies readonly ActivityEvent['type'][]
 
 const VAULT_ACTIVITY_EVENT_TYPES = {
@@ -340,10 +301,8 @@ export const getVaultActivityFilterOptions = (
 const ACCOUNT_ACTIVITY_CATEGORIES = [
   'lending',
   'borrowing',
-  'swaps',
   'liquidations',
   'account',
-  'rewards',
 ] as const satisfies readonly ActivityCategory[]
 
 export const getAccountActivityFilterOptions = (): ActivityFilterOption[] =>

--- a/utils/activity-display.ts
+++ b/utils/activity-display.ts
@@ -310,6 +310,22 @@ export const getVaultActivityFilterOptions = (
   return options
 }
 
+const ACCOUNT_ACTIVITY_CATEGORIES = [
+  'lending',
+  'borrowing',
+  'swaps',
+  'liquidations',
+  'account',
+  'rewards',
+] as const satisfies readonly ActivityCategory[]
+
+export const getAccountActivityFilterOptions = (): ActivityFilterOption[] =>
+  ACCOUNT_ACTIVITY_CATEGORIES.map(category => ({
+    value: category,
+    label: getActivityCategoryLabel(category),
+    categories: [category],
+  }))
+
 export const titleizeActivityType = (type: string): string => {
   const words = type
     .replace(/[_-]+/g, ' ')

--- a/utils/activity-display.ts
+++ b/utils/activity-display.ts
@@ -2,14 +2,13 @@ import type {
   ActivityAssetAmount,
   ActivityAssetKind,
   ActivityCategory,
-  ActivityChange,
   ActivityChangeValue,
   ActivityCoverageStatus,
   ActivityEvent,
   ActivityValuation,
   ActivityVaultType,
 } from '@eulerxyz/euler-v2-sdk'
-import { formatUnits, type Address } from 'viem'
+import { formatUnits, isAddress, maxUint256, type Address } from 'viem'
 import { formatCompactUsdValue, formatSmartAmount, shortenAddress } from '~/utils/string-utils'
 
 interface ActivityTokenMetadata {
@@ -22,6 +21,7 @@ interface ActivityTokenMetadata {
 interface ActivityVaultMetadata {
   asset?: ActivityTokenMetadata
   shares?: ActivityTokenMetadata
+  vaultType?: ActivityVaultType
 }
 
 interface ActivityAssetContext {
@@ -74,25 +74,58 @@ const CATEGORY_LABELS: Record<ActivityCategory, string> = {
 const ACCOUNT_ACTIVITY_EVENT_TYPES = [
   'deposit',
   'withdraw',
+  'transfer',
   'borrow',
   'repay',
+  'swap',
+  'debt_socialized',
   'pull_debt',
   'liquidation',
+  'approval',
+  'balance_forwarder_status',
+  'convert_fees',
+  'reallocate_supply',
+  'reallocate_withdraw',
+  'set_fee',
+  'set_guardian',
+  'set_timelock',
+  'set_cap',
+  'set_supply_queue',
+  'set_withdraw_queue',
+  'submit_cap',
+  'submit_market_removal',
+  'revoke_pending_cap',
+  'revoke_pending_guardian',
+  'revoke_pending_timelock',
+  'revoke_pending_market_removal',
+  'frozen',
+  'unfrozen',
+  'seized',
+  'owner_registered',
+  'collateral_status',
   'operator_status',
+  'controller_status',
+  'lockdown_mode_status',
+  'nonce_status',
+  'nonce_used',
+  'permit_disabled_mode_status',
+  'reward_lock_created',
+  'reward_lock_removed',
+  'reward_transfer',
+  'reward_whitelist_status',
+  'public_reallocate_to',
+  'public_withdrawal',
+  'set_admin',
+  'set_allocation_fee',
+  'set_flow_caps',
+  'transfer_allocation_fee',
+  'buy',
+  'terms_of_use_signed',
 ] as const satisfies readonly ActivityEvent['type'][]
 
 const VAULT_ACTIVITY_EVENT_TYPES = {
   evk: [
-    'deposit',
-    'withdraw',
-    'transfer',
-    'borrow',
-    'repay',
-    'debt_socialized',
-    'pull_debt',
     'liquidation',
-    'approval',
-    'balance_forwarder_status',
     'convert_fees',
     'set_caps',
     'set_ltv',
@@ -106,12 +139,6 @@ const VAULT_ACTIVITY_EVENT_TYPES = {
     'set_max_liquidation_discount',
   ],
   earn: [
-    'deposit',
-    'withdraw',
-    'transfer',
-    'update_last_total_assets',
-    'update_lost_assets',
-    'approval',
     'reallocate_supply',
     'reallocate_withdraw',
     'set_name',
@@ -143,10 +170,6 @@ const VAULT_ACTIVITY_EVENT_TYPES = {
     'transfer_allocation_fee',
   ],
   securitize: [
-    'deposit',
-    'withdraw',
-    'transfer',
-    'approval',
     'seized',
     'frozen',
     'unfrozen',
@@ -281,28 +304,30 @@ export const getActivityCategoryIcon = (category: ActivityCategory): string =>
 export const getVaultActivityFilterOptions = (
   vaultType: ActivityVaultType,
 ): ActivityFilterOption[] => {
-  const lendingCategories: ActivityCategory[] = vaultType === 'evk'
-    ? ['lending', 'borrowing']
-    : ['lending']
-  const options: ActivityFilterOption[] = [
-    {
-      value: vaultType === 'evk' ? 'lending-borrowing' : 'lending',
-      label: vaultType === 'evk' ? 'Lending and borrowing' : 'Lending',
-      categories: lendingCategories,
-    },
+  if (vaultType === 'evk') {
+    return [
+      { value: 'governance', label: 'Governance', categories: ['governance'] },
+      { value: 'liquidations', label: 'Liquidations', categories: ['liquidations'] },
+    ]
+  }
+  if (vaultType === 'earn') {
+    return [
+      { value: 'governance', label: 'Governance', categories: ['governance'] },
+    ]
+  }
+  return [
+    { value: 'controls', label: 'Controls', categories: ['account'] },
     { value: 'governance', label: 'Governance', categories: ['governance'] },
   ]
-  if (vaultType === 'evk') {
-    options.push({ value: 'liquidations', label: 'Liquidations', categories: ['liquidations'] })
-  }
-  return options
 }
 
 const ACCOUNT_ACTIVITY_CATEGORIES = [
   'lending',
   'borrowing',
+  'swaps',
   'liquidations',
   'account',
+  'rewards',
 ] as const satisfies readonly ActivityCategory[]
 
 export const getAccountActivityFilterOptions = (): ActivityFilterOption[] =>
@@ -400,7 +425,20 @@ const resolveAssetAmount = (asset: ActivityAssetAmount): string | undefined => {
   }
 }
 
-export const formatActivityAssetAmount = (asset: ActivityAssetAmount): string => {
+export const formatActivityAssetAmount = (
+  asset: ActivityAssetAmount,
+  eventType?: ActivityEvent['type'],
+): string => {
+  if (eventType === 'approval') {
+    try {
+      const allowance = BigInt(asset.amountRaw)
+      if (allowance === maxUint256) return 'Unlimited'
+      if (allowance === 0n) return 'Revoked'
+    }
+    catch {
+      return 'Amount unavailable'
+    }
+  }
   const amount = resolveAssetAmount(asset)
   if (amount === undefined) return 'Amount unavailable'
   const formatted = formatSmartAmount(amount)
@@ -473,7 +511,9 @@ const ASSET_KIND_LABELS: Record<ActivityAssetKind, string> = {
 export const getActivityAssetLabel = (
   kind: ActivityAssetKind,
   category: ActivityCategory,
+  eventType?: ActivityEvent['type'],
 ): string => {
+  if (eventType === 'approval') return 'Allowance'
   if (category === 'liquidations' && kind === 'assets') return 'Debt repaid'
   if (category === 'liquidations' && (kind === 'collateral' || kind === 'yield')) {
     return 'Collateral seized'
@@ -499,23 +539,211 @@ export const formatActivityChangeValue = (value: ActivityChangeValue): string =>
   return String(value)
 }
 
+export type ActivityAddressLinkKind = 'explorer' | 'spy' | 'vault'
+
+export interface ActivityChangeAddress {
+  address: Address
+  label?: string
+  linkKind: Exclude<ActivityAddressLinkKind, 'spy'>
+  vaultType?: ActivityVaultType
+}
+
 export interface ActivityChangeEntry {
   field: string
   label: string
-  value: string
+  value?: string
+  addresses?: ActivityChangeAddress[]
+}
+
+type ActivityChangeEventSource = Pick<ActivityEvent, 'change' | 'type' | 'vault' | 'vaultType'>
+
+const VAULT_ADDRESS_FIELDS_BY_EVENT: Partial<Record<ActivityEvent['type'], readonly string[]>> = {
+  liquidation: ['collateral'],
+  public_reallocate_to: ['market', 'strategy', 'to', 'vault'],
+  public_withdrawal: ['market', 'strategy', 'from', 'vault'],
+  reallocate_supply: ['market', 'strategy', 'to', 'vault'],
+  reallocate_withdraw: ['market', 'strategy', 'from', 'vault'],
+  revoke_pending_cap: ['market', 'strategy', 'vault'],
+  revoke_pending_market_removal: ['market', 'strategy', 'vault'],
+  set_cap: ['market', 'strategy', 'vault'],
+  set_flow_caps: ['market', 'strategy', 'from', 'to', 'vault'],
+  set_ltv: ['collateral'],
+  set_supply_queue: ['queue', 'supply_queue', 'new_supply_queue'],
+  set_withdraw_queue: ['queue', 'withdraw_queue', 'new_withdraw_queue'],
+  submit_cap: ['market', 'strategy', 'vault'],
+  submit_market_removal: ['market', 'strategy', 'vault'],
+}
+
+const parseActivityInteger = (value: ActivityChangeValue): bigint | null => {
+  if (typeof value !== 'string' && typeof value !== 'number') return null
+  try {
+    return BigInt(value)
+  }
+  catch {
+    return null
+  }
+}
+
+/** Decodes the EVK AmountCap uint16 encoding into underlying token units. */
+export const decodeEvkAmountCap = (value: ActivityChangeValue): bigint | null => {
+  const raw = parseActivityInteger(value)
+  if (raw === null || raw < 0n || raw > 65_535n) return null
+  if (raw === 0n) return 0n
+  const exponent = raw & 0x3fn
+  const mantissa = raw >> 6n
+  return (mantissa * 10n ** exponent) / 100n
+}
+
+const formatActivityCap = (
+  value: ActivityChangeValue,
+  vault: Address | undefined,
+  getVaultMetadata: ActivityVaultMetadataLookup | undefined,
+): string | null => {
+  const decoded = decodeEvkAmountCap(value)
+  const asset = vault && getVaultMetadata?.(vault)?.asset
+  if (decoded === null || !asset) return null
+  const amount = formatSmartAmount(formatUnits(decoded, asset.decimals))
+  return `${amount} ${asset.symbol}`
+}
+
+const formatActivityTokenAmount = (
+  value: ActivityChangeValue,
+  token: ActivityTokenMetadata | undefined,
+): string | null => {
+  const amount = parseActivityInteger(value)
+  if (amount === null || !token) return null
+  return `${formatSmartAmount(formatUnits(amount, token.decimals))} ${token.symbol}`
+}
+
+const formatActivityBps = (value: ActivityChangeValue): string | null => {
+  const bps = parseActivityInteger(value)
+  if (bps === null) return null
+  const whole = bps / 100n
+  const fraction = (bps % 100n).toString().padStart(2, '0').replace(/0+$/, '')
+  return `${whole}${fraction ? `.${fraction}` : ''}%`
+}
+
+const formatActivityDuration = (value: ActivityChangeValue): string | null => {
+  const seconds = parseActivityInteger(value)
+  if (seconds === null || seconds < 0n) return null
+  if (seconds === 0n) return 'Immediately'
+  const units = [
+    { label: 'day', seconds: 86_400n },
+    { label: 'hour', seconds: 3_600n },
+    { label: 'minute', seconds: 60n },
+    { label: 'second', seconds: 1n },
+  ]
+  let remaining = seconds
+  const parts: string[] = []
+  for (const unit of units) {
+    const count = remaining / unit.seconds
+    if (count === 0n) continue
+    parts.push(`${count} ${unit.label}${count === 1n ? '' : 's'}`)
+    remaining %= unit.seconds
+    if (parts.length === 2) break
+  }
+  return parts.join(' ')
+}
+
+const formatActivityUnixTimestamp = (value: ActivityChangeValue): string | null => {
+  const seconds = parseActivityInteger(value)
+  if (seconds === null || seconds < 0n || seconds > BigInt(Number.MAX_SAFE_INTEGER)) return null
+  const date = new Date(Number(seconds) * 1_000)
+  if (!Number.isFinite(date.getTime())) return null
+  return formatActivityTimestamp(date.toISOString())
+}
+
+const formatActivityChangeLabel = (field: string): string => titleizeActivityType(field)
+  .replace(/\bltv\b/gi, 'LTV')
+  .replace(/\birm\b/gi, 'IRM')
+  .replace(/\busd\b/gi, 'USD')
+
+const resolveChangeAddresses = (
+  event: ActivityChangeEventSource,
+  field: string,
+  value: ActivityChangeValue,
+  getVaultMetadata: ActivityVaultMetadataLookup | undefined,
+): ActivityChangeAddress[] | null => {
+  const values = Array.isArray(value) ? value : [value]
+  if (!values.length || !values.every(item => typeof item === 'string' && isAddress(item))) return null
+
+  const isVaultAddress = VAULT_ADDRESS_FIELDS_BY_EVENT[event.type]?.includes(field) ?? false
+  return values.map((item) => {
+    const address = item as Address
+    if (!isVaultAddress) return { address, linkKind: 'explorer' as const }
+    const display = getVaultMetadata
+      ? resolveActivityVaultDisplay(address, getVaultMetadata)
+      : null
+    return {
+      address,
+      linkKind: 'vault' as const,
+      label: display?.name ?? display?.addressLabel,
+      vaultType: getVaultMetadata?.(address)?.vaultType ?? event.vaultType,
+    }
+  })
 }
 
 export const getActivityChangeEntries = (
-  change: ActivityChange | undefined,
-): ActivityChangeEntry[] => Object.entries(change?.fields ?? {}).map(([field, value]) => ({
-  field,
-  label: titleizeActivityType(field),
-  value: formatActivityChangeValue(value),
-}))
+  event: ActivityChangeEventSource,
+  getVaultMetadata?: ActivityVaultMetadataLookup,
+): ActivityChangeEntry[] => Object.entries(event.change?.fields ?? {}).map(([field, value]) => {
+  const addresses = resolveChangeAddresses(event, field, value, getVaultMetadata)
+  if (addresses) return { field, label: formatActivityChangeLabel(field), addresses }
+
+  let formatted: string | null = null
+  const vaultMetadata = event.vault ? getVaultMetadata?.(event.vault) : undefined
+  const strategy = event.change?.fields.strategy
+  const strategyMetadata = typeof strategy === 'string' && isAddress(strategy)
+    ? getVaultMetadata?.(strategy)?.shares
+    : undefined
+  if (event.type === 'set_caps' && (field === 'supply_cap' || field === 'borrow_cap')) {
+    formatted = formatActivityCap(value, event.vault, getVaultMetadata)
+  }
+  else if (
+    (event.type === 'set_cap' || event.type === 'submit_cap')
+    && field === 'cap'
+  ) {
+    formatted = formatActivityTokenAmount(value, vaultMetadata?.asset)
+  }
+  else if (
+    event.type === 'set_supply_cap'
+    && (field === 'cap' || field === 'supply_cap' || field === 'new_supply_cap')
+  ) {
+    formatted = formatActivityTokenAmount(value, vaultMetadata?.asset)
+  }
+  else if (
+    (event.type === 'reallocate_supply' || event.type === 'reallocate_withdraw')
+    && (field === 'supplied_assets' || field === 'withdrawn_assets')
+  ) {
+    formatted = formatActivityTokenAmount(value, vaultMetadata?.asset)
+  }
+  else if (
+    (event.type === 'reallocate_supply' || event.type === 'reallocate_withdraw')
+    && (field === 'supplied_shares' || field === 'withdrawn_shares')
+  ) {
+    formatted = formatActivityTokenAmount(value, strategyMetadata)
+  }
+  else if (event.type === 'set_ltv' && field.endsWith('_ltv')) {
+    formatted = formatActivityBps(value)
+  }
+  else if (field === 'target_timestamp') {
+    formatted = formatActivityUnixTimestamp(value)
+  }
+  else if (field === 'ramp_duration' || field.endsWith('_timelock') || field.endsWith('_cool_off_time')) {
+    formatted = formatActivityDuration(value)
+  }
+
+  return {
+    field,
+    label: formatActivityChangeLabel(field),
+    value: formatted ?? formatActivityChangeValue(value),
+  }
+})
 
 export interface ActivityParticipant {
   address: Address
   label: string
+  linkKind: Exclude<ActivityAddressLinkKind, 'vault'>
 }
 
 interface ActivityParticipantSource {
@@ -530,30 +758,33 @@ export const getActivityParticipants = (
   event: ActivityParticipantSource,
 ): ActivityParticipant[] => {
   const participants: ActivityParticipant[] = []
-  const add = (label: string, address: Address | undefined) => {
+  const add = (
+    label: string,
+    address: Address | undefined,
+    linkKind: ActivityParticipant['linkKind'],
+  ) => {
     if (
       !address
       || participants.some(participant => participant.address.toLowerCase() === address.toLowerCase())
     ) return
-    participants.push({ label, address })
+    participants.push({ label, address, linkKind })
   }
 
   if (event.category === 'liquidations') {
-    add('Liquidator', event.actor)
-    add('Violator', event.counterparty)
+    add('Liquidator', event.actor, 'explorer')
+    add('Violator', event.counterparty, 'spy')
     return participants
   }
 
   if (event.category === 'governance') {
-    add('Actor', event.actor)
-    add('Target', event.counterparty)
+    add('Actor', event.actor, 'explorer')
+    add('Target', event.counterparty, 'explorer')
     return participants
   }
 
-  const user = event.account ?? event.owner ?? event.actor
-  add('User', user)
-  add('Actor', event.actor)
-  add('Counterparty', event.counterparty)
+  add('User', event.account ?? event.owner, 'spy')
+  add('Actor', event.actor, 'explorer')
+  add('Counterparty', event.counterparty, 'explorer')
   return participants
 }
 
@@ -567,4 +798,15 @@ export const formatActivityValuation = (
   }
   const amount = formatCompactUsdValue(valuation.amountUsd)
   return valuation.status === 'partial' ? `${amount} (partial)` : amount
+}
+
+export const formatActivityValuationForAssets = (
+  valuation: ActivityValuation | undefined,
+  assets: readonly ActivityAssetAmount[],
+): string | null => {
+  if (
+    valuation?.status === 'available'
+    && assets.some(asset => asset.amountUsd !== undefined)
+  ) return null
+  return formatActivityValuation(valuation)
 }


### PR DESCRIPTION
## Summary

- Add Activity as a conditional fourth Portfolio tab after Rewards.
- Load the effective connected or spy wallet history for the currently selected chain through the shared Activity feed.
- Keep unavailable V3 data distinct from a real empty account timeline.

Linear: https://linear.app/euler-labs/issue/LITE-220/add-activity-events-tab-to-portfolio-per-wallet-event

## Portfolio UX

- The new route is `/portfolio/activity`.
- Tab order is Positions, Rewards, Activity, then Migrate when migration is available.
- The query owner is `useEffectiveAddress()`, so spy mode and a connected wallet follow the same path.
- A disconnected wallet receives an explicit connect-or-use-spy prompt instead of a zero-address request.
- The account feed exposes the six ticket categories in product order: Lending, Borrowing, Swaps, Liquidations, Account, and Rewards. Governance is intentionally excluded from Portfolio.
- The shared feed provides loading skeletons, partial/syncing coverage messaging, pagination, retryable errors, transaction links, account/subaccount context, counterparties, vault context, raw amounts, and source-provided valuations.

## Availability and fallback behavior

This initial implementation is V3-only. It does not query the subgraph directly.

The tab combines three signals:

1. The selected chain must have a configured V3 Activity source.
2. The SDK static capability and account-scope capability check must support the chain.
3. Runtime coverage from the account events response must not be authoritatively `unsupported`.

An authoritative unsupported result hides the tab and redirects a direct Activity route back to Portfolio. Runtime support state is scoped by effective owner and chain so a negative result cannot leak across wallets or networks.

Transient capability checks and request failures remain visible as retryable error states. They do not become empty timelines and do not permanently hide the tab. A successful empty response is the only path to the no-indexed-activity message.

The SDK adapter boundary remains the extension point for a future subgraph implementation if product decides that Activity must work on chains without V3.

## Enrichment rules

- V3 owns historical event identity, classification, ordering, coverage, and source-authoritative raw values.
- Lite adds current token and vault metadata when available.
- Event-time USD is displayed only when the source provides it.
- Lite does not reconstruct historical USD from current prices.
- Missing optional metadata falls back to addresses and raw values without dropping the event.

## Cross-repo dependencies and merge order

1. **V3 indexed-event repair:** https://github.com/euler-xyz/euler-data-v3/pull/273
2. **V3 normalized Activity API:** https://github.com/euler-xyz/euler-data-v3/pull/274
3. **SDK Activity service and adapter contract:** https://github.com/euler-xyz/euler-sdks/pull/66
4. **Publish the SDK and bump the Lite Activity stack.**
5. **Deploy the normalized V3 Activity API on supported chains.**
6. **Lite shared feed and vault Activity:** https://github.com/euler-xyz/euler-lite/pull/736
7. **This Portfolio Activity PR**

This PR is stacked on the LITE-219 branch so its diff contains only Portfolio-specific work. Rebase onto `development` after #736 merges.

Both Lite Activity PRs remain draft until the published SDK is consumed and V3 #274 is deployed on the supported chains.

## Known overlap

https://github.com/euler-xyz/euler-lite/pull/718 currently overlaps `pages/portfolio.vue` and is reported as conflicting. The changes are semantically compatible, but whichever PR lands second needs a manual rebase that preserves both the migration load-error handling and the Activity tab availability watcher.

## Current draft CI gate

GitHub lint passes. Typecheck fails only on Activity exports, `activityService`, and Activity query names absent from the currently published SDK. The remote test job passes 1,281 of 1,282 tests; the sole failure is the SDK query-policy check for those two unpublished Activity query names. Local validation against the built SDK #66 passes typecheck and all 1,282 tests. This gate clears when #66 is published and the Lite dependency is bumped.

## Test plan

- [x] Portfolio runtime-support, Activity availability, shared feed, and display helper suites: 4 files, 28 tests passed.
- [x] Full Vitest suite: 136 files, 1,282 tests passed.
- [x] Nuxt typecheck passed against the built SDK PR.
- [x] Production build passed against the built SDK PR.
- [x] Changed-file ESLint and commit hooks passed.
- [x] `git diff --check` passed.
- [ ] Publish SDK #66 and bump the Lite dependency.
- [ ] Re-run GitHub typecheck and SDK query-policy CI against the published package.
- [ ] Smoke connected-wallet, spy-mode, unsupported-chain, partial-coverage, empty, error, and load-more states against a deployed V3 Activity API.