### PR TITLE
fix: keep borrow risk estimates coherent

### DIFF
--- a/composables/borrow/useBorrowForm.ts
+++ b/composables/borrow/useBorrowForm.ts
@@ -1056,6 +1056,10 @@ export const useBorrowForm = (options: UseBorrowFormOptions) => {
   )
 
   // --- Watchers ---
+  watch(ltv, () => {
+    updateSyncEstimates()
+  })
+
   watch([collateralAmount, borrowAmount], () => {
     clearBorrowSimulationError()
     if (!pair.value) {

--- a/pages/position/[number]/borrow/index.vue
+++ b/pages/position/[number]/borrow/index.vue
@@ -21,6 +21,7 @@ import {
   getBorrowMoreLtvHeadroomAmount,
   getBorrowMoreMaxBorrowAmount,
   getBorrowMorePositionLtv,
+  getBorrowMoreProjectedLtv,
 } from '~/utils/borrow-more'
 import type { DisabledReasonInfo } from '~/components/entities/vault/form/types'
 import { useModal } from '~/components/ui/composables/useModal'
@@ -196,8 +197,10 @@ const availableLiquidity = computed(() => borrowVault.value?.availableLiquidity)
 const availableLiquidityDisplay = computed(() => getBorrowMoreAvailableLiquidityDisplay(borrowVault.value))
 
 const loadGuard = createRaceGuard()
+const asyncEstimatesGuard = createRaceGuard()
 const load = async () => {
   const generation = loadGuard.next()
+  asyncEstimatesGuard.next()
   if (!isConnected.value && !isSpyMode.value) {
     isLoading.value = false
     return
@@ -259,6 +262,17 @@ const load = async () => {
       getAssetUsdValueOrZero(currentPosition.borrowed || 0, nextPair.borrow, 'off-chain'),
     ])
     if (loadGuard.isStale(generation)) return
+    asyncEstimatesGuard.next()
+
+    const retainedBorrowAmount = borrowAmount.value
+    const retainedProjectedLtv = !isLtvDriven.value && (+retainedBorrowAmount || 0) > 0
+      ? getBorrowMoreProjectedLtv({
+          borrowed: currentPosition.borrowed,
+          borrowDecimals: nextPair.borrow.shares.decimals,
+          additionalBorrowAmount: retainedBorrowAmount,
+          totalCollateral: getTotalCollateralValue(currentPosition),
+        })
+      : undefined
 
     const nextCurrentNetAPY = getNetAPY(
       collUsd,
@@ -272,12 +286,28 @@ const load = async () => {
     pair.value = nextPair
     userLTV.value = nextUserLTV
     currentUserLTV.value = nextUserLTV
-    ltv.value = nextUserLTV
     collateralAmount.value = trimTrailingZeros(suppliedFixed.toString())
     currentHealth.value = nextCurrentHealth
     currentLiquidationPrice.value = nextCurrentLiquidationPrice
     currentNetAPY.value = nextCurrentNetAPY
     updateBalance()
+
+    if (retainedProjectedLtv !== undefined) {
+      ltv.value = retainedProjectedLtv
+      updateSyncEstimates()
+      netAPY.value = undefined
+      isEstimatesLoading.value = true
+      updateAsyncEstimates()
+    }
+    else {
+      isLtvDriven.value = true
+      borrowAmount.value = ''
+      ltv.value = nextUserLTV
+      health.value = nextCurrentHealth
+      liquidationPrice.value = nextCurrentLiquidationPrice
+      netAPY.value = nextCurrentNetAPY
+      isEstimatesLoading.value = false
+    }
   }
   catch (e) {
     if (loadGuard.isStale(generation)) return
@@ -446,10 +476,15 @@ const onBorrowInput = async () => {
   isLtvDriven.value = false
   await nextTick()
   if (!position.value) return
-  const totalCollateral = getTotalCollateralValue(position.value)
-  if (!totalCollateral || totalCollateral <= 0) return
-  const totalBorrow = nanoToValue(position.value.borrowed, borrowVault.value?.shares.decimals || 18) + (+borrowAmount.value || 0)
-  ltv.value = +((totalBorrow / totalCollateral) * 100).toFixed(2)
+  const projectedLtv = getBorrowMoreProjectedLtv({
+    borrowed: position.value.borrowed,
+    borrowDecimals: borrowVault.value?.shares.decimals || 18,
+    additionalBorrowAmount: borrowAmount.value,
+    totalCollateral: getTotalCollateralValue(position.value),
+  })
+  if (projectedLtv !== undefined) {
+    ltv.value = projectedLtv
+  }
 }
 const onLtvInput = () => {
   isLtvDriven.value = true
@@ -470,7 +505,6 @@ const updateSyncEstimates = () => {
   }
 }
 
-const asyncEstimatesGuard = createRaceGuard()
 const updateAsyncEstimates = useDebounceFn(async () => {
   if (!pair.value || !borrowVault.value || !collateralVault.value) return
   const gen = asyncEstimatesGuard.next()

--- a/pages/position/[number]/borrow/index.vue
+++ b/pages/position/[number]/borrow/index.vue
@@ -63,7 +63,6 @@ const isSubmitting = ref(false)
 const isPreparing = ref(false)
 const isBalanceLoading = ref(false)
 const isEstimatesLoading = ref(false)
-const isOracleUnavailable = ref(false)
 const plan = ref<TransactionPlan | null>(null)
 const pair: Ref<BorrowVaultPair | undefined> = ref()
 const health = ref()
@@ -186,7 +185,6 @@ const load = async () => {
     return
   }
   isLoading.value = true
-  isOracleUnavailable.value = false
   // `position` is a layer-aware computed; load() only seeds the one-shot
   // "before" baseline (current LTV/health/APY) off the initial real state.
   if (!position.value) {
@@ -197,12 +195,13 @@ const load = async () => {
   const borrowAddress = position.value.borrowVault?.address
   if (!collateralAddress || !borrowAddress) {
     isLoading.value = false
+    await router.replace({ path: `/position/${positionIndex}`, query: _route.query })
     return
   }
   const positionLtv = getBorrowMorePositionLtv(position.value)
   if (positionLtv === undefined) {
-    isOracleUnavailable.value = true
     isLoading.value = false
+    await router.replace({ path: `/position/${positionIndex}`, query: _route.query })
     return
   }
   userLTV.value = Number(formatNumber(ltvToPercent(nanoToValue(positionLtv, 18))))
@@ -516,14 +515,7 @@ watch([collateralAmount, borrowAmount], async () => {
       class="flex flex-col gap-16"
       @submit.prevent="submit"
     >
-      <UiAlert
-        v-if="isOracleUnavailable"
-        title="Oracle unavailable"
-        description="Oracle pricing is currently unavailable, so borrowing is temporarily disabled. You can still repay debt and supply collateral from the position page."
-        variant="warning"
-        size="compact"
-      />
-      <template v-else-if="pair">
+      <template v-if="pair">
         <VaultLabelsAndAssets
           v-if="collateralVault && borrowVault"
           :vault="collateralVault"

--- a/pages/position/[number]/borrow/index.vue
+++ b/pages/position/[number]/borrow/index.vue
@@ -73,6 +73,21 @@ const liquidationPrice = ref()
 const position = computed<PortfolioBorrowPosition<VaultEntity> | undefined>(() =>
   (!isConnected.value && !isSpyMode.value) ? undefined : getPositionBySubAccountIndex(+positionIndex),
 )
+// Re-seed the form only when its position baseline changes. Portfolio refreshes
+// can replace the position object without changing these values, which should
+// not wipe an amount the user is editing.
+const positionBaselineKey = computed(() => {
+  const current = position.value
+  if (!current) return ''
+  return [
+    current.subAccount,
+    current.collateralVault?.address ?? '',
+    current.borrowVault?.address ?? '',
+    current.supplied.toString(),
+    current.borrowed.toString(),
+    getBorrowMorePositionLtv(current)?.toString() ?? '',
+  ].join(':')
+})
 const userLTV = ref(0)
 const currentNetAPY = ref<number>()
 const currentHealth = ref<number>()
@@ -185,8 +200,8 @@ const load = async () => {
     return
   }
   isLoading.value = true
-  // `position` is a layer-aware computed; load() only seeds the one-shot
-  // "before" baseline (current LTV/health/APY) off the initial real state.
+  // `position` is layer-aware; load() seeds the "before" baseline for the
+  // currently active real or simulated position.
   if (!position.value) {
     isLoading.value = false
     return
@@ -472,9 +487,9 @@ const updateAsyncEstimates = useDebounceFn(async () => {
   }
 }, 500)
 
-watch(isPositionsLoaded, (val) => {
-  if (val) {
-    load()
+watch([isPositionsLoaded, positionBaselineKey], ([positionsLoaded, baselineKey]) => {
+  if (positionsLoaded && baselineKey) {
+    void load()
   }
 }, { immediate: true })
 watch(isConnected, () => {

--- a/pages/position/[number]/borrow/index.vue
+++ b/pages/position/[number]/borrow/index.vue
@@ -20,6 +20,7 @@ import {
   getBorrowMoreAvailableLiquidityDisplay,
   getBorrowMoreLtvHeadroomAmount,
   getBorrowMoreMaxBorrowAmount,
+  getBorrowMorePositionLtv,
 } from '~/utils/borrow-more'
 import type { DisabledReasonInfo } from '~/components/entities/vault/form/types'
 import { useModal } from '~/components/ui/composables/useModal'
@@ -62,6 +63,7 @@ const isSubmitting = ref(false)
 const isPreparing = ref(false)
 const isBalanceLoading = ref(false)
 const isEstimatesLoading = ref(false)
+const isOracleUnavailable = ref(false)
 const plan = ref<TransactionPlan | null>(null)
 const pair: Ref<BorrowVaultPair | undefined> = ref()
 const health = ref()
@@ -184,6 +186,7 @@ const load = async () => {
     return
   }
   isLoading.value = true
+  isOracleUnavailable.value = false
   // `position` is a layer-aware computed; load() only seeds the one-shot
   // "before" baseline (current LTV/health/APY) off the initial real state.
   if (!position.value) {
@@ -196,8 +199,9 @@ const load = async () => {
     isLoading.value = false
     return
   }
-  const positionLtv = position.value.userLTV ?? position.value.currentLTV
+  const positionLtv = getBorrowMorePositionLtv(position.value)
   if (positionLtv === undefined) {
+    isOracleUnavailable.value = true
     isLoading.value = false
     return
   }
@@ -512,7 +516,14 @@ watch([collateralAmount, borrowAmount], async () => {
       class="flex flex-col gap-16"
       @submit.prevent="submit"
     >
-      <template v-if="pair">
+      <UiAlert
+        v-if="isOracleUnavailable"
+        title="Oracle unavailable"
+        description="Oracle pricing is currently unavailable, so borrowing is temporarily disabled. You can still repay debt and supply collateral from the position page."
+        variant="warning"
+        size="compact"
+      />
+      <template v-else-if="pair">
         <VaultLabelsAndAssets
           v-if="collateralVault && borrowVault"
           :vault="collateralVault"

--- a/pages/position/[number]/borrow/index.vue
+++ b/pages/position/[number]/borrow/index.vue
@@ -18,11 +18,13 @@ import { createRaceGuard } from '~/utils/race-guard'
 import {
   formatBorrowMoreInputAmount,
   getBorrowMoreAvailableLiquidityDisplay,
+  getBorrowMoreDraftReconciliation,
   getBorrowMoreLtvHeadroomAmount,
   getBorrowMoreMaxBorrowAmount,
   getBorrowMorePositionIdentityKey,
   getBorrowMorePositionLtv,
   getBorrowMoreProjectedLtv,
+  reconcileBorrowMoreDraftBeforeYieldRefresh,
 } from '~/utils/borrow-more'
 import type { DisabledReasonInfo } from '~/components/entities/vault/form/types'
 import { useModal } from '~/components/ui/composables/useModal'
@@ -175,7 +177,7 @@ const isSubmitDisabled = computed(() => {
     : 0n
 
   return (additionalCollateralNeeded > 0n && balance.value < additionalCollateralNeeded)
-    || isLoading.value || !(+collateralAmount.value)
+    || isLoading.value || !isProjectedRiskAvailable.value || !(+collateralAmount.value)
     || ((borrowVault.value?.availableLiquidity ?? 0n) < valueToNano(borrowAmount.value, borrowVault.value?.asset.decimals))
 })
 const isGeoBlocked = computed(() => {
@@ -191,6 +193,7 @@ const reviewBorrowDisabled = computed(() => isGeoBlocked.value || isBorrowRestri
 const disabledReasonInfo = computed((): DisabledReasonInfo | undefined => {
   if (isGeoBlocked.value) return { message: 'This operation is not available in your region', variant: 'warning' }
   if (isBorrowRestricted.value) return { message: 'Borrowing this asset is not available in your region', variant: 'warning' }
+  if (!isProjectedRiskAvailable.value) return { message: 'Projected risk estimates are unavailable', variant: 'warning' }
   if (errorText.value) return { message: errorText.value, variant: 'error' }
   if (simulationError.value) return { message: simulationError.value, variant: 'error' }
   return undefined
@@ -350,19 +353,16 @@ const load = async () => {
     ).toUnsafeFloat()
     const nextCurrentLiquidationPrice = nextCurrentHealth < 0.1 ? Infinity : nextPrice / nextCurrentHealth
 
-    const retainedBorrowAmount = borrowAmount.value
-    const canRetainManualAmount = loadedPositionIdentityKey !== ''
-      && loadedPositionIdentityKey === nextPositionIdentityKey
-      && !isLtvDriven.value
-      && (+retainedBorrowAmount || 0) > 0
-    const retainedProjectedLtv = canRetainManualAmount
-      ? getBorrowMoreProjectedLtv({
-          borrowed: currentPosition.borrowed,
-          borrowDecimals: nextPair.borrow.shares.decimals,
-          additionalBorrowAmount: retainedBorrowAmount,
-          totalCollateral: getTotalCollateralValue(currentPosition),
-        })
-      : undefined
+    const nextDraft = getBorrowMoreDraftReconciliation({
+      loadedPositionIdentityKey,
+      nextPositionIdentityKey,
+      isLtvDriven: isLtvDriven.value,
+      borrowAmount: borrowAmount.value,
+      borrowed: currentPosition.borrowed,
+      borrowDecimals: nextPair.borrow.shares.decimals,
+      totalCollateral: getTotalCollateralValue(currentPosition),
+      baselineLtv: nextUserLTV,
+    })
 
     pair.value = nextPair
     userLTV.value = nextUserLTV
@@ -372,25 +372,36 @@ const load = async () => {
     currentLiquidationPrice.value = nextCurrentLiquidationPrice
     loadedPositionIdentityKey = nextPositionIdentityKey
     updateBalance()
-    await refreshCurrentYield()
-    if (loadGuard.isStale(generation)) return
 
-    if (retainedProjectedLtv !== undefined) {
-      isProjectedRiskAvailable.value = true
-      ltv.value = retainedProjectedLtv
-      updateSyncEstimates()
+    await reconcileBorrowMoreDraftBeforeYieldRefresh({
+      draft: nextDraft,
+      commitDraft: (draft) => {
+        isProjectedRiskAvailable.value = true
+        isLtvDriven.value = draft.isLtvDriven
+        borrowAmount.value = draft.borrowAmount
+        ltv.value = draft.ltv
+        if (draft.retained) {
+          updateSyncEstimates()
+          netAPY.value = undefined
+          projectedYieldDetails.value = undefined
+          isEstimatesLoading.value = true
+        }
+        else {
+          health.value = nextCurrentHealth
+          liquidationPrice.value = nextCurrentLiquidationPrice
+          netAPY.value = undefined
+          projectedYieldDetails.value = undefined
+          isEstimatesLoading.value = false
+        }
+      },
+      refreshYield: refreshCurrentYield,
+      onYieldError: (e) => {
+        if (!loadGuard.isStale(generation)) logWarn('borrow-more/currentYield', e)
+      },
+    })
+    if (loadGuard.isStale(generation)) return
+    if (nextDraft.retained) {
       queueAsyncEstimates()
-    }
-    else {
-      isProjectedRiskAvailable.value = true
-      isLtvDriven.value = true
-      borrowAmount.value = ''
-      ltv.value = nextUserLTV
-      health.value = nextCurrentHealth
-      liquidationPrice.value = nextCurrentLiquidationPrice
-      netAPY.value = undefined
-      projectedYieldDetails.value = undefined
-      isEstimatesLoading.value = false
     }
   }
   catch (e) {
@@ -411,7 +422,7 @@ const updateBalance = () => {
 }
 const submit = async () => {
   if (isOperationBlocked.value) return
-  if (isPreparing.value || isGeoBlocked.value || isBorrowRestricted.value) return
+  if (isPreparing.value || reviewBorrowDisabled.value) return
   isPreparing.value = true
   try {
     if (!borrowVault.value || !collateralVault.value) {

--- a/pages/position/[number]/borrow/index.vue
+++ b/pages/position/[number]/borrow/index.vue
@@ -195,68 +195,99 @@ const borrowApy = computed(() => withVaultIntrinsicApy(
 const availableLiquidity = computed(() => borrowVault.value?.availableLiquidity)
 const availableLiquidityDisplay = computed(() => getBorrowMoreAvailableLiquidityDisplay(borrowVault.value))
 
+const loadGuard = createRaceGuard()
 const load = async () => {
+  const generation = loadGuard.next()
   if (!isConnected.value && !isSpyMode.value) {
+    isLoading.value = false
     return
   }
   isLoading.value = true
   // `position` is layer-aware; load() seeds the "before" baseline for the
   // currently active real or simulated position.
-  if (!position.value) {
+  const currentPosition = position.value
+  if (!currentPosition) {
     isLoading.value = false
     return
   }
-  const collateralAddress = position.value.collateralVault?.address
-  const borrowAddress = position.value.borrowVault?.address
+  const collateralAddress = currentPosition.collateralVault?.address
+  const borrowAddress = currentPosition.borrowVault?.address
   if (!collateralAddress || !borrowAddress) {
     isLoading.value = false
     await router.replace({ path: `/position/${positionIndex}`, query: _route.query })
     return
   }
-  const positionLtv = getBorrowMorePositionLtv(position.value)
+  const positionLtv = getBorrowMorePositionLtv(currentPosition)
   if (positionLtv === undefined) {
     isLoading.value = false
     await router.replace({ path: `/position/${positionIndex}`, query: _route.query })
     return
   }
-  userLTV.value = Number(formatNumber(ltvToPercent(nanoToValue(positionLtv, 18))))
-  currentUserLTV.value = userLTV.value
-  ltv.value = userLTV.value
   try {
-    pair.value = await getBorrowVaultPair(collateralAddress as string, borrowAddress as string) as BorrowVaultPair
-    // Set collateral amount from existing position supply so LTV slider and borrow input work
+    const nextPair = await getBorrowVaultPair(collateralAddress as string, borrowAddress as string) as BorrowVaultPair
+    if (loadGuard.isStale(generation)) return
+
+    const nextUserLTV = Number(formatNumber(ltvToPercent(nanoToValue(positionLtv, 18))))
     const suppliedFixed = FixedPoint.fromValue(
-      position.value!.supplied,
-      Number(collateralVault.value!.asset.decimals),
+      currentPosition.supplied,
+      Number(nextPair.collateral.asset.decimals),
     )
-    collateralAmount.value = trimTrailingZeros(suppliedFixed.toString())
-    // Fetch fresh underlying asset balance for this specific vault
-    await updateBalance()
-    // Compute current position values for before→after display
     const currentLtvPercent = ltvToPercent(nanoToValue(positionLtv, 18))
-    currentHealth.value = currentLtvPercent <= 0
+    const nextCurrentHealth = currentLtvPercent <= 0
       ? Infinity
-      : ltvToPercent(pair.value!.ltv.liquidationLTV) / currentLtvPercent
-    currentLiquidationPrice.value = currentHealth.value < 0.1 ? Infinity : priceFixed.value.toUnsafeFloat() / currentHealth.value
-    const [collUsd, borUsd] = await Promise.all([
-      getAssetUsdValueOrZero(position.value!.supplied || 0, collateralVault.value!, 'off-chain'),
-      getAssetUsdValueOrZero(position.value!.borrowed || 0, borrowVault.value!, 'off-chain'),
-    ])
-    currentNetAPY.value = getNetAPY(
-      collUsd,
-      collateralSupplyApy.value,
-      borUsd,
-      borrowApy.value,
-      collateralSupplyRewardApy.value || null,
-      borrowRewardApy.value || null,
+      : ltvToPercent(nextPair.ltv.liquidationLTV) / currentLtvPercent
+    const nextPrice = FixedPoint.fromValue(
+      conservativePriceRatio(
+        getCollateralOraclePrice(nextPair.borrow, nextPair.collateral),
+        getAssetOraclePrice(nextPair.borrow),
+      ),
+      18,
+    ).toUnsafeFloat()
+    const nextCurrentLiquidationPrice = nextCurrentHealth < 0.1 ? Infinity : nextPrice / nextCurrentHealth
+    const nextCollateralSupplyApy = withVaultIntrinsicApy(
+      getVaultSupplyApy(nextPair.collateral),
+      nextPair.collateral,
+      enableIntrinsicApy.value,
     )
+    const nextBorrowApy = withVaultIntrinsicApy(
+      getVaultBorrowApy(nextPair.borrow),
+      nextPair.borrow,
+      enableIntrinsicApy.value,
+    )
+    const [collUsd, borUsd] = await Promise.all([
+      getAssetUsdValueOrZero(currentPosition.supplied || 0, nextPair.collateral, 'off-chain'),
+      getAssetUsdValueOrZero(currentPosition.borrowed || 0, nextPair.borrow, 'off-chain'),
+    ])
+    if (loadGuard.isStale(generation)) return
+
+    const nextCurrentNetAPY = getNetAPY(
+      collUsd,
+      nextCollateralSupplyApy,
+      borUsd,
+      nextBorrowApy,
+      getSupplyRewardApy(nextPair.collateral.address) || null,
+      getBorrowRewardApy(nextPair.borrow.address, nextPair.collateral.address) || null,
+    )
+
+    pair.value = nextPair
+    userLTV.value = nextUserLTV
+    currentUserLTV.value = nextUserLTV
+    ltv.value = nextUserLTV
+    collateralAmount.value = trimTrailingZeros(suppliedFixed.toString())
+    currentHealth.value = nextCurrentHealth
+    currentLiquidationPrice.value = nextCurrentLiquidationPrice
+    currentNetAPY.value = nextCurrentNetAPY
+    updateBalance()
   }
   catch (e) {
+    if (loadGuard.isStale(generation)) return
     showError('Unable to load Vault')
     console.warn(e)
   }
   finally {
-    isLoading.value = false
+    if (!loadGuard.isStale(generation)) {
+      isLoading.value = false
+    }
   }
 }
 // `balance` is now a reactive computed over the wallet entity; this just clears
@@ -487,10 +518,13 @@ const updateAsyncEstimates = useDebounceFn(async () => {
   }
 }, 500)
 
-watch([isPositionsLoaded, positionBaselineKey], ([positionsLoaded, baselineKey]) => {
-  if (positionsLoaded && baselineKey) {
-    void load()
+watch([isPositionsLoaded, positionBaselineKey], ([positionsLoaded]) => {
+  if (!positionsLoaded) {
+    loadGuard.next()
+    isLoading.value = false
+    return
   }
+  void load()
 }, { immediate: true })
 watch(isConnected, () => {
   updateBalance()

--- a/pages/position/[number]/borrow/index.vue
+++ b/pages/position/[number]/borrow/index.vue
@@ -20,6 +20,7 @@ import {
   getBorrowMoreAvailableLiquidityDisplay,
   getBorrowMoreLtvHeadroomAmount,
   getBorrowMoreMaxBorrowAmount,
+  getBorrowMorePositionIdentityKey,
   getBorrowMorePositionLtv,
   getBorrowMoreProjectedLtv,
 } from '~/utils/borrow-more'
@@ -40,7 +41,8 @@ const { redirectAfterAdd } = useBatchRedirect()
 const { account: planAccount } = usePlanAccount()
 const { getBorrowVaultPair } = useVaults()
 const { isConnected, address } = useWagmi()
-const { isSpyMode } = useSpyMode()
+const { isSpyMode, spyAddress } = useSpyMode()
+const { chainId } = useEulerAddresses()
 const { isPositionsLoading, isPositionsLoaded, getPositionBySubAccountIndex } = useEulerAccount()
 const positionIndex = usePositionIndex()
 const { getBalance } = useWallets()
@@ -69,21 +71,30 @@ const pair: Ref<BorrowVaultPair | undefined> = ref()
 const health = ref()
 const netAPY = ref()
 const liquidationPrice = ref()
+const isProjectedRiskAvailable = ref(true)
 // Layer-aware: tracks the active batch layer's portfolio so the form reflects
 // simulated debt/collateral (a one-shot ref would freeze at the real state).
 const position = computed<PortfolioBorrowPosition<VaultEntity> | undefined>(() =>
   (!isConnected.value && !isSpyMode.value) ? undefined : getPositionBySubAccountIndex(+positionIndex),
 )
-// Re-seed the form only when its position baseline changes. Portfolio refreshes
-// can replace the position object without changing these values, which should
-// not wipe an amount the user is editing.
+const positionIdentityKey = computed(() => {
+  const current = position.value
+  if (!current) return ''
+  return getBorrowMorePositionIdentityKey({
+    chainId: chainId.value,
+    account: spyAddress.value || address.value,
+    subAccount: current.subAccount,
+    collateralVaultAddress: current.collateralVault?.address,
+    borrowVaultAddress: current.borrowVault?.address,
+  })
+})
+// Same-position baseline refreshes preserve manual input. Identity changes are
+// part of the key so an amount cannot carry into another account or vault pair.
 const positionBaselineKey = computed(() => {
   const current = position.value
   if (!current) return ''
   return [
-    current.subAccount,
-    current.collateralVault?.address ?? '',
-    current.borrowVault?.address ?? '',
+    positionIdentityKey.value,
     current.supplied.toString(),
     current.borrowed.toString(),
     getBorrowMorePositionLtv(current)?.toString() ?? '',
@@ -198,10 +209,12 @@ const availableLiquidityDisplay = computed(() => getBorrowMoreAvailableLiquidity
 
 const loadGuard = createRaceGuard()
 const asyncEstimatesGuard = createRaceGuard()
+let loadedPositionIdentityKey = ''
 const load = async () => {
   const generation = loadGuard.next()
   asyncEstimatesGuard.next()
   if (!isConnected.value && !isSpyMode.value) {
+    loadedPositionIdentityKey = ''
     isLoading.value = false
     return
   }
@@ -210,9 +223,11 @@ const load = async () => {
   // currently active real or simulated position.
   const currentPosition = position.value
   if (!currentPosition) {
+    loadedPositionIdentityKey = ''
     isLoading.value = false
     return
   }
+  const nextPositionIdentityKey = positionIdentityKey.value
   const collateralAddress = currentPosition.collateralVault?.address
   const borrowAddress = currentPosition.borrowVault?.address
   if (!collateralAddress || !borrowAddress) {
@@ -265,7 +280,11 @@ const load = async () => {
     asyncEstimatesGuard.next()
 
     const retainedBorrowAmount = borrowAmount.value
-    const retainedProjectedLtv = !isLtvDriven.value && (+retainedBorrowAmount || 0) > 0
+    const canRetainManualAmount = loadedPositionIdentityKey !== ''
+      && loadedPositionIdentityKey === nextPositionIdentityKey
+      && !isLtvDriven.value
+      && (+retainedBorrowAmount || 0) > 0
+    const retainedProjectedLtv = canRetainManualAmount
       ? getBorrowMoreProjectedLtv({
           borrowed: currentPosition.borrowed,
           borrowDecimals: nextPair.borrow.shares.decimals,
@@ -290,9 +309,11 @@ const load = async () => {
     currentHealth.value = nextCurrentHealth
     currentLiquidationPrice.value = nextCurrentLiquidationPrice
     currentNetAPY.value = nextCurrentNetAPY
+    loadedPositionIdentityKey = nextPositionIdentityKey
     updateBalance()
 
     if (retainedProjectedLtv !== undefined) {
+      isProjectedRiskAvailable.value = true
       ltv.value = retainedProjectedLtv
       updateSyncEstimates()
       netAPY.value = undefined
@@ -300,6 +321,7 @@ const load = async () => {
       updateAsyncEstimates()
     }
     else {
+      isProjectedRiskAvailable.value = true
       isLtvDriven.value = true
       borrowAmount.value = ''
       ltv.value = nextUserLTV
@@ -311,7 +333,7 @@ const load = async () => {
   }
   catch (e) {
     if (loadGuard.isStale(generation)) return
-    showError('Unable to load Vault')
+    error('Unable to load Vault')
     console.warn(e)
   }
   finally {
@@ -483,13 +505,28 @@ const onBorrowInput = async () => {
     totalCollateral: getTotalCollateralValue(position.value),
   })
   if (projectedLtv !== undefined) {
+    isProjectedRiskAvailable.value = true
     ltv.value = projectedLtv
+  }
+  else {
+    isProjectedRiskAvailable.value = false
+    asyncEstimatesGuard.next()
+    health.value = undefined
+    liquidationPrice.value = undefined
+    netAPY.value = undefined
+    isEstimatesLoading.value = false
   }
 }
 const onLtvInput = () => {
+  isProjectedRiskAvailable.value = true
   isLtvDriven.value = true
 }
 const updateSyncEstimates = () => {
+  if (!isProjectedRiskAvailable.value) {
+    health.value = undefined
+    liquidationPrice.value = undefined
+    return
+  }
   if (!pair.value) return
   try {
     const newLtvFloat = ltvFixed.value.toUnsafeFloat()
@@ -506,6 +543,11 @@ const updateSyncEstimates = () => {
 }
 
 const updateAsyncEstimates = useDebounceFn(async () => {
+  if (!isProjectedRiskAvailable.value) {
+    netAPY.value = undefined
+    isEstimatesLoading.value = false
+    return
+  }
   if (!pair.value || !borrowVault.value || !collateralVault.value) return
   const gen = asyncEstimatesGuard.next()
   try {

--- a/pages/position/[number]/borrow/index.vue
+++ b/pages/position/[number]/borrow/index.vue
@@ -480,6 +480,9 @@ watch(isConnected, () => {
 watch(address, () => {
   updateBalance()
 })
+watch(ltv, () => {
+  updateSyncEstimates()
+})
 watch([collateralAmount, borrowAmount], async () => {
   clearSimulationError()
   if (!pair.value) {

--- a/pages/position/[number]/index.vue
+++ b/pages/position/[number]/index.vue
@@ -119,7 +119,15 @@ const isBorrowSimulatedModified = computed(() =>
 const isCollateralSimulatedModified = (vault: EVault | SecuritizeCollateralVault) =>
   modifiedBalanceKeys.value.has(batchPositionKey(vault.address))
 const hasNoBorrow = computed(() => (position.value?.borrowed ?? 0n) === 0n)
-const hasQueryFailure = computed(() => !borrowVault.value || !collateralVault.value)
+const positionLTVPercent = computed(() => {
+  if (!position.value) return null
+  return getBorrowPositionUserLTVPercent(position.value) ?? null
+})
+const hasQueryFailure = computed(() =>
+  !borrowVault.value
+  || !collateralVault.value
+  || (!hasNoBorrow.value && positionLTVPercent.value === null),
+)
 const isEligibleForLiquidation = computed(() => position.value?.liquidatable ?? false)
 const effectiveLiquidationLTVPercent = computed(() => {
   if (!position.value) return null
@@ -129,10 +137,6 @@ const effectiveLiquidationLTVPercent = computed(() => {
 const effectiveLiquidationLTVDisplay = computed(() =>
   effectiveLiquidationLTVPercent.value === null ? '-' : `${effectiveLiquidationLTVPercent.value}%`,
 )
-const positionLTVPercent = computed(() => {
-  if (!position.value) return null
-  return getBorrowPositionUserLTVPercent(position.value) ?? null
-})
 const positionLTVDisplay = computed(() => {
   if (positionLTVPercent.value === null) return ''
   return Number.isFinite(positionLTVPercent.value) ? formatNumber(positionLTVPercent.value, 2) : '∞'

--- a/tests/composables/useBorrowForm.test.ts
+++ b/tests/composables/useBorrowForm.test.ts
@@ -396,7 +396,7 @@ describe('useBorrowForm savings collateral', () => {
 
     expect(form.ltv.value).toBe(40)
     expect(form.health.value).toBeCloseTo(1.875)
-    expect(form.liquidationPrice.value).toBeCloseTo(initialLiquidationPrice * 4, 24)
+    expect(form.liquidationPrice.value).toBeCloseTo(initialLiquidationPrice * 4, 6)
   })
 
   it('opens the review modal after a non-blocking borrow simulation', async () => {

--- a/tests/composables/useBorrowForm.test.ts
+++ b/tests/composables/useBorrowForm.test.ts
@@ -1,4 +1,4 @@
-import { computed, ref, shallowRef, watch, watchEffect, type Ref } from 'vue'
+import { computed, nextTick, ref, shallowRef, watch, watchEffect, type Ref } from 'vue'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Account, EVault, IHasVaultAddress, PortfolioSavingsPosition, VaultEntity } from '@eulerxyz/euler-v2-sdk'
 import { useBorrowForm } from '~/composables/borrow/useBorrowForm'
@@ -192,6 +192,7 @@ describe('useBorrowForm savings collateral', () => {
     vi.stubGlobal('computed', computed)
     vi.stubGlobal('watch', watch)
     vi.stubGlobal('watchEffect', watchEffect)
+    vi.stubGlobal('nextTick', nextTick)
     vi.stubGlobal('useDebounceFn', (fn: unknown) => fn)
     vi.stubGlobal('useEulerTx', () => ({
       planBorrow: mocks.planBorrow,
@@ -243,6 +244,7 @@ describe('useBorrowForm savings collateral', () => {
     vi.stubGlobal('valueToNano', (value: string | number, decimals = 0) => {
       return BigInt(Math.round(Number(value || 0) * 10 ** Number(decimals)))
     })
+    vi.stubGlobal('ltvToPercent', (value: bigint | number) => typeof value === 'number' ? value * 100 : Number(value) / 1e16)
     vi.stubGlobal('getIsSupplyCapReached', () => false)
     vi.stubGlobal('getIsBorrowCapReached', () => false)
     vi.stubGlobal('getVaultSupplyApy', () => 0)
@@ -296,6 +298,30 @@ describe('useBorrowForm savings collateral', () => {
     expect(form.borrowActiveBalance.value).toBe(0n)
     expect(form.errorText.value).toBe('Savings position not found')
     expect(form.isSubmitDisabled.value).toBe(true)
+  })
+
+  it('updates risk estimates when the borrow input-derived LTV changes', async () => {
+    const form = makeForm(shallowRef<PortfolioSavingsPosition<VaultEntity>[]>([]))
+
+    form.collateralAmount.value = '100'
+    form.borrowAmount.value = '10'
+    await nextTick()
+    form.ltv.value = 10
+    await nextTick()
+
+    expect(form.ltv.value).toBe(10)
+    expect(form.health.value).toBeCloseTo(7.5)
+    expect(form.liquidationPrice.value).toBeGreaterThan(0)
+    const initialLiquidationPrice = form.liquidationPrice.value!
+
+    form.borrowAmount.value = '40'
+    await nextTick()
+    form.ltv.value = 40
+    await nextTick()
+
+    expect(form.ltv.value).toBe(40)
+    expect(form.health.value).toBeCloseTo(1.875)
+    expect(form.liquidationPrice.value).toBeCloseTo(initialLiquidationPrice * 4, 24)
   })
 
   it('opens the review modal after a non-blocking borrow simulation', async () => {

--- a/tests/composables/useBorrowForm.test.ts
+++ b/tests/composables/useBorrowForm.test.ts
@@ -17,12 +17,12 @@ const { USER, SUB_ACCOUNT_A, SUB_ACCOUNT_B, VAULT, vault, planAccount, mocks } =
     asset: {
       address: ASSET,
       symbol: 'USDC',
-      decimals: 0,
+      decimals: 6,
     },
     shares: {
       address: VAULT,
       symbol: 'eUSDC',
-      decimals: 0,
+      decimals: 6,
     },
     collaterals: [],
     convertToShares: vi.fn((assets: bigint) => assets * 2n),
@@ -105,7 +105,7 @@ vi.mock('~/utils/sdk-prices', () => ({
   getAssetOraclePrice: vi.fn(() => ({ amountOutMid: 1n })),
   getCollateralOraclePrice: vi.fn(() => ({ amountOutMid: 1n })),
   getCollateralUsdPrice: vi.fn(async () => ({ amountOutMid: 1_000_000_000_000_000_000n })),
-  conservativePriceRatio: vi.fn(() => 1),
+  conservativePriceRatio: vi.fn(() => 1_000_000_000_000_000_000n),
   getTokenUsdPrice: vi.fn(async () => 1),
 }))
 
@@ -305,8 +305,7 @@ describe('useBorrowForm savings collateral', () => {
 
     form.collateralAmount.value = '100'
     form.borrowAmount.value = '10'
-    await nextTick()
-    form.ltv.value = 10
+    await form.onBorrowInput()
     await nextTick()
 
     expect(form.ltv.value).toBe(10)
@@ -315,8 +314,7 @@ describe('useBorrowForm savings collateral', () => {
     const initialLiquidationPrice = form.liquidationPrice.value!
 
     form.borrowAmount.value = '40'
-    await nextTick()
-    form.ltv.value = 40
+    await form.onBorrowInput()
     await nextTick()
 
     expect(form.ltv.value).toBe(40)

--- a/tests/utils/borrow-more.test.ts
+++ b/tests/utils/borrow-more.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, it } from 'vitest'
 import {
   formatBorrowMoreInputAmount,
   getBorrowMoreAvailableLiquidityDisplay,
+  getBorrowMoreDraftReconciliation,
   getBorrowMoreLtvHeadroomAmount,
   getBorrowMoreMaxBorrowAmount,
   getBorrowMorePositionIdentityKey,
   getBorrowMorePositionLtv,
   getBorrowMoreProjectedLtv,
+  reconcileBorrowMoreDraftBeforeYieldRefresh,
 } from '~/utils/borrow-more'
 
 const usdc = {
@@ -68,6 +70,36 @@ describe('borrow-more position risk', () => {
     expect(getBorrowMorePositionIdentityKey({ ...positionA, subAccount: '0xSubAccountB' })).not.toBe(keyA)
     expect(getBorrowMorePositionIdentityKey({ ...positionA, collateralVaultAddress: '0xCollateralB' })).not.toBe(keyA)
     expect(getBorrowMorePositionIdentityKey({ ...positionA, borrowVaultAddress: '0xBorrowB' })).not.toBe(keyA)
+  })
+
+  it('reconciles an A draft to B before optional yield enrichment can fail', async () => {
+    const nextDraft = getBorrowMoreDraftReconciliation({
+      loadedPositionIdentityKey: 'chain:account-a:sub-account:vault-a:debt-a',
+      nextPositionIdentityKey: 'chain:account-b:sub-account:vault-b:debt-b',
+      isLtvDriven: false,
+      borrowAmount: '20',
+      borrowed: 100_000_000n,
+      borrowDecimals: 6,
+      totalCollateral: 400,
+      baselineLtv: 25,
+    })
+
+    let visibleDraft: ReturnType<typeof getBorrowMoreDraftReconciliation> | undefined
+    let yieldError: unknown
+    await reconcileBorrowMoreDraftBeforeYieldRefresh({
+      draft: nextDraft,
+      commitDraft: (draft) => { visibleDraft = draft },
+      refreshYield: () => Promise.reject(new Error('yield unavailable')),
+      onYieldError: (error) => { yieldError = error },
+    })
+
+    expect(visibleDraft).toEqual({
+      borrowAmount: '',
+      isLtvDriven: true,
+      ltv: 25,
+      retained: false,
+    })
+    expect(yieldError).toEqual(new Error('yield unavailable'))
   })
 })
 

--- a/tests/utils/borrow-more.test.ts
+++ b/tests/utils/borrow-more.test.ts
@@ -5,6 +5,7 @@ import {
   getBorrowMoreLtvHeadroomAmount,
   getBorrowMoreMaxBorrowAmount,
   getBorrowMorePositionLtv,
+  getBorrowMoreProjectedLtv,
 } from '~/utils/borrow-more'
 
 const usdc = {
@@ -28,6 +29,26 @@ describe('borrow-more position risk', () => {
 
   it('stays unavailable when oracle-derived risk is missing', () => {
     expect(getBorrowMorePositionLtv({})).toBeUndefined()
+  })
+
+  it('recomputes a retained manual amount from the refreshed position baseline', () => {
+    const input = {
+      borrowDecimals: 6,
+      additionalBorrowAmount: '20',
+      totalCollateral: 400,
+    }
+
+    expect(getBorrowMoreProjectedLtv({ ...input, borrowed: 100_000_000n })).toBe(30)
+    expect(getBorrowMoreProjectedLtv({ ...input, borrowed: 160_000_000n })).toBe(45)
+  })
+
+  it('does not project risk without collateral value', () => {
+    expect(getBorrowMoreProjectedLtv({
+      borrowed: 100_000_000n,
+      borrowDecimals: 6,
+      additionalBorrowAmount: '20',
+      totalCollateral: 0,
+    })).toBeUndefined()
   })
 })
 

--- a/tests/utils/borrow-more.test.ts
+++ b/tests/utils/borrow-more.test.ts
@@ -4,6 +4,7 @@ import {
   getBorrowMoreAvailableLiquidityDisplay,
   getBorrowMoreLtvHeadroomAmount,
   getBorrowMoreMaxBorrowAmount,
+  getBorrowMorePositionLtv,
 } from '~/utils/borrow-more'
 
 const usdc = {
@@ -12,6 +13,23 @@ const usdc = {
     symbol: 'USDC',
   },
 }
+
+describe('borrow-more position risk', () => {
+  it('uses the user LTV when it is available', () => {
+    expect(getBorrowMorePositionLtv({
+      userLTV: 40n,
+      currentLTV: 30n,
+    })).toBe(40n)
+  })
+
+  it('falls back to the current LTV', () => {
+    expect(getBorrowMorePositionLtv({ currentLTV: 30n })).toBe(30n)
+  })
+
+  it('stays unavailable when oracle-derived risk is missing', () => {
+    expect(getBorrowMorePositionLtv({})).toBeUndefined()
+  })
+})
 
 describe('borrow-more liquidity display', () => {
   it('formats available liquidity for the selected borrow vault', () => {

--- a/tests/utils/borrow-more.test.ts
+++ b/tests/utils/borrow-more.test.ts
@@ -4,6 +4,7 @@ import {
   getBorrowMoreAvailableLiquidityDisplay,
   getBorrowMoreLtvHeadroomAmount,
   getBorrowMoreMaxBorrowAmount,
+  getBorrowMorePositionIdentityKey,
   getBorrowMorePositionLtv,
   getBorrowMoreProjectedLtv,
 } from '~/utils/borrow-more'
@@ -49,6 +50,24 @@ describe('borrow-more position risk', () => {
       additionalBorrowAmount: '20',
       totalCollateral: 0,
     })).toBeUndefined()
+  })
+
+  it('scopes retained input to the same chain, account, sub-account, and vault pair', () => {
+    const positionA = {
+      chainId: 56,
+      account: '0xAccountA',
+      subAccount: '0xSubAccountA',
+      collateralVaultAddress: '0xCollateral',
+      borrowVaultAddress: '0xBorrow',
+    }
+    const keyA = getBorrowMorePositionIdentityKey(positionA)
+
+    expect(getBorrowMorePositionIdentityKey({ ...positionA, account: '0xaccounta' })).toBe(keyA)
+    expect(getBorrowMorePositionIdentityKey({ ...positionA, chainId: 1 })).not.toBe(keyA)
+    expect(getBorrowMorePositionIdentityKey({ ...positionA, account: '0xAccountB' })).not.toBe(keyA)
+    expect(getBorrowMorePositionIdentityKey({ ...positionA, subAccount: '0xSubAccountB' })).not.toBe(keyA)
+    expect(getBorrowMorePositionIdentityKey({ ...positionA, collateralVaultAddress: '0xCollateralB' })).not.toBe(keyA)
+    expect(getBorrowMorePositionIdentityKey({ ...positionA, borrowVaultAddress: '0xBorrowB' })).not.toBe(keyA)
   })
 })
 

--- a/utils/borrow-more.ts
+++ b/utils/borrow-more.ts
@@ -18,6 +18,15 @@ export interface BorrowMoreAvailableLiquidityDisplay {
   display: string
 }
 
+export interface BorrowMoreRiskPosition {
+  userLTV?: bigint
+  currentLTV?: bigint
+}
+
+export const getBorrowMorePositionLtv = (
+  position: BorrowMoreRiskPosition,
+): bigint | undefined => position.userLTV ?? position.currentLTV
+
 export const getBorrowMoreAvailableLiquidityDisplay = (
   vault: BorrowMoreLiquidityVault | undefined,
 ): BorrowMoreAvailableLiquidityDisplay | null => {

--- a/utils/borrow-more.ts
+++ b/utils/borrow-more.ts
@@ -27,6 +27,23 @@ export const getBorrowMorePositionLtv = (
   position: BorrowMoreRiskPosition,
 ): bigint | undefined => position.userLTV ?? position.currentLTV
 
+export const getBorrowMoreProjectedLtv = ({
+  borrowed,
+  borrowDecimals,
+  additionalBorrowAmount,
+  totalCollateral,
+}: {
+  borrowed: bigint
+  borrowDecimals: Decimals
+  additionalBorrowAmount: string
+  totalCollateral: number
+}): number | undefined => {
+  if (!Number.isFinite(totalCollateral) || totalCollateral <= 0) return undefined
+
+  const totalBorrow = nanoToValue(borrowed, borrowDecimals) + (+additionalBorrowAmount || 0)
+  return +((totalBorrow / totalCollateral) * 100).toFixed(2)
+}
+
 export const getBorrowMoreAvailableLiquidityDisplay = (
   vault: BorrowMoreLiquidityVault | undefined,
 ): BorrowMoreAvailableLiquidityDisplay | null => {

--- a/utils/borrow-more.ts
+++ b/utils/borrow-more.ts
@@ -64,6 +64,70 @@ export const getBorrowMoreProjectedLtv = ({
   return +((totalBorrow / totalCollateral) * 100).toFixed(2)
 }
 
+export interface BorrowMoreDraftReconciliation {
+  borrowAmount: string
+  isLtvDriven: boolean
+  ltv: number
+  retained: boolean
+}
+
+export const getBorrowMoreDraftReconciliation = ({
+  loadedPositionIdentityKey,
+  nextPositionIdentityKey,
+  isLtvDriven,
+  borrowAmount,
+  borrowed,
+  borrowDecimals,
+  totalCollateral,
+  baselineLtv,
+}: {
+  loadedPositionIdentityKey: string
+  nextPositionIdentityKey: string
+  isLtvDriven: boolean
+  borrowAmount: string
+  borrowed: bigint
+  borrowDecimals: Decimals
+  totalCollateral: number
+  baselineLtv: number
+}): BorrowMoreDraftReconciliation => {
+  const canRetain = loadedPositionIdentityKey !== ''
+    && loadedPositionIdentityKey === nextPositionIdentityKey
+    && !isLtvDriven
+    && (+borrowAmount || 0) > 0
+  const retainedProjectedLtv = canRetain
+    ? getBorrowMoreProjectedLtv({
+        borrowed,
+        borrowDecimals,
+        additionalBorrowAmount: borrowAmount,
+        totalCollateral,
+      })
+    : undefined
+
+  return retainedProjectedLtv === undefined
+    ? { borrowAmount: '', isLtvDriven: true, ltv: baselineLtv, retained: false }
+    : { borrowAmount, isLtvDriven: false, ltv: retainedProjectedLtv, retained: true }
+}
+
+export const reconcileBorrowMoreDraftBeforeYieldRefresh = async ({
+  draft,
+  commitDraft,
+  refreshYield,
+  onYieldError,
+}: {
+  draft: BorrowMoreDraftReconciliation
+  commitDraft: (draft: BorrowMoreDraftReconciliation) => void
+  refreshYield: () => Promise<void>
+  onYieldError: (error: unknown) => void
+}): Promise<void> => {
+  commitDraft(draft)
+  try {
+    await refreshYield()
+  }
+  catch (error) {
+    onYieldError(error)
+  }
+}
+
 export const getBorrowMoreAvailableLiquidityDisplay = (
   vault: BorrowMoreLiquidityVault | undefined,
 ): BorrowMoreAvailableLiquidityDisplay | null => {

--- a/utils/borrow-more.ts
+++ b/utils/borrow-more.ts
@@ -27,6 +27,26 @@ export const getBorrowMorePositionLtv = (
   position: BorrowMoreRiskPosition,
 ): bigint | undefined => position.userLTV ?? position.currentLTV
 
+export const getBorrowMorePositionIdentityKey = ({
+  chainId,
+  account,
+  subAccount,
+  collateralVaultAddress,
+  borrowVaultAddress,
+}: {
+  chainId: number | undefined
+  account: string | undefined
+  subAccount: string
+  collateralVaultAddress: string | undefined
+  borrowVaultAddress: string | undefined
+}): string => [
+  chainId ?? '',
+  account ?? '',
+  subAccount,
+  collateralVaultAddress ?? '',
+  borrowVaultAddress ?? '',
+].map(value => value.toString().toLowerCase()).join(':')
+
 export const getBorrowMoreProjectedLtv = ({
   borrowed,
   borrowDecimals,


### PR DESCRIPTION
## Summary

- Keep health, liquidation price, and projected yield synchronized with input-derived LTV in both new-borrow and borrow-more flows.
- Keep the full position experience available when oracle-derived risk data is missing while disabling actions that require reliable risk projections.
- Scope borrow-more drafts and asynchronous estimates to the active chain, account, sub-account, and vault pair so position refreshes cannot display stale risk state.

## Changes

- Recompute synchronous risk estimates whenever LTV changes and derive projected LTV from the active debt, token decimals, and collateral value.
- Treat missing position LTV or invalid projected collateral value as unavailable risk data, clear projected estimates, and disable Review, direct submit, and Add to batch.
- Redirect incomplete borrow-more routes to the position page while preserving network and spy-mode query parameters.
- Refresh the borrow-more baseline when the reactive position changes, retain manual input only for the same position identity, and reproject it from the refreshed baseline.
- Guard position, yield, and estimate loads against stale asynchronous responses and reconcile visible draft state before optional yield enrichment.
- Keep Borrow, Multiply, Withdraw, and Refinance unavailable when oracle risk data is missing while Repay and Supply remain available.
- Cover input-derived LTV updates, missing-risk behavior, position identity scoping, baseline refreshes, and failed optional enrichment with regression tests.

## Test plan

- [x] npm run test:run -- tests/utils/borrow-more.test.ts tests/composables/useBorrowForm.test.ts
- [x] npm run test:run (143 files passed, 1 skipped; 1,368 tests passed, 1 skipped)
- [x] npx eslint composables/borrow/useBorrowForm.ts pages/position/[number]/borrow/index.vue pages/position/[number]/index.vue tests/composables/useBorrowForm.test.ts tests/utils/borrow-more.test.ts utils/borrow-more.ts
- [x] npm run typecheck
- [x] Confirm the BNB Chain INTCon/USDT spy flow shows the full position warning when oracle risk data is unavailable and keeps risk-increasing actions disabled.
- [x] Confirm the active-oracle borrow flows update LTV, health, and liquidation price as the borrow amount changes.