### PR TITLE
feat: authenticate Pyth Hermes requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,7 +33,9 @@ WALLET_SCREENING_URI=
 
 # API URLs
 NUXT_PUBLIC_SWAP_API_URL="https://swap-dev.euler.finance"
-NUXT_PUBLIC_PYTH_HERMES_URL=https://hermes.pyth.network
+
+# Pyth Hermes authentication (server-side only, required for Pyth-backed markets)
+PYTH_API_KEY=
 
 # Stablewatch intrinsic APY (server-side only, optional)
 # If not set, Stablewatch APY data will not be fetched even if tokens are configured.

--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ cp .env.example .env
 | `V3_API_URL` | `https://v3.euler.finance`    | Euler V3 upstream used by the server `/api/internal/v3` proxy |
 | `EULER_SDK_V3_API_KEY` | —                  | Optional server-side V3 API key forwarded by `/api/internal/v3` as `X-API-Key` |
 | `SWAP_API_URL` or `NUXT_PUBLIC_SWAP_API_URL` | —           | Euler swap API                        |
-| `PYTH_HERMES_URL` or `NUXT_PUBLIC_PYTH_HERMES_URL` | `https://hermes.pyth.network` | Pyth oracle endpoint (proxied via `/api/internal/pyth/updates`) |
+| `PYTH_API_KEY` | — | Server-side API key sent to `https://hermes.pyth.network` as Bearer authentication by `/api/internal/pyth/updates` |
 
-> **Doppler compatibility:** If your secret manager injects prefixed URL names, the server also accepts `EULER_SDK_V3_API_URL` and `NUXT_PUBLIC_V3_API_URL`. V3 API keys should use server-side names such as `EULER_SDK_V3_API_KEY`.
+> **Doppler compatibility:** If your secret manager injects prefixed URL names, the server also accepts `EULER_SDK_V3_API_URL` and `NUXT_PUBLIC_V3_API_URL`. API keys use server-side names such as `EULER_SDK_V3_API_KEY` and `PYTH_API_KEY`.
 
 #### SDK Data Source Controls
 

--- a/composables/useEnvConfig.ts
+++ b/composables/useEnvConfig.ts
@@ -74,7 +74,7 @@ function scanEnv(): EnvConfig {
     appDescription: env('APP_DESCRIPTION', 'NUXT_PUBLIC_CONFIG_APP_DESCRIPTION') || DEFAULTS.appDescription,
     logoUrl: env('LOGO_URL', 'NUXT_PUBLIC_CONFIG_LOGO_URL') || DEFAULTS.logoUrl,
     socialImageUrl: env('SOCIAL_IMAGE_URL', 'NUXT_PUBLIC_CONFIG_SOCIAL_IMAGE_URL') || DEFAULTS.socialImageUrl,
-    pythHermesUrl: env('PYTH_HERMES_URL', 'NUXT_PUBLIC_PYTH_HERMES_URL') || '',
+    pythHermesUrl: env('PYTH_API_KEY').trim() ? 'proxy' : '',
     appKitProjectId: env('APPKIT_PROJECT_ID', 'NUXT_PUBLIC_APP_KIT_PROJECT_ID') || DEFAULTS.appKitProjectId,
     appUrl: env('NUXT_PUBLIC_APP_URL') || DEFAULTS.appUrl,
     v3ApiUrl: V3_API_PROXY_URL,

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -98,7 +98,7 @@ External metadata (contract addresses, labels, oracle checks) is fetched through
 | `GET\|HEAD\|POST /api/internal/proxy/incentra/:path` | Incentra API (`sdk/v1/`, `v1/` allowlist) | 30 s | `INCENTRA_API_URL`, `NUXT_PUBLIC_INCENTRA_API_URL` |
 | `POST /api/internal/proxy/subgraph/:chainId` | Per-chain Goldsky subgraph | 30 s | `SUBGRAPH_URL_<chainId>` (server-only) or `NUXT_PUBLIC_SUBGRAPH_URI_<chainId>` |
 | `GET\|POST /api/internal/v3/...path` | Exact SDK-owned V3 endpoint allowlist (`tokens`, `prices`, APYs, rewards, account positions, vault reads, vault batch/resolve) | none — V3 caches upstream | `V3_API_URL`, `EULER_SDK_V3_API_URL`, `NUXT_PUBLIC_V3_API_URL`, `EULER_SDK_V3_API_KEY` |
-| `GET /api/internal/pyth/updates?ids[]=...` | Pyth Hermes (`/v2/updates/price/latest`) | No cache | `PYTH_HERMES_URL` (server-only) |
+| `GET /api/internal/pyth/updates?ids[]=...` | Pyth Hermes (`https://hermes.pyth.network/v2/updates/price/latest`) | No cache | `PYTH_API_KEY` (server-only) |
 
 All endpoints use rate limiting and return stale cached data when upstream is unavailable (except `/api/internal/pyth/updates` which requires real-time data and returns no-store cache headers). The shared caching utility is in `server/utils/cache.ts`; the per-host external proxies share `server/utils/external-proxy.ts`.
 
@@ -124,11 +124,11 @@ Priority for deduplication: Euler SDK token list > DefiLlama > Uniswap > Merkl. 
 
 ### Pyth Proxy Endpoint Details
 
-The `/api/internal/pyth/updates` endpoint proxies Pyth Hermes price update requests through the server. This avoids CORS restrictions and prevents the Hermes URL (which may contain credentials) from reaching the browser.
+The `/api/internal/pyth/updates` endpoint proxies Pyth Hermes price update requests through the server. It authenticates requests to `https://hermes.pyth.network` with a server-side Bearer token, keeping the API key out of the browser.
 
-- **Rate limit**: 600 requests per 60-second window
+- **Rate limit**: 1,000 requests per 60-second window
 - **Validation**: Feed IDs must match `0x[64 hex chars]` format, max 100 per request
-- **Env var**: `PYTH_HERMES_URL` (server-only; not exposed to client)
+- **Env var**: `PYTH_API_KEY` (server-only; not exposed to client)
 
 ## Code layout (high level)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -114,7 +114,7 @@ SUBGRAPH_URL_1=https://your-subgraph.com
 ### Pyth Network
 
 - **Purpose**: Pull-based oracle price feeds
-- **Integration**: Hermes API (`PYTH_HERMES_URL`)
+- **Integration**: Hermes API (`PYTH_API_KEY`)
 - **Data Source**: Real-time price updates for oracle feeds
 
 ### Merkl

--- a/docs/pyth-oracle-handling.md
+++ b/docs/pyth-oracle-handling.md
@@ -26,7 +26,7 @@ Feeds are deduplicated by `pythAddress:feedId`.
 
 ## Hermes Updates
 
-`fetchPythUpdateData(feedIds, endpoint)` fetches binary update payloads through the server-side `/api/internal/pyth/updates` proxy. The proxy forwards to the configured Hermes endpoint and keeps browser clients away from upstream URL details.
+`fetchPythUpdateData(feedIds, endpoint)` fetches binary update payloads through the server-side `/api/internal/pyth/updates` proxy. The proxy authenticates to `https://hermes.pyth.network` with `PYTH_API_KEY` and keeps the credential out of the browser.
 
 The client helper:
 

--- a/server/api/internal/pyth/updates.get.ts
+++ b/server/api/internal/pyth/updates.get.ts
@@ -2,6 +2,11 @@ import { createError, getQuery, setResponseHeader } from 'h3'
 import { createRateLimiter } from '~/server/utils/rate-limit'
 import { fetchWithTimeout } from '~/server/utils/fetchWithTimeout'
 import { logger } from '~/server/utils/logger'
+import {
+  buildPythProxyRequestHeaders,
+  isPythProxyConfigured,
+  PYTH_HERMES_URL,
+} from '~/server/utils/pyth-proxy'
 
 const FEED_ID_RE = /^0x[0-9a-fA-F]{64}$/
 
@@ -11,16 +16,11 @@ const rateLimiter = createRateLimiter({
   label: 'pyth-updates',
 })
 
-function getHermesUrl(): string {
-  return (process.env.PYTH_HERMES_URL || process.env.NUXT_PUBLIC_PYTH_HERMES_URL || '').replace(/\/+$/, '')
-}
-
 export default defineEventHandler(async (event) => {
   rateLimiter.consume(event)
 
-  const hermesUrl = getHermesUrl()
-  if (!hermesUrl) {
-    throw createError({ statusCode: 503, statusMessage: 'Pyth Hermes endpoint not configured' })
+  if (!isPythProxyConfigured()) {
+    throw createError({ statusCode: 503, statusMessage: 'Pyth API key not configured' })
   }
 
   const query = getQuery(event)
@@ -42,7 +42,7 @@ export default defineEventHandler(async (event) => {
     }
   }
 
-  const url = new URL(`${hermesUrl}/v2/updates/price/latest`)
+  const url = new URL('/v2/updates/price/latest', PYTH_HERMES_URL)
   ids.forEach(id => url.searchParams.append('ids[]', id))
 
   const encoding = String(query.encoding || 'hex')
@@ -55,7 +55,9 @@ export default defineEventHandler(async (event) => {
   }
 
   try {
-    const resp = await fetchWithTimeout(url.toString())
+    const resp = await fetchWithTimeout(url.toString(), undefined, {
+      headers: buildPythProxyRequestHeaders(),
+    })
     setResponseHeader(event, 'Cache-Control', 'no-store')
 
     // Hermes returns 404 with a body listing the missing feed IDs when some

--- a/server/plugins/app-config.ts
+++ b/server/plugins/app-config.ts
@@ -54,7 +54,7 @@ function readAppConfig() {
     appDescription: env('APP_DESCRIPTION', 'NUXT_PUBLIC_CONFIG_APP_DESCRIPTION') || DEFAULTS.appDescription,
     logoUrl: env('LOGO_URL', 'NUXT_PUBLIC_CONFIG_LOGO_URL'),
     socialImageUrl: env('SOCIAL_IMAGE_URL', 'NUXT_PUBLIC_CONFIG_SOCIAL_IMAGE_URL'),
-    pythHermesUrl: env('PYTH_HERMES_URL', 'NUXT_PUBLIC_PYTH_HERMES_URL') ? 'proxy' : '',
+    pythHermesUrl: env('PYTH_API_KEY').trim() ? 'proxy' : '',
     appKitProjectId: env('APPKIT_PROJECT_ID', 'NUXT_PUBLIC_APP_KIT_PROJECT_ID'),
     appUrl: env('NUXT_PUBLIC_APP_URL'),
     v3ApiUrl: V3_API_PROXY_URL,

--- a/server/utils/pyth-proxy.ts
+++ b/server/utils/pyth-proxy.ts
@@ -1,0 +1,18 @@
+export const PYTH_HERMES_URL = 'https://hermes.pyth.network'
+
+type PythProxyEnv = Record<string, string | undefined>
+
+export function readPythApiKey(env: PythProxyEnv = process.env): string {
+  return env.PYTH_API_KEY?.trim() || ''
+}
+
+export function isPythProxyConfigured(env: PythProxyEnv = process.env): boolean {
+  return readPythApiKey(env).length > 0
+}
+
+export function buildPythProxyRequestHeaders(env: PythProxyEnv = process.env): Headers {
+  const headers = new Headers({ accept: 'application/json' })
+  const apiKey = readPythApiKey(env)
+  if (apiKey) headers.set('authorization', `Bearer ${apiKey}`)
+  return headers
+}

--- a/tests/server/pyth-proxy.test.ts
+++ b/tests/server/pyth-proxy.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildPythProxyRequestHeaders,
+  isPythProxyConfigured,
+  PYTH_HERMES_URL,
+  readPythApiKey,
+} from '~/server/utils/pyth-proxy'
+
+describe('pyth proxy configuration', () => {
+  it('uses the Pyth Hermes automatic-upgrade endpoint', () => {
+    expect(PYTH_HERMES_URL).toBe('https://hermes.pyth.network')
+  })
+
+  it('injects the server-side Pyth API key as Bearer authentication', () => {
+    const headers = buildPythProxyRequestHeaders({ PYTH_API_KEY: 'pyth-secret' })
+
+    expect(headers.get('accept')).toBe('application/json')
+    expect(headers.get('authorization')).toBe('Bearer pyth-secret')
+  })
+
+  it('trims the configured API key', () => {
+    expect(readPythApiKey({ PYTH_API_KEY: '  pyth-secret  ' })).toBe('pyth-secret')
+    expect(isPythProxyConfigured({ PYTH_API_KEY: '  pyth-secret  ' })).toBe(true)
+  })
+
+  it('treats a blank API key as unconfigured', () => {
+    const env = { PYTH_API_KEY: '   ' }
+
+    expect(isPythProxyConfigured(env)).toBe(false)
+    expect(buildPythProxyRequestHeaders(env).has('authorization')).toBe(false)
+  })
+
+  it('does not read a public API key variable', () => {
+    const env = { NUXT_PUBLIC_PYTH_API_KEY: 'public-key' }
+
+    expect(isPythProxyConfigured(env)).toBe(false)
+    expect(buildPythProxyRequestHeaders(env).has('authorization')).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

- Authenticate Lite Pyth price-update requests directly against the Pyth Hermes automatic-upgrade endpoint.
- Keep the API key server-side and remove endpoint configuration that could continue routing through a third-party provider.

## Changes

- Fix the upstream to `https://hermes.pyth.network` and require `PYTH_API_KEY`.
- Send the key as `Authorization: Bearer ...` from `/api/internal/pyth/updates`.
- Gate the client proxy marker on server-side key availability and document the deployment configuration.
- Add focused coverage for the endpoint and secret-handling behavior.

## Test plan

- [x] `npm run test:run -- tests/server/pyth-proxy.test.ts tests/server/security.test.ts tests/composables/useEulerSdk.test.ts`
- [x] `npm run typecheck`
- [x] Changed-file ESLint and `git diff --check`
- [ ] Configure a real `PYTH_API_KEY` locally and verify a Pyth-backed price read and transaction simulation.
- [ ] Deploy with `PYTH_API_KEY`, remove the Liquify endpoint secret, and verify no requests reach Liquify.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added server-side Pyth Hermes authentication using `PYTH_API_KEY`.
  * Pyth market data requests now use a secure proxy, keeping credentials out of the browser.
  * Increased the documented proxy rate limit to 1,000 requests per 60 seconds.

* **Documentation**
  * Updated setup and development documentation to describe the new API key configuration and authentication flow.

* **Tests**
  * Added coverage for API key handling, trimming, missing credentials, and secure server-side configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->