### PR TITLE
fix: keep Keyring onboarding state coherent

### DIFF
--- a/components/entities/vault/form/VaultFormSubmit.vue
+++ b/components/entities/vault/form/VaultFormSubmit.vue
@@ -17,6 +17,9 @@ interface KeyringGuardState {
   isExpired: boolean
   flowState: KeyringFlowState
   credentialData: CredentialData | null
+  isCheckingStatus: boolean
+  statusMessage?: string
+  error?: string
   launchExtension: () => Promise<void>
   checkStatus: () => Promise<void>
   cancelVerification: () => void
@@ -299,6 +302,9 @@ const handleAddToBatch = () => {
           <KeyringVerificationFlow
             :flow-state="keyringGuard.flowState"
             :credential-cost="keyringGuard.credentialData?.cost"
+            :checking-status="keyringGuard.isCheckingStatus"
+            :status-message="keyringGuard.statusMessage"
+            :error-message="keyringGuard.error"
             @launch="keyringGuard.launchExtension()"
             @check="keyringGuard.checkStatus()"
             @cancel="keyringGuard.cancelVerification()"

--- a/components/keyring/KeyringVerificationFlow.vue
+++ b/components/keyring/KeyringVerificationFlow.vue
@@ -7,6 +7,9 @@ import { getChainById } from '~/entities/chainRegistry'
 const props = defineProps<{
   flowState: KeyringFlowState
   credentialCost?: number
+  checkingStatus?: boolean
+  statusMessage?: string
+  errorMessage?: string
 }>()
 
 const chainId = useChainId()
@@ -46,21 +49,22 @@ defineEmits<{
       <p class="text-p3 text-content-secondary text-center">
         The Keyring browser extension is required to complete verification.
       </p>
-      <a
-        href="https://app.keyring.network/connect"
-        target="_blank"
-        rel="noopener noreferrer"
+      <UiButton
+        variant="primary"
+        size="large"
+        @click="$emit('launch')"
       >
-        <UiButton
-          variant="primary"
-          size="large"
-        >
-          Install Keyring Extension
-        </UiButton>
-      </a>
+        Install Keyring Extension
+      </UiButton>
     </template>
 
     <template v-else-if="flowState === KeyringFlowState.Start">
+      <p
+        v-if="statusMessage"
+        class="text-p3 text-content-secondary text-center"
+      >
+        {{ statusMessage }}
+      </p>
       <UiButton
         variant="primary"
         size="large"
@@ -74,10 +78,17 @@ defineEmits<{
       <p class="text-p3 text-content-secondary text-center">
         Complete the verification in the Keyring extension, then check your status.
       </p>
+      <p
+        v-if="statusMessage"
+        class="text-p3 text-content-secondary text-center"
+      >
+        {{ statusMessage }}
+      </p>
       <div class="flex flex-col gap-8">
         <UiButton
           variant="primary"
           size="large"
+          :loading="checkingStatus"
           @click="$emit('check')"
         >
           Check Status
@@ -119,7 +130,7 @@ defineEmits<{
           class="!w-20 !h-20 text-error-500"
         />
         <p class="text-p3 text-error-600">
-          Verification failed. Please try again.
+          {{ errorMessage || 'Verification failed. Please try again.' }}
         </p>
       </div>
       <UiButton

--- a/composables/useKeyring/index.ts
+++ b/composables/useKeyring/index.ts
@@ -5,6 +5,7 @@ import {
   KeyringConnect,
   type CredentialData,
   type ExtensionSDKConfig,
+  type ExtensionState,
 } from '@keyringnetwork/keyring-connect-sdk'
 import { keyringHookTargetAbi } from '~/abis/keyring'
 import { isVaultKeyring } from '~/utils/eulerLabelsUtils'
@@ -23,6 +24,19 @@ export enum KeyringFlowState {
   Ready = 'ready',
   Error = 'error',
 }
+
+export const isCredentialForContext = (
+  credential: CredentialData | null | undefined,
+  trader: string | undefined,
+  policyId: number | undefined,
+  chainId: number | undefined,
+): credential is CredentialData => Boolean(
+  credential
+  && trader
+  && credential.trader?.toLowerCase() === trader.toLowerCase()
+  && credential.policyId === policyId
+  && credential.chainId === chainId,
+)
 
 const readHookTargetField = async <T>(
   rpcUrl: string,
@@ -60,8 +74,9 @@ export const useKeyring = (vaultAddress: string | Ref<string>) => {
   const credentialData = ref<CredentialData | null>(null)
   const flowState = ref<KeyringFlowState>(KeyringFlowState.Idle)
   const error = ref<string>()
+  const isCheckingStatus = ref(false)
+  const statusMessage = ref<string>()
 
-  let statusCheckInterval: ReturnType<typeof setInterval> | null = null
   let unsubscribeExtension: (() => void) | null = null
 
   const isKeyringVault = computed(() => isVaultKeyring(addressRef.value))
@@ -76,8 +91,9 @@ export const useKeyring = (vaultAddress: string | Ref<string>) => {
 
   const isVerificationRequired = computed(() =>
     isKeyringVault.value
-    && !isLoading.value
+    && Boolean(userAddress.value)
     && !hasValidCredential.value
+    && flowState.value !== KeyringFlowState.Idle
     && flowState.value !== KeyringFlowState.Ready,
   )
 
@@ -94,6 +110,9 @@ export const useKeyring = (vaultAddress: string | Ref<string>) => {
     if (!ht || !user || !rpcUrl.value) return
 
     isLoading.value = true
+    flowState.value = KeyringFlowState.Loading
+    error.value = undefined
+    statusMessage.value = undefined
     try {
       const client = getPublicClient(rpcUrl.value)
 
@@ -160,14 +179,7 @@ export const useKeyring = (vaultAddress: string | Ref<string>) => {
 
       const state = await KeyringConnect.getExtensionState()
       const cred = state?.credentialData
-      // The extension echoes the trader address in its own casing — compare
-      // case-insensitively so a casing difference doesn't force a re-auth.
-      if (
-        cred
-        && cred.trader?.toLowerCase() === userAddress.value?.toLowerCase()
-        && cred.policyId === policyId.value
-        && cred.chainId === chainId.value
-      ) {
+      if (isCredentialForContext(cred, userAddress.value, policyId.value, chainId.value)) {
         credentialData.value = cred
         flowState.value = KeyringFlowState.Ready
       }
@@ -196,6 +208,8 @@ export const useKeyring = (vaultAddress: string | Ref<string>) => {
 
     flowState.value = KeyringFlowState.Progress
     credentialData.value = null
+    error.value = undefined
+    statusMessage.value = undefined
 
     try {
       await KeyringConnect.launchExtension(config)
@@ -208,51 +222,90 @@ export const useKeyring = (vaultAddress: string | Ref<string>) => {
     }
   }
 
-  const startStatusPolling = () => {
-    stopStatusPolling()
-    // Use subscribeToExtensionState if available, otherwise poll
-    unsubscribeExtension = KeyringConnect.subscribeToExtensionState((state) => {
-      if (!state) return
-      if (state.credentialData) {
-        credentialData.value = state.credentialData
-        flowState.value = KeyringFlowState.Ready
-        stopStatusPolling()
-      }
-      else if (state.user?.credential_status === 'valid') {
-        hasValidCredential.value = true
-        flowState.value = KeyringFlowState.Idle
-        stopStatusPolling()
-      }
-    })
-  }
-
   const stopStatusPolling = () => {
-    if (statusCheckInterval) {
-      clearInterval(statusCheckInterval)
-      statusCheckInterval = null
-    }
     if (unsubscribeExtension) {
       unsubscribeExtension()
       unsubscribeExtension = null
     }
   }
 
+  const handleExtensionState = async (state: ExtensionState | null, manualCheck = false) => {
+    if (!state) {
+      credentialData.value = null
+      flowState.value = KeyringFlowState.Install
+      statusMessage.value = undefined
+      stopStatusPolling()
+      return
+    }
+
+    const cred = state.credentialData
+    if (cred) {
+      if (isCredentialForContext(cred, userAddress.value, policyId.value, chainId.value)) {
+        credentialData.value = cred
+        flowState.value = KeyringFlowState.Ready
+        statusMessage.value = undefined
+      }
+      else {
+        credentialData.value = null
+        flowState.value = KeyringFlowState.Start
+        statusMessage.value = 'Restart verification for the connected wallet, policy, and network.'
+      }
+      stopStatusPolling()
+      return
+    }
+
+    if (state.status === 'error' || state.status === 'prove_error') {
+      credentialData.value = null
+      flowState.value = KeyringFlowState.Error
+      error.value = state.error || 'Keyring verification failed'
+      statusMessage.value = undefined
+      stopStatusPolling()
+      return
+    }
+
+    const extensionUserMatches = state.user?.wallet_address?.toLowerCase() === userAddress.value?.toLowerCase()
+    if (extensionUserMatches && state.user?.credential_status === 'valid') {
+      await checkCredential()
+      if (flowState.value === KeyringFlowState.Idle || flowState.value === KeyringFlowState.Ready) {
+        stopStatusPolling()
+      }
+      return
+    }
+
+    if (state.status === 'proving') {
+      flowState.value = KeyringFlowState.Progress
+      statusMessage.value = 'Verification is still in progress in the Keyring extension.'
+      return
+    }
+
+    if (manualCheck) {
+      flowState.value = KeyringFlowState.Start
+      statusMessage.value = 'Verification is not complete yet. Continue in the Keyring extension.'
+      stopStatusPolling()
+    }
+  }
+
+  const startStatusPolling = () => {
+    stopStatusPolling()
+    unsubscribeExtension = KeyringConnect.subscribeToExtensionState((state) => {
+      void handleExtensionState(state)
+    })
+  }
+
   const checkStatus = async () => {
+    isCheckingStatus.value = true
     try {
       const state = await KeyringConnect.getExtensionState()
-      if (state?.credentialData) {
-        credentialData.value = state.credentialData
-        flowState.value = KeyringFlowState.Ready
-        stopStatusPolling()
-      }
-      else if (state?.user?.credential_status === 'valid') {
-        hasValidCredential.value = true
-        flowState.value = KeyringFlowState.Idle
-        stopStatusPolling()
-      }
+      await handleExtensionState(state, true)
     }
     catch (err) {
       logWarn('useKeyring: Failed to check extension status', err)
+      flowState.value = KeyringFlowState.Error
+      error.value = 'Failed to check Keyring extension status'
+      statusMessage.value = undefined
+    }
+    finally {
+      isCheckingStatus.value = false
     }
   }
 
@@ -260,6 +313,8 @@ export const useKeyring = (vaultAddress: string | Ref<string>) => {
     stopStatusPolling()
     flowState.value = KeyringFlowState.Start
     credentialData.value = null
+    error.value = undefined
+    statusMessage.value = undefined
   }
 
   // Re-check extension state when user returns to the tab (e.g. after installing the extension)
@@ -289,11 +344,14 @@ export const useKeyring = (vaultAddress: string | Ref<string>) => {
     () => {
       credentialData.value = null
       hasValidCredential.value = false
-      if (isKeyringVault.value && hookTarget.value && userAddress.value) {
-        checkCredential()
-      }
-      else if (!isKeyringVault.value) {
+      if (!isKeyringVault.value || !userAddress.value) {
         flowState.value = KeyringFlowState.Idle
+      }
+      else if (hookTarget.value) {
+        void checkCredential()
+      }
+      else {
+        flowState.value = KeyringFlowState.Loading
       }
     },
     { immediate: true },
@@ -319,6 +377,8 @@ export const useKeyring = (vaultAddress: string | Ref<string>) => {
     credentialData,
     flowState,
     error,
+    isCheckingStatus,
+    statusMessage,
     launchExtension,
     checkStatus,
     cancelVerification,

--- a/composables/useOperationGuard.ts
+++ b/composables/useOperationGuard.ts
@@ -1,7 +1,7 @@
 import { computed, isRef, watch, onUnmounted, provide, reactive, type Ref } from 'vue'
 import { useChainId } from '@wagmi/vue'
 import type { Address } from 'viem'
-import { useKeyring, KeyringFlowState } from '~/composables/useKeyring'
+import { useKeyring } from '~/composables/useKeyring'
 import { useTosGuard } from '~/composables/guards/useTosGuard'
 import { useUnverifiedVaultGuard } from '~/composables/guards/useUnverifiedVaultGuard'
 import { clearOperationMeta, registerOperationBlocker, setOperationMeta, unregisterOperationBlocker } from '~/utils/operationGuardRegistry'
@@ -30,12 +30,7 @@ export const useOperationGuard = (vaultAddresses: Ref<(string | undefined)[]> | 
 
   const keyring = useKeyring(keyringVaultAddress)
 
-  const needsVerification = computed(() =>
-    keyring.isKeyringVault.value
-    && !keyring.hasValidCredential.value
-    && keyring.flowState.value !== KeyringFlowState.Idle
-    && keyring.flowState.value !== KeyringFlowState.Ready,
-  )
+  const needsVerification = computed(() => keyring.isVerificationRequired.value)
 
   // Provide keyring state to descendant components (VaultFormSubmit)
   provide('keyring-guard', reactive({
@@ -43,6 +38,9 @@ export const useOperationGuard = (vaultAddresses: Ref<(string | undefined)[]> | 
     isExpired: keyring.isExpired,
     flowState: keyring.flowState,
     credentialData: keyring.credentialData,
+    isCheckingStatus: keyring.isCheckingStatus,
+    statusMessage: keyring.statusMessage,
+    error: keyring.error,
     launchExtension: keyring.launchExtension,
     checkStatus: keyring.checkStatus,
     cancelVerification: keyring.cancelVerification,

--- a/tests/composables/useKeyring.test.ts
+++ b/tests/composables/useKeyring.test.ts
@@ -1,0 +1,260 @@
+import { effectScope, nextTick, ref } from 'vue'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Address } from 'viem'
+import type { CredentialData, ExtensionState } from '@keyringnetwork/keyring-connect-sdk'
+
+const USER = '0x1111111111111111111111111111111111111111' as Address
+const OTHER_USER = '0x2222222222222222222222222222222222222222' as Address
+const VAULT = '0x3333333333333333333333333333333333333333' as Address
+const HOOK_TARGET = '0x4444444444444444444444444444444444444444' as Address
+const KEYRING = '0x5555555555555555555555555555555555555555' as Address
+
+const userAddress = ref<Address | undefined>(USER)
+const chainId = ref(1)
+const readContract = vi.fn()
+const isInstalled = vi.fn()
+const getExtensionState = vi.fn()
+const launchExtension = vi.fn()
+const subscribeToExtensionState = vi.fn()
+const vaultAvailable = ref(true)
+
+vi.mock('vue', async importOriginal => ({
+  ...await importOriginal<typeof import('vue')>(),
+  onUnmounted: vi.fn(),
+}))
+
+vi.mock('@wagmi/vue', () => ({
+  useChainId: () => chainId,
+}))
+
+vi.mock('@keyringnetwork/keyring-connect-sdk', () => ({
+  KeyringConnect: {
+    isKeyringConnectInstalled: isInstalled,
+    getExtensionState,
+    launchExtension,
+    subscribeToExtensionState,
+  },
+}))
+
+vi.mock('~/utils/eulerLabelsUtils', () => ({
+  isVaultKeyring: (address: string) => address.toLowerCase() === VAULT.toLowerCase(),
+}))
+
+vi.mock('~/utils/public-client', () => ({
+  getPublicClient: () => ({ readContract }),
+}))
+
+vi.mock('~/utils/vault-hooks', () => ({
+  getVaultHookTarget: () => HOOK_TARGET,
+}))
+
+vi.mock('~/utils/errorHandling', () => ({
+  logWarn: vi.fn(),
+}))
+
+const credential = (overrides: Partial<CredentialData> = {}): CredentialData => ({
+  trader: USER,
+  policyId: 7,
+  chainId: 1,
+  validUntil: 2_000_000_000,
+  cost: 1,
+  key: '0x01',
+  signature: '0x02',
+  backdoor: '0x03',
+  ...overrides,
+})
+
+const extensionState = (overrides: Partial<ExtensionState> = {}): ExtensionState => ({
+  status: 'mounted',
+  manifest: {},
+  ...overrides,
+})
+
+const installContractReads = (hasCredential = false) => {
+  readContract.mockImplementation(async ({ functionName }: { functionName: string }) => {
+    if (functionName === 'policyId') return 7
+    if (functionName === 'keyring') return KEYRING
+    if (functionName === 'checkKeyringCredentialOrWildCard') return hasCredential
+    if (functionName === 'entityExp') return 0n
+    throw new Error(`Unexpected contract read: ${functionName}`)
+  })
+}
+
+describe('useKeyring', () => {
+  let scope = effectScope()
+
+  beforeEach(() => {
+    scope.stop()
+    scope = effectScope()
+    userAddress.value = USER
+    chainId.value = 1
+    readContract.mockReset()
+    isInstalled.mockReset()
+    getExtensionState.mockReset()
+    launchExtension.mockReset()
+    subscribeToExtensionState.mockReset()
+    subscribeToExtensionState.mockReturnValue(vi.fn())
+    vaultAvailable.value = true
+    vi.stubGlobal('useWagmi', () => ({ address: userAddress }))
+    vi.stubGlobal('useVaultRegistry', () => ({
+      getVault: () => vaultAvailable.value ? { address: VAULT } : undefined,
+    }))
+    vi.stubGlobal('useRpcClient', () => ({ rpcUrl: ref('/api/internal/rpc/1') }))
+    vi.stubGlobal('document', {
+      visibilityState: 'visible',
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    })
+    vi.stubGlobal('window', {
+      location: {
+        origin: 'https://app.euler.finance',
+      },
+    })
+  })
+
+  afterEach(() => {
+    scope.stop()
+    vi.unstubAllGlobals()
+  })
+
+  it('blocks the operation while the initial on-chain check is pending', async () => {
+    let resolveCredentialCheck: ((value: boolean) => void) | undefined
+    const pendingCredentialCheck = new Promise<boolean>((resolve) => {
+      resolveCredentialCheck = resolve
+    })
+    installContractReads()
+    readContract.mockImplementation(async ({ functionName }: { functionName: string }) => {
+      if (functionName === 'policyId') return 7
+      if (functionName === 'keyring') return KEYRING
+      if (functionName === 'checkKeyringCredentialOrWildCard') return pendingCredentialCheck
+      if (functionName === 'entityExp') return 0n
+      throw new Error(`Unexpected contract read: ${functionName}`)
+    })
+    isInstalled.mockResolvedValue(false)
+
+    const { KeyringFlowState, useKeyring } = await import('~/composables/useKeyring')
+    const state = scope.run(() => useKeyring(VAULT))!
+
+    expect(state.flowState.value).toBe(KeyringFlowState.Loading)
+    expect(state.isVerificationRequired.value).toBe(true)
+
+    resolveCredentialCheck?.(false)
+    await vi.waitFor(() => expect(state.flowState.value).toBe(KeyringFlowState.Install))
+  })
+
+  it('keeps the Keyring gate loading until hook metadata is available', async () => {
+    vaultAvailable.value = false
+    installContractReads()
+    isInstalled.mockResolvedValue(false)
+
+    const { KeyringFlowState, useKeyring } = await import('~/composables/useKeyring')
+    const state = scope.run(() => useKeyring(VAULT))!
+
+    expect(state.flowState.value).toBe(KeyringFlowState.Loading)
+    expect(state.isVerificationRequired.value).toBe(true)
+    expect(readContract).not.toHaveBeenCalled()
+
+    vaultAvailable.value = true
+    await vi.waitFor(() => expect(state.flowState.value).toBe(KeyringFlowState.Install))
+  })
+
+  it('launches the SDK flow from the install state', async () => {
+    installContractReads()
+    isInstalled.mockResolvedValue(false)
+    launchExtension.mockResolvedValue(undefined)
+
+    const { KeyringFlowState, useKeyring } = await import('~/composables/useKeyring')
+    const state = scope.run(() => useKeyring(VAULT))!
+    await vi.waitFor(() => expect(state.flowState.value).toBe(KeyringFlowState.Install))
+
+    await state.launchExtension()
+
+    expect(launchExtension).toHaveBeenCalledWith(expect.objectContaining({
+      app_url: 'https://app.euler.finance',
+      policy_id: 7,
+      credential_config: {
+        chain_id: 1,
+        wallet_address: USER,
+      },
+    }))
+    expect(subscribeToExtensionState).toHaveBeenCalledOnce()
+  })
+
+  it.each([
+    ['wallet', { trader: OTHER_USER }],
+    ['policy', { policyId: 8 }],
+    ['network', { chainId: 8453 }],
+  ] as const)('does not accept credential data for another %s', async (_context, credentialOverrides) => {
+    installContractReads()
+    isInstalled.mockResolvedValue(true)
+    getExtensionState
+      .mockResolvedValueOnce(extensionState())
+      .mockResolvedValueOnce(extensionState({ credentialData: credential(credentialOverrides) }))
+
+    const { KeyringFlowState, useKeyring } = await import('~/composables/useKeyring')
+    const state = scope.run(() => useKeyring(VAULT))!
+    await vi.waitFor(() => expect(state.flowState.value).toBe(KeyringFlowState.Start))
+
+    state.flowState.value = KeyringFlowState.Progress
+    await state.checkStatus()
+
+    expect(state.credentialData.value).toBeNull()
+    expect(state.flowState.value).toBe(KeyringFlowState.Start)
+    expect(state.statusMessage.value).toContain('connected wallet, policy, and network')
+  })
+
+  it('accepts credential data only for the active wallet, policy, and chain', async () => {
+    installContractReads()
+    isInstalled.mockResolvedValue(true)
+    getExtensionState
+      .mockResolvedValueOnce(extensionState())
+      .mockResolvedValueOnce(extensionState({ credentialData: credential() }))
+
+    const { KeyringFlowState, useKeyring } = await import('~/composables/useKeyring')
+    const state = scope.run(() => useKeyring(VAULT))!
+    await vi.waitFor(() => expect(state.flowState.value).toBe(KeyringFlowState.Start))
+
+    state.flowState.value = KeyringFlowState.Progress
+    await state.checkStatus()
+
+    expect(state.credentialData.value).toEqual(credential())
+    expect(state.flowState.value).toBe(KeyringFlowState.Ready)
+  })
+
+  it('returns to install when the extension disappears during verification', async () => {
+    installContractReads()
+    isInstalled.mockResolvedValue(true)
+    getExtensionState
+      .mockResolvedValueOnce(extensionState())
+      .mockResolvedValueOnce(null)
+
+    const { KeyringFlowState, useKeyring } = await import('~/composables/useKeyring')
+    const state = scope.run(() => useKeyring(VAULT))!
+    await vi.waitFor(() => expect(state.flowState.value).toBe(KeyringFlowState.Start))
+
+    state.flowState.value = KeyringFlowState.Progress
+    await state.checkStatus()
+
+    expect(state.flowState.value).toBe(KeyringFlowState.Install)
+  })
+
+  it('reports an incomplete manual status check instead of silently staying in progress', async () => {
+    installContractReads()
+    isInstalled.mockResolvedValue(true)
+    getExtensionState
+      .mockResolvedValueOnce(extensionState())
+      .mockResolvedValueOnce(extensionState({ status: 'mounted' }))
+
+    const { KeyringFlowState, useKeyring } = await import('~/composables/useKeyring')
+    const state = scope.run(() => useKeyring(VAULT))!
+    await vi.waitFor(() => expect(state.flowState.value).toBe(KeyringFlowState.Start))
+
+    state.flowState.value = KeyringFlowState.Progress
+    await state.checkStatus()
+    await nextTick()
+
+    expect(state.flowState.value).toBe(KeyringFlowState.Start)
+    expect(state.statusMessage.value).toContain('not complete yet')
+    expect(state.isCheckingStatus.value).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- Keep Keyring-gated operations blocked while hook metadata and credential status are loading.
- Route extension installation through the Keyring SDK so install and return navigation use the supported flow.
- Reject extension credentials that do not match the active wallet, policy, and network.

## Changes
- Reconcile install, progress, incomplete, error, and ready extension states through one scoped handler.
- Surface status-check loading and incomplete verification feedback in the form.
- Add focused composable coverage for loading gates, SDK launch, extension loss, incomplete checks, and credential context validation.

## Test plan
- [x] `npm run test:run` — 1,377 passed, 1 skipped
- [x] `npm run typecheck`
- [x] ESLint on the changed Keyring files and tests
- [ ] Complete a real Keyring KYC and credential-injection transaction with an eligible CEX account

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer status messages and loading indicators during keyring verification.
  - Verification errors now display specific messages when available.
  - The keyring extension can be launched directly from the verification flow.
  - Verification now better handles wallet, policy, network, and extension status changes.

- **Bug Fixes**
  - Improved transitions and recovery when verification is incomplete or the extension becomes unavailable.

- **Tests**
  - Added coverage for keyring verification states and credential validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->