### PR TITLE
fix: preserve locked preview SDK installs

### DIFF
--- a/scripts/install-preview-sdk.sh
+++ b/scripts/install-preview-sdk.sh
@@ -106,7 +106,7 @@ mkdir -p "$SDK_PACK_DIR"
 npm pack --ignore-scripts ./packages/euler-v2-sdk --pack-destination "$SDK_PACK_DIR"
 
 cd /usr/src/app
-npm install --no-save --package-lock=false --ignore-scripts "$SDK_PACK_DIR"/*.tgz
+npm install --no-save --ignore-scripts "$SDK_PACK_DIR"/*.tgz
 if ! npm ls @eulerxyz/euler-v2-sdk --depth=0; then
   echo "npm ls reported a version mismatch for the preview SDK tarball; validating runtime exports instead."
 fi


### PR DESCRIPTION
## Summary
- Keep Railway preview SDK installs on the committed Lite dependency graph while replacing the SDK package with a branch tarball.
- Prevent npm dependency-tree re-resolution from breaking previews that set EULER_SDK_BRANCH.

## Changes
- Install the packed preview SDK with no-save and ignore-scripts while retaining package-lock.json resolution.
- Keep package.json and package-lock.json unchanged during the preview-only override.

## Test plan
- [x] Run shell syntax validation for scripts/install-preview-sdk.sh.
- [x] Reproduce the install with Node 24.14.1 and npm 11.11.0 using the fix/keyring-hook-target-getter-fallback SDK branch.
- [x] Confirm the corrected install changes only the SDK package and preserves package.json and package-lock.json hashes.
- [x] Confirm the installed preview SDK exports load successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preview SDK installation now generates package-lock updates when installing packed SDK tarballs.
  * Existing no-save and scripts-disabled installation behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->