### PR TITLE
feat: require scrolling terms to bottom before accepting

### DIFF
--- a/components/entities/operation/AcknowledgeTermsModal.vue
+++ b/components/entities/operation/AcknowledgeTermsModal.vue
@@ -1,4 +1,7 @@
 <script setup lang="ts">
+import { useResizeObserver } from '@vueuse/core'
+import { isScrolledToEnd } from './termsScrollGate'
+
 const props = defineProps<{
   onAccept?: () => void
   onReject?: () => void
@@ -33,6 +36,27 @@ const terms = [
     text: `I acknowledge that Safe Harbor programs have separate rules, and by using the Protocol, I consent to the Whitehat Agreement terms, including eligible fund rescues, bounty deductions, associated risks (including loss and taxes), and holding Euler Community Members harmless.`,
   },
 ]
+
+// Gate the Accept button until the user has scrolled the terms to the bottom,
+// so it can only be clicked after the full text has been surfaced. Once the end
+// has been reached it stays unlocked, even if the user scrolls back up.
+const termsContainer = ref<HTMLElement | null>(null)
+const hasScrolledToEnd = ref(false)
+
+const checkScrolledToEnd = () => {
+  const el = termsContainer.value
+  if (!el || hasScrolledToEnd.value) {
+    return
+  }
+  if (isScrolledToEnd(el)) {
+    hasScrolledToEnd.value = true
+  }
+}
+
+// Re-evaluate on mount and whenever the container is resized (e.g. viewport
+// changes) so a non-overflowing list unlocks the button immediately.
+useResizeObserver(termsContainer, checkScrolledToEnd)
+onMounted(() => nextTick(checkScrolledToEnd))
 
 const onReject = () => {
   if (props.onReject) {
@@ -78,7 +102,11 @@ const onAccept = () => {
         I further represent and warrant:
       </div>
 
-      <div class="bg-surface-secondary rounded-12 overflow-y-auto flex-1 styled-scrollbar">
+      <div
+        ref="termsContainer"
+        class="bg-surface-secondary rounded-12 overflow-y-auto flex-1 styled-scrollbar"
+        @scroll="checkScrolledToEnd"
+      >
         <div
           v-for="(term, index) in terms"
           :key="index"
@@ -110,6 +138,7 @@ const onAccept = () => {
           variant="primary"
           size="xlarge"
           rounded
+          :disabled="!hasScrolledToEnd"
           @click="onAccept"
         >
           Accept

--- a/components/entities/operation/AcknowledgeTermsModal.vue
+++ b/components/entities/operation/AcknowledgeTermsModal.vue
@@ -104,6 +104,9 @@ const onAccept = () => {
 
       <div
         ref="termsContainer"
+        tabindex="0"
+        role="region"
+        aria-label="Terms to review before accepting"
         class="bg-surface-secondary rounded-12 overflow-y-auto flex-1 styled-scrollbar"
         @scroll="checkScrolledToEnd"
       >

--- a/components/entities/operation/termsScrollGate.ts
+++ b/components/entities/operation/termsScrollGate.ts
@@ -1,0 +1,20 @@
+// Default pixel tolerance for treating a scroll position as "at the bottom".
+// Absorbs sub-pixel rounding and momentum scrolling so the Accept button in the
+// Acknowledge terms modal reliably unlocks once the end of the text is reached.
+export const TERMS_SCROLL_END_THRESHOLD = 8
+
+interface ScrollMetrics {
+  scrollTop: number
+  clientHeight: number
+  scrollHeight: number
+}
+
+// Returns true when the scroll position has reached (within `threshold` px) the
+// bottom of the content, or when the content does not overflow at all (in which
+// case there is nothing to scroll and the end is already visible).
+export const isScrolledToEnd = (
+  { scrollTop, clientHeight, scrollHeight }: ScrollMetrics,
+  threshold: number = TERMS_SCROLL_END_THRESHOLD,
+): boolean => {
+  return scrollTop + clientHeight >= scrollHeight - threshold
+}

--- a/tests/components/termsScrollGate.test.ts
+++ b/tests/components/termsScrollGate.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { TERMS_SCROLL_END_THRESHOLD, isScrolledToEnd } from '~/components/entities/operation/termsScrollGate'
+
+describe('isScrolledToEnd', () => {
+  it('is false at the top of overflowing content', () => {
+    expect(isScrolledToEnd({ scrollTop: 0, clientHeight: 400, scrollHeight: 1000 })).toBe(false)
+  })
+
+  it('is false partway through overflowing content', () => {
+    expect(isScrolledToEnd({ scrollTop: 300, clientHeight: 400, scrollHeight: 1000 })).toBe(false)
+  })
+
+  it('is true when scrolled exactly to the bottom', () => {
+    expect(isScrolledToEnd({ scrollTop: 600, clientHeight: 400, scrollHeight: 1000 })).toBe(true)
+  })
+
+  it('is true when within the default threshold of the bottom', () => {
+    expect(isScrolledToEnd({ scrollTop: 600 - TERMS_SCROLL_END_THRESHOLD, clientHeight: 400, scrollHeight: 1000 })).toBe(true)
+  })
+
+  it('is false just beyond the default threshold from the bottom', () => {
+    expect(isScrolledToEnd({ scrollTop: 600 - TERMS_SCROLL_END_THRESHOLD - 1, clientHeight: 400, scrollHeight: 1000 })).toBe(false)
+  })
+
+  it('is true when the content does not overflow (nothing to scroll)', () => {
+    expect(isScrolledToEnd({ scrollTop: 0, clientHeight: 500, scrollHeight: 400 })).toBe(true)
+  })
+
+  it('respects a custom threshold', () => {
+    const metrics = { scrollTop: 550, clientHeight: 400, scrollHeight: 1000 }
+    expect(isScrolledToEnd(metrics, 0)).toBe(false)
+    expect(isScrolledToEnd(metrics, 50)).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

Disables the **Accept** button in the *Acknowledge terms* modal until the user has scrolled the terms text to the bottom, so the full disclosure is surfaced before it can be accepted.

## Behaviour

- Accept starts disabled and unlocks once the terms container is scrolled to its end (with an 8px tolerance for sub-pixel rounding / momentum scrolling).
- Once the end has been reached, Accept stays enabled even if the user scrolls back up.
- If the terms content is short enough that it does not overflow (nothing to scroll), Accept is enabled immediately — handled on mount and via a resize observer, so viewport changes are covered too.
- Reject is unaffected.

## Implementation

- `AcknowledgeTermsModal.vue`: track scroll position on the terms container via a template ref + `@scroll` handler, gate the Accept button with `:disabled`, and re-check on mount and container resize (`useResizeObserver`).
- Extracted the scroll-position check into a pure, framework-agnostic helper (`termsScrollGate.ts`), following the existing sibling-module pattern (`cowSwapReviewState.ts`).

## Tests

- Added `tests/components/termsScrollGate.test.ts` covering top / partway / exact-bottom / within-threshold / beyond-threshold / non-overflowing / custom-threshold cases.
- `vitest` (new test), `eslint`, and `nuxt typecheck` all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terms acceptance is now scroll-gated in the acknowledgement modal: **Accept** remains disabled until the user reaches the end of the terms.
  * The button can unlock automatically when the content doesn’t overflow, and stays enabled once unlocked.
* **Bug Fixes**
  * Improved “scrolled to bottom” detection using a small threshold to handle rounding/sub-pixel scrolling differences.
  * Re-evaluates unlock state on initial render and when the terms area is resized.
* **Tests**
  * Added unit tests covering top/middle/bottom, non-scrollable content, default threshold, and custom threshold behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->