### PR TITLE
fix: remove duplicate unknown exposure badge

### DIFF
--- a/components/entities/vault/overview/earn/VaultOverviewEarnBlockExposure.vue
+++ b/components/entities/vault/overview/earn/VaultOverviewEarnBlockExposure.vue
@@ -30,7 +30,7 @@ const onExposureClick = (address: string) => {
 }
 const { vault, defaultOpen = true } = defineProps<{ vault: EulerEarn, defaultOpen?: boolean }>()
 
-const { getOrFetch, get: registryGet } = useVaultRegistry()
+const { getOrFetch, get: registryGet, isVerifiedVault } = useVaultRegistry()
 const {
   load: loadOpenInterest,
   getOpenInterestForVault,
@@ -351,6 +351,7 @@ load()
               </div>
             </div>
             <VaultTypeBadges
+              v-if="isVerifiedVault(row.vault.address)"
               class="justify-end mt-8 mobile:order-3 mobile:basis-full mobile:justify-end mobile:mt-0 mobile:pt-4"
               :vault="row.vault"
               summary-only


### PR DESCRIPTION
## Summary
- Keep the unverified strategy warning in the Earn exposure card without repeating the same `Unknown` state beside Supply APY.
- Preserve summary badges for strategies recognized by the vault registry.

## Changes
- Show right-side strategy type badges only when the strategy has a verified registry identity.
- Keep stricter governor-verification warnings available for otherwise recognized strategies.

## Test plan
- [x] `npm run test:run -- tests/composables/useVaultTypeBadges.test.ts`
- [x] `npm run typecheck`
- [x] `npx eslint components/entities/vault/overview/earn/VaultOverviewEarnBlockExposure.vue`
- [x] Verify the affected local Earn exposure card renders one left-side `Unknown` and no right-side `Unknown` badge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Vault type badges are now displayed only for verified vaults, improving accuracy and consistency in the vault overview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->