### PR TITLE
fix: render projected-only campaign APR

### DIFF
--- a/components/entities/vault/ProjectedYieldBreakdownModal.vue
+++ b/components/entities/vault/ProjectedYieldBreakdownModal.vue
@@ -1,7 +1,12 @@
 <script setup lang="ts">
 import { formatNumber } from '~/utils/string-utils'
 import { PROVIDER_LABELS, PROVIDER_LOGOS } from '~/entities/reward-campaign'
-import type { ProjectedYieldDetails, ProjectedYieldRateLine } from '~/utils/projected-yield'
+import {
+  getProjectedRewardAprPresentation,
+  type ProjectedYieldDetails,
+  type ProjectedYieldRateLine,
+  type ProjectedYieldRewardLine,
+} from '~/utils/projected-yield'
 
 const emit = defineEmits<{ close: [] }>()
 const {
@@ -60,6 +65,8 @@ const duplicateRateIdentities = computed(() => {
 })
 const showRateVaultAddress = (rate: ProjectedYieldRateLine) =>
   Boolean(rate.vaultAddress && duplicateRateIdentities.value.has(rateIdentity(rate)))
+const rewardAprPresentation = (reward: ProjectedYieldRewardLine) =>
+  getProjectedRewardAprPresentation(reward.beforeApr, reward.afterApr)
 </script>
 
 <template>
@@ -193,12 +200,12 @@ const showRateVaultAddress = (rate: ProjectedYieldRateLine) =>
           </div>
         </div>
         <p class="text-p2 whitespace-nowrap">
-          <template v-if="showTransition(reward.beforeApr, reward.afterApr) || reward.beforeApr == null || reward.afterApr == null">
-            <span class="text-content-tertiary">{{ displayPercent(reward.beforeApr) }}</span>
-            &rarr; {{ displayPercent(reward.afterApr) }}
+          <template v-if="rewardAprPresentation(reward).before != null">
+            <span class="text-content-tertiary">{{ rewardAprPresentation(reward).before }}</span>
+            &rarr; {{ rewardAprPresentation(reward).after }}
           </template>
           <template v-else>
-            {{ displayPercent(reward.afterApr) }}
+            {{ rewardAprPresentation(reward).after }}
           </template>
         </p>
       </div>

--- a/tests/utils/projected-yield.test.ts
+++ b/tests/utils/projected-yield.test.ts
@@ -3,11 +3,19 @@ import type { RewardCampaign } from '~/entities/reward-campaign'
 import type { CollateralApySnapshot } from '~/composables/usePositionCollateralApy'
 import {
   getCollateralSnapshotRateLines,
+  getProjectedRewardAprPresentation,
   getProjectedYieldState,
   mergeProjectedRewardCampaigns,
   projectedYieldHasRewards,
   type ProjectedYieldDetails,
 } from '~/utils/projected-yield'
+
+const renderedRewardApr = (before: number | null | undefined, after: number | null | undefined) => {
+  const presentation = getProjectedRewardAprPresentation(before, after)
+  return presentation.before
+    ? `${presentation.before} → ${presentation.after}`
+    : presentation.after
+}
 
 const campaign = (overrides: Partial<RewardCampaign>): RewardCampaign => ({
   campaignId: 'campaign',
@@ -126,6 +134,30 @@ describe('mergeProjectedRewardCampaigns', () => {
       rewards: [],
     }
     expect(projectedYieldHasRewards(details)).toBe(true)
+  })
+})
+
+describe('getProjectedRewardAprPresentation', () => {
+  it('renders only the projected APR when the current campaign is missing or inapplicable', () => {
+    expect(renderedRewardApr(undefined, 7.23)).toBe('7.23%')
+    expect(renderedRewardApr(null, 7.23)).toBe('7.23%')
+  })
+
+  it('preserves a real zero current APR as an explicit transition', () => {
+    expect(renderedRewardApr(0, 7.23)).toBe('0.00% → 7.23%')
+  })
+
+  it('renders the normal transition when positive current and projected APRs differ', () => {
+    expect(renderedRewardApr(4.56, 7.23)).toBe('4.56% → 7.23%')
+  })
+
+  it('preserves the single-value presentation when current and projected APRs are equal', () => {
+    expect(renderedRewardApr(7.23, 7.23)).toBe('7.23%')
+  })
+
+  it('preserves the transition to missing when there is no projected campaign', () => {
+    expect(renderedRewardApr(7.23, undefined)).toBe('7.23% → -')
+    expect(renderedRewardApr(7.23, null)).toBe('7.23% → -')
   })
 })
 

--- a/utils/projected-yield.ts
+++ b/utils/projected-yield.ts
@@ -2,6 +2,7 @@ import type { YieldApyBreakdown } from '@eulerxyz/euler-v2-sdk'
 import type { RewardCampaign, RewardAction, RewardSource } from '~/entities/reward-campaign'
 import { rewardCampaignDisplay, rewardCampaignKey } from '~/entities/reward-campaign'
 import type { CollateralApySnapshot } from '~/composables/usePositionCollateralApy'
+import { formatNumber } from '~/utils/string-utils'
 
 export type ProjectedYieldMetric = 'net-apy' | 'roe' | 'supply-apy'
 
@@ -51,12 +52,38 @@ export interface ProjectedYieldRewardLine {
   afterApr?: number | null
 }
 
+export interface ProjectedRewardAprPresentation {
+  before?: string
+  after: string
+}
+
 export interface ProjectedYieldDetails {
   metric: ProjectedYieldMetric
   before?: ProjectedYieldState | null
   after: ProjectedYieldState
   rateLines: ProjectedYieldRateLine[]
   rewards: ProjectedYieldRewardLine[]
+}
+
+/**
+ * Format a projected campaign row without treating an inapplicable current
+ * campaign as a negative-looking dash. A numeric zero remains a real current
+ * APR, while a campaign that no longer applies keeps its transition to "-".
+ */
+export const getProjectedRewardAprPresentation = (
+  before: number | null | undefined,
+  after: number | null | undefined,
+): ProjectedRewardAprPresentation => {
+  const display = (value: number | null | undefined) =>
+    value == null ? '-' : `${formatNumber(value)}%`
+  const beforeDisplay = display(before)
+  const afterDisplay = display(after)
+
+  if (before != null && (after == null || beforeDisplay !== afterDisplay)) {
+    return { before: beforeDisplay, after: afterDisplay }
+  }
+
+  return { after: afterDisplay }
 }
 
 const zeroBreakdown = (): YieldApyBreakdown => ({


### PR DESCRIPTION
## Summary
- Show only the projected campaign APR when the campaign is missing or inapplicable in the current position.
- Preserve explicit transitions for real zero values, changed values, and campaigns that no longer apply.

## Changes
- Add campaign-specific APR presentation logic for the projected yield breakdown.
- Keep Net APY totals, market rates, contribution rows, and shared percentage formatting unchanged.
- Cover missing, null, zero, changed, equal, and current-only campaign values.

## Test plan
- [x] npm run test:run -- tests/utils/projected-yield.test.ts --reporter=dot
- [x] npm run test:run -- --reporter=dot (1,389 passed; 1 skipped)
- [x] npm run typecheck
- [x] Scoped ESLint for all changed files
- [x] git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved projected reward APR displays in yield breakdowns.
  * APR transitions now show a clear before-and-after format only when meaningful.
  * Missing APR values are displayed as “-”, while unchanged values are shown once for clarity.

* **Tests**
  * Added coverage for missing, zero, changed, unchanged, and unavailable projected APR values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->