### PR TITLE
fix: defer terms acceptance until wallet connects

### DIFF
--- a/composables/guards/useTosGuard.ts
+++ b/composables/guards/useTosGuard.ts
@@ -12,6 +12,27 @@ export interface TosGuardState {
   acceptTerms: () => void
 }
 
+interface TosRequirementState {
+  hasWalletAddress: boolean
+  enableTosSignature: boolean
+  hasSigned: boolean | null
+  sessionAccepted: boolean
+  tosLoadFailed: boolean
+}
+
+export const isTosAcceptanceRequired = ({
+  hasWalletAddress,
+  enableTosSignature,
+  hasSigned,
+  sessionAccepted,
+  tosLoadFailed,
+}: TosRequirementState): boolean =>
+  hasWalletAddress
+  && enableTosSignature
+  && hasSigned === false
+  && !sessionAccepted
+  && !tosLoadFailed
+
 export const useTosGuard = () => {
   const { address } = useWagmi()
   const { eulerPeripheryAddresses, isReady, loadEulerConfig, chainId } = useEulerAddresses()
@@ -23,9 +44,13 @@ export const useTosGuard = () => {
   const tosLoadFailed = useState<boolean>('tosGuardLoadFailed', () => false)
   const tosData = ref<TosData | null>(null)
 
-  const isTermsRequired = computed(() =>
-    enableTosSignature && hasSigned.value === false && !sessionAccepted.value && !tosLoadFailed.value,
-  )
+  const isTermsRequired = computed(() => isTosAcceptanceRequired({
+    hasWalletAddress: !!address.value,
+    enableTosSignature,
+    hasSigned: hasSigned.value,
+    sessionAccepted: sessionAccepted.value,
+    tosLoadFailed: tosLoadFailed.value,
+  }))
 
   const tosSignerAddress = computed(() =>
     eulerPeripheryAddresses.value?.termsOfUseSigner as Address | undefined,
@@ -118,7 +143,10 @@ export const useTosGuard = () => {
 
   // Register/unregister blocker — fail closed
   const updateBlockerRegistration = () => {
-    if (enableTosSignature && tosLoadFailed.value) {
+    if (!address.value) {
+      unregisterOperationBlocker('tos')
+    }
+    else if (enableTosSignature && tosLoadFailed.value) {
       registerOperationBlocker('tos', 'Unable to load Terms of Use')
     }
     else if (isTermsRequired.value) {

--- a/composables/guards/useTosGuard.ts
+++ b/composables/guards/useTosGuard.ts
@@ -20,6 +20,10 @@ interface TosRequirementState {
   tosLoadFailed: boolean
 }
 
+export const TOS_ACCEPTANCE_PENDING_REASON = 'Checking Terms of Use acceptance'
+export const TOS_LOAD_FAILED_REASON = 'Unable to load Terms of Use'
+export const TOS_ACCEPTANCE_REQUIRED_REASON = 'Terms of Use acceptance required'
+
 export const isTosAcceptanceRequired = ({
   hasWalletAddress,
   enableTosSignature,
@@ -33,6 +37,20 @@ export const isTosAcceptanceRequired = ({
   && !sessionAccepted
   && !tosLoadFailed
 
+export const getTosBlockReason = ({
+  hasWalletAddress,
+  enableTosSignature,
+  hasSigned,
+  sessionAccepted,
+  tosLoadFailed,
+}: TosRequirementState): string | undefined => {
+  if (!hasWalletAddress || !enableTosSignature) return undefined
+  if (tosLoadFailed) return TOS_LOAD_FAILED_REASON
+  if (hasSigned === null) return TOS_ACCEPTANCE_PENDING_REASON
+  if (hasSigned === false && !sessionAccepted) return TOS_ACCEPTANCE_REQUIRED_REASON
+  return undefined
+}
+
 export const useTosGuard = () => {
   const { address } = useWagmi()
   const { eulerPeripheryAddresses, isReady, loadEulerConfig, chainId } = useEulerAddresses()
@@ -44,13 +62,15 @@ export const useTosGuard = () => {
   const tosLoadFailed = useState<boolean>('tosGuardLoadFailed', () => false)
   const tosData = ref<TosData | null>(null)
 
-  const isTermsRequired = computed(() => isTosAcceptanceRequired({
+  const tosRequirementState = computed<TosRequirementState>(() => ({
     hasWalletAddress: !!address.value,
     enableTosSignature,
     hasSigned: hasSigned.value,
     sessionAccepted: sessionAccepted.value,
     tosLoadFailed: tosLoadFailed.value,
   }))
+  const isTermsRequired = computed(() => isTosAcceptanceRequired(tosRequirementState.value))
+  const tosBlockReason = computed(() => getTosBlockReason(tosRequirementState.value))
 
   const tosSignerAddress = computed(() =>
     eulerPeripheryAddresses.value?.termsOfUseSigner as Address | undefined,
@@ -141,30 +161,17 @@ export const useTosGuard = () => {
     }
   }
 
-  // Register/unregister blocker — fail closed
-  const updateBlockerRegistration = () => {
-    if (!address.value) {
-      unregisterOperationBlocker('tos')
-    }
-    else if (enableTosSignature && tosLoadFailed.value) {
-      registerOperationBlocker('tos', 'Unable to load Terms of Use')
-    }
-    else if (isTermsRequired.value) {
-      registerOperationBlocker('tos', 'Terms of Use acceptance required')
-    }
-    else {
-      unregisterOperationBlocker('tos')
-    }
-  }
-
   watch([sessionAccepted, hasSigned, tosSignerAddress, () => tosData.value, address, chainId], () => {
     updateSdkSignature()
-    updateBlockerRegistration()
   }, { immediate: true })
 
-  watch(isTermsRequired, () => {
-    updateBlockerRegistration()
-  })
+  // Keep execution fail-closed while the connected account's signature state
+  // is pending or TOS data is unavailable, without showing the acceptance UI
+  // until the account is confirmed unsigned.
+  watch(tosBlockReason, (reason) => {
+    if (reason) registerOperationBlocker('tos', reason)
+    else unregisterOperationBlocker('tos')
+  }, { immediate: true })
 
   watch(address, (next, prev) => {
     hasSigned.value = null

--- a/tests/composables/useTosGuard.test.ts
+++ b/tests/composables/useTosGuard.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { isTosAcceptanceRequired } from '~/composables/guards/useTosGuard'
+import {
+  getTosBlockReason,
+  isTosAcceptanceRequired,
+  TOS_ACCEPTANCE_PENDING_REASON,
+  TOS_ACCEPTANCE_REQUIRED_REASON,
+  TOS_LOAD_FAILED_REASON,
+} from '~/composables/guards/useTosGuard'
 
 const unsignedAccount = {
   hasWalletAddress: true,
@@ -21,6 +27,13 @@ describe('isTosAcceptanceRequired', () => {
     expect(isTosAcceptanceRequired(unsignedAccount)).toBe(true)
   })
 
+  it('does not prompt while the connected account signature check is pending', () => {
+    expect(isTosAcceptanceRequired({
+      ...unsignedAccount,
+      hasSigned: null,
+    })).toBe(false)
+  })
+
   it('does not require acceptance again after the session accepts it', () => {
     expect(isTosAcceptanceRequired({
       ...unsignedAccount,
@@ -33,5 +46,41 @@ describe('isTosAcceptanceRequired', () => {
       ...unsignedAccount,
       tosLoadFailed: true,
     })).toBe(false)
+  })
+})
+
+describe('getTosBlockReason', () => {
+  it('does not block before a wallet is connected', () => {
+    expect(getTosBlockReason({
+      ...unsignedAccount,
+      hasWalletAddress: false,
+      hasSigned: null,
+    })).toBeUndefined()
+  })
+
+  it('blocks without prompting while the signature check is pending', () => {
+    expect(getTosBlockReason({
+      ...unsignedAccount,
+      hasSigned: null,
+    })).toBe(TOS_ACCEPTANCE_PENDING_REASON)
+  })
+
+  it('blocks a connected unsigned account until terms are accepted', () => {
+    expect(getTosBlockReason(unsignedAccount)).toBe(TOS_ACCEPTANCE_REQUIRED_REASON)
+  })
+
+  it('reacts to load failures even when the account was already signed', () => {
+    expect(getTosBlockReason({
+      ...unsignedAccount,
+      hasSigned: true,
+      tosLoadFailed: true,
+    })).toBe(TOS_LOAD_FAILED_REASON)
+  })
+
+  it('unblocks a connected account that already signed', () => {
+    expect(getTosBlockReason({
+      ...unsignedAccount,
+      hasSigned: true,
+    })).toBeUndefined()
   })
 })

--- a/tests/composables/useTosGuard.test.ts
+++ b/tests/composables/useTosGuard.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { isTosAcceptanceRequired } from '~/composables/guards/useTosGuard'
+
+const unsignedAccount = {
+  hasWalletAddress: true,
+  enableTosSignature: true,
+  hasSigned: false,
+  sessionAccepted: false,
+  tosLoadFailed: false,
+}
+
+describe('isTosAcceptanceRequired', () => {
+  it('does not require acceptance before a wallet is connected', () => {
+    expect(isTosAcceptanceRequired({
+      ...unsignedAccount,
+      hasWalletAddress: false,
+    })).toBe(false)
+  })
+
+  it('requires acceptance for a connected unsigned account', () => {
+    expect(isTosAcceptanceRequired(unsignedAccount)).toBe(true)
+  })
+
+  it('does not require acceptance again after the session accepts it', () => {
+    expect(isTosAcceptanceRequired({
+      ...unsignedAccount,
+      sessionAccepted: true,
+    })).toBe(false)
+  })
+
+  it('leaves load failures to the fail-closed blocker', () => {
+    expect(isTosAcceptanceRequired({
+      ...unsignedAccount,
+      tosLoadFailed: true,
+    })).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- Require a connected wallet before showing Terms of Use acceptance.
- Keep operations fail-closed while signature status is pending or TOS data is unavailable.

## Changes
- Scope the TOS prompt and blocker to connected wallet addresses.
- Track pending, load-failure, and acceptance-required blocker reasons independently from prompt visibility.
- Add focused coverage for disconnected, pending, unsigned, signed, session-accepted, and load-failure states.

## Test plan
- [x] Run focused Vitest coverage for the TOS guard and terms scroll gate (17 tests).
- [x] Run ESLint on the changed files.
- [x] Run the Nuxt typecheck.
- [x] Verify the disconnected supply form renders Connect wallet without a Terms of Use prompt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Terms acceptance requirements are now correctly cleared when no wallet is connected.
  * Terms acceptance is no longer required when terms loading fails, allowing fallback handling to apply.

* **Tests**
  * Added coverage for wallet connection, signature status, session acceptance, and terms-loading failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->