### PR TITLE
fix: keep Keyring polling lifecycle coherent

### DIFF
--- a/composables/useKeyring/index.ts
+++ b/composables/useKeyring/index.ts
@@ -124,6 +124,7 @@ export const useKeyring = (vaultAddress: string | Ref<string>) => {
   let extensionStateVersion = 0
   let credentialExpiryTimer: ReturnType<typeof setTimeout> | null = null
   let credentialExpiryVersion = 0
+  let disposed = false
 
   const isKeyringVault = computed(() => isVaultKeyring(addressRef.value))
 
@@ -136,6 +137,7 @@ export const useKeyring = (vaultAddress: string | Ref<string>) => {
   })
 
   const captureContext = (): KeyringContext | undefined => {
+    if (disposed) return undefined
     const currentHookTarget = hookTarget.value
     const currentUser = userAddress.value
     const currentChainId = chainId.value
@@ -153,7 +155,8 @@ export const useKeyring = (vaultAddress: string | Ref<string>) => {
   }
 
   const isContextCurrent = (context: KeyringContext): boolean =>
-    context.version === contextVersion
+    !disposed
+    && context.version === contextVersion
     && addressRef.value.toLowerCase() === context.vaultAddress
     && hookTarget.value?.toLowerCase() === context.hookTarget.toLowerCase()
     && userAddress.value?.toLowerCase() === context.userAddress.toLowerCase()
@@ -594,6 +597,7 @@ export const useKeyring = (vaultAddress: string | Ref<string>) => {
   )
 
   onUnmounted(() => {
+    disposed = true
     if (typeof document !== 'undefined') {
       document.removeEventListener('visibilitychange', onVisibilityChange)
     }

--- a/composables/useKeyring/index.ts
+++ b/composables/useKeyring/index.ts
@@ -122,6 +122,7 @@ export const useKeyring = (vaultAddress: string | Ref<string>) => {
   let credentialCheckVersion = 0
   let verificationAttempt = 0
   let extensionStateVersion = 0
+  let statusPollingVersion = 0
   let credentialExpiryTimer: ReturnType<typeof setTimeout> | null = null
   let credentialExpiryVersion = 0
   let disposed = false
@@ -415,6 +416,7 @@ export const useKeyring = (vaultAddress: string | Ref<string>) => {
   }
 
   const stopStatusPolling = () => {
+    statusPollingVersion += 1
     if (unsubscribeExtension) {
       unsubscribeExtension()
       unsubscribeExtension = null
@@ -501,7 +503,9 @@ export const useKeyring = (vaultAddress: string | Ref<string>) => {
 
   const startStatusPolling = (context: KeyringContext, attempt: number) => {
     stopStatusPolling()
+    const pollingVersion = statusPollingVersion
     unsubscribeExtension = KeyringConnect.subscribeToExtensionState((state) => {
+      if (pollingVersion !== statusPollingVersion) return
       void processExtensionState(state, context, attempt)
     })
   }

--- a/composables/useKeyring/index.ts
+++ b/composables/useKeyring/index.ts
@@ -480,9 +480,8 @@ export const useKeyring = (vaultAddress: string | Ref<string>) => {
     }
 
     if (manualCheck) {
-      flowState.value = KeyringFlowState.Start
+      flowState.value = KeyringFlowState.Progress
       statusMessage.value = 'Verification is not complete yet. Continue in the Keyring extension.'
-      stopStatusPolling()
     }
   }
 

--- a/tests/composables/useKeyring.test.ts
+++ b/tests/composables/useKeyring.test.ts
@@ -386,24 +386,35 @@ describe('useKeyring', () => {
     expect(unsubscribe).toHaveBeenCalledOnce()
   })
 
-  it('reports an incomplete manual status check instead of silently staying in progress', async () => {
+  it('keeps polling after an incomplete manual status check and accepts a later credential', async () => {
     installContractReads()
     isInstalled.mockResolvedValue(true)
     getExtensionState
       .mockResolvedValueOnce(extensionState())
       .mockResolvedValueOnce(extensionState({ status: 'mounted' }))
+    launchExtension.mockResolvedValue(undefined)
+    const unsubscribe = vi.fn()
+    subscribeToExtensionState.mockReturnValue(unsubscribe)
 
     const { KeyringFlowState, useKeyring } = await import('~/composables/useKeyring')
     const state = scope.run(() => useKeyring(VAULT))!
     await vi.waitFor(() => expect(state.flowState.value).toBe(KeyringFlowState.Start))
 
-    state.flowState.value = KeyringFlowState.Progress
+    await state.launchExtension()
+    const onExtensionState = subscribeToExtensionState.mock.calls[0][0] as (state: ExtensionState | null) => void
     await state.checkStatus()
     await nextTick()
 
-    expect(state.flowState.value).toBe(KeyringFlowState.Start)
+    expect(state.flowState.value).toBe(KeyringFlowState.Progress)
     expect(state.statusMessage.value).toContain('not complete yet')
     expect(state.isCheckingStatus.value).toBe(false)
+    expect(unsubscribe).not.toHaveBeenCalled()
+
+    onExtensionState(extensionState({ credentialData: credential() }))
+    await vi.waitFor(() => expect(state.flowState.value).toBe(KeyringFlowState.Ready))
+
+    expect(state.credentialData.value).toEqual(credential())
+    expect(unsubscribe).toHaveBeenCalledOnce()
   })
 
   it('rejects a cached extension credential after it expires', async () => {

--- a/tests/composables/useKeyring.test.ts
+++ b/tests/composables/useKeyring.test.ts
@@ -426,6 +426,35 @@ describe('useKeyring', () => {
     expect(unsubscribe).toHaveBeenCalledOnce()
   })
 
+  it('ignores an in-flight polling response after a manual check stops polling', async () => {
+    installContractReads()
+    isInstalled.mockResolvedValue(true)
+    getExtensionState
+      .mockResolvedValueOnce(extensionState())
+      .mockResolvedValueOnce(extensionState({ credentialData: credential() }))
+    launchExtension.mockResolvedValue(undefined)
+    const unsubscribe = vi.fn()
+    subscribeToExtensionState.mockReturnValue(unsubscribe)
+
+    const { KeyringFlowState, useKeyring } = await import('~/composables/useKeyring')
+    const state = scope.run(() => useKeyring(VAULT))!
+    await vi.waitFor(() => expect(state.flowState.value).toBe(KeyringFlowState.Start))
+
+    await state.launchExtension()
+    const onExtensionState = subscribeToExtensionState.mock.calls[0][0] as (state: ExtensionState | null) => void
+    await state.checkStatus()
+
+    expect(state.flowState.value).toBe(KeyringFlowState.Ready)
+    expect(state.credentialData.value).toEqual(credential())
+    expect(unsubscribe).toHaveBeenCalledOnce()
+
+    onExtensionState(null)
+    await nextTick()
+
+    expect(state.flowState.value).toBe(KeyringFlowState.Ready)
+    expect(state.credentialData.value).toEqual(credential())
+  })
+
   it('rejects a cached extension credential after it expires', async () => {
     installContractReads()
     isInstalled.mockResolvedValue(true)

--- a/tests/composables/useKeyring.test.ts
+++ b/tests/composables/useKeyring.test.ts
@@ -19,10 +19,13 @@ const getExtensionState = vi.fn()
 const launchExtension = vi.fn()
 const subscribeToExtensionState = vi.fn()
 const vaultAvailable = ref(true)
+const { unmountCallbacks } = vi.hoisted(() => ({
+  unmountCallbacks: [] as Array<() => void>,
+}))
 
 vi.mock('vue', async importOriginal => ({
   ...await importOriginal<typeof import('vue')>(),
-  onUnmounted: vi.fn(),
+  onUnmounted: (callback: () => void) => unmountCallbacks.push(callback),
 }))
 
 vi.mock('@wagmi/vue', () => ({
@@ -80,6 +83,10 @@ const deferred = <T>() => {
   return { promise, resolve }
 }
 
+const runUnmountCallbacks = () => {
+  for (const callback of unmountCallbacks.splice(0)) callback()
+}
+
 const installContractReads = (hasCredential = false) => {
   readContract.mockImplementation(async ({ functionName }: { functionName: string }) => {
     if (functionName === 'policyId') return 7
@@ -94,6 +101,7 @@ describe('useKeyring', () => {
   let scope = effectScope()
 
   beforeEach(() => {
+    runUnmountCallbacks()
     scope.stop()
     scope = effectScope()
     userAddress.value = USER
@@ -125,6 +133,7 @@ describe('useKeyring', () => {
   })
 
   afterEach(() => {
+    runUnmountCallbacks()
     scope.stop()
     vi.useRealTimers()
     vi.unstubAllGlobals()
@@ -508,6 +517,25 @@ describe('useKeyring', () => {
     await launching
 
     expect(state.flowState.value).toBe(KeyringFlowState.Start)
+    expect(subscribeToExtensionState).not.toHaveBeenCalled()
+  })
+
+  it('does not restart polling after the Keyring scope unmounts during launch', async () => {
+    installContractReads()
+    isInstalled.mockResolvedValue(false)
+    const launch = deferred<undefined>()
+    launchExtension.mockReturnValue(launch.promise)
+
+    const { KeyringFlowState, useKeyring } = await import('~/composables/useKeyring')
+    const state = scope.run(() => useKeyring(VAULT))!
+    await vi.waitFor(() => expect(state.flowState.value).toBe(KeyringFlowState.Install))
+
+    const launching = state.launchExtension()
+    expect(state.flowState.value).toBe(KeyringFlowState.Progress)
+    runUnmountCallbacks()
+    launch.resolve(undefined)
+    await launching
+
     expect(subscribeToExtensionState).not.toHaveBeenCalled()
   })
 


### PR DESCRIPTION
## Summary
- Keep Keyring verification active when a manual status check returns a non-terminal mounted state.
- Prevent pending verification work from restarting polling after its component scope unmounts.

## Changes
- Keep the flow in Progress and preserve the active subscription after an incomplete manual check.
- Mark the Keyring context disposed during unmount so pending checks, launches, retries, events, and timers fail their existing context guards.
- Cover both a later credential after an incomplete check and a delayed launch after unmount.

## Test plan
- [x] Run focused Keyring and SDK credential tests (29 passed).
- [x] Run the complete unit test suite (1,475 passed).
- [x] Run typecheck and changed-file ESLint.
- [x] Build the production application.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Keyring status checks to prevent outdated responses from changing the flow after polling stops or restarts.
  * Manual verification now remains in progress when completion is pending, allowing later updates to finish successfully.
  * Prevented background updates and polling from restarting after the Keyring flow is closed.
  * Improved cleanup of in-flight checks during unmounting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->