### PR TITLE
fix: position projected yield sparkles with values

### DIFF
--- a/components/entities/vault/form/ProjectedYieldSummaryRow.vue
+++ b/components/entities/vault/form/ProjectedYieldSummaryRow.vue
@@ -24,7 +24,10 @@ const afterDisplay = computed(() => props.after != null ? formatNumber(props.aft
 </script>
 
 <template>
-  <SummaryRow :label="label">
+  <SummaryRow
+    class="mobile:flex-col mobile:!items-stretch"
+    :label="label"
+  >
     <template #label>
       <span class="inline-flex items-center gap-4">
         <span>{{ label }}</span>

--- a/components/entities/vault/form/ProjectedYieldSummaryRow.vue
+++ b/components/entities/vault/form/ProjectedYieldSummaryRow.vue
@@ -30,29 +30,39 @@ const afterDisplay = computed(() => props.after != null ? formatNumber(props.aft
         <span>{{ label }}</span>
         <UiModalPreviewTrigger
           v-if="details"
-          class="inline-flex min-w-24 min-h-24 items-center justify-center gap-2"
+          class="inline-flex min-w-24 min-h-24 items-center justify-center"
           :component="ProjectedYieldBreakdownModal"
           :modal-data="modalData"
-          :aria-label="`Show ${label} projection${hasRewards ? ' and reward' : ''} breakdown`"
+          :aria-label="`Show ${label} projection breakdown`"
           popover-width="wide"
         >
           <SvgIcon
             class="!w-16 !h-16 text-content-muted hover:text-content-secondary transition-colors"
             name="info-circle"
           />
-          <SvgIcon
-            v-if="hasRewards"
-            class="!w-16 !h-16 text-accent-500"
-            name="sparks"
-          />
         </UiModalPreviewTrigger>
       </span>
     </template>
-    <SummaryValue
-      :before="beforeDisplay"
-      :after="afterDisplay"
-      suffix="%"
-      :estimate-only="estimateOnly"
-    />
+    <div class="inline-flex items-center gap-4">
+      <UiModalPreviewTrigger
+        v-if="details && hasRewards"
+        class="inline-flex min-w-24 min-h-24 items-center justify-center"
+        :component="ProjectedYieldBreakdownModal"
+        :modal-data="modalData"
+        :aria-label="`Show ${label} reward breakdown`"
+        popover-width="wide"
+      >
+        <SvgIcon
+          class="!w-16 !h-16 text-accent-500"
+          name="sparks"
+        />
+      </UiModalPreviewTrigger>
+      <SummaryValue
+        :before="beforeDisplay"
+        :after="afterDisplay"
+        suffix="%"
+        :estimate-only="estimateOnly"
+      />
+    </div>
   </SummaryRow>
 </template>

--- a/components/entities/vault/form/ProjectedYieldSummaryRow.vue
+++ b/components/entities/vault/form/ProjectedYieldSummaryRow.vue
@@ -24,10 +24,7 @@ const afterDisplay = computed(() => props.after != null ? formatNumber(props.aft
 </script>
 
 <template>
-  <SummaryRow
-    class="mobile:flex-col mobile:!items-stretch"
-    :label="label"
-  >
+  <SummaryRow :label="label">
     <template #label>
       <span class="inline-flex items-center gap-4">
         <span>{{ label }}</span>


### PR DESCRIPTION
## Summary
- Places reward sparkles beside projected APY and ROE values so the indicator is visually associated with the metric it affects.
- Keeps the projection info control beside each metric label.
- Keeps projected-yield rows inline when space allows and lets the shared summary layout wrap naturally when content is constrained.

## Changes
- Separates the reward and projection breakdown triggers while reusing the same projected-yield breakdown modal.
- Applies the icon placement consistently through the shared `ProjectedYieldSummaryRow` component.

## Test plan
- [x] `npx eslint components/entities/vault/form/ProjectedYieldSummaryRow.vue`
- [x] `npm run typecheck`
- [x] Verify the PYUSD lend form at `http://127.0.0.1:3211/lend/0xba98fC35C9dfd69178AD5dcE9FA29c64554783b5?network=1` shows reward sparkles beside `5.36%`.
- [x] Verify the projected Supply APY row remains inline at a `390x844` viewport.
- [x] Verify projected-yield rows remain inline at a `1200x800` viewport.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility Improvements**
  * Added dedicated accessible labels for the projection breakdown and reward breakdown controls to improve screen reader clarity.
* **UI Improvements**
  * Refined the projected yield summary layout to better separate projection and reward breakdown actions.
  * Reward breakdown controls and the associated value now appear only when reward details are available, reducing clutter and improving consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->