### PR TITLE
Speed up first batch additions

### DIFF
--- a/composables/batchPrefetchState.ts
+++ b/composables/batchPrefetchState.ts
@@ -1,16 +1,28 @@
-import type { Account, IHasVaultAddress, SlotHints } from '@eulerxyz/euler-v2-sdk'
+import type { Account, IHasVaultAddress } from '@eulerxyz/euler-v2-sdk'
 
 /**
- * Form-load data that the batch builder can safely reuse on the first add.
+ * Form-load accounts the batch builder can safely reuse on the first add.
  *
  * This module deliberately has no composable dependencies. Account, wallet, and
  * batch composables import each other for their simulated-state overlays, so a
  * small neutral registry keeps the prefetch hand-off free of another import
  * cycle.
+ *
+ * Both accounts are stored *pre-overlay* — they are written by the loaders
+ * (`useFreshAccount`, `useEulerAccount`), never read back off the layer-aware
+ * `usePlanAccount` / `useEulerAccount().portfolio` computeds. That matters:
+ * those computeds return the active batch layer's *simulated* account when a
+ * layer is active, which must never become the batch's own layer 0. Consumers
+ * still have to validate chain + owner before reuse (see `isAccountForContext`
+ * in `useTxBatch`) because a wallet or chain switch can land before the
+ * matching loader run replaces these.
+ *
+ * Slot hints are deliberately *not* mirrored here: the SDK's `fetchErc20SlotHints`
+ * already memoises module-scope by `chainId:token`, so once any form has primed a
+ * token the batch's own probe short-circuits to a Map lookup with no RPC.
  */
 let planningAccount: Account<IHasVaultAddress> | undefined
 let baseAccount: Account<IHasVaultAddress> | undefined
-const slotHintsByChain = new Map<number, SlotHints>()
 
 export const setBatchPrefetchedPlanningAccount = (
   account: Account<IHasVaultAddress> | undefined,
@@ -28,22 +40,12 @@ export const setBatchPrefetchedBaseAccount = (
 
 export const getBatchPrefetchedBaseAccount = () => baseAccount
 
-export const mergeBatchPrefetchedSlotHints = (
-  chainId: number,
-  slotHints: SlotHints,
-) => {
-  slotHintsByChain.set(chainId, {
-    ...slotHintsByChain.get(chainId),
-    ...slotHints,
-  })
-}
-
-export const getBatchPrefetchedSlotHints = (chainId: number): SlotHints => ({
-  ...slotHintsByChain.get(chainId),
-})
-
+/**
+ * Drops both prefetched accounts. Production resets flow through the owning
+ * loaders (`useFreshAccount.reset`, `useEulerAccount.resetLoadingState`); this
+ * exists so tests can isolate module state between cases.
+ */
 export const resetBatchPrefetchState = () => {
   planningAccount = undefined
   baseAccount = undefined
-  slotHintsByChain.clear()
 }

--- a/composables/batchPrefetchState.ts
+++ b/composables/batchPrefetchState.ts
@@ -1,0 +1,49 @@
+import type { Account, IHasVaultAddress, SlotHints } from '@eulerxyz/euler-v2-sdk'
+
+/**
+ * Form-load data that the batch builder can safely reuse on the first add.
+ *
+ * This module deliberately has no composable dependencies. Account, wallet, and
+ * batch composables import each other for their simulated-state overlays, so a
+ * small neutral registry keeps the prefetch hand-off free of another import
+ * cycle.
+ */
+let planningAccount: Account<IHasVaultAddress> | undefined
+let baseAccount: Account<IHasVaultAddress> | undefined
+const slotHintsByChain = new Map<number, SlotHints>()
+
+export const setBatchPrefetchedPlanningAccount = (
+  account: Account<IHasVaultAddress> | undefined,
+) => {
+  planningAccount = account
+}
+
+export const getBatchPrefetchedPlanningAccount = () => planningAccount
+
+export const setBatchPrefetchedBaseAccount = (
+  account: Account<IHasVaultAddress> | undefined,
+) => {
+  baseAccount = account
+}
+
+export const getBatchPrefetchedBaseAccount = () => baseAccount
+
+export const mergeBatchPrefetchedSlotHints = (
+  chainId: number,
+  slotHints: SlotHints,
+) => {
+  slotHintsByChain.set(chainId, {
+    ...slotHintsByChain.get(chainId),
+    ...slotHints,
+  })
+}
+
+export const getBatchPrefetchedSlotHints = (chainId: number): SlotHints => ({
+  ...slotHintsByChain.get(chainId),
+})
+
+export const resetBatchPrefetchState = () => {
+  planningAccount = undefined
+  baseAccount = undefined
+  slotHintsByChain.clear()
+}

--- a/composables/repay/useWalletRepay.ts
+++ b/composables/repay/useWalletRepay.ts
@@ -112,10 +112,13 @@ export const useWalletRepay = (options: UseWalletRepayOptions) => {
   })
   const { getVault: registryGetVault } = useVaultRegistry()
 
+  // Pre-prime the repaid asset's ERC20 slot hints so later estimate/sim calls skip
+  // access-list discovery. Speculative, so it must not gate the submit button
+  // (`background: true`) — see `useStateOverrideResolution`.
   watch(
     () => borrowVault.value?.asset.address,
     (assetAddress) => {
-      if (assetAddress) void primeSlotHintsFor([assetAddress as Address])
+      if (assetAddress) void primeSlotHintsFor([assetAddress as Address], { background: true })
     },
     { immediate: true },
   )

--- a/composables/repay/useWalletRepay.ts
+++ b/composables/repay/useWalletRepay.ts
@@ -69,6 +69,7 @@ export const useWalletRepay = (options: UseWalletRepayOptions) => {
   const { error } = useToast()
   const { planRepayFromWallet, executePlan } = useEulerTx()
   const { account: planAccount } = usePlanAccount()
+  const { primeSlotHintsFor } = useStateOverrideOptions()
   const { isConnected } = useWagmi()
   const { isSpyMode } = useSpyMode()
   const { finalizeTxAndRedirect } = useTxFinalization()
@@ -110,6 +111,14 @@ export const useWalletRepay = (options: UseWalletRepayOptions) => {
     return FixedPoint.fromValue(0n, 18)
   })
   const { getVault: registryGetVault } = useVaultRegistry()
+
+  watch(
+    () => borrowVault.value?.asset.address,
+    (assetAddress) => {
+      if (assetAddress) void primeSlotHintsFor([assetAddress as Address])
+    },
+    { immediate: true },
+  )
 
   // Wallet repay touches the liability vault (OP_REPAY). A full repay also
   // sweeps residual collateral shares back to the main account via

--- a/composables/useEulerAccount.ts
+++ b/composables/useEulerAccount.ts
@@ -4,6 +4,7 @@ import { accountDiagnosticOwner, dataIssueLocation, type DataIssue, type Portfol
 import type { EulerLensAddresses } from '~/composables/useEulerAddresses'
 import { useVaults } from '~/composables/useVaults'
 import { useWallets } from '~/composables/useWallets'
+import { setBatchPrefetchedBaseAccount } from '~/composables/batchPrefetchState'
 import { normalizeAddressOrEmpty } from '~/utils/accountPositionHelpers'
 import { createAddressRefreshCoordinator } from '~/utils/address-refresh-coordinator'
 import { logWarn } from '~/utils/errorHandling'
@@ -100,6 +101,7 @@ export const useEulerAccount = () => {
   const resetLoadingState = () => {
     visiblePortfolio.value = undefined
     allPortfolio.value = undefined
+    setBatchPrefetchedBaseAccount(undefined)
     portfolioDiagnostics.value = []
     isPositionsLoaded.value = false
     isPositionsLoading.value = true
@@ -124,6 +126,7 @@ export const useEulerAccount = () => {
       if (!walletAddress) {
         visiblePortfolio.value = undefined
         allPortfolio.value = undefined
+        setBatchPrefetchedBaseAccount(undefined)
         portfolioDiagnostics.value = []
         markLoaded()
         return
@@ -156,11 +159,13 @@ export const useEulerAccount = () => {
 
       allPortfolio.value = nextAllPortfolio
       visiblePortfolio.value = nextVisiblePortfolio
+      setBatchPrefetchedBaseAccount(nextAllPortfolio.account)
       portfolioDiagnostics.value = fetched.errors
       markLoaded()
     }
     catch (error) {
       if (positionGuard.isStale(gen)) return
+      setBatchPrefetchedBaseAccount(undefined)
       logWarn('useEulerAccount/fetchAndUpdatePortfolio', error)
       portfolioDiagnostics.value = [{
         code: 'SOURCE_UNAVAILABLE',

--- a/composables/useFreshAccount.ts
+++ b/composables/useFreshAccount.ts
@@ -2,6 +2,7 @@ import { computed, ref, shallowRef, watch, type Ref } from 'vue'
 import { getAddress, type Address } from 'viem'
 import type { Account, AccountFetchOptions, IHasVaultAddress } from '@eulerxyz/euler-v2-sdk'
 import { getEulerSdkForChain, getEulerSdkFresh } from '~/composables/useEulerSdk'
+import { setBatchPrefetchedPlanningAccount } from '~/composables/batchPrefetchState'
 import { logWarn } from '~/utils/errorHandling'
 
 /**
@@ -45,6 +46,7 @@ const apply = (
   // Priority: fresh always replaces; fast only fills 'none'.
   if (which === 'fresh' || current === 'none') {
     account.value = result
+    setBatchPrefetchedPlanningAccount(result)
     freshnessByCursor.set(cursor, which)
   }
 }
@@ -86,6 +88,7 @@ const load = async (owner: Address, chainId: number) => {
 const reset = () => {
   loadCursor++ // invalidate any in-flight applies
   account.value = undefined
+  setBatchPrefetchedPlanningAccount(undefined)
   isLoading.value = false
 }
 

--- a/composables/useStateOverrideOptions.ts
+++ b/composables/useStateOverrideOptions.ts
@@ -2,7 +2,6 @@ import { ref, watch } from 'vue'
 import { type Address, getAddress } from 'viem'
 import { fetchErc20SlotHints, type SlotHints, type SimulationStateOverrideOptions } from '@eulerxyz/euler-v2-sdk'
 import { getEulerSdkForChain } from '~/composables/useEulerSdk'
-import { mergeBatchPrefetchedSlotHints } from '~/composables/batchPrefetchState'
 import { logWarn } from '~/utils/errorHandling'
 
 const pendingStateOverrideHintResolutions = ref(0)
@@ -33,28 +32,43 @@ export const useStateOverrideResolution = () => ({
  * The composable exposes:
  *  - `buildStateOverrideOptions({ tokens, noBalanceOverride })` — assembles the
  *    options object for the next call.
- *  - `primeSlotHintsFor(tokens)` — fires the slot probes in the background as
- *    soon as the form knows which assets matter. The cache is module-scope so
- *    later calls reuse without re-probing.
+ *  - `primeSlotHintsFor(tokens, { background })` — fires the slot probes as soon
+ *    as the form knows which assets matter. Probes are deduped inside the SDK,
+ *    which memoises resolved hints module-scope by `chainId:token`, so repeat
+ *    calls for a token already primed anywhere in the app cost a Map lookup and
+ *    no RPC. Pass `background: true` for speculative page-load priming so the
+ *    probe does not register as pending work and gate submit buttons (see
+ *    `useStateOverrideResolution`).
  */
 export const useStateOverrideOptions = () => {
   const { balances } = useWallets()
   const { chainId } = useEulerAddresses()
 
-  // Local mirror of slot-hint state so callers can pass it explicitly and the
-  // SDK has a fast path even on the first call after probing. The module-scope
-  // cache inside the SDK is the source of truth long-term; this Map just lets
-  // us snapshot it for the very-next call.
+  // Per-instance mirror of the hints this form has primed, so
+  // `buildStateOverrideOptions` can pass them explicitly and the SDK has a fast
+  // path even on the very first call after probing. The SDK's module-scope cache
+  // is the long-term source of truth; this ref is only a snapshot of what *this*
+  // form asked for. Hints are chain-scoped, so a chain switch has to clear it —
+  // otherwise a token's slot indices from the old chain would be handed to the
+  // new chain's simulator.
   const slotHints = ref<SlotHints>({})
 
   watch(chainId, () => {
     slotHints.value = {}
   }, { flush: 'sync' })
 
-  const primeSlotHintsFor = async (tokens: Address[]): Promise<void> => {
+  const primeSlotHintsFor = async (
+    tokens: Address[],
+    options?: { background?: boolean },
+  ): Promise<void> => {
     if (!tokens.length) return
     const cid = chainId.value
     if (!cid) return
+    // Speculative page-load priming must not gate submit: the counter this
+    // guards hard-disables submit / add-to-batch across every mounted form.
+    // Skipping a cold probe only means the simulator falls back to access-list
+    // discovery, which is what it did before priming existed.
+    const tracksPendingWork = !options?.background
     try {
       const sdk = await getEulerSdkForChain(cid)
       const permit2Address = sdk.deploymentService.getDeployment(cid).addresses.coreAddrs.permit2 as Address
@@ -64,7 +78,7 @@ export const useStateOverrideOptions = () => {
       const provider = sdk.providerService?.getProvider(cid)
       if (!provider) return
       const resolvedHints: SlotHints = {}
-      pendingStateOverrideHintResolutions.value += 1
+      if (tracksPendingWork) pendingStateOverrideHintResolutions.value += 1
       try {
         await Promise.all(tokens.map(async (rawToken) => {
           try {
@@ -78,7 +92,9 @@ export const useStateOverrideOptions = () => {
             logWarn('useStateOverrideOptions/primeSlotHintsFor', e)
           }
         }))
-        mergeBatchPrefetchedSlotHints(cid, resolvedHints)
+        // Re-read after the await: a concurrent prime may have landed its own
+        // hints while these probes were in flight, and snapshotting before the
+        // await would drop them.
         if (chainId.value === cid) {
           slotHints.value = {
             ...slotHints.value,
@@ -87,7 +103,9 @@ export const useStateOverrideOptions = () => {
         }
       }
       finally {
-        pendingStateOverrideHintResolutions.value = Math.max(0, pendingStateOverrideHintResolutions.value - 1)
+        if (tracksPendingWork) {
+          pendingStateOverrideHintResolutions.value = Math.max(0, pendingStateOverrideHintResolutions.value - 1)
+        }
       }
     }
     catch (e) {

--- a/composables/useStateOverrideOptions.ts
+++ b/composables/useStateOverrideOptions.ts
@@ -1,3 +1,4 @@
+import { ref, watch } from 'vue'
 import { type Address, getAddress } from 'viem'
 import { fetchErc20SlotHints, type SlotHints, type SimulationStateOverrideOptions } from '@eulerxyz/euler-v2-sdk'
 import { getEulerSdkForChain } from '~/composables/useEulerSdk'
@@ -46,6 +47,10 @@ export const useStateOverrideOptions = () => {
   // us snapshot it for the very-next call.
   const slotHints = ref<SlotHints>({})
 
+  watch(chainId, () => {
+    slotHints.value = {}
+  }, { flush: 'sync' })
+
   const primeSlotHintsFor = async (tokens: Address[]): Promise<void> => {
     if (!tokens.length) return
     const cid = chainId.value
@@ -58,7 +63,7 @@ export const useStateOverrideOptions = () => {
       // up).
       const provider = sdk.providerService?.getProvider(cid)
       if (!provider) return
-      const next: SlotHints = { ...slotHints.value }
+      const resolvedHints: SlotHints = {}
       pendingStateOverrideHintResolutions.value += 1
       try {
         await Promise.all(tokens.map(async (rawToken) => {
@@ -67,14 +72,19 @@ export const useStateOverrideOptions = () => {
             const hint = await fetchErc20SlotHints(provider, token, {
               allowanceSpender: permit2Address,
             })
-            next[token] = hint
+            resolvedHints[token] = hint
           }
           catch (e) {
             logWarn('useStateOverrideOptions/primeSlotHintsFor', e)
           }
         }))
-        slotHints.value = next
-        mergeBatchPrefetchedSlotHints(cid, next)
+        mergeBatchPrefetchedSlotHints(cid, resolvedHints)
+        if (chainId.value === cid) {
+          slotHints.value = {
+            ...slotHints.value,
+            ...resolvedHints,
+          }
+        }
       }
       finally {
         pendingStateOverrideHintResolutions.value = Math.max(0, pendingStateOverrideHintResolutions.value - 1)

--- a/composables/useStateOverrideOptions.ts
+++ b/composables/useStateOverrideOptions.ts
@@ -1,6 +1,7 @@
 import { type Address, getAddress } from 'viem'
 import { fetchErc20SlotHints, type SlotHints, type SimulationStateOverrideOptions } from '@eulerxyz/euler-v2-sdk'
 import { getEulerSdkForChain } from '~/composables/useEulerSdk'
+import { mergeBatchPrefetchedSlotHints } from '~/composables/batchPrefetchState'
 import { logWarn } from '~/utils/errorHandling'
 
 const pendingStateOverrideHintResolutions = ref(0)
@@ -73,6 +74,7 @@ export const useStateOverrideOptions = () => {
           }
         }))
         slotHints.value = next
+        mergeBatchPrefetchedSlotHints(cid, next)
       }
       finally {
         pendingStateOverrideHintResolutions.value = Math.max(0, pendingStateOverrideHintResolutions.value - 1)

--- a/composables/useTxBatch.ts
+++ b/composables/useTxBatch.ts
@@ -1672,7 +1672,7 @@ export const useTxBatch = () => {
       lastMerged = merged
       const sim = await sdk.executionService.simulateTransactionPlan(
         cid,
-        baseAccount,
+        ownerAddr,
         merged,
         {
           stateOverrides: true,

--- a/composables/useTxBatch.ts
+++ b/composables/useTxBatch.ts
@@ -11,6 +11,12 @@ import type {
   VaultEntity,
 } from '@eulerxyz/euler-v2-sdk'
 import { getEulerSdkFresh } from '~/composables/useEulerSdk'
+import {
+  getBatchPrefetchedBaseAccount,
+  getBatchPrefetchedPlanningAccount,
+  getBatchPrefetchedSlotHints,
+  mergeBatchPrefetchedSlotHints,
+} from '~/composables/batchPrefetchState'
 import { getCurrentEulerLabelsData } from '~/composables/useEulerLabels'
 import { useTenderlySimulation } from '~/composables/useTenderlySimulation'
 import {
@@ -137,7 +143,16 @@ type BatchEntryBuildResult = TransactionPlan | {
 
 type BatchEntryInputBase = Omit<BatchEntry, 'id' | 'plan'>
 
-export type BatchEntryInput = BatchEntryInputBase & (
+interface BatchEntryPrefetchedContext {
+  /** Fresh account already loaded by the form for add-time plan construction. */
+  planningAccount?: Account<IHasVaultAddress>
+  /** Enriched portfolio account to keep as layer 0 and reuse during simulation. */
+  baseAccount?: Account<IHasVaultAddress>
+  /** Slot hints already primed by the form; avoids probing the same token again. */
+  slotHints?: SlotHints
+}
+
+export type BatchEntryInput = BatchEntryInputBase & BatchEntryPrefetchedContext & (
   {
     /** Builds this entry once, at add-time, against the current batch end-state. */
     buildPlan: (account: Account<IHasVaultAddress>) => Promise<BatchEntryBuildResult>
@@ -448,6 +463,7 @@ const primeBatchSlotHintsFor = async (chainId: number, tokens: Address[]): Promi
       }
     }))
     batchSlotHints = next
+    mergeBatchPrefetchedSlotHints(chainId, next)
   }
   catch (error) {
     logWarn('useTxBatch/primeBatchSlotHintsFor', error)
@@ -620,6 +636,20 @@ export const fetchBaseAccountSnapshot = async (
     populateAll: true,
   })
   return fetched.result as Account<IHasVaultAddress>
+}
+
+const isAccountForContext = (
+  account: Account<IHasVaultAddress> | undefined,
+  chainId: number,
+  owner: Address,
+): account is Account<IHasVaultAddress> => {
+  if (!account || account.chainId !== chainId) return false
+  try {
+    return getAddress(account.owner) === owner
+  }
+  catch {
+    return false
+  }
 }
 
 /**
@@ -1619,10 +1649,14 @@ export const useTxBatch = () => {
     try {
       const sdk = await getEulerSdkFresh()
       const ownerAddr = getAddress(o)
+      const prefetchedBaseAccount = getBatchPrefetchedBaseAccount()
       // Keep the real base state fixed for the lifetime of the cart. Entry plans
       // are immutable add-time payloads; later real-state drift should not cause
       // the whole batch to rebuild around a different base account.
       const baseAccount = baseAccountSnapshot
+        ?? (isAccountForContext(prefetchedBaseAccount, cid, ownerAddr)
+          ? prefetchedBaseAccount
+          : undefined)
         ?? await fetchBaseAccountSnapshot(sdk, cid, ownerAddr)
       baseAccountSnapshot = baseAccount
 
@@ -1638,7 +1672,7 @@ export const useTxBatch = () => {
       lastMerged = merged
       const sim = await sdk.executionService.simulateTransactionPlan(
         cid,
-        ownerAddr,
+        baseAccount,
         merged,
         {
           stateOverrides: true,
@@ -1944,7 +1978,10 @@ export const useTxBatch = () => {
     })
   }
 
-  const getEntryPlanningAccount = async (): Promise<Account<IHasVaultAddress>> => {
+  const getEntryPlanningAccount = async (
+    preferredPlanningAccount?: Account<IHasVaultAddress>,
+    preferredBaseAccount?: Account<IHasVaultAddress>,
+  ): Promise<Account<IHasVaultAddress>> => {
     const getCurrentFinalLayer = () => (
       entries.value.length > 0 && layers.value.length === entries.value.length + 1
         ? layers.value[layers.value.length - 1]?.account
@@ -1984,20 +2021,49 @@ export const useTxBatch = () => {
       }
     }
 
-    if (baseAccountSnapshot) {
-      logBatchDiag('getEntryPlanningAccount:base-snapshot-cached')
-      return baseAccountSnapshot
-    }
-
     const o = owner.value
     const cid = chainId.value
     if (!o || !cid) {
       logBatchDiag('getEntryPlanningAccount:account-not-loaded', { owner: o, chainId: cid }, 'error')
       throw new Error('Account not loaded')
     }
+    const ownerAddress = getAddress(o)
+    const suppliedBaseAccount = isAccountForContext(preferredBaseAccount, cid, ownerAddress)
+      ? preferredBaseAccount
+      : undefined
+    const sharedBaseAccount = getBatchPrefetchedBaseAccount()
+    const resolvedBaseAccount = suppliedBaseAccount
+      ?? (isAccountForContext(sharedBaseAccount, cid, ownerAddress)
+        ? sharedBaseAccount
+        : undefined)
+    const suppliedPlanningAccount = isAccountForContext(preferredPlanningAccount, cid, ownerAddress)
+      ? preferredPlanningAccount
+      : undefined
+    const sharedPlanningAccount = getBatchPrefetchedPlanningAccount()
+    const resolvedPlanningAccount = suppliedPlanningAccount
+      ?? (isAccountForContext(sharedPlanningAccount, cid, ownerAddress)
+        ? sharedPlanningAccount
+        : undefined)
+
+    if (resolvedBaseAccount) {
+      baseAccountSnapshot = resolvedBaseAccount
+    }
+    if (resolvedPlanningAccount) {
+      logBatchDiag('getEntryPlanningAccount:preferred-planning-account')
+      return resolvedPlanningAccount
+    }
+    if (resolvedBaseAccount) {
+      logBatchDiag('getEntryPlanningAccount:preferred-base-account')
+      return resolvedBaseAccount
+    }
+    if (baseAccountSnapshot) {
+      logBatchDiag('getEntryPlanningAccount:base-snapshot-cached')
+      return baseAccountSnapshot
+    }
+
     logBatchDiag('getEntryPlanningAccount:base-snapshot-fetch', { owner: o, chainId: cid })
     const sdk = await getEulerSdkFresh()
-    baseAccountSnapshot = await fetchBaseAccountSnapshot(sdk, cid, getAddress(o))
+    baseAccountSnapshot = await fetchBaseAccountSnapshot(sdk, cid, ownerAddress)
     return baseAccountSnapshot
   }
 
@@ -2016,16 +2082,47 @@ export const useTxBatch = () => {
         subAccount: entry.subAccount,
         requiresPlanningAccount: entry.requiresPlanningAccount !== false,
       })
+      const preflightChainId = chainId.value
+      const currentOwner = owner.value
+      if (!baseAccountSnapshot && preflightChainId && currentOwner && entry.baseAccount) {
+        try {
+          const ownerAddress = getAddress(currentOwner)
+          if (isAccountForContext(entry.baseAccount, preflightChainId, ownerAddress)) {
+            baseAccountSnapshot = entry.baseAccount
+          }
+        }
+        catch {
+          // Account-free entries can still build without a valid wallet context.
+          // The simulator will surface the normal account-loading error later.
+        }
+      }
       const buildResult = entry.requiresPlanningAccount === false
         ? await entry.buildPlan()
-        : await entry.buildPlan(await getEntryPlanningAccount())
+        : await entry.buildPlan(await getEntryPlanningAccount(
+            entry.planningAccount,
+            entry.baseAccount,
+          ))
       const plan = Array.isArray(buildResult) ? buildResult : buildResult.plan
       const builtStateOverrides = Array.isArray(buildResult) ? undefined : buildResult.stateOverrides
       const cid = chainId.value
       if (cid) {
-        await primeBatchSlotHintsFor(cid, collectRequiredApprovalTokens(plan))
+        batchSlotHints = {
+          ...getBatchPrefetchedSlotHints(cid),
+          ...batchSlotHints,
+          ...entry.slotHints,
+        }
+        const missingSlotHintTokens = collectRequiredApprovalTokens(plan)
+          .filter(token => batchSlotHints[token] === undefined)
+        await primeBatchSlotHintsFor(cid, missingSlotHintTokens)
       }
-      const { buildPlan: _buildPlan, requiresPlanningAccount: _requiresPlanningAccount, ...fixedEntry } = entry
+      const {
+        buildPlan: _buildPlan,
+        requiresPlanningAccount: _requiresPlanningAccount,
+        planningAccount: _planningAccount,
+        baseAccount: _baseAccount,
+        slotHints: _slotHints,
+        ...fixedEntry
+      } = entry
       registerReviewAssetMeta(fixedEntry.review)
       entries.value = [...entries.value, {
         ...fixedEntry,

--- a/composables/useTxBatch.ts
+++ b/composables/useTxBatch.ts
@@ -14,8 +14,6 @@ import { getEulerSdkFresh } from '~/composables/useEulerSdk'
 import {
   getBatchPrefetchedBaseAccount,
   getBatchPrefetchedPlanningAccount,
-  getBatchPrefetchedSlotHints,
-  mergeBatchPrefetchedSlotHints,
 } from '~/composables/batchPrefetchState'
 import { getCurrentEulerLabelsData } from '~/composables/useEulerLabels'
 import { useTenderlySimulation } from '~/composables/useTenderlySimulation'
@@ -143,16 +141,7 @@ type BatchEntryBuildResult = TransactionPlan | {
 
 type BatchEntryInputBase = Omit<BatchEntry, 'id' | 'plan'>
 
-interface BatchEntryPrefetchedContext {
-  /** Fresh account already loaded by the form for add-time plan construction. */
-  planningAccount?: Account<IHasVaultAddress>
-  /** Enriched portfolio account to keep as layer 0 and reuse during simulation. */
-  baseAccount?: Account<IHasVaultAddress>
-  /** Slot hints already primed by the form; avoids probing the same token again. */
-  slotHints?: SlotHints
-}
-
-export type BatchEntryInput = BatchEntryInputBase & BatchEntryPrefetchedContext & (
+export type BatchEntryInput = BatchEntryInputBase & (
   {
     /** Builds this entry once, at add-time, against the current batch end-state. */
     buildPlan: (account: Account<IHasVaultAddress>) => Promise<BatchEntryBuildResult>
@@ -463,7 +452,6 @@ const primeBatchSlotHintsFor = async (chainId: number, tokens: Address[]): Promi
       }
     }))
     batchSlotHints = next
-    mergeBatchPrefetchedSlotHints(chainId, next)
   }
   catch (error) {
     logWarn('useTxBatch/primeBatchSlotHintsFor', error)
@@ -649,6 +637,31 @@ const isAccountForContext = (
   }
   catch {
     return false
+  }
+}
+
+/**
+ * Prefetched accounts the forms already loaded, valid for this wallet context.
+ *
+ * Read straight from the registry rather than accepting them per entry: the refs
+ * a page would hand over (`usePlanAccount().account`,
+ * `useEulerAccount().portfolio`) are layer-aware and resolve to the active
+ * *simulated* layer once the batch is non-empty, which must never be adopted as
+ * the batch's own layer 0. The registry only ever holds pre-overlay loader
+ * output, so chain + owner is the whole validation.
+ */
+const resolvePrefetchedAccounts = (
+  chainId: number,
+  owner: Address,
+): {
+  planningAccount?: Account<IHasVaultAddress>
+  baseAccount?: Account<IHasVaultAddress>
+} => {
+  const planningAccount = getBatchPrefetchedPlanningAccount()
+  const baseAccount = getBatchPrefetchedBaseAccount()
+  return {
+    planningAccount: isAccountForContext(planningAccount, chainId, owner) ? planningAccount : undefined,
+    baseAccount: isAccountForContext(baseAccount, chainId, owner) ? baseAccount : undefined,
   }
 }
 
@@ -1649,14 +1662,11 @@ export const useTxBatch = () => {
     try {
       const sdk = await getEulerSdkFresh()
       const ownerAddr = getAddress(o)
-      const prefetchedBaseAccount = getBatchPrefetchedBaseAccount()
       // Keep the real base state fixed for the lifetime of the cart. Entry plans
       // are immutable add-time payloads; later real-state drift should not cause
       // the whole batch to rebuild around a different base account.
       const baseAccount = baseAccountSnapshot
-        ?? (isAccountForContext(prefetchedBaseAccount, cid, ownerAddr)
-          ? prefetchedBaseAccount
-          : undefined)
+        ?? resolvePrefetchedAccounts(cid, ownerAddr).baseAccount
         ?? await fetchBaseAccountSnapshot(sdk, cid, ownerAddr)
       baseAccountSnapshot = baseAccount
 
@@ -1978,10 +1988,7 @@ export const useTxBatch = () => {
     })
   }
 
-  const getEntryPlanningAccount = async (
-    preferredPlanningAccount?: Account<IHasVaultAddress>,
-    preferredBaseAccount?: Account<IHasVaultAddress>,
-  ): Promise<Account<IHasVaultAddress>> => {
+  const getEntryPlanningAccount = async (): Promise<Account<IHasVaultAddress>> => {
     const getCurrentFinalLayer = () => (
       entries.value.length > 0 && layers.value.length === entries.value.length + 1
         ? layers.value[layers.value.length - 1]?.account
@@ -2028,33 +2035,21 @@ export const useTxBatch = () => {
       throw new Error('Account not loaded')
     }
     const ownerAddress = getAddress(o)
-    const suppliedBaseAccount = isAccountForContext(preferredBaseAccount, cid, ownerAddress)
-      ? preferredBaseAccount
-      : undefined
-    const sharedBaseAccount = getBatchPrefetchedBaseAccount()
-    const resolvedBaseAccount = suppliedBaseAccount
-      ?? (isAccountForContext(sharedBaseAccount, cid, ownerAddress)
-        ? sharedBaseAccount
-        : undefined)
-    const suppliedPlanningAccount = isAccountForContext(preferredPlanningAccount, cid, ownerAddress)
-      ? preferredPlanningAccount
-      : undefined
-    const sharedPlanningAccount = getBatchPrefetchedPlanningAccount()
-    const resolvedPlanningAccount = suppliedPlanningAccount
-      ?? (isAccountForContext(sharedPlanningAccount, cid, ownerAddress)
-        ? sharedPlanningAccount
-        : undefined)
+    // Only reachable with an empty cart (non-empty carts return the final layer
+    // above), so `baseAccountSnapshot` is null here and adopting the prefetched
+    // base cannot displace a snapshot already pinned for this cart.
+    const { planningAccount, baseAccount } = resolvePrefetchedAccounts(cid, ownerAddress)
 
-    if (resolvedBaseAccount) {
-      baseAccountSnapshot = resolvedBaseAccount
+    if (baseAccount) {
+      baseAccountSnapshot = baseAccount
     }
-    if (resolvedPlanningAccount) {
-      logBatchDiag('getEntryPlanningAccount:preferred-planning-account')
-      return resolvedPlanningAccount
+    if (planningAccount) {
+      logBatchDiag('getEntryPlanningAccount:prefetched-planning-account')
+      return planningAccount
     }
-    if (resolvedBaseAccount) {
-      logBatchDiag('getEntryPlanningAccount:preferred-base-account')
-      return resolvedBaseAccount
+    if (baseAccount) {
+      logBatchDiag('getEntryPlanningAccount:prefetched-base-account')
+      return baseAccount
     }
     if (baseAccountSnapshot) {
       logBatchDiag('getEntryPlanningAccount:base-snapshot-cached')
@@ -2082,14 +2077,14 @@ export const useTxBatch = () => {
         subAccount: entry.subAccount,
         requiresPlanningAccount: entry.requiresPlanningAccount !== false,
       })
+      // Account-free entries never reach `getEntryPlanningAccount`, so seed layer 0
+      // from the prefetched base here too — otherwise resimulate would refetch it.
       const preflightChainId = chainId.value
       const currentOwner = owner.value
-      if (!baseAccountSnapshot && preflightChainId && currentOwner && entry.baseAccount) {
+      if (!baseAccountSnapshot && preflightChainId && currentOwner) {
         try {
-          const ownerAddress = getAddress(currentOwner)
-          if (isAccountForContext(entry.baseAccount, preflightChainId, ownerAddress)) {
-            baseAccountSnapshot = entry.baseAccount
-          }
+          const { baseAccount } = resolvePrefetchedAccounts(preflightChainId, getAddress(currentOwner))
+          if (baseAccount) baseAccountSnapshot = baseAccount
         }
         catch {
           // Account-free entries can still build without a valid wallet context.
@@ -2098,19 +2093,14 @@ export const useTxBatch = () => {
       }
       const buildResult = entry.requiresPlanningAccount === false
         ? await entry.buildPlan()
-        : await entry.buildPlan(await getEntryPlanningAccount(
-            entry.planningAccount,
-            entry.baseAccount,
-          ))
+        : await entry.buildPlan(await getEntryPlanningAccount())
       const plan = Array.isArray(buildResult) ? buildResult : buildResult.plan
       const builtStateOverrides = Array.isArray(buildResult) ? undefined : buildResult.stateOverrides
       const cid = chainId.value
       if (cid) {
-        batchSlotHints = {
-          ...getBatchPrefetchedSlotHints(cid),
-          ...batchSlotHints,
-          ...entry.slotHints,
-        }
+        // Probe only what this batch has not resolved yet. Tokens any form already
+        // primed cost no RPC — the SDK memoises hints by `chainId:token` — but they
+        // still have to land in `batchSlotHints`, which is what the simulator reads.
         const missingSlotHintTokens = collectRequiredApprovalTokens(plan)
           .filter(token => batchSlotHints[token] === undefined)
         await primeBatchSlotHintsFor(cid, missingSlotHintTokens)
@@ -2118,9 +2108,6 @@ export const useTxBatch = () => {
       const {
         buildPlan: _buildPlan,
         requiresPlanningAccount: _requiresPlanningAccount,
-        planningAccount: _planningAccount,
-        baseAccount: _baseAccount,
-        slotHints: _slotHints,
         ...fixedEntry
       } = entry
       registerReviewAssetMeta(fixedEntry.review)

--- a/pages/earn/[vault]/index.vue
+++ b/pages/earn/[vault]/index.vue
@@ -7,6 +7,7 @@ import { isVaultBlockedByCountry } from '~/composables/useGeoBlock'
 import VaultFormInfoBlock from '~/components/entities/vault/form/VaultFormInfoBlock.vue'
 import VaultFormSubmit from '~/components/entities/vault/form/VaultFormSubmit.vue'
 import { formatNumber } from '~/utils/string-utils'
+import { isNativeCurrencyAddress } from '~/utils/native-currency'
 import { isOperationBlocked } from '~/utils/operationGuardRegistry'
 import type { DisabledReasonInfo } from '~/components/entities/vault/form/types'
 import { useModal } from '~/components/ui/composables/useModal'
@@ -64,10 +65,14 @@ const supplyApyBreakdown = computed(() => vault.value ? computeSupplyApyBreakdow
 const visibleApyBreakdown = computed(() => visibleBreakdown(supplyApyBreakdown.value))
 const supplyApyTotal = computed(() => visibleTotal(supplyApyBreakdown.value) ?? 0)
 
+// Pre-prime ERC20 slot hints for the vault asset. One probe per token,
+// owner-/spender-agnostic; later estimate/sim calls skip access-list discovery.
+// Speculative, so it must not gate the submit button (`background: true`).
 watch(
   () => asset.value?.address,
   (assetAddress) => {
-    if (assetAddress) void primeSlotHintsFor([assetAddress as Address])
+    if (!assetAddress || isNativeCurrencyAddress(assetAddress)) return
+    void primeSlotHintsFor([assetAddress as Address], { background: true })
   },
   { immediate: true },
 )

--- a/pages/earn/[vault]/index.vue
+++ b/pages/earn/[vault]/index.vue
@@ -27,6 +27,7 @@ const { isReady: isLabelsReady } = useEulerLabels()
 const { isConnected, address } = useWagmi()
 const { isSpyMode } = useSpyMode()
 const { chainId } = useEulerAddresses()
+const { primeSlotHintsFor } = useStateOverrideOptions()
 const shareLinkQuery = computed(() => {
   const network = route.query.network
 
@@ -62,6 +63,14 @@ const hasRewards = computed(() => settings.value.enableRewardsApy && hasSupplyRe
 const supplyApyBreakdown = computed(() => vault.value ? computeSupplyApyBreakdown(vault.value, viewer.value) : undefined)
 const visibleApyBreakdown = computed(() => visibleBreakdown(supplyApyBreakdown.value))
 const supplyApyTotal = computed(() => visibleTotal(supplyApyBreakdown.value) ?? 0)
+
+watch(
+  () => asset.value?.address,
+  (assetAddress) => {
+    if (assetAddress) void primeSlotHintsFor([assetAddress as Address])
+  },
+  { immediate: true },
+)
 
 const applyLoadedVault = (loadedVault: EulerEarn) => {
   vault.value = loadedVault

--- a/pages/lend/[vault]/index.vue
+++ b/pages/lend/[vault]/index.vue
@@ -79,10 +79,11 @@ const { planDeposit, planDepositWithSwap, prepareTransactionPlan, executePrepare
 const { addEntry: addBatchEntry } = useTxBatch()
 const { redirectAfterAdd } = useBatchRedirect()
 const { account: planAccount } = usePlanAccount()
+const { portfolio } = useEulerAccount()
 // Page validates "Not enough balance" up front (see `errorText` / `isSubmitDisabled`),
 // so the simulator never needs to forge wallet balances — `noBalanceOverride: true`
 // skips per-call balanceOf + slot probing.
-const { primeSlotHintsFor, buildStateOverrideOptions } = useStateOverrideOptions()
+const { primeSlotHintsFor, buildStateOverrideOptions, slotHints } = useStateOverrideOptions()
 const buildLendStateOverrideOptions = () => buildStateOverrideOptions({ noBalanceOverride: true })
 const lendPluginPrefetch: PluginPrefetchData = { pyth: { entries: [] } }
 const getLendPluginPrefetch = async (): Promise<PluginPrefetchData> => lendPluginPrefetch
@@ -615,6 +616,9 @@ const addToBatch = async () => {
       if (!swapAsset) return
       await addBatchEntry({
         label: `Deposit ${asset.value.symbol}`,
+        planningAccount: planAccount.value,
+        baseAccount: portfolio.value?.account,
+        slotHints: slotHints.value,
         buildPlan: account => buildSwapSupplyPlanFromQuote(quote, account, { selectedAsset: swapAsset, amount: swapAmount }),
         subAccount: effectiveAddress.value as Address | undefined,
         review: { type: 'swap-supply', asset: swapAsset, amount: swapAmount, swapToAsset: asset.value, swapToAmount: swapOutput, swapMode: SwapperMode.EXACT_IN, quoteFetchedAt: swapEffectiveQuoteFetchedAt.value },
@@ -625,6 +629,9 @@ const addToBatch = async () => {
       const supplyAmount = valueToNano(amount.value, asset.value.decimals)
       await addBatchEntry({
         label: `Deposit ${amount.value} ${asset.value.symbol}`,
+        planningAccount: planAccount.value,
+        baseAccount: portfolio.value?.account,
+        slotHints: slotHints.value,
         buildPlan: account => planDeposit({ vaultAddress: vaultAddress as Address, assetAddress: assetAddr, amount: supplyAmount, account }),
         subAccount: effectiveAddress.value as Address | undefined,
         review: { type: 'supply', asset: asset.value, amount: amount.value },

--- a/pages/lend/[vault]/index.vue
+++ b/pages/lend/[vault]/index.vue
@@ -79,11 +79,10 @@ const { planDeposit, planDepositWithSwap, prepareTransactionPlan, executePrepare
 const { addEntry: addBatchEntry } = useTxBatch()
 const { redirectAfterAdd } = useBatchRedirect()
 const { account: planAccount } = usePlanAccount()
-const { portfolio } = useEulerAccount()
 // Page validates "Not enough balance" up front (see `errorText` / `isSubmitDisabled`),
 // so the simulator never needs to forge wallet balances — `noBalanceOverride: true`
 // skips per-call balanceOf + slot probing.
-const { primeSlotHintsFor, buildStateOverrideOptions, slotHints } = useStateOverrideOptions()
+const { primeSlotHintsFor, buildStateOverrideOptions } = useStateOverrideOptions()
 const buildLendStateOverrideOptions = () => buildStateOverrideOptions({ noBalanceOverride: true })
 const lendPluginPrefetch: PluginPrefetchData = { pyth: { entries: [] } }
 const getLendPluginPrefetch = async (): Promise<PluginPrefetchData> => lendPluginPrefetch
@@ -616,9 +615,6 @@ const addToBatch = async () => {
       if (!swapAsset) return
       await addBatchEntry({
         label: `Deposit ${asset.value.symbol}`,
-        planningAccount: planAccount.value,
-        baseAccount: portfolio.value?.account,
-        slotHints: slotHints.value,
         buildPlan: account => buildSwapSupplyPlanFromQuote(quote, account, { selectedAsset: swapAsset, amount: swapAmount }),
         subAccount: effectiveAddress.value as Address | undefined,
         review: { type: 'swap-supply', asset: swapAsset, amount: swapAmount, swapToAsset: asset.value, swapToAmount: swapOutput, swapMode: SwapperMode.EXACT_IN, quoteFetchedAt: swapEffectiveQuoteFetchedAt.value },
@@ -629,9 +625,6 @@ const addToBatch = async () => {
       const supplyAmount = valueToNano(amount.value, asset.value.decimals)
       await addBatchEntry({
         label: `Deposit ${amount.value} ${asset.value.symbol}`,
-        planningAccount: planAccount.value,
-        baseAccount: portfolio.value?.account,
-        slotHints: slotHints.value,
         buildPlan: account => planDeposit({ vaultAddress: vaultAddress as Address, assetAddress: assetAddr, amount: supplyAmount, account }),
         subAccount: effectiveAddress.value as Address | undefined,
         review: { type: 'supply', asset: asset.value, amount: amount.value },
@@ -909,7 +902,7 @@ watch(
     }
     push(vaultAsset?.address)
     push(payWith?.address)
-    if (tokens.length) void primeSlotHintsFor(tokens)
+    if (tokens.length) void primeSlotHintsFor(tokens, { background: true })
   },
   { immediate: true },
 )

--- a/tests/composables/useStateOverrideOptions.test.ts
+++ b/tests/composables/useStateOverrideOptions.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import { fetchErc20SlotHints } from '@eulerxyz/euler-v2-sdk'
+import { getEulerSdkForChain } from '~/composables/useEulerSdk'
+import { useStateOverrideOptions } from '~/composables/useStateOverrideOptions'
+import {
+  getBatchPrefetchedSlotHints,
+  resetBatchPrefetchState,
+} from '~/composables/batchPrefetchState'
+
+vi.mock('@eulerxyz/euler-v2-sdk', () => ({
+  fetchErc20SlotHints: vi.fn(),
+}))
+
+vi.mock('~/composables/useEulerSdk', () => ({
+  getEulerSdkForChain: vi.fn(),
+}))
+
+const chainId = ref<number | undefined>(1)
+const tokenA = '0x1000000000000000000000000000000000000001' as const
+const tokenB = '0x2000000000000000000000000000000000000002' as const
+const permit2 = '0x3000000000000000000000000000000000000003' as const
+
+describe('useStateOverrideOptions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetBatchPrefetchState()
+    chainId.value = 1
+    vi.stubGlobal('useWallets', () => ({ balances: ref(new Map()) }))
+    vi.stubGlobal('useEulerAddresses', () => ({ chainId }))
+    vi.mocked(getEulerSdkForChain).mockImplementation(async cid => ({
+      deploymentService: {
+        getDeployment: () => ({
+          addresses: { coreAddrs: { permit2 } },
+        }),
+      },
+      providerService: {
+        getProvider: () => ({ chainId: cid }),
+      },
+    }) as never)
+    vi.mocked(fetchErc20SlotHints).mockImplementation(async (provider) => {
+      const providerChainId = (provider as unknown as { chainId: number }).chainId
+      return { balanceSlotIndex: BigInt(providerChainId) }
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('keeps local and shared slot hints isolated across chain changes', async () => {
+    const stateOverrideOptions = useStateOverrideOptions()
+
+    await stateOverrideOptions.primeSlotHintsFor([tokenA])
+    expect(getBatchPrefetchedSlotHints(1)).toEqual({
+      [tokenA]: { balanceSlotIndex: 1n },
+    })
+
+    chainId.value = 8453
+    expect(stateOverrideOptions.slotHints.value).toEqual({})
+
+    await stateOverrideOptions.primeSlotHintsFor([tokenB])
+
+    expect(stateOverrideOptions.slotHints.value).toEqual({
+      [tokenB]: { balanceSlotIndex: 8453n },
+    })
+    expect(getBatchPrefetchedSlotHints(8453)).toEqual({
+      [tokenB]: { balanceSlotIndex: 8453n },
+    })
+    expect(getBatchPrefetchedSlotHints(8453)).not.toHaveProperty(tokenA)
+    expect(stateOverrideOptions.buildStateOverrideOptions().slotHints).toEqual({
+      [tokenB]: { balanceSlotIndex: 8453n },
+    })
+  })
+
+  it('does not restore old-chain local hints when a probe resolves after switching chains', async () => {
+    let resolveChainOneHint!: (hint: { balanceSlotIndex: bigint }) => void
+    vi.mocked(fetchErc20SlotHints)
+      .mockImplementationOnce(() => new Promise((resolve) => {
+        resolveChainOneHint = resolve
+      }))
+      .mockResolvedValueOnce({ balanceSlotIndex: 8453n })
+    const stateOverrideOptions = useStateOverrideOptions()
+
+    const chainOnePrime = stateOverrideOptions.primeSlotHintsFor([tokenA])
+    await vi.waitFor(() => expect(fetchErc20SlotHints).toHaveBeenCalledTimes(1))
+
+    chainId.value = 8453
+    await stateOverrideOptions.primeSlotHintsFor([tokenB])
+    resolveChainOneHint({ balanceSlotIndex: 1n })
+    await chainOnePrime
+
+    expect(stateOverrideOptions.slotHints.value).toEqual({
+      [tokenB]: { balanceSlotIndex: 8453n },
+    })
+    expect(getBatchPrefetchedSlotHints(1)).toEqual({
+      [tokenA]: { balanceSlotIndex: 1n },
+    })
+    expect(getBatchPrefetchedSlotHints(8453)).toEqual({
+      [tokenB]: { balanceSlotIndex: 8453n },
+    })
+  })
+})

--- a/tests/composables/useStateOverrideOptions.test.ts
+++ b/tests/composables/useStateOverrideOptions.test.ts
@@ -2,11 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 import { fetchErc20SlotHints } from '@eulerxyz/euler-v2-sdk'
 import { getEulerSdkForChain } from '~/composables/useEulerSdk'
-import { useStateOverrideOptions } from '~/composables/useStateOverrideOptions'
-import {
-  getBatchPrefetchedSlotHints,
-  resetBatchPrefetchState,
-} from '~/composables/batchPrefetchState'
+import { useStateOverrideOptions, useStateOverrideResolution } from '~/composables/useStateOverrideOptions'
 
 vi.mock('@eulerxyz/euler-v2-sdk', () => ({
   fetchErc20SlotHints: vi.fn(),
@@ -24,7 +20,6 @@ const permit2 = '0x3000000000000000000000000000000000000003' as const
 describe('useStateOverrideOptions', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    resetBatchPrefetchState()
     chainId.value = 1
     vi.stubGlobal('useWallets', () => ({ balances: ref(new Map()) }))
     vi.stubGlobal('useEulerAddresses', () => ({ chainId }))
@@ -48,11 +43,11 @@ describe('useStateOverrideOptions', () => {
     vi.unstubAllGlobals()
   })
 
-  it('keeps local and shared slot hints isolated across chain changes', async () => {
+  it('drops hints from the previous chain when the chain changes', async () => {
     const stateOverrideOptions = useStateOverrideOptions()
 
     await stateOverrideOptions.primeSlotHintsFor([tokenA])
-    expect(getBatchPrefetchedSlotHints(1)).toEqual({
+    expect(stateOverrideOptions.slotHints.value).toEqual({
       [tokenA]: { balanceSlotIndex: 1n },
     })
 
@@ -61,19 +56,16 @@ describe('useStateOverrideOptions', () => {
 
     await stateOverrideOptions.primeSlotHintsFor([tokenB])
 
+    // Chain 1's slot indices must not leak into chain 8453's simulator options.
     expect(stateOverrideOptions.slotHints.value).toEqual({
       [tokenB]: { balanceSlotIndex: 8453n },
     })
-    expect(getBatchPrefetchedSlotHints(8453)).toEqual({
-      [tokenB]: { balanceSlotIndex: 8453n },
-    })
-    expect(getBatchPrefetchedSlotHints(8453)).not.toHaveProperty(tokenA)
     expect(stateOverrideOptions.buildStateOverrideOptions().slotHints).toEqual({
       [tokenB]: { balanceSlotIndex: 8453n },
     })
   })
 
-  it('does not restore old-chain local hints when a probe resolves after switching chains', async () => {
+  it('does not restore old-chain hints when a probe resolves after switching chains', async () => {
     let resolveChainOneHint!: (hint: { balanceSlotIndex: bigint }) => void
     vi.mocked(fetchErc20SlotHints)
       .mockImplementationOnce(() => new Promise((resolve) => {
@@ -93,11 +85,65 @@ describe('useStateOverrideOptions', () => {
     expect(stateOverrideOptions.slotHints.value).toEqual({
       [tokenB]: { balanceSlotIndex: 8453n },
     })
-    expect(getBatchPrefetchedSlotHints(1)).toEqual({
+  })
+
+  it('keeps hints from concurrent primes instead of letting the last one win', async () => {
+    let resolveFirst!: (hint: { balanceSlotIndex: bigint }) => void
+    vi.mocked(fetchErc20SlotHints)
+      .mockImplementationOnce(() => new Promise((resolve) => {
+        resolveFirst = resolve
+      }))
+      .mockResolvedValueOnce({ balanceSlotIndex: 2n })
+    const stateOverrideOptions = useStateOverrideOptions()
+
+    const firstPrime = stateOverrideOptions.primeSlotHintsFor([tokenA])
+    await vi.waitFor(() => expect(fetchErc20SlotHints).toHaveBeenCalledTimes(1))
+
+    // Second prime resolves and writes first; the slower first prime must merge
+    // onto that result rather than overwrite it with a pre-await snapshot.
+    await stateOverrideOptions.primeSlotHintsFor([tokenB])
+    resolveFirst({ balanceSlotIndex: 1n })
+    await firstPrime
+
+    expect(stateOverrideOptions.slotHints.value).toEqual({
       [tokenA]: { balanceSlotIndex: 1n },
+      [tokenB]: { balanceSlotIndex: 2n },
     })
-    expect(getBatchPrefetchedSlotHints(8453)).toEqual({
-      [tokenB]: { balanceSlotIndex: 8453n },
-    })
+  })
+
+  it('does not report background primes as pending work', async () => {
+    const { isResolvingStateOverrideHints } = useStateOverrideResolution()
+    const stateOverrideOptions = useStateOverrideOptions()
+
+    let resolveHint!: (hint: { balanceSlotIndex: bigint }) => void
+    vi.mocked(fetchErc20SlotHints).mockImplementationOnce(() => new Promise((resolve) => {
+      resolveHint = resolve
+    }))
+
+    const backgroundPrime = stateOverrideOptions.primeSlotHintsFor([tokenA], { background: true })
+    await vi.waitFor(() => expect(fetchErc20SlotHints).toHaveBeenCalledTimes(1))
+
+    // Page-load priming must not disable submit / add-to-batch while in flight.
+    expect(isResolvingStateOverrideHints.value).toBe(false)
+    resolveHint({ balanceSlotIndex: 1n })
+    await backgroundPrime
+    expect(isResolvingStateOverrideHints.value).toBe(false)
+  })
+
+  it('reports foreground primes as pending work', async () => {
+    const { isResolvingStateOverrideHints } = useStateOverrideResolution()
+    const stateOverrideOptions = useStateOverrideOptions()
+
+    let resolveHint!: (hint: { balanceSlotIndex: bigint }) => void
+    vi.mocked(fetchErc20SlotHints).mockImplementationOnce(() => new Promise((resolve) => {
+      resolveHint = resolve
+    }))
+
+    const prime = stateOverrideOptions.primeSlotHintsFor([tokenA])
+    await vi.waitFor(() => expect(isResolvingStateOverrideHints.value).toBe(true))
+
+    resolveHint({ balanceSlotIndex: 1n })
+    await prime
+    expect(isResolvingStateOverrideHints.value).toBe(false)
   })
 })

--- a/tests/composables/useTxBatch.test.ts
+++ b/tests/composables/useTxBatch.test.ts
@@ -4,6 +4,12 @@ import { Account, Portfolio, type IAccountPosition, type IHasVaultAddress, type 
 import { getAddress, type Address, type Hex } from 'viem'
 import { getEulerSdkFresh } from '~/composables/useEulerSdk'
 import { awaitFinalPlanningLayer, buildWalletBalanceLayers, buildWalletChanges, fetchBaseAccountSnapshot, normalizeSimulatedVaultLayers, stitchAccount, useTxBatch } from '~/composables/useTxBatch'
+import {
+  mergeBatchPrefetchedSlotHints,
+  resetBatchPrefetchState,
+  setBatchPrefetchedBaseAccount,
+  setBatchPrefetchedPlanningAccount,
+} from '~/composables/batchPrefetchState'
 import { activeLayerVaultsRef } from '~/composables/useLayeredVaults'
 import { WalletExecutionContextChangedError } from '~/utils/walletExecutionContext'
 import type { WalletExecutionContext } from '~/utils/walletExecutionContext'
@@ -316,6 +322,7 @@ beforeEach(() => {
   routeQuery.network = '1'
   stubBatchComposableGlobals()
   vi.mocked(getEulerSdkFresh).mockResolvedValue(createMockSdk() as never)
+  resetBatchPrefetchState()
   useTxBatch().clearBatch()
 })
 
@@ -699,6 +706,153 @@ describe('normalizeSimulatedVaultLayers', () => {
 })
 
 describe('useTxBatch execution errors', () => {
+  it('reuses a supplied portfolio account for account-free reward entries', async () => {
+    const sdk = createMockSdk()
+    const portfolioAccount = accountWithPosition(subAccount, subAccount, 22n)
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+
+    await useTxBatch().addEntry({
+      label: 'Claim reward',
+      requiresPlanningAccount: false,
+      baseAccount: portfolioAccount,
+      buildPlan: async () => [] as TransactionPlan,
+    })
+    await vi.waitFor(() =>
+      expect(sdk.executionService.simulateTransactionPlan).toHaveBeenCalled(),
+    )
+
+    expect(sdk.accountService.fetchAccount).not.toHaveBeenCalled()
+    expect(sdk.executionService.simulateTransactionPlan).toHaveBeenCalledWith(
+      1,
+      portfolioAccount,
+      [],
+      expect.any(Object),
+    )
+  })
+
+  it('reuses shared form-prefetched accounts and slot hints for every first-entry caller', async () => {
+    const sdk = createMockSdk()
+    const getProvider = vi.fn()
+    Object.assign(sdk, { providerService: { getProvider } })
+    const planningAccount = accountWithPosition(subAccount, subAccount, 11n)
+    const portfolioAccount = accountWithPosition(subAccount, subAccount, 22n)
+    const suppliedSlotHints = {
+      [vault]: { balanceSlotIndex: 9n },
+    }
+    const plan: TransactionPlan = [{
+      type: 'requiredApproval',
+      token: vault,
+      owner,
+      spender: subAccount,
+      amount: 1n,
+    }]
+    let buildAccount: Account<IHasVaultAddress> | undefined
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    setBatchPrefetchedPlanningAccount(planningAccount)
+    setBatchPrefetchedBaseAccount(portfolioAccount)
+    mergeBatchPrefetchedSlotHints(1, suppliedSlotHints)
+
+    await useTxBatch().addEntry({
+      label: 'Supply USDC',
+      buildPlan: async (account) => {
+        buildAccount = account
+        return plan
+      },
+      subAccount,
+    })
+    await vi.waitFor(() =>
+      expect(sdk.executionService.simulateTransactionPlan).toHaveBeenCalled(),
+    )
+
+    expect(buildAccount).toBe(planningAccount)
+    expect(sdk.accountService.fetchAccount).not.toHaveBeenCalled()
+    expect(getProvider).not.toHaveBeenCalled()
+    expect(sdk.executionService.simulateTransactionPlan).toHaveBeenCalledWith(
+      1,
+      portfolioAccount,
+      plan,
+      expect.objectContaining({
+        stateOverrideOptions: expect.objectContaining({
+          slotHints: suppliedSlotHints,
+        }),
+      }),
+    )
+  })
+
+  it('reuses supplied accounts and slot hints for the first entry and simulation', async () => {
+    const sdk = createMockSdk()
+    const getProvider = vi.fn()
+    Object.assign(sdk, { providerService: { getProvider } })
+    const planningAccount = accountWithPosition(subAccount, subAccount, 11n)
+    const portfolioAccount = accountWithPosition(subAccount, subAccount, 22n)
+    const suppliedSlotHints = {
+      [vault]: { balanceSlotIndex: 9n },
+    }
+    const plan: TransactionPlan = [{
+      type: 'requiredApproval',
+      token: vault,
+      owner,
+      spender: subAccount,
+      amount: 1n,
+    }]
+    let buildAccount: Account<IHasVaultAddress> | undefined
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+
+    await useTxBatch().addEntry({
+      label: 'Deposit USDC',
+      planningAccount,
+      baseAccount: portfolioAccount,
+      slotHints: suppliedSlotHints,
+      buildPlan: async (account) => {
+        buildAccount = account
+        return plan
+      },
+      subAccount,
+    })
+    await vi.waitFor(() =>
+      expect(sdk.executionService.simulateTransactionPlan).toHaveBeenCalled(),
+    )
+
+    expect(buildAccount).toBe(planningAccount)
+    expect(sdk.accountService.fetchAccount).not.toHaveBeenCalled()
+    expect(getProvider).not.toHaveBeenCalled()
+    expect(sdk.executionService.simulateTransactionPlan).toHaveBeenCalledWith(
+      1,
+      portfolioAccount,
+      plan,
+      expect.objectContaining({
+        stateOverrideOptions: expect.objectContaining({
+          slotHints: suppliedSlotHints,
+        }),
+      }),
+    )
+  })
+
+  it('ignores prefetched accounts from another chain', async () => {
+    const sdk = createMockSdk()
+    const staleAccount = accountWithPosition(subAccount, subAccount, 99n)
+    staleAccount.chainId = 8453
+    let buildAccount: Account<IHasVaultAddress> | undefined
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+
+    await useTxBatch().addEntry({
+      label: 'Deposit USDC',
+      planningAccount: staleAccount,
+      baseAccount: staleAccount,
+      buildPlan: async (account) => {
+        buildAccount = account
+        return [] as TransactionPlan
+      },
+      subAccount,
+    })
+
+    expect(sdk.accountService.fetchAccount).toHaveBeenCalledWith(1, owner, {
+      populateAll: true,
+    })
+    expect(buildAccount).not.toBe(staleAccount)
+    expect(buildAccount?.chainId).toBe(1)
+  })
+
   it('publishes per-layer simulated vault state even without an enriched account position', async () => {
     const sdk = createMockSdk()
     const simulatedVault = {

--- a/tests/composables/useTxBatch.test.ts
+++ b/tests/composables/useTxBatch.test.ts
@@ -5,7 +5,6 @@ import { getAddress, type Address, type Hex } from 'viem'
 import { getEulerSdkFresh } from '~/composables/useEulerSdk'
 import { awaitFinalPlanningLayer, buildWalletBalanceLayers, buildWalletChanges, fetchBaseAccountSnapshot, normalizeSimulatedVaultLayers, stitchAccount, useTxBatch } from '~/composables/useTxBatch'
 import {
-  mergeBatchPrefetchedSlotHints,
   resetBatchPrefetchState,
   setBatchPrefetchedBaseAccount,
   setBatchPrefetchedPlanningAccount,
@@ -706,15 +705,17 @@ describe('normalizeSimulatedVaultLayers', () => {
 })
 
 describe('useTxBatch execution errors', () => {
-  it('reuses a supplied portfolio account as layer 0 while keeping SDK plugins fresh', async () => {
+  it('reuses the prefetched portfolio account as layer 0 for account-free entries', async () => {
     const sdk = createMockSdk()
     const portfolioAccount = accountWithPosition(subAccount, subAccount, 22n)
     vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    setBatchPrefetchedBaseAccount(portfolioAccount)
 
+    // `requiresPlanningAccount: false` skips getEntryPlanningAccount entirely, so
+    // this covers the addEntry preflight that seeds layer 0 on its own.
     await useTxBatch().addEntry({
       label: 'Claim reward',
       requiresPlanningAccount: false,
-      baseAccount: portfolioAccount,
       buildPlan: async () => [] as TransactionPlan,
     })
     await vi.waitFor(() =>
@@ -731,33 +732,20 @@ describe('useTxBatch execution errors', () => {
     expect(useTxBatch().layers.value[0]?.account).toBe(portfolioAccount)
   })
 
-  it('reuses shared form-prefetched accounts and slot hints for every first-entry caller', async () => {
+  it('reuses prefetched accounts for the first entry without an add-time account fetch', async () => {
     const sdk = createMockSdk()
-    const getProvider = vi.fn()
-    Object.assign(sdk, { providerService: { getProvider } })
     const planningAccount = accountWithPosition(subAccount, subAccount, 11n)
     const portfolioAccount = accountWithPosition(subAccount, subAccount, 22n)
-    const suppliedSlotHints = {
-      [vault]: { balanceSlotIndex: 9n },
-    }
-    const plan: TransactionPlan = [{
-      type: 'requiredApproval',
-      token: vault,
-      owner,
-      spender: subAccount,
-      amount: 1n,
-    }]
     let buildAccount: Account<IHasVaultAddress> | undefined
     vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
     setBatchPrefetchedPlanningAccount(planningAccount)
     setBatchPrefetchedBaseAccount(portfolioAccount)
-    mergeBatchPrefetchedSlotHints(1, suppliedSlotHints)
 
     await useTxBatch().addEntry({
       label: 'Supply USDC',
       buildPlan: async (account) => {
         buildAccount = account
-        return plan
+        return [] as TransactionPlan
       },
       subAccount,
     })
@@ -765,68 +753,11 @@ describe('useTxBatch execution errors', () => {
       expect(sdk.executionService.simulateTransactionPlan).toHaveBeenCalled(),
     )
 
+    // The plan builds against the fresh planning account; layer 0 stays the
+    // enriched portfolio account. Neither costs a populateAll fetchAccount.
     expect(buildAccount).toBe(planningAccount)
     expect(sdk.accountService.fetchAccount).not.toHaveBeenCalled()
-    expect(getProvider).not.toHaveBeenCalled()
-    expect(sdk.executionService.simulateTransactionPlan).toHaveBeenCalledWith(
-      1,
-      owner,
-      plan,
-      expect.objectContaining({
-        stateOverrideOptions: expect.objectContaining({
-          slotHints: suppliedSlotHints,
-        }),
-      }),
-    )
-  })
-
-  it('reuses supplied accounts and slot hints for the first entry and simulation', async () => {
-    const sdk = createMockSdk()
-    const getProvider = vi.fn()
-    Object.assign(sdk, { providerService: { getProvider } })
-    const planningAccount = accountWithPosition(subAccount, subAccount, 11n)
-    const portfolioAccount = accountWithPosition(subAccount, subAccount, 22n)
-    const suppliedSlotHints = {
-      [vault]: { balanceSlotIndex: 9n },
-    }
-    const plan: TransactionPlan = [{
-      type: 'requiredApproval',
-      token: vault,
-      owner,
-      spender: subAccount,
-      amount: 1n,
-    }]
-    let buildAccount: Account<IHasVaultAddress> | undefined
-    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
-
-    await useTxBatch().addEntry({
-      label: 'Deposit USDC',
-      planningAccount,
-      baseAccount: portfolioAccount,
-      slotHints: suppliedSlotHints,
-      buildPlan: async (account) => {
-        buildAccount = account
-        return plan
-      },
-      subAccount,
-    })
-    await vi.waitFor(() =>
-      expect(sdk.executionService.simulateTransactionPlan).toHaveBeenCalled(),
-    )
-
-    expect(buildAccount).toBe(planningAccount)
-    expect(sdk.accountService.fetchAccount).not.toHaveBeenCalled()
-    expect(getProvider).not.toHaveBeenCalled()
-    expect(sdk.executionService.simulateTransactionPlan).toHaveBeenCalledWith(
-      1,
-      owner,
-      plan,
-      expect.objectContaining({
-        stateOverrideOptions: expect.objectContaining({
-          slotHints: suppliedSlotHints,
-        }),
-      }),
-    )
+    expect(useTxBatch().layers.value[0]?.account).toBe(portfolioAccount)
   })
 
   it('ignores prefetched accounts from another chain', async () => {
@@ -835,11 +766,11 @@ describe('useTxBatch execution errors', () => {
     staleAccount.chainId = 8453
     let buildAccount: Account<IHasVaultAddress> | undefined
     vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    setBatchPrefetchedPlanningAccount(staleAccount)
+    setBatchPrefetchedBaseAccount(staleAccount)
 
     await useTxBatch().addEntry({
       label: 'Deposit USDC',
-      planningAccount: staleAccount,
-      baseAccount: staleAccount,
       buildPlan: async (account) => {
         buildAccount = account
         return [] as TransactionPlan
@@ -852,6 +783,33 @@ describe('useTxBatch execution errors', () => {
     })
     expect(buildAccount).not.toBe(staleAccount)
     expect(buildAccount?.chainId).toBe(1)
+  })
+
+  it('ignores prefetched accounts belonging to another owner', async () => {
+    const sdk = createMockSdk()
+    const otherOwnerAccount = accountWithPosition(subAccount, subAccount, 99n)
+    otherOwnerAccount.owner = getAddress('0x2000000000000000000000000000000000000002')
+    let buildAccount: Account<IHasVaultAddress> | undefined
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    setBatchPrefetchedPlanningAccount(otherOwnerAccount)
+    setBatchPrefetchedBaseAccount(otherOwnerAccount)
+
+    // A wallet switch replaces the loaders' accounts asynchronously, so the batch
+    // can observe the previous wallet's snapshot with the new owner already active.
+    await useTxBatch().addEntry({
+      label: 'Deposit USDC',
+      buildPlan: async (account) => {
+        buildAccount = account
+        return [] as TransactionPlan
+      },
+      subAccount,
+    })
+
+    expect(sdk.accountService.fetchAccount).toHaveBeenCalledWith(1, owner, {
+      populateAll: true,
+    })
+    expect(buildAccount).not.toBe(otherOwnerAccount)
+    expect(buildAccount?.owner).toBe(owner)
   })
 
   it('publishes per-layer simulated vault state even without an enriched account position', async () => {

--- a/tests/composables/useTxBatch.test.ts
+++ b/tests/composables/useTxBatch.test.ts
@@ -706,7 +706,7 @@ describe('normalizeSimulatedVaultLayers', () => {
 })
 
 describe('useTxBatch execution errors', () => {
-  it('reuses a supplied portfolio account for account-free reward entries', async () => {
+  it('reuses a supplied portfolio account as layer 0 while keeping SDK plugins fresh', async () => {
     const sdk = createMockSdk()
     const portfolioAccount = accountWithPosition(subAccount, subAccount, 22n)
     vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
@@ -724,10 +724,11 @@ describe('useTxBatch execution errors', () => {
     expect(sdk.accountService.fetchAccount).not.toHaveBeenCalled()
     expect(sdk.executionService.simulateTransactionPlan).toHaveBeenCalledWith(
       1,
-      portfolioAccount,
+      owner,
       [],
       expect.any(Object),
     )
+    expect(useTxBatch().layers.value[0]?.account).toBe(portfolioAccount)
   })
 
   it('reuses shared form-prefetched accounts and slot hints for every first-entry caller', async () => {
@@ -769,7 +770,7 @@ describe('useTxBatch execution errors', () => {
     expect(getProvider).not.toHaveBeenCalled()
     expect(sdk.executionService.simulateTransactionPlan).toHaveBeenCalledWith(
       1,
-      portfolioAccount,
+      owner,
       plan,
       expect.objectContaining({
         stateOverrideOptions: expect.objectContaining({
@@ -818,7 +819,7 @@ describe('useTxBatch execution errors', () => {
     expect(getProvider).not.toHaveBeenCalled()
     expect(sdk.executionService.simulateTransactionPlan).toHaveBeenCalledWith(
       1,
-      portfolioAccount,
+      owner,
       plan,
       expect.objectContaining({
         stateOverrideOptions: expect.objectContaining({

--- a/tests/composables/useWalletRepay.test.ts
+++ b/tests/composables/useWalletRepay.test.ts
@@ -92,6 +92,7 @@ describe('useWalletRepay projected Net APY', () => {
       executePlan: vi.fn(),
     }))
     vi.stubGlobal('usePlanAccount', () => ({ account: shallowRef(planAccount) }))
+    vi.stubGlobal('useStateOverrideOptions', () => ({ primeSlotHintsFor: vi.fn() }))
     vi.stubGlobal('useWagmi', () => ({ isConnected: ref(true) }))
     vi.stubGlobal('useSpyMode', () => ({ isSpyMode: ref(false) }))
     vi.stubGlobal('useTxFinalization', () => ({ finalizeTxAndRedirect: vi.fn() }))


### PR DESCRIPTION
## Summary
- Reuse the account snapshots the forms already loaded when adding the first batch entry, instead of refetching them at add-time.
- Remove the redundant `fetchAccount({ populateAll: true })` from the user-visible Add to batch path while preserving safe fallbacks.

## Changes
- Add a neutral prefetch registry (`batchPrefetchState`) for the planning account (`useFreshAccount`) and the enriched base account (`useEulerAccount`). No composable dependencies, so the prefetch hand-off does not add another import cycle.
- Read those accounts **only** from the registry, never per entry. `usePlanAccount().account` and `useEulerAccount().portfolio` are layer-aware — they resolve to the active *simulated* layer once the batch is non-empty — so they must never become the batch's own layer 0. The registry holds pre-overlay loader output by construction.
- Validate chain + owner before reuse (`resolvePrefetchedAccounts`), shared by the `addEntry` preflight, `getEntryPlanningAccount`, and `resimulate`. A wallet switch replaces the loaders' accounts asynchronously, so the batch can observe the previous wallet's snapshot with the new owner already active.
- Keep the enriched base account fixed for the cart lifetime and simulate directly against it.
- Prime ERC20 slot hints from the Earn and wallet-repay forms as the lend page already did, with `background: true` so speculative page-load probes no longer register as pending work.

### Behaviour changes worth flagging
- **The first entry's plan is now built against a different account shape.** It was `fetchAccount({ populateAll: true })`; it is now the planning account's `PLAN_ACCOUNT_FETCH_OPTIONS` (`populateVaults: true`, no market prices or user rewards). This is the same account the non-batch submit path already builds against via `usePlanAccount`, so plan construction with this shape is already exercised in production — but it is a behaviour change, not purely a caching win.
- **Layer 0 is shape-equivalent.** `portfolioService.fetchPortfolio` internally calls `fetchAccount(chainId, address, { populateAll: true })`, identical to `fetchBaseAccountSnapshot`, so reusing the portfolio account as layer 0 does not change what the simulated layers stitch onto. It also comes from the same `getEulerSdkFresh` instance (`source: 'fast'` has no production caller).
- **Speculative priming no longer gates submit.** `isResolvingStateOverrideHints` is a global counter that hard-disables submit and add-to-batch on every mounted form and replaces the tooltip with the generic "Complete the form fields above to continue." Page-load priming now opts out via `background: true`; on a cold cache the simulator falls back to access-list discovery, as it did before priming existed. This also fixes the pre-existing flash on the lend page.

### Incidental fix
- `primeSlotHintsFor` snapshotted `slotHints.value` *before* awaiting its probes, so two concurrent primes clobbered each other's results. It now merges after the await. Covered directly.

### Deliberately not included
- A batch-side mirror of slot hints. The SDK's `fetchErc20SlotHints` already memoises module-scope by `chainId:token`, so once any form primes a token the batch's own probe short-circuits to a Map lookup with no RPC. Mirroring it would buy the removal of an `await`, not a round-trip, at the cost of a chain-keyed Map, a three-way merge with ambiguous precedence, and its own teardown. The batch still probes only tokens missing from `batchSlotHints`, which is what the simulator reads.

## Test plan
- [x] Full suite: 1489 passed, 1 skipped.
- [x] `npm run typecheck`.
- [x] ESLint against every changed file.
- [x] Add a deposit to a batch in Chrome and verify the portfolio redirect and simulated-state overlay.
- Coverage added for: prefetched reuse with no add-time `fetchAccount`, layer 0 seeding for account-free entries, rejection of wrong-chain and wrong-owner prefetches, chain-switch hint isolation, the concurrent-prime merge, and background vs foreground pending-work accounting.
