### PR TITLE
fix: clarify Activity vault identities

### DIFF
--- a/components/entities/activity/ActivityAddress.vue
+++ b/components/entities/activity/ActivityAddress.vue
@@ -106,19 +106,20 @@ const handleInternalClick = (event: MouseEvent) => {
 </script>
 
 <template>
-  <span class="inline-flex min-w-0 max-w-full items-center gap-2">
+  <span class="flex w-full min-w-0 max-w-full items-center gap-2">
     <NuxtLink
       v-if="internalLink && resolvedVault && compactVault"
       :to="internalLink"
-      class="inline-flex min-w-0 max-w-full items-center gap-6 rounded-8 transition-opacity hover:opacity-80"
+      class="flex min-w-0 flex-1 items-center gap-6 overflow-hidden rounded-8 transition-opacity hover:opacity-80"
       :title="address"
     >
       <AssetAvatar
         :asset="[resolvedVault.asset]"
         size="20"
+        class="shrink-0"
       />
       <span
-        class="min-w-0 truncate text-p4 text-content-secondary"
+        class="min-w-0 flex-1 truncate text-p4 text-content-secondary"
         :title="compactVaultName"
       >
         <VaultDisplayName

--- a/components/entities/activity/ActivityAddress.vue
+++ b/components/entities/activity/ActivityAddress.vue
@@ -28,6 +28,7 @@ const {
 } = useVaultRegistry()
 const addressRef = toRef(props, 'address')
 const product = useEulerProductOfVault(addressRef)
+const { getTokenByAddress } = useTokenList()
 const copyKey = computed(() => `activity-address-${props.address.toLowerCase()}`)
 const explorerLink = computed(() => getExplorerLink(props.address, props.chainId, true))
 const resolvedVault = computed(() => {
@@ -42,6 +43,11 @@ const compactVaultName = computed(() => {
     return 'Escrowed collateral'
   }
   return product.name || resolvedVault.value.shares.name
+})
+const compactAssetName = computed(() => {
+  const asset = resolvedVault.value?.asset
+  if (!asset) return ''
+  return getTokenByAddress(asset.address)?.name || asset.name || asset.symbol
 })
 const internalLink = computed(() => {
   const query = typeof route.query.network === 'string'
@@ -110,25 +116,30 @@ const handleInternalClick = (event: MouseEvent) => {
     <NuxtLink
       v-if="internalLink && resolvedVault && compactVault"
       :to="internalLink"
-      class="flex min-w-0 flex-1 items-center gap-6 overflow-hidden rounded-8 transition-opacity hover:opacity-80"
+      class="flex min-w-0 flex-1 items-center gap-10 overflow-hidden rounded-8 transition-opacity hover:opacity-80"
       :title="address"
     >
       <AssetAvatar
         :asset="[resolvedVault.asset]"
-        size="20"
+        size="32"
         class="shrink-0"
       />
-      <span
-        class="min-w-0 flex-1 truncate text-p4 text-content-secondary"
-        :title="compactVaultName"
-      >
-        <VaultDisplayName
-          :name="compactVaultName"
-          :is-unverified="!isVerifiedVault(resolvedVault.address)"
-        />
-      </span>
-      <span class="shrink-0 text-p4 font-medium text-content-primary">
-        {{ resolvedVault.asset.symbol }}
+      <span class="min-w-0 flex-1">
+        <span
+          class="block truncate text-p4 text-content-secondary"
+          :title="compactVaultName"
+        >
+          <VaultDisplayName
+            :name="compactVaultName"
+            :is-unverified="!isVerifiedVault(resolvedVault.address)"
+          />
+        </span>
+        <span
+          class="block truncate text-p4 font-medium text-content-primary"
+          :title="compactAssetName"
+        >
+          {{ compactAssetName }}
+        </span>
       </span>
     </NuxtLink>
     <NuxtLink

--- a/components/entities/activity/ActivityEventRow.vue
+++ b/components/entities/activity/ActivityEventRow.vue
@@ -527,6 +527,10 @@ const vaultDisplay = computed(() => {
   grid-column: 1 / -1;
 }
 
+.activity-event-row__details--expanded .activity-event-row__detail:not(.hidden) {
+  width: 100%;
+}
+
 @container activity-feed (min-width: 520px) {
   /* One rule for every row: the icon, details column, and transaction link
      center against the full card height beside the title line. */
@@ -624,7 +628,6 @@ const vaultDisplay = computed(() => {
 
   .activity-event-row__details--expanded .activity-event-row__detail:not(.hidden) {
     display: grid;
-    width: 100%;
     grid-template-columns: 130px minmax(0, 1fr);
     align-items: center;
     column-gap: 12px;


### PR DESCRIPTION
## Summary
- Keep long vault identities contained within Activity detail columns at every responsive breakpoint.
- Separate the market name from the underlying asset name so governance changes remain readable without ambiguous truncation.

## Changes
- Render compact vault identities as two lines: the label-aware market name followed by the token-list asset name, with onchain name and symbol fallbacks.
- Keep the avatar, identity text, and copy action within a shrinkable full-width flex layout.
- Constrain expanded detail rows to their available grid column so intermediate desktop widths cannot grow from long content.

## Test plan
- [x] Run focused Activity component and display utility tests.
- [x] Run ESLint for the affected Activity components.
- [x] Run Nuxt typecheck and production build.
- [x] Verify collapsed and expanded Set LTV rows on the Monad Lend vault at localhost.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the compact vault link layout with better spacing, sizing, and alignment, including clearer two-line truncated labels for vault and asset names.
  * Enhanced avatar sizing and shrink behavior to fit constrained layouts more consistently.
  * Refined expanded activity row details styling so visible items take full width when expanded, while preserving the existing grid layout at larger sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->