### PR TITLE
Reuse form slot hints across batch additions

### DIFF
--- a/composables/batchPrefetchState.ts
+++ b/composables/batchPrefetchState.ts
@@ -1,4 +1,4 @@
-import type { Account, IHasVaultAddress } from '@eulerxyz/euler-v2-sdk'
+import type { Account, IHasVaultAddress, SlotHints } from '@eulerxyz/euler-v2-sdk'
 
 /**
  * Form-load accounts the batch builder can safely reuse on the first add.
@@ -17,12 +17,14 @@ import type { Account, IHasVaultAddress } from '@eulerxyz/euler-v2-sdk'
  * in `useTxBatch`) because a wallet or chain switch can land before the
  * matching loader run replaces these.
  *
- * Slot hints are deliberately *not* mirrored here: the SDK's `fetchErc20SlotHints`
- * already memoises module-scope by `chainId:token`, so once any form has primed a
- * token the batch's own probe short-circuits to a Map lookup with no RPC.
+ * Slot hints are safe to share independently: ERC20 storage-slot indices are
+ * owner- and spender-agnostic, and the registry scopes them by chain. Keeping
+ * the handoff here also avoids relying on the SDK module cache being shared
+ * across separately bundled form and batch call paths.
  */
 let planningAccount: Account<IHasVaultAddress> | undefined
 let baseAccount: Account<IHasVaultAddress> | undefined
+const slotHintsByChain = new Map<number, SlotHints>()
 
 export const setBatchPrefetchedPlanningAccount = (
   account: Account<IHasVaultAddress> | undefined,
@@ -40,12 +42,27 @@ export const setBatchPrefetchedBaseAccount = (
 
 export const getBatchPrefetchedBaseAccount = () => baseAccount
 
+export const mergeBatchPrefetchedSlotHints = (
+  chainId: number,
+  slotHints: SlotHints,
+) => {
+  slotHintsByChain.set(chainId, {
+    ...slotHintsByChain.get(chainId),
+    ...slotHints,
+  })
+}
+
+export const getBatchPrefetchedSlotHints = (chainId: number): SlotHints => ({
+  ...slotHintsByChain.get(chainId),
+})
+
 /**
- * Drops both prefetched accounts. Production resets flow through the owning
+ * Drops prefetched state. Production account resets flow through the owning
  * loaders (`useFreshAccount.reset`, `useEulerAccount.resetLoadingState`); this
  * exists so tests can isolate module state between cases.
  */
 export const resetBatchPrefetchState = () => {
   planningAccount = undefined
   baseAccount = undefined
+  slotHintsByChain.clear()
 }

--- a/composables/useStateOverrideOptions.ts
+++ b/composables/useStateOverrideOptions.ts
@@ -2,6 +2,7 @@ import { ref, watch } from 'vue'
 import { type Address, getAddress } from 'viem'
 import { fetchErc20SlotHints, type SlotHints, type SimulationStateOverrideOptions } from '@eulerxyz/euler-v2-sdk'
 import { getEulerSdkForChain } from '~/composables/useEulerSdk'
+import { mergeBatchPrefetchedSlotHints } from '~/composables/batchPrefetchState'
 import { logWarn } from '~/utils/errorHandling'
 
 const pendingStateOverrideHintResolutions = ref(0)
@@ -92,6 +93,7 @@ export const useStateOverrideOptions = () => {
             logWarn('useStateOverrideOptions/primeSlotHintsFor', e)
           }
         }))
+        mergeBatchPrefetchedSlotHints(cid, resolvedHints)
         // Re-read after the await: a concurrent prime may have landed its own
         // hints while these probes were in flight, and snapshotting before the
         // await would drop them.

--- a/composables/useTxBatch.ts
+++ b/composables/useTxBatch.ts
@@ -14,6 +14,8 @@ import { getEulerSdkFresh } from '~/composables/useEulerSdk'
 import {
   getBatchPrefetchedBaseAccount,
   getBatchPrefetchedPlanningAccount,
+  getBatchPrefetchedSlotHints,
+  mergeBatchPrefetchedSlotHints,
 } from '~/composables/batchPrefetchState'
 import { getCurrentEulerLabelsData } from '~/composables/useEulerLabels'
 import { useTenderlySimulation } from '~/composables/useTenderlySimulation'
@@ -139,21 +141,7 @@ type BatchEntryBuildResult = TransactionPlan | {
   stateOverrides?: StateOverride
 }
 
-export interface BatchEntryPrefetchedSlotHints {
-  /** Chain the hints were probed against. Prevents stale hints crossing a chain switch. */
-  chainId: number
-  /** Owner-/spender-agnostic ERC20 storage-slot indices already resolved by the form. */
-  hints: SlotHints
-}
-
-type BatchEntryInputBase = Omit<BatchEntry, 'id' | 'plan'> & {
-  /**
-   * Form-prefetched slot hints for the add-time approval tokens. This context is
-   * consumed before the entry is stored; unlike form accounts, it is not
-   * layer-aware and cannot seed the batch's account state.
-   */
-  prefetchedSlotHints?: BatchEntryPrefetchedSlotHints
-}
+type BatchEntryInputBase = Omit<BatchEntry, 'id' | 'plan'>
 
 export type BatchEntryInput = BatchEntryInputBase & (
   {
@@ -466,6 +454,7 @@ const primeBatchSlotHintsFor = async (chainId: number, tokens: Address[]): Promi
       }
     }))
     batchSlotHints = next
+    mergeBatchPrefetchedSlotHints(chainId, next)
   }
   catch (error) {
     logWarn('useTxBatch/primeBatchSlotHintsFor', error)
@@ -2112,15 +2101,11 @@ export const useTxBatch = () => {
       const builtStateOverrides = Array.isArray(buildResult) ? undefined : buildResult.stateOverrides
       const cid = chainId.value
       if (cid) {
-        if (entry.prefetchedSlotHints?.chainId === cid) {
-          batchSlotHints = {
-            ...batchSlotHints,
-            ...entry.prefetchedSlotHints.hints,
-          }
+        batchSlotHints = {
+          ...getBatchPrefetchedSlotHints(cid),
+          ...batchSlotHints,
         }
-        // Probe only what this batch has not resolved yet. Tokens any form already
-        // primed cost no RPC — the SDK memoises hints by `chainId:token` — but they
-        // still have to land in `batchSlotHints`, which is what the simulator reads.
+        // Probe only what no form or earlier batch entry has resolved yet.
         const missingSlotHintTokens = collectRequiredApprovalTokens(plan)
           .filter(token => batchSlotHints[token] === undefined)
         await primeBatchSlotHintsFor(cid, missingSlotHintTokens)
@@ -2128,7 +2113,6 @@ export const useTxBatch = () => {
       const {
         buildPlan: _buildPlan,
         requiresPlanningAccount: _requiresPlanningAccount,
-        prefetchedSlotHints: _prefetchedSlotHints,
         ...fixedEntry
       } = entry
       registerReviewAssetMeta(fixedEntry.review)

--- a/composables/useTxBatch.ts
+++ b/composables/useTxBatch.ts
@@ -139,7 +139,21 @@ type BatchEntryBuildResult = TransactionPlan | {
   stateOverrides?: StateOverride
 }
 
-type BatchEntryInputBase = Omit<BatchEntry, 'id' | 'plan'>
+export interface BatchEntryPrefetchedSlotHints {
+  /** Chain the hints were probed against. Prevents stale hints crossing a chain switch. */
+  chainId: number
+  /** Owner-/spender-agnostic ERC20 storage-slot indices already resolved by the form. */
+  hints: SlotHints
+}
+
+type BatchEntryInputBase = Omit<BatchEntry, 'id' | 'plan'> & {
+  /**
+   * Form-prefetched slot hints for the add-time approval tokens. This context is
+   * consumed before the entry is stored; unlike form accounts, it is not
+   * layer-aware and cannot seed the batch's account state.
+   */
+  prefetchedSlotHints?: BatchEntryPrefetchedSlotHints
+}
 
 export type BatchEntryInput = BatchEntryInputBase & (
   {
@@ -2098,6 +2112,12 @@ export const useTxBatch = () => {
       const builtStateOverrides = Array.isArray(buildResult) ? undefined : buildResult.stateOverrides
       const cid = chainId.value
       if (cid) {
+        if (entry.prefetchedSlotHints?.chainId === cid) {
+          batchSlotHints = {
+            ...batchSlotHints,
+            ...entry.prefetchedSlotHints.hints,
+          }
+        }
         // Probe only what this batch has not resolved yet. Tokens any form already
         // primed cost no RPC — the SDK memoises hints by `chainId:token` — but they
         // still have to land in `batchSlotHints`, which is what the simulator reads.
@@ -2108,6 +2128,7 @@ export const useTxBatch = () => {
       const {
         buildPlan: _buildPlan,
         requiresPlanningAccount: _requiresPlanningAccount,
+        prefetchedSlotHints: _prefetchedSlotHints,
         ...fixedEntry
       } = entry
       registerReviewAssetMeta(fixedEntry.review)

--- a/pages/lend/[vault]/index.vue
+++ b/pages/lend/[vault]/index.vue
@@ -79,24 +79,18 @@ const { planDeposit, planDepositWithSwap, prepareTransactionPlan, executePrepare
 const { addEntry: addBatchEntry } = useTxBatch()
 const { redirectAfterAdd } = useBatchRedirect()
 const { account: planAccount } = usePlanAccount()
-const { chainId } = useEulerAddresses()
 // Page validates "Not enough balance" up front (see `errorText` / `isSubmitDisabled`),
 // so the simulator never needs to forge wallet balances — `noBalanceOverride: true`
 // skips per-call balanceOf + slot probing.
-const { primeSlotHintsFor, buildStateOverrideOptions, slotHints } = useStateOverrideOptions()
+const { primeSlotHintsFor, buildStateOverrideOptions } = useStateOverrideOptions()
 const buildLendStateOverrideOptions = () => buildStateOverrideOptions({ noBalanceOverride: true })
-const getBatchPrefetchedSlotHints = () => chainId.value
-  ? {
-      chainId: chainId.value,
-      hints: { ...slotHints.value },
-    }
-  : undefined
 const lendPluginPrefetch: PluginPrefetchData = { pyth: { entries: [] } }
 const getLendPluginPrefetch = async (): Promise<PluginPrefetchData> => lendPluginPrefetch
 const { getVault, getSecuritizeVault, getEscrowVault, updateVault, isEscrowLoadedOnce, isMarketDataResolved } = useVaults()
 const { isReady: isLabelsReady } = useEulerLabels()
 const { get: registryGet, getVault: _registryGetVault, isKnownEscrowAddress } = useVaultRegistry()
 const { isConnected, isSpyMode, effectiveAddress } = useEffectiveAddress()
+const { chainId } = useEulerAddresses()
 const shareLinkQuery = computed(() => {
   const network = route.query.network
 
@@ -621,7 +615,6 @@ const addToBatch = async () => {
       if (!swapAsset) return
       await addBatchEntry({
         label: `Deposit ${asset.value.symbol}`,
-        prefetchedSlotHints: getBatchPrefetchedSlotHints(),
         buildPlan: account => buildSwapSupplyPlanFromQuote(quote, account, { selectedAsset: swapAsset, amount: swapAmount }),
         subAccount: effectiveAddress.value as Address | undefined,
         review: { type: 'swap-supply', asset: swapAsset, amount: swapAmount, swapToAsset: asset.value, swapToAmount: swapOutput, swapMode: SwapperMode.EXACT_IN, quoteFetchedAt: swapEffectiveQuoteFetchedAt.value },
@@ -632,7 +625,6 @@ const addToBatch = async () => {
       const supplyAmount = valueToNano(amount.value, asset.value.decimals)
       await addBatchEntry({
         label: `Deposit ${amount.value} ${asset.value.symbol}`,
-        prefetchedSlotHints: getBatchPrefetchedSlotHints(),
         buildPlan: account => planDeposit({ vaultAddress: vaultAddress as Address, assetAddress: assetAddr, amount: supplyAmount, account }),
         subAccount: effectiveAddress.value as Address | undefined,
         review: { type: 'supply', asset: asset.value, amount: amount.value },

--- a/pages/lend/[vault]/index.vue
+++ b/pages/lend/[vault]/index.vue
@@ -79,18 +79,24 @@ const { planDeposit, planDepositWithSwap, prepareTransactionPlan, executePrepare
 const { addEntry: addBatchEntry } = useTxBatch()
 const { redirectAfterAdd } = useBatchRedirect()
 const { account: planAccount } = usePlanAccount()
+const { chainId } = useEulerAddresses()
 // Page validates "Not enough balance" up front (see `errorText` / `isSubmitDisabled`),
 // so the simulator never needs to forge wallet balances — `noBalanceOverride: true`
 // skips per-call balanceOf + slot probing.
-const { primeSlotHintsFor, buildStateOverrideOptions } = useStateOverrideOptions()
+const { primeSlotHintsFor, buildStateOverrideOptions, slotHints } = useStateOverrideOptions()
 const buildLendStateOverrideOptions = () => buildStateOverrideOptions({ noBalanceOverride: true })
+const getBatchPrefetchedSlotHints = () => chainId.value
+  ? {
+      chainId: chainId.value,
+      hints: { ...slotHints.value },
+    }
+  : undefined
 const lendPluginPrefetch: PluginPrefetchData = { pyth: { entries: [] } }
 const getLendPluginPrefetch = async (): Promise<PluginPrefetchData> => lendPluginPrefetch
 const { getVault, getSecuritizeVault, getEscrowVault, updateVault, isEscrowLoadedOnce, isMarketDataResolved } = useVaults()
 const { isReady: isLabelsReady } = useEulerLabels()
 const { get: registryGet, getVault: _registryGetVault, isKnownEscrowAddress } = useVaultRegistry()
 const { isConnected, isSpyMode, effectiveAddress } = useEffectiveAddress()
-const { chainId } = useEulerAddresses()
 const shareLinkQuery = computed(() => {
   const network = route.query.network
 
@@ -615,6 +621,7 @@ const addToBatch = async () => {
       if (!swapAsset) return
       await addBatchEntry({
         label: `Deposit ${asset.value.symbol}`,
+        prefetchedSlotHints: getBatchPrefetchedSlotHints(),
         buildPlan: account => buildSwapSupplyPlanFromQuote(quote, account, { selectedAsset: swapAsset, amount: swapAmount }),
         subAccount: effectiveAddress.value as Address | undefined,
         review: { type: 'swap-supply', asset: swapAsset, amount: swapAmount, swapToAsset: asset.value, swapToAmount: swapOutput, swapMode: SwapperMode.EXACT_IN, quoteFetchedAt: swapEffectiveQuoteFetchedAt.value },
@@ -625,6 +632,7 @@ const addToBatch = async () => {
       const supplyAmount = valueToNano(amount.value, asset.value.decimals)
       await addBatchEntry({
         label: `Deposit ${amount.value} ${asset.value.symbol}`,
+        prefetchedSlotHints: getBatchPrefetchedSlotHints(),
         buildPlan: account => planDeposit({ vaultAddress: vaultAddress as Address, assetAddress: assetAddr, amount: supplyAmount, account }),
         subAccount: effectiveAddress.value as Address | undefined,
         review: { type: 'supply', asset: asset.value, amount: amount.value },

--- a/tests/composables/useStateOverrideOptions.test.ts
+++ b/tests/composables/useStateOverrideOptions.test.ts
@@ -3,6 +3,10 @@ import { ref } from 'vue'
 import { fetchErc20SlotHints } from '@eulerxyz/euler-v2-sdk'
 import { getEulerSdkForChain } from '~/composables/useEulerSdk'
 import { useStateOverrideOptions, useStateOverrideResolution } from '~/composables/useStateOverrideOptions'
+import {
+  getBatchPrefetchedSlotHints,
+  resetBatchPrefetchState,
+} from '~/composables/batchPrefetchState'
 
 vi.mock('@eulerxyz/euler-v2-sdk', () => ({
   fetchErc20SlotHints: vi.fn(),
@@ -20,6 +24,7 @@ const permit2 = '0x3000000000000000000000000000000000000003' as const
 describe('useStateOverrideOptions', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    resetBatchPrefetchState()
     chainId.value = 1
     vi.stubGlobal('useWallets', () => ({ balances: ref(new Map()) }))
     vi.stubGlobal('useEulerAddresses', () => ({ chainId }))
@@ -63,6 +68,17 @@ describe('useStateOverrideOptions', () => {
     expect(stateOverrideOptions.buildStateOverrideOptions().slotHints).toEqual({
       [tokenB]: { balanceSlotIndex: 8453n },
     })
+  })
+
+  it('shares resolved hints with the chain-matched batch path', async () => {
+    const stateOverrideOptions = useStateOverrideOptions()
+
+    await stateOverrideOptions.primeSlotHintsFor([tokenA])
+
+    expect(getBatchPrefetchedSlotHints(1)).toEqual({
+      [tokenA]: { balanceSlotIndex: 1n },
+    })
+    expect(getBatchPrefetchedSlotHints(8453)).toEqual({})
   })
 
   it('does not restore old-chain hints when a probe resolves after switching chains', async () => {

--- a/tests/composables/useTxBatch.test.ts
+++ b/tests/composables/useTxBatch.test.ts
@@ -5,6 +5,7 @@ import { getAddress, type Address, type Hex } from 'viem'
 import { getEulerSdkFresh } from '~/composables/useEulerSdk'
 import { awaitFinalPlanningLayer, buildWalletBalanceLayers, buildWalletChanges, fetchBaseAccountSnapshot, normalizeSimulatedVaultLayers, stitchAccount, useTxBatch } from '~/composables/useTxBatch'
 import {
+  mergeBatchPrefetchedSlotHints,
   resetBatchPrefetchState,
   setBatchPrefetchedBaseAccount,
   setBatchPrefetchedPlanningAccount,
@@ -775,19 +776,16 @@ describe('useTxBatch execution errors', () => {
     vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
     setBatchPrefetchedPlanningAccount(planningAccount)
     setBatchPrefetchedBaseAccount(portfolioAccount)
+    mergeBatchPrefetchedSlotHints(1, {
+      [approvalToken]: {
+        balanceSlotIndex: 9n,
+        allowanceSlotIndex: 10n,
+      },
+    })
 
     await useTxBatch().addEntry({
       label: 'Supply USDC',
       buildPlan: async () => approvalPlan,
-      prefetchedSlotHints: {
-        chainId: 1,
-        hints: {
-          [approvalToken]: {
-            balanceSlotIndex: 9n,
-            allowanceSlotIndex: 10n,
-          },
-        },
-      },
       subAccount,
     })
     await vi.waitFor(() =>
@@ -809,7 +807,6 @@ describe('useTxBatch execution errors', () => {
         },
       }),
     )
-    expect(useTxBatch().entries.value[0]).not.toHaveProperty('prefetchedSlotHints')
   })
 
   it('ignores prefetched accounts from another chain', async () => {

--- a/tests/composables/useTxBatch.test.ts
+++ b/tests/composables/useTxBatch.test.ts
@@ -760,6 +760,58 @@ describe('useTxBatch execution errors', () => {
     expect(useTxBatch().layers.value[0]?.account).toBe(portfolioAccount)
   })
 
+  it('passes chain-matched form slot hints into the first batch simulation', async () => {
+    const sdk = createMockSdk()
+    const planningAccount = accountWithPosition(subAccount, subAccount, 11n)
+    const portfolioAccount = accountWithPosition(subAccount, subAccount, 22n)
+    const approvalToken = getAddress('0x2000000000000000000000000000000000000001')
+    const approvalPlan = [{
+      type: 'requiredApproval',
+      token: approvalToken,
+      owner,
+      spender: vault,
+      amount: 1n,
+    }] as TransactionPlan
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    setBatchPrefetchedPlanningAccount(planningAccount)
+    setBatchPrefetchedBaseAccount(portfolioAccount)
+
+    await useTxBatch().addEntry({
+      label: 'Supply USDC',
+      buildPlan: async () => approvalPlan,
+      prefetchedSlotHints: {
+        chainId: 1,
+        hints: {
+          [approvalToken]: {
+            balanceSlotIndex: 9n,
+            allowanceSlotIndex: 10n,
+          },
+        },
+      },
+      subAccount,
+    })
+    await vi.waitFor(() =>
+      expect(sdk.executionService.simulateTransactionPlan).toHaveBeenCalled(),
+    )
+
+    expect(sdk.executionService.simulateTransactionPlan).toHaveBeenCalledWith(
+      1,
+      owner,
+      approvalPlan,
+      expect.objectContaining({
+        stateOverrideOptions: {
+          slotHints: {
+            [approvalToken]: {
+              balanceSlotIndex: 9n,
+              allowanceSlotIndex: 10n,
+            },
+          },
+        },
+      }),
+    )
+    expect(useTxBatch().entries.value[0]).not.toHaveProperty('prefetchedSlotHints')
+  })
+
   it('ignores prefetched accounts from another chain', async () => {
     const sdk = createMockSdk()
     const staleAccount = accountWithPosition(subAccount, subAccount, 99n)


### PR DESCRIPTION
## Summary
- share ERC20 slot hints resolved by transaction forms with the batch builder
- avoid repeating add-time storage-slot probes across deposit, withdraw, borrow, repay, multiply, swap, and Earn flows

## Changes
- restore a chain-scoped slot-hint registry at the neutral batch prefetch boundary
- merge form and batch probe results before checking which approval tokens are still unresolved
- keep account prefetch isolated to loader-owned snapshots and cover chain isolation plus the form-to-batch handoff

## Test plan
- [x] run 111 tests across 11 form and batch composable suites
- [x] run `npm run typecheck`
- [x] run focused ESLint on all changed TypeScript, Vue, and test files
- [x] profile 21 reachable direct and swap-backed add-to-batch variants in spy mode on mainnet
- [x] confirm every measured add path completes in 3-20 ms with no fallback account fetch
