### PR TITLE
fix: reject incomplete batch snapshots

### DIFF
--- a/composables/useTxBatch.ts
+++ b/composables/useTxBatch.ts
@@ -1713,6 +1713,21 @@ export const useTxBatch = () => {
         return
       }
 
+      // Account Lens read failures leave one or more simulated account layers
+      // incomplete. Do not publish or reuse those layers: stitching can preserve
+      // stale pre-operation debt/collateral, and the next entry would otherwise
+      // plan against that stale projection. Invalidating the layers also makes
+      // getEntryPlanningAccount fail closed while the affected entry remains.
+      if (sim.snapshotReadFailures?.length) {
+        invalidateSimulationLayers()
+        simError.value = describeFailure(sim)
+        logBatchDiag('resimulate:snapshot-read-failed', {
+          token,
+          failures: sim.snapshotReadFailures.length,
+        }, 'error')
+        return
+      }
+
       // Two distinct failure shapes, both blocking but handled differently:
       //  - simulationError: the EVC call reverted at the top level (couldn't even
       //    decode the batch) — no per-layer state exists.

--- a/pages/position/[number]/borrow/index.vue
+++ b/pages/position/[number]/borrow/index.vue
@@ -52,8 +52,7 @@ const { addEntry: addBatchEntry } = useTxBatch()
 const { redirectAfterAdd } = useBatchRedirect()
 const { account: planAccount } = usePlanAccount()
 const { getBorrowVaultPair } = useVaults()
-const { isConnected, address } = useWagmi()
-const { isSpyMode, spyAddress } = useSpyMode()
+const { isConnected, address, isSpyMode, effectiveAddress } = useEffectiveAddress()
 const { chainId } = useEulerAddresses()
 const { isPositionsLoading, isPositionsLoaded, getPositionBySubAccountIndex } = useEulerAccount()
 const positionIndex = usePositionIndex()
@@ -102,7 +101,7 @@ const positionIdentityKey = computed(() => {
   if (!current) return ''
   return getBorrowMorePositionIdentityKey({
     chainId: chainId.value,
-    account: spyAddress.value || address.value,
+    account: effectiveAddress.value,
     subAccount: current.subAccount,
     collateralVaultAddress: current.collateralVault?.address,
     borrowVaultAddress: current.borrowVault?.address,

--- a/tests/composables/useTxBatch.test.ts
+++ b/tests/composables/useTxBatch.test.ts
@@ -706,6 +706,54 @@ describe('normalizeSimulatedVaultLayers', () => {
 })
 
 describe('useTxBatch execution errors', () => {
+  it('rejects incomplete account snapshots before publishing or reusing their layers', async () => {
+    const sdk = createMockSdk()
+    sdk.executionService.simulateTransactionPlan.mockResolvedValue({
+      simulatedAccounts: [accountWithPosition(subAccount, subAccount, 2n)],
+      simulatedVaultsLayers: [[]],
+      simulatedWalletBalances: [],
+      simulatedVaults: [],
+      failedBatchItems: [],
+      insufficientWalletAssets: [],
+      snapshotReadFailures: [{
+        layerIndex: 1,
+        subAccount,
+        vault,
+        kind: 'vaultAccount',
+        cause: 'inBand',
+        reason: '0x1234',
+      }],
+    } as never)
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    const batch = useTxBatch()
+
+    await batch.addEntry({
+      label: 'Withdraw USDC',
+      buildPlan: async () => [] as TransactionPlan,
+      subAccount,
+    })
+    await vi.waitFor(() => expect(batch.simError.value).toBe(
+      'The complete account state could not be verified. Please try the simulation again.',
+    ))
+
+    expect(batch.layers.value).toEqual([])
+    expect(batch.activeLayer.value).toBe(0)
+    expect(batch.isSimulated.value).toBe(false)
+    expect(batch.canExecuteBatch.value).toBe(false)
+    expect(activeLayerVaultsRef.value).toEqual({})
+
+    const nextBuildPlan = vi.fn(async () => [] as TransactionPlan)
+    await expect(batch.addEntry({
+      label: 'Borrow USDC',
+      buildPlan: nextBuildPlan,
+      subAccount,
+    })).rejects.toThrow(
+      'The complete account state could not be verified. Please try the simulation again.',
+    )
+    expect(nextBuildPlan).not.toHaveBeenCalled()
+    expect(batch.entryCount.value).toBe(1)
+  })
+
   it('reuses the prefetched portfolio account as layer 0 for account-free entries', async () => {
     const sdk = createMockSdk()
     const portfolioAccount = accountWithPosition(subAccount, subAccount, 22n)

--- a/tests/utils/tx-errors.test.ts
+++ b/tests/utils/tx-errors.test.ts
@@ -117,6 +117,23 @@ describe('formatSimulationFailure: friendly message mapping', () => {
     } as never
     expect(formatSimulationFailure(result)).toContain('E_SomethingUnmapped()')
   })
+
+  it('reports incomplete Account Lens snapshots with actionable copy', () => {
+    const result = {
+      snapshotReadFailures: [{
+        layerIndex: 1,
+        subAccount: '0x2222222222222222222222222222222222222222',
+        vault: '0x3333333333333333333333333333333333333333',
+        kind: 'vaultAccount',
+        cause: 'inBand',
+        reason: '0x1234',
+      }],
+    } as never
+
+    expect(formatSimulationFailure(result)).toBe(
+      'The complete account state could not be verified. Please try the simulation again.',
+    )
+  })
 })
 
 describe('isNonBlockingApprovalSimulationFailure', () => {

--- a/utils/tx-errors.ts
+++ b/utils/tx-errors.ts
@@ -362,7 +362,12 @@ export const formatSimulationFailure = <T extends VaultEntity>(
       : `Vault check failed for ${shortenAddress(vaultErr.vault)}`
   }
 
-  // 4. Insufficiency diagnostics — last resort when no revert detail exists.
+  // 4. Account Lens failures leave the simulated account snapshot incomplete.
+  if (result.snapshotReadFailures?.length) {
+    return 'The complete account state could not be verified. Please try the simulation again.'
+  }
+
+  // 5. Insufficiency diagnostics — last resort when no revert detail exists.
   const insufficientWallet = formatInsufficiency('Insufficient wallet balance', result.insufficientWalletAssets)
   if (insufficientWallet) return insufficientWallet
   const insufficientPermit2 = formatInsufficiency('Insufficient Permit2 allowance', result.insufficientPermit2Allowances)


### PR DESCRIPTION
## Summary
- Fail closed when SDK simulation reports an incomplete account snapshot so stale projected state cannot drive batch display, execution, or subsequent entry planning.
- Use the verified effective owner when deriving borrow-position identity during spy-mode transitions.

## Changes
- Invalidate batch simulation layers before any incomplete Account Lens snapshot can be stitched or exposed.
- Surface an actionable retry message and keep affected carts non-executable until a complete simulation succeeds.
- Cover overlay invalidation, execution gating, and rejection of follow-on entry planning with regression tests.

## Test plan
- [x] `npm run test:run` — 167 files passed, 1 skipped; 1,582 tests passed, 1 skipped
- [x] `npm run typecheck`
- [x] Focused ESLint on all changed TypeScript, Vue, and test files
- [x] `npm run build`
- [x] `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved transaction simulation handling when account state cannot be fully verified.
  - Prevented incomplete or outdated simulation results from being published or reused.
  - Added clearer, actionable error messages for incomplete account snapshots.
  - Improved borrowing position identification by consistently using the effective account address.
  - Blocked subsequent transaction actions when an earlier simulation fails verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->