### PR TITLE
chore: drop pruned euler-interfaces address keys from the addresses composable

### DIFF
--- a/composables/useEulerAddresses.ts
+++ b/composables/useEulerAddresses.ts
@@ -13,8 +13,6 @@ export type EulerLensAddresses = {
 export type EulerTokenAddresses = {
   EUL: string | undefined
   rEUL: string | undefined
-  eUSD: string | undefined
-  seUSD: string | undefined
 } | null
 
 const allowedChainIds = ref<number[]>([])
@@ -135,8 +133,6 @@ export const useEulerAddresses = () => {
     return {
       EUL: config.addresses.tokenAddrs.EUL,
       rEUL: config.addresses.tokenAddrs.rEUL,
-      eUSD: config.addresses.tokenAddrs.eUSD,
-      seUSD: config.addresses.tokenAddrs.seUSD,
     }
   })
 
@@ -150,18 +146,11 @@ export const useEulerAddresses = () => {
       capRiskStewardFactory: peripheryAddrs.capRiskStewardFactory,
       escrowedCollateralPerspective: peripheryAddrs.escrowedCollateralPerspective,
       eulerEarnFactoryPerspective: peripheryAddrs.eulerEarnFactoryPerspective,
-      eulerEarnGovernedPerspective: peripheryAddrs.eulerEarnGovernedPerspective,
-      eulerUngoverned0xPerspective: peripheryAddrs.eulerUngoverned0xPerspective,
-      eulerUngovernedNzxPerspective: peripheryAddrs.eulerUngovernedNzxPerspective,
       evkFactoryPerspective: peripheryAddrs.evkFactoryPerspective,
-      externalVaultRegistry: peripheryAddrs.externalVaultRegistry,
       feeFlowController: peripheryAddrs.feeFlowController,
-      governedPerspective: peripheryAddrs.governedPerspective,
       governorAccessControlEmergencyFactory: peripheryAddrs.governorAccessControlEmergencyFactory,
-      irmRegistry: peripheryAddrs.irmRegistry,
       kinkIRMFactory: peripheryAddrs.kinkIRMFactory,
       kinkyIRMFactory: peripheryAddrs.kinkyIRMFactory,
-      oracleAdapterRegistry: peripheryAddrs.oracleAdapterRegistry,
       oracleRouterFactory: peripheryAddrs.oracleRouterFactory,
       securitizeFactory: peripheryAddrs.securitizeFactory,
       swapVerifier: peripheryAddrs.swapVerifier,

--- a/docs/vault-labels-and-verification.md
+++ b/docs/vault-labels-and-verification.md
@@ -258,17 +258,16 @@ This keeps the bridge endpoint verification aligned with the UI: label/entity ma
 | Vault Source | Verification Method |
 |-------------|---------------------|
 | **EVaults** | Address appears in `verifiedVaultAddresses` from labels |
-| **Earn vaults** | Default repo: loaded from `eulerEarnGovernedPerspective` on-chain. Alternative repos: verified if in `earnVaults` from labels |
+| **Earn vaults** | Verified if in `earnVaults` from labels (`earn-vaults.json`) |
 | **Escrow vaults** | Loaded from `escrowedCollateralPerspective` on-chain (always verified) |
 | **Securitize vaults** | Address appears in `verifiedVaultAddresses` from labels |
 | **Unknown vaults** | Resolved via subgraph; verified only if in labels |
 
 ### On-Chain Perspectives
 
-Two on-chain perspective contracts provide additional verification:
+One on-chain perspective contract provides additional verification:
 
 - **`escrowedCollateralPerspective`**: Lists all verified escrow collateral vaults. Vaults from this perspective are marked `verified: true` and `vaultCategory: 'escrow'`.
-- **`eulerEarnGovernedPerspective`**: Lists all governed EulerEarn vaults. Vaults from this perspective are always verified.
 
 ## Vault Categories and Types
 

--- a/tests/composables/useREULLocks.test.ts
+++ b/tests/composables/useREULLocks.test.ts
@@ -51,8 +51,6 @@ const importUseREULLocks = async (wallet: {
     eulerTokenAddresses: ref({
       EUL: eulAddress,
       rEUL: reulAddress,
-      eUSD: undefined,
-      seUSD: undefined,
     }),
   }))
   vi.stubGlobal('useSpyMode', () => ({


### PR DESCRIPTION
## Summary

Prepares for euler-xyz/euler-interfaces#226 (removes the deprecated perspective/registry/eUSD address keys from `EulerChains.json`) and the matching SDK `Deployment` type cleanup (euler-xyz/euler-sdks#93).

None of the removed keys were actually read anywhere in the app — the only consumed periphery keys are `termsOfUseSigner`, `swapVerifier` and `swapper`, and the token consumers read only `EUL`/`rEUL`. This drops the dead pass-through fields from `useEulerAddresses` so the composable compiles cleanly once the SDK types are bumped:

- `eulerPeripheryAddresses`: remove `governedPerspective`, `eulerUngoverned0x/NzxPerspective`, `eulerEarnGovernedPerspective`, `externalVaultRegistry`, `irmRegistry`, `oracleAdapterRegistry` (kept: escrow + EVK factory + EulerEarn factory perspectives)
- `eulerTokenAddresses`: remove `eUSD`/`seUSD` (all-zero placeholders, never launched)
- docs: Earn-vault verification is sourced from the `earn-vaults.json` label file, not the retired `eulerEarnGovernedPerspective` (the docs claim was already stale vs the code)

No runtime behavior change — removal of unused fields plus a docs correction.

## Test plan
- [x] `vitest run tests/composables/useREULLocks.test.ts`: 5 passed
- [x] `eslint` on touched files: clean