### PR TITLE
feat: badge unknown risk-manager vaults in discovery graph

### DIFF
--- a/components/entities/vault/discovery/DiscoveryMarketGraph.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketGraph.vue
@@ -3,6 +3,7 @@ import { isEulerEarn, isSecuritizeCollateralVault } from '@eulerxyz/euler-v2-sdk
 import type { MarketGroup, MiniDiagramData } from '~/entities/lend-discovery'
 import { getAssetLogoUrl } from '~/composables/useTokenList'
 import { isVaultDeprecated, isVaultKeyring, isVaultCyclicalNote } from '~/utils/eulerLabelsUtils'
+import { hasResolvedGovernorAdmin } from '~/utils/vault/governor-verification'
 import { stringToColor } from '~/utils/string-utils'
 import { getEnlargedDiagram, getArrow, getLabelPosition, getGraphConnectedAddresses, isNodeRampingDown, isExternalCollateral, findVault } from '~/utils/discoveryCalculations'
 
@@ -49,9 +50,10 @@ const isNodeRiskManagerUnknown = (address: string): boolean => {
   if (!vault) return false
   if (isEulerEarn(vault)) return !isEarnVaultOwnerVerified(vault)
   if (isSecuritizeCollateralVault(vault)) return !isSecuritizeGovernorVerified(vault)
-  // Governance info can be absent on lazily-hydrated collateral vaults — don't
-  // flag what simply hasn't been fetched yet (mirrors useMarketGroups).
-  if (!('governorAdmin' in vault)) return false
+  // Governance can be unresolved on lazily-hydrated collateral vaults — the
+  // guard is VALUE-based because SDK EVault instances always own the
+  // property. Don't flag what simply hasn't been fetched yet.
+  if (!hasResolvedGovernorAdmin(vault)) return false
   return !isVaultGovernorVerified(vault)
 }
 </script>

--- a/components/entities/vault/discovery/DiscoveryMarketGraph.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketGraph.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
+import { isEulerEarn, isSecuritizeCollateralVault } from '@eulerxyz/euler-v2-sdk'
 import type { MarketGroup, MiniDiagramData } from '~/entities/lend-discovery'
 import { getAssetLogoUrl } from '~/composables/useTokenList'
 import { isVaultDeprecated, isVaultKeyring, isVaultCyclicalNote } from '~/utils/eulerLabelsUtils'
 import { stringToColor } from '~/utils/string-utils'
-import { getEnlargedDiagram, getArrow, getLabelPosition, getGraphConnectedAddresses, isNodeRampingDown, isExternalCollateral } from '~/utils/discoveryCalculations'
+import { getEnlargedDiagram, getArrow, getLabelPosition, getGraphConnectedAddresses, isNodeRampingDown, isExternalCollateral, findVault } from '~/utils/discoveryCalculations'
 
 const props = defineProps<{
   market: MarketGroup
@@ -35,6 +36,23 @@ const isGraphEdgeHighlighted = (fromAddr: string, toAddr: string): boolean => {
 
 const isNodeCyclicalNote = (address: string): boolean => {
   return isVaultCyclicalNote(address)
+}
+
+const { isVaultGovernorVerified, isSecuritizeGovernorVerified, isEarnVaultOwnerVerified } = useVaults()
+
+// Same signal as the per-pair "Unknown" risk-manager pill: the vault resolved,
+// but its governor/owner isn't part of any declared product entity. Applies to
+// group members too — the curator's label attests membership, not that the
+// declared entity actually holds the governor keys.
+const isNodeRiskManagerUnknown = (address: string): boolean => {
+  const vault = findVault(props.market, address)
+  if (!vault) return false
+  if (isEulerEarn(vault)) return !isEarnVaultOwnerVerified(vault)
+  if (isSecuritizeCollateralVault(vault)) return !isSecuritizeGovernorVerified(vault)
+  // Governance info can be absent on lazily-hydrated collateral vaults — don't
+  // flag what simply hasn't been fetched yet (mirrors useMarketGroups).
+  if (!('governorAdmin' in vault)) return false
+  return !isVaultGovernorVerified(vault)
 }
 </script>
 
@@ -238,8 +256,10 @@ const isNodeCyclicalNote = (address: string): boolean => {
           >
             {{ node.assetSymbol.slice(0, 2) }}
           </text>
-          <!-- Unknown collateral badge: governor not in any declared product entity, or vault truly missing -->
-          <g v-if="node.isUnknown">
+          <!-- Unknown risk-manager badge: governor/owner not in any declared
+               product entity (members and externals alike — same signal as the
+               per-pair "Unknown" pill), or vault truly missing -->
+          <g v-if="node.isUnknown || isNodeRiskManagerUnknown(node.address)">
             <circle
               :cx="node.x + 9"
               :cy="node.y - 9"

--- a/composables/useMarketGroups.ts
+++ b/composables/useMarketGroups.ts
@@ -8,12 +8,13 @@ import { getAssetUsdValueOrZero } from '~/utils/sdk-prices'
 import { isVaultNotExplorable, isVaultRecentlyAdded, isVaultDeprecated, getProductKeyByVault } from '~/utils/eulerLabelsUtils'
 import { isLiveCollateralEdge } from '~/utils/vault/ltv'
 import { isVaultBorrowable } from '~/utils/vault/classification'
+import { hasResolvedGovernorAdmin } from '~/utils/vault/governor-verification'
 import { liteVaultFetchOptions } from '~/utils/sdk-fetch-options'
 
 // -- Helpers --
 
 const hasGovernorAdmin = (vault: AnyVault): vault is EVault =>
-  isEVault(vault) && 'governorAdmin' in vault
+  hasResolvedGovernorAdmin(vault)
 
 const isBorrowableVault = (vault: AnyVault): boolean =>
   isEVault(vault) && isVaultBorrowable(vault)

--- a/tests/utils/vault/governor-verification.test.ts
+++ b/tests/utils/vault/governor-verification.test.ts
@@ -6,8 +6,10 @@ import {
   resolveGoverningEntityKeys,
   resolveEarnGoverningEntityKeys,
   type VerificationLabels,
+  hasResolvedGovernorAdmin,
 } from '~/utils/vault/governor-verification'
-import type { EulerEarn, EVault, SecuritizeCollateralVault } from '@eulerxyz/euler-v2-sdk'
+import { EVault as SdkEVault } from '@eulerxyz/euler-v2-sdk'
+import type { EulerEarn, EVault, IEVault, SecuritizeCollateralVault } from '@eulerxyz/euler-v2-sdk'
 
 type Vault = EVault & { verified?: boolean, vaultCategory?: 'standard' | 'escrow' }
 type SecuritizeVault = SecuritizeCollateralVault & { verified?: boolean, vaultCategory?: 'standard' | 'escrow' }
@@ -332,5 +334,52 @@ describe('resolveEarnGoverningEntityKeys', () => {
       entityAddresses: { euler: [GOV_A], dao: [GOV_A] },
     })
     expect(resolveEarnGoverningEntityKeys(earn, labels)).toEqual(['euler', 'dao'])
+  })
+})
+
+describe('hasResolvedGovernorAdmin', () => {
+  // A REAL SDK EVault instance, not a plain-object stub: the constructor
+  // assigns `governorAdmin` even when undefined, so property-existence
+  // (`in`) checks pass on every instance — the false-Unknown-badge bug.
+  const makeSdkVault = (governorAdmin: Address | undefined): EVault =>
+    Object.assign(
+      new SdkEVault({
+        address: VAULT_ADDR,
+        governorAdmin,
+        // Minimal nested shapes the constructor dereferences.
+        oracle: { oracle: GOV_B, name: 'EulerRouter' },
+        asset: { address: GOV_B, symbol: 'TST', decimals: 18 },
+        shares: { decimals: 18 },
+        collaterals: [],
+      } as unknown as IEVault),
+      // The adapters stamp the discriminant on real instances post-construction.
+      { type: 'EVault' },
+    )
+
+  it('treats an unresolved (constructor-assigned undefined) governor as not hydrated', () => {
+    const vault = makeSdkVault(undefined)
+    // The in-operator lies on real instances — this is the wrong guard:
+    expect('governorAdmin' in vault).toBe(true)
+    // The value-based guard reads it correctly:
+    expect(hasResolvedGovernorAdmin(vault)).toBe(false)
+  })
+
+  it('passes once governance resolves — even to an unmatched governor', () => {
+    const vault = makeSdkVault(GOV_A)
+    expect(hasResolvedGovernorAdmin(vault)).toBe(true)
+    // Unmatched governor → verification legitimately fails (real Unknown).
+    const labels = buildLabels({
+      declaredKeys: { [VAULT_ADDR]: ['euler'] },
+      entityAddresses: { euler: [GOV_B] },
+    })
+    expect(isVaultGovernorVerified(
+      Object.assign(vault, { verified: true }) as never,
+      labels,
+    )).toBe(false)
+  })
+
+  it('rejects non-EVault shapes', () => {
+    expect(hasResolvedGovernorAdmin(undefined)).toBe(false)
+    expect(hasResolvedGovernorAdmin({ governorAdmin: GOV_A })).toBe(false)
   })
 })

--- a/utils/vault/governor-verification.ts
+++ b/utils/vault/governor-verification.ts
@@ -1,6 +1,17 @@
 import { getAddress, zeroAddress, type Address } from 'viem'
+import type { EulerEarn, OracleDetailedInfo, isEVault, type EVault } from '@eulerxyz/euler-v2-sdk'
 import { getEulerRouterGovernor } from '~/entities/oracle'
-import type { EulerEarn, OracleDetailedInfo } from '@eulerxyz/euler-v2-sdk'
+
+/**
+ * Value-based governance hydration guard. SDK 2.0 EVault instances always
+ * OWN the `governorAdmin` property — the constructor assigns it even when
+ * governance was never fetched — so an `in`-operator check passes on every
+ * real instance and misreads lazily-hydrated vaults as "governance resolved
+ * to nothing", producing false Unknown badges. Only a defined value means
+ * governance actually resolved.
+ */
+export const hasResolvedGovernorAdmin = (vault: unknown): vault is EVault =>
+  isEVault(vault) && vault.governorAdmin !== undefined
 
 interface VerifiableVault {
   address: string

--- a/utils/vault/governor-verification.ts
+++ b/utils/vault/governor-verification.ts
@@ -1,5 +1,5 @@
 import { getAddress, zeroAddress, type Address } from 'viem'
-import type { EulerEarn, OracleDetailedInfo, isEVault, type EVault } from '@eulerxyz/euler-v2-sdk'
+import { isEVault, type EulerEarn, type EVault, type OracleDetailedInfo } from '@eulerxyz/euler-v2-sdk'
 import { getEulerRouterGovernor } from '~/entities/oracle'
 
 /**


### PR DESCRIPTION
## Summary

The expanded discovery graph already badges unknown *external* collateral (via `market.unknownCollateral`), but product member vaults with an unverified governor showed no indicator — even though the pair cards below render the red "Unknown" risk-manager pill for them. A market like Alterscope LRT could have every vault flagged "Unknown" in the Lend/Borrow cards while the graph looked perfectly clean.

This adds a per-node check in `DiscoveryMarketGraph.vue` that runs the same verification predicates the cards use:

- `isVaultGovernorVerified` for EVK vaults
- `isSecuritizeGovernorVerified` for Securitize vaults
- `isEarnVaultOwnerVerified` for Earn vaults

and renders the existing red "!" badge when verification fails. The check is wired into the same badge chain as the unknown-collateral badge, so precedence over the deprecated/ramping/keyring/cyclical badges is unchanged. Vaults hydrated without governance data (`governorAdmin` not yet fetched) are not flagged, mirroring the guard in `useMarketGroups`, so lazily-loaded collateral doesn't flash the badge.

Out of scope (left as-is): the collapsed market card's "X unknown" counter still counts only external collateral, and the Matrix view has no unknown indicator.

## Test plan

- [x] `npm run typecheck`
- [x] `npx eslint components/entities/vault/discovery/DiscoveryMarketGraph.vue`
- [x] `npx vitest run tests/utils/discovery-calculations.test.ts` (22 passing)
- [ ] Visual check: expand a market whose member vaults show the "Unknown" risk-manager pill (e.g. Alterscope LRT) and confirm the red badge renders on those graph nodes
- [ ] Confirm verified markets render no new badges

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved risk-manager verification indicators in the vault discovery graph.
  * Added badges for unverified governors or owners, including external vaults and resolved group members.
  * Prevented incorrect warnings for vaults whose details load progressively.
  * Improved detection of verified governor administrators and reduced false verification results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->