### PR TITLE
feat: disable CoW swap quotes for Safe wallets

### DIFF
--- a/composables/borrow/useMultiplyForm.ts
+++ b/composables/borrow/useMultiplyForm.ts
@@ -103,6 +103,7 @@ export const useMultiplyForm = (options: UseMultiplyFormOptions) => {
   const { getBalance } = useWallets()
   const { finalizeTxAndRedirect } = useTxFinalization()
   const { entryCount: batchEntryCount } = useTxBatch()
+  const { cowSwapForcedOff } = useCowSwapEligibility()
   const {
     version: rewardsVersion,
     getSupplyRewardApy,
@@ -167,7 +168,7 @@ export const useMultiplyForm = (options: UseMultiplyFormOptions) => {
   } = useSwapQuotesParallel({
     amountField: 'amountOut',
     compare: 'max',
-    includeCowSwap: () => batchEntryCount.value === 0 && !isMultiplySavingCollateral.value,
+    includeCowSwap: () => !cowSwapForcedOff.value && batchEntryCount.value === 0 && !isMultiplySavingCollateral.value,
     buildTxPlanForQuote: (quote, _provider, context) => buildMultiplyPlanFromQuote(quote, context.account),
     getStateOverrideOptions: () => buildMultiplyStateOverrideOptions(),
     // First quote in each sweep computes plugin prefetch (Pyth Hermes updates

--- a/composables/cowswap/useCowSwapExecutionCore.ts
+++ b/composables/cowswap/useCowSwapExecutionCore.ts
@@ -46,6 +46,7 @@ export const useCowSwapExecutionCore = () => {
   const { signTypedDataAsync } = useSignTypedData()
   const { sendTransactionAsync } = useSendTransaction()
   const { isSpyMode } = useSpyMode()
+  const { cowSwapForcedOff } = useCowSwapEligibility()
   const { triggerPortfolioRefresh } = usePortfolioRefresh()
 
   const status = ref<CowSwapExecutionStatus>('idle')
@@ -69,6 +70,10 @@ export const useCowSwapExecutionCore = () => {
 
   const assertTransactionsEnabled = () => {
     if (isSpyMode.value) throw new Error('Transactions are disabled in spy mode')
+    // Backstop behind the quote-level gate: a Safe cannot produce the ECDSA
+    // order signature the CoW executor requires, and failing here is cheaper
+    // than failing after the approval transactions have been sent.
+    if (cowSwapForcedOff.value) throw new Error('CoW Swap is not available with Safe wallets')
   }
 
   const requireWallet = () => {

--- a/composables/repay/useCollateralSwapRepay.ts
+++ b/composables/repay/useCollateralSwapRepay.ts
@@ -89,6 +89,7 @@ export const useCollateralSwapRepay = (options: UseCollateralSwapRepayOptions) =
   const { account: planAccount } = usePlanAccount()
   const { client: rpcClient } = useRpcClient()
   const { entryCount: batchEntryCount, getMergedPlan } = useTxBatch()
+  const { cowSwapForcedOff } = useCowSwapEligibility()
   const { settings } = useUserSettings()
   const enableIntrinsicApy = computed(() => settings.value.enableIntrinsicApy)
   const { getSupplyRewardApy, getBorrowRewardApyForCollaterals } = useRewardsApy()
@@ -157,7 +158,7 @@ export const useCollateralSwapRepay = (options: UseCollateralSwapRepayOptions) =
     slippage,
     clearSimulationError,
     getCurrentDebt,
-    includeCowSwap: () => batchEntryCount.value === 0,
+    includeCowSwap: () => !cowSwapForcedOff.value && batchEntryCount.value === 0,
     buildTxPlanForQuote: (quote, _provider, context) => buildRepayPlan(quote, context.account),
     buildGasEstimatePlan: buildBatchAwareGasEstimatePlan,
     prefetchPluginData: (plan, account) => prefetchPluginData(plan, { account }),

--- a/composables/useCowSwapEligibility.ts
+++ b/composables/useCowSwapEligibility.ts
@@ -1,0 +1,22 @@
+import { computed } from 'vue'
+
+/**
+ * Wallet-level CoW Swap eligibility.
+ *
+ * CoW orders require a recoverable ECDSA signature — the SDK's cowExecutor
+ * rejects anything else (`normalizeCowSignature`), and it does so only
+ * AFTER the user has already sent ERC-20 approval transactions. Safe
+ * multisigs cannot produce such a signature, so CoW is removed from their
+ * quote pipeline entirely and they route to on-chain swap providers.
+ *
+ * Fail closed while Safe detection for the current connector is pending —
+ * guessing wrong costs the user stranded approvals (and, on close-position
+ * flows, a burned EVC permit nonce).
+ */
+export const useCowSwapEligibility = () => {
+  const { isSafeWallet, isSafeWalletResolved } = useSafeWallet()
+
+  const cowSwapForcedOff = computed(() => isSafeWallet.value || !isSafeWalletResolved.value)
+
+  return { cowSwapForcedOff }
+}

--- a/composables/useSwapQuotesParallel.ts
+++ b/composables/useSwapQuotesParallel.ts
@@ -113,6 +113,16 @@ export const useSwapQuotesParallel = (options: SwapQuotesParallelOptions) => {
   // gating). First quote to need it computes; subsequent ones await. Reset on
   // each new sweep so a fresh asset selection re-resolves.
   let sweepPrefetchPromise: Promise<PluginPrefetchData | undefined> | null = null
+  // The last sweep's request, replayed when CoW eligibility resolves to true
+  // while the on-screen quote set lacks CoW because of the gate — a sweep made
+  // during the fail-closed Safe-detection window, or one whose CoW cards were
+  // evicted when the gate flipped off. Eviction alone can't be undone locally:
+  // the CoW quote was never fetched (or is stale), so the sweep re-runs.
+  let lastQuoteRequest: {
+    params: SwapQuoteInput
+    requestOptions: SwapQuotesRequestOptions
+    cowGatedOff: boolean
+  } | null = null
   const guard = createRaceGuard()
 
   const sortedQuoteCards = computed(() =>
@@ -373,6 +383,7 @@ export const useSwapQuotesParallel = (options: SwapQuotesParallelOptions) => {
       quoteAbort = null
     }
     sweepPrefetchPromise = null
+    lastQuoteRequest = null
     guard.next()
     isLoading.value = false
   }
@@ -442,6 +453,13 @@ export const useSwapQuotesParallel = (options: SwapQuotesParallelOptions) => {
     const gen = guard.next()
     sweepPrefetchPromise = null
 
+    const includeCowSwap = shouldIncludeCowSwap()
+    lastQuoteRequest = {
+      params,
+      requestOptions,
+      cowGatedOff: includeCowSwap === false,
+    }
+
     isLoading.value = true
     quoteCards.value = []
     // Preserve user's manual selection — it will be validated against
@@ -453,7 +471,7 @@ export const useSwapQuotesParallel = (options: SwapQuotesParallelOptions) => {
     providersCount.value = 0
 
     try {
-      const providers = requestOptions.providers ?? await getSwapProviders({ includeCowSwap: shouldIncludeCowSwap() })
+      const providers = requestOptions.providers ?? await getSwapProviders({ includeCowSwap })
       if (guard.isStale(gen)) {
         return
       }
@@ -588,6 +606,19 @@ export const useSwapQuotesParallel = (options: SwapQuotesParallelOptions) => {
   watch(() => shouldIncludeCowSwap(), (includeCowSwap) => {
     if (includeCowSwap === false) {
       hideCowQuoteCards()
+      // The displayed sweep now lacks CoW because of the gate — remember
+      // that so a later return to eligibility replays it.
+      if (lastQuoteRequest) {
+        lastQuoteRequest = { ...lastQuoteRequest, cowGatedOff: true }
+      }
+      return
+    }
+    // Eligibility resolving to true (Safe detection finishing on a regular
+    // wallet, or a switch back to one) must widen a sweep that ran or was
+    // evicted during the gated window — eviction is one-way, so without a
+    // replay the reduced quote set persists until the next input change.
+    if (includeCowSwap === true && lastQuoteRequest?.cowGatedOff) {
+      void requestQuotes(lastQuoteRequest.params, lastQuoteRequest.requestOptions)
     }
   })
 

--- a/composables/useSwapQuotesParallel.ts
+++ b/composables/useSwapQuotesParallel.ts
@@ -378,6 +378,13 @@ export const useSwapQuotesParallel = (options: SwapQuotesParallelOptions) => {
   }
 
   const upsertQuote = (card: SwapQuoteCard) => {
+    // An in-flight CoW response can resolve after the gate flipped mid-sweep
+    // (e.g. Safe detection landing): the sweep generation is still current,
+    // and the eviction watcher only removes cards already displayed. Re-check
+    // eligibility at acceptance time so the resolved card cannot reinsert.
+    if (isCowProviderOrQuote(card.provider, card.quote) && !shouldIncludeCowSwap()) {
+      return
+    }
     const { provider } = card
     const next = quoteCards.value.filter(existing => existing.provider !== provider)
     next.push({ ...card, fetchedAt: card.fetchedAt ?? Date.now() })

--- a/pages/position/[number]/borrow/swap.vue
+++ b/pages/position/[number]/borrow/swap.vue
@@ -1063,8 +1063,11 @@ const buildRefinancePlan = async (
   return planRefinancePosition(input)
 }
 
+const { cowSwapForcedOff } = useCowSwapEligibility()
+
 const canRequestCollateralCowSwap = computed(() =>
-  collateralNeedsSwap.value
+  !cowSwapForcedOff.value
+  && collateralNeedsSwap.value
   && !hasDebtChange.value
   && currentCollateralShares.value > 0n
   && !!getCowSwapChainConfig(currentChainId.value ?? 0),

--- a/tests/composables/useCollateralSwapRepay.test.ts
+++ b/tests/composables/useCollateralSwapRepay.test.ts
@@ -218,6 +218,7 @@ describe('useCollateralSwapRepay', () => {
       entryCount: ref(0),
       getMergedPlan: vi.fn(() => null),
     }))
+    vi.stubGlobal('useCowSwapEligibility', () => ({ cowSwapForcedOff: ref(false) }))
     vi.stubGlobal('useUserSettings', () => ({
       settings: ref({ enableIntrinsicApy: false }),
     }))

--- a/tests/composables/useCowSwapEligibility.test.ts
+++ b/tests/composables/useCowSwapEligibility.test.ts
@@ -1,0 +1,48 @@
+import { ref, type Ref } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+describe('useCowSwapEligibility', () => {
+  let isSafeWallet: Ref<boolean>
+  let isSafeWalletResolved: Ref<boolean>
+
+  const setupComposable = async () => {
+    const { useCowSwapEligibility } = await import('~/composables/useCowSwapEligibility')
+    return useCowSwapEligibility()
+  }
+
+  beforeEach(() => {
+    vi.resetModules()
+    isSafeWallet = ref(false)
+    isSafeWalletResolved = ref(true)
+    vi.stubGlobal('useSafeWallet', () => ({ isSafeWallet, isSafeWalletResolved }))
+  })
+
+  it('allows CoW for resolved regular wallets', async () => {
+    const { cowSwapForcedOff } = await setupComposable()
+    expect(cowSwapForcedOff.value).toBe(false)
+  })
+
+  it('forces CoW off for Safe wallets', async () => {
+    isSafeWallet.value = true
+    const { cowSwapForcedOff } = await setupComposable()
+    expect(cowSwapForcedOff.value).toBe(true)
+  })
+
+  it('fails closed while Safe detection is pending', async () => {
+    isSafeWalletResolved.value = false
+    const { cowSwapForcedOff } = await setupComposable()
+    expect(cowSwapForcedOff.value).toBe(true)
+
+    // Detection resolves to a regular wallet — CoW becomes available.
+    isSafeWalletResolved.value = true
+    expect(cowSwapForcedOff.value).toBe(false)
+  })
+
+  it('reacts to mid-session Safe connection', async () => {
+    const { cowSwapForcedOff } = await setupComposable()
+    expect(cowSwapForcedOff.value).toBe(false)
+
+    isSafeWallet.value = true
+    expect(cowSwapForcedOff.value).toBe(true)
+  })
+})

--- a/tests/composables/useCowSwapExecutionCore.test.ts
+++ b/tests/composables/useCowSwapExecutionCore.test.ts
@@ -1,0 +1,61 @@
+import { ref, type Ref } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { TransactionPlan } from '@eulerxyz/euler-v2-sdk'
+
+vi.mock('@wagmi/vue', () => ({
+  useSendTransaction: () => ({ sendTransactionAsync: vi.fn() }),
+  useSignTypedData: () => ({ signTypedDataAsync: vi.fn() }),
+}))
+
+vi.mock('~/composables/useEulerSdk', () => ({
+  getEulerSdkFresh: vi.fn(),
+}))
+
+vi.mock('~/composables/usePortfolioRefresh', () => ({
+  usePortfolioRefresh: () => ({ triggerPortfolioRefresh: vi.fn() }),
+}))
+
+const OWNER = '0x1000000000000000000000000000000000000000'
+
+describe('useCowSwapExecutionCore Safe backstop', () => {
+  let isSafeWallet: Ref<boolean>
+  let isSafeWalletResolved: Ref<boolean>
+
+  const setupCore = async () => {
+    const { useCowSwapExecutionCore } = await import('~/composables/cowswap/useCowSwapExecutionCore')
+    return useCowSwapExecutionCore()
+  }
+
+  const dummyFlow = {
+    plan: [] as TransactionPlan,
+    chainId: 1,
+    cancellationMode: 'cow-api' as const,
+    orderbookUrl: 'https://api.cow.fi/mainnet',
+  }
+
+  beforeEach(() => {
+    vi.resetModules()
+    isSafeWallet = ref(false)
+    isSafeWalletResolved = ref(true)
+    vi.stubGlobal('useWagmi', () => ({ address: ref(OWNER) }))
+    vi.stubGlobal('useSpyMode', () => ({ isSpyMode: ref(false) }))
+    vi.stubGlobal('useSafeWallet', () => ({ isSafeWallet, isSafeWalletResolved }))
+    vi.stubGlobal('useCowSwapEligibility', () => ({
+      cowSwapForcedOff: computed(() => isSafeWallet.value || !isSafeWalletResolved.value),
+    }))
+  })
+
+  it('rejects execution for Safe wallets before any transaction is sent', async () => {
+    isSafeWallet.value = true
+    const core = await setupCore()
+
+    await expect(core.executePlan(dummyFlow)).rejects.toThrow('CoW Swap is not available with Safe wallets')
+  })
+
+  it('rejects execution while Safe detection is pending', async () => {
+    isSafeWalletResolved.value = false
+    const core = await setupCore()
+
+    await expect(core.executePlan(dummyFlow)).rejects.toThrow('CoW Swap is not available with Safe wallets')
+  })
+})

--- a/tests/composables/useMultiplyForm.test.ts
+++ b/tests/composables/useMultiplyForm.test.ts
@@ -275,6 +275,7 @@ describe('useMultiplyForm cap validation', () => {
     vi.stubGlobal('useTxBatch', () => ({
       entryCount: ref(0),
     }))
+    vi.stubGlobal('useCowSwapEligibility', () => ({ cowSwapForcedOff: ref(false) }))
     vi.stubGlobal('useTxFinalization', () => ({
       finalizeTxAndRedirect: vi.fn(),
     }))

--- a/tests/composables/useSwapQuotesParallel.test.ts
+++ b/tests/composables/useSwapQuotesParallel.test.ts
@@ -264,4 +264,93 @@ describe('useSwapQuotesParallel', () => {
     // The resolved CoW card must not reinsert past the eviction.
     expect(quotes.sortedQuoteCards.value.map(card => card.provider)).toEqual(['other'])
   })
+
+  it('replays the sweep when CoW eligibility resolves after a gated sweep', async () => {
+    const includeCowSwap = ref(false)
+    const cowQuote = makeQuote('100', '300')
+    const otherQuote = makeQuote('100', '200')
+    getSwapProviders.mockImplementation(async ({ includeCowSwap: include }: { includeCowSwap?: boolean }) =>
+      include ? ['cow', 'other'] : ['other'],
+    )
+    getSwapQuotes.mockImplementation(({ provider }: { provider: string }) =>
+      Promise.resolve([provider === 'cow' ? cowQuote : otherQuote]),
+    )
+
+    const quotes = useSwapQuotesParallel({
+      amountField: 'amountOut',
+      compare: 'max',
+      includeCowSwap: () => includeCowSwap.value,
+    })
+
+    // Sweep made during the fail-closed detection window — CoW resolved out
+    // of the provider list entirely.
+    await quotes.requestQuotes(requestParams)
+    await flushPromises()
+    await nextTick()
+    expect(quotes.sortedQuoteCards.value.map(card => card.provider)).toEqual(['other'])
+
+    // Detection lands on a regular wallet: eligibility resolves to true.
+    includeCowSwap.value = true
+    await nextTick()
+    await flushPromises()
+    await nextTick()
+
+    // The reduced quote set must not persist until the next input change —
+    // the sweep replays with the full provider list.
+    expect(getSwapProviders).toHaveBeenLastCalledWith({ includeCowSwap: true })
+    expect(quotes.sortedQuoteCards.value.map(card => card.provider)).toEqual(['cow', 'other'])
+  })
+
+  it('re-fetches evicted CoW quotes when eligibility returns', async () => {
+    const includeCowSwap = ref(true)
+    const cowQuote = makeQuote('100', '300')
+    const otherQuote = makeQuote('100', '200')
+    getSwapProviders.mockImplementation(async ({ includeCowSwap: include }: { includeCowSwap?: boolean }) =>
+      include ? ['cow', 'other'] : ['other'],
+    )
+    getSwapQuotes.mockImplementation(({ provider }: { provider: string }) =>
+      Promise.resolve([provider === 'cow' ? cowQuote : otherQuote]),
+    )
+
+    const quotes = useSwapQuotesParallel({
+      amountField: 'amountOut',
+      compare: 'max',
+      includeCowSwap: () => includeCowSwap.value,
+    })
+
+    await quotes.requestQuotes(requestParams)
+    await flushPromises()
+    await nextTick()
+    expect(quotes.sortedQuoteCards.value.map(card => card.provider)).toEqual(['cow', 'other'])
+
+    // Gate flips off (e.g. switch to a Safe): CoW cards evict.
+    includeCowSwap.value = false
+    await nextTick()
+    expect(quotes.sortedQuoteCards.value.map(card => card.provider)).toEqual(['other'])
+
+    // Gate returns (switch back to the EOA): eviction was one-way, so the
+    // sweep replays to restore the CoW route.
+    includeCowSwap.value = true
+    await nextTick()
+    await flushPromises()
+    await nextTick()
+    expect(quotes.sortedQuoteCards.value.map(card => card.provider)).toEqual(['cow', 'other'])
+  })
+
+  it('does not fetch when eligibility resolves before any sweep', async () => {
+    const includeCowSwap = ref(false)
+    getSwapProviders.mockResolvedValue(['cow', 'other'])
+
+    useSwapQuotesParallel({
+      amountField: 'amountOut',
+      compare: 'max',
+      includeCowSwap: () => includeCowSwap.value,
+    })
+
+    includeCowSwap.value = true
+    await nextTick()
+    await flushPromises()
+
+    expect(getSwapProviders).not.toHaveBeenCalled()
+  })
 })

--- a/tests/composables/useSwapQuotesParallel.test.ts
+++ b/tests/composables/useSwapQuotesParallel.test.ts
@@ -226,4 +226,42 @@ describe('useSwapQuotesParallel', () => {
     expect(quotes.sortedQuoteCards.value.map(card => card.provider)).toEqual(['other'])
     expect(quotes.selectedProvider.value).toBeNull()
   })
+
+  it('drops an in-flight CoW response that resolves after the gate flips to false', async () => {
+    const includeCowSwap = ref(true)
+    const otherQuote = makeQuote('100', '200')
+    let releaseCowQuote!: (quotes: SwapQuote[]) => void
+    getSwapProviders.mockResolvedValue(['cow', 'other'])
+    getSwapQuotes.mockImplementation(({ provider }: { provider: string }) =>
+      provider === 'cow'
+        ? new Promise<SwapQuote[]>((resolve) => {
+            releaseCowQuote = resolve
+          })
+        : Promise.resolve([otherQuote]),
+    )
+
+    const quotes = useSwapQuotesParallel({
+      amountField: 'amountOut',
+      compare: 'max',
+      includeCowSwap: () => includeCowSwap.value,
+    })
+
+    await quotes.requestQuotes(requestParams)
+    await flushPromises()
+    await nextTick()
+    expect(quotes.sortedQuoteCards.value.map(card => card.provider)).toEqual(['other'])
+
+    // The gate flips (e.g. Safe detection lands) while the CoW request is
+    // still in flight — same sweep generation, so the staleness guard does
+    // not cover it.
+    includeCowSwap.value = false
+    await nextTick()
+
+    releaseCowQuote([makeQuote('100', '300')])
+    await flushPromises()
+    await nextTick()
+
+    // The resolved CoW card must not reinsert past the eviction.
+    expect(quotes.sortedQuoteCards.value.map(card => card.provider)).toEqual(['other'])
+  })
 })


### PR DESCRIPTION
## Summary

Removes CoW Swap from the quote pipeline for Safe multisigs, routing them to on-chain swap providers (LITE-322). **Stacked on #797** — depends on `useSafeWallet`; retarget to `development` once #797 merges.

## Why

CoW orders require a recoverable 65-byte ECDSA signature: the SDK's `cowExecutor` funnels every order (and EVC permit) signature through `normalizeCowSignature`, which throws `Unsupported signature length` for anything else — and it does so **after** the user has already sent ERC-20 approval transaction(s). On close-position flows a burned EVC permit nonce compounds the damage. A Safe cannot produce such a signature, so for Safe wallets the CoW route is unusable-by-construction today. Proper Safe+CoW support (presign / EIP-1271 order placement) requires SDK `cowExecutor` changes and is out of scope — this PR makes the failure impossible instead.

## Implementation

No SDK changes needed — CoW is opt-in app-side (`includeCowSwap`, filtered in `useSwapApi.getSwapProviders` before any quote request), and `useSwapQuotesParallel` already evicts on-screen CoW cards and clears a manual CoW selection when the gate flips mid-session, auto-falling through to the next-best provider.

- `composables/useCowSwapEligibility.ts` — `cowSwapForcedOff = isSafeWallet || !isSafeWalletResolved` (fail-closed while detection is pending, mirroring the signature-preference gate from #797)
- ANDed into the three `includeCowSwap` call sites (`useMultiplyForm`, `useCollateralSwapRepay`, `borrow/swap.vue`), preserving a literal `false` return so the eviction watcher fires
- Defence-in-depth: `useCowSwapExecutionCore.assertTransactionsEnabled` throws `CoW Swap is not available with Safe wallets` before any transaction is sent, should a stale CoW quote ever survive to a submit branch

## Test plan

- [x] `useCowSwapEligibility`: regular wallet, Safe, detection pending (fail-closed), mid-session Safe connect
- [x] `useCowSwapExecutionCore`: execution rejects for Safe and for pending detection before any transaction
- [x] Existing quote-pipeline behavior locked by `useSwapQuotesParallel` tests (callable `includeCowSwap` re-evaluated per sweep; eviction on flip to `false`)
- [x] Full suite 1648 passing; typecheck + lint clean
- [ ] Manual: Safe connected on mainnet → multiply/repay/collateral-swap quotes show only on-chain providers; EOA unaffected