### PR TITLE
feat: bundle migration authorizations + EVC batch into one Safe proposal

### DIFF
--- a/components/BatchReviewModal.vue
+++ b/components/BatchReviewModal.vue
@@ -103,6 +103,11 @@ const overrideBundled = (steps: DisplayStep[], entry: typeof entries.value[numbe
     : steps
 
 const getEntrySignatureSteps = (entry: typeof entries.value[number]): DisplayStep[] => {
+  // A latched bundled ceremony carries its own rows, derived from the SAME
+  // authorization resolution the proposal executes — the add-time captures
+  // can be stale (authorization state drifts between add and review).
+  const latchedSteps = latchedBundledExecution.value?.stepsByEntryId[entry.id]
+  if (latchedSteps) return normalizeDisplaySteps(latchedSteps.grantSteps)
   const review = entry.review as unknown as ReviewWithSteps | undefined
   return isExternalProtocolMigrationReview(review)
     ? overrideBundled(normalizeDisplaySteps(review?.signatureSteps), entry)
@@ -110,6 +115,8 @@ const getEntrySignatureSteps = (entry: typeof entries.value[number]): DisplaySte
 }
 
 const getEntryPostSteps = (entry: typeof entries.value[number]): DisplayStep[] => {
+  const latchedSteps = latchedBundledExecution.value?.stepsByEntryId[entry.id]
+  if (latchedSteps) return normalizeDisplaySteps(latchedSteps.revokeSteps)
   const review = entry.review as unknown as ReviewWithSteps | undefined
   return isExternalProtocolMigrationReview(review)
     ? overrideBundled(normalizeDisplaySteps(review?.postSteps), entry)

--- a/components/BatchReviewModal.vue
+++ b/components/BatchReviewModal.vue
@@ -47,6 +47,8 @@ const {
   simulateOnTenderly,
   dismissExecutionError,
   willBundlePrerequisites,
+  prepareBundledExecution,
+  latchedBundledExecution,
 } = useTxBatch()
 
 const { isSpyMode, effectiveAddress } = useEffectiveAddress()
@@ -152,8 +154,10 @@ const postStepsByEntryId = computed<Record<string, DisplayStep[]>>(() => {
   return out
 })
 
+// Keys on the LATCHED resolution (what this modal session resolved,
+// displayed, and will execute) — never on live wallet classification.
 const isBundledEntry = (entry: typeof entries.value[number]): boolean =>
-  willBundlePrerequisites.value && !!entry.buildBundledExecution
+  latchedBundledExecution.value !== null && !!entry.buildBundledExecution
 
 const signatureStepsHeading = (entryId: string): string => {
   const entry = entries.value.find(candidate => candidate.id === entryId)
@@ -349,6 +353,9 @@ onMounted(async () => {
   isPreparing.value = true
   prepareError.value = ''
   try {
+    // Resolve the bundled ceremony once for this review session: the same
+    // resolution drives the rows, Copy calldata, and execution.
+    await prepareBundledExecution()
     const prepared = await prepareBatchPlan()
     preparedPlanRef.value = prepared?.plan
     const known = buildKnownSymbols()
@@ -390,6 +397,12 @@ const copyCalldata = async () => {
     const cid = chainId.value
     const sdk = await getEulerSdkForChain(cid)
     const out: { to: string, data: string, value: string }[] = []
+    // The latched Safe proposal wraps the plan with grants/revocations —
+    // the copied JSON must match the actual submission.
+    const latched = latchedBundledExecution.value
+    for (const call of latched?.grants ?? []) {
+      out.push({ to: call.to, data: call.data, value: (call.value ?? 0n).toString() })
+    }
     for (const item of plan) {
       if (item.type === 'requiredApproval') {
         for (const r of item.resolved ?? []) {
@@ -412,6 +425,9 @@ const copyCalldata = async () => {
           value: item.value.toString(),
         })
       }
+    }
+    for (const call of latched?.revokes ?? []) {
+      out.push({ to: call.to, data: call.data, value: (call.value ?? 0n).toString() })
     }
     copyToClipboard(JSON.stringify(out, null, 2), 'calldata')
   }

--- a/components/BatchReviewModal.vue
+++ b/components/BatchReviewModal.vue
@@ -46,6 +46,7 @@ const {
   fetchTenderlyEnabled,
   simulateOnTenderly,
   dismissExecutionError,
+  willBundlePrerequisites,
 } = useTxBatch()
 
 const { isSpyMode, effectiveAddress } = useEffectiveAddress()
@@ -91,17 +92,25 @@ const isExternalProtocolMigrationReview = (review: ReviewWithSteps | undefined):
 const normalizeDisplaySteps = (steps: DisplayStep[] | undefined): DisplayStep[] =>
   (steps ?? []).map((step, idx) => ({ ...step, index: idx + 1 }))
 
+// When a Safe will execute the cart, bundled-capable prerequisites ride in
+// the batch proposal — the rows captured at add-time say "Separate tx", so
+// override the flag at display time to describe the actual ceremony.
+const overrideBundled = (steps: DisplayStep[], entry: typeof entries.value[number]): DisplayStep[] =>
+  willBundlePrerequisites.value && entry.buildBundledExecution
+    ? steps.map(step => ({ ...step, isSeparateTx: false }))
+    : steps
+
 const getEntrySignatureSteps = (entry: typeof entries.value[number]): DisplayStep[] => {
   const review = entry.review as unknown as ReviewWithSteps | undefined
   return isExternalProtocolMigrationReview(review)
-    ? normalizeDisplaySteps(review?.signatureSteps)
+    ? overrideBundled(normalizeDisplaySteps(review?.signatureSteps), entry)
     : []
 }
 
 const getEntryPostSteps = (entry: typeof entries.value[number]): DisplayStep[] => {
   const review = entry.review as unknown as ReviewWithSteps | undefined
   return isExternalProtocolMigrationReview(review)
-    ? normalizeDisplaySteps(review?.postSteps)
+    ? overrideBundled(normalizeDisplaySteps(review?.postSteps), entry)
     : []
 }
 
@@ -143,22 +152,37 @@ const postStepsByEntryId = computed<Record<string, DisplayStep[]>>(() => {
   return out
 })
 
-const signatureStepsHeading = (entryId: string): string =>
-  getAuthorizationStepDisplay(
+const isBundledEntry = (entry: typeof entries.value[number]): boolean =>
+  willBundlePrerequisites.value && !!entry.buildBundledExecution
+
+const signatureStepsHeading = (entryId: string): string => {
+  const entry = entries.value.find(candidate => candidate.id === entryId)
+  if (entry && isBundledEntry(entry)) return 'Authorization transactions'
+  return getAuthorizationStepDisplay(
     (signatureStepsByEntryId.value[entryId] ?? []).some(step => step.isSeparateTx),
   ).detailHeading
+}
 
 const authorizationRows = computed(() =>
   entries.value.flatMap(entry =>
-    (signatureStepsByEntryId.value[entry.id] ?? []).map(step => ({ entry, step })),
+    (signatureStepsByEntryId.value[entry.id] ?? []).map(step => ({ entry, step, bundledTx: isBundledEntry(entry) })),
   ),
 )
-const authorizationSummaryGroups = computed(() =>
-  [true, false].map((isSeparateTx) => {
-    const rows = authorizationRows.value.filter(({ step }) => step.isSeparateTx === isSeparateTx)
-    return { rows, display: getAuthorizationStepDisplay(isSeparateTx) }
-  }).filter(({ rows }) => rows.length),
-)
+// Three ceremonies, three groups: standalone transactions, transactions
+// riding in the Safe proposal, and wallet signatures.
+const authorizationSummaryGroups = computed(() => {
+  const rows = authorizationRows.value
+  const groups: Array<{ rows: typeof rows, display: { summaryHeading: string, itemCountLabel: string } }> = []
+  const separate = rows.filter(({ step }) => step.isSeparateTx)
+  if (separate.length) groups.push({ rows: separate, display: getAuthorizationStepDisplay(true) })
+  const bundled = rows.filter(({ step, bundledTx }) => !step.isSeparateTx && bundledTx)
+  if (bundled.length) {
+    groups.push({ rows: bundled, display: { summaryHeading: 'Authorization transactions', itemCountLabel: 'bundled in proposal' } })
+  }
+  const signatures = rows.filter(({ step, bundledTx }) => !step.isSeparateTx && !bundledTx)
+  if (signatures.length) groups.push({ rows: signatures, display: getAuthorizationStepDisplay(false) })
+  return groups
+})
 
 // Post-execution transactions (e.g. a migration's approval restoration) are
 // real wallet transactions sent after the batch settles. Surfacing them only
@@ -516,7 +540,7 @@ const onCloseRequested = () => {
               />
               <span class="truncate">{{ step.label }}</span>
             </span>
-            <span class="text-p3 text-content-tertiary shrink-0">{{ step.isSeparateTx ? '1 transaction' : 'bundled' }}</span>
+            <span class="text-p3 text-content-tertiary shrink-0">{{ step.isSeparateTx ? '1 transaction' : 'bundled in proposal' }}</span>
           </div>
         </div>
       </div>

--- a/components/entities/operation/OperationReviewModal.vue
+++ b/components/entities/operation/OperationReviewModal.vue
@@ -11,6 +11,7 @@ import { formatNumber } from '~/utils/string-utils'
 import { getAssetLogoUrl } from '~/composables/useTokenList'
 import { useStateOverrideResolution } from '~/composables/useStateOverrideOptions'
 import { hasPermit2Signature, hasPermit2TokenApproval } from '~/utils/transactionPlanApprovals'
+import type { PlainTxRequest } from '~/utils/migrationAuthorizationTxs'
 import { isPlanBundleable } from '~/utils/transaction-plan-calls'
 import { buildTenderlySimulationPayload } from '~/utils/tenderly-plan'
 
@@ -23,7 +24,7 @@ interface REULUnlockInfo {
   daysUntilMaturity: number
 }
 
-const { type, asset, assetIconUrl, reulUnlockInfo, amount, onConfirm, plan, prepared, calldataPrepared, calldataUsesPlaceholderSignatures, tenderlyPrepared, tenderlyPlan, tenderlyStateOverrides, displayPlan, signatureSteps: providedSignatureSteps, postSteps, swapFromAsset, swapFromAmount, swapToAsset, swapToAmount, swapMode, swapEstimatedSide, supplyingAssetForBorrow, supplyingAmount, transferAmounts, vaultAmounts, knownAssets, swapQuoteOutputs, confirmLabel: providedConfirmLabel, submittingLabel, quoteFetchedAt, hideExecute, subAccount, marketLabel, allowConfirmWithoutPlan } = defineProps<{
+const { type, asset, assetIconUrl, reulUnlockInfo, amount, onConfirm, plan, prepared, calldataPrepared, calldataUsesPlaceholderSignatures, calldataWrapCalls, tenderlyPrepared, tenderlyPlan, tenderlyStateOverrides, displayPlan, signatureSteps: providedSignatureSteps, postSteps, swapFromAsset, swapFromAmount, swapToAsset, swapToAmount, swapMode, swapEstimatedSide, supplyingAssetForBorrow, supplyingAmount, transferAmounts, vaultAmounts, knownAssets, swapQuoteOutputs, confirmLabel: providedConfirmLabel, submittingLabel, quoteFetchedAt, hideExecute, subAccount, marketLabel, allowConfirmWithoutPlan } = defineProps<{
   type?: 'supply' | 'withdraw' | 'borrow' | 'repay' | 'swap' | 'transfer' | 'refinance' | 'migration' | 'reward' | 'brevis-reward' | 'fuul-reward' | 'turtle-reward' | 'reul-unlock' | 'disableCollateral' | 'swap-supply' | 'swap-withdraw' | 'swap-borrow'
   asset: VaultAsset
   assetIconUrl?: string
@@ -39,6 +40,13 @@ const { type, asset, assetIconUrl, reulUnlockInfo, amount, onConfirm, plan, prep
   calldataPrepared?: TransactionPlanPrepared
   /** The copy-calldata-only plan contains placeholder wallet signatures. */
   calldataUsesPlaceholderSignatures?: boolean
+  /**
+   * Plain calls that execution wraps around the plan in the same Safe
+   * submission (migration authorization grants before it, revocations
+   * after). Included in Copy calldata so the copied JSON matches the actual
+   * proposal.
+   */
+  calldataWrapCalls?: { before: PlainTxRequest[], after: PlainTxRequest[] }
   /** Tenderly-only raw plan fallback. */
   tenderlyPlan?: TransactionPlan
   /** Additional simulation overrides required by the Tenderly-only plan. */
@@ -327,6 +335,16 @@ const copyCalldata = async () => {
     const sdk = await getEulerSdkForChain(cid)
     const entries: { to: string, data: string, value: string }[] = []
 
+    const pushWrapCalls = (calls: PlainTxRequest[] | undefined) => {
+      for (const call of calls ?? []) {
+        entries.push({ to: call.to, data: call.data, value: (call.value ?? 0n).toString() })
+      }
+    }
+
+    // Execution wraps the plan with these in the same Safe submission —
+    // the copied JSON must match the actual proposal.
+    pushWrapCalls(calldataWrapCalls?.before)
+
     for (const item of currentPlan) {
       if (item.type === 'requiredApproval') {
         for (const r of item.resolved ?? []) {
@@ -357,6 +375,8 @@ const copyCalldata = async () => {
         })
       }
     }
+
+    pushWrapCalls(calldataWrapCalls?.after)
 
     await copyToClipboard(JSON.stringify(entries, null, 2), 'calldata')
     hasCopiedCalldata.value = true

--- a/composables/borrow/useMultiplyForm.ts
+++ b/composables/borrow/useMultiplyForm.ts
@@ -103,6 +103,7 @@ export const useMultiplyForm = (options: UseMultiplyFormOptions) => {
   const { getBalance } = useWallets()
   const { finalizeTxAndRedirect } = useTxFinalization()
   const { entryCount: batchEntryCount } = useTxBatch()
+  const { cowSwapForcedOff } = useCowSwapEligibility()
   const {
     version: rewardsVersion,
     getSupplyRewardApy,
@@ -167,7 +168,7 @@ export const useMultiplyForm = (options: UseMultiplyFormOptions) => {
   } = useSwapQuotesParallel({
     amountField: 'amountOut',
     compare: 'max',
-    includeCowSwap: () => batchEntryCount.value === 0 && !isMultiplySavingCollateral.value,
+    includeCowSwap: () => !cowSwapForcedOff.value && batchEntryCount.value === 0 && !isMultiplySavingCollateral.value,
     buildTxPlanForQuote: (quote, _provider, context) => buildMultiplyPlanFromQuote(quote, context.account),
     getStateOverrideOptions: () => buildMultiplyStateOverrideOptions(),
     // First quote in each sweep computes plugin prefetch (Pyth Hermes updates

--- a/composables/cowswap/useCowSwapExecutionCore.ts
+++ b/composables/cowswap/useCowSwapExecutionCore.ts
@@ -46,6 +46,7 @@ export const useCowSwapExecutionCore = () => {
   const { signTypedDataAsync } = useSignTypedData()
   const { sendTransactionAsync } = useSendTransaction()
   const { isSpyMode } = useSpyMode()
+  const { cowSwapForcedOff } = useCowSwapEligibility()
   const { triggerPortfolioRefresh } = usePortfolioRefresh()
 
   const status = ref<CowSwapExecutionStatus>('idle')
@@ -69,6 +70,10 @@ export const useCowSwapExecutionCore = () => {
 
   const assertTransactionsEnabled = () => {
     if (isSpyMode.value) throw new Error('Transactions are disabled in spy mode')
+    // Backstop behind the quote-level gate: a Safe cannot produce the ECDSA
+    // order signature the CoW executor requires, and failing here is cheaper
+    // than failing after the approval transactions have been sent.
+    if (cowSwapForcedOff.value) throw new Error('CoW Swap is not available with Safe wallets')
   }
 
   const requireWallet = () => {

--- a/composables/repay/useCollateralSwapRepay.ts
+++ b/composables/repay/useCollateralSwapRepay.ts
@@ -89,6 +89,7 @@ export const useCollateralSwapRepay = (options: UseCollateralSwapRepayOptions) =
   const { account: planAccount } = usePlanAccount()
   const { client: rpcClient } = useRpcClient()
   const { entryCount: batchEntryCount, getMergedPlan } = useTxBatch()
+  const { cowSwapForcedOff } = useCowSwapEligibility()
   const { settings } = useUserSettings()
   const enableIntrinsicApy = computed(() => settings.value.enableIntrinsicApy)
   const { getSupplyRewardApy, getBorrowRewardApyForCollaterals } = useRewardsApy()
@@ -157,7 +158,7 @@ export const useCollateralSwapRepay = (options: UseCollateralSwapRepayOptions) =
     slippage,
     clearSimulationError,
     getCurrentDebt,
-    includeCowSwap: () => batchEntryCount.value === 0,
+    includeCowSwap: () => !cowSwapForcedOff.value && batchEntryCount.value === 0,
     buildTxPlanForQuote: (quote, _provider, context) => buildRepayPlan(quote, context.account),
     buildGasEstimatePlan: buildBatchAwareGasEstimatePlan,
     prefetchPluginData: (plan, account) => prefetchPluginData(plan, { account }),

--- a/composables/useCowSwapEligibility.ts
+++ b/composables/useCowSwapEligibility.ts
@@ -1,0 +1,22 @@
+import { computed } from 'vue'
+
+/**
+ * Wallet-level CoW Swap eligibility.
+ *
+ * CoW orders require a recoverable ECDSA signature — the SDK's cowExecutor
+ * rejects anything else (`normalizeCowSignature`), and it does so only
+ * AFTER the user has already sent ERC-20 approval transactions. Safe
+ * multisigs cannot produce such a signature, so CoW is removed from their
+ * quote pipeline entirely and they route to on-chain swap providers.
+ *
+ * Fail closed while Safe detection for the current connector is pending —
+ * guessing wrong costs the user stranded approvals (and, on close-position
+ * flows, a burned EVC permit nonce).
+ */
+export const useCowSwapEligibility = () => {
+  const { isSafeWallet, isSafeWalletResolved } = useSafeWallet()
+
+  const cowSwapForcedOff = computed(() => isSafeWallet.value || !isSafeWalletResolved.value)
+
+  return { cowSwapForcedOff }
+}

--- a/composables/useEulerTx.ts
+++ b/composables/useEulerTx.ts
@@ -1,4 +1,4 @@
-import { getAddress, type Address, type Hash, type Hex, type TransactionReceipt } from 'viem'
+import { getAddress, type Address, type Hash, type Hex, type StateOverride, type TransactionReceipt } from 'viem'
 import type {
   Account,
   CollateralShareSource,
@@ -1184,12 +1184,20 @@ export const useEulerTx = () => {
     })
   }
 
-  const simulatePreparedPlan = async (prepared: TransactionPlanPrepared, stateOverrideOptions?: SimulationStateOverrideOptions) => {
+  const simulatePreparedPlan = async (
+    prepared: TransactionPlanPrepared,
+    stateOverrideOptions?: SimulationStateOverrideOptions,
+    extraStateOverrides?: StateOverride,
+  ) => {
     return profAsync('sdk', 'simulatePreparedTransactionPlan', async () => {
       const sdk = await getEulerSdkForChain(prepared.chainId)
       return sdk.executionService.simulatePreparedTransactionPlan(prepared, {
         stateOverrides: true,
         stateOverrideOptions,
+        // Caller-supplied overrides for state the plan assumes but which is
+        // not on-chain yet (e.g. migration authorizations that will be
+        // granted inside the same Safe bundle).
+        ...(extraStateOverrides?.length ? { extraStateOverrides } : {}),
       })
     })
   }
@@ -1397,11 +1405,13 @@ export const useEulerTx = () => {
    * Submit every plan transaction as one EIP-5792 call bundle. Safe turns
    * the bundle into a single MultiSend proposal, so signers approve once
    * instead of once per transaction (approve + EVC batch collapse into one
-   * proposal). Returns undefined when the plan cannot be bundled (permit2 /
-   * CoW swap items) or when bundling brings no benefit (fewer than two
-   * calls) — callers fall back to sequential execution.
+   * proposal). `extraCalls` wrap the plan inside the same bundle (migration
+   * authorization grants before it, revocations after it). Returns undefined
+   * when the plan cannot be bundled (permit2 / CoW swap items) or when
+   * bundling brings no benefit (fewer than two calls) — callers fall back to
+   * sequential execution.
    */
-  const executePlanAsSafeBundle = async ({ plan, chainId, owner, provider, connector, safeWalletProvider, sdk }: {
+  const executePlanAsSafeBundle = async ({ plan, chainId, owner, provider, connector, safeWalletProvider, sdk, extraCalls }: {
     plan: TransactionPlan
     chainId: number
     owner: Address
@@ -1410,15 +1420,25 @@ export const useEulerTx = () => {
     connector: NonNullable<ReturnType<typeof getAccount>['connector']>
     safeWalletProvider: WalletProviderLike
     sdk: PlanEncodingSdk
+    extraCalls?: {
+      before?: readonly PlainTxRequest[]
+      after?: readonly PlainTxRequest[]
+    }
   }) => {
-    let calls
+    let planCalls
     try {
-      calls = transactionPlanToCalls(plan, sdk, chainId)
+      planCalls = transactionPlanToCalls(plan, sdk, chainId)
     }
     catch (err) {
       if (err instanceof PlanNotBundleableError) return undefined
       throw err
     }
+    const toPlanCall = (tx: PlainTxRequest) => ({ to: tx.to, data: tx.data, value: tx.value ?? 0n })
+    const calls = [
+      ...(extraCalls?.before ?? []).map(toPlanCall),
+      ...planCalls,
+      ...(extraCalls?.after ?? []).map(toPlanCall),
+    ]
     if (calls.length < 2) return undefined
 
     const currentAccount = getAccount(config)
@@ -1629,6 +1649,72 @@ export const useEulerTx = () => {
   }
 
   /**
+   * Execute a prepared plan as one Safe call bundle wrapped by extra plain
+   * calls: migration authorization grants before the plan, revocations after
+   * it. Atomicity is the point — a failed migration reverts its grants with
+   * it, and the revocations land in the same proposal, so no standing
+   * authorization ever needs unwind bookkeeping.
+   *
+   * Returns undefined when no Safe bundle context is available (regular
+   * wallet, or a Safe whose provider could not be acquired) — the caller
+   * owns the sequential fallback, which must broadcast the grants and wait
+   * for them to mine before the migration plan is rebuilt.
+   */
+  const executePreparedPlanWithPlainCalls = async (
+    prepared: TransactionPlanPrepared,
+    extraCalls: {
+      before?: readonly PlainTxRequest[]
+      after?: readonly PlainTxRequest[]
+    },
+  ) => {
+    if (isSpyMode.value) {
+      throw new Error('Transactions are disabled in spy mode')
+    }
+    const sdk = await getEulerSdkFresh()
+    const provider = sdk.providerService?.getProvider(prepared.chainId)
+    if (!provider) {
+      throw new Error('No provider available to confirm the transaction')
+    }
+    const connector = getAccount(config).connector
+    const safeWalletProvider = await getSafeWalletProvider(connector)
+    if (!safeWalletProvider || !connector) return undefined
+
+    const preparedOwner = typeof prepared.account === 'string'
+      ? getAddress(prepared.account)
+      : getAddress(prepared.account.owner)
+
+    // Same invariant as executePreparedPlan: an envelope executed for a Safe
+    // never carries permit2.
+    let effectivePrepared = prepared
+    if (hasPermit2Signature(prepared.plan)) {
+      const repairedPlan = await sdk.executionService.resolveRequiredApprovals({
+        plan: prepared.plan,
+        chainId: prepared.chainId,
+        account: preparedOwner,
+        usePermit2: false,
+      })
+      effectivePrepared = { ...prepared, plan: repairedPlan, usePermit2: false }
+    }
+    else if (prepared.usePermit2) {
+      effectivePrepared = { ...prepared, usePermit2: false }
+    }
+
+    const bundled = await executePlanAsSafeBundle({
+      plan: effectivePrepared.plan,
+      chainId: prepared.chainId,
+      owner: preparedOwner,
+      provider,
+      connector,
+      safeWalletProvider,
+      sdk,
+      extraCalls,
+    })
+    if (!bundled) return undefined
+    finalizeExecution(bundled)
+    return bundled
+  }
+
+  /**
    * Attach a fresh snapshot of a sub-account onto a pre-loaded Account. Call
    * once per form interaction (after the receiver/borrow sub-account is known
    * and before fanning out per-quote plan builds) to amortise what would
@@ -1688,6 +1774,7 @@ export const useEulerTx = () => {
     estimateGasForPlan,
     prefetchPluginData,
     simulatePreparedPlan,
+    executePreparedPlanWithPlainCalls,
     executePlan,
     executePreparedPlan,
   }

--- a/composables/useEulerTx.ts
+++ b/composables/useEulerTx.ts
@@ -1433,6 +1433,16 @@ export const useEulerTx = () => {
       if (err instanceof PlanNotBundleableError) return undefined
       throw err
     }
+    if (planCalls.length === 0) {
+      // Wrapper calls must never satisfy the bundle on their own: submitting
+      // [grant, revoke] around an empty plan would finalize a no-op
+      // migration as success. Without wrappers an empty plan simply has
+      // nothing to bundle and falls back to sequential execution.
+      if (extraCalls?.before?.length || extraCalls?.after?.length) {
+        throw new Error('Transaction plan produced no calls to bundle')
+      }
+      return undefined
+    }
     const toPlanCall = (tx: PlainTxRequest) => ({ to: tx.to, data: tx.data, value: tx.value ?? 0n })
     const calls = [
       ...(extraCalls?.before ?? []).map(toPlanCall),

--- a/composables/useEulerTx.ts
+++ b/composables/useEulerTx.ts
@@ -1421,7 +1421,7 @@ export const useEulerTx = () => {
    * bundling brings no benefit (fewer than two calls) — callers fall back to
    * sequential execution.
    */
-  const executePlanAsSafeBundle = async ({ plan, chainId, owner, provider, connector, safeWalletProvider, sdk, extraCalls }: {
+  const executePlanAsSafeBundle = async ({ plan, chainId, owner, provider, connector, safeWalletProvider, sdk, extraCalls, allowSingleCall }: {
     plan: TransactionPlan
     chainId: number
     owner: Address
@@ -1434,6 +1434,12 @@ export const useEulerTx = () => {
       before?: readonly PlainTxRequest[]
       after?: readonly PlainTxRequest[]
     }
+    /**
+     * Submit even a single-call bundle. Callers that promised the review a
+     * Safe proposal use this so "no benefit" can never be conflated with
+     * "no Safe context" — with it set, undefined strictly means the latter.
+     */
+    allowSingleCall?: boolean
   }) => {
     let planCalls
     try {
@@ -1459,7 +1465,7 @@ export const useEulerTx = () => {
       ...planCalls,
       ...(extraCalls?.after ?? []).map(toPlanCall),
     ]
-    if (calls.length < 2) return undefined
+    if (calls.length < 2 && !allowSingleCall) return undefined
 
     const currentAccount = getAccount(config)
     assertWalletExecutionContext({
@@ -1688,6 +1694,7 @@ export const useEulerTx = () => {
       before?: readonly PlainTxRequest[]
       after?: readonly PlainTxRequest[]
     },
+    options?: { allowSingleCall?: boolean },
   ) => {
     if (isSpyMode.value) {
       throw new Error('Transactions are disabled in spy mode')
@@ -1730,6 +1737,7 @@ export const useEulerTx = () => {
       safeWalletProvider,
       sdk,
       extraCalls,
+      allowSingleCall: options?.allowSingleCall,
     })
     if (!bundled) return undefined
     finalizeExecution(bundled)

--- a/composables/useSwapQuotesParallel.ts
+++ b/composables/useSwapQuotesParallel.ts
@@ -113,6 +113,16 @@ export const useSwapQuotesParallel = (options: SwapQuotesParallelOptions) => {
   // gating). First quote to need it computes; subsequent ones await. Reset on
   // each new sweep so a fresh asset selection re-resolves.
   let sweepPrefetchPromise: Promise<PluginPrefetchData | undefined> | null = null
+  // The last sweep's request, replayed when CoW eligibility resolves to true
+  // while the on-screen quote set lacks CoW because of the gate — a sweep made
+  // during the fail-closed Safe-detection window, or one whose CoW cards were
+  // evicted when the gate flipped off. Eviction alone can't be undone locally:
+  // the CoW quote was never fetched (or is stale), so the sweep re-runs.
+  let lastQuoteRequest: {
+    params: SwapQuoteInput
+    requestOptions: SwapQuotesRequestOptions
+    cowGatedOff: boolean
+  } | null = null
   const guard = createRaceGuard()
 
   const sortedQuoteCards = computed(() =>
@@ -373,6 +383,7 @@ export const useSwapQuotesParallel = (options: SwapQuotesParallelOptions) => {
       quoteAbort = null
     }
     sweepPrefetchPromise = null
+    lastQuoteRequest = null
     guard.next()
     isLoading.value = false
   }
@@ -442,6 +453,13 @@ export const useSwapQuotesParallel = (options: SwapQuotesParallelOptions) => {
     const gen = guard.next()
     sweepPrefetchPromise = null
 
+    const includeCowSwap = shouldIncludeCowSwap()
+    lastQuoteRequest = {
+      params,
+      requestOptions,
+      cowGatedOff: includeCowSwap === false,
+    }
+
     isLoading.value = true
     quoteCards.value = []
     // Preserve user's manual selection — it will be validated against
@@ -453,7 +471,7 @@ export const useSwapQuotesParallel = (options: SwapQuotesParallelOptions) => {
     providersCount.value = 0
 
     try {
-      const providers = requestOptions.providers ?? await getSwapProviders({ includeCowSwap: shouldIncludeCowSwap() })
+      const providers = requestOptions.providers ?? await getSwapProviders({ includeCowSwap })
       if (guard.isStale(gen)) {
         return
       }
@@ -588,6 +606,19 @@ export const useSwapQuotesParallel = (options: SwapQuotesParallelOptions) => {
   watch(() => shouldIncludeCowSwap(), (includeCowSwap) => {
     if (includeCowSwap === false) {
       hideCowQuoteCards()
+      // The displayed sweep now lacks CoW because of the gate — remember
+      // that so a later return to eligibility replays it.
+      if (lastQuoteRequest) {
+        lastQuoteRequest = { ...lastQuoteRequest, cowGatedOff: true }
+      }
+      return
+    }
+    // Eligibility resolving to true (Safe detection finishing on a regular
+    // wallet, or a switch back to one) must widen a sweep that ran or was
+    // evicted during the gated window — eviction is one-way, so without a
+    // replay the reduced quote set persists until the next input change.
+    if (includeCowSwap === true && lastQuoteRequest?.cowGatedOff) {
+      void requestQuotes(lastQuoteRequest.params, lastQuoteRequest.requestOptions)
     }
   })
 

--- a/composables/useSwapQuotesParallel.ts
+++ b/composables/useSwapQuotesParallel.ts
@@ -378,6 +378,13 @@ export const useSwapQuotesParallel = (options: SwapQuotesParallelOptions) => {
   }
 
   const upsertQuote = (card: SwapQuoteCard) => {
+    // An in-flight CoW response can resolve after the gate flipped mid-sweep
+    // (e.g. Safe detection landing): the sweep generation is still current,
+    // and the eviction watcher only removes cards already displayed. Re-check
+    // eligibility at acceptance time so the resolved card cannot reinsert.
+    if (isCowProviderOrQuote(card.provider, card.quote) && !shouldIncludeCowSwap()) {
+      return
+    }
     const { provider } = card
     const next = quoteCards.value.filter(existing => existing.provider !== provider)
     next.push({ ...card, fetchedAt: card.fetchedAt ?? Date.now() })

--- a/composables/useTransactionPlanSimulation.ts
+++ b/composables/useTransactionPlanSimulation.ts
@@ -1,3 +1,4 @@
+import type { StateOverride } from 'viem'
 import type { SimulationStateOverrideOptions, TransactionPlan, TransactionPlanPrepared } from '@eulerxyz/euler-v2-sdk'
 import {
   formatSimulationFailure,
@@ -62,11 +63,15 @@ export const useTransactionPlanSimulation = () => {
     }
   }
 
-  const runPreparedSimulation = async (prepared: TransactionPlanPrepared, stateOverrideOptions?: SimulationStateOverrideOptions) => {
+  const runPreparedSimulation = async (
+    prepared: TransactionPlanPrepared,
+    stateOverrideOptions?: SimulationStateOverrideOptions,
+    extraStateOverrides?: StateOverride,
+  ) => {
     clearSimulationError()
     isSimulating.value = true
     try {
-      return handleResult(prepared, await simulatePreparedPlan(prepared, stateOverrideOptions))
+      return handleResult(prepared, await simulatePreparedPlan(prepared, stateOverrideOptions, extraStateOverrides))
     }
     catch (e) {
       if (await isNonBlockingApprovalSimulationError(prepared, e)) return true

--- a/composables/useTxBatch.ts
+++ b/composables/useTxBatch.ts
@@ -89,6 +89,19 @@ export interface BatchEntryExecutionPrerequisites {
   postTxsByPreTx?: Array<BatchEntryExternalTx | undefined>
 }
 
+export interface BatchEntryBundledExecution {
+  /**
+   * Execution payload built WITHOUT live authorization reads (the
+   * simulation-variant plan) — the grants ride in the same Safe proposal
+   * and are not mined when this plan is built.
+   */
+  plan: TransactionPlan
+  /** Grant calls to prepend to the proposal, in dependency order. */
+  grants: BatchEntryExternalTx[]
+  /** Revocation calls to append, already in unwind order for this entry. */
+  revokes: BatchEntryExternalTx[]
+}
+
 export interface BatchEntry {
   id: string
   label: string
@@ -104,6 +117,12 @@ export interface BatchEntry {
   buildExecutionPrerequisites?: (
     account: Account<IHasVaultAddress>,
   ) => Promise<BatchEntryExecutionPrerequisites | undefined>
+  /** Bundled-mode counterpart of the two builders above: plan + grant/revoke
+   *  calls for ONE atomic Safe proposal. Entries providing this let the cart
+   *  skip the standalone grant broadcasts entirely when a Safe executes. */
+  buildBundledExecution?: (
+    account: Account<IHasVaultAddress>,
+  ) => Promise<BatchEntryBundledExecution>
   /** Extra simulation-only overrides required by this entry, e.g. migration authorization. */
   stateOverrides?: StateOverride
   /** Props for the per-operation review modal (OperationReviewModal), captured at
@@ -1701,7 +1720,8 @@ export const useTxBatch = () => {
     () => effectiveAddress.value as Address | undefined,
   )
   const chainId = computed(() => wagmiChainId.value ?? addressesChainId.value)
-  const { prepareTransactionPlan, executePreparedPlan, estimateGasForPlan, sendPlainTransactions } = useEulerTx()
+  const { prepareTransactionPlan, executePreparedPlan, executePreparedPlanWithPlainCalls, estimateGasForPlan, sendPlainTransactions } = useEulerTx()
+  const { isSafeWallet } = useSafeWallet()
   const { restorePendingBeforeRetry, revokeAfterSuccess, revokeAfterAbort } = useMigrationAuthorizationFlow()
   const { getTokenByAddress } = useTokenList()
   const ownerSubAccountKey = computed(() => {
@@ -2404,6 +2424,43 @@ export const useTxBatch = () => {
   }
 
   /**
+   * A Safe executes the cart's prerequisites inside the batch proposal when
+   * every prerequisite-bearing entry provides a bundled builder — mixed
+   * carts (a prerequisite entry without bundled support) keep the sequential
+   * ceremony for all entries, so the review never half-describes it.
+   */
+  const willBundlePrerequisites = computed(() =>
+    isSafeWallet.value
+    && entries.value.some(entry => entry.buildBundledExecution)
+    && entries.value.every(entry => !entry.buildExecutionPrerequisites || entry.buildBundledExecution),
+  )
+
+  /**
+   * Assemble the bundled ceremony: each entry's simulation-variant plan plus
+   * its grant/revoke calls. Grants keep entry order; revokes unwind in
+   * reverse entry order (each entry's own revokes are already reversed).
+   */
+  const collectBundledExecution = async () => {
+    const plans: TransactionPlan[] = []
+    const grants: BatchEntryExternalTx[] = []
+    const revokesByEntry: BatchEntryExternalTx[][] = []
+    for (const [index, entry] of entries.value.entries()) {
+      if (entry.buildBundledExecution) {
+        const bundled = await entry.buildBundledExecution(await getExecutionPlanningAccount(index))
+        plans.push(bundled.plan)
+        grants.push(...bundled.grants)
+        revokesByEntry.push(bundled.revokes)
+        continue
+      }
+      plans.push(entry.buildExecutionPlan
+        ? await entry.buildExecutionPlan(await getExecutionPlanningAccount(index))
+        : entry.plan)
+      revokesByEntry.push([])
+    }
+    return { plans, grants, revokes: revokesByEntry.reverse().flat() }
+  }
+
+  /**
    * Send each entry's prerequisite grants, mined, before the merged plan is
    * built — plan builders read live on-chain allowances to decide whether their
    * batch still needs an authorization item.
@@ -2466,6 +2523,38 @@ export const useTxBatch = () => {
       // would revert (against the current chain state, which may have moved since
       // the last simulation), surface the decoded reason and don't send.
       const shouldRefreshExternalMigrationPositions = entries.value.some(entry => entry.refreshExternalMigrationPositions)
+
+      if (willBundlePrerequisites.value) {
+        const collected = await collectBundledExecution()
+        if (collected.grants.length || collected.revokes.length) {
+          // One atomic Safe proposal: grants + merged batch + revocations.
+          // No standalone gas estimate — the grants are unmined until the
+          // proposal executes, so a plain estimate against current state
+          // would revert; the cart's continuous simulation (which runs with
+          // the entries' authorization state overrides) is the pre-flight
+          // validation. Atomicity also removes the unwind bookkeeping: a
+          // failed proposal reverts its grants with it.
+          const sdk = await getEulerSdkFresh()
+          const executionPlan = sdk.executionService.mergePlans(collected.plans)
+          const prepared = await prepareTransactionPlan(executionPlan)
+          const result = await executePreparedPlanWithPlainCalls(prepared, {
+            before: collected.grants,
+            after: collected.revokes,
+          })
+          if (!result) {
+            // The review described ONE proposal; never silently degrade to
+            // the sequential multi-proposal ceremony.
+            throw new Error('Safe connection unavailable — the reviewed single-proposal submission cannot run. Reconnect your Safe and retry.')
+          }
+          clearBatch()
+          if (shouldRefreshExternalMigrationPositions) scheduleExternalMigrationRefreshes()
+          await redirectAfterBatchExecution()
+          return
+        }
+        // Every prerequisite resolved empty (grants already live) — the
+        // classic path below is a single proposal anyway.
+      }
+
       await sendExecutionPrerequisites(grantedRevokes)
       const executionPlan = await buildMergedExecutionPlan()
       await estimateGasForPlan(executionPlan)
@@ -2606,6 +2695,7 @@ export const useTxBatch = () => {
     dismissExecutionError,
     setActiveLayer,
     executeBatch,
+    willBundlePrerequisites,
     // Tenderly "Simulate on Tenderly" for the whole batch.
     tenderlyEnabled,
     isTenderlySimulating: tenderly.isSimulating,

--- a/composables/useTxBatch.ts
+++ b/composables/useTxBatch.ts
@@ -27,7 +27,7 @@ import {
   type LayeredVaultMap,
 } from '~/composables/useLayeredVaults'
 import { buildTenderlySimulationPayload } from '~/utils/tenderly-plan'
-import { buildPlanMarketLabel } from '~/utils/stepDecoding'
+import { buildPlanMarketLabel, type DisplayStep } from '~/utils/stepDecoding'
 import { formatSmartAmount } from '~/utils/string-utils'
 import { formatSimulationFailure, getTxErrorMessage } from '~/utils/tx-errors'
 import { logWarn } from '~/utils/errorHandling'
@@ -100,6 +100,14 @@ export interface BatchEntryBundledExecution {
   grants: BatchEntryExternalTx[]
   /** Revocation calls to append, already in unwind order for this entry. */
   revokes: BatchEntryExternalTx[]
+  /**
+   * Review rows for the grants above, derived from the SAME authorization
+   * resolution — the modal renders these, never the add-time captures, so
+   * the displayed ceremony cannot drift from the executed one.
+   */
+  grantSteps: DisplayStep[]
+  /** Review rows for the revocations above, same resolution. */
+  revokeSteps: DisplayStep[]
 }
 
 export interface BatchEntry {
@@ -230,6 +238,8 @@ const latchedBundledExecution = shallowRef<{
   plans: TransactionPlan[]
   grants: BatchEntryExternalTx[]
   revokes: BatchEntryExternalTx[]
+  /** Per-entry review rows from the same resolution, for the modal to render. */
+  stepsByEntryId: Record<string, { grantSteps: DisplayStep[], revokeSteps: DisplayStep[] }>
 } | null>(null)
 // Per-entry fixed plan (keyed by entry id), used by the review modal and by the
 // merged whole-batch plan. These are captured once when the entry is added.
@@ -2480,12 +2490,14 @@ export const useTxBatch = () => {
     const plans: TransactionPlan[] = []
     const grants: BatchEntryExternalTx[] = []
     const revokesByEntry: BatchEntryExternalTx[][] = []
+    const stepsByEntryId: Record<string, { grantSteps: DisplayStep[], revokeSteps: DisplayStep[] }> = {}
     for (const [index, entry] of entries.value.entries()) {
       if (entry.buildBundledExecution) {
         const bundled = await entry.buildBundledExecution(await getExecutionPlanningAccount(index))
         plans.push(bundled.plan)
         grants.push(...bundled.grants)
         revokesByEntry.push(bundled.revokes)
+        stepsByEntryId[entry.id] = { grantSteps: bundled.grantSteps, revokeSteps: bundled.revokeSteps }
         continue
       }
       plans.push(entry.buildExecutionPlan
@@ -2493,7 +2505,7 @@ export const useTxBatch = () => {
         : entry.plan)
       revokesByEntry.push([])
     }
-    return { plans, grants, revokes: revokesByEntry.reverse().flat() }
+    return { plans, grants, revokes: revokesByEntry.reverse().flat(), stepsByEntryId }
   }
 
   /**

--- a/composables/useTxBatch.ts
+++ b/composables/useTxBatch.ts
@@ -218,6 +218,19 @@ export interface WalletShortfall {
 // --- module-scoped state (single shared cart for the session) ---
 const entries: Ref<BatchEntry[]> = ref([])
 const layers = shallowRef<BatchLayer[]>([])
+/**
+ * Bundled ceremony resolved ONCE when the review modal opens, displayed,
+ * copied, and executed verbatim — the latch that keeps the reviewed
+ * ceremony, the copied payload, and the submitted proposal identical. A
+ * cart edit or account/chain reset clears it; executeBatch treats its
+ * presence as the reviewed promise of ONE proposal. Module-scoped like the
+ * rest of the cart state so every component instance shares it.
+ */
+const latchedBundledExecution = shallowRef<{
+  plans: TransactionPlan[]
+  grants: BatchEntryExternalTx[]
+  revokes: BatchEntryExternalTx[]
+} | null>(null)
 // Per-entry fixed plan (keyed by entry id), used by the review modal and by the
 // merged whole-batch plan. These are captured once when the entry is added.
 const entryPlans = computed<Record<string, TransactionPlan>>(() =>
@@ -2111,6 +2124,9 @@ export const useTxBatch = () => {
       watch(entries, () => {
         logBatchDiag('watch:entries-changed')
         tenderly.clearSimulation()
+        // A cart edit invalidates the latched bundled ceremony — the modal
+        // re-latches on next open.
+        latchedBundledExecution.value = null
         void runResimulate()
       })
       watch([activeLayer, layers], syncOverlay)
@@ -2119,6 +2135,7 @@ export const useTxBatch = () => {
         logBatchDiag('watch:owner-or-chain-reset', {}, 'error')
         resimToken++
         entries.value = []
+        latchedBundledExecution.value = null
         layers.value = []
         activeLayer.value = 0
         isSimulating.value = false
@@ -2438,6 +2455,23 @@ export const useTxBatch = () => {
   )
 
   /**
+   * Bundled ceremony resolved ONCE when the review modal opens, displayed,
+   * copied, and executed verbatim — the latch that keeps the reviewed
+   * ceremony, the copied payload, and the submitted proposal identical. A
+   * cart edit or account/chain reset clears it; executeBatch treats its
+   * presence as the reviewed promise of ONE proposal.
+   */
+  const prepareBundledExecution = async () => {
+    if (!willBundlePrerequisites.value) {
+      latchedBundledExecution.value = null
+      return null
+    }
+    const collected = await collectBundledExecution()
+    latchedBundledExecution.value = collected
+    return collected
+  }
+
+  /**
    * Assemble the bundled ceremony: each entry's simulation-variant plan plus
    * its grant/revoke calls. Grants keep entry order; revokes unwind in
    * reverse entry order (each entry's own revokes are already reversed).
@@ -2526,35 +2560,37 @@ export const useTxBatch = () => {
       // the last simulation), surface the decoded reason and don't send.
       const shouldRefreshExternalMigrationPositions = entries.value.some(entry => entry.refreshExternalMigrationPositions)
 
-      if (willBundlePrerequisites.value) {
-        const collected = await collectBundledExecution()
-        if (collected.grants.length || collected.revokes.length) {
-          // One atomic Safe proposal: grants + merged batch + revocations.
-          // No standalone gas estimate — the grants are unmined until the
-          // proposal executes, so a plain estimate against current state
-          // would revert; the cart's continuous simulation (which runs with
-          // the entries' authorization state overrides) is the pre-flight
-          // validation. Atomicity also removes the unwind bookkeeping: a
-          // failed proposal reverts its grants with it.
-          const sdk = await getEulerSdkFresh()
-          const executionPlan = sdk.executionService.mergePlans(collected.plans)
-          const prepared = await prepareTransactionPlan(executionPlan)
-          const result = await executePreparedPlanWithPlainCalls(prepared, {
-            before: collected.grants,
-            after: collected.revokes,
-          })
-          if (!result) {
-            // The review described ONE proposal; never silently degrade to
-            // the sequential multi-proposal ceremony.
-            throw new Error('Safe connection unavailable — the reviewed single-proposal submission cannot run. Reconnect your Safe and retry.')
-          }
-          clearBatch()
-          if (shouldRefreshExternalMigrationPositions) scheduleExternalMigrationRefreshes()
-          await redirectAfterBatchExecution()
-          return
+      if (latchedBundledExecution.value) {
+        // The review modal latched and displayed ONE atomic proposal built
+        // from this exact resolution — execute it verbatim (payload
+        // identity), even when the grants resolved empty: the provider-bound
+        // Safe path must not silently degrade into anything else.
+        if (!isSafeWallet.value) {
+          throw new Error('Wallet changed since review — please review the batch again.')
         }
-        // Every prerequisite resolved empty (grants already live) — the
-        // classic path below is a single proposal anyway.
+        const collected = latchedBundledExecution.value
+        // No standalone gas estimate — grants are unmined until the
+        // proposal executes; the cart's continuous simulation (which runs
+        // with the entries' authorization state overrides) is the
+        // pre-flight validation. Atomicity also removes the unwind
+        // bookkeeping: a failed proposal reverts its grants with it.
+        const sdk = await getEulerSdkFresh()
+        const executionPlan = sdk.executionService.mergePlans(collected.plans)
+        const prepared = await prepareTransactionPlan(executionPlan)
+        const result = await executePreparedPlanWithPlainCalls(prepared, {
+          before: collected.grants,
+          after: collected.revokes,
+        }, { allowSingleCall: true })
+        if (!result) {
+          // The review described ONE proposal; never silently degrade to
+          // the sequential multi-proposal ceremony.
+          throw new Error('Safe connection unavailable — the reviewed single-proposal submission cannot run. Reconnect your Safe and retry.')
+        }
+        latchedBundledExecution.value = null
+        clearBatch()
+        if (shouldRefreshExternalMigrationPositions) scheduleExternalMigrationRefreshes()
+        await redirectAfterBatchExecution(scope)
+        return
       }
 
       await sendExecutionPrerequisites(grantedRevokes)
@@ -2698,6 +2734,8 @@ export const useTxBatch = () => {
     setActiveLayer,
     executeBatch,
     willBundlePrerequisites,
+    prepareBundledExecution,
+    latchedBundledExecution,
     // Tenderly "Simulate on Tenderly" for the whole batch.
     tenderlyEnabled,
     isTenderlySimulating: tenderly.isSimulating,

--- a/pages/position/[number]/borrow/swap.vue
+++ b/pages/position/[number]/borrow/swap.vue
@@ -3431,7 +3431,7 @@ const sendInboundExternalMigration = async (execution: TrackedExecutionScope, pr
         if (bundleAuthorizationRequest) {
           const outcome = await sendInboundExternalMigrationAsSafeBundle(input, bundleAuthorizationRequest, account, useSignatures)
           if (outcome === 'aborted') return
-          finishInboundExternalMigrationSuccess(input)
+          finishInboundExternalMigrationSuccess(execution, input)
           return
         }
         // The grant went live since review (fresh request is empty): nothing
@@ -3489,12 +3489,13 @@ function buildInboundExternalCalldataWrapCalls(
   return { before: grants, after: revokes }
 }
 
-function finishInboundExternalMigrationSuccess(input: InboundExternalMigrationInput) {
+function finishInboundExternalMigrationSuccess(execution: TrackedExecutionScope, input: InboundExternalMigrationInput) {
   // Success signal for a detached Safe completion toast; a proposal that
   // confirmed after its modal was closed must not yank the user mid-flow.
-  markTrackedExecutionSucceeded()
+  // Bound to THIS execution's record.
+  execution.markSucceeded()
   schedulePostMigrationRefreshes(input.owner)
-  if (shouldSuppressPostTxNavigation()) return
+  if (execution.suppressPostTxUi()) return
   modal.close()
   // Land on the Positions (or Deposits) list rather than returning to the
   // external migration route, which no longer has a source position after tx.
@@ -3543,7 +3544,7 @@ const sendInboundExternalMigrationAsSafeBundle = async (
   )
   if (!ok) return 'aborted'
 
-  const result = await executePreparedPlanWithPlainCalls(prepared, { before: grants, after: revokes })
+  const result = await executePreparedPlanWithPlainCalls(prepared, { before: grants, after: revokes }, { allowSingleCall: true })
   if (!result) {
     // The review showed ONE atomic proposal. A Safe whose provider cannot be
     // acquired at confirm time must abort loudly, never silently degrade

--- a/pages/position/[number]/borrow/swap.vue
+++ b/pages/position/[number]/borrow/swap.vue
@@ -112,11 +112,13 @@ const {
   planCrossProtocolMigration,
   planCrossProtocolMigrationSimulation,
   executePreparedPlan,
+  executePreparedPlanWithPlainCalls,
   executePlan,
   prepareTransactionPlan,
   prefetchPluginData,
 } = useEulerTx()
 const { signaturesEnabled } = useSignaturePreference()
+const { isSafeWallet } = useSafeWallet()
 const {
   restorePendingBeforeRetry,
   revokeAfterSuccess,
@@ -3406,6 +3408,23 @@ const sendInboundExternalMigration = async (preview: InboundExternalMigrationPre
     inboundExternalPreparedPlan.value = null
     const revokeTxs: MigrationAuthorizationRevoke[] = []
     try {
+      if (!useSignatures && isSafeWallet.value) {
+        const bundleAuthorizationRequest = await getInboundExternalMigrationAuthorizationRequest(input, useSignatures)
+        inboundExternalAuthorizationConnector.value = bundleAuthorizationRequest ? input.source.connectorId : null
+        if (bundleAuthorizationRequest) {
+          // Safe wallets: grants + migration batch + revocations as one
+          // atomic proposal. 'aborted' means the pre-bundle simulation
+          // rejected with nothing on-chain; 'unavailable' falls through to
+          // the sequential grant flow below.
+          const outcome = await sendInboundExternalMigrationAsSafeBundle(input, bundleAuthorizationRequest, account, useSignatures)
+          if (outcome === 'aborted') return
+          if (outcome === 'executed') {
+            finishInboundExternalMigrationSuccess(input)
+            return
+          }
+        }
+      }
+
       const authorization = await resolveInboundExternalMigrationAuthorization(input, revokeTxs, useSignatures)
       inboundExternalPlan.value = await buildInboundExternalMigrationExecutionPlan(input, authorization, useSignatures)
       inboundExternalPreparedPlan.value = await prepareTransactionPlan(inboundExternalPlan.value, {
@@ -3429,18 +3448,7 @@ const sendInboundExternalMigration = async (preview: InboundExternalMigrationPre
     }
 
     await revokeAfterSuccess(revokeTxs)
-    schedulePostMigrationRefreshes(input.owner)
-    modal.close()
-    // Land on the Positions (or Deposits) list rather than returning to the
-    // external migration route, which no longer has a source position after tx.
-    const redirectPath = input.eulerTarget.borrowVault
-      ? '/portfolio'
-      : input.eulerTarget.collateralVault
-        ? '/portfolio/saving'
-        : '/portfolio'
-    setTimeout(() => {
-      void router.replace({ path: redirectPath, query: { network: route.query.network } })
-    }, MODAL_CLOSE_REDIRECT_DELAY_MS)
+    finishInboundExternalMigrationSuccess(input)
   }
   catch (err) {
     showError(err instanceof Error ? err.message : 'Migration failed')
@@ -3449,6 +3457,60 @@ const sendInboundExternalMigration = async (preview: InboundExternalMigrationPre
   finally {
     isSubmitting.value = false
   }
+}
+
+function finishInboundExternalMigrationSuccess(input: InboundExternalMigrationInput) {
+  schedulePostMigrationRefreshes(input.owner)
+  modal.close()
+  // Land on the Positions (or Deposits) list rather than returning to the
+  // external migration route, which no longer has a source position after tx.
+  const redirectPath = input.eulerTarget.borrowVault
+    ? '/portfolio'
+    : input.eulerTarget.collateralVault
+      ? '/portfolio/saving'
+      : '/portfolio'
+  setTimeout(() => {
+    void router.replace({ path: redirectPath, query: { network: route.query.network } })
+  }, MODAL_CLOSE_REDIRECT_DELAY_MS)
+}
+
+/**
+ * Execute the inbound migration as one atomic Safe proposal: authorization
+ * grants, the migration batch, and the revocations in a single
+ * wallet_sendCalls bundle. The plan comes from the simulation variant, which
+ * is byte-identical to the execution plan for transaction-kind authorizations
+ * but validates the grant instead of reading the live allowance — so nothing
+ * needs to be mined before the bundle is built. The pre-bundle simulation
+ * runs with the SDK's authorization state overrides for the same reason.
+ *
+ * Returns 'executed' when the bundle confirmed, 'aborted' when the simulation
+ * rejected (nothing on-chain, nothing to unwind), or 'unavailable' when there
+ * is no Safe bundle context — the caller falls back to sequential grants.
+ */
+const sendInboundExternalMigrationAsSafeBundle = async (
+  input: InboundExternalMigrationInput,
+  authorizationRequest: MigrationAuthorizationRequest,
+  account: Account<IHasVaultAddress> | undefined,
+  useSignatures: boolean,
+): Promise<'executed' | 'aborted' | 'unavailable'> => {
+  const { grants, revokes } = encodeMigrationAuthorizationTxs(authorizationRequest)
+  const simulation = await buildInboundExternalMigrationSimulationResult(input, authorizationRequest, account, useSignatures)
+  const prepared = await prepareTransactionPlan(simulation.plan, {
+    account,
+    chainId: input.position.chainId,
+    usePermit2: false,
+  })
+  inboundExternalPlan.value = simulation.plan
+  inboundExternalPreparedPlan.value = prepared
+  const ok = await runPreparedSimulation(
+    prepared,
+    buildRefinanceStateOverrideOptions(),
+    simulation.stateOverrides,
+  )
+  if (!ok) return 'aborted'
+
+  const result = await executePreparedPlanWithPlainCalls(prepared, { before: grants, after: revokes })
+  return result ? 'executed' : 'unavailable'
 }
 
 const addInboundExternalMigrationToBatch = async () => {
@@ -3870,7 +3932,7 @@ function buildInboundExternalMigrationSignatureSteps(
   const sourceCollateral = externalCollateralAsset.value
   if (!sourceCollateral) return []
   if (!useSignatures) {
-    return buildMigrationAuthorizationTxSteps(authorizationRequest, 'grant')
+    return buildMigrationAuthorizationTxSteps(authorizationRequest, 'grant', 1, { bundled: isSafeWallet.value })
   }
   if (inboundExternalAuthorizationConnector.value === AAVE_CONNECTOR_ID) {
     const permitValue = getTypedDataAuthorizationValue(authorizationRequest)
@@ -3909,7 +3971,7 @@ function buildInboundExternalMigrationRevokeSteps(
   useSignatures: boolean,
 ): DisplayStep[] {
   if (!authorizationRequest || useSignatures) return []
-  return buildMigrationAuthorizationTxSteps(authorizationRequest, 'revoke')
+  return buildMigrationAuthorizationTxSteps(authorizationRequest, 'revoke', 1, { bundled: isSafeWallet.value })
 }
 
 function getRoutedVia(provider: string | null, quote: SwapQuote | null): string | null {

--- a/pages/position/[number]/borrow/swap.vue
+++ b/pages/position/[number]/borrow/swap.vue
@@ -57,6 +57,7 @@ import type { DisplayStep } from '~/utils/stepDecoding'
 import {
   buildMigrationAuthorizationTxSteps,
   encodeMigrationAuthorizationTxs,
+  migrationAuthorizationPayloadKey,
   type MigrationAuthorizationRevoke,
 } from '~/utils/migrationAuthorizationTxs'
 import {
@@ -2842,15 +2843,16 @@ const buildInboundExternalMigrationCalldataPreview = async (
 
 /**
  * Resolve the migration authorization: sign it, or grant it on-chain and return
- * the revokes to send once the batch has settled.
+ * the revokes to send once the batch has settled. Takes the request the
+ * confirmation gate already fetched and validated against the review — never
+ * re-fetches, so what executes is exactly what passed the payload-equality
+ * check.
  */
 const resolveInboundExternalMigrationAuthorization = async (
-  input: InboundExternalMigrationInput,
+  authorizationRequest: MigrationAuthorizationRequest | undefined,
   revokeTxs: MigrationAuthorizationRevoke[],
   useSignatures: boolean,
 ): Promise<SignedMigrationAuthorization | undefined> => {
-  const authorizationRequest = await getInboundExternalMigrationAuthorizationRequest(input, useSignatures)
-  inboundExternalAuthorizationConnector.value = authorizationRequest ? input.source.connectorId : null
   // No request means the grant is already live on-chain: nothing to sign, and
   // nothing of ours to revoke afterwards.
   if (!authorizationRequest) return undefined
@@ -3418,6 +3420,20 @@ const sendInboundExternalMigration = async (execution: TrackedExecutionScope, pr
     })
     if (!await restorePendingBeforeRetry()) return
     inboundExternalPreparedPlan.value = null
+    const authorizationRequest = await getInboundExternalMigrationAuthorizationRequest(input, useSignatures)
+    inboundExternalAuthorizationConnector.value = authorizationRequest ? input.source.connectorId : null
+
+    // The reviewed ceremony is defined by the authorization payload the modal
+    // displayed and copied. Authorization state can drift between review and
+    // confirmation (an allowance granted or revoked elsewhere, a restore
+    // value that moved) — executing the fresh payload would add or remove
+    // grant/revoke calls the user never reviewed. Drop the cached preview so
+    // the re-review builds against the current state.
+    if (migrationAuthorizationPayloadKey(authorizationRequest) !== migrationAuthorizationPayloadKey(preview.authorizationRequest)) {
+      inboundExternalMigrationPreview.value = null
+      throw new Error('Authorization requirements changed since review — please review the migration again.')
+    }
+
     const revokeTxs: MigrationAuthorizationRevoke[] = []
     try {
       if (preview.bundledReview) {
@@ -3429,19 +3445,20 @@ const sendInboundExternalMigration = async (execution: TrackedExecutionScope, pr
         if (!isSafeWallet.value) {
           throw new Error('Wallet changed since review — please review the migration again.')
         }
-        const bundleAuthorizationRequest = await getInboundExternalMigrationAuthorizationRequest(input, useSignatures)
-        inboundExternalAuthorizationConnector.value = bundleAuthorizationRequest ? input.source.connectorId : null
-        if (bundleAuthorizationRequest) {
-          const outcome = await sendInboundExternalMigrationAsSafeBundle(input, bundleAuthorizationRequest, account, useSignatures)
-          if (outcome === 'aborted') return
-          finishInboundExternalMigrationSuccess(execution, input)
-          return
+        // bundledReview implies the review carried a request, and payload
+        // equality above pins the fresh one to it — reaching here without
+        // one is drift the gate somehow missed, so fail closed.
+        if (!authorizationRequest) {
+          inboundExternalMigrationPreview.value = null
+          throw new Error('Authorization requirements changed since review — please review the migration again.')
         }
-        // The grant went live since review (fresh request is empty): nothing
-        // to wrap; the plain plan below still submits as one Safe proposal.
+        const outcome = await sendInboundExternalMigrationAsSafeBundle(input, authorizationRequest, account, useSignatures)
+        if (outcome === 'aborted') return
+        finishInboundExternalMigrationSuccess(execution, input)
+        return
       }
 
-      const authorization = await resolveInboundExternalMigrationAuthorization(input, revokeTxs, useSignatures)
+      const authorization = await resolveInboundExternalMigrationAuthorization(authorizationRequest, revokeTxs, useSignatures)
       inboundExternalPlan.value = await buildInboundExternalMigrationExecutionPlan(input, authorization, useSignatures)
       inboundExternalPreparedPlan.value = await prepareTransactionPlan(inboundExternalPlan.value, {
         account,
@@ -3612,14 +3629,22 @@ const addInboundExternalMigrationToBatch = async () => {
             // Bundled counterpart for Safe execution: the simulation-variant
             // plan validates the grant instead of reading the live
             // allowance, so nothing needs to mine before the proposal is
-            // assembled.
+            // assembled. The review rows come from the SAME resolution so
+            // the modal cannot display a ceremony other than the one that
+            // executes.
             buildBundledExecution: async (account: Account<IHasVaultAddress>) => {
               const request = await getInboundExternalMigrationAuthorizationRequest(input, useSignatures)
               const { grants, revokes } = request
                 ? encodeMigrationAuthorizationTxs(request)
                 : { grants: [], revokes: [] }
               const simulation = await buildInboundExternalMigrationSimulationResult(input, request, account, useSignatures)
-              return { plan: simulation.plan, grants, revokes }
+              return {
+                plan: simulation.plan,
+                grants,
+                revokes,
+                grantSteps: buildMigrationAuthorizationTxSteps(request, 'grant', 1, { bundled: true }),
+                revokeSteps: buildMigrationAuthorizationTxSteps(request, 'revoke', 1, { bundled: true }),
+              }
             },
           }),
       stateOverrides: preview.tenderlySimulation.stateOverrides,

--- a/pages/position/[number]/borrow/swap.vue
+++ b/pages/position/[number]/borrow/swap.vue
@@ -3370,6 +3370,7 @@ const reviewInboundExternalMigration = async () => {
         postSteps: buildInboundExternalMigrationRevokeSteps(preview.authorizationRequest, preview.useSignatures),
         calldataPrepared: preview.calldataPrepared,
         calldataUsesPlaceholderSignatures: preview.useSignatures && !!preview.authorizationRequest,
+        calldataWrapCalls: buildInboundExternalCalldataWrapCalls(preview.authorizationRequest, preview.useSignatures),
         tenderlyPrepared: preview.tenderlySimulation.prepared,
         tenderlyStateOverrides: preview.tenderlySimulation.stateOverrides,
         allowConfirmWithoutPlan: true,
@@ -3457,6 +3458,21 @@ const sendInboundExternalMigration = async (preview: InboundExternalMigrationPre
   finally {
     isSubmitting.value = false
   }
+}
+
+/**
+ * The grant/revocation calls the Safe bundle wraps around the migration plan
+ * — surfaced so Copy calldata matches the actual proposal. Empty for
+ * signature-mode migrations and non-Safe wallets (which broadcast them as
+ * standalone transactions instead).
+ */
+function buildInboundExternalCalldataWrapCalls(
+  authorizationRequest: MigrationAuthorizationRequest | undefined,
+  useSignatures: boolean,
+) {
+  if (!authorizationRequest || useSignatures || !isSafeWallet.value) return undefined
+  const { grants, revokes } = encodeMigrationAuthorizationTxs(authorizationRequest)
+  return { before: grants, after: revokes }
 }
 
 function finishInboundExternalMigrationSuccess(input: InboundExternalMigrationInput) {

--- a/pages/position/[number]/borrow/swap.vue
+++ b/pages/position/[number]/borrow/swap.vue
@@ -33,6 +33,7 @@ import { getNewSubAccount } from '~/composables/useSubAccounts'
 import type { CowSwapCollateralSwapExecuteParams } from '~/composables/cowswap'
 import { useCowSwapCollateralSwapExecution, useCowSwapOrderStatus, openCowSwapReviewModal, buildApprovalSignSteps } from '~/composables/cowswap'
 import { POST_EXTERNAL_MIGRATION_REFRESH_DELAYS_MS, useExternalMigrationPositions, type ExternalMigrationCandidate } from '~/composables/useExternalMigrationPositions'
+import { markTrackedExecutionSucceeded, shouldSuppressPostTxNavigation } from '~/composables/useSafeExecutionDetachment'
 import { useModal } from '~/components/ui/composables/useModal'
 import { useToast } from '~/components/ui/composables/useToast'
 import { buildSwapRouteItems } from '~/utils/swapRouteItems'
@@ -3415,14 +3416,13 @@ const sendInboundExternalMigration = async (preview: InboundExternalMigrationPre
         if (bundleAuthorizationRequest) {
           // Safe wallets: grants + migration batch + revocations as one
           // atomic proposal. 'aborted' means the pre-bundle simulation
-          // rejected with nothing on-chain; 'unavailable' falls through to
-          // the sequential grant flow below.
+          // rejected with nothing on-chain; a degraded Safe (provider
+          // unavailable) throws instead of silently running the sequential
+          // ceremony the review never showed.
           const outcome = await sendInboundExternalMigrationAsSafeBundle(input, bundleAuthorizationRequest, account, useSignatures)
           if (outcome === 'aborted') return
-          if (outcome === 'executed') {
-            finishInboundExternalMigrationSuccess(input)
-            return
-          }
+          finishInboundExternalMigrationSuccess(input)
+          return
         }
       }
 
@@ -3476,7 +3476,11 @@ function buildInboundExternalCalldataWrapCalls(
 }
 
 function finishInboundExternalMigrationSuccess(input: InboundExternalMigrationInput) {
+  // Success signal for a detached Safe completion toast; a proposal that
+  // confirmed after its modal was closed must not yank the user mid-flow.
+  markTrackedExecutionSucceeded()
   schedulePostMigrationRefreshes(input.owner)
+  if (shouldSuppressPostTxNavigation()) return
   modal.close()
   // Land on the Positions (or Deposits) list rather than returning to the
   // external migration route, which no longer has a source position after tx.
@@ -3508,7 +3512,7 @@ const sendInboundExternalMigrationAsSafeBundle = async (
   authorizationRequest: MigrationAuthorizationRequest,
   account: Account<IHasVaultAddress> | undefined,
   useSignatures: boolean,
-): Promise<'executed' | 'aborted' | 'unavailable'> => {
+): Promise<'executed' | 'aborted'> => {
   const { grants, revokes } = encodeMigrationAuthorizationTxs(authorizationRequest)
   const simulation = await buildInboundExternalMigrationSimulationResult(input, authorizationRequest, account, useSignatures)
   const prepared = await prepareTransactionPlan(simulation.plan, {
@@ -3526,7 +3530,13 @@ const sendInboundExternalMigrationAsSafeBundle = async (
   if (!ok) return 'aborted'
 
   const result = await executePreparedPlanWithPlainCalls(prepared, { before: grants, after: revokes })
-  return result ? 'executed' : 'unavailable'
+  if (!result) {
+    // The review showed ONE atomic proposal. A Safe whose provider cannot be
+    // acquired at confirm time must abort loudly, never silently degrade
+    // into the sequential multi-proposal ceremony the user never reviewed.
+    throw new Error('Safe connection unavailable — the reviewed single-proposal submission cannot run. Reconnect your Safe and retry.')
+  }
+  return 'executed'
 }
 
 const addInboundExternalMigrationToBatch = async () => {

--- a/pages/position/[number]/borrow/swap.vue
+++ b/pages/position/[number]/borrow/swap.vue
@@ -2626,6 +2626,12 @@ type PreparedMigrationTenderlySimulation = {
 type InboundExternalMigrationPreview = {
   key: string
   useSignatures: boolean
+  /**
+   * The review showed the authorization riding in ONE atomic Safe proposal.
+   * Latched at review time and revalidated at confirmation — execution must
+   * never silently run a ceremony the user did not review.
+   */
+  bundledReview: boolean
   input: InboundExternalMigrationInput
   account: Account<IHasVaultAddress>
   tenderlySimulation: PreparedMigrationTenderlySimulation
@@ -2937,6 +2943,7 @@ const prepareInboundExternalMigrationPreview = async (): Promise<InboundExternal
     const preview: InboundExternalMigrationPreview = {
       key,
       useSignatures,
+      bundledReview: !useSignatures && isSafeWallet.value && !!authorizationRequest,
       input,
       account,
       tenderlySimulation: {
@@ -3410,20 +3417,25 @@ const sendInboundExternalMigration = async (preview: InboundExternalMigrationPre
     inboundExternalPreparedPlan.value = null
     const revokeTxs: MigrationAuthorizationRevoke[] = []
     try {
-      if (!useSignatures && isSafeWallet.value) {
+      if (preview.bundledReview) {
+        // The review promised ONE atomic Safe proposal. Revalidate that mode
+        // at confirmation: a wallet that no longer classifies as a Safe must
+        // re-review, never silently receive the sequential multi-proposal
+        // ceremony; a degraded Safe (provider unavailable) throws inside the
+        // bundle helper.
+        if (!isSafeWallet.value) {
+          throw new Error('Wallet changed since review — please review the migration again.')
+        }
         const bundleAuthorizationRequest = await getInboundExternalMigrationAuthorizationRequest(input, useSignatures)
         inboundExternalAuthorizationConnector.value = bundleAuthorizationRequest ? input.source.connectorId : null
         if (bundleAuthorizationRequest) {
-          // Safe wallets: grants + migration batch + revocations as one
-          // atomic proposal. 'aborted' means the pre-bundle simulation
-          // rejected with nothing on-chain; a degraded Safe (provider
-          // unavailable) throws instead of silently running the sequential
-          // ceremony the review never showed.
           const outcome = await sendInboundExternalMigrationAsSafeBundle(input, bundleAuthorizationRequest, account, useSignatures)
           if (outcome === 'aborted') return
           finishInboundExternalMigrationSuccess(input)
           return
         }
+        // The grant went live since review (fresh request is empty): nothing
+        // to wrap; the plain plan below still submits as one Safe proposal.
       }
 
       const authorization = await resolveInboundExternalMigrationAuthorization(input, revokeTxs, useSignatures)

--- a/pages/position/[number]/borrow/swap.vue
+++ b/pages/position/[number]/borrow/swap.vue
@@ -3605,6 +3605,18 @@ const addInboundExternalMigrationToBatch = async () => {
                 postTxsByPreTx: revokesByGrant,
               }
             },
+            // Bundled counterpart for Safe execution: the simulation-variant
+            // plan validates the grant instead of reading the live
+            // allowance, so nothing needs to mine before the proposal is
+            // assembled.
+            buildBundledExecution: async (account: Account<IHasVaultAddress>) => {
+              const request = await getInboundExternalMigrationAuthorizationRequest(input, useSignatures)
+              const { grants, revokes } = request
+                ? encodeMigrationAuthorizationTxs(request)
+                : { grants: [], revokes: [] }
+              const simulation = await buildInboundExternalMigrationSimulationResult(input, request, account, useSignatures)
+              return { plan: simulation.plan, grants, revokes }
+            },
           }),
       stateOverrides: preview.tenderlySimulation.stateOverrides,
       subAccount: input.eulerTarget.eulerAccount,

--- a/pages/position/[number]/borrow/swap.vue
+++ b/pages/position/[number]/borrow/swap.vue
@@ -1063,8 +1063,11 @@ const buildRefinancePlan = async (
   return planRefinancePosition(input)
 }
 
+const { cowSwapForcedOff } = useCowSwapEligibility()
+
 const canRequestCollateralCowSwap = computed(() =>
-  collateralNeedsSwap.value
+  !cowSwapForcedOff.value
+  && collateralNeedsSwap.value
   && !hasDebtChange.value
   && currentCollateralShares.value > 0n
   && !!getCowSwapChainConfig(currentChainId.value ?? 0),

--- a/pages/position/[number]/borrow/swap.vue
+++ b/pages/position/[number]/borrow/swap.vue
@@ -3374,11 +3374,11 @@ const reviewInboundExternalMigration = async () => {
         type: 'migration',
         asset: reviewAsset,
         amount: formatUnits(reviewAsset.amount, Number(reviewAsset.decimals)),
-        signatureSteps: buildInboundExternalMigrationSignatureSteps(preview.authorizationRequest, preview.useSignatures),
-        postSteps: buildInboundExternalMigrationRevokeSteps(preview.authorizationRequest, preview.useSignatures),
+        signatureSteps: buildInboundExternalMigrationSignatureSteps(preview.authorizationRequest, preview.useSignatures, preview.bundledReview),
+        postSteps: buildInboundExternalMigrationRevokeSteps(preview.authorizationRequest, preview.useSignatures, preview.bundledReview),
         calldataPrepared: preview.calldataPrepared,
         calldataUsesPlaceholderSignatures: preview.useSignatures && !!preview.authorizationRequest,
-        calldataWrapCalls: buildInboundExternalCalldataWrapCalls(preview.authorizationRequest, preview.useSignatures),
+        calldataWrapCalls: buildInboundExternalCalldataWrapCalls(preview.authorizationRequest, preview.bundledReview),
         tenderlyPrepared: preview.tenderlySimulation.prepared,
         tenderlyStateOverrides: preview.tenderlySimulation.stateOverrides,
         allowConfirmWithoutPlan: true,
@@ -3480,9 +3480,11 @@ const sendInboundExternalMigration = async (preview: InboundExternalMigrationPre
  */
 function buildInboundExternalCalldataWrapCalls(
   authorizationRequest: MigrationAuthorizationRequest | undefined,
-  useSignatures: boolean,
+  bundledReview: boolean,
 ) {
-  if (!authorizationRequest || useSignatures || !isSafeWallet.value) return undefined
+  // Driven by the latched review mode, not live detection — displayed and
+  // copied calldata must match the ceremony the confirmation will run.
+  if (!authorizationRequest || !bundledReview) return undefined
   const { grants, revokes } = encodeMigrationAuthorizationTxs(authorizationRequest)
   return { before: grants, after: revokes }
 }
@@ -3611,8 +3613,10 @@ const addInboundExternalMigrationToBatch = async () => {
         type: 'migration',
         asset: reviewAsset,
         amount: formatUnits(reviewAsset.amount, Number(reviewAsset.decimals)),
-        signatureSteps: buildInboundExternalMigrationSignatureSteps(preview.authorizationRequest, useSignatures),
-        postSteps: buildInboundExternalMigrationRevokeSteps(preview.authorizationRequest, useSignatures),
+        // Batch prerequisites broadcast as standalone transactions
+        // (sendPlainTransactions), never inside the cart's Safe bundle.
+        signatureSteps: buildInboundExternalMigrationSignatureSteps(preview.authorizationRequest, useSignatures, false),
+        postSteps: buildInboundExternalMigrationRevokeSteps(preview.authorizationRequest, useSignatures, false),
         displayPlan: preview.calldataPrepared.plan,
         quoteFetchedAt: effectiveQuoteFetchedAt.value,
         knownAssets: externalMigrationKnownAssets.value,
@@ -3971,11 +3975,12 @@ function getTypedDataAuthorizationValue(request: MigrationAuthorizationRequest |
 function buildInboundExternalMigrationSignatureSteps(
   authorizationRequest: MigrationAuthorizationRequest | undefined,
   useSignatures: boolean,
+  bundled: boolean,
 ): DisplayStep[] {
   const sourceCollateral = externalCollateralAsset.value
   if (!sourceCollateral) return []
   if (!useSignatures) {
-    return buildMigrationAuthorizationTxSteps(authorizationRequest, 'grant', 1, { bundled: isSafeWallet.value })
+    return buildMigrationAuthorizationTxSteps(authorizationRequest, 'grant', 1, { bundled })
   }
   if (inboundExternalAuthorizationConnector.value === AAVE_CONNECTOR_ID) {
     const permitValue = getTypedDataAuthorizationValue(authorizationRequest)
@@ -4012,9 +4017,10 @@ function buildInboundExternalMigrationSignatureSteps(
 function buildInboundExternalMigrationRevokeSteps(
   authorizationRequest: MigrationAuthorizationRequest | undefined,
   useSignatures: boolean,
+  bundled: boolean,
 ): DisplayStep[] {
   if (!authorizationRequest || useSignatures) return []
-  return buildMigrationAuthorizationTxSteps(authorizationRequest, 'revoke', 1, { bundled: isSafeWallet.value })
+  return buildMigrationAuthorizationTxSteps(authorizationRequest, 'revoke', 1, { bundled })
 }
 
 function getRoutedVia(provider: string | null, quote: SwapQuote | null): string | null {

--- a/pages/position/[number]/migrate.vue
+++ b/pages/position/[number]/migrate.vue
@@ -918,7 +918,7 @@ async function sendMigration(execution: TrackedExecutionScope, preview: Outgoing
         if (authorizationRequest) {
           const outcome = await sendMigrationAsSafeBundle(input, migrationPosition, authorizationRequest, reviewedAccount)
           if (outcome === 'aborted') return
-          finishMigrationSuccess()
+          finishMigrationSuccess(execution)
           return
         }
         // The grant went live since review (fresh request is empty): nothing
@@ -983,12 +983,13 @@ function buildCalldataWrapCalls(
   return { before: grants, after: revokes }
 }
 
-function finishMigrationSuccess() {
+function finishMigrationSuccess(execution: TrackedExecutionScope) {
   // Success signal for a detached Safe completion toast; a proposal that
   // confirmed after its modal was closed must not yank the user mid-flow.
-  markTrackedExecutionSucceeded()
+  // Bound to THIS execution's record.
+  execution.markSucceeded()
   schedulePostMigrationRefreshes()
-  if (shouldSuppressPostTxNavigation()) return
+  if (execution.suppressPostTxUi()) return
   modal.close()
   setTimeout(() => {
     void router.replace({ path: '/portfolio', query: { network: route.query.network } })
@@ -1028,7 +1029,7 @@ async function sendMigrationAsSafeBundle(
   )
   if (!ok) return 'aborted'
 
-  const result = await executePreparedPlanWithPlainCalls(prepared, { before: grants, after: revokes })
+  const result = await executePreparedPlanWithPlainCalls(prepared, { before: grants, after: revokes }, { allowSingleCall: true })
   if (!result) {
     throw new Error('Safe connection unavailable — the reviewed single-proposal submission cannot run. Reconnect your Safe and retry.')
   }

--- a/pages/position/[number]/migrate.vue
+++ b/pages/position/[number]/migrate.vue
@@ -853,6 +853,7 @@ async function reviewMigration(target: OutgoingMigrationTarget) {
         postSteps: buildRevokeSteps(preview.authorizationRequest, preview.useSignatures),
         calldataPrepared: preview.calldataPrepared,
         calldataUsesPlaceholderSignatures: preview.useSignatures && !!preview.authorizationRequest,
+        calldataWrapCalls: buildCalldataWrapCalls(preview.authorizationRequest, preview.useSignatures),
         tenderlyPrepared: preview.tenderlySimulation.prepared,
         tenderlyStateOverrides: preview.tenderlySimulation.stateOverrides,
         allowConfirmWithoutPlan: true,
@@ -949,6 +950,21 @@ async function sendMigration(preview: OutgoingMigrationPreview) {
   finally {
     submittingTargetId.value = ''
   }
+}
+
+/**
+ * The grant/revocation calls the Safe bundle wraps around the migration plan
+ * — surfaced so Copy calldata matches the actual proposal. Empty for
+ * signature-mode migrations and non-Safe wallets (which broadcast them as
+ * standalone transactions instead).
+ */
+function buildCalldataWrapCalls(
+  authorizationRequest: MigrationAuthorizationRequest | undefined,
+  useSignatures: boolean,
+) {
+  if (!authorizationRequest || useSignatures || !isSafeWallet.value) return undefined
+  const { grants, revokes } = encodeMigrationAuthorizationTxs(authorizationRequest)
+  return { before: grants, after: revokes }
 }
 
 function finishMigrationSuccess() {

--- a/pages/position/[number]/migrate.vue
+++ b/pages/position/[number]/migrate.vue
@@ -73,6 +73,12 @@ type OutgoingMigrationInput = ReturnType<typeof buildMigrationInput>
 type OutgoingMigrationPreview = {
   key: string
   useSignatures: boolean
+  /**
+   * The review showed the authorization riding in ONE atomic Safe proposal.
+   * Latched at review time and revalidated at confirmation — execution must
+   * never silently run a ceremony the user did not review.
+   */
+  bundledReview: boolean
   input: OutgoingMigrationInput
   account: Account<IHasVaultAddress>
   position: MigrationPosition
@@ -788,6 +794,7 @@ async function prepareOutgoingMigrationPreview(
     const preview: OutgoingMigrationPreview = {
       key,
       useSignatures,
+      bundledReview: !useSignatures && isSafeWallet.value && !!authorizationRequest,
       input,
       account,
       position: migrationPosition,
@@ -899,18 +906,23 @@ async function sendMigration(preview: OutgoingMigrationPreview) {
     let authorization: SignedMigrationAuthorization | undefined
     const revokeTxs: MigrationAuthorizationRevoke[] = []
     try {
-      if (authorizationRequest && !useSignatures) {
-        // Safe wallets: grants + batch + revocations as one atomic proposal.
-        // 'aborted' means the pre-bundle simulation rejected with nothing
-        // on-chain; a degraded Safe (provider unavailable) throws instead of
-        // silently running the sequential multi-proposal ceremony the review
-        // never showed. Only non-Safe wallets fall through.
-        const outcome = await sendMigrationAsSafeBundle(input, migrationPosition, authorizationRequest, reviewedAccount)
-        if (outcome === 'aborted') return
-        if (outcome === 'executed') {
+      if (preview.bundledReview) {
+        // The review promised ONE atomic Safe proposal. Revalidate that mode
+        // at confirmation: a wallet that no longer classifies as a Safe must
+        // re-review, never silently receive the sequential multi-proposal
+        // ceremony; a degraded Safe (provider unavailable) throws inside the
+        // bundle helper.
+        if (!isSafeWallet.value) {
+          throw new Error('Wallet changed since review — please review the migration again.')
+        }
+        if (authorizationRequest) {
+          const outcome = await sendMigrationAsSafeBundle(input, migrationPosition, authorizationRequest, reviewedAccount)
+          if (outcome === 'aborted') return
           finishMigrationSuccess()
           return
         }
+        // The grant went live since review (fresh request is empty): nothing
+        // to wrap; the plain plan below still submits as one Safe proposal.
       }
 
       if (authorizationRequest) {
@@ -999,13 +1011,7 @@ async function sendMigrationAsSafeBundle(
   migrationPosition: MigrationPosition,
   authorizationRequest: MigrationAuthorizationRequest,
   account?: Account<IHasVaultAddress>,
-): Promise<'executed' | 'aborted' | 'not-safe'> {
-  // Revalidate the reviewed execution mode at confirmation: the review
-  // showed ONE atomic proposal for a Safe, so a Safe whose provider cannot
-  // be acquired must abort loudly rather than silently degrade into the
-  // sequential grant → migration → revoke ceremony the user never reviewed.
-  if (!isSafeWallet.value) return 'not-safe'
-
+): Promise<'executed' | 'aborted'> {
   const { grants, revokes } = encodeMigrationAuthorizationTxs(authorizationRequest)
   const simulation = await buildMigrationSimulation(input, migrationPosition, authorizationRequest, account)
   const prepared = await prepareTransactionPlan(simulation.plan, {

--- a/pages/position/[number]/migrate.vue
+++ b/pages/position/[number]/migrate.vue
@@ -42,6 +42,7 @@ import { isOperationBlocked } from '~/utils/operationGuardRegistry'
 import { BATCH_ACTIVE_REASON } from '~/utils/tx-batch-messages'
 import { assertReviewedExecutionCurrent } from '~/utils/reviewedExecution'
 import { assertWalletExecutionContext } from '~/utils/walletExecutionContext'
+import { markTrackedExecutionSucceeded, shouldSuppressPostTxNavigation } from '~/composables/useSafeExecutionDetachment'
 import { useModal } from '~/components/ui/composables/useModal'
 import { useToast } from '~/components/ui/composables/useToast'
 
@@ -899,10 +900,11 @@ async function sendMigration(preview: OutgoingMigrationPreview) {
     const revokeTxs: MigrationAuthorizationRevoke[] = []
     try {
       if (authorizationRequest && !useSignatures) {
-        // Safe wallets: try grants + batch + revocations as one atomic
-        // proposal. 'aborted' means the pre-bundle simulation rejected with
-        // nothing on-chain; 'unavailable' falls through to the sequential
-        // grant flow below.
+        // Safe wallets: grants + batch + revocations as one atomic proposal.
+        // 'aborted' means the pre-bundle simulation rejected with nothing
+        // on-chain; a degraded Safe (provider unavailable) throws instead of
+        // silently running the sequential multi-proposal ceremony the review
+        // never showed. Only non-Safe wallets fall through.
         const outcome = await sendMigrationAsSafeBundle(input, migrationPosition, authorizationRequest, reviewedAccount)
         if (outcome === 'aborted') return
         if (outcome === 'executed') {
@@ -968,7 +970,11 @@ function buildCalldataWrapCalls(
 }
 
 function finishMigrationSuccess() {
+  // Success signal for a detached Safe completion toast; a proposal that
+  // confirmed after its modal was closed must not yank the user mid-flow.
+  markTrackedExecutionSucceeded()
   schedulePostMigrationRefreshes()
+  if (shouldSuppressPostTxNavigation()) return
   modal.close()
   setTimeout(() => {
     void router.replace({ path: '/portfolio', query: { network: route.query.network } })
@@ -993,10 +999,12 @@ async function sendMigrationAsSafeBundle(
   migrationPosition: MigrationPosition,
   authorizationRequest: MigrationAuthorizationRequest,
   account?: Account<IHasVaultAddress>,
-): Promise<'executed' | 'aborted' | 'unavailable'> {
-  // Cheap reactive pre-check; the authoritative provider probe happens inside
-  // executePreparedPlanWithPlainCalls.
-  if (!isSafeWallet.value) return 'unavailable'
+): Promise<'executed' | 'aborted' | 'not-safe'> {
+  // Revalidate the reviewed execution mode at confirmation: the review
+  // showed ONE atomic proposal for a Safe, so a Safe whose provider cannot
+  // be acquired must abort loudly rather than silently degrade into the
+  // sequential grant → migration → revoke ceremony the user never reviewed.
+  if (!isSafeWallet.value) return 'not-safe'
 
   const { grants, revokes } = encodeMigrationAuthorizationTxs(authorizationRequest)
   const simulation = await buildMigrationSimulation(input, migrationPosition, authorizationRequest, account)
@@ -1013,7 +1021,10 @@ async function sendMigrationAsSafeBundle(
   if (!ok) return 'aborted'
 
   const result = await executePreparedPlanWithPlainCalls(prepared, { before: grants, after: revokes })
-  return result ? 'executed' : 'unavailable'
+  if (!result) {
+    throw new Error('Safe connection unavailable — the reviewed single-proposal submission cannot run. Reconnect your Safe and retry.')
+  }
+  return 'executed'
 }
 
 async function addMigrationToBatch(target: OutgoingMigrationTarget) {

--- a/pages/position/[number]/migrate.vue
+++ b/pages/position/[number]/migrate.vue
@@ -112,10 +112,12 @@ const {
   planCrossProtocolMigration,
   planCrossProtocolMigrationSimulation,
   executePreparedPlan,
+  executePreparedPlanWithPlainCalls,
   prepareTransactionPlan,
   prefetchPluginData,
 } = useEulerTx()
 const { signaturesEnabled } = useSignaturePreference()
+const { isSafeWallet } = useSafeWallet()
 const {
   restorePendingBeforeRetry,
   revokeAfterSuccess,
@@ -895,6 +897,19 @@ async function sendMigration(preview: OutgoingMigrationPreview) {
     let authorization: SignedMigrationAuthorization | undefined
     const revokeTxs: MigrationAuthorizationRevoke[] = []
     try {
+      if (authorizationRequest && !useSignatures) {
+        // Safe wallets: try grants + batch + revocations as one atomic
+        // proposal. 'aborted' means the pre-bundle simulation rejected with
+        // nothing on-chain; 'unavailable' falls through to the sequential
+        // grant flow below.
+        const outcome = await sendMigrationAsSafeBundle(input, migrationPosition, authorizationRequest, reviewedAccount)
+        if (outcome === 'aborted') return
+        if (outcome === 'executed') {
+          finishMigrationSuccess()
+          return
+        }
+      }
+
       if (authorizationRequest) {
         if (useSignatures) {
           authorization = await signMigrationAuthorization(authorizationRequest)
@@ -925,11 +940,7 @@ async function sendMigration(preview: OutgoingMigrationPreview) {
     }
 
     await revokeAfterSuccess(revokeTxs)
-    schedulePostMigrationRefreshes()
-    modal.close()
-    setTimeout(() => {
-      void router.replace({ path: '/portfolio', query: { network: route.query.network } })
-    }, MODAL_CLOSE_REDIRECT_DELAY_MS)
+    finishMigrationSuccess()
   }
   catch (err) {
     showError(err instanceof Error ? err.message : 'Migration failed')
@@ -938,6 +949,55 @@ async function sendMigration(preview: OutgoingMigrationPreview) {
   finally {
     submittingTargetId.value = ''
   }
+}
+
+function finishMigrationSuccess() {
+  schedulePostMigrationRefreshes()
+  modal.close()
+  setTimeout(() => {
+    void router.replace({ path: '/portfolio', query: { network: route.query.network } })
+  }, MODAL_CLOSE_REDIRECT_DELAY_MS)
+}
+
+/**
+ * Execute the migration as one atomic Safe proposal: authorization grants,
+ * the migration batch, and the revocations in a single wallet_sendCalls
+ * bundle. The plan comes from the simulation variant, which is byte-identical
+ * to the execution plan for transaction-kind authorizations but validates the
+ * grant instead of reading the live allowance — so nothing needs to be mined
+ * before the bundle is built. The pre-bundle simulation runs with the SDK's
+ * authorization state overrides for the same reason.
+ *
+ * Returns 'executed' when the bundle confirmed, 'aborted' when the simulation
+ * rejected (nothing on-chain, nothing to unwind), or 'unavailable' when there
+ * is no Safe bundle context — the caller falls back to sequential grants.
+ */
+async function sendMigrationAsSafeBundle(
+  input: OutgoingMigrationInput,
+  migrationPosition: MigrationPosition,
+  authorizationRequest: MigrationAuthorizationRequest,
+  account?: Account<IHasVaultAddress>,
+): Promise<'executed' | 'aborted' | 'unavailable'> {
+  // Cheap reactive pre-check; the authoritative provider probe happens inside
+  // executePreparedPlanWithPlainCalls.
+  if (!isSafeWallet.value) return 'unavailable'
+
+  const { grants, revokes } = encodeMigrationAuthorizationTxs(authorizationRequest)
+  const simulation = await buildMigrationSimulation(input, migrationPosition, authorizationRequest, account)
+  const prepared = await prepareTransactionPlan(simulation.plan, {
+    account,
+    chainId: input.target.chainId,
+    usePermit2: false,
+  })
+  const ok = await runPreparedSimulation(
+    prepared,
+    buildStateOverrideOptions({ noBalanceOverride: true }),
+    simulation.stateOverrides,
+  )
+  if (!ok) return 'aborted'
+
+  const result = await executePreparedPlanWithPlainCalls(prepared, { before: grants, after: revokes })
+  return result ? 'executed' : 'unavailable'
 }
 
 async function addMigrationToBatch(target: OutgoingMigrationTarget) {
@@ -1069,7 +1129,7 @@ function buildSignatureSteps(
 ): DisplayStep[] {
   if (!authorizationRequest || !target) return []
   if (!useSignatures) {
-    return buildMigrationAuthorizationTxSteps(authorizationRequest, 'grant')
+    return buildMigrationAuthorizationTxSteps(authorizationRequest, 'grant', 1, { bundled: isSafeWallet.value })
   }
   if (target.connectorId === AAVE_CONNECTOR_ID) {
     return [{
@@ -1093,7 +1153,7 @@ function buildRevokeSteps(
   useSignatures: boolean,
 ): DisplayStep[] {
   if (!authorizationRequest || useSignatures) return []
-  return buildMigrationAuthorizationTxSteps(authorizationRequest, 'revoke')
+  return buildMigrationAuthorizationTxSteps(authorizationRequest, 'revoke', 1, { bundled: isSafeWallet.value })
 }
 
 function targetLiquidityDisplay(target: OutgoingMigrationTarget): string {

--- a/pages/position/[number]/migrate.vue
+++ b/pages/position/[number]/migrate.vue
@@ -857,11 +857,11 @@ async function reviewMigration(target: OutgoingMigrationTarget) {
         type: 'migration',
         asset: sourceDebtVault.value.asset,
         amount: formatVaultAmount(currentDebt.value, sourceDebtVault.value),
-        signatureSteps: buildSignatureSteps(preview.input.target, preview.authorizationRequest, preview.useSignatures),
-        postSteps: buildRevokeSteps(preview.authorizationRequest, preview.useSignatures),
+        signatureSteps: buildSignatureSteps(preview.input.target, preview.authorizationRequest, preview.useSignatures, preview.bundledReview),
+        postSteps: buildRevokeSteps(preview.authorizationRequest, preview.useSignatures, preview.bundledReview),
         calldataPrepared: preview.calldataPrepared,
         calldataUsesPlaceholderSignatures: preview.useSignatures && !!preview.authorizationRequest,
-        calldataWrapCalls: buildCalldataWrapCalls(preview.authorizationRequest, preview.useSignatures),
+        calldataWrapCalls: buildCalldataWrapCalls(preview.authorizationRequest, preview.bundledReview),
         tenderlyPrepared: preview.tenderlySimulation.prepared,
         tenderlyStateOverrides: preview.tenderlySimulation.stateOverrides,
         allowConfirmWithoutPlan: true,
@@ -974,9 +974,11 @@ async function sendMigration(preview: OutgoingMigrationPreview) {
  */
 function buildCalldataWrapCalls(
   authorizationRequest: MigrationAuthorizationRequest | undefined,
-  useSignatures: boolean,
+  bundledReview: boolean,
 ) {
-  if (!authorizationRequest || useSignatures || !isSafeWallet.value) return undefined
+  // Driven by the latched review mode, not live detection — displayed and
+  // copied calldata must match the ceremony the confirmation will run.
+  if (!authorizationRequest || !bundledReview) return undefined
   const { grants, revokes } = encodeMigrationAuthorizationTxs(authorizationRequest)
   return { before: grants, after: revokes }
 }
@@ -1100,8 +1102,10 @@ async function addPreparedMigrationToBatch(preview: OutgoingMigrationPreview) {
       type: 'migration',
       asset: sourceDebtAsset,
       amount: debtAmount,
-      signatureSteps: buildSignatureSteps(input.target, authorizationRequest, useSignatures),
-      postSteps: buildRevokeSteps(authorizationRequest, useSignatures),
+      // Batch prerequisites broadcast as standalone transactions
+      // (sendPlainTransactions), never inside the cart's Safe bundle.
+      signatureSteps: buildSignatureSteps(input.target, authorizationRequest, useSignatures, false),
+      postSteps: buildRevokeSteps(authorizationRequest, useSignatures, false),
       displayPlan: preview.calldataPrepared.plan,
     },
   }
@@ -1159,10 +1163,11 @@ function buildSignatureSteps(
   target: OutgoingMigrationTarget | undefined,
   authorizationRequest: MigrationAuthorizationRequest | undefined,
   useSignatures: boolean,
+  bundled: boolean,
 ): DisplayStep[] {
   if (!authorizationRequest || !target) return []
   if (!useSignatures) {
-    return buildMigrationAuthorizationTxSteps(authorizationRequest, 'grant', 1, { bundled: isSafeWallet.value })
+    return buildMigrationAuthorizationTxSteps(authorizationRequest, 'grant', 1, { bundled })
   }
   if (target.connectorId === AAVE_CONNECTOR_ID) {
     return [{
@@ -1184,9 +1189,10 @@ function buildSignatureSteps(
 function buildRevokeSteps(
   authorizationRequest: MigrationAuthorizationRequest | undefined,
   useSignatures: boolean,
+  bundled: boolean,
 ): DisplayStep[] {
   if (!authorizationRequest || useSignatures) return []
-  return buildMigrationAuthorizationTxSteps(authorizationRequest, 'revoke', 1, { bundled: isSafeWallet.value })
+  return buildMigrationAuthorizationTxSteps(authorizationRequest, 'revoke', 1, { bundled })
 }
 
 function targetLiquidityDisplay(target: OutgoingMigrationTarget): string {

--- a/pages/position/[number]/migrate.vue
+++ b/pages/position/[number]/migrate.vue
@@ -35,6 +35,7 @@ import type { DisplayStep } from '~/utils/stepDecoding'
 import {
   buildMigrationAuthorizationTxSteps,
   encodeMigrationAuthorizationTxs,
+  migrationAuthorizationPayloadKey,
   type MigrationAuthorizationRevoke,
 } from '~/utils/migrationAuthorizationTxs'
 import { logWarn } from '~/utils/errorHandling'
@@ -713,6 +714,19 @@ const outgoingPreviewKeyFor = (target: OutgoingMigrationTarget) => {
   return base ? `${base}|${target.id}` : ''
 }
 
+/**
+ * Evict one cached preview so the next review rebuilds it. Used when the
+ * confirmation gate detects that authorization state drifted since review —
+ * returning the stale cache would re-present the very ceremony that was
+ * rejected.
+ */
+function invalidateOutgoingMigrationPreview(key: string) {
+  if (!(key in outgoingPreviews.value)) return
+  outgoingPreviews.value = Object.fromEntries(
+    Object.entries(outgoingPreviews.value).filter(([cachedKey]) => cachedKey !== key),
+  )
+}
+
 async function prepareOutgoingMigrationPreview(
   target: OutgoingMigrationTarget,
 ): Promise<OutgoingMigrationPreview> {
@@ -901,6 +915,17 @@ async function sendMigration(execution: TrackedExecutionScope, preview: Outgoing
     const input = reviewedInput
     const authorizationRequest = await getAuthorizationRequest(input, migrationPosition, reviewedAccount, useSignatures)
 
+    // The reviewed ceremony is defined by the authorization payload the modal
+    // displayed and copied. Authorization state can drift between review and
+    // confirmation (an allowance granted or revoked elsewhere, a restore
+    // value that moved) — executing the fresh payload would add or remove
+    // grant/revoke calls the user never reviewed. Evict the cached preview so
+    // the re-review builds against the current state.
+    if (migrationAuthorizationPayloadKey(authorizationRequest) !== migrationAuthorizationPayloadKey(preview.authorizationRequest)) {
+      invalidateOutgoingMigrationPreview(preview.key)
+      throw new Error('Authorization requirements changed since review — please review the migration again.')
+    }
+
     // An undefined request means the grant is already live on-chain: nothing to
     // sign, nothing to grant, and nothing of ours to revoke afterwards.
     let authorization: SignedMigrationAuthorization | undefined
@@ -915,14 +940,17 @@ async function sendMigration(execution: TrackedExecutionScope, preview: Outgoing
         if (!isSafeWallet.value) {
           throw new Error('Wallet changed since review — please review the migration again.')
         }
-        if (authorizationRequest) {
-          const outcome = await sendMigrationAsSafeBundle(input, migrationPosition, authorizationRequest, reviewedAccount)
-          if (outcome === 'aborted') return
-          finishMigrationSuccess(execution)
-          return
+        // bundledReview implies the review carried a request, and payload
+        // equality above pins the fresh one to it — reaching here without
+        // one is drift the gate somehow missed, so fail closed.
+        if (!authorizationRequest) {
+          invalidateOutgoingMigrationPreview(preview.key)
+          throw new Error('Authorization requirements changed since review — please review the migration again.')
         }
-        // The grant went live since review (fresh request is empty): nothing
-        // to wrap; the plain plan below still submits as one Safe proposal.
+        const outcome = await sendMigrationAsSafeBundle(input, migrationPosition, authorizationRequest, reviewedAccount)
+        if (outcome === 'aborted') return
+        finishMigrationSuccess(execution)
+        return
       }
 
       if (authorizationRequest) {
@@ -1093,14 +1121,22 @@ async function addPreparedMigrationToBatch(preview: OutgoingMigrationPreview) {
           },
           // Bundled counterpart for Safe execution: the simulation-variant
           // plan validates the grant instead of reading the live allowance,
-          // so nothing needs to mine before the proposal is assembled.
+          // so nothing needs to mine before the proposal is assembled. The
+          // review rows come from the SAME resolution so the modal cannot
+          // display a ceremony other than the one that executes.
           buildBundledExecution: async (account: Account<IHasVaultAddress>) => {
             const request = await getAuthorizationRequest(input, migrationPosition, account, useSignatures)
             const { grants, revokes } = request
               ? encodeMigrationAuthorizationTxs(request)
               : { grants: [], revokes: [] }
             const simulation = await buildMigrationSimulation(input, migrationPosition, request, account)
-            return { plan: simulation.plan, grants, revokes }
+            return {
+              plan: simulation.plan,
+              grants,
+              revokes,
+              grantSteps: buildMigrationAuthorizationTxSteps(request, 'grant', 1, { bundled: true }),
+              revokeSteps: buildMigrationAuthorizationTxSteps(request, 'revoke', 1, { bundled: true }),
+            }
           },
         }),
     stateOverrides: preview.tenderlySimulation.stateOverrides,

--- a/pages/position/[number]/migrate.vue
+++ b/pages/position/[number]/migrate.vue
@@ -1090,6 +1090,17 @@ async function addPreparedMigrationToBatch(preview: OutgoingMigrationPreview) {
               postTxsByPreTx: revokesByGrant,
             }
           },
+          // Bundled counterpart for Safe execution: the simulation-variant
+          // plan validates the grant instead of reading the live allowance,
+          // so nothing needs to mine before the proposal is assembled.
+          buildBundledExecution: async (account: Account<IHasVaultAddress>) => {
+            const request = await getAuthorizationRequest(input, migrationPosition, account, useSignatures)
+            const { grants, revokes } = request
+              ? encodeMigrationAuthorizationTxs(request)
+              : { grants: [], revokes: [] }
+            const simulation = await buildMigrationSimulation(input, migrationPosition, request, account)
+            return { plan: simulation.plan, grants, revokes }
+          },
         }),
     stateOverrides: preview.tenderlySimulation.stateOverrides,
     subAccount: migrationAccount.value,

--- a/tests/composables/useCollateralSwapRepay.test.ts
+++ b/tests/composables/useCollateralSwapRepay.test.ts
@@ -218,6 +218,7 @@ describe('useCollateralSwapRepay', () => {
       entryCount: ref(0),
       getMergedPlan: vi.fn(() => null),
     }))
+    vi.stubGlobal('useCowSwapEligibility', () => ({ cowSwapForcedOff: ref(false) }))
     vi.stubGlobal('useUserSettings', () => ({
       settings: ref({ enableIntrinsicApy: false }),
     }))

--- a/tests/composables/useCowSwapEligibility.test.ts
+++ b/tests/composables/useCowSwapEligibility.test.ts
@@ -1,0 +1,48 @@
+import { ref, type Ref } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+describe('useCowSwapEligibility', () => {
+  let isSafeWallet: Ref<boolean>
+  let isSafeWalletResolved: Ref<boolean>
+
+  const setupComposable = async () => {
+    const { useCowSwapEligibility } = await import('~/composables/useCowSwapEligibility')
+    return useCowSwapEligibility()
+  }
+
+  beforeEach(() => {
+    vi.resetModules()
+    isSafeWallet = ref(false)
+    isSafeWalletResolved = ref(true)
+    vi.stubGlobal('useSafeWallet', () => ({ isSafeWallet, isSafeWalletResolved }))
+  })
+
+  it('allows CoW for resolved regular wallets', async () => {
+    const { cowSwapForcedOff } = await setupComposable()
+    expect(cowSwapForcedOff.value).toBe(false)
+  })
+
+  it('forces CoW off for Safe wallets', async () => {
+    isSafeWallet.value = true
+    const { cowSwapForcedOff } = await setupComposable()
+    expect(cowSwapForcedOff.value).toBe(true)
+  })
+
+  it('fails closed while Safe detection is pending', async () => {
+    isSafeWalletResolved.value = false
+    const { cowSwapForcedOff } = await setupComposable()
+    expect(cowSwapForcedOff.value).toBe(true)
+
+    // Detection resolves to a regular wallet — CoW becomes available.
+    isSafeWalletResolved.value = true
+    expect(cowSwapForcedOff.value).toBe(false)
+  })
+
+  it('reacts to mid-session Safe connection', async () => {
+    const { cowSwapForcedOff } = await setupComposable()
+    expect(cowSwapForcedOff.value).toBe(false)
+
+    isSafeWallet.value = true
+    expect(cowSwapForcedOff.value).toBe(true)
+  })
+})

--- a/tests/composables/useCowSwapExecutionCore.test.ts
+++ b/tests/composables/useCowSwapExecutionCore.test.ts
@@ -1,0 +1,61 @@
+import { ref, type Ref } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { TransactionPlan } from '@eulerxyz/euler-v2-sdk'
+
+vi.mock('@wagmi/vue', () => ({
+  useSendTransaction: () => ({ sendTransactionAsync: vi.fn() }),
+  useSignTypedData: () => ({ signTypedDataAsync: vi.fn() }),
+}))
+
+vi.mock('~/composables/useEulerSdk', () => ({
+  getEulerSdkFresh: vi.fn(),
+}))
+
+vi.mock('~/composables/usePortfolioRefresh', () => ({
+  usePortfolioRefresh: () => ({ triggerPortfolioRefresh: vi.fn() }),
+}))
+
+const OWNER = '0x1000000000000000000000000000000000000000'
+
+describe('useCowSwapExecutionCore Safe backstop', () => {
+  let isSafeWallet: Ref<boolean>
+  let isSafeWalletResolved: Ref<boolean>
+
+  const setupCore = async () => {
+    const { useCowSwapExecutionCore } = await import('~/composables/cowswap/useCowSwapExecutionCore')
+    return useCowSwapExecutionCore()
+  }
+
+  const dummyFlow = {
+    plan: [] as TransactionPlan,
+    chainId: 1,
+    cancellationMode: 'cow-api' as const,
+    orderbookUrl: 'https://api.cow.fi/mainnet',
+  }
+
+  beforeEach(() => {
+    vi.resetModules()
+    isSafeWallet = ref(false)
+    isSafeWalletResolved = ref(true)
+    vi.stubGlobal('useWagmi', () => ({ address: ref(OWNER) }))
+    vi.stubGlobal('useSpyMode', () => ({ isSpyMode: ref(false) }))
+    vi.stubGlobal('useSafeWallet', () => ({ isSafeWallet, isSafeWalletResolved }))
+    vi.stubGlobal('useCowSwapEligibility', () => ({
+      cowSwapForcedOff: computed(() => isSafeWallet.value || !isSafeWalletResolved.value),
+    }))
+  })
+
+  it('rejects execution for Safe wallets before any transaction is sent', async () => {
+    isSafeWallet.value = true
+    const core = await setupCore()
+
+    await expect(core.executePlan(dummyFlow)).rejects.toThrow('CoW Swap is not available with Safe wallets')
+  })
+
+  it('rejects execution while Safe detection is pending', async () => {
+    isSafeWalletResolved.value = false
+    const core = await setupCore()
+
+    await expect(core.executePlan(dummyFlow)).rejects.toThrow('CoW Swap is not available with Safe wallets')
+  })
+})

--- a/tests/composables/useEulerTx.test.ts
+++ b/tests/composables/useEulerTx.test.ts
@@ -607,6 +607,19 @@ describe('useEulerTx Safe wallet bundling', () => {
     expect(executePreparedTransactionPlan).not.toHaveBeenCalled()
   })
 
+  it('rejects wrapper calls around a plan that encodes no calls', async () => {
+    const { executePreparedPlanWithPlainCalls } = useEulerTx()
+
+    // A no-op migration must never submit [grant, revoke] alone and
+    // finalize as success.
+    await expect(executePreparedPlanWithPlainCalls(buildPrepared([] as TransactionPlan), {
+      before: [GRANT_CALL],
+      after: [REVOKE_CALL],
+    })).rejects.toThrow('produced no calls to bundle')
+    expect(wagmiMocks.sendCalls).not.toHaveBeenCalled()
+    expect(executePreparedTransactionPlan).not.toHaveBeenCalled()
+  })
+
   it('returns undefined from the plain-calls bundle for non-Safe connectors', async () => {
     vi.mocked(getAccount).mockImplementation(() => ({
       address: currentAccount,

--- a/tests/composables/useEulerTx.test.ts
+++ b/tests/composables/useEulerTx.test.ts
@@ -576,4 +576,117 @@ describe('useEulerTx Safe wallet bundling', () => {
     expect(executeTransactionPlan).not.toHaveBeenCalled()
     expect(result.hashes).toEqual([SAFE_TX_HASH])
   })
+
+  const GRANT_CALL = { to: TOKEN, data: '0x11ff' as Hex, value: 0n }
+  const REVOKE_CALL = { to: TOKEN, data: '0x22ff' as Hex }
+
+  it('wraps the plan with plain calls inside one Safe bundle in order', async () => {
+    const { executePreparedPlanWithPlainCalls } = useEulerTx()
+    const batchOnly = [approvedPlan[1]] as TransactionPlan
+
+    const result = await executePreparedPlanWithPlainCalls(buildPrepared(batchOnly), {
+      before: [GRANT_CALL],
+      after: [REVOKE_CALL],
+    })
+
+    expect(wagmiMocks.sendCalls).toHaveBeenCalledTimes(1)
+    expect(wagmiMocks.sendCalls).toHaveBeenCalledWith(wagmiMocks.config, {
+      account: OWNER,
+      chainId: 1,
+      connector: safeConnector,
+      forceAtomic: true,
+      calls: [
+        // Grants before the batch, revocations after — one atomic proposal.
+        { to: TOKEN, data: '0x11ff', value: 0n },
+        { to: EVC, data: BATCH_DATA, value: 0n },
+        { to: TOKEN, data: '0x22ff', value: 0n },
+      ],
+    })
+    expect(result?.hashes).toEqual([SAFE_TX_HASH])
+    expect(result?.receipts[0].transactionHash).toBe(SAFE_TX_HASH)
+    expect(executePreparedTransactionPlan).not.toHaveBeenCalled()
+  })
+
+  it('returns undefined from the plain-calls bundle for non-Safe connectors', async () => {
+    vi.mocked(getAccount).mockImplementation(() => ({
+      address: currentAccount,
+      chainId: currentChainId,
+      connector: { id: 'io.metamask', name: 'MetaMask', getProvider: async () => ({ request: vi.fn() }) },
+    }) as never)
+    const { executePreparedPlanWithPlainCalls } = useEulerTx()
+
+    const result = await executePreparedPlanWithPlainCalls(buildPrepared([approvedPlan[1]] as TransactionPlan), {
+      before: [GRANT_CALL],
+      after: [REVOKE_CALL],
+    })
+
+    // The caller owns the sequential fallback (grants must mine first).
+    expect(result).toBeUndefined()
+    expect(wagmiMocks.sendCalls).not.toHaveBeenCalled()
+    expect(executePreparedTransactionPlan).not.toHaveBeenCalled()
+  })
+
+  it('returns undefined from the plain-calls bundle for a Safe without a provider', async () => {
+    vi.mocked(getAccount).mockImplementation(() => ({
+      address: currentAccount,
+      chainId: currentChainId,
+      connector: {
+        id: 'safe',
+        name: 'Safe',
+        getProvider: async () => {
+          throw new Error('provider unavailable')
+        },
+      },
+    }) as never)
+    const { executePreparedPlanWithPlainCalls } = useEulerTx()
+
+    const result = await executePreparedPlanWithPlainCalls(buildPrepared([approvedPlan[1]] as TransactionPlan), {
+      before: [GRANT_CALL],
+    })
+
+    expect(result).toBeUndefined()
+    expect(wagmiMocks.sendCalls).not.toHaveBeenCalled()
+  })
+
+  it('throws on a reverted plain-calls bundle instead of finalizing it', async () => {
+    const provider = {
+      getTransactionReceipt: vi.fn(async ({ hash }: { hash: Hash }) => ({
+        transactionHash: hash,
+        status: 'reverted',
+        blockNumber: 123n,
+      }) as TransactionReceipt),
+    }
+    vi.mocked(getEulerSdkFresh).mockResolvedValue({
+      providerService: { getProvider: vi.fn(() => provider) },
+      deploymentService: { getDeployment: vi.fn(() => ({ addresses: { coreAddrs: { evc: EVC } } })) },
+      executionService: { encodeBatch: vi.fn(() => BATCH_DATA), executePreparedTransactionPlan },
+    } as never)
+    const { executePreparedPlanWithPlainCalls } = useEulerTx()
+
+    await expect(executePreparedPlanWithPlainCalls(buildPrepared([approvedPlan[1]] as TransactionPlan), {
+      before: [GRANT_CALL],
+      after: [REVOKE_CALL],
+    })).rejects.toThrow('Safe transaction reverted')
+  })
+
+  it('passes extra state overrides through prepared simulation', async () => {
+    const simulatePreparedTransactionPlan = vi.fn(async () => ({ kind: 'simulated' }))
+    const { getEulerSdkForChain } = await import('~/composables/useEulerSdk')
+    vi.mocked(getEulerSdkForChain).mockResolvedValue({
+      executionService: { simulatePreparedTransactionPlan },
+    } as never)
+    const { simulatePreparedPlan } = useEulerTx()
+    const prepared = buildPrepared([approvedPlan[1]] as TransactionPlan)
+    const overrides = [{ address: TOKEN, stateDiff: [] }]
+
+    await simulatePreparedPlan(prepared, undefined, overrides as never)
+    expect(simulatePreparedTransactionPlan).toHaveBeenCalledWith(prepared, expect.objectContaining({
+      extraStateOverrides: overrides,
+    }))
+
+    await simulatePreparedPlan(prepared)
+    expect(simulatePreparedTransactionPlan).toHaveBeenLastCalledWith(prepared, expect.not.objectContaining({
+      extraStateOverrides: expect.anything(),
+    }))
+  })
 })

--- a/tests/composables/useMultiplyForm.test.ts
+++ b/tests/composables/useMultiplyForm.test.ts
@@ -275,6 +275,7 @@ describe('useMultiplyForm cap validation', () => {
     vi.stubGlobal('useTxBatch', () => ({
       entryCount: ref(0),
     }))
+    vi.stubGlobal('useCowSwapEligibility', () => ({ cowSwapForcedOff: ref(false) }))
     vi.stubGlobal('useTxFinalization', () => ({
       finalizeTxAndRedirect: vi.fn(),
     }))

--- a/tests/composables/useSwapQuotesParallel.test.ts
+++ b/tests/composables/useSwapQuotesParallel.test.ts
@@ -264,4 +264,93 @@ describe('useSwapQuotesParallel', () => {
     // The resolved CoW card must not reinsert past the eviction.
     expect(quotes.sortedQuoteCards.value.map(card => card.provider)).toEqual(['other'])
   })
+
+  it('replays the sweep when CoW eligibility resolves after a gated sweep', async () => {
+    const includeCowSwap = ref(false)
+    const cowQuote = makeQuote('100', '300')
+    const otherQuote = makeQuote('100', '200')
+    getSwapProviders.mockImplementation(async ({ includeCowSwap: include }: { includeCowSwap?: boolean }) =>
+      include ? ['cow', 'other'] : ['other'],
+    )
+    getSwapQuotes.mockImplementation(({ provider }: { provider: string }) =>
+      Promise.resolve([provider === 'cow' ? cowQuote : otherQuote]),
+    )
+
+    const quotes = useSwapQuotesParallel({
+      amountField: 'amountOut',
+      compare: 'max',
+      includeCowSwap: () => includeCowSwap.value,
+    })
+
+    // Sweep made during the fail-closed detection window — CoW resolved out
+    // of the provider list entirely.
+    await quotes.requestQuotes(requestParams)
+    await flushPromises()
+    await nextTick()
+    expect(quotes.sortedQuoteCards.value.map(card => card.provider)).toEqual(['other'])
+
+    // Detection lands on a regular wallet: eligibility resolves to true.
+    includeCowSwap.value = true
+    await nextTick()
+    await flushPromises()
+    await nextTick()
+
+    // The reduced quote set must not persist until the next input change —
+    // the sweep replays with the full provider list.
+    expect(getSwapProviders).toHaveBeenLastCalledWith({ includeCowSwap: true })
+    expect(quotes.sortedQuoteCards.value.map(card => card.provider)).toEqual(['cow', 'other'])
+  })
+
+  it('re-fetches evicted CoW quotes when eligibility returns', async () => {
+    const includeCowSwap = ref(true)
+    const cowQuote = makeQuote('100', '300')
+    const otherQuote = makeQuote('100', '200')
+    getSwapProviders.mockImplementation(async ({ includeCowSwap: include }: { includeCowSwap?: boolean }) =>
+      include ? ['cow', 'other'] : ['other'],
+    )
+    getSwapQuotes.mockImplementation(({ provider }: { provider: string }) =>
+      Promise.resolve([provider === 'cow' ? cowQuote : otherQuote]),
+    )
+
+    const quotes = useSwapQuotesParallel({
+      amountField: 'amountOut',
+      compare: 'max',
+      includeCowSwap: () => includeCowSwap.value,
+    })
+
+    await quotes.requestQuotes(requestParams)
+    await flushPromises()
+    await nextTick()
+    expect(quotes.sortedQuoteCards.value.map(card => card.provider)).toEqual(['cow', 'other'])
+
+    // Gate flips off (e.g. switch to a Safe): CoW cards evict.
+    includeCowSwap.value = false
+    await nextTick()
+    expect(quotes.sortedQuoteCards.value.map(card => card.provider)).toEqual(['other'])
+
+    // Gate returns (switch back to the EOA): eviction was one-way, so the
+    // sweep replays to restore the CoW route.
+    includeCowSwap.value = true
+    await nextTick()
+    await flushPromises()
+    await nextTick()
+    expect(quotes.sortedQuoteCards.value.map(card => card.provider)).toEqual(['cow', 'other'])
+  })
+
+  it('does not fetch when eligibility resolves before any sweep', async () => {
+    const includeCowSwap = ref(false)
+    getSwapProviders.mockResolvedValue(['cow', 'other'])
+
+    useSwapQuotesParallel({
+      amountField: 'amountOut',
+      compare: 'max',
+      includeCowSwap: () => includeCowSwap.value,
+    })
+
+    includeCowSwap.value = true
+    await nextTick()
+    await flushPromises()
+
+    expect(getSwapProviders).not.toHaveBeenCalled()
+  })
 })

--- a/tests/composables/useSwapQuotesParallel.test.ts
+++ b/tests/composables/useSwapQuotesParallel.test.ts
@@ -226,4 +226,42 @@ describe('useSwapQuotesParallel', () => {
     expect(quotes.sortedQuoteCards.value.map(card => card.provider)).toEqual(['other'])
     expect(quotes.selectedProvider.value).toBeNull()
   })
+
+  it('drops an in-flight CoW response that resolves after the gate flips to false', async () => {
+    const includeCowSwap = ref(true)
+    const otherQuote = makeQuote('100', '200')
+    let releaseCowQuote!: (quotes: SwapQuote[]) => void
+    getSwapProviders.mockResolvedValue(['cow', 'other'])
+    getSwapQuotes.mockImplementation(({ provider }: { provider: string }) =>
+      provider === 'cow'
+        ? new Promise<SwapQuote[]>((resolve) => {
+            releaseCowQuote = resolve
+          })
+        : Promise.resolve([otherQuote]),
+    )
+
+    const quotes = useSwapQuotesParallel({
+      amountField: 'amountOut',
+      compare: 'max',
+      includeCowSwap: () => includeCowSwap.value,
+    })
+
+    await quotes.requestQuotes(requestParams)
+    await flushPromises()
+    await nextTick()
+    expect(quotes.sortedQuoteCards.value.map(card => card.provider)).toEqual(['other'])
+
+    // The gate flips (e.g. Safe detection lands) while the CoW request is
+    // still in flight — same sweep generation, so the staleness guard does
+    // not cover it.
+    includeCowSwap.value = false
+    await nextTick()
+
+    releaseCowQuote([makeQuote('100', '300')])
+    await flushPromises()
+    await nextTick()
+
+    // The resolved CoW card must not reinsert past the eviction.
+    expect(quotes.sortedQuoteCards.value.map(card => card.provider)).toEqual(['other'])
+  })
 })

--- a/tests/composables/useTxBatch.test.ts
+++ b/tests/composables/useTxBatch.test.ts
@@ -1320,6 +1320,9 @@ describe('useTxBatch execution prerequisites', () => {
     items: [{ type: 'operation', name: 'bundled-migration', items: [] }],
   }] as unknown as TransactionPlan
 
+  const bundledGrantStep = { index: 1, label: 'Approve aToken transfer', isSeparateTx: false }
+  const bundledRevokeStep = { index: 1, label: 'Restore previous aToken approval', isSeparateTx: false }
+
   const addBundledMigrationEntry = (batch: ReturnType<typeof useTxBatch>) =>
     batch.addEntry({
       label: 'Migrate Aave position',
@@ -1334,6 +1337,8 @@ describe('useTxBatch execution prerequisites', () => {
         plan: singleOpBundledPlan,
         grants: [grantTx],
         revokes: [revokeTx],
+        grantSteps: [bundledGrantStep],
+        revokeSteps: [bundledRevokeStep],
       }),
       refreshExternalMigrationPositions: true,
     })
@@ -1402,7 +1407,7 @@ describe('useTxBatch execution prerequisites', () => {
       // Grant already live: nothing to wrap — but the reviewed ceremony is
       // still ONE provider-bound proposal, never a silent executePreparedPlan
       // whose internals could degrade to sequential sends.
-      buildBundledExecution: async () => ({ plan: singleOpBundledPlan, grants: [], revokes: [] }),
+      buildBundledExecution: async () => ({ plan: singleOpBundledPlan, grants: [], revokes: [], grantSteps: [], revokeSteps: [] }),
     })
     await batch.prepareBundledExecution()
     await batch.executeBatch()
@@ -1412,6 +1417,26 @@ describe('useTxBatch execution prerequisites', () => {
       after: [],
     }, { allowSingleCall: true })
     expect(eulerTxMocks.executePreparedPlan).not.toHaveBeenCalled()
+  })
+
+  it('latches per-entry review rows from the bundled resolution', async () => {
+    const sdk = createMockSdk()
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    isSafeWalletRef.value = true
+
+    const batch = useTxBatch()
+    await addBundledMigrationEntry(batch)
+    const latched = await batch.prepareBundledExecution()
+
+    // The modal renders THESE rows — derived from the same authorization
+    // resolution the proposal executes — never the add-time captures, which
+    // can be stale by the time the review opens.
+    const entryId = batch.entries.value[0]!.id
+    expect(latched?.stepsByEntryId[entryId]).toEqual({
+      grantSteps: [bundledGrantStep],
+      revokeSteps: [bundledRevokeStep],
+    })
+    batch.latchedBundledExecution.value = null
   })
 
   it('throws a re-review error when the wallet stopped being a safe after latching', async () => {

--- a/tests/composables/useTxBatch.test.ts
+++ b/tests/composables/useTxBatch.test.ts
@@ -1348,6 +1348,8 @@ describe('useTxBatch execution prerequisites', () => {
 
     const batch = useTxBatch()
     await addBundledMigrationEntry(batch)
+    // The review modal latches the ceremony at open; execution consumes it.
+    await batch.prepareBundledExecution()
     await batch.executeBatch()
 
     // Grants ride in the proposal — no standalone broadcasts, no unwind
@@ -1357,7 +1359,7 @@ describe('useTxBatch execution prerequisites', () => {
     expect(eulerTxMocks.executePreparedPlanWithPlainCalls).toHaveBeenCalledWith(prepared, {
       before: [grantTx],
       after: [revokeTx],
-    })
+    }, { allowSingleCall: true })
     expect(eulerTxMocks.executePreparedPlan).not.toHaveBeenCalled()
     // Revokes rode in the proposal — nothing standalone to send afterwards.
     expect(migrationFlowMocks.revokeAfterSuccess).not.toHaveBeenCalled()
@@ -1373,6 +1375,7 @@ describe('useTxBatch execution prerequisites', () => {
 
     const batch = useTxBatch()
     await addBundledMigrationEntry(batch)
+    await batch.prepareBundledExecution()
     await batch.executeBatch()
 
     expect(batch.execError.value).toBeTruthy()
@@ -1380,6 +1383,54 @@ describe('useTxBatch execution prerequisites', () => {
     expect(eulerTxMocks.sendPlainTransactions).not.toHaveBeenCalled()
     expect(migrationFlowMocks.revokeAfterAbort).toHaveBeenCalledWith([])
     expect(batch.entryCount.value).toBe(1)
+    batch.latchedBundledExecution.value = null
+  })
+
+  it('bundles a latched ceremony even when its grants resolved empty', async () => {
+    const sdk = createMockSdk()
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    isSafeWalletRef.value = true
+    const prepared = { kind: 'prepared' }
+    eulerTxMocks.prepareTransactionPlan.mockResolvedValue(prepared)
+    eulerTxMocks.executePreparedPlanWithPlainCalls.mockResolvedValue({ receipts: [] })
+
+    const batch = useTxBatch()
+    await batch.addEntry({
+      label: 'Migrate Aave position',
+      buildPlan: async () => singleOpBundledPlan,
+      buildExecutionPrerequisites: async () => undefined,
+      // Grant already live: nothing to wrap — but the reviewed ceremony is
+      // still ONE provider-bound proposal, never a silent executePreparedPlan
+      // whose internals could degrade to sequential sends.
+      buildBundledExecution: async () => ({ plan: singleOpBundledPlan, grants: [], revokes: [] }),
+    })
+    await batch.prepareBundledExecution()
+    await batch.executeBatch()
+
+    expect(eulerTxMocks.executePreparedPlanWithPlainCalls).toHaveBeenCalledWith(prepared, {
+      before: [],
+      after: [],
+    }, { allowSingleCall: true })
+    expect(eulerTxMocks.executePreparedPlan).not.toHaveBeenCalled()
+  })
+
+  it('throws a re-review error when the wallet stopped being a safe after latching', async () => {
+    const sdk = createMockSdk()
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    isSafeWalletRef.value = true
+    eulerTxMocks.prepareTransactionPlan.mockResolvedValue({ kind: 'prepared' })
+
+    const batch = useTxBatch()
+    await addBundledMigrationEntry(batch)
+    await batch.prepareBundledExecution()
+    // Safe disconnected between review and confirm.
+    isSafeWalletRef.value = false
+    await batch.executeBatch()
+
+    expect(batch.execError.value).toBeTruthy()
+    expect(eulerTxMocks.executePreparedPlanWithPlainCalls).not.toHaveBeenCalled()
+    expect(eulerTxMocks.sendPlainTransactions).not.toHaveBeenCalled()
+    batch.latchedBundledExecution.value = null
   })
 
   it('keeps the sequential ceremony for non-safe wallets', async () => {
@@ -1395,31 +1446,11 @@ describe('useTxBatch execution prerequisites', () => {
 
     const batch = useTxBatch()
     await addBundledMigrationEntry(batch)
+    await batch.prepareBundledExecution()
     await batch.executeBatch()
 
     expect(eulerTxMocks.executePreparedPlanWithPlainCalls).not.toHaveBeenCalled()
     expect(eulerTxMocks.sendPlainTransactions).toHaveBeenCalled()
-    expect(eulerTxMocks.executePreparedPlan).toHaveBeenCalled()
-  })
-
-  it('falls back to the classic single proposal when grants resolved empty', async () => {
-    const sdk = createMockSdk()
-    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
-    isSafeWalletRef.value = true
-    eulerTxMocks.prepareTransactionPlan.mockResolvedValue({ kind: 'prepared' })
-    eulerTxMocks.executePreparedPlan.mockResolvedValue(undefined)
-
-    const batch = useTxBatch()
-    await batch.addEntry({
-      label: 'Migrate Aave position',
-      buildPlan: async () => singleOpBundledPlan,
-      buildExecutionPrerequisites: async () => undefined,
-      // Grant went live since add-time: nothing to wrap.
-      buildBundledExecution: async () => ({ plan: singleOpBundledPlan, grants: [], revokes: [] }),
-    })
-    await batch.executeBatch()
-
-    expect(eulerTxMocks.executePreparedPlanWithPlainCalls).not.toHaveBeenCalled()
     expect(eulerTxMocks.executePreparedPlan).toHaveBeenCalled()
   })
 

--- a/tests/composables/useTxBatch.test.ts
+++ b/tests/composables/useTxBatch.test.ts
@@ -31,9 +31,11 @@ const routerReplace = vi.fn()
 const eulerTxMocks = {
   prepareTransactionPlan: vi.fn(),
   executePreparedPlan: vi.fn(),
+  executePreparedPlanWithPlainCalls: vi.fn(),
   estimateGasForPlan: vi.fn(),
   sendPlainTransactions: vi.fn(),
 }
+const isSafeWalletRef = ref(false)
 const grantWalletContext: WalletExecutionContext = { account: owner, chainId: 1 }
 type PlainTxSendOptions = {
   onBroadcast?: (index: number, walletContext: WalletExecutionContext) => void
@@ -272,6 +274,8 @@ const stubBatchComposableGlobals = () => {
   }))
   vi.stubGlobal('useEulerAddresses', () => ({ chainId: ref(1) }))
   vi.stubGlobal('useEulerTx', () => eulerTxMocks)
+  isSafeWalletRef.value = false
+  vi.stubGlobal('useSafeWallet', () => ({ isSafeWallet: isSafeWalletRef, isSafeWalletResolved: ref(true) }))
   vi.stubGlobal('useMigrationAuthorizationFlow', () => migrationFlowMocks)
   vi.stubGlobal('useExternalMigrationRefresh', () => ({ scheduleExternalMigrationRefreshes }))
   vi.stubGlobal('useRouter', () => ({ replace: routerReplace }))
@@ -310,6 +314,7 @@ beforeEach(() => {
   vi.restoreAllMocks()
   eulerTxMocks.prepareTransactionPlan.mockReset()
   eulerTxMocks.executePreparedPlan.mockReset()
+  eulerTxMocks.executePreparedPlanWithPlainCalls.mockReset()
   eulerTxMocks.estimateGasForPlan.mockReset()
   eulerTxMocks.sendPlainTransactions.mockReset()
   eulerTxMocks.sendPlainTransactions.mockImplementation(broadcastAllTransactions)
@@ -1309,6 +1314,114 @@ describe('useTxBatch execution prerequisites', () => {
       postTxs: [revokeTx],
       postTxsByPreTx: [revokeTx],
     })
+
+  const singleOpBundledPlan = [{
+    type: 'evcBatch',
+    items: [{ type: 'operation', name: 'bundled-migration', items: [] }],
+  }] as unknown as TransactionPlan
+
+  const addBundledMigrationEntry = (batch: ReturnType<typeof useTxBatch>) =>
+    batch.addEntry({
+      label: 'Migrate Aave position',
+      buildPlan: async () => singleOpBundledPlan,
+      buildExecutionPrerequisites: async () => ({
+        preTxs: [grantTx],
+        walletContext: grantWalletContext,
+        postTxs: [revokeTx],
+        postTxsByPreTx: [revokeTx],
+      }),
+      buildBundledExecution: async () => ({
+        plan: singleOpBundledPlan,
+        grants: [grantTx],
+        revokes: [revokeTx],
+      }),
+      refreshExternalMigrationPositions: true,
+    })
+
+  it('bundles grants + batch + revokes into one safe proposal', async () => {
+    const sdk = createMockSdk()
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    isSafeWalletRef.value = true
+    const prepared = { kind: 'prepared' }
+    eulerTxMocks.prepareTransactionPlan.mockResolvedValue(prepared)
+    eulerTxMocks.executePreparedPlanWithPlainCalls.mockResolvedValue({ receipts: [] })
+
+    const batch = useTxBatch()
+    await addBundledMigrationEntry(batch)
+    await batch.executeBatch()
+
+    // Grants ride in the proposal — no standalone broadcasts, no unwind
+    // bookkeeping, no standalone gas estimate against unmined grants.
+    expect(eulerTxMocks.sendPlainTransactions).not.toHaveBeenCalled()
+    expect(eulerTxMocks.estimateGasForPlan).not.toHaveBeenCalled()
+    expect(eulerTxMocks.executePreparedPlanWithPlainCalls).toHaveBeenCalledWith(prepared, {
+      before: [grantTx],
+      after: [revokeTx],
+    })
+    expect(eulerTxMocks.executePreparedPlan).not.toHaveBeenCalled()
+    // Revokes rode in the proposal — nothing standalone to send afterwards.
+    expect(migrationFlowMocks.revokeAfterSuccess).not.toHaveBeenCalled()
+    expect(batch.entryCount.value).toBe(0)
+  })
+
+  it('throws instead of degrading when the safe bundle context is unavailable', async () => {
+    const sdk = createMockSdk()
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    isSafeWalletRef.value = true
+    eulerTxMocks.prepareTransactionPlan.mockResolvedValue({ kind: 'prepared' })
+    eulerTxMocks.executePreparedPlanWithPlainCalls.mockResolvedValue(undefined)
+
+    const batch = useTxBatch()
+    await addBundledMigrationEntry(batch)
+    await batch.executeBatch()
+
+    expect(batch.execError.value).toBeTruthy()
+    // Nothing broadcast standalone, nothing to unwind, cart retained.
+    expect(eulerTxMocks.sendPlainTransactions).not.toHaveBeenCalled()
+    expect(migrationFlowMocks.revokeAfterAbort).toHaveBeenCalledWith([])
+    expect(batch.entryCount.value).toBe(1)
+  })
+
+  it('keeps the sequential ceremony for non-safe wallets', async () => {
+    const sdk = createMockSdk()
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    isSafeWalletRef.value = false
+    eulerTxMocks.prepareTransactionPlan.mockResolvedValue({ kind: 'prepared' })
+    eulerTxMocks.executePreparedPlan.mockResolvedValue(undefined)
+    eulerTxMocks.sendPlainTransactions.mockImplementation(async (txs: { data: Hex }[], options?: PlainTxSendOptions) => {
+      txs.forEach((_tx, index) => options?.onBroadcast?.(index, grantWalletContext))
+      return []
+    })
+
+    const batch = useTxBatch()
+    await addBundledMigrationEntry(batch)
+    await batch.executeBatch()
+
+    expect(eulerTxMocks.executePreparedPlanWithPlainCalls).not.toHaveBeenCalled()
+    expect(eulerTxMocks.sendPlainTransactions).toHaveBeenCalled()
+    expect(eulerTxMocks.executePreparedPlan).toHaveBeenCalled()
+  })
+
+  it('falls back to the classic single proposal when grants resolved empty', async () => {
+    const sdk = createMockSdk()
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    isSafeWalletRef.value = true
+    eulerTxMocks.prepareTransactionPlan.mockResolvedValue({ kind: 'prepared' })
+    eulerTxMocks.executePreparedPlan.mockResolvedValue(undefined)
+
+    const batch = useTxBatch()
+    await batch.addEntry({
+      label: 'Migrate Aave position',
+      buildPlan: async () => singleOpBundledPlan,
+      buildExecutionPrerequisites: async () => undefined,
+      // Grant went live since add-time: nothing to wrap.
+      buildBundledExecution: async () => ({ plan: singleOpBundledPlan, grants: [], revokes: [] }),
+    })
+    await batch.executeBatch()
+
+    expect(eulerTxMocks.executePreparedPlanWithPlainCalls).not.toHaveBeenCalled()
+    expect(eulerTxMocks.executePreparedPlan).toHaveBeenCalled()
+  })
 
   it('revokes an already-granted entry when a later entry\'s grant is rejected', async () => {
     // A two-entry batch needs a simulated account per layer, or executeBatch

--- a/tests/utils/migrationAuthorizationTxs.test.ts
+++ b/tests/utils/migrationAuthorizationTxs.test.ts
@@ -5,6 +5,7 @@ import type { MigrationAuthorizationRequest } from '@eulerxyz/euler-v2-sdk'
 import {
   buildMigrationAuthorizationTxSteps,
   encodeMigrationAuthorizationTxs,
+  migrationAuthorizationPayloadKey,
 } from '~/utils/migrationAuthorizationTxs'
 
 const owner = '0x0000000000000000000000000000000000000001' as Address
@@ -215,5 +216,56 @@ describe('buildMigrationAuthorizationTxSteps', () => {
     expect(buildMigrationAuthorizationTxSteps(request, 'revoke', 1, { bundled: true })[0]!.isSeparateTx).toBe(false)
     // Default stays standalone.
     expect(buildMigrationAuthorizationTxSteps(request, 'grant')[0]!.isSeparateTx).toBe(true)
+  })
+})
+
+describe('migrationAuthorizationPayloadKey', () => {
+  it('is stable for the same request and distinguishes no request from one', () => {
+    expect(migrationAuthorizationPayloadKey(aaveApprovalRequest()))
+      .toBe(migrationAuthorizationPayloadKey(aaveApprovalRequest()))
+    expect(migrationAuthorizationPayloadKey(undefined)).toBe('none')
+    expect(migrationAuthorizationPayloadKey(aaveApprovalRequest())).not.toBe('none')
+  })
+
+  it('changes when the encoded grant or restoration drifts', () => {
+    const base = migrationAuthorizationPayloadKey(aaveApprovalRequest())
+
+    // The restore value moved (allowance changed elsewhere since review).
+    const driftedRevocation = {
+      ...aaveApprovalRequest(),
+      revocation: { to: aToken, abi: erc20Abi, functionName: 'approve', args: [swapVerifier, 999n] },
+    } as unknown as MigrationAuthorizationRequest
+    expect(migrationAuthorizationPayloadKey(driftedRevocation)).not.toBe(base)
+
+    // A restoration disappeared entirely.
+    const noRevocation = {
+      ...aaveApprovalRequest(),
+      revocation: undefined,
+    } as unknown as MigrationAuthorizationRequest
+    expect(migrationAuthorizationPayloadKey(noRevocation)).not.toBe(base)
+
+    // A chained authorization appeared.
+    const chained = {
+      ...aaveApprovalRequest(),
+      postMigrationAuthorization: morphoAuthorizationRequest(),
+    } as unknown as MigrationAuthorizationRequest
+    expect(migrationAuthorizationPayloadKey(chained)).not.toBe(base)
+  })
+
+  it('keys typed-data requests without choking on bigint fields', () => {
+    const key = migrationAuthorizationPayloadKey(typedDataRequest())
+    expect(key).toContain('typedData:')
+    expect(key).toBe(migrationAuthorizationPayloadKey(typedDataRequest()))
+
+    const drifted = {
+      ...typedDataRequest(),
+      typedData: {
+        domain: { verifyingContract: aToken, chainId: 1 },
+        types: { Permit: [] },
+        primaryType: 'Permit',
+        message: { owner, spender: swapVerifier, value: 2000n },
+      },
+    } as unknown as MigrationAuthorizationRequest
+    expect(migrationAuthorizationPayloadKey(drifted)).not.toBe(key)
   })
 })

--- a/tests/utils/migrationAuthorizationTxs.test.ts
+++ b/tests/utils/migrationAuthorizationTxs.test.ts
@@ -172,4 +172,13 @@ describe('buildMigrationAuthorizationTxSteps', () => {
     expect(buildMigrationAuthorizationTxSteps(typedDataRequest(), 'grant')).toEqual([])
     expect(buildMigrationAuthorizationTxSteps(undefined, 'grant')).toEqual([])
   })
+
+  it('marks rows as same-submission when bundled into a Safe proposal', () => {
+    const request = aaveApprovalRequest() as unknown as MigrationAuthorizationRequest
+
+    expect(buildMigrationAuthorizationTxSteps(request, 'grant', 1, { bundled: true })[0]!.isSeparateTx).toBe(false)
+    expect(buildMigrationAuthorizationTxSteps(request, 'revoke', 1, { bundled: true })[0]!.isSeparateTx).toBe(false)
+    // Default stays standalone.
+    expect(buildMigrationAuthorizationTxSteps(request, 'grant')[0]!.isSeparateTx).toBe(true)
+  })
 })

--- a/utils/migrationAuthorizationTxs.ts
+++ b/utils/migrationAuthorizationTxs.ts
@@ -56,6 +56,34 @@ const flattenRequests = (
     ? [request, ...flattenRequests(request.postMigrationAuthorization)]
     : []
 
+const bigintSafeStringify = (value: unknown): string =>
+  JSON.stringify(value, (_key, entry) => (typeof entry === 'bigint' ? `${entry.toString()}n` : entry))
+
+/**
+ * Identity of the ceremony an authorization request implies: the encoded
+ * grant/revoke transactions for transaction-form requests, the typed-data
+ * payload for signature-form ones, `'none'` for no request. Compared between
+ * review and confirmation — authorization state can drift in between (an
+ * allowance granted or revoked elsewhere, a restore value that moved), and a
+ * drifted payload means the reviewed ceremony no longer matches what would
+ * execute, so the flow must invalidate and re-review rather than proceed.
+ */
+export const migrationAuthorizationPayloadKey = (
+  request: MigrationAuthorizationRequest | undefined,
+): string => {
+  if (!request) return 'none'
+  return flattenRequests(request)
+    .map((entry) => {
+      if (entry.kind !== 'transaction') {
+        return `typedData:${bigintSafeStringify(entry.typedData)}`
+      }
+      const grant = plainTxKey(encodeCall(entry.call))
+      const revoke = entry.revocation ? plainTxKey(encodeCall(entry.revocation)) : 'none'
+      return `tx:${grant}|${revoke}`
+    })
+    .join(';')
+}
+
 /**
  * Encode an authorization request into its grant and restoration transactions.
  *

--- a/utils/migrationAuthorizationTxs.ts
+++ b/utils/migrationAuthorizationTxs.ts
@@ -94,11 +94,16 @@ const RESTORE_LABELS: Record<string, string> = {
   metamorphoApproval: 'Restore previous Morpho vault share approval',
 }
 
-/** Review-modal rows for the standalone grant or restoration transactions. */
+/**
+ * Review-modal rows for the grant or restoration transactions. `bundled`
+ * marks them as riding in the same Safe submission as the migration batch
+ * instead of standalone transactions.
+ */
 export const buildMigrationAuthorizationTxSteps = (
   request: MigrationAuthorizationRequest | undefined,
   phase: 'grant' | 'revoke',
   startIndex = 1,
+  options?: { bundled?: boolean },
 ): DisplayStep[] => {
   const labels = phase === 'grant' ? GRANT_LABELS : RESTORE_LABELS
   const fallback = phase === 'grant' ? 'Approve migration' : 'Restore previous migration authorization'
@@ -113,7 +118,7 @@ export const buildMigrationAuthorizationTxSteps = (
     steps.push({
       index: startIndex + steps.length,
       label: (authorizationType && labels[authorizationType]) || fallback,
-      isSeparateTx: true,
+      isSeparateTx: !options?.bundled,
     })
   }
 


### PR DESCRIPTION
## Summary

Transaction-kind migrations for Safe wallets now submit **authorization grants + the migration EVC batch + revocations as one atomic `wallet_sendCalls` bundle** — a single Safe proposal instead of two to three sequential ones (LITE-323). **Stacked on #797**; retarget to `development` once it merges.

## Why atomicity is also a safety win

Today, if the migration batch fails after a grant landed, the authorization stays live on-chain until the revoke unwind succeeds — and receipt-ambiguous failures leave revokes queued in `pendingRevokes` bookkeeping. In one atomic bundle a failed migration reverts its grants with it, and the revocations ride in the same proposal, so **no standing-authorization window exists on success or failure** and the bundled path needs no unwind bookkeeping at all.

## The key design question: plan correctness before grants mine

The sequential flow is ordered the way it is because `planCrossProtocolMigration` does a **live allowance read** inside the connector and throws when the grant is not yet on-chain. The bundle path instead builds its plan from the SDK's **simulation variant** (`planCrossProtocolMigrationSimulation`): for transaction-kind authorization requests this plan is **byte-identical to the execution plan** (`plan === previewPlan`, a fact the codebase already relies on for calldata previews) — the connector validates the grant's target/spender/amount instead of reading live state. So nothing needs to mine before the bundle is assembled, and the pre-submission blocking simulation runs with the SDK's authorization `stateOverrides` threaded through a new `extraStateOverrides` pass-through on `simulatePreparedPlan` / `runPreparedSimulation` (the same SDK field `useTxBatch` already uses).

## Implementation

- `useEulerTx.executePreparedPlanWithPlainCalls(prepared, { before, after })` — wraps the Safe bundle with plain calls (grants before the plan, revocations after); returns `undefined` when there is no Safe bundle context, keeping the caller in charge of the sequential fallback (which must mine grants first)
- `executePlanAsSafeBundle` gains the `extraCalls` wrapper; all existing guards apply unchanged (context assertion, connector pinning, hash-shaped bundle id, reverted-receipt throw)
- `migrate.vue` (outgoing) and `borrow/swap.vue` (inbound external): a bundle-first branch — simulation-variant plan → prepare (`usePermit2: false`) → blocking simulation with authorization overrides → bundle. `'aborted'` (simulation rejected, nothing on-chain) returns cleanly with no unwind; `'unavailable'` falls through to today's sequential grant flow untouched
- Review display: `buildMigrationAuthorizationTxSteps` gains a `bundled` option — grant/revoke rows drop the "Separate tx" badge when a Safe is connected, matching the `bundledApprovals` precedent

## Test plan

- [x] `executePreparedPlanWithPlainCalls`: exact bundle ordering `[grant, batch, revoke]` with connector pinning + `forceAtomic`; `undefined` for non-Safe connectors and provider-less Safes; reverted bundle throws before finalizing
- [x] `simulatePreparedPlan`: `extraStateOverrides` passed through when present, omitted otherwise
- [x] `buildMigrationAuthorizationTxSteps`: bundled flag flips `isSeparateTx`, default unchanged
- [x] Existing migration cleanup/drift/revoke suites unchanged and green; full suite 1648 passing; typecheck + lint clean
- [ ] Manual with a real Safe: Aave outgoing + inbound migration produce ONE proposal each; simulation rejection leaves nothing on-chain; EOA migrations unchanged
- [ ] Manual: degraded Safe (provider unavailable) falls back to sequential grants