### PR TITLE
chore: migrate off deprecated perspective APIs (SDK 2.0 / euler-sdks#93)

### DIFF
--- a/composables/useEulerAddresses.ts
+++ b/composables/useEulerAddresses.ts
@@ -13,8 +13,6 @@ export type EulerLensAddresses = {
 export type EulerTokenAddresses = {
   EUL: string | undefined
   rEUL: string | undefined
-  eUSD: string | undefined
-  seUSD: string | undefined
 } | null
 
 const allowedChainIds = ref<number[]>([])
@@ -135,8 +133,6 @@ export const useEulerAddresses = () => {
     return {
       EUL: config.addresses.tokenAddrs.EUL,
       rEUL: config.addresses.tokenAddrs.rEUL,
-      eUSD: config.addresses.tokenAddrs.eUSD,
-      seUSD: config.addresses.tokenAddrs.seUSD,
     }
   })
 
@@ -150,18 +146,11 @@ export const useEulerAddresses = () => {
       capRiskStewardFactory: peripheryAddrs.capRiskStewardFactory,
       escrowedCollateralPerspective: peripheryAddrs.escrowedCollateralPerspective,
       eulerEarnFactoryPerspective: peripheryAddrs.eulerEarnFactoryPerspective,
-      eulerEarnGovernedPerspective: peripheryAddrs.eulerEarnGovernedPerspective,
-      eulerUngoverned0xPerspective: peripheryAddrs.eulerUngoverned0xPerspective,
-      eulerUngovernedNzxPerspective: peripheryAddrs.eulerUngovernedNzxPerspective,
       evkFactoryPerspective: peripheryAddrs.evkFactoryPerspective,
-      externalVaultRegistry: peripheryAddrs.externalVaultRegistry,
       feeFlowController: peripheryAddrs.feeFlowController,
-      governedPerspective: peripheryAddrs.governedPerspective,
       governorAccessControlEmergencyFactory: peripheryAddrs.governorAccessControlEmergencyFactory,
-      irmRegistry: peripheryAddrs.irmRegistry,
       kinkIRMFactory: peripheryAddrs.kinkIRMFactory,
       kinkyIRMFactory: peripheryAddrs.kinkyIRMFactory,
-      oracleAdapterRegistry: peripheryAddrs.oracleAdapterRegistry,
       oracleRouterFactory: peripheryAddrs.oracleRouterFactory,
       securitizeFactory: peripheryAddrs.securitizeFactory,
       swapVerifier: peripheryAddrs.swapVerifier,

--- a/server/utils/labels-view.ts
+++ b/server/utils/labels-view.ts
@@ -229,7 +229,7 @@ async function buildSnapshot(
   labels: EulerLabelsData,
 ): Promise<{ snapshot: ChainVaultsSnapshot, escrowAddresses: Set<Address> }> {
   const escrowAddresses = new Set<Address>(
-    uniqueAddresses(await sdk.eVaultService.fetchVerifiedVaultAddresses(chainId, [StandardEVaultPerspectives.ESCROW])),
+    uniqueAddresses(await sdk.eVaultService.fetchPerspectiveVaultAddresses(chainId, [StandardEVaultPerspectives.ESCROW])),
   )
   const candidates = uniqueAddresses([
     ...labels.verifiedVaultAddresses,

--- a/server/utils/vaults-cache.ts
+++ b/server/utils/vaults-cache.ts
@@ -151,7 +151,7 @@ const partitionVerified = async (
 
 const fetchEscrowAddrs = async (sdk: EulerSDK, chainId: number): Promise<Address[]> => {
   try {
-    const list = await sdk.eVaultService.fetchVerifiedVaultAddresses(
+    const list = await sdk.eVaultService.fetchPerspectiveVaultAddresses(
       chainId,
       [StandardEVaultPerspectives.ESCROW],
     )

--- a/tests/composables/useVaults.test.ts
+++ b/tests/composables/useVaults.test.ts
@@ -27,7 +27,7 @@ const makeEarnVault = (address: string): EulerEarn => ({
 const fetchVaults = vi.fn()
 const fetchEarnVaults = vi.fn()
 const fetchEarnVault = vi.fn()
-const fetchVerifiedVaultAddresses = vi.fn()
+const fetchPerspectiveVaultAddresses = vi.fn()
 const fetchVaultTypes = vi.fn()
 const chainId = ref(1)
 
@@ -36,7 +36,7 @@ describe('useVaults EVault verification metadata', () => {
     fetchVaults.mockReset()
     fetchEarnVaults.mockReset()
     fetchEarnVault.mockReset()
-    fetchVerifiedVaultAddresses.mockReset()
+    fetchPerspectiveVaultAddresses.mockReset()
     fetchVaultTypes.mockReset()
 
     fetchVaults.mockImplementation(async (_chainId: number, addresses: Address[]) => ({
@@ -48,7 +48,7 @@ describe('useVaults EVault verification metadata', () => {
       errors: [],
       result: makeEarnVault(address),
     }))
-    fetchVerifiedVaultAddresses.mockResolvedValue([])
+    fetchPerspectiveVaultAddresses.mockResolvedValue([])
     fetchVaultTypes.mockResolvedValue({})
     chainId.value = 1
 
@@ -61,7 +61,7 @@ describe('useVaults EVault verification metadata', () => {
     }))
     vi.stubGlobal('useEulerLabels', useEulerLabels)
     const sdk = {
-      eVaultService: { fetchVaults, fetchVerifiedVaultAddresses },
+      eVaultService: { fetchVaults, fetchPerspectiveVaultAddresses },
       eulerEarnService: { fetchVaults: fetchEarnVaults, fetchVault: fetchEarnVault },
       vaultMetaService: { fetchVaultTypes },
     }

--- a/tests/server/vaults-cache.test.ts
+++ b/tests/server/vaults-cache.test.ts
@@ -13,7 +13,7 @@ const VAULTS = [
 
 const mocks = vi.hoisted(() => ({
   fetchVaults: vi.fn(),
-  fetchVerifiedVaultAddresses: vi.fn(),
+  fetchPerspectiveVaultAddresses: vi.fn(),
   fetchVaultTypes: vi.fn(),
   refreshLabelFile: vi.fn(),
   warn: vi.fn(),
@@ -39,7 +39,7 @@ vi.mock('~/server/utils/sdk-server', () => ({
   getServerSdk: vi.fn(async () => ({
     eVaultService: {
       fetchVaults: mocks.fetchVaults,
-      fetchVerifiedVaultAddresses: mocks.fetchVerifiedVaultAddresses,
+      fetchPerspectiveVaultAddresses: mocks.fetchPerspectiveVaultAddresses,
     },
     eulerEarnService: {
       fetchVaults: vi.fn(async () => ({ result: [], errors: [] })),
@@ -64,14 +64,14 @@ describe('vaults cache', () => {
   beforeEach(() => {
     vi.resetModules()
     mocks.fetchVaults.mockReset()
-    mocks.fetchVerifiedVaultAddresses.mockReset()
+    mocks.fetchPerspectiveVaultAddresses.mockReset()
     mocks.fetchVaultTypes.mockReset()
     mocks.refreshLabelFile.mockReset()
     mocks.warn.mockReset()
     mocks.error.mockReset()
     process.env.EVAULT_FETCH_CHUNK_CHAINS = '146'
 
-    mocks.fetchVerifiedVaultAddresses.mockResolvedValue([])
+    mocks.fetchPerspectiveVaultAddresses.mockResolvedValue([])
     mocks.fetchVaultTypes.mockResolvedValue({})
     mocks.refreshLabelFile.mockImplementation(async (_scope, file) => {
       if (file === 'products.json') {

--- a/utils/sdk-vault-meta-stub.ts
+++ b/utils/sdk-vault-meta-stub.ts
@@ -59,11 +59,11 @@ export const buildRegistryMetaService = (registry: Registry): IVaultMetaService<
   ): Promise<ServiceResult<(VaultEntity | undefined)[]>> {
     throw new Error('registry meta-stub: fetchVaults() not supported')
   },
-  async fetchVerifiedVaultAddresses(): Promise<Address[]> {
-    throw new Error('registry meta-stub: fetchVerifiedVaultAddresses() not supported')
+  async fetchPerspectiveVaultAddresses(): Promise<Address[]> {
+    throw new Error('registry meta-stub: fetchPerspectiveVaultAddresses() not supported')
   },
-  async fetchVerifiedVaults(): Promise<ServiceResult<(VaultEntity | undefined)[]>> {
-    throw new Error('registry meta-stub: fetchVerifiedVaults() not supported')
+  async fetchPerspectiveVaults(): Promise<ServiceResult<(VaultEntity | undefined)[]>> {
+    throw new Error('registry meta-stub: fetchPerspectiveVaults() not supported')
   },
   async fetchAllVaults(
     _chainId: number,

--- a/utils/vault/categories.ts
+++ b/utils/vault/categories.ts
@@ -82,7 +82,7 @@ const fetchEscrowAddressSet = async (chainId: number): Promise<Set<string>> => {
   if (existing) return existing
 
   const promise = getSdk(chainId)
-    .then(sdk => sdk.eVaultService.fetchVerifiedVaultAddresses(chainId, [StandardEVaultPerspectives.ESCROW]))
+    .then(sdk => sdk.eVaultService.fetchPerspectiveVaultAddresses(chainId, [StandardEVaultPerspectives.ESCROW]))
     .then(addresses => new Set(uniqueAddresses(addresses).map(address => address.toLowerCase())))
     .then((set) => {
       escrowAddressCache.set(chainId, set)


### PR DESCRIPTION
## Summary

Prepares euler-lite for the SDK release containing euler-xyz/euler-sdks#93 (LITE-324). **Draft — do not merge until that release publishes and the version-bump commit is added.** CI typecheck will fail on this PR until then: the renamed APIs don't exist in the pinned 1.2.5.

## Changes

**Method renames** (behavior identical — the `ESCROW` enum member survives; #93 only retires `GOVERNED`/`EDGE`):
- `server/utils/labels-view.ts`, `server/utils/vaults-cache.ts`, `utils/vault/categories.ts` — the three real escrow-discovery call sites: `fetchVerifiedVaultAddresses` → `fetchPerspectiveVaultAddresses`
- `utils/sdk-vault-meta-stub.ts` — `IVaultMetaService` throw-stubs renamed to match the new interface
- Test mocks in `tests/server/vaults-cache.test.ts` and `tests/composables/useVaults.test.ts`

**Dead mapping removal** — #93 also deletes these from the SDK deployment types; lite mapped them into its address objects but nothing consumed them (verified by repo-wide trace):
- Perspective addresses: `eulerEarnGovernedPerspective`, `eulerUngoverned0xPerspective`, `eulerUngovernedNzxPerspective`, `governedPerspective`
- Non-perspective fields removed by the same PR: `eUSD`, `seUSD` (incl. lite's `EulerTokenAddresses` type), `externalVaultRegistry`, `irmRegistry`, `oracleAdapterRegistry`

Conceptually lite is already aligned with #93's rationale: trust comes from euler-labels + governor verification, and lite only uses the structural ESCROW perspective.

## Verification

Validated against an SDK built locally from the #93 branch head (installed as a tarball, not committed):
- [x] `nuxt typecheck` clean
- [x] Full suite: 1612 passed, 1 skipped
- [x] Lint clean
- [ ] After the SDK release: add the `package.json`/lockfile bump commit, re-run CI (note `.npmrc` `min-release-age=7` — install the fresh version from outside the repo or wait out the window)

## Merge dependency

Blocked on euler-xyz/euler-sdks#93 publishing (planned as the 2.0.0 breaking release, separate from the additive 1.3.0 carrying safeAccountService from euler-xyz/euler-sdks#94).