### PR TITLE
fix: decode flow cap activity details

### DIFF
--- a/components/entities/activity/ActivityEventRow.vue
+++ b/components/entities/activity/ActivityEventRow.vue
@@ -208,6 +208,7 @@ const changes = computed(() => {
       valueTitle: entry.value,
       summary: entry.summary,
       addresses: entry.addresses,
+      addressDetails: entry.addressDetails,
       avatarAssets: entry.field === 'asset_pair'
         || (event.type === 'set_resolved_vault' && entry.field === 'asset')
         ? entry.addresses?.map(address => ({
@@ -468,7 +469,7 @@ const vaultDisplay = computed(() => {
               <div
                 v-for="(address, addressIndex) in detail.addresses"
                 :key="`${address.address}:${addressIndex}`"
-                class="flex w-full min-w-0 items-center gap-8"
+                class="flex w-full min-w-0 flex-wrap items-center gap-x-8 gap-y-2"
               >
                 <AssetAvatar
                   v-if="'avatarAssets' in detail && detail.avatarAssets?.[addressIndex]"
@@ -484,6 +485,10 @@ const vaultDisplay = computed(() => {
                   :vault-type="address.vaultType"
                   compact-vault
                 />
+                <span
+                  v-if="'addressDetails' in detail && detail.addressDetails?.[addressIndex]"
+                  class="text-p4 text-content-secondary"
+                >{{ detail.addressDetails[addressIndex] }}</span>
               </div>
             </div>
           </template>

--- a/tests/utils/activity-display.test.ts
+++ b/tests/utils/activity-display.test.ts
@@ -202,6 +202,7 @@ describe('activity display helpers', () => {
     expect(formatActivityEventLabel({ type: 'set_interest_rate_model' })).toBe('Interest rate model updated')
     expect(formatActivityEventLabel({ type: 'set_liquidation_cool_off_time' })).toBe('Liquidation cool-off time updated')
     expect(formatActivityEventLabel({ type: 'set_is_allocator' })).toBe('Allocator status updated')
+    expect(formatActivityEventLabel({ label: 'Flow caps updated', type: 'set_flow_caps' })).toBe('Strategy caps updated')
     expect(formatActivityEventLabel({ type: 'set_oracle_config' })).toBe('Oracle route updated')
     expect(formatActivityEventLabel({ type: 'set_fallback_oracle' })).toBe('Fallback oracle updated')
     expect(formatActivityEventLabel({ type: 'set_resolved_vault' })).toBe('Resolved vault updated')

--- a/tests/utils/activity-display.test.ts
+++ b/tests/utils/activity-display.test.ts
@@ -202,7 +202,7 @@ describe('activity display helpers', () => {
     expect(formatActivityEventLabel({ type: 'set_interest_rate_model' })).toBe('Interest rate model updated')
     expect(formatActivityEventLabel({ type: 'set_liquidation_cool_off_time' })).toBe('Liquidation cool-off time updated')
     expect(formatActivityEventLabel({ type: 'set_is_allocator' })).toBe('Allocator status updated')
-    expect(formatActivityEventLabel({ type: 'set_flow_caps' })).toBe('Flow caps updated')
+    expect(formatActivityEventLabel({ label: 'Flow caps updated', type: 'set_flow_caps' })).toBe('Public allocator limits updated')
     expect(formatActivityEventLabel({ type: 'set_oracle_config' })).toBe('Oracle route updated')
     expect(formatActivityEventLabel({ type: 'set_fallback_oracle' })).toBe('Fallback oracle updated')
     expect(formatActivityEventLabel({ type: 'set_resolved_vault' })).toBe('Resolved vault updated')

--- a/tests/utils/activity-display.test.ts
+++ b/tests/utils/activity-display.test.ts
@@ -202,7 +202,7 @@ describe('activity display helpers', () => {
     expect(formatActivityEventLabel({ type: 'set_interest_rate_model' })).toBe('Interest rate model updated')
     expect(formatActivityEventLabel({ type: 'set_liquidation_cool_off_time' })).toBe('Liquidation cool-off time updated')
     expect(formatActivityEventLabel({ type: 'set_is_allocator' })).toBe('Allocator status updated')
-    expect(formatActivityEventLabel({ label: 'Flow caps updated', type: 'set_flow_caps' })).toBe('Strategy caps updated')
+    expect(formatActivityEventLabel({ type: 'set_flow_caps' })).toBe('Flow caps updated')
     expect(formatActivityEventLabel({ type: 'set_oracle_config' })).toBe('Oracle route updated')
     expect(formatActivityEventLabel({ type: 'set_fallback_oracle' })).toBe('Fallback oracle updated')
     expect(formatActivityEventLabel({ type: 'set_resolved_vault' })).toBe('Resolved vault updated')

--- a/tests/utils/activity-display.test.ts
+++ b/tests/utils/activity-display.test.ts
@@ -21,6 +21,7 @@ import {
   getActivityChangeEntries,
   getActivityEventIcon,
   getActivityLiquidationDisplayDetails,
+  getActivityResolvableVaultAddresses,
   getPortfolioActivityPositionParticipant,
   getActivityTransferDirection,
   getActivityTransactionGroupLabel,
@@ -713,6 +714,51 @@ describe('activity display helpers', () => {
     }, getVaultMetadata)).toEqual([
       { field: 'new_supply_cap', label: 'New supply cap', value: '155M USDC' },
     ])
+
+    const flowCapsConfig = JSON.stringify([
+      { id: OTHER_VAULT, caps: { maxIn: '10000000000', maxOut: '2500000000' } },
+      { id: SHARES, caps: { maxIn: '0', maxOut: '10000000000' } },
+    ])
+    expect(getActivityChangeEntries({
+      type: 'set_flow_caps',
+      vault: VAULT,
+      vaultType: 'earn',
+      change: { fields: { config: flowCapsConfig } },
+    }, getVaultMetadata)).toEqual([{
+      field: 'config',
+      label: 'Strategies',
+      summary: '2 strategies',
+      addresses: [
+        {
+          address: OTHER_VAULT,
+          label: 'Collateral vault',
+          linkKind: 'vault',
+          vaultType: 'evk',
+        },
+        { address: SHARES, linkKind: 'explorer' },
+      ],
+      addressDetails: [
+        'Max in 10K USDC · Max out 2.5K USDC',
+        'Max in 0 USDC · Max out 10K USDC',
+      ],
+    }])
+    expect(getActivityResolvableVaultAddresses({
+      type: 'set_flow_caps',
+      vault: VAULT,
+      change: { fields: { config: flowCapsConfig } },
+    })).toEqual([VAULT, OTHER_VAULT, SHARES])
+
+    const malformedFlowCapsConfig = '[{"id":"not-an-address"}]'
+    expect(getActivityChangeEntries({
+      type: 'set_flow_caps',
+      vault: VAULT,
+      vaultType: 'earn',
+      change: { fields: { config: malformedFlowCapsConfig } },
+    }, getVaultMetadata)).toEqual([{
+      field: 'config',
+      label: 'Config',
+      value: malformedFlowCapsConfig,
+    }])
 
     expect(getActivityChangeEntries({
       type: 'set_oracle_config',

--- a/utils/activity-display.ts
+++ b/utils/activity-display.ts
@@ -448,6 +448,7 @@ export const getActivityTransferDirection = (
 export const formatActivityEventLabel = (
   event: ActivityEventLabelSource,
 ): string => {
+  if (event.type === 'set_flow_caps') return 'Public allocator limits updated'
   const sourceLabel = event.label?.trim()
   if (sourceLabel) return sourceLabel
   const normalizedLabel = {

--- a/utils/activity-display.ts
+++ b/utils/activity-display.ts
@@ -448,7 +448,6 @@ export const getActivityTransferDirection = (
 export const formatActivityEventLabel = (
   event: ActivityEventLabelSource,
 ): string => {
-  if (event.type === 'set_flow_caps') return 'Strategy caps updated'
   const sourceLabel = event.label?.trim()
   if (sourceLabel) return sourceLabel
   const normalizedLabel = {

--- a/utils/activity-display.ts
+++ b/utils/activity-display.ts
@@ -9,7 +9,7 @@ import type {
   ActivityVaultType,
   LiquidationRecord,
 } from '@eulerxyz/euler-v2-sdk'
-import { formatUnits, isAddress, maxUint256, zeroAddress, type Address } from 'viem'
+import { formatUnits, getAddress, isAddress, maxUint256, zeroAddress, type Address } from 'viem'
 import { compactNumber, formatCompactUsdValue, formatSmartAmount, shortenAddress } from '~/utils/string-utils'
 import { CFG_DONT_SOCIALIZE_DEBT } from '~/entities/constants'
 import { decodeHookedOperationsMask, getHookedOperationMetas } from '~/utils/vault-hooks'
@@ -76,6 +76,7 @@ const CATEGORY_LABELS: Record<ActivityCategory, string> = {
   governance: 'Governance',
 }
 
+const UINT128_MAX = 2n ** 128n - 1n
 const UINT136_MAX = 2n ** 136n - 1n
 
 const ACCOUNT_ACTIVITY_EVENT_TYPES = [
@@ -832,6 +833,7 @@ export interface ActivityChangeEntry {
   value?: string
   summary?: string
   addresses?: ActivityChangeAddress[]
+  addressDetails?: string[]
 }
 
 type ActivityChangeEventSource = Pick<ActivityEvent, 'change' | 'type' | 'vault' | 'vaultType'>
@@ -863,6 +865,56 @@ const parseActivityInteger = (value: ActivityChangeValue): bigint | null => {
   if (typeof value !== 'string' && typeof value !== 'number') return null
   try {
     return BigInt(value)
+  }
+  catch {
+    return null
+  }
+}
+
+interface ActivityFlowCapsConfig {
+  id: Address
+  maxIn: string
+  maxOut: string
+}
+
+const isActivityRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const isActivityUint128 = (value: unknown): value is string =>
+  typeof value === 'string'
+  && value.length <= UINT128_MAX.toString().length
+  && /^\d+$/.test(value)
+  && BigInt(value) <= UINT128_MAX
+
+/**
+ * The activity API serializes FlowCapsConfig[] into a string because the SDK
+ * change-value contract intentionally accepts only scalars and string arrays.
+ * Keep this parser event-specific and fail closed to the generic raw display.
+ */
+const parseActivityFlowCapsConfig = (
+  value: ActivityChangeValue | undefined,
+): ActivityFlowCapsConfig[] | null => {
+  if (typeof value !== 'string') return null
+
+  try {
+    const parsed: unknown = JSON.parse(value)
+    if (!Array.isArray(parsed)) return null
+
+    const configs: ActivityFlowCapsConfig[] = []
+    for (const item of parsed) {
+      if (
+        !isActivityRecord(item)
+        || typeof item.id !== 'string'
+        || !isAddress(item.id)
+        || !isActivityRecord(item.caps)
+      ) {
+        return null
+      }
+      const { maxIn, maxOut } = item.caps
+      if (!isActivityUint128(maxIn) || !isActivityUint128(maxOut)) return null
+      configs.push({ id: getAddress(item.id), maxIn, maxOut })
+    }
+    return configs
   }
   catch {
     return null
@@ -1094,14 +1146,51 @@ const resolveOracleAssetPair = (
   }
 }
 
+const resolveFlowCapsConfig = (
+  event: ActivityChangeEventSource,
+  getVaultMetadata: ActivityVaultMetadataLookup | undefined,
+  getTokenSymbol: ActivityAddressLabelLookup | undefined,
+): ActivityChangeEntry | null => {
+  if (event.type !== 'set_flow_caps') return null
+  const configs = parseActivityFlowCapsConfig(event.change?.fields.config)
+  if (configs === null) return null
+  if (configs.length === 0) {
+    return { field: 'config', label: 'Strategies', value: 'None' }
+  }
+
+  const addresses = resolveChangeAddresses(
+    event,
+    'strategy',
+    configs.map(config => config.id),
+    getVaultMetadata,
+    getTokenSymbol,
+  )
+  if (!addresses) return null
+
+  const asset = event.vault ? getVaultMetadata?.(event.vault)?.asset : undefined
+  const formatCap = (value: string) =>
+    formatActivityTokenAmount(value, asset, true) ?? value
+  return {
+    field: 'config',
+    label: configs.length === 1 ? 'Strategy' : 'Strategies',
+    ...(configs.length > 1 ? { summary: `${configs.length} strategies` } : {}),
+    addresses,
+    addressDetails: configs.map(config =>
+      `Max in ${formatCap(config.maxIn)} · Max out ${formatCap(config.maxOut)}`),
+  }
+}
+
 export const getActivityChangeEntries = (
   event: ActivityChangeEventSource,
   getVaultMetadata?: ActivityVaultMetadataLookup,
   getTokenSymbol?: ActivityAddressLabelLookup,
 ): ActivityChangeEntry[] => {
   const assetPair = resolveOracleAssetPair(event, getTokenSymbol)
+  const flowCapsConfig = resolveFlowCapsConfig(event, getVaultMetadata, getTokenSymbol)
   const fields = orderedActivityChangeFields(event)
-    .filter(([field]) => !assetPair || (field !== 'asset0' && field !== 'asset1'))
+    .filter(([field]) =>
+      (!assetPair || (field !== 'asset0' && field !== 'asset1'))
+      && (!flowCapsConfig || field !== 'config'))
 
   const entries = fields.map(([field, value]): ActivityChangeEntry => {
   // The zero address reads better as an explicit "None" than as a linked,
@@ -1179,7 +1268,11 @@ export const getActivityChangeEntries = (
       value: formatted ?? formatActivityChangeValue(value),
     }
   })
-  return assetPair ? [assetPair, ...entries] : entries
+  return [
+    ...(assetPair ? [assetPair] : []),
+    ...(flowCapsConfig ? [flowCapsConfig] : []),
+    ...entries,
+  ]
 }
 
 interface ActivityParticipantSource {
@@ -1233,6 +1326,11 @@ export const getActivityResolvableVaultAddresses = (
     const value = event.change?.fields[field]
     for (const item of Array.isArray(value) ? value : [value]) {
       if (typeof item === 'string' && isAddress(item)) addresses.add(item as Address)
+    }
+  }
+  if (event.type === 'set_flow_caps') {
+    for (const config of parseActivityFlowCapsConfig(event.change?.fields.config) ?? []) {
+      addresses.add(config.id)
     }
   }
   return [...addresses]

--- a/utils/activity-display.ts
+++ b/utils/activity-display.ts
@@ -448,6 +448,7 @@ export const getActivityTransferDirection = (
 export const formatActivityEventLabel = (
   event: ActivityEventLabelSource,
 ): string => {
+  if (event.type === 'set_flow_caps') return 'Strategy caps updated'
   const sourceLabel = event.label?.trim()
   if (sourceLabel) return sourceLabel
   const normalizedLabel = {


### PR DESCRIPTION
## Summary
- Decode serialized Euler Earn Public Allocator flow-cap configs into readable per-strategy limit details.
- Resolve strategy vaults and format maximum inflow and outflow in the Earn vault underlying asset units.

## Changes
- Parse and validate FlowCapsConfig payloads with a raw fallback for malformed or future shapes.
- Show a compact strategy count while collapsed and linked per-strategy limits when expanded.
- Display set_flow_caps events as Public allocator limits updated.
- Hydrate strategy metadata and cover decoding, formatting, resolution, labeling, and fallback behavior with tests.

## Preview
- [Open the Monad Earn vault on the PR 801 Railway preview](https://dev-build-euler-lite-pr-801.up.railway.app/earn/0x6A144D277412B35696F29D8dE3D141CDE68f4d2F?network=143)

## Screenshots

**Collapsed**

<img width="1905" height="856" alt="Collapsed Public allocator limits activity row" src="https://github.com/user-attachments/assets/679bb14c-e5a2-4323-aaf3-98209173b67d" />

**Expanded**

<img width="1905" height="856" alt="Expanded Public allocator limits activity details" src="https://github.com/user-attachments/assets/5798ccce-ed77-49c3-9e87-800be102140b" />

## Test plan
- [x] npm run build
- [x] npm run lint
- [x] npm run typecheck
- [x] npm run test:run
- [x] Verified collapsed and expanded Public Allocator limit activity on the PR 801 Railway preview.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Activity details now show additional metadata alongside relevant addresses.
  * Flow-cap changes display strategy details, including maximum incoming and outgoing amounts.
  * Vault and explorer addresses in flow-cap activity entries are linked for easier navigation.
  * Flow-cap activities use clearer “Public allocator limits updated” labeling.

* **Bug Fixes**
  * Invalid or incomplete flow-cap configurations retain available raw details.
  * Address rows can wrap content for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->