### PR TITLE
fix: batch simulation dies with 'not loaded' when ToS registration rides in the batch

### DIFF
--- a/composables/useTxBatch.ts
+++ b/composables/useTxBatch.ts
@@ -534,6 +534,28 @@ export const normalizeSimulatedVaultLayers = <T>(
   return null
 }
 
+/**
+ * Strip layers produced by plugin-prepended loose batch items (e.g. the lite
+ * ToS registration for an account whose acceptance hasn't landed on-chain).
+ * The layered simulation emits one layer per top-level batch unit, so those
+ * items surface as extra layers between the pre-batch snapshot and the first
+ * entry's layer, breaking the layer[i] ↔ entry[i-1] contract that
+ * getCurrentFinalLayer enforces (`layers.length === entries.length + 1`).
+ *
+ * `hasBaseLayer` arrays keep index 0 (the pre-batch snapshot) and drop the
+ * following `extra` plugin layers; base-less arrays drop the first `extra`.
+ */
+export const stripLeadingPluginLayers = <T>(
+  layerArray: T[],
+  extra: number,
+  hasBaseLayer: boolean,
+): T[] => {
+  if (extra <= 0) return layerArray
+  return hasBaseLayer
+    ? [...layerArray.slice(0, 1), ...layerArray.slice(1 + extra)]
+    : layerArray.slice(extra)
+}
+
 type BatchSimulationWalletBalances = {
   simulatedWalletBalances?: Record<string, bigint>[]
 }
@@ -1733,11 +1755,34 @@ export const useTxBatch = () => {
       // layer's touched positions onto the previous full account. This preserves
       // the user's existing positions in vaults the batch never touched.
       const rawSimAccounts = (sim.simulatedAccounts ?? []) as Account<IHasVaultAddress>[]
-      const simAccounts = rawSimAccounts.length === plans.length
+      const paddedSimAccounts = rawSimAccounts.length === plans.length
         ? [baseAccount, ...rawSimAccounts]
         : rawSimAccounts
+      // Plan plugins may prepend loose batch items ahead of the entry
+      // operations (the lite ToS registration is the known case). Each loose
+      // item produces its own simulation layer, so fold those away — keeping
+      // the real pre-batch snapshot as layer 0 — and strip the vault/wallet
+      // layer arrays in lockstep so all layer indices keep mapping to cart
+      // entries. Failure attribution (operationIndex) is left untouched: its
+      // indexing for loose items is SDK-internal, and the ToS registration
+      // cannot realistically fail.
+      const extraLeadingLayers = Math.max(0, paddedSimAccounts.length - (plans.length + 1))
+      if (extraLeadingLayers > 0) {
+        logBatchDiag('resimulate:plugin-layers-stripped', {
+          token,
+          extraLeadingLayers,
+          rawSimAccounts: paddedSimAccounts.length,
+          plans: plans.length,
+        }, 'warn')
+      }
+      const simAccounts = stripLeadingPluginLayers(paddedSimAccounts, extraLeadingLayers, true)
       const rawSimVaultLayers = sim.simulatedVaultsLayers ?? []
-      const normalizedSimVaultLayers = normalizeSimulatedVaultLayers(rawSimVaultLayers, plans.length)
+      const strippedSimVaultLayers = stripLeadingPluginLayers(
+        rawSimVaultLayers,
+        extraLeadingLayers,
+        rawSimVaultLayers.length === plans.length + 1 + extraLeadingLayers,
+      )
+      const normalizedSimVaultLayers = normalizeSimulatedVaultLayers(strippedSimVaultLayers, plans.length)
       const simVaultLayers = normalizedSimVaultLayers ?? []
       if (normalizedSimVaultLayers === null) {
         logBatchDiag('resimulate:vault-layer-cardinality-invalid', {
@@ -1823,7 +1868,12 @@ export const useTxBatch = () => {
         }
         return out
       }
-      const simWb = ((sim as BatchSimulationWalletBalances).simulatedWalletBalances ?? []).map(normalizeWalletBalances)
+      const rawSimWb = (sim as BatchSimulationWalletBalances).simulatedWalletBalances ?? []
+      const simWb = stripLeadingPluginLayers(
+        rawSimWb,
+        extraLeadingLayers,
+        rawSimWb.length === plans.length + 1 + extraLeadingLayers,
+      ).map(normalizeWalletBalances)
       const touchedTokens = collectWalletBalanceTokens(simWb)
       const realWallet: Record<string, bigint> = {}
       if (touchedTokens.length) {

--- a/composables/useTxBatch.ts
+++ b/composables/useTxBatch.ts
@@ -535,25 +535,77 @@ export const normalizeSimulatedVaultLayers = <T>(
 }
 
 /**
- * Strip layers produced by plugin-prepended loose batch items (e.g. the lite
- * ToS registration for an account whose acceptance hasn't landed on-chain).
- * The layered simulation emits one layer per top-level batch unit, so those
- * items surface as extra layers between the pre-batch snapshot and the first
- * entry's layer, breaking the layer[i] ↔ entry[i-1] contract that
- * getCurrentFinalLayer enforces (`layers.length === entries.length + 1`).
- *
- * `hasBaseLayer` arrays keep index 0 (the pre-batch snapshot) and drop the
- * following `extra` plugin layers; base-less arrays drop the first `extra`.
+ * Mirror of the SDK simulator's `collectOperations` grouping: every top-level
+ * entry of an evcBatch — a named operation or a loose item — is one
+ * simulation operation, producing one state layer and one slot in the
+ * `failedBatchItems.operationIndex` space. Non-evcBatch plan items produce
+ * neither.
  */
-export const stripLeadingPluginLayers = <T>(
-  layerArray: T[],
-  extra: number,
-  hasBaseLayer: boolean,
-): T[] => {
-  if (extra <= 0) return layerArray
-  return hasBaseLayer
-    ? [...layerArray.slice(0, 1), ...layerArray.slice(1 + extra)]
-    : layerArray.slice(extra)
+export const countPlanOperations = (plan: TransactionPlan): number => {
+  let count = 0
+  for (const item of plan) {
+    if (item.type !== 'evcBatch') continue
+    count += item.items.length
+  }
+  return count
+}
+
+export interface BatchOperationEntryMap {
+  /**
+   * Operations the simulated plan carries ahead of the entries' own —
+   * plan plugins (ToS registration, Pyth updates) prepend loose items, each
+   * of which the simulator treats as its own operation.
+   */
+  pluginOperations: number
+  /** Operations contributed by each cart entry, in entry order. */
+  operationCounts: number[]
+  /** Simulation layer index holding the state after entry i completed. */
+  entryLayerIndices: number[]
+  /** Cart entry owning an SDK operationIndex; null for plugin operations. */
+  entryOfOperation: (operationIndex: number) => number | null
+}
+
+/**
+ * Explicit SDK-operation ↔ cart-entry boundary map.
+ *
+ * Layer/failure cardinality cannot be inferred from entry count alone: a
+ * single cart entry may contribute several operations (a collateral+debt
+ * refinance is the concrete case), and plan plugins prepend operations of
+ * their own. Entry operation counts come from the entry plans the cart
+ * holds; the plugin prefix is the difference against the simulated plan's
+ * operation count (plugins run inside `simulateTransactionPlan`, so the app
+ * never holds the plan that was actually simulated). Known plugins prepend —
+ * a negative difference means the shapes disagree and the caller must treat
+ * the simulation as unusable.
+ */
+export const buildOperationEntryMap = (
+  entryPlans: TransactionPlan[],
+  simulatedOperationCount: number,
+): BatchOperationEntryMap | null => {
+  const operationCounts = entryPlans.map(countPlanOperations)
+  const totalEntryOperations = operationCounts.reduce((sum, count) => sum + count, 0)
+  const pluginOperations = simulatedOperationCount - totalEntryOperations
+  if (pluginOperations < 0) return null
+
+  const entryLayerIndices: number[] = []
+  let cumulative = pluginOperations
+  for (const count of operationCounts) {
+    cumulative += count
+    entryLayerIndices.push(cumulative)
+  }
+
+  return {
+    pluginOperations,
+    operationCounts,
+    entryLayerIndices,
+    entryOfOperation: (operationIndex: number) => {
+      if (operationIndex < pluginOperations || operationIndex >= simulatedOperationCount) return null
+      for (let i = 0; i < entryLayerIndices.length; i++) {
+        if (operationIndex < entryLayerIndices[i]!) return i
+      }
+      return null
+    },
+  }
 }
 
 type BatchSimulationWalletBalances = {
@@ -1758,45 +1810,49 @@ export const useTxBatch = () => {
       const paddedSimAccounts = rawSimAccounts.length === plans.length
         ? [baseAccount, ...rawSimAccounts]
         : rawSimAccounts
-      // Plan plugins may prepend loose batch items ahead of the entry
-      // operations (the lite ToS registration is the known case). Each loose
-      // item produces its own simulation layer, so fold those away — keeping
-      // the real pre-batch snapshot as layer 0 — and strip the vault/wallet
-      // layer arrays in lockstep so all layer indices keep mapping to cart
-      // entries. Failure attribution (operationIndex) is left untouched: its
-      // indexing for loose items is SDK-internal, and the ToS registration
-      // cannot realistically fail.
-      const extraLeadingLayers = Math.max(0, paddedSimAccounts.length - (plans.length + 1))
-      if (extraLeadingLayers > 0) {
-        logBatchDiag('resimulate:plugin-layers-stripped', {
+      // The simulator emits one layer per SDK operation — where an operation
+      // is any top-level batch unit, so plan plugins (ToS registration, Pyth
+      // updates) contribute prefix operations and a single cart entry may
+      // contribute several (collateral+debt refinance). Map those operations
+      // back to cart entries explicitly: each entry's display layer is the
+      // state after its LAST operation, plugin prefix layers fold into the
+      // base, and failedBatchItems.operationIndex resolves through the same
+      // map so failures mark the right row.
+      const simulatedOperationCount = Math.max(0, paddedSimAccounts.length - 1)
+      const operationMap = buildOperationEntryMap(plans, simulatedOperationCount)
+      if (operationMap && operationMap.pluginOperations > 0) {
+        logBatchDiag('resimulate:plugin-operations-mapped', {
           token,
-          extraLeadingLayers,
-          rawSimAccounts: paddedSimAccounts.length,
-          plans: plans.length,
+          pluginOperations: operationMap.pluginOperations,
+          operationCounts: operationMap.operationCounts,
+          simulatedOperationCount,
         }, 'warn')
       }
-      const simAccounts = stripLeadingPluginLayers(paddedSimAccounts, extraLeadingLayers, true)
+      const selectEntryLayers = <T>(baseInclusiveLayers: T[]): T[] => [
+        baseInclusiveLayers[0]!,
+        ...(operationMap?.entryLayerIndices ?? []).map(k => baseInclusiveLayers[k]!),
+      ]
+      const simAccounts = operationMap ? selectEntryLayers(paddedSimAccounts) : paddedSimAccounts
       const rawSimVaultLayers = sim.simulatedVaultsLayers ?? []
-      const strippedSimVaultLayers = stripLeadingPluginLayers(
-        rawSimVaultLayers,
-        extraLeadingLayers,
-        rawSimVaultLayers.length === plans.length + 1 + extraLeadingLayers,
-      )
-      const normalizedSimVaultLayers = normalizeSimulatedVaultLayers(strippedSimVaultLayers, plans.length)
-      const simVaultLayers = normalizedSimVaultLayers ?? []
+      const normalizedSimVaultLayers = normalizeSimulatedVaultLayers(rawSimVaultLayers, simulatedOperationCount)
+      const simVaultLayers = normalizedSimVaultLayers === null || normalizedSimVaultLayers.length === 0
+        ? []
+        : operationMap
+          ? selectEntryLayers(normalizedSimVaultLayers)
+          : normalizedSimVaultLayers
       if (normalizedSimVaultLayers === null) {
         logBatchDiag('resimulate:vault-layer-cardinality-invalid', {
           token,
           rawVaultLayers: rawSimVaultLayers.length,
-          plans: plans.length,
-          acceptedVaultLayerCounts: [0, plans.length, plans.length + 1],
+          simulatedOperationCount,
+          acceptedVaultLayerCounts: [0, simulatedOperationCount, simulatedOperationCount + 1],
         }, 'error')
       }
-      // A healthy sim returns exactly one account per operation on top of the
-      // pre-batch snapshot, i.e. simAccounts.length === plans.length + 1. Anything
-      // else is the smoking gun for the "not loaded" symptom (getCurrentFinalLayer
-      // needs layers.length === entries.length + 1), so escalate to error on a
-      // mismatch.
+      // After entry-boundary selection a healthy sim yields exactly
+      // entries + 1 layers (getCurrentFinalLayer's contract). A null map means
+      // the simulated plan carries FEWER operations than the entry plans
+      // declare — an SDK build without layered simulation, or a plan-shape
+      // disagreement — and the layers cannot be trusted.
       logBatchDiag(
         'resimulate:sim-resolved',
         {
@@ -1804,6 +1860,8 @@ export const useTxBatch = () => {
           rawSimAccounts: rawSimAccounts.length,
           simAccounts: simAccounts.length,
           plans: plans.length,
+          simulatedOperationCount,
+          pluginOperations: operationMap?.pluginOperations ?? null,
           expectedLayers: plans.length + 1,
           countMatchesExpected: simAccounts.length === plans.length + 1,
           simulationError: !!sim.simulationError,
@@ -1812,15 +1870,10 @@ export const useTxBatch = () => {
         },
         simAccounts.length === plans.length + 1 ? 'warn' : 'error',
       )
-      // Version guard: the builder needs one simulated account per operation on
-      // top of the pre-batch snapshot (the layered simulation API). An SDK build
-      // without it would otherwise silently render the real state forever. The
-      // final-only shape is still enough for one operation, so normalize that
-      // case into [base, afterOp0].
-      if (!simError.value && simAccounts.length < plans.length + 1) {
+      if (!simError.value && !operationMap) {
         logBatchDiag('resimulate:version-guard-tripped', {
           token,
-          simAccounts: simAccounts.length,
+          simulatedOperationCount,
           plans: plans.length,
         }, 'error')
         simError.value = 'Batch simulation did not return per-operation state layers — the installed @eulerxyz/euler-v2-sdk build does not support the batch builder.'
@@ -1869,11 +1922,15 @@ export const useTxBatch = () => {
         return out
       }
       const rawSimWb = (sim as BatchSimulationWalletBalances).simulatedWalletBalances ?? []
-      const simWb = stripLeadingPluginLayers(
-        rawSimWb,
-        extraLeadingLayers,
-        rawSimWb.length === plans.length + 1 + extraLeadingLayers,
-      ).map(normalizeWalletBalances)
+      // Same base-inclusive normalization + entry-boundary selection as the
+      // account/vault layers, so wallet indices keep mapping to cart entries.
+      const baseInclusiveSimWb = rawSimWb.length === simulatedOperationCount
+        ? [{}, ...rawSimWb]
+        : rawSimWb
+      const selectedSimWb = operationMap && baseInclusiveSimWb.length === simulatedOperationCount + 1
+        ? selectEntryLayers(baseInclusiveSimWb)
+        : baseInclusiveSimWb
+      const simWb = selectedSimWb.map(normalizeWalletBalances)
       const touchedTokens = collectWalletBalanceTokens(simWb)
       const realWallet: Record<string, bigint> = {}
       if (touchedTokens.length) {
@@ -1941,7 +1998,17 @@ export const useTxBatch = () => {
       const failedEntries = new Map<number, string>()
       for (const f of sim.failedBatchItems ?? []) {
         const failedIndex = 'operationIndex' in f && typeof f.operationIndex === 'number' ? f.operationIndex : f.index
-        if (typeof failedIndex === 'number') failedEntries.set(failedIndex, failureMessage)
+        if (typeof failedIndex !== 'number') continue
+        // operationIndex counts plugin prefix operations too — resolve it to
+        // the owning cart entry through the boundary map. A failing plugin
+        // operation belongs to no row; block the batch instead of leaving
+        // hasFailedOps (and the Execute gate) silently green.
+        const entryIdx = operationMap ? operationMap.entryOfOperation(failedIndex) : failedIndex
+        if (entryIdx === null) {
+          if (!simError.value) simError.value = failureMessage
+          continue
+        }
+        if (!failedEntries.has(entryIdx)) failedEntries.set(entryIdx, failureMessage)
       }
       const planTargets = plans.map(collectPlanTargets)
       for (const e of sim.vaultStatusErrors ?? []) {

--- a/tests/composables/useTxBatch.test.ts
+++ b/tests/composables/useTxBatch.test.ts
@@ -3,7 +3,7 @@ import { ref } from 'vue'
 import { Account, Portfolio, type IAccountPosition, type IHasVaultAddress, type IAccountLiquidity, type TransactionPlan } from '@eulerxyz/euler-v2-sdk'
 import { getAddress, type Address, type Hex } from 'viem'
 import { getEulerSdkFresh } from '~/composables/useEulerSdk'
-import { awaitFinalPlanningLayer, buildWalletBalanceLayers, buildWalletChanges, fetchBaseAccountSnapshot, normalizeSimulatedVaultLayers, stitchAccount, useTxBatch } from '~/composables/useTxBatch'
+import { awaitFinalPlanningLayer, buildWalletBalanceLayers, buildWalletChanges, fetchBaseAccountSnapshot, normalizeSimulatedVaultLayers, stitchAccount, stripLeadingPluginLayers, useTxBatch } from '~/composables/useTxBatch'
 import {
   mergeBatchPrefetchedSlotHints,
   resetBatchPrefetchState,
@@ -705,6 +705,22 @@ describe('normalizeSimulatedVaultLayers', () => {
   })
 })
 
+describe('stripLeadingPluginLayers', () => {
+  it('keeps the base layer and drops the plugin layers after it', () => {
+    expect(stripLeadingPluginLayers(['base', 'tos', 'op1', 'op2'], 1, true)).toEqual(['base', 'op1', 'op2'])
+    expect(stripLeadingPluginLayers(['base', 'a', 'b', 'op1'], 2, true)).toEqual(['base', 'op1'])
+  })
+
+  it('drops leading plugin layers from base-less arrays', () => {
+    expect(stripLeadingPluginLayers(['tos', 'op1', 'op2'], 1, false)).toEqual(['op1', 'op2'])
+  })
+
+  it('is a no-op without extra layers', () => {
+    expect(stripLeadingPluginLayers(['base', 'op1'], 0, true)).toEqual(['base', 'op1'])
+    expect(stripLeadingPluginLayers(['op1'], 0, false)).toEqual(['op1'])
+  })
+})
+
 describe('useTxBatch execution errors', () => {
   it('reuses the prefetched portfolio account as layer 0 for account-free entries', async () => {
     const sdk = createMockSdk()
@@ -885,6 +901,40 @@ describe('useTxBatch execution errors', () => {
     })
 
     expect(activeLayerVaultsRef.value[vault.toLowerCase()]).toBe(simulatedVault)
+  })
+
+  it('folds plugin-prepended simulation layers into the base layer (ToS registration)', async () => {
+    const sdk = createMockSdk()
+    // Base + the loose ToS-registration item's layer + the entry's layer: the
+    // layered simulation emits one layer per top-level batch unit, so an
+    // account whose ToS acceptance has not landed on-chain gets entries + 2
+    // layers. Without folding, getCurrentFinalLayer never finds its
+    // entries + 1 final layer and the cart dies with "Batch simulation not
+    // loaded" after the retry budget.
+    sdk.executionService.simulateTransactionPlan.mockResolvedValue({
+      simulatedAccounts: [
+        accountWithPosition(subAccount, subAccount, 1n),
+        accountWithPosition(subAccount, subAccount, 1n),
+        accountWithPosition(subAccount, subAccount, 5n),
+      ],
+      simulatedVaultsLayers: [],
+      simulatedWalletBalances: [],
+      simulatedVaults: [],
+      failedBatchItems: [],
+      insufficientWalletAssets: [],
+    } as never)
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    const batch = useTxBatch()
+
+    await batch.addEntry({
+      label: 'Supply USDC',
+      buildPlan: async () => [] as TransactionPlan,
+      subAccount,
+    })
+
+    await vi.waitFor(() => expect(batch.layers.value).toHaveLength(2))
+    expect(batch.simError.value).toBeUndefined()
+    expect(batch.activeLayer.value).toBe(1)
   })
 
   it('does not apply a final-only vault snapshot to earlier layers of a multi-operation batch', async () => {

--- a/tests/composables/useTxBatch.test.ts
+++ b/tests/composables/useTxBatch.test.ts
@@ -3,7 +3,7 @@ import { ref } from 'vue'
 import { Account, Portfolio, type IAccountPosition, type IHasVaultAddress, type IAccountLiquidity, type TransactionPlan } from '@eulerxyz/euler-v2-sdk'
 import { getAddress, type Address, type Hex } from 'viem'
 import { getEulerSdkFresh } from '~/composables/useEulerSdk'
-import { awaitFinalPlanningLayer, buildWalletBalanceLayers, buildWalletChanges, fetchBaseAccountSnapshot, normalizeSimulatedVaultLayers, stitchAccount, stripLeadingPluginLayers, useTxBatch } from '~/composables/useTxBatch'
+import { awaitFinalPlanningLayer, buildOperationEntryMap, buildWalletBalanceLayers, buildWalletChanges, countPlanOperations, fetchBaseAccountSnapshot, normalizeSimulatedVaultLayers, stitchAccount, useTxBatch } from '~/composables/useTxBatch'
 import {
   mergeBatchPrefetchedSlotHints,
   resetBatchPrefetchState,
@@ -705,19 +705,56 @@ describe('normalizeSimulatedVaultLayers', () => {
   })
 })
 
-describe('stripLeadingPluginLayers', () => {
-  it('keeps the base layer and drops the plugin layers after it', () => {
-    expect(stripLeadingPluginLayers(['base', 'tos', 'op1', 'op2'], 1, true)).toEqual(['base', 'op1', 'op2'])
-    expect(stripLeadingPluginLayers(['base', 'a', 'b', 'op1'], 2, true)).toEqual(['base', 'op1'])
+describe('countPlanOperations / buildOperationEntryMap', () => {
+  const opPlan = (operations: number, looseItems = 0): TransactionPlan => [{
+    type: 'evcBatch',
+    items: [
+      ...Array.from({ length: operations }, (_, i) => ({ type: 'operation', name: `op-${i}`, items: [] })),
+      ...Array.from({ length: looseItems }, () => ({ targetContract: '0x1', onBehalfOfAccount: '0x2', value: 0n, data: '0x' })),
+    ],
+  }] as unknown as TransactionPlan
+
+  it('counts named operations and loose items alike, mirroring the SDK', () => {
+    expect(countPlanOperations(opPlan(2))).toBe(2)
+    expect(countPlanOperations(opPlan(1, 1))).toBe(2)
+    expect(countPlanOperations([] as TransactionPlan)).toBe(0)
   })
 
-  it('drops leading plugin layers from base-less arrays', () => {
-    expect(stripLeadingPluginLayers(['tos', 'op1', 'op2'], 1, false)).toEqual(['op1', 'op2'])
+  it('maps single-op entries without plugins one-to-one', () => {
+    const map = buildOperationEntryMap([opPlan(1), opPlan(1)], 2)!
+    expect(map.pluginOperations).toBe(0)
+    expect(map.entryLayerIndices).toEqual([1, 2])
+    expect(map.entryOfOperation(0)).toBe(0)
+    expect(map.entryOfOperation(1)).toBe(1)
   })
 
-  it('is a no-op without extra layers', () => {
-    expect(stripLeadingPluginLayers(['base', 'op1'], 0, true)).toEqual(['base', 'op1'])
-    expect(stripLeadingPluginLayers(['op1'], 0, false)).toEqual(['op1'])
+  it('assigns plugin prefix operations to no entry and shifts the rest', () => {
+    const map = buildOperationEntryMap([opPlan(1), opPlan(1)], 3)!
+    expect(map.pluginOperations).toBe(1)
+    expect(map.entryLayerIndices).toEqual([2, 3])
+    expect(map.entryOfOperation(0)).toBeNull()
+    expect(map.entryOfOperation(1)).toBe(0)
+    expect(map.entryOfOperation(2)).toBe(1)
+  })
+
+  it('handles multi-operation entries (collateral+debt refinance)', () => {
+    const map = buildOperationEntryMap([opPlan(2), opPlan(1)], 4)!
+    expect(map.pluginOperations).toBe(1)
+    expect(map.entryLayerIndices).toEqual([3, 4])
+    expect(map.entryOfOperation(0)).toBeNull()
+    expect(map.entryOfOperation(1)).toBe(0)
+    expect(map.entryOfOperation(2)).toBe(0)
+    expect(map.entryOfOperation(3)).toBe(1)
+  })
+
+  it('returns null when the simulated plan has fewer operations than the entries', () => {
+    expect(buildOperationEntryMap([opPlan(2)], 1)).toBeNull()
+  })
+
+  it('rejects out-of-range operation indices', () => {
+    const map = buildOperationEntryMap([opPlan(1)], 2)!
+    expect(map.entryOfOperation(2)).toBeNull()
+    expect(map.entryOfOperation(-1)).toBeNull()
   })
 })
 
@@ -903,14 +940,19 @@ describe('useTxBatch execution errors', () => {
     expect(activeLayerVaultsRef.value[vault.toLowerCase()]).toBe(simulatedVault)
   })
 
+  const singleOperationPlan = (name: string): TransactionPlan => [{
+    type: 'evcBatch',
+    items: [{ type: 'operation', name, items: [] }],
+  }] as unknown as TransactionPlan
+
   it('folds plugin-prepended simulation layers into the base layer (ToS registration)', async () => {
     const sdk = createMockSdk()
     // Base + the loose ToS-registration item's layer + the entry's layer: the
-    // layered simulation emits one layer per top-level batch unit, so an
-    // account whose ToS acceptance has not landed on-chain gets entries + 2
-    // layers. Without folding, getCurrentFinalLayer never finds its
-    // entries + 1 final layer and the cart dies with "Batch simulation not
-    // loaded" after the retry budget.
+    // layered simulation emits one layer per operation (any top-level batch
+    // unit), so an account whose ToS acceptance has not landed on-chain gets
+    // entries + 2 layers. Without the boundary map, getCurrentFinalLayer never
+    // finds its entries + 1 final layer and the cart dies with "Batch
+    // simulation not loaded" after the retry budget.
     sdk.executionService.simulateTransactionPlan.mockResolvedValue({
       simulatedAccounts: [
         accountWithPosition(subAccount, subAccount, 1n),
@@ -928,13 +970,111 @@ describe('useTxBatch execution errors', () => {
 
     await batch.addEntry({
       label: 'Supply USDC',
-      buildPlan: async () => [] as TransactionPlan,
+      buildPlan: async () => singleOperationPlan('supply'),
       subAccount,
     })
 
     await vi.waitFor(() => expect(batch.layers.value).toHaveLength(2))
     expect(batch.simError.value).toBeUndefined()
     expect(batch.activeLayer.value).toBe(1)
+  })
+
+  it('marks the failing first entry when a plugin operation precedes it', async () => {
+    const sdk = createMockSdk()
+    // ToS prefix shifts operationIndex: the first entry's operation is
+    // index 1, and its failure must mark row 0 (layers[1]), not slide onto
+    // the following row or vanish.
+    sdk.executionService.simulateTransactionPlan.mockResolvedValue({
+      simulatedAccounts: [
+        accountWithPosition(subAccount, subAccount, 1n),
+        accountWithPosition(subAccount, subAccount, 1n),
+        accountWithPosition(subAccount, subAccount, 5n),
+      ],
+      simulatedVaultsLayers: [],
+      simulatedWalletBalances: [],
+      simulatedVaults: [],
+      failedBatchItems: [{ index: 3, operationIndex: 1, error: '0x' }],
+      insufficientWalletAssets: [],
+    } as never)
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    const batch = useTxBatch()
+
+    await batch.addEntry({
+      label: 'Supply USDC',
+      buildPlan: async () => singleOperationPlan('supply'),
+      subAccount,
+    })
+
+    await vi.waitFor(() => expect(batch.layers.value).toHaveLength(2))
+    expect(batch.layers.value[1]?.failed).toBe(true)
+  })
+
+  it('blocks the batch when a plugin operation itself fails', async () => {
+    const sdk = createMockSdk()
+    sdk.executionService.simulateTransactionPlan.mockResolvedValue({
+      simulatedAccounts: [
+        accountWithPosition(subAccount, subAccount, 1n),
+        accountWithPosition(subAccount, subAccount, 1n),
+        accountWithPosition(subAccount, subAccount, 5n),
+      ],
+      simulatedVaultsLayers: [],
+      simulatedWalletBalances: [],
+      simulatedVaults: [],
+      failedBatchItems: [{ index: 0, operationIndex: 0, error: '0x' }],
+      insufficientWalletAssets: [],
+    } as never)
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    const batch = useTxBatch()
+
+    await batch.addEntry({
+      label: 'Supply USDC',
+      buildPlan: async () => singleOperationPlan('supply'),
+      subAccount,
+    })
+
+    await vi.waitFor(() => expect(batch.layers.value).toHaveLength(2))
+    // Belongs to no row, so it must block at batch level instead of leaving
+    // the Execute gate green.
+    expect(batch.layers.value[1]?.failed).toBe(false)
+    expect(batch.simError.value).toBeDefined()
+  })
+
+  it('selects the last layer of a multi-operation entry (refinance)', async () => {
+    const sdk = createMockSdk()
+    const multiOpPlan = [{
+      type: 'evcBatch',
+      items: [
+        { type: 'operation', name: 'refinance-collateral', items: [] },
+        { type: 'operation', name: 'refinance-debt', items: [] },
+      ],
+    }] as unknown as TransactionPlan
+    sdk.executionService.simulateTransactionPlan.mockResolvedValue({
+      simulatedAccounts: [
+        accountWithPosition(subAccount, subAccount, 1n),
+        accountWithPosition(subAccount, subAccount, 3n),
+        accountWithPosition(subAccount, subAccount, 7n),
+      ],
+      simulatedVaultsLayers: [],
+      simulatedWalletBalances: [],
+      simulatedVaults: [],
+      failedBatchItems: [{ index: 1, operationIndex: 0, error: '0x' }],
+      insufficientWalletAssets: [],
+    } as never)
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    const batch = useTxBatch()
+
+    await batch.addEntry({
+      label: 'Refinance to USDC',
+      buildPlan: async () => multiOpPlan,
+      subAccount,
+    })
+
+    // One cart row: base + the state after the entry's LAST operation.
+    await vi.waitFor(() => expect(batch.layers.value).toHaveLength(2))
+    expect(batch.layers.value[1]?.account.getSubAccount(subAccount)?.positions[0]?.shares).toBe(7n)
+    // A failure in EITHER of the entry's operations marks its single row.
+    expect(batch.layers.value[1]?.failed).toBe(true)
+    expect(batch.simError.value).toBeUndefined()
   })
 
   it('does not apply a final-only vault snapshot to earlier layers of a multi-operation batch', async () => {
@@ -1100,9 +1240,15 @@ describe('useTxBatch execution errors', () => {
 
     const batch = useTxBatch()
     const prepared = { kind: 'prepared' }
-    const borrowPlan = [{ type: 'borrow' }] as unknown as TransactionPlan
-    const migrationPreviewPlan = [{ type: 'migration-preview' }] as unknown as TransactionPlan
-    const migrationExecutionPlan = [{ type: 'migration-execution' }] as unknown as TransactionPlan
+    // Shape-faithful entry plans: one evcBatch operation each, so the
+    // operation↔entry boundary map sees the same cardinality the SDK would.
+    const singleOpPlan = (name: string): TransactionPlan => [{
+      type: 'evcBatch',
+      items: [{ type: 'operation', name, items: [] }],
+    }] as unknown as TransactionPlan
+    const borrowPlan = singleOpPlan('borrow')
+    const migrationPreviewPlan = singleOpPlan('migration-preview')
+    const migrationExecutionPlan = singleOpPlan('migration-execution')
     let executionAccount: Account<IHasVaultAddress> | undefined
     eulerTxMocks.estimateGasForPlan.mockResolvedValue(undefined)
     eulerTxMocks.prepareTransactionPlan.mockResolvedValue(prepared)


### PR DESCRIPTION
## Summary

Fixes the "Batch simulation not loaded" failure reported while testing the Safe stack (LITE-326) — but the bug is **pre-existing and not Safe-specific**: it hits any account whose ToS acceptance hasn't been registered on-chain yet whose first action is a batch. Fresh Safes reproduce it reliably because every Safe is a new account; long-standing EOA testers never see it because their registration landed long ago.

## Root cause

The lite ToS plugin prepends the on-chain `signTermsOfUse` registration as a **loose `EVCBatchItem`** ahead of the entry operations. The SDK's layered batch simulation emits one account layer per top-level batch unit, so the loose item produces its own layer: `simulatedAccounts.length = entries + 2`. The version guard in `useTxBatch` only catches *fewer* layers than expected; `getCurrentFinalLayer` requires **exactly** `entries + 1`, so the final-layer lookup returns undefined forever and `awaitFinalPlanningLayer` exhausts its 8 attempts into the generic error.

## Fix

`stripLeadingPluginLayers`: compute `extra = simAccounts − (plans + 1)` and drop the plugin layers between the pre-batch snapshot (kept as layer 0) and the first entry's layer — applied in lockstep to the account, vault (`simulatedVaultsLayers`, pre-normalization), and wallet (`simulatedWalletBalances`) layer arrays so all layer indices keep mapping to cart entries. Failure attribution is deliberately untouched: `operationIndex` semantics for loose items are SDK-internal and the ToS registration cannot realistically fail; noted in a comment.

## Test plan

- [x] Regression test: one entry + ToS-extra simulation shape (`[base, tos, afterOp]`) → 2 layers, no simError, active layer settles (previously: retry exhaustion)
- [x] Unit tests for `stripLeadingPluginLayers` (base-inclusive, base-less, no-op)
- [x] Full suite 1616 passing; typecheck + lint clean
- [ ] Manual: fresh account (unsigned ToS) + supply-to-Earn + withdraw batch simulates and executes

## Rollout

Merges to `development` directly, then gets merged forward into #797 → #798/#799 so Safe testing works on those heads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction batch simulation when plugin operations add extra layers.
  * Preserved base account, vault, and wallet states while keeping simulation results aligned with batch entries.
  * Prevented simulation errors and ensured final batch states are calculated correctly.
  * Improved error reporting by identifying the affected batch entry, while reporting plugin failures at the batch level.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->