### PR TITLE
fix: discover Aave supply-only migrations

### DIFF
--- a/composables/useExternalMigrationPositions.ts
+++ b/composables/useExternalMigrationPositions.ts
@@ -403,9 +403,9 @@ const readContractsAllowFailure = async (
   }
 }
 
-// Failed reads must reject the whole Aave fetch (mirroring the Morpho fetch)
-// rather than decode as "no balance" — otherwise an RPC blip silently makes a
-// real position disappear from discovery with zero observability.
+// Failed root and candidate reads reject the whole Aave fetch rather than
+// decode as "no balance". Individual unconfigured reserve probes may be skipped
+// so an unrelated reserve failure cannot discard already-confirmed positions.
 const requireReadResult = (result: ContractReadResult | undefined, label: string): unknown => {
   if (result?.status === 'success') return result.result
   const cause = result?.status === 'failure' ? result.error : undefined
@@ -686,9 +686,27 @@ export const useExternalMigrationPositions = (options: {
       'externalMigration/aaveReserveMulticall',
     )
     const reserveTokensByAsset = new Map<Address, AaveReserveTokens>()
+    const configuredAssets = new Set(
+      [...collateralAssets, ...debtAssets].map(asset => asset.toLowerCase()),
+    )
     reserves.forEach((asset, index) => {
-      const tokens = parseAaveReserveTokens(requireReadResult(reserveDataResults[index], `getReserveData(${asset})`))
-      if (tokens) reserveTokensByAsset.set(asset, tokens)
+      const result = reserveDataResults[index]
+      const isConfiguredAsset = configuredAssets.has(asset.toLowerCase())
+      if (result?.status !== 'success') {
+        if (isConfiguredAsset) requireReadResult(result, `getReserveData(${asset})`)
+        const cause = result?.status === 'failure' ? result.error : new Error('Aave reserve data result missing')
+        logWarn('externalMigration/aaveReserveDataSkipped', cause, { data: { asset } })
+        return
+      }
+
+      const tokens = parseAaveReserveTokens(result.result)
+      if (!tokens) {
+        const invalidResult = new Error(`Aave discovery read returned invalid reserve data: ${asset}`)
+        if (isConfiguredAsset) throw invalidResult
+        logWarn('externalMigration/aaveReserveDataSkipped', invalidResult, { data: { asset } })
+        return
+      }
+      reserveTokensByAsset.set(asset, tokens)
     })
 
     const balanceReadEntries: { kind: 'supply' | 'variableDebt' | 'stableDebt', asset: Address }[] = [

--- a/composables/useExternalMigrationPositions.ts
+++ b/composables/useExternalMigrationPositions.ts
@@ -403,9 +403,9 @@ const readContractsAllowFailure = async (
   }
 }
 
-// Failed root and candidate reads reject the whole Aave fetch rather than
-// decode as "no balance". Unconfigured reserve-data and supply-balance probes
-// may be skipped so an unrelated failure cannot discard confirmed positions.
+// Failed root and configured-position reads reject the whole Aave fetch rather
+// than decode as "no balance". Unconfigured reserve probes and per-asset
+// metadata failures are isolated so they cannot discard confirmed positions.
 const requireReadResult = (result: ContractReadResult | undefined, label: string): unknown => {
   if (result?.status === 'success') return result.result
   const cause = result?.status === 'failure' ? result.error : undefined
@@ -793,14 +793,26 @@ export const useExternalMigrationPositions = (options: {
     )
     const assetsByAddress = new Map<Address, ExternalMigrationAsset>()
     activeAssets.forEach((asset, index) => {
+      const symbolResult = metadataResults[index * 2]
+      const decimalsResult = metadataResults[index * 2 + 1]
+      if (symbolResult?.status !== 'success' || decimalsResult?.status !== 'success') {
+        const field = symbolResult?.status !== 'success' ? 'symbol' : 'decimals'
+        const result = field === 'symbol' ? symbolResult : decimalsResult
+        const cause = result?.status === 'failure' ? result.error : new Error(`Aave ${field} result missing`)
+        logWarn('externalMigration/aaveMetadataSkipped', cause, {
+          data: { asset, field },
+        })
+        return
+      }
+
       assetsByAddress.set(asset, parseAaveAsset(
         asset,
-        requireReadResult(metadataResults[index * 2], `symbol(${asset})`),
-        requireReadResult(metadataResults[index * 2 + 1], `decimals(${asset})`),
+        symbolResult.result,
+        decimalsResult.result,
       ))
     })
 
-    const usdPricesByAsset = await fetchAaveAssetUsdPrices(targetChainId, activeAssets)
+    const usdPricesByAsset = await fetchAaveAssetUsdPrices(targetChainId, [...assetsByAddress.keys()])
 
     const candidates: AaveMigrationCandidate[] = []
     for (const collateralAsset of suppliedAssets) {

--- a/composables/useExternalMigrationPositions.ts
+++ b/composables/useExternalMigrationPositions.ts
@@ -668,18 +668,16 @@ export const useExternalMigrationPositions = (options: {
           }
         })
       : []
-    if (userConfiguration === 0n || reserves.length === 0) return []
+    if (reserves.length === 0) return []
 
     const collateralAssets = reserves.filter((_, index) => hasAaveCollateralBit(userConfiguration, index))
     const debtAssets = reserves.filter((_, index) => hasAaveBorrowBit(userConfiguration, index))
-    if (!collateralAssets.length) return []
 
-    const activeAssets = [...new Set([...collateralAssets, ...debtAssets].map(asset => asset.toLowerCase()))]
-      .map(asset => getAddress(asset))
-
+    // Aave's configuration bitmap omits supplies that are not enabled as
+    // collateral, so aToken balances must be checked across every reserve.
     const reserveDataResults = await readContractsAllowFailure(
       client,
-      activeAssets.map(asset => ({
+      reserves.map(asset => ({
         address: pool,
         abi: AAVE_POOL_DISCOVERY_ABI,
         functionName: 'getReserveData',
@@ -688,11 +686,64 @@ export const useExternalMigrationPositions = (options: {
       'externalMigration/aaveReserveMulticall',
     )
     const reserveTokensByAsset = new Map<Address, AaveReserveTokens>()
-    activeAssets.forEach((asset, index) => {
+    reserves.forEach((asset, index) => {
       const tokens = parseAaveReserveTokens(requireReadResult(reserveDataResults[index], `getReserveData(${asset})`))
       if (tokens) reserveTokensByAsset.set(asset, tokens)
     })
 
+    const balanceReadEntries: { kind: 'supply' | 'variableDebt' | 'stableDebt', asset: Address }[] = [
+      ...reserves.map(asset => ({ kind: 'supply' as const, asset })),
+      ...debtAssets.flatMap(asset => [
+        { kind: 'variableDebt' as const, asset },
+        { kind: 'stableDebt' as const, asset },
+      ]),
+    ]
+    const balanceResults = await readContractsAllowFailure(
+      client,
+      balanceReadEntries.flatMap((entry) => {
+        const tokens = reserveTokensByAsset.get(entry.asset)
+        if (!tokens) return []
+        const address = entry.kind === 'supply'
+          ? tokens.aTokenAddress
+          : entry.kind === 'variableDebt'
+            ? tokens.variableDebtTokenAddress
+            : tokens.stableDebtTokenAddress
+        return [{
+          address,
+          abi: erc20Abi,
+          functionName: 'balanceOf',
+          args: [targetOwner],
+        }]
+      }),
+      'externalMigration/aaveBalancesMulticall',
+    )
+
+    let resultIndex = 0
+    const supplyAmounts = new Map<Address, bigint>()
+    const debtAmounts = new Map<Address, { variableDebt: bigint, stableDebt: bigint }>()
+    for (const entry of balanceReadEntries) {
+      if (!reserveTokensByAsset.has(entry.asset)) continue
+      const amount = parseBigIntAmount(requireReadResult(balanceResults[resultIndex], `balanceOf(${entry.kind}:${entry.asset})`))
+      resultIndex += 1
+      if (entry.kind === 'supply') {
+        supplyAmounts.set(entry.asset, amount)
+        continue
+      }
+      const debt = debtAmounts.get(entry.asset) ?? { variableDebt: 0n, stableDebt: 0n }
+      if (entry.kind === 'variableDebt') debt.variableDebt = amount
+      else debt.stableDebt = amount
+      debtAmounts.set(entry.asset, debt)
+    }
+
+    const suppliedAssets = reserves.filter(asset => (supplyAmounts.get(asset) ?? 0n) > 0n)
+    const borrowedAssets = debtAssets.filter((asset) => {
+      const debt = debtAmounts.get(asset)
+      return !!debt && debt.variableDebt + debt.stableDebt > 0n
+    })
+    if (!suppliedAssets.length) return []
+
+    const activeAssets = [...new Set([...suppliedAssets, ...borrowedAssets].map(asset => asset.toLowerCase()))]
+      .map(asset => getAddress(asset))
     const metadataResults = await readContractsAllowFailure(
       client,
       activeAssets.flatMap(asset => [
@@ -718,59 +769,16 @@ export const useExternalMigrationPositions = (options: {
       ))
     })
 
-    const balanceReadEntries: { kind: 'collateral' | 'variableDebt' | 'stableDebt', asset: Address }[] = [
-      ...collateralAssets.map(asset => ({ kind: 'collateral' as const, asset })),
-      ...debtAssets.flatMap(asset => [
-        { kind: 'variableDebt' as const, asset },
-        { kind: 'stableDebt' as const, asset },
-      ]),
-    ]
-    const balanceResults = await readContractsAllowFailure(
-      client,
-      balanceReadEntries.flatMap((entry) => {
-        const tokens = reserveTokensByAsset.get(entry.asset)
-        if (!tokens) return []
-        const address = entry.kind === 'collateral'
-          ? tokens.aTokenAddress
-          : entry.kind === 'variableDebt'
-            ? tokens.variableDebtTokenAddress
-            : tokens.stableDebtTokenAddress
-        return [{
-          address,
-          abi: erc20Abi,
-          functionName: 'balanceOf',
-          args: [targetOwner],
-        }]
-      }),
-      'externalMigration/aaveBalancesMulticall',
-    )
-
-    let resultIndex = 0
-    const collateralAmounts = new Map<Address, bigint>()
-    const debtAmounts = new Map<Address, { variableDebt: bigint, stableDebt: bigint }>()
-    for (const entry of balanceReadEntries) {
-      if (!reserveTokensByAsset.has(entry.asset)) continue
-      const amount = parseBigIntAmount(requireReadResult(balanceResults[resultIndex], `balanceOf(${entry.kind}:${entry.asset})`))
-      resultIndex += 1
-      if (entry.kind === 'collateral') {
-        collateralAmounts.set(entry.asset, amount)
-        continue
-      }
-      const debt = debtAmounts.get(entry.asset) ?? { variableDebt: 0n, stableDebt: 0n }
-      if (entry.kind === 'variableDebt') debt.variableDebt = amount
-      else debt.stableDebt = amount
-      debtAmounts.set(entry.asset, debt)
-    }
-
     const usdPricesByAsset = await fetchAaveAssetUsdPrices(targetChainId, activeAssets)
 
     const candidates: AaveMigrationCandidate[] = []
-    for (const collateralAsset of collateralAssets) {
-      const collateralAmount = collateralAmounts.get(collateralAsset) ?? 0n
+    for (const collateralAsset of suppliedAssets) {
+      const collateralAmount = supplyAmounts.get(collateralAsset) ?? 0n
       const collateral = assetsByAddress.get(collateralAsset)
       if (collateralAmount <= 0n || !collateral) continue
 
-      if (!debtAssets.length) {
+      const isCollateralEnabled = collateralAssets.includes(collateralAsset)
+      if (!isCollateralEnabled || !borrowedAssets.length) {
         const ref: AavePositionRef = {
           collateralAsset,
           pool,
@@ -798,7 +806,7 @@ export const useExternalMigrationPositions = (options: {
         continue
       }
 
-      for (const debtAsset of debtAssets) {
+      for (const debtAsset of borrowedAssets) {
         const debt = debtAmounts.get(debtAsset) ?? { variableDebt: 0n, stableDebt: 0n }
         const debtAmount = debt.variableDebt + debt.stableDebt
         const debtMeta = assetsByAddress.get(debtAsset)

--- a/composables/useExternalMigrationPositions.ts
+++ b/composables/useExternalMigrationPositions.ts
@@ -404,8 +404,8 @@ const readContractsAllowFailure = async (
 }
 
 // Failed root and candidate reads reject the whole Aave fetch rather than
-// decode as "no balance". Individual unconfigured reserve probes may be skipped
-// so an unrelated reserve failure cannot discard already-confirmed positions.
+// decode as "no balance". Unconfigured reserve-data and supply-balance probes
+// may be skipped so an unrelated failure cannot discard confirmed positions.
 const requireReadResult = (result: ContractReadResult | undefined, label: string): unknown => {
   if (result?.status === 'success') return result.result
   const cause = result?.status === 'failure' ? result.error : undefined
@@ -741,8 +741,21 @@ export const useExternalMigrationPositions = (options: {
     const debtAmounts = new Map<Address, { variableDebt: bigint, stableDebt: bigint }>()
     for (const entry of balanceReadEntries) {
       if (!reserveTokensByAsset.has(entry.asset)) continue
-      const amount = parseBigIntAmount(requireReadResult(balanceResults[resultIndex], `balanceOf(${entry.kind}:${entry.asset})`))
+      const result = balanceResults[resultIndex]
       resultIndex += 1
+      if (result?.status !== 'success') {
+        const isConfiguredAsset = configuredAssets.has(entry.asset.toLowerCase())
+        if (entry.kind !== 'supply' || isConfiguredAsset) {
+          requireReadResult(result, `balanceOf(${entry.kind}:${entry.asset})`)
+        }
+        const cause = result?.status === 'failure' ? result.error : new Error('Aave balance result missing')
+        logWarn('externalMigration/aaveBalanceSkipped', cause, {
+          data: { asset: entry.asset, kind: entry.kind },
+        })
+        continue
+      }
+
+      const amount = parseBigIntAmount(result.result)
       if (entry.kind === 'supply') {
         supplyAmounts.set(entry.asset, amount)
         continue

--- a/tests/composables/useExternalMigrationPositions.test.ts
+++ b/tests/composables/useExternalMigrationPositions.test.ts
@@ -19,6 +19,7 @@ const USDC = getAddress('0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913')
 const WETH = getAddress('0x4200000000000000000000000000000000000006')
 const AAVE_POOL = getAddress('0xA238Dd80C259a72e81d7e4664a9801593F98d1c5')
 const AAVE_WETH = getAddress('0xD4a0e0b9149BCee3C920d2E00b5dE09138fd8bb7')
+const AAVE_USDC = getAddress('0x4e65fE4DbA92790696d040ac24Aa414708F5c0AB')
 const AAVE_STABLE_DEBT_USDC = getAddress('0x0000000000000000000000000000000000000001')
 const AAVE_VARIABLE_DEBT_USDC = getAddress('0x59dca05b6c26dbd64b5381374aAaC5CD05644C28')
 const MORPHO_ORACLE = getAddress('0xFEa2D58cEfCb9fcb597723c6bAE66fFE4193aFE4')
@@ -408,6 +409,11 @@ describe('useExternalMigrationPositions', () => {
       stableDebtTokenAddress: getAddress('0x0000000000000000000000000000000000000011'),
       variableDebtTokenAddress: getAddress('0x0000000000000000000000000000000000000012'),
     })
+    reserveTokensByAsset.set(USDC, {
+      aTokenAddress: AAVE_USDC,
+      stableDebtTokenAddress: AAVE_STABLE_DEBT_USDC,
+      variableDebtTokenAddress: AAVE_VARIABLE_DEBT_USDC,
+    })
     balancesByToken.set(AAVE_WETH, 1_000_000_000_000_000n)
     fetchMock.mockImplementation(async (_url: string, init?: RequestInit) => {
       const body = JSON.parse(String(init?.body ?? '{}')) as { query?: string }
@@ -449,6 +455,70 @@ describe('useExternalMigrationPositions', () => {
     })
   })
 
+  it('discovers Aave V3 supply-only positions that are not enabled as collateral', async () => {
+    aaveUserConfiguration = 0n
+    aaveReserves = [WETH, USDC]
+    reserveTokensByAsset.set(WETH, {
+      aTokenAddress: AAVE_WETH,
+      stableDebtTokenAddress: getAddress('0x0000000000000000000000000000000000000011'),
+      variableDebtTokenAddress: getAddress('0x0000000000000000000000000000000000000012'),
+    })
+    reserveTokensByAsset.set(USDC, {
+      aTokenAddress: AAVE_USDC,
+      stableDebtTokenAddress: AAVE_STABLE_DEBT_USDC,
+      variableDebtTokenAddress: AAVE_VARIABLE_DEBT_USDC,
+    })
+    balancesByToken.set(AAVE_USDC, 4_000_001n)
+
+    const result = useExternalMigrationPositions()
+
+    await flushPromises()
+    await nextTick()
+
+    expect(result.positions.value).toHaveLength(1)
+    expect(result.positions.value[0]).toMatchObject({
+      connectorId: 'aave',
+      protocol: 'Aave V3',
+      id: `aave:${AAVE_POOL}:${USDC}:supply`,
+      owner: OWNER,
+      debt: null,
+      collateral: expect.objectContaining({
+        address: USDC,
+        amount: 4_000_001n,
+        amountUsd: 4.000001,
+        symbol: 'USDC',
+      }),
+    })
+  })
+
+  it('keeps non-collateral supplies separate from debt-backed Aave positions', async () => {
+    aaveUserConfiguration = 6n
+    aaveReserves = [WETH, USDC]
+    reserveTokensByAsset.set(WETH, {
+      aTokenAddress: AAVE_WETH,
+      stableDebtTokenAddress: getAddress('0x0000000000000000000000000000000000000011'),
+      variableDebtTokenAddress: getAddress('0x0000000000000000000000000000000000000012'),
+    })
+    reserveTokensByAsset.set(USDC, {
+      aTokenAddress: AAVE_USDC,
+      stableDebtTokenAddress: AAVE_STABLE_DEBT_USDC,
+      variableDebtTokenAddress: AAVE_VARIABLE_DEBT_USDC,
+    })
+    balancesByToken.set(AAVE_WETH, 1_000_000_000_000_000n)
+    balancesByToken.set(AAVE_USDC, 4_000_001n)
+    balancesByToken.set(AAVE_VARIABLE_DEBT_USDC, 1_000_000n)
+
+    const result = useExternalMigrationPositions()
+
+    await flushPromises()
+    await nextTick()
+
+    expect(result.positions.value.map(position => ({ id: position.id, debt: position.debt?.amount ?? null }))).toEqual([
+      { id: `aave:${AAVE_POOL}:${USDC}:supply`, debt: null },
+      { id: `aave:${AAVE_POOL}:${WETH}:${USDC}:variable`, debt: 1_000_000n },
+    ])
+  })
+
   it('sorts discovered positions by net asset or deposit value descending', async () => {
     aaveUserConfiguration = 2n
     aaveReserves = [WETH, USDC]
@@ -456,6 +526,11 @@ describe('useExternalMigrationPositions', () => {
       aTokenAddress: AAVE_WETH,
       stableDebtTokenAddress: getAddress('0x0000000000000000000000000000000000000011'),
       variableDebtTokenAddress: getAddress('0x0000000000000000000000000000000000000012'),
+    })
+    reserveTokensByAsset.set(USDC, {
+      aTokenAddress: AAVE_USDC,
+      stableDebtTokenAddress: AAVE_STABLE_DEBT_USDC,
+      variableDebtTokenAddress: AAVE_VARIABLE_DEBT_USDC,
     })
     balancesByToken.set(AAVE_WETH, 1_000_000_000_000_000n)
     fetchMock.mockImplementation(async (_url: string, init?: RequestInit) => {

--- a/tests/composables/useExternalMigrationPositions.test.ts
+++ b/tests/composables/useExternalMigrationPositions.test.ts
@@ -439,6 +439,58 @@ describe('useExternalMigrationPositions', () => {
     expect(result.error.value).toBe('')
   })
 
+  it('keeps valid Aave and Morpho rows when an unrelated Aave supply balance read fails', async () => {
+    aaveUserConfiguration = 2n
+    aaveReserves = [WETH, USDC]
+    reserveTokensByAsset.set(WETH, {
+      aTokenAddress: AAVE_WETH,
+      stableDebtTokenAddress: getAddress('0x0000000000000000000000000000000000000011'),
+      variableDebtTokenAddress: getAddress('0x0000000000000000000000000000000000000012'),
+    })
+    reserveTokensByAsset.set(USDC, {
+      aTokenAddress: AAVE_USDC,
+      stableDebtTokenAddress: AAVE_STABLE_DEBT_USDC,
+      variableDebtTokenAddress: AAVE_VARIABLE_DEBT_USDC,
+    })
+    balancesByToken.set(AAVE_WETH, 1_000_000_000_000_000n)
+    const baseReadContract = readContract.getMockImplementation() as (
+      call: { address: Address, functionName: string, args?: readonly unknown[] },
+    ) => Promise<unknown>
+    readContract.mockImplementation(async (call: { address: Address, functionName: string, args?: readonly unknown[] }) => {
+      if (call.functionName === 'balanceOf' && getAddress(call.address) === AAVE_USDC) {
+        throw new Error('unrelated USDC balance failure')
+      }
+      return baseReadContract(call)
+    })
+    fetchMock.mockResolvedValue(new Response(JSON.stringify({
+      data: {
+        userByAddress: {
+          address: OWNER,
+          marketPositions: [{
+            market,
+            state: {
+              borrowAssets: '25',
+              borrowAssetsUsd: '25',
+              collateral: '100',
+              collateralUsd: '250000',
+            },
+          }],
+        },
+      },
+    })))
+
+    const result = useExternalMigrationPositions()
+
+    await flushPromises()
+    await nextTick()
+
+    expect(result.positions.value.map(position => position.id)).toEqual([
+      MARKET_ID,
+      `aave:${AAVE_POOL}:${WETH}:supply`,
+    ])
+    expect(result.error.value).toBe('')
+  })
+
   it('fails Aave discovery when reserve data fails for a configured collateral', async () => {
     aaveUserConfiguration = 2n
     aaveReserves = [WETH, USDC]

--- a/tests/composables/useExternalMigrationPositions.test.ts
+++ b/tests/composables/useExternalMigrationPositions.test.ts
@@ -401,6 +401,62 @@ describe('useExternalMigrationPositions', () => {
     expect(result.error.value).toContain('Aave discovery read failed')
   })
 
+  it('keeps valid Aave and Morpho rows when an unrelated Aave reserve read fails', async () => {
+    aaveUserConfiguration = 2n
+    aaveReserves = [WETH, USDC]
+    reserveTokensByAsset.set(WETH, {
+      aTokenAddress: AAVE_WETH,
+      stableDebtTokenAddress: getAddress('0x0000000000000000000000000000000000000011'),
+      variableDebtTokenAddress: getAddress('0x0000000000000000000000000000000000000012'),
+    })
+    balancesByToken.set(AAVE_WETH, 1_000_000_000_000_000n)
+    fetchMock.mockResolvedValue(new Response(JSON.stringify({
+      data: {
+        userByAddress: {
+          address: OWNER,
+          marketPositions: [{
+            market,
+            state: {
+              borrowAssets: '25',
+              borrowAssetsUsd: '25',
+              collateral: '100',
+              collateralUsd: '250000',
+            },
+          }],
+        },
+      },
+    })))
+
+    const result = useExternalMigrationPositions()
+
+    await flushPromises()
+    await nextTick()
+
+    expect(result.positions.value.map(position => position.id)).toEqual([
+      MARKET_ID,
+      `aave:${AAVE_POOL}:${WETH}:supply`,
+    ])
+    expect(result.error.value).toBe('')
+  })
+
+  it('fails Aave discovery when reserve data fails for a configured collateral', async () => {
+    aaveUserConfiguration = 2n
+    aaveReserves = [WETH, USDC]
+    reserveTokensByAsset.set(USDC, {
+      aTokenAddress: AAVE_USDC,
+      stableDebtTokenAddress: AAVE_STABLE_DEBT_USDC,
+      variableDebtTokenAddress: AAVE_VARIABLE_DEBT_USDC,
+    })
+
+    const result = useExternalMigrationPositions()
+
+    await flushPromises()
+    await nextTick()
+
+    expect(result.positions.value).toEqual([])
+    expect(result.error.value).toContain(`Aave discovery read failed: getReserveData(${WETH})`)
+  })
+
   it('discovers Aave V3 supply-only positions when the wallet has collateral and no debt', async () => {
     aaveUserConfiguration = 2n
     aaveReserves = [WETH, USDC]

--- a/tests/composables/useExternalMigrationPositions.test.ts
+++ b/tests/composables/useExternalMigrationPositions.test.ts
@@ -491,6 +491,59 @@ describe('useExternalMigrationPositions', () => {
     expect(result.error.value).toBe('')
   })
 
+  it('keeps valid Aave and Morpho rows when another supplied asset metadata read fails', async () => {
+    aaveUserConfiguration = 2n
+    aaveReserves = [WETH, USDC]
+    reserveTokensByAsset.set(WETH, {
+      aTokenAddress: AAVE_WETH,
+      stableDebtTokenAddress: getAddress('0x0000000000000000000000000000000000000011'),
+      variableDebtTokenAddress: getAddress('0x0000000000000000000000000000000000000012'),
+    })
+    reserveTokensByAsset.set(USDC, {
+      aTokenAddress: AAVE_USDC,
+      stableDebtTokenAddress: AAVE_STABLE_DEBT_USDC,
+      variableDebtTokenAddress: AAVE_VARIABLE_DEBT_USDC,
+    })
+    balancesByToken.set(AAVE_WETH, 1_000_000_000_000_000n)
+    balancesByToken.set(AAVE_USDC, 4_000_001n)
+    const baseReadContract = readContract.getMockImplementation() as (
+      call: { address: Address, functionName: string, args?: readonly unknown[] },
+    ) => Promise<unknown>
+    readContract.mockImplementation(async (call: { address: Address, functionName: string, args?: readonly unknown[] }) => {
+      if (call.functionName === 'symbol' && getAddress(call.address) === USDC) {
+        throw new Error('USDC symbol failure')
+      }
+      return baseReadContract(call)
+    })
+    fetchMock.mockResolvedValue(new Response(JSON.stringify({
+      data: {
+        userByAddress: {
+          address: OWNER,
+          marketPositions: [{
+            market,
+            state: {
+              borrowAssets: '25',
+              borrowAssetsUsd: '25',
+              collateral: '100',
+              collateralUsd: '250000',
+            },
+          }],
+        },
+      },
+    })))
+
+    const result = useExternalMigrationPositions()
+
+    await flushPromises()
+    await nextTick()
+
+    expect(result.positions.value.map(position => position.id)).toEqual([
+      MARKET_ID,
+      `aave:${AAVE_POOL}:${WETH}:supply`,
+    ])
+    expect(result.error.value).toBe('')
+  })
+
   it('fails Aave discovery when reserve data fails for a configured collateral', async () => {
     aaveUserConfiguration = 2n
     aaveReserves = [WETH, USDC]


### PR DESCRIPTION
## Summary

- Discover Aave supplies even when they are not enabled as collateral.
- Keep non-collateral supplies separate from debt-backed migration positions.

## Changes

- Scan aToken balances across every configured Aave reserve before identifying supplied assets.
- Read debt balances only for reserves marked as borrowed, then limit metadata and pricing calls to active assets.
- Add regression coverage for configuration-zero supplies and mixed supply/debt accounts.

## Test plan

- [x] `npm run test:run -- tests/composables/useExternalMigrationPositions.test.ts` (11 tests)
- [x] `npm run test:run` (1,618 tests)
- [x] Targeted ESLint on both changed files
- [x] `npm run build`
- [x] Local Base smoke: `0x7FD92603BEDB13fe74e4A60eb2738d86680A3d25` shows the 4.000001 USDC Aave supply and 1 USDC Morpho position
- [ ] `npm run typecheck` currently fails on unrelated SDK/type drift already present on `development` (activity event types, `eulerInterfacesBranch`, and `unitOfAccountValuation`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Aave position discovery to include supplied assets even when collateral is disabled.
  - Excluded zero-balance supplies and debts from detected positions.
  - Ensured debt candidates use only assets with positive borrowed balances.
  - Preserved valid positions when unrelated reserve, metadata, or balance data is unavailable.
  - Continued to surface errors for configured reserve data failures.
  - Kept non-collateral supplies eligible for supply-only migration candidates.

- **Tests**
  - Added coverage for reserve-read failures, supply-only positions, and separating non-collateral supplies from debt-backed positions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->