### PR TITLE
feat: support Morpho migrations on more chains

### DIFF
--- a/composables/useExternalMigrationPositions.ts
+++ b/composables/useExternalMigrationPositions.ts
@@ -838,9 +838,9 @@ export const useExternalMigrationPositions = (options: {
   }
 
   const fetchMorphoMigrationPositions = async (targetChainId: number, targetOwner: Address): Promise<(MorphoMigrationCandidate | MetamorphoMigrationCandidate)[]> => {
-    // Morpho's indexer only covers a fixed set of chains. Querying an unindexed
-    // chain (e.g. BSC) returns an "unsupported chainId" error that would surface
-    // as a scan failure, so treat those chains as "nothing to migrate" instead.
+    // Enable discovery only where Morpho indexing, the SDK connector, and Euler
+    // migration infrastructure are all available. Treat every other chain as
+    // "nothing to migrate" instead of surfacing an upstream support error.
     if (!MORPHO_MIGRATION_SUPPORTED_CHAIN_IDS.has(targetChainId)) return []
     try {
       const res = await fetch('/api/internal/proxy/morpho', {

--- a/entities/migration/constants.ts
+++ b/entities/migration/constants.ts
@@ -3,15 +3,18 @@ export const MORPHO_CONNECTOR_ID = 'morpho'
 export const METAMORPHO_CONNECTOR_ID = 'metamorpho'
 
 /**
- * Chains whose positions Morpho's hosted GraphQL indexer (api.morpho.org) can
- * return. Discovery must skip every other chain: querying an unindexed chain
- * (e.g. BNB Smart Chain, 56) makes the API reject the request with an
- * "unsupported chainId" error, which would otherwise surface as a "could not
- * scan external positions" failure even when the user simply has nothing to
- * migrate. Aave discovery self-gates on connector pool presence, so it needs no
- * equivalent list.
+ * Chains supported end-to-end by Lite's Morpho migration flow: Morpho indexes
+ * positions, the SDK configures the Morpho connector, and Euler migration
+ * infrastructure is deployed. Discovery skips every other chain so an
+ * unsupported indexer request cannot surface as a position-scan failure. Aave
+ * discovery self-gates on connector pool presence, so it needs no equivalent
+ * list.
  */
 export const MORPHO_MIGRATION_SUPPORTED_CHAIN_IDS: ReadonlySet<number> = new Set([
   1, // Ethereum
+  130, // Unichain
+  143, // Monad
+  999, // HyperEVM
   8453, // Base
+  42161, // Arbitrum
 ])

--- a/tests/composables/useExternalMigrationPositions.test.ts
+++ b/tests/composables/useExternalMigrationPositions.test.ts
@@ -243,10 +243,10 @@ describe('useExternalMigrationPositions', () => {
     expect(result.isLoading.value).toBe(false)
   })
 
-  it('skips Morpho discovery on chains its indexer does not support', async () => {
-    // BNB Smart Chain (56) is not indexed by api.morpho.org, and no Aave pool is
-    // registered there either — so the scan must resolve to an empty list rather
-    // than surfacing the API's "unsupported chainId" error.
+  it('skips Morpho discovery outside the supported migration chains', async () => {
+    // BNB Smart Chain (56) is outside Lite's end-to-end Morpho migration set,
+    // and no Aave pool is registered there either, so the scan resolves to an
+    // empty list without an unnecessary proxy request.
     vi.stubGlobal('useEulerAddresses', () => ({ chainId: ref(56) }))
 
     const result = useExternalMigrationPositions()
@@ -258,6 +258,33 @@ describe('useExternalMigrationPositions', () => {
       String((init as RequestInit | undefined)?.body ?? '').includes('LiteMorphoMigrationPositions'),
     )
     expect(morphoQueried).toBe(false)
+    expect(result.positions.value).toEqual([])
+    expect(result.error.value).toBe('')
+  })
+
+  it.each([
+    { chainId: 130, name: 'Unichain' },
+    { chainId: 143, name: 'Monad' },
+    { chainId: 999, name: 'HyperEVM' },
+    { chainId: 42161, name: 'Arbitrum' },
+  ])('discovers Morpho positions on $name ($chainId)', async ({ chainId }) => {
+    vi.stubGlobal('useEulerAddresses', () => ({ chainId: ref(chainId) }))
+
+    const result = useExternalMigrationPositions()
+
+    await flushPromises()
+    await nextTick()
+
+    const morphoRequest = fetchMock.mock.calls.find(([, init]) =>
+      String((init as RequestInit | undefined)?.body ?? '').includes('LiteMorphoMigrationPositions'),
+    )
+    expect(morphoRequest).toBeDefined()
+    expect(JSON.parse(String((morphoRequest?.[1] as RequestInit | undefined)?.body))).toMatchObject({
+      variables: {
+        chainId,
+        address: OWNER,
+      },
+    })
     expect(result.positions.value).toEqual([])
     expect(result.error.value).toBe('')
   })


### PR DESCRIPTION
## Summary

- Enable Morpho market and vault migration discovery on Unichain, Monad, HyperEVM, and Arbitrum.
- Keep discovery limited to networks where Morpho indexing, the SDK connector, and Euler migration infrastructure are all available.

## Changes

- Add chain IDs `130`, `143`, `999`, and `42161` to the Morpho migration support set.
- Describe the allowlist as the end-to-end migration boundary used by position discovery.
- Add table-driven coverage that verifies the exact owner and chain passed to the Morpho proxy for every added network.

## Test plan

- [x] `npm run test:run -- tests/composables/useExternalMigrationPositions.test.ts` (13 tests)
- [x] `npm run test:run` (1,616 passed; one expected bundle-dependent skip)
- [x] `npm run lint` (zero errors; six existing warnings)
- [x] `npm run typecheck`
- [x] Verify Lite’s exact Morpho position query is accepted by the live Morpho API for all four added chain IDs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded Morpho migration discovery support to Unichain, Monad, and HyperEVM.
  * Morpho migration discovery now covers Ethereum, Base, Arbitrum, Unichain, Monad, and HyperEVM.

* **Tests**
  * Added coverage confirming discovery requests use the correct chain and account details across supported networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->