### PR TITLE
fix: surface post-execution transactions in the batch review summary

### DIFF
--- a/components/BatchReviewModal.vue
+++ b/components/BatchReviewModal.vue
@@ -157,6 +157,15 @@ const authorizationSummaryGroups = computed(() =>
   }).filter(({ rows }) => rows.length),
 )
 
+// Post-execution transactions (e.g. a migration's approval restoration) are
+// real wallet transactions sent after the batch settles. Surfacing them only
+// inside the expanded row undercounts the ceremony in the collapsed summary.
+const postExecutionSummaryRows = computed(() =>
+  entries.value.flatMap(entry =>
+    (postStepsByEntryId.value[entry.id] ?? []).map(step => ({ entry, step })),
+  ),
+)
+
 // Unverified vaults the batch touches — surfaced as a warning. A vault is the
 // target of an op's core action; we read targets off each op's contextual plan
 // and check the registry's verification flag (same source the forms use).
@@ -440,6 +449,29 @@ const handleClose = () => {
           </div>
         </div>
       </template>
+
+      <!-- Transactions sent after the batch settles (e.g. approval restoration). -->
+      <div v-if="postExecutionSummaryRows.length">
+        <p class="text-p3 text-content-tertiary uppercase tracking-[0.04em] mb-8">
+          After execution
+        </p>
+        <div class="bg-surface-secondary rounded-12 px-12 divide-y divide-line-default">
+          <div
+            v-for="({ entry, step }, i) in postExecutionSummaryRows"
+            :key="`${entry.id}-post-${i}`"
+            class="flex items-center justify-between gap-12 py-10"
+          >
+            <span class="flex items-center gap-8 text-p3 text-content-secondary min-w-0">
+              <SvgIcon
+                name="check-circle"
+                class="!w-16 !h-16 text-accent-500 shrink-0"
+              />
+              <span class="truncate">{{ step.label }}</span>
+            </span>
+            <span class="text-p3 text-content-tertiary shrink-0">{{ step.isSeparateTx ? '1 transaction' : 'bundled' }}</span>
+          </div>
+        </div>
+      </div>
 
       <!-- Approvals -->
       <div v-if="approvals.length">

--- a/components/BatchReviewModal.vue
+++ b/components/BatchReviewModal.vue
@@ -162,18 +162,21 @@ const authorizationSummaryGroups = computed(() =>
 // inside the expanded row undercounts the ceremony in the collapsed summary.
 //
 // Rows render in EXECUTION order: restorations unwind in reverse entry order
-// (each entry's own steps are already reversed by the encoder). Rows that
-// resolve to the identical restoration are consolidated — a grant an earlier
-// entry already made resolves to no prerequisite at execution, so its
-// duplicate displayed revoke would never run.
+// (each entry's own steps are already reversed by the encoder). Rows carrying
+// the identical encoded restoration TRANSACTION are consolidated — a grant an
+// earlier entry already made resolves to no prerequisite at execution, so its
+// duplicate displayed revoke would never run. Labels are NOT identity: two
+// different aTokens share "Restore previous aToken approval", so rows without
+// a txKey are never collapsed.
 const postExecutionSummaryRows = computed(() => {
   const rows = [...entries.value].reverse().flatMap(entry =>
     (postStepsByEntryId.value[entry.id] ?? []).map(step => ({ entry, step })),
   )
   const seen = new Set<string>()
   return rows.filter(({ step }) => {
-    if (seen.has(step.label)) return false
-    seen.add(step.label)
+    if (!step.txKey) return true
+    if (seen.has(step.txKey)) return false
+    seen.add(step.txKey)
     return true
   })
 })

--- a/components/BatchReviewModal.vue
+++ b/components/BatchReviewModal.vue
@@ -160,11 +160,23 @@ const authorizationSummaryGroups = computed(() =>
 // Post-execution transactions (e.g. a migration's approval restoration) are
 // real wallet transactions sent after the batch settles. Surfacing them only
 // inside the expanded row undercounts the ceremony in the collapsed summary.
-const postExecutionSummaryRows = computed(() =>
-  entries.value.flatMap(entry =>
+//
+// Rows render in EXECUTION order: restorations unwind in reverse entry order
+// (each entry's own steps are already reversed by the encoder). Rows that
+// resolve to the identical restoration are consolidated — a grant an earlier
+// entry already made resolves to no prerequisite at execution, so its
+// duplicate displayed revoke would never run.
+const postExecutionSummaryRows = computed(() => {
+  const rows = [...entries.value].reverse().flatMap(entry =>
     (postStepsByEntryId.value[entry.id] ?? []).map(step => ({ entry, step })),
-  ),
-)
+  )
+  const seen = new Set<string>()
+  return rows.filter(({ step }) => {
+    if (seen.has(step.label)) return false
+    seen.add(step.label)
+    return true
+  })
+})
 
 // Unverified vaults the batch touches — surfaced as a warning. A vault is the
 // target of an op's core action; we read targets off each op's contextual plan
@@ -450,29 +462,6 @@ const handleClose = () => {
         </div>
       </template>
 
-      <!-- Transactions sent after the batch settles (e.g. approval restoration). -->
-      <div v-if="postExecutionSummaryRows.length">
-        <p class="text-p3 text-content-tertiary uppercase tracking-[0.04em] mb-8">
-          After execution
-        </p>
-        <div class="bg-surface-secondary rounded-12 px-12 divide-y divide-line-default">
-          <div
-            v-for="({ entry, step }, i) in postExecutionSummaryRows"
-            :key="`${entry.id}-post-${i}`"
-            class="flex items-center justify-between gap-12 py-10"
-          >
-            <span class="flex items-center gap-8 text-p3 text-content-secondary min-w-0">
-              <SvgIcon
-                name="check-circle"
-                class="!w-16 !h-16 text-accent-500 shrink-0"
-              />
-              <span class="truncate">{{ step.label }}</span>
-            </span>
-            <span class="text-p3 text-content-tertiary shrink-0">{{ step.isSeparateTx ? '1 transaction' : 'bundled' }}</span>
-          </div>
-        </div>
-      </div>
-
       <!-- Approvals -->
       <div v-if="approvals.length">
         <p class="text-p3 text-content-tertiary uppercase tracking-[0.04em] mb-8">
@@ -631,6 +620,29 @@ const handleClose = () => {
         title="rEUL burn mechanics"
         :description="warning.description"
       />
+
+      <!-- Transactions sent after the batch settles (e.g. approval restoration). -->
+      <div v-if="postExecutionSummaryRows.length">
+        <p class="text-p3 text-content-tertiary uppercase tracking-[0.04em] mb-8">
+          After execution
+        </p>
+        <div class="bg-surface-secondary rounded-12 px-12 divide-y divide-line-default">
+          <div
+            v-for="({ entry, step }, i) in postExecutionSummaryRows"
+            :key="`${entry.id}-post-${i}`"
+            class="flex items-center justify-between gap-12 py-10"
+          >
+            <span class="flex items-center gap-8 text-p3 text-content-secondary min-w-0">
+              <SvgIcon
+                name="check-circle"
+                class="!w-16 !h-16 text-accent-500 shrink-0"
+              />
+              <span class="truncate">{{ step.label }}</span>
+            </span>
+            <span class="text-p3 text-content-tertiary shrink-0">{{ step.isSeparateTx ? '1 transaction' : 'bundled' }}</span>
+          </div>
+        </div>
+      </div>
 
       <!-- Wallet changes -->
       <BatchWalletChanges

--- a/tests/utils/migrationAuthorizationTxs.test.ts
+++ b/tests/utils/migrationAuthorizationTxs.test.ts
@@ -139,14 +139,49 @@ describe('encodeMigrationAuthorizationTxs', () => {
   })
 })
 
+const txKeyOf = (to: Address, data: string): string => `${to.toLowerCase()}:0:${data}`
+
 describe('buildMigrationAuthorizationTxSteps', () => {
   it('labels grant and restoration rows per connector', () => {
     expect(buildMigrationAuthorizationTxSteps(aaveApprovalRequest(), 'grant')).toEqual([
-      { index: 1, label: 'Approve aToken transfer', isSeparateTx: true },
+      {
+        index: 1,
+        label: 'Approve aToken transfer',
+        isSeparateTx: true,
+        txKey: txKeyOf(aToken, encodeFunctionData({ abi: erc20Abi, functionName: 'approve', args: [swapVerifier, 1000n] })),
+      },
     ])
     expect(buildMigrationAuthorizationTxSteps(morphoAuthorizationRequest(), 'revoke', 4)).toEqual([
-      { index: 4, label: 'Restore previous Morpho authorization', isSeparateTx: true },
+      {
+        index: 4,
+        label: 'Restore previous Morpho authorization',
+        isSeparateTx: true,
+        txKey: txKeyOf(morphoBlue, encodeFunctionData({ abi: setAuthorizationAbi, functionName: 'setAuthorization', args: [swapVerifier, false] })),
+      },
     ])
+  })
+
+  it('keys row identity on the encoded transaction, not the label', () => {
+    const otherAToken = '0x0000000000000000000000000000000000000009' as Address
+    const otherRequest = {
+      ...aaveApprovalRequest(),
+      token: otherAToken,
+      call: { to: otherAToken, abi: erc20Abi, functionName: 'approve', args: [swapVerifier, 1000n] },
+      revocation: { to: otherAToken, abi: erc20Abi, functionName: 'approve', args: [swapVerifier, 250n] },
+    } as unknown as MigrationAuthorizationRequest
+
+    const [first] = buildMigrationAuthorizationTxSteps(aaveApprovalRequest(), 'revoke')
+    const [second] = buildMigrationAuthorizationTxSteps(otherRequest, 'revoke')
+
+    // Two different aTokens share a generic label but are distinct
+    // restoration transactions — consolidating them by label would hide a
+    // real transaction from the batch summary.
+    expect(first!.label).toBe(second!.label)
+    expect(first!.txKey).not.toBe(second!.txKey)
+
+    // Identical requests resolve to the identical transaction identity.
+    const [repeat] = buildMigrationAuthorizationTxSteps(aaveApprovalRequest(), 'revoke')
+    expect(repeat!.txKey).toBe(first!.txKey)
   })
 
   it('orders restoration rows to match the transactions actually sent', () => {

--- a/utils/migrationAuthorizationTxs.ts
+++ b/utils/migrationAuthorizationTxs.ts
@@ -45,6 +45,10 @@ const encodeCall = (call: MigrationAuthorizationCall): PlainTxRequest => ({
   ...(call.value === undefined ? {} : { value: call.value }),
 })
 
+/** Stable identity of an encoded transaction, for consolidating display rows. */
+const plainTxKey = (tx: PlainTxRequest): string =>
+  `${tx.to.toLowerCase()}:${(tx.value ?? 0n).toString()}:${tx.data}`
+
 const flattenRequests = (
   request: MigrationAuthorizationRequest | undefined,
 ): MigrationAuthorizationRequest[] =>
@@ -114,6 +118,7 @@ export const buildMigrationAuthorizationTxSteps = (
       index: startIndex + steps.length,
       label: (authorizationType && labels[authorizationType]) || fallback,
       isSeparateTx: true,
+      txKey: plainTxKey(encodeCall(phase === 'grant' ? entry.call : entry.revocation!)),
     })
   }
 

--- a/utils/stepDecoding.ts
+++ b/utils/stepDecoding.ts
@@ -37,6 +37,14 @@ export interface DisplayStep {
   assetInfo?: StepAssetInfo
   toAssetInfo?: StepAssetInfo
   iconOnly?: boolean
+  /**
+   * Identity of the underlying encoded transaction, present when the step
+   * maps 1:1 to a concrete transaction. Rows sharing a txKey ARE the same
+   * transaction and may be consolidated in summaries; rows without one must
+   * never be — labels are generic per authorization type, so two different
+   * tokens can share a label while being distinct transactions.
+   */
+  txKey?: string
 }
 
 /** Structurally matches useVaultRegistry().getVault */


### PR DESCRIPTION
## Summary

Tester finding while exercising the Safe stack, but pre-existing on `development` for all wallet types: post-execution transactions (e.g. a batched migration's approval restoration) appear only inside the expanded entry row's "After execution" section — the collapsed batch summary undercounts the ceremony. A batched migration read as 2 proposals (grant + batch) when the real count is 3 (grant → batch → revoke).

## Fix

The summary now renders an **After execution** section built from the entries' `postSteps`, matching the shape of the Authorization-transactions section above it (per-row "1 transaction" for standalone sends). No behavior change — display honesty only.

## Test plan

- [x] Full suite 1612 passing; typecheck + lint clean
- [ ] Visual: batch a migration → collapsed summary shows Authorization transactions (grant), operations, and After execution (restore)

Will be merged forward into the Safe stack branches (#797/#798/#799) like #802.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “After execution” section to batch review summaries.
  * Displays post-execution transactions in execution order with descriptive labels and transaction or bundled status.
  * Consolidates duplicate transactions while preserving distinct transactions that cannot be matched, resulting in clearer and more accurate summaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->