### PR TITLE
fix: preserve pruned address cleanup

### DIFF
--- a/docs/vault-labels-and-verification.md
+++ b/docs/vault-labels-and-verification.md
@@ -258,17 +258,16 @@ This keeps the bridge endpoint verification aligned with the UI: label/entity ma
 | Vault Source | Verification Method |
 |-------------|---------------------|
 | **EVaults** | Address appears in `verifiedVaultAddresses` from labels |
-| **Earn vaults** | Default repo: loaded from `eulerEarnGovernedPerspective` on-chain. Alternative repos: verified if in `earnVaults` from labels |
+| **Earn vaults** | Verified if in `earnVaults` from labels (`earn-vaults.json`) |
 | **Escrow vaults** | Loaded from `escrowedCollateralPerspective` on-chain (always verified) |
 | **Securitize vaults** | Address appears in `verifiedVaultAddresses` from labels |
 | **Unknown vaults** | Resolved via subgraph; verified only if in labels |
 
 ### On-Chain Perspectives
 
-Two on-chain perspective contracts provide additional verification:
+One on-chain perspective contract provides additional verification:
 
 - **`escrowedCollateralPerspective`**: Lists all verified escrow collateral vaults. Vaults from this perspective are marked `verified: true` and `vaultCategory: 'escrow'`.
-- **`eulerEarnGovernedPerspective`**: Lists all governed EulerEarn vaults. Vaults from this perspective are always verified.
 
 ## Vault Categories and Types
 

--- a/tests/composables/useREULLocks.test.ts
+++ b/tests/composables/useREULLocks.test.ts
@@ -51,8 +51,6 @@ const importUseREULLocks = async (wallet: {
     eulerTokenAddresses: ref({
       EUL: eulAddress,
       rEUL: reulAddress,
-      eUSD: undefined,
-      seUSD: undefined,
     }),
   }))
   vi.stubGlobal('useSpyMode', () => ({


### PR DESCRIPTION
## Summary
- Keep Earn vault verification documentation aligned with the label-backed implementation.
- Keep the rEUL test fixture aligned with the SDK 2.0 token-address surface.

## Changes
- Document `earn-vaults.json` as the Earn vault verification source and list only the escrow perspective as an on-chain verification source.
- Remove the pruned `eUSD` and `seUSD` keys from the `useEulerAddresses` test stub.
- Preserve the same address cleanup on `development` and `master` so the promotion diff does not reintroduce stale fields or documentation.

## Test plan
- [x] `npm run test:run -- tests/composables/useREULLocks.test.ts` (5 passed)
- [x] `npx eslint tests/composables/useREULLocks.test.ts`
- [x] `npm run typecheck`
- [x] `git diff --check`
- [x] Confirm both touched files match `origin/master`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated vault verification guidance to use labels from `earn-vaults.json`.
  * Clarified the list of supported on-chain perspectives.

* **Tests**
  * Simplified address test setup by removing unused token address mocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->