### PR TITLE
fix: align Safe batch review ceremony

### DIFF
--- a/components/BatchReviewModal.vue
+++ b/components/BatchReviewModal.vue
@@ -10,7 +10,7 @@ import { getAssetLogoUrl } from '~/composables/useTokenList'
 import { buildTransactionPlanDisplaySteps, type DisplayStep, type StepDecodingContext } from '~/utils/stepDecoding'
 import { logWarn } from '~/utils/errorHandling'
 import { buildBatchHealthSummary } from '~/utils/batchHealthSummary'
-import { getAuthorizationStepDisplay } from '~/utils/batchReviewDisplay'
+import { getAuthorizationStepDisplay, groupRestorationSummaryRows, isBundledReviewEntry } from '~/utils/batchReviewDisplay'
 import { hasPermit2TokenApproval } from '~/utils/transactionPlanApprovals'
 import { isPlanBundleable } from '~/utils/transaction-plan-calls'
 import type { TrackedExecutionHandle } from '~/composables/useSafeExecutionDetachment'
@@ -46,7 +46,6 @@ const {
   fetchTenderlyEnabled,
   simulateOnTenderly,
   dismissExecutionError,
-  willBundlePrerequisites,
   prepareBundledExecution,
   latchedBundledExecution,
 } = useTxBatch()
@@ -94,11 +93,14 @@ const isExternalProtocolMigrationReview = (review: ReviewWithSteps | undefined):
 const normalizeDisplaySteps = (steps: DisplayStep[] | undefined): DisplayStep[] =>
   (steps ?? []).map((step, idx) => ({ ...step, index: idx + 1 }))
 
-// When a Safe will execute the cart, bundled-capable prerequisites ride in
-// the batch proposal — the rows captured at add-time say "Separate tx", so
-// override the flag at display time to describe the actual ceremony.
+// Bundled styling follows the ceremony latched when this modal opened. Live
+// Safe detection can resolve later, but it cannot change what this review will
+// execute without a fresh review.
+const isBundledEntry = (entry: typeof entries.value[number]): boolean =>
+  isBundledReviewEntry(latchedBundledExecution.value !== null, !!entry.buildBundledExecution)
+
 const overrideBundled = (steps: DisplayStep[], entry: typeof entries.value[number]): DisplayStep[] =>
-  willBundlePrerequisites.value && entry.buildBundledExecution
+  isBundledEntry(entry)
     ? steps.map(step => ({ ...step, isSeparateTx: false }))
     : steps
 
@@ -161,11 +163,6 @@ const postStepsByEntryId = computed<Record<string, DisplayStep[]>>(() => {
   return out
 })
 
-// Keys on the LATCHED resolution (what this modal session resolved,
-// displayed, and will execute) — never on live wallet classification.
-const isBundledEntry = (entry: typeof entries.value[number]): boolean =>
-  latchedBundledExecution.value !== null && !!entry.buildBundledExecution
-
 const signatureStepsHeading = (entryId: string): string => {
   const entry = entries.value.find(candidate => candidate.id === entryId)
   if (entry && isBundledEntry(entry)) return 'Authorization transactions'
@@ -173,6 +170,9 @@ const signatureStepsHeading = (entryId: string): string => {
     (signatureStepsByEntryId.value[entryId] ?? []).some(step => step.isSeparateTx),
   ).detailHeading
 }
+
+const restorationStepsHeading = (entry: typeof entries.value[number]): string =>
+  isBundledEntry(entry) ? 'Authorization restorations' : 'After execution'
 
 const authorizationRows = computed(() =>
   entries.value.flatMap(entry =>
@@ -195,9 +195,9 @@ const authorizationSummaryGroups = computed(() => {
   return groups
 })
 
-// Post-execution transactions (e.g. a migration's approval restoration) are
-// real wallet transactions sent after the batch settles. Surfacing them only
-// inside the expanded row undercounts the ceremony in the collapsed summary.
+// Authorization restorations run after the operation. They either ride at the
+// tail of the same Safe proposal or are sent as standalone post-execution
+// transactions; the collapsed summary keeps those ceremonies distinct.
 //
 // Rows render in EXECUTION order: restorations unwind in reverse entry order
 // (each entry's own steps are already reversed by the encoder). Rows carrying
@@ -206,7 +206,7 @@ const authorizationSummaryGroups = computed(() => {
 // duplicate displayed revoke would never run. Labels are NOT identity: two
 // different aTokens share "Restore previous aToken approval", so rows without
 // a txKey are never collapsed.
-const postExecutionSummaryRows = computed(() => {
+const restorationSummaryRows = computed(() => {
   const rows = [...entries.value].reverse().flatMap(entry =>
     (postStepsByEntryId.value[entry.id] ?? []).map(step => ({ entry, step })),
   )
@@ -217,6 +217,18 @@ const postExecutionSummaryRows = computed(() => {
     seen.add(step.txKey)
     return true
   })
+})
+
+const restorationSummaryGroups = computed(() => {
+  const rows = groupRestorationSummaryRows(restorationSummaryRows.value)
+  return [
+    ...(rows.bundled.length
+      ? [{ key: 'bundled', heading: 'Authorization restorations', itemCountLabel: 'bundled in proposal', rows: rows.bundled }]
+      : []),
+    ...(rows.postExecution.length
+      ? [{ key: 'post-execution', heading: 'After execution', itemCountLabel: '1 transaction', rows: rows.postExecution }]
+      : []),
+  ]
 })
 
 // Unverified vaults the batch touches — surfaced as a warning. A vault is the
@@ -688,7 +700,7 @@ const onCloseRequested = () => {
                     class="border-t border-line-default"
                   />
                   <p class="text-p4 text-content-tertiary uppercase tracking-[0.04em]">
-                    After execution
+                    {{ restorationStepsHeading(entry) }}
                   </p>
                   <OperationStepsList :steps="postStepsByEntryId[entry.id]" />
                 </template>
@@ -719,28 +731,33 @@ const onCloseRequested = () => {
         :description="warning.description"
       />
 
-      <!-- Transactions sent after the batch settles (e.g. approval restoration). -->
-      <div v-if="postExecutionSummaryRows.length">
-        <p class="text-p3 text-content-tertiary uppercase tracking-[0.04em] mb-8">
-          After execution
-        </p>
-        <div class="bg-surface-secondary rounded-12 px-12 divide-y divide-line-default">
-          <div
-            v-for="({ entry, step }, i) in postExecutionSummaryRows"
-            :key="`${entry.id}-post-${i}`"
-            class="flex items-center justify-between gap-12 py-10"
-          >
-            <span class="flex items-center gap-8 text-p3 text-content-secondary min-w-0">
-              <SvgIcon
-                name="check-circle"
-                class="!w-16 !h-16 text-accent-500 shrink-0"
-              />
-              <span class="truncate">{{ step.label }}</span>
-            </span>
-            <span class="text-p3 text-content-tertiary shrink-0">{{ step.isSeparateTx ? '1 transaction' : 'bundled in proposal' }}</span>
+      <!-- Authorization restorations, grouped by the ceremony that submits them. -->
+      <template
+        v-for="group in restorationSummaryGroups"
+        :key="group.key"
+      >
+        <div>
+          <p class="text-p3 text-content-tertiary uppercase tracking-[0.04em] mb-8">
+            {{ group.heading }}
+          </p>
+          <div class="bg-surface-secondary rounded-12 px-12 divide-y divide-line-default">
+            <div
+              v-for="({ entry, step }, i) in group.rows"
+              :key="`${entry.id}-${group.key}-${i}`"
+              class="flex items-center justify-between gap-12 py-10"
+            >
+              <span class="flex items-center gap-8 text-p3 text-content-secondary min-w-0">
+                <SvgIcon
+                  name="check-circle"
+                  class="!w-16 !h-16 text-accent-500 shrink-0"
+                />
+                <span class="truncate">{{ step.label }}</span>
+              </span>
+              <span class="text-p3 text-content-tertiary shrink-0">{{ group.itemCountLabel }}</span>
+            </div>
           </div>
         </div>
-      </div>
+      </template>
 
       <!-- Wallet changes -->
       <BatchWalletChanges

--- a/pages/position/[number]/borrow/swap.vue
+++ b/pages/position/[number]/borrow/swap.vue
@@ -3654,8 +3654,8 @@ const addInboundExternalMigrationToBatch = async () => {
         type: 'migration',
         asset: reviewAsset,
         amount: formatUnits(reviewAsset.amount, Number(reviewAsset.decimals)),
-        // Batch prerequisites broadcast as standalone transactions
-        // (sendPlainTransactions), never inside the cart's Safe bundle.
+        // Add-time rows describe the sequential fallback. A latched Safe review
+        // uses rows from the exact bundled resolution instead.
         signatureSteps: buildInboundExternalMigrationSignatureSteps(preview.authorizationRequest, useSignatures, false),
         postSteps: buildInboundExternalMigrationRevokeSteps(preview.authorizationRequest, useSignatures, false),
         displayPlan: preview.calldataPrepared.plan,

--- a/pages/position/[number]/migrate.vue
+++ b/pages/position/[number]/migrate.vue
@@ -1150,8 +1150,8 @@ async function addPreparedMigrationToBatch(preview: OutgoingMigrationPreview) {
       type: 'migration',
       asset: sourceDebtAsset,
       amount: debtAmount,
-      // Batch prerequisites broadcast as standalone transactions
-      // (sendPlainTransactions), never inside the cart's Safe bundle.
+      // Add-time rows describe the sequential fallback. A latched Safe review
+      // uses rows from the exact bundled resolution instead.
       signatureSteps: buildSignatureSteps(input.target, authorizationRequest, useSignatures, false),
       postSteps: buildRevokeSteps(authorizationRequest, useSignatures, false),
       displayPlan: preview.calldataPrepared.plan,

--- a/tests/utils/batchReviewDisplay.test.ts
+++ b/tests/utils/batchReviewDisplay.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { getAuthorizationStepDisplay } from '~/utils/batchReviewDisplay'
+import { getAuthorizationStepDisplay, groupRestorationSummaryRows, isBundledReviewEntry } from '~/utils/batchReviewDisplay'
 
 describe('getAuthorizationStepDisplay', () => {
   it('describes signature-mode authorization rows as signatures', () => {
@@ -15,6 +15,33 @@ describe('getAuthorizationStepDisplay', () => {
       detailHeading: 'Authorization transactions',
       summaryHeading: 'Authorization transactions',
       itemCountLabel: '1 transaction',
+    })
+  })
+})
+
+describe('isBundledReviewEntry', () => {
+  it('requires both a latched ceremony and a bundled execution builder', () => {
+    expect(isBundledReviewEntry(true, true)).toBe(true)
+    expect(isBundledReviewEntry(false, true)).toBe(false)
+    expect(isBundledReviewEntry(true, false)).toBe(false)
+  })
+})
+
+describe('groupRestorationSummaryRows', () => {
+  it('separates in-proposal restorations from post-execution transactions', () => {
+    const bundled = { id: 'bundled', step: { isSeparateTx: false } }
+    const postExecution = { id: 'post-execution', step: { isSeparateTx: true } }
+
+    expect(groupRestorationSummaryRows([bundled, postExecution])).toEqual({
+      bundled: [bundled],
+      postExecution: [postExecution],
+    })
+  })
+
+  it('returns empty groups when there are no restoration rows', () => {
+    expect(groupRestorationSummaryRows([])).toEqual({
+      bundled: [],
+      postExecution: [],
     })
   })
 })

--- a/utils/batchReviewDisplay.ts
+++ b/utils/batchReviewDisplay.ts
@@ -6,6 +6,18 @@ export interface AuthorizationStepsDisplay {
   itemCountLabel: '1 transaction' | '1 signature'
 }
 
+export const isBundledReviewEntry = (
+  hasLatchedBundledExecution: boolean,
+  hasBundledExecutionBuilder: boolean,
+): boolean => hasLatchedBundledExecution && hasBundledExecutionBuilder
+
+export const groupRestorationSummaryRows = <TRow extends { step: Pick<DisplayStep, 'isSeparateTx'> }>(
+  rows: readonly TRow[],
+): { bundled: TRow[], postExecution: TRow[] } => ({
+  bundled: rows.filter(({ step }) => !step.isSeparateTx),
+  postExecution: rows.filter(({ step }) => step.isSeparateTx),
+})
+
 export const getAuthorizationStepDisplay = (
   isSeparateTx: DisplayStep['isSeparateTx'],
 ): AuthorizationStepsDisplay => {


### PR DESCRIPTION
## Summary
- Keep batch authorization labels tied to the Safe ceremony latched when review opens.
- Distinguish authorization restorations inside a Safe proposal from standalone transactions sent after execution.

## Changes
- Derive bundled entry styling from the latched bundled execution instead of live Safe detection.
- Group in-proposal restoration rows under Authorization restorations and reserve After execution for standalone restoration transactions.
- Align expanded entry headings and migration comments with the actual bundled or sequential ceremony.
- Add display-helper regression coverage for late Safe detection and restoration grouping.

## Test plan
- [x] npm run test:run -- tests/utils/batchReviewDisplay.test.ts tests/composables/useTxBatch.test.ts (61 passed)
- [x] ESLint on all changed TypeScript and Vue files
- [x] npm run typecheck
- [x] git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Batch review details now accurately reflect whether execution is bundled.
  * Restoration entries are grouped into bundled-proposal and post-execution sections with clearer headings and transaction labels.
  * Per-entry restoration headings now distinguish bundled execution from sequential fallback processing.
  * Migration reviews now clearly explain which rows apply to bundled execution versus sequential fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->