### PR TITLE
fix: close promotion review gaps

### DIFF
--- a/components/BatchReviewModal.vue
+++ b/components/BatchReviewModal.vue
@@ -10,7 +10,7 @@ import { getAssetLogoUrl } from '~/composables/useTokenList'
 import { buildTransactionPlanDisplaySteps, type DisplayStep, type StepDecodingContext } from '~/utils/stepDecoding'
 import { logWarn } from '~/utils/errorHandling'
 import { buildBatchHealthSummary } from '~/utils/batchHealthSummary'
-import { getAuthorizationStepDisplay } from '~/utils/batchReviewDisplay'
+import { consolidateRestorationSummaryRows, getAuthorizationStepDisplay } from '~/utils/batchReviewDisplay'
 import { hasPermit2TokenApproval } from '~/utils/transactionPlanApprovals'
 import { isPlanBundleable } from '~/utils/transaction-plan-calls'
 import type { TrackedExecutionHandle } from '~/composables/useSafeExecutionDetachment'
@@ -200,23 +200,16 @@ const authorizationSummaryGroups = computed(() => {
 // inside the expanded row undercounts the ceremony in the collapsed summary.
 //
 // Rows render in EXECUTION order: restorations unwind in reverse entry order
-// (each entry's own steps are already reversed by the encoder). Rows carrying
-// the identical encoded restoration TRANSACTION are consolidated — a grant an
-// earlier entry already made resolves to no prerequisite at execution, so its
-// duplicate displayed revoke would never run. Labels are NOT identity: two
-// different aTokens share "Restore previous aToken approval", so rows without
-// a txKey are never collapsed.
+// (each entry's own steps are already reversed by the encoder). Identical
+// standalone restorations are consolidated because sequential prerequisite
+// resolution sends them once. Bundled Safe restorations are already collected
+// proposal calls, so every call remains visible. Labels are NOT identity: two
+// different aTokens can share a label while representing distinct transactions.
 const postExecutionSummaryRows = computed(() => {
   const rows = [...entries.value].reverse().flatMap(entry =>
     (postStepsByEntryId.value[entry.id] ?? []).map(step => ({ entry, step })),
   )
-  const seen = new Set<string>()
-  return rows.filter(({ step }) => {
-    if (!step.txKey) return true
-    if (seen.has(step.txKey)) return false
-    seen.add(step.txKey)
-    return true
-  })
+  return consolidateRestorationSummaryRows(rows)
 })
 
 // Unverified vaults the batch touches — surfaced as a warning. A vault is the

--- a/composables/useExternalMigrationPositions.ts
+++ b/composables/useExternalMigrationPositions.ts
@@ -73,6 +73,7 @@ export type MetamorphoMigrationCandidate = BaseMigrationCandidate<typeof METAMOR
   shares: bigint
 }
 export type ExternalMigrationCandidate = MorphoMigrationCandidate | AaveMigrationCandidate | MetamorphoMigrationCandidate
+export type ExternalMigrationSource = 'Aave V3' | 'Morpho'
 
 export const EXTERNAL_MIGRATION_DUST_USD = 0.01
 export const POST_EXTERNAL_MIGRATION_REFRESH_DELAYS_MS = [0, 5_000, 15_000, 30_000] as const
@@ -621,6 +622,7 @@ export const useExternalMigrationPositions = (options: {
   const positions = useState<ExternalMigrationCandidate[]>('external-migration:positions', () => [])
   const isLoading = useState('external-migration:is-loading', () => false)
   const error = useState('external-migration:error', () => '')
+  const unavailableSources = useState<ExternalMigrationSource[]>('external-migration:unavailable-sources', () => [])
   const hasLoaded = useState('external-migration:has-loaded', () => false)
   const lastLoadedAt = useState<number | null>('external-migration:last-loaded-at', () => null)
   const loadedFor = useState<ExternalMigrationStateKey>('external-migration:loaded-for', () => ({}))
@@ -924,6 +926,7 @@ export const useExternalMigrationPositions = (options: {
   const resetForMissingOwner = () => {
     positions.value = []
     error.value = ''
+    unavailableSources.value = []
     hasLoaded.value = false
     lastLoadedAt.value = null
     loadedFor.value = {}
@@ -949,6 +952,7 @@ export const useExternalMigrationPositions = (options: {
     if (!loadedKeyMatches) {
       positions.value = []
       error.value = ''
+      unavailableSources.value = []
       hasLoaded.value = false
       lastLoadedAt.value = null
       loadedFor.value = { owner: targetOwner, chainId: targetChainId }
@@ -956,6 +960,7 @@ export const useExternalMigrationPositions = (options: {
 
     isLoading.value = true
     error.value = ''
+    unavailableSources.value = []
     try {
       const [morphoResult, aaveResult] = await Promise.allSettled([
         fetchMorphoMigrationPositions(targetChainId, targetOwner),
@@ -977,6 +982,10 @@ export const useExternalMigrationPositions = (options: {
       }
       if (loadedFor.value.owner !== targetOwner || loadedFor.value.chainId !== targetChainId) return
       positions.value = nextPositions
+      unavailableSources.value = [
+        ...(aaveResult.status === 'rejected' ? ['Aave V3' as const] : []),
+        ...(morphoResult.status === 'rejected' ? ['Morpho' as const] : []),
+      ]
       hasLoaded.value = true
       lastLoadedAt.value = Date.now()
     }
@@ -984,6 +993,7 @@ export const useExternalMigrationPositions = (options: {
       if (loadedFor.value.owner !== targetOwner || loadedFor.value.chainId !== targetChainId) return
       positions.value = []
       error.value = err instanceof Error ? err.message : 'Failed to load external positions'
+      unavailableSources.value = []
       hasLoaded.value = true
       lastLoadedAt.value = Date.now()
       logWarn('externalMigration/positions', err)
@@ -1007,6 +1017,7 @@ export const useExternalMigrationPositions = (options: {
     positions,
     isLoading,
     error,
+    unavailableSources,
     hasLoaded,
     lastLoadedAt,
     load,

--- a/composables/useExternalMigrationPositions.ts
+++ b/composables/useExternalMigrationPositions.ts
@@ -79,6 +79,7 @@ export const EXTERNAL_MIGRATION_DUST_USD = 0.01
 export const POST_EXTERNAL_MIGRATION_REFRESH_DELAYS_MS = [0, 5_000, 15_000, 30_000] as const
 
 const externalMigrationRefreshCounter = ref(0)
+let externalMigrationLoadGeneration = 0
 
 export const useExternalMigrationRefresh = () => {
   const triggerExternalMigrationRefresh = () => {
@@ -924,6 +925,7 @@ export const useExternalMigrationPositions = (options: {
   }
 
   const resetForMissingOwner = () => {
+    externalMigrationLoadGeneration += 1
     positions.value = []
     error.value = ''
     unavailableSources.value = []
@@ -958,6 +960,12 @@ export const useExternalMigrationPositions = (options: {
       loadedFor.value = { owner: targetOwner, chainId: targetChainId }
     }
 
+    const generation = ++externalMigrationLoadGeneration
+    const isCurrentLoad = () =>
+      generation === externalMigrationLoadGeneration
+      && loadedFor.value.owner === targetOwner
+      && loadedFor.value.chainId === targetChainId
+
     isLoading.value = true
     error.value = ''
     unavailableSources.value = []
@@ -980,7 +988,7 @@ export const useExternalMigrationPositions = (options: {
       if (firstError && nextPositions.length === 0) {
         throw firstError
       }
-      if (loadedFor.value.owner !== targetOwner || loadedFor.value.chainId !== targetChainId) return
+      if (!isCurrentLoad()) return
       positions.value = nextPositions
       unavailableSources.value = [
         ...(aaveResult.status === 'rejected' ? ['Aave V3' as const] : []),
@@ -990,7 +998,7 @@ export const useExternalMigrationPositions = (options: {
       lastLoadedAt.value = Date.now()
     }
     catch (err) {
-      if (loadedFor.value.owner !== targetOwner || loadedFor.value.chainId !== targetChainId) return
+      if (!isCurrentLoad()) return
       positions.value = []
       error.value = err instanceof Error ? err.message : 'Failed to load external positions'
       unavailableSources.value = []
@@ -999,7 +1007,7 @@ export const useExternalMigrationPositions = (options: {
       logWarn('externalMigration/positions', err)
     }
     finally {
-      if (loadedFor.value.owner === targetOwner && loadedFor.value.chainId === targetChainId) {
+      if (isCurrentLoad()) {
         isLoading.value = false
       }
     }

--- a/composables/useMarketGroups.ts
+++ b/composables/useMarketGroups.ts
@@ -10,6 +10,8 @@ import { isLiveCollateralEdge } from '~/utils/vault/ltv'
 import { isVaultBorrowable } from '~/utils/vault/classification'
 import { hasResolvedGovernorAdmin } from '~/utils/vault/governor-verification'
 import { liteVaultFetchOptions } from '~/utils/sdk-fetch-options'
+import { resolveEulerRouterGovernors } from '~/utils/vault/euler-router-governance'
+import { governableGovernorAbi } from '~/abis/oracle'
 
 // -- Helpers --
 
@@ -519,7 +521,17 @@ export const useMarketGroups = () => {
         liteVaultFetchOptions,
       )
       result.errors.forEach(issue => logWarn('useMarketGroups/fetchMarketGroupOnDemand', issue))
-      memberVaults.push(...(result.result.filter(Boolean) as EVault[]))
+      const fetchedVaults = result.result.filter(Boolean) as EVault[]
+      await resolveEulerRouterGovernors(fetchedVaults, (router) => {
+        const provider = sdk.providerService.getProvider(targetChainId)
+        return provider.readContract({
+          address: router,
+          abi: governableGovernorAbi,
+          functionName: 'governor',
+          authorizationList: undefined,
+        })
+      })
+      memberVaults.push(...fetchedVaults)
     }
     catch (e) {
       logWarn('useMarketGroups/fetchMarketGroupOnDemand', e)

--- a/composables/useVaultRegistry.ts
+++ b/composables/useVaultRegistry.ts
@@ -5,6 +5,8 @@ import { logWarn } from '~/utils/errorHandling'
 import { normalizeAddress } from '~/utils/normalizeAddress'
 import { isVaultNotExplorable } from '~/utils/eulerLabelsUtils'
 import { liteSecuritizeVaultFetchOptions, liteVaultFetchOptions } from '~/utils/sdk-fetch-options'
+import { resolveEulerRouterGovernors } from '~/utils/vault/euler-router-governance'
+import { governableGovernorAbi } from '~/abis/oracle'
 
 // Vault type enum - 3 types (escrow is a category of evk, not a separate type)
 export type VaultType = 'evk' | 'earn' | 'securitize'
@@ -237,6 +239,15 @@ const fetchVaultByType = async (address: string, type: VaultType): Promise<Vault
     default: {
       const { result } = await sdk.eVaultService.fetchVault(targetChainId, vaultAddress, liteVaultFetchOptions)
       if (!result) throw new Error(`EVault not found for ${address}`)
+      await resolveEulerRouterGovernors([result], (router) => {
+        const provider = sdk.providerService.getProvider(targetChainId)
+        return provider.readContract({
+          address: router,
+          abi: governableGovernorAbi,
+          functionName: 'governor',
+          authorizationList: undefined,
+        })
+      })
       return result
     }
   }

--- a/composables/useVaults.ts
+++ b/composables/useVaults.ts
@@ -38,6 +38,8 @@ import {
   type SnapshotArgsByAddress,
 } from '~/utils/sdk-snapshot-populate-stubs'
 import type { SerialisedSnapshot, SerialisedVault } from '~/utils/snapshot-types'
+import { resolveEulerRouterGovernors, retainEulerRouterGovernor } from '~/utils/vault/euler-router-governance'
+import { governableGovernorAbi } from '~/abis/oracle'
 
 const isReady = ref(false)
 const isEVaultLoading = ref(false)
@@ -315,8 +317,19 @@ const updateEVaults = async (vaultAddresses: string[], generation?: number, sile
     )
     if (!isCurrentVaultLoad(gen, targetChainId)) return
     result.errors.forEach(issue => logWarn('useVaults/updateEVaults', issue))
+    const fetchedVaults = result.result.filter(Boolean) as EVault[]
+    await resolveEulerRouterGovernors(fetchedVaults, (router) => {
+      const provider = sdk.providerService.getProvider(targetChainId)
+      return provider.readContract({
+        address: router,
+        abi: governableGovernorAbi,
+        functionName: 'governor',
+        authorizationList: undefined,
+      })
+    })
+    if (!isCurrentVaultLoad(gen, targetChainId)) return
 
-    registrySetMany((result.result.filter(Boolean) as EVault[]).map((vault) => {
+    registrySetMany(fetchedVaults.map((vault) => {
       const existing = registryGet(vault.address)
       const vaultCategory = existing?.vaultCategory ?? (isKnownEscrowAddress(vault.address) ? 'escrow' : undefined)
       const verified = vaultCategory === 'escrow' || existing?.verified === true || options.verifiedAddresses?.has(vault.address.toLowerCase()) === true
@@ -616,7 +629,9 @@ const decodeArgs = (entry: SerialisedVault): Record<string, unknown> | undefined
 
 const instantiateEvk = (entry: SerialisedVault): Hydrated<EVaultClass> | undefined => {
   const args = decodeArgs(entry)
-  return args ? { vault: new EVault(args as unknown as IEVault), args } : undefined
+  if (!args) return undefined
+  const vault = retainEulerRouterGovernor(new EVault(args as unknown as IEVault), args.eulerRouterGovernor)
+  return { vault, args }
 }
 
 const instantiateEarn = (entry: SerialisedVault): Hydrated<EulerEarnClass> | undefined => {

--- a/pages/portfolio.vue
+++ b/pages/portfolio.vue
@@ -33,6 +33,7 @@ const {
   positions: migrationPositions,
   isLoading: isMigrationLoading,
   error: migrationError,
+  unavailableSources: migrationUnavailableSources,
   hasLoaded: hasMigrationLoaded,
 } = useExternalMigrationPositions()
 const activityAvailability = useActivityAvailability({ kind: 'account' }, chainId)
@@ -90,6 +91,7 @@ const showMigrationTab = computed(() =>
   && (
     visibleMigrationPositionCount.value > 0
     || isMigrationLoading.value
+    || migrationUnavailableSources.value.length > 0
     || (!!migrationError.value && hasShownMigrationTab.value)
   ),
 )

--- a/pages/portfolio/migrate.vue
+++ b/pages/portfolio/migrate.vue
@@ -12,6 +12,7 @@ const {
   positions,
   isLoading,
   error,
+  unavailableSources,
   hasLoaded,
   load,
 } = useExternalMigrationPositions()
@@ -24,9 +25,15 @@ const disabledReason = (position: ExternalMigrationCandidate) => {
   return position.disabledReason ?? ''
 }
 
+const incompleteScanDescription = computed(() => {
+  if (!unavailableSources.value.length) return ''
+  return `Some positions may be missing because ${unavailableSources.value.join(' and ')} could not be scanned.`
+})
+
 const liveStatus = computed(() => {
   if (isLoading.value) return 'Scanning Aave and Morpho'
   if (error.value) return 'Migration scan failed'
+  if (incompleteScanDescription.value) return `Migration scan incomplete. ${incompleteScanDescription.value}`
   if (hasLoaded.value) return `${visiblePositions.value.length} migration positions available`
   return ''
 })
@@ -105,6 +112,14 @@ onActivated(() => {
         v-else
         class="portfolio-migrate__list flex-1"
       >
+        <UiAlert
+          v-if="incompleteScanDescription"
+          variant="warning"
+          title="Migration scan incomplete"
+          :description="incompleteScanDescription"
+          action-text="Retry scan"
+          @action="load({ force: true })"
+        />
         <PortfolioMigrateRow
           v-for="position in visiblePositions"
           :key="position.id"

--- a/server/utils/labels-view.ts
+++ b/server/utils/labels-view.ts
@@ -24,6 +24,8 @@ import { summarizeSdkIssue } from './observability'
 import { getServerSdk } from './sdk-server'
 import { isSdkErrorDiagnostic } from './sdk-diagnostics'
 import type { VerificationLabels } from '~/utils/vault/governor-verification'
+import { resolveEulerRouterGovernors } from '~/utils/vault/euler-router-governance'
+import { governableGovernorAbi } from '~/abis/oracle'
 
 export interface ChainVaultsSnapshot {
   evkVaults: EVault[]
@@ -283,7 +285,17 @@ async function buildSnapshot(
     }
   }
 
-  const evkVaults = (evk.result.filter(Boolean) as EVault[]).map(vault =>
+  const fetchedEVaults = evk.result.filter(Boolean) as EVault[]
+  await resolveEulerRouterGovernors(fetchedEVaults, (router) => {
+    const provider = sdk.providerService.getProvider(chainId)
+    return provider.readContract({
+      address: router,
+      abi: governableGovernorAbi,
+      functionName: 'governor',
+      authorizationList: undefined,
+    })
+  })
+  const evkVaults = fetchedEVaults.map(vault =>
     withVaultMetadata(vault, {
       verified: true,
       vaultCategory: escrowAddresses.has(vault.address) ? 'escrow' : 'standard',

--- a/server/utils/vaults-cache.ts
+++ b/server/utils/vaults-cache.ts
@@ -24,6 +24,7 @@ import {
   StandardEVaultPerspectives,
   VaultType,
   type EulerSDK,
+  type EVault,
   type VaultFetchOptions,
 } from '@eulerxyz/euler-v2-sdk'
 import { getAddress, type Address } from 'viem'
@@ -51,6 +52,8 @@ import type {
   SerialisedVault,
   SerialisedVaultKind,
 } from '~/utils/snapshot-types'
+import { resolveEulerRouterGovernors } from '~/utils/vault/euler-router-governance'
+import { governableGovernorAbi } from '~/abis/oracle'
 
 // With V3 configured the SDK falls back through V3's batched endpoints —
 // each refresh is cheap, so we can afford a tighter cache TTL and rewarm
@@ -271,6 +274,19 @@ export const refreshChainVaults = (chainId: number): Promise<SerialisedSnapshot>
         }
       }
     }
+
+    await resolveEulerRouterGovernors(
+      [...evk.result, ...escrow.result].filter(Boolean) as EVault[],
+      (router) => {
+        const provider = sdk.providerService.getProvider(chainId)
+        return provider.readContract({
+          address: router,
+          abi: governableGovernorAbi,
+          functionName: 'governor',
+          authorizationList: undefined,
+        })
+      },
+    )
 
     const payload: SerialisedSnapshot = encodeBigints({
       chainId,

--- a/tests/composables/useExternalMigrationPositions.test.ts
+++ b/tests/composables/useExternalMigrationPositions.test.ts
@@ -26,6 +26,13 @@ const MORPHO_ORACLE = getAddress('0xFEa2D58cEfCb9fcb597723c6bAE66fFE4193aFE4')
 const MORPHO_IRM = getAddress('0x46415998764C29aB2a25CbeA6254146D50D22687')
 
 const flushPromises = () => new Promise(resolve => setTimeout(resolve, 0))
+const deferred = <T>() => {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
 const priceResult = (price: string) => {
   const amountOutMid = parseUnits(price, 18)
   return {
@@ -333,6 +340,55 @@ describe('useExternalMigrationPositions', () => {
         symbol: 'WETH',
       }),
     })
+  })
+
+  it('does not let an older forced scan overwrite a newer result', async () => {
+    vi.stubGlobal('useEulerAddresses', () => ({ chainId: ref(130) }))
+    const first = deferred<Response>()
+    const second = deferred<Response>()
+    fetchMock
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise)
+
+    const result = useExternalMigrationPositions()
+    const secondLoad = result.load({ force: true })
+
+    second.resolve(new Response(JSON.stringify({
+      data: {
+        userByAddress: {
+          address: OWNER,
+          marketPositions: [{
+            market,
+            state: {
+              borrowAssets: '25',
+              borrowAssetsUsd: '25',
+              collateral: '100',
+              collateralUsd: '250000',
+            },
+          }],
+        },
+      },
+    })))
+    await secondLoad
+    await flushPromises()
+    await nextTick()
+
+    expect(result.positions.value.map(position => position.id)).toEqual([MARKET_ID])
+    expect(result.isLoading.value).toBe(false)
+
+    first.resolve(new Response(JSON.stringify({
+      data: {
+        userByAddress: {
+          address: OWNER,
+          marketPositions: [],
+        },
+      },
+    })))
+    await flushPromises()
+    await nextTick()
+
+    expect(result.positions.value.map(position => position.id)).toEqual([MARKET_ID])
+    expect(result.isLoading.value).toBe(false)
   })
 
   it('discovers Aave V3 collateral and variable debt positions from reserve data', async () => {

--- a/tests/composables/useExternalMigrationPositions.test.ts
+++ b/tests/composables/useExternalMigrationPositions.test.ts
@@ -428,6 +428,36 @@ describe('useExternalMigrationPositions', () => {
     expect(result.error.value).toContain('Aave discovery read failed')
   })
 
+  it('keeps Morpho rows and identifies Aave when only the Aave scan fails', async () => {
+    aaveUserConfiguration = 2n
+    aaveReserves = [WETH]
+    fetchMock.mockResolvedValue(new Response(JSON.stringify({
+      data: {
+        userByAddress: {
+          address: OWNER,
+          marketPositions: [{
+            market,
+            state: {
+              borrowAssets: '25',
+              borrowAssetsUsd: '25',
+              collateral: '100',
+              collateralUsd: '250000',
+            },
+          }],
+        },
+      },
+    })))
+
+    const result = useExternalMigrationPositions()
+
+    await flushPromises()
+    await nextTick()
+
+    expect(result.positions.value.map(position => position.id)).toEqual([MARKET_ID])
+    expect(result.error.value).toBe('')
+    expect(result.unavailableSources.value).toEqual(['Aave V3'])
+  })
+
   it('keeps valid Aave and Morpho rows when an unrelated Aave reserve read fails', async () => {
     aaveUserConfiguration = 2n
     aaveReserves = [WETH, USDC]

--- a/tests/composables/useTxBatch.test.ts
+++ b/tests/composables/useTxBatch.test.ts
@@ -1321,7 +1321,12 @@ describe('useTxBatch execution prerequisites', () => {
   }] as unknown as TransactionPlan
 
   const bundledGrantStep = { index: 1, label: 'Approve aToken transfer', isSeparateTx: false }
-  const bundledRevokeStep = { index: 1, label: 'Restore previous aToken approval', isSeparateTx: false }
+  const bundledRevokeStep = {
+    index: 1,
+    label: 'Restore previous aToken approval',
+    isSeparateTx: false,
+    txKey: `${aToken.toLowerCase()}:0:${revokeTx.data}`,
+  }
 
   const addBundledMigrationEntry = (batch: ReturnType<typeof useTxBatch>) =>
     batch.addEntry({
@@ -1436,6 +1441,35 @@ describe('useTxBatch execution prerequisites', () => {
       grantSteps: [bundledGrantStep],
       revokeSteps: [bundledRevokeStep],
     })
+    batch.latchedBundledExecution.value = null
+  })
+
+  it('keeps duplicate bundled restoration rows in parity with proposal calls', async () => {
+    const sdk = createMockSdk()
+    sdk.executionService.simulateTransactionPlan.mockImplementation(async (...args: unknown[]) => ({
+      simulatedAccounts: Array.from(
+        { length: countPlanOperations(args[2] as TransactionPlan) },
+        (_, index) => accountWithPosition(subAccount, subAccount, BigInt(index + 2)),
+      ),
+      simulatedWalletBalances: [],
+      simulatedVaults: [],
+      failedBatchItems: [],
+      insufficientWalletAssets: [],
+    }))
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    isSafeWalletRef.value = true
+
+    const batch = useTxBatch()
+    await addBundledMigrationEntry(batch)
+    await addBundledMigrationEntry(batch)
+    await vi.waitFor(() => expect(batch.layers.value).toHaveLength(3))
+    const latched = await batch.prepareBundledExecution()
+
+    expect(latched?.revokes).toEqual([revokeTx, revokeTx])
+    expect(Object.values(latched?.stepsByEntryId ?? {}).flatMap(steps => steps.revokeSteps)).toEqual([
+      bundledRevokeStep,
+      bundledRevokeStep,
+    ])
     batch.latchedBundledExecution.value = null
   })
 

--- a/tests/composables/useVaults.test.ts
+++ b/tests/composables/useVaults.test.ts
@@ -1,4 +1,4 @@
-import type { EVault, EulerEarn } from '@eulerxyz/euler-v2-sdk'
+import { EVault as SdkEVault, type EVault, type EulerEarn, type IEVault } from '@eulerxyz/euler-v2-sdk'
 import { getAddress, type Address } from 'viem'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
@@ -14,6 +14,8 @@ const VISIBLE_WETH_EVAULT = '0xD8b27CF359b7D15710a5BE299AF6e7Bf904984C2'
 const HIDDEN_WETH_LENDING_EVAULT = '0x2ff5F1Ca35f5100226ac58E1BFE5aac56919443B'
 const HIDDEN_TELOSC_WORMHOLE_EVAULT = '0x2e6Dff8907aFdA5D62A278e21B2e65c8595D746E'
 const BASE_EARN_VAULT = '0x8bF41Ad2b816F7c220b22F4BCD63fC2A35Ab4247'
+const EULER_ROUTER = getAddress('0x0000000000000000000000000000000000000201')
+const EULER_ROUTER_GOVERNOR = getAddress('0x0000000000000000000000000000000000000202')
 
 const makeVault = (address: string): EVault => ({
   address: getAddress(address),
@@ -29,6 +31,7 @@ const fetchEarnVaults = vi.fn()
 const fetchEarnVault = vi.fn()
 const fetchVerifiedVaultAddresses = vi.fn()
 const fetchVaultTypes = vi.fn()
+const readContract = vi.fn()
 const chainId = ref(1)
 
 describe('useVaults EVault verification metadata', () => {
@@ -38,6 +41,7 @@ describe('useVaults EVault verification metadata', () => {
     fetchEarnVault.mockReset()
     fetchVerifiedVaultAddresses.mockReset()
     fetchVaultTypes.mockReset()
+    readContract.mockReset()
 
     fetchVaults.mockImplementation(async (_chainId: number, addresses: Address[]) => ({
       errors: [],
@@ -64,6 +68,7 @@ describe('useVaults EVault verification metadata', () => {
       eVaultService: { fetchVaults, fetchVerifiedVaultAddresses },
       eulerEarnService: { fetchVaults: fetchEarnVaults, fetchVault: fetchEarnVault },
       vaultMetaService: { fetchVaultTypes },
+      providerService: { getProvider: vi.fn(() => ({ readContract })) },
     }
     vi.stubGlobal('useEulerSdk', () => ({
       getEulerSdk: vi.fn(async () => sdk),
@@ -98,6 +103,33 @@ describe('useVaults EVault verification metadata', () => {
     const registry = useVaultRegistry()
     expect(registry.get(LABELED_EVAULT)?.verified).toBe(true)
     expect(registry.getVerifiedEVaults().map(vault => vault.address)).toEqual([getAddress(LABELED_EVAULT)])
+  })
+
+  it('retains independently resolved EulerRouter governance on a real SDK EVault', async () => {
+    const vault = Object.assign(new SdkEVault({
+      address: getAddress(LABELED_EVAULT),
+      governorAdmin: EULER_ROUTER_GOVERNOR,
+      oracle: { oracle: EULER_ROUTER, name: 'EulerRouter' },
+      asset: { address: EULER_ROUTER, symbol: 'TST', decimals: 18 },
+      shares: { decimals: 18 },
+      collaterals: [],
+    } as unknown as IEVault), { type: 'EVault' })
+    fetchVaults.mockResolvedValueOnce({ errors: [], result: [vault] })
+    readContract.mockResolvedValueOnce(EULER_ROUTER_GOVERNOR)
+
+    await useVaults().updateEVaults([LABELED_EVAULT], undefined, true, {
+      verifiedAddresses: new Set([getAddress(LABELED_EVAULT).toLowerCase()]),
+    })
+
+    const stored = useVaultRegistry().get(LABELED_EVAULT)?.vault as EVault & {
+      eulerRouterGovernor?: Address | null
+    }
+    expect(stored).toBeInstanceOf(SdkEVault)
+    expect(stored.eulerRouterGovernor).toBe(EULER_ROUTER_GOVERNOR)
+    expect(readContract).toHaveBeenCalledWith(expect.objectContaining({
+      address: EULER_ROUTER,
+      functionName: 'governor',
+    }))
   })
 
   it('hides not-explorable deprecated WETH lend vaults unless showAll is enabled', () => {

--- a/tests/server/vaults-cache.test.ts
+++ b/tests/server/vaults-cache.test.ts
@@ -1,4 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { EVault as SdkEVault, type IEVault } from '@eulerxyz/euler-v2-sdk'
+import { getAddress } from 'viem'
 import type { SerialisedSnapshot } from '~/server/utils/vaults-cache'
 
 const VAULTS = [
@@ -18,16 +20,7 @@ const mocks = vi.hoisted(() => ({
   refreshLabelFile: vi.fn(),
   warn: vi.fn(),
   error: vi.fn(),
-}))
-
-vi.mock('@eulerxyz/euler-v2-sdk', () => ({
-  StandardEVaultPerspectives: {
-    ESCROW: 'escrow',
-  },
-  VaultType: {
-    EulerEarn: 'EulerEarn',
-    SecuritizeCollateral: 'SecuritizeCollateral',
-  },
+  readContract: vi.fn(),
 }))
 
 vi.mock('~/server/api/internal/labels/[file].get', () => ({
@@ -50,6 +43,9 @@ vi.mock('~/server/utils/sdk-server', () => ({
     vaultMetaService: {
       fetchVaultTypes: mocks.fetchVaultTypes,
     },
+    providerService: {
+      getProvider: vi.fn(() => ({ readContract: mocks.readContract })),
+    },
   })),
 }))
 
@@ -69,6 +65,7 @@ describe('vaults cache', () => {
     mocks.refreshLabelFile.mockReset()
     mocks.warn.mockReset()
     mocks.error.mockReset()
+    mocks.readContract.mockReset()
     process.env.EVAULT_FETCH_CHUNK_CHAINS = '146'
 
     mocks.fetchVerifiedVaultAddresses.mockResolvedValue([])
@@ -116,5 +113,38 @@ describe('vaults cache', () => {
       }),
       'eVault chunk fetch failed',
     )
+  })
+
+  it('serialises resolved EulerRouter governance from real SDK EVaults', async () => {
+    const router = getAddress('0x0000000000000000000000000000000000000101')
+    const governor = getAddress('0x0000000000000000000000000000000000000102')
+    const sdkVault = Object.assign(new SdkEVault({
+      address: getAddress(VAULTS[0]),
+      governorAdmin: governor,
+      oracle: { oracle: router, name: 'EulerRouter' },
+      asset: { address: router, symbol: 'TST', decimals: 18 },
+      shares: { decimals: 18 },
+      collaterals: [],
+    } as unknown as IEVault), {
+      type: 'EVault',
+      caps: { supplyCap: 0n, borrowCap: 0n },
+    })
+    mocks.fetchVaults.mockImplementation(async (_chainId, addresses: string[]) => ({
+      result: addresses.map(address => getAddress(address) === sdkVault.address ? sdkVault : { address }),
+      errors: [],
+    }))
+    mocks.readContract.mockResolvedValue(governor)
+
+    const { refreshChainVaults } = await import('~/server/utils/vaults-cache')
+    const snapshot = await refreshChainVaults(1)
+    const data = snapshot.evkVaults.find(entry =>
+      (entry.data as { address?: string }).address === sdkVault.address,
+    )?.data as { eulerRouterGovernor?: string }
+
+    expect(data.eulerRouterGovernor).toBe(governor)
+    expect(mocks.readContract).toHaveBeenCalledWith(expect.objectContaining({
+      address: router,
+      functionName: 'governor',
+    }))
   })
 })

--- a/tests/utils/batchReviewDisplay.test.ts
+++ b/tests/utils/batchReviewDisplay.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { getAuthorizationStepDisplay } from '~/utils/batchReviewDisplay'
+import { consolidateRestorationSummaryRows, getAuthorizationStepDisplay } from '~/utils/batchReviewDisplay'
 
 describe('getAuthorizationStepDisplay', () => {
   it('describes signature-mode authorization rows as signatures', () => {
@@ -16,5 +16,21 @@ describe('getAuthorizationStepDisplay', () => {
       summaryHeading: 'Authorization transactions',
       itemCountLabel: '1 transaction',
     })
+  })
+})
+
+describe('consolidateRestorationSummaryRows', () => {
+  it('keeps every bundled Safe call visible', () => {
+    const first = { id: 'first', step: { isSeparateTx: false, txKey: 'same-transaction' } }
+    const second = { id: 'second', step: { isSeparateTx: false, txKey: 'same-transaction' } }
+
+    expect(consolidateRestorationSummaryRows([first, second])).toEqual([first, second])
+  })
+
+  it('consolidates identical standalone restorations resolved sequentially', () => {
+    const first = { id: 'first', step: { isSeparateTx: true, txKey: 'same-transaction' } }
+    const second = { id: 'second', step: { isSeparateTx: true, txKey: 'same-transaction' } }
+
+    expect(consolidateRestorationSummaryRows([first, second])).toEqual([first])
   })
 })

--- a/tests/utils/vault/governor-verification.test.ts
+++ b/tests/utils/vault/governor-verification.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { getAddress, type Address } from 'viem'
+import { encodeAbiParameters, getAddress, type Address, zeroAddress } from 'viem'
 import {
   isVaultGovernorVerified,
   isEarnVaultOwnerVerified,
@@ -10,6 +10,7 @@ import {
 } from '~/utils/vault/governor-verification'
 import { EVault as SdkEVault } from '@eulerxyz/euler-v2-sdk'
 import type { EulerEarn, EVault, IEVault, SecuritizeCollateralVault } from '@eulerxyz/euler-v2-sdk'
+import { EULER_ROUTER_COMPONENTS } from '~/entities/constants'
 
 type Vault = EVault & { verified?: boolean, vaultCategory?: 'standard' | 'escrow' }
 type SecuritizeVault = SecuritizeCollateralVault & { verified?: boolean, vaultCategory?: 'standard' | 'escrow' }
@@ -76,19 +77,29 @@ const makeEarn = (overrides: Partial<EarnVault> & { owner?: string } = {}): Earn
   } as unknown as EarnVault
 }
 
-const makeRouterOracle = (governor: Address | typeof getAddress = ROUTER_GOV_A) => {
-  // Encode an EulerRouter info payload with the given governor in the
-  // governor slot. The rule reads via decodeEulerRouterInfo -> .governor.
-  // Construct a tuple: (governor, fallbackOracle, fallbackOracleInfo(...),
-  // bases, quotes, resolvedAssets, resolvedOracles, resolvedOraclesInfo).
-  // For test purposes we just need the governor decoding to succeed; the
-  // exact ABI must match EULER_ROUTER_COMPONENTS, so we mock the helper.
-  return {
-    oracle: getAddress('0x000000000000000000000000000000000000DEAD'),
-    name: 'EulerRouter',
-    oracleInfo: governor as unknown as `0x${string}`,
-  }
-}
+const makeRouterOracle = (governor: Address = ROUTER_GOV_A) => ({
+  oracle: getAddress('0x000000000000000000000000000000000000DEAD'),
+  name: 'EulerRouter',
+  oracleInfo: encodeAbiParameters(
+    [{ type: 'tuple', components: EULER_ROUTER_COMPONENTS }],
+    [{
+      governor,
+      fallbackOracle: zeroAddress,
+      fallbackOracleInfo: { oracle: zeroAddress, name: '', oracleInfo: '0x' },
+      bases: [],
+      quotes: [],
+      resolvedAssets: [],
+      resolvedOracles: [],
+      resolvedOraclesInfo: [],
+    }],
+  ),
+})
+
+const makeMalformedRouterOracle = () => ({
+  oracle: getAddress('0x000000000000000000000000000000000000DEAD'),
+  name: 'EulerRouter',
+  oracleInfo: '0xdead' as const,
+})
 
 describe('isVaultGovernorVerified', () => {
   it('returns true for escrow vaults regardless of governor', () => {
@@ -151,22 +162,40 @@ describe('isVaultGovernorVerified', () => {
     expect(isVaultGovernorVerified(vault, labels)).toBe(true)
   })
 
-  it('skips the router governor check when oracleInfo cannot be decoded', () => {
+  it('fails closed when EulerRouter metadata cannot be decoded', () => {
+    const vault = makeVault({
+      governorAdmin: GOV_A,
+      oracleDetailedInfo: makeMalformedRouterOracle(),
+    } as Partial<Vault>)
+    const labels = buildLabels({
+      declaredKeys: { [VAULT_ADDR]: ['euler'] },
+      entityAddresses: { euler: [GOV_A] },
+    })
+    expect(isVaultGovernorVerified(vault, labels)).toBe(false)
+  })
+
+  it('accepts a decoded EulerRouter governor owned by the declared entity', () => {
+    const vault = makeVault({
+      governorAdmin: GOV_A,
+      oracleDetailedInfo: makeRouterOracle(ROUTER_GOV_A),
+    } as Partial<Vault>)
+    const labels = buildLabels({
+      declaredKeys: { [VAULT_ADDR]: ['euler'] },
+      entityAddresses: { euler: [GOV_A, ROUTER_GOV_A] },
+    })
+    expect(isVaultGovernorVerified(vault, labels)).toBe(true)
+  })
+
+  it('rejects a decoded EulerRouter governor outside the declared entity', () => {
     const vault = makeVault({
       governorAdmin: GOV_A,
       oracleDetailedInfo: makeRouterOracle(ROUTER_GOV_OTHER),
     } as Partial<Vault>)
     const labels = buildLabels({
       declaredKeys: { [VAULT_ADDR]: ['euler'] },
-      entityAddresses: { euler: [GOV_A] },
+      entityAddresses: { euler: [GOV_A, ROUTER_GOV_A] },
     })
-    // The router governor is decoded from oracleInfo via decodeEulerRouterInfo.
-    // Decoding fails on our placeholder payload (not a valid ABI-encoded
-    // EulerRouter tuple), so the rule's `routerGovernor` is null and the
-    // router-gate is a no-op — the vault stays verified on governorAdmin alone.
-    // A real "router mismatch" path needs an end-to-end test with a real
-    // encoded payload.
-    expect(isVaultGovernorVerified(vault, labels)).toBe(true)
+    expect(isVaultGovernorVerified(vault, labels)).toBe(false)
   })
 
   it('works for SecuritizeVault (no oracleDetailedInfo branch)', () => {

--- a/tests/utils/vault/governor-verification.test.ts
+++ b/tests/utils/vault/governor-verification.test.ts
@@ -407,6 +407,30 @@ describe('hasResolvedGovernorAdmin', () => {
     )).toBe(false)
   })
 
+  it('fails closed for a real SDK EulerRouter vault without retained router governance', () => {
+    const vault = Object.assign(makeSdkVault(GOV_A), { verified: true })
+    const labels = buildLabels({
+      declaredKeys: { [VAULT_ADDR]: ['euler'] },
+      entityAddresses: { euler: [GOV_A, ROUTER_GOV_A] },
+    })
+
+    expect('oracleDetailedInfo' in vault).toBe(false)
+    expect(isVaultGovernorVerified(vault, labels)).toBe(false)
+  })
+
+  it('accepts a real SDK EulerRouter vault with retained matching router governance', () => {
+    const vault = Object.assign(makeSdkVault(GOV_A), {
+      verified: true,
+      eulerRouterGovernor: ROUTER_GOV_A,
+    })
+    const labels = buildLabels({
+      declaredKeys: { [VAULT_ADDR]: ['euler'] },
+      entityAddresses: { euler: [GOV_A, ROUTER_GOV_A] },
+    })
+
+    expect(isVaultGovernorVerified(vault, labels)).toBe(true)
+  })
+
   it('rejects non-EVault shapes', () => {
     expect(hasResolvedGovernorAdmin(undefined)).toBe(false)
     expect(hasResolvedGovernorAdmin({ governorAdmin: GOV_A })).toBe(false)

--- a/utils/batchReviewDisplay.ts
+++ b/utils/batchReviewDisplay.ts
@@ -21,3 +21,24 @@ export const getAuthorizationStepDisplay = (
         itemCountLabel: '1 signature',
       }
 }
+
+type RestorationSummaryRow = {
+  step: Pick<DisplayStep, 'isSeparateTx' | 'txKey'>
+}
+
+/**
+ * Standalone prerequisites resolve sequentially, so a repeated restoration
+ * transaction is sent only once. Bundled Safe calls are already resolved and
+ * every collected call remains in the proposal, so every row stays visible.
+ */
+export const consolidateRestorationSummaryRows = <TRow extends RestorationSummaryRow>(
+  rows: readonly TRow[],
+): TRow[] => {
+  const seenStandaloneTransactions = new Set<string>()
+  return rows.filter(({ step }) => {
+    if (!step.isSeparateTx || !step.txKey) return true
+    if (seenStandaloneTransactions.has(step.txKey)) return false
+    seenStandaloneTransactions.add(step.txKey)
+    return true
+  })
+}

--- a/utils/vault/euler-router-governance.ts
+++ b/utils/vault/euler-router-governance.ts
@@ -1,0 +1,56 @@
+import { getAddress, isAddress, type Address } from 'viem'
+
+export interface EulerRouterGovernanceCarrier {
+  oracle?: {
+    oracle?: string
+    name?: string
+  } | null
+  eulerRouterGovernor?: Address | null
+}
+
+const getEulerRouterAddress = (vault: EulerRouterGovernanceCarrier): Address | null => {
+  const address = vault.oracle?.oracle
+  if (vault.oracle?.name !== 'EulerRouter' || !address || !isAddress(address)) return null
+  return getAddress(address)
+}
+
+export const retainEulerRouterGovernor = <T extends object>(
+  vault: T,
+  governor: unknown,
+): T & EulerRouterGovernanceCarrier => {
+  if (governor === null) {
+    return Object.assign(vault, { eulerRouterGovernor: null })
+  }
+  if (typeof governor === 'string' && isAddress(governor)) {
+    return Object.assign(vault, { eulerRouterGovernor: getAddress(governor) })
+  }
+  return vault as T & EulerRouterGovernanceCarrier
+}
+
+export const resolveEulerRouterGovernors = async <T extends EulerRouterGovernanceCarrier>(
+  vaults: T[],
+  readGovernor: (router: Address) => Promise<unknown>,
+): Promise<T[]> => {
+  const routers = new Map<string, Address>()
+  for (const vault of vaults) {
+    const router = getEulerRouterAddress(vault)
+    if (router) routers.set(router.toLowerCase(), router)
+  }
+
+  const governors = new Map<string, Address | null>()
+  await Promise.all([...routers].map(async ([key, router]) => {
+    try {
+      const governor = await readGovernor(router)
+      governors.set(key, typeof governor === 'string' && isAddress(governor) ? getAddress(governor) : null)
+    }
+    catch {
+      governors.set(key, null)
+    }
+  }))
+
+  for (const vault of vaults) {
+    const router = getEulerRouterAddress(vault)
+    if (router) retainEulerRouterGovernor(vault, governors.get(router.toLowerCase()) ?? null)
+  }
+  return vaults
+}

--- a/utils/vault/governor-verification.ts
+++ b/utils/vault/governor-verification.ts
@@ -17,7 +17,12 @@ interface VerifiableVault {
   address: string
   governorAdmin?: string
   governor?: string
+  oracle?: {
+    oracle?: string
+    name?: string
+  } | null
   oracleDetailedInfo?: OracleDetailedInfo | null
+  eulerRouterGovernor?: Address | null
   verified?: boolean
   vaultCategory?: 'standard' | 'escrow'
 }
@@ -87,16 +92,19 @@ export const isVaultGovernorVerified = (
     return false
   }
 
-  if ('oracleDetailedInfo' in vault) {
-    const oracleInfo = vault.oracleDetailedInfo
-    if (oracleInfo?.name === 'EulerRouter') {
-      const routerGovernor = getEulerRouterGovernor(oracleInfo)
-      // An identified EulerRouter is a governance boundary. Its metadata must
-      // decode before the vault can inherit verified entity branding.
-      if (!routerGovernor) return false
-      if (routerGovernor !== zeroAddress && !findDeclaredEntityFor(getAddress(routerGovernor), declaredKeys, labels)) {
-        return false
-      }
+  const oracleInfo = vault.oracleDetailedInfo
+  const isEulerRouter = vault.oracle?.name === 'EulerRouter' || oracleInfo?.name === 'EulerRouter'
+  if (isEulerRouter) {
+    const routerGovernor = 'eulerRouterGovernor' in vault
+      ? vault.eulerRouterGovernor
+      : oracleInfo?.name === 'EulerRouter'
+        ? getEulerRouterGovernor(oracleInfo)
+        : null
+    // EulerRouter governance must resolve independently before the vault can
+    // inherit verified entity branding.
+    if (!routerGovernor) return false
+    if (routerGovernor !== zeroAddress && !findDeclaredEntityFor(getAddress(routerGovernor), declaredKeys, labels)) {
+      return false
     }
   }
 

--- a/utils/vault/governor-verification.ts
+++ b/utils/vault/governor-verification.ts
@@ -88,9 +88,13 @@ export const isVaultGovernorVerified = (
   }
 
   if ('oracleDetailedInfo' in vault) {
-    const routerGovernor = getEulerRouterGovernor(vault.oracleDetailedInfo)
-    if (routerGovernor && routerGovernor !== zeroAddress) {
-      if (!findDeclaredEntityFor(getAddress(routerGovernor), declaredKeys, labels)) {
+    const oracleInfo = vault.oracleDetailedInfo
+    if (oracleInfo?.name === 'EulerRouter') {
+      const routerGovernor = getEulerRouterGovernor(oracleInfo)
+      // An identified EulerRouter is a governance boundary. Its metadata must
+      // decode before the vault can inherit verified entity branding.
+      if (!routerGovernor) return false
+      if (routerGovernor !== zeroAddress && !findDeclaredEntityFor(getAddress(routerGovernor), declaredKeys, labels)) {
         return false
       }
     }


### PR DESCRIPTION
## Summary
- Preserve successful external migration results while clearly warning when Aave V3 or Morpho discovery is incomplete.
- Keep external migration refreshes ordered so stale scans cannot overwrite newer results.
- Verify identified EulerRouter governance independently across client and server EVault hydration paths.
- Keep bundled Safe restoration summaries in one-to-one parity with the calls in the proposal.

## Changes
- Track unavailable migration sources separately from full scan failures and render a retryable, source-specific warning without discarding usable rows.
- Assign each migration scan a monotonic generation and allow only the newest request to commit success, failure, timestamps, or loading state.
- Read `governor()` from every identified EulerRouter, retain the resolved value through SDK instances and server snapshots, and fail verification closed when it is missing, malformed, or outside the declared entity.
- Consolidate repeated restoration rows only for sequential standalone prerequisites; every bundled Safe restoration call remains visible.
- Add discriminating coverage for partial discovery, out-of-order scans, real SDK EVault hydration, router governance retention, and duplicate bundled restoration parity.

## Test plan
- [x] Run ESLint on all changed files.
- [x] Run `npm run typecheck`.
- [x] Run `npm run build`.
- [x] Run `npm run test:run`: 1,748 tests passed across 180 files, including the production bundle inspection suite.

## Out of scope
- The existing five-minute Safe status polling limit is unchanged and remains a separate resumable-tracking follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Migration scans now identify unavailable sources such as Aave V3 or Morpho while preserving successful results.
  - The migration area remains accessible when source data is unavailable, with status messaging and a retry action for incomplete scans.
  - EulerRouter governance information is now resolved for more accurate vault classification and verification.

- **Bug Fixes**
  - Restoration summaries remove duplicate standalone entries while preserving bundled transactions.
  - Invalid or undeclared EulerRouter governors are rejected, while valid configurations continue to be accepted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
