### PR TITLE
fix: preserve batch review and execution parity

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -208,6 +208,10 @@ onUnmounted(() => {
   >
     <SpyModeBanner />
     <TheHeader v-if="isHeaderVisible" />
+    <!-- Manual recovery for armed submission records orphaned by a reload
+         before the wallet answered — they block every send for the wallet
+         until dismissed after the user checked the wallet itself. -->
+    <PendingSubmissionRecovery />
   </div>
   <main>
     <section

--- a/components/BatchContents.vue
+++ b/components/BatchContents.vue
@@ -11,6 +11,7 @@ import { useModal } from '~/components/ui/composables/useModal'
 const {
   entries,
   layers,
+  hasPendingAdds,
   isSimulated,
   isSimulating,
   simError,
@@ -182,11 +183,11 @@ const simEyeLabel = computed(() =>
       <button
         type="button"
         class="w-full h-40 rounded-12 bg-accent-600 hover:bg-accent-700 text-black text-p2 font-semibold shadow-accent-sm transition-colors disabled:opacity-50 disabled:cursor-not-allowed disabled:shadow-none"
-        :disabled="!entries.length || isSimulating"
+        :disabled="!entries.length || isSimulating || hasPendingAdds"
         data-testid="batch-review"
         @click="openBatchReview"
       >
-        {{ isSimulating ? 'Simulating…' : 'Review batch' }}
+        {{ hasPendingAdds ? 'Adding operation…' : isSimulating ? 'Simulating…' : 'Review batch' }}
       </button>
     </div>
   </div>

--- a/components/BatchContents.vue
+++ b/components/BatchContents.vue
@@ -23,6 +23,8 @@ const {
   dismissExecutionError,
   setActiveLayer,
   entryPlans,
+  hasReleasableArmedSubmission,
+  releaseArmedQuarantineAfterManualCheck,
 } = useTxBatch()
 
 const modal = useModal()
@@ -148,6 +150,29 @@ const simEyeLabel = computed(() =>
       class="mx-16 mb-4"
       :message="execError || simError || insufficientBalanceMessage"
     />
+
+    <!-- Manual recovery for an armed submission orphaned by a reload: it has
+         no transaction id to verify on-chain, so only the user checking the
+         wallet itself can rule it out. Submitted records never show this —
+         they are verified automatically. -->
+    <div
+      v-if="hasReleasableArmedSubmission"
+      class="mx-16 mb-4 flex flex-col gap-6"
+    >
+      <p class="text-p3 text-content-tertiary">
+        A previous submission was handed to the wallet but no transaction id
+        came back. If your wallet's pending activity shows nothing pending, you
+        can dismiss it.
+      </p>
+      <button
+        type="button"
+        class="self-start text-p3 text-content-tertiary underline hover:text-content-primary"
+        data-testid="batch-release-armed"
+        @click="releaseArmedQuarantineAfterManualCheck"
+      >
+        My wallet shows nothing pending — dismiss it
+      </button>
+    </div>
 
     <!-- Footer -->
     <div class="px-16 pt-8 pb-14">

--- a/components/BatchReviewModal.vue
+++ b/components/BatchReviewModal.vue
@@ -10,7 +10,7 @@ import { getAssetLogoUrl } from '~/composables/useTokenList'
 import { buildTransactionPlanDisplaySteps, type DisplayStep, type StepDecodingContext } from '~/utils/stepDecoding'
 import { logWarn } from '~/utils/errorHandling'
 import { buildBatchHealthSummary } from '~/utils/batchHealthSummary'
-import { consolidateRestorationSummaryRows, getAuthorizationStepDisplay, groupRestorationSummaryRows, isBundledReviewEntry } from '~/utils/batchReviewDisplay'
+import { consolidateRestorationSummaryRows, getAuthorizationStepDisplay, getBatchReviewDisplayPlan, groupRestorationSummaryRows, isBundledReviewEntry } from '~/utils/batchReviewDisplay'
 import { hasPermit2TokenApproval } from '~/utils/transactionPlanApprovals'
 import { isPlanBundleable } from '~/utils/transaction-plan-calls'
 import type { TrackedExecutionHandle } from '~/composables/useSafeExecutionDetachment'
@@ -111,7 +111,7 @@ const getEntrySignatureSteps = (entry: typeof entries.value[number]): DisplaySte
   // A bundled ceremony carries its own rows, derived from the SAME
   // authorization resolution the proposal executes — the add-time captures
   // can be stale (authorization state drifts between add and review).
-  const latchedSteps = bundledExecutionRef.value?.stepsByEntryId[entry.id]
+  const latchedSteps = bundledExecutionRef.value?.reviewByEntryId[entry.id]
   if (latchedSteps) return normalizeDisplaySteps(latchedSteps.grantSteps)
   const review = entry.review as unknown as ReviewWithSteps | undefined
   return isExternalProtocolMigrationReview(review)
@@ -120,7 +120,7 @@ const getEntrySignatureSteps = (entry: typeof entries.value[number]): DisplaySte
 }
 
 const getEntryPostSteps = (entry: typeof entries.value[number]): DisplayStep[] => {
-  const latchedSteps = bundledExecutionRef.value?.stepsByEntryId[entry.id]
+  const latchedSteps = bundledExecutionRef.value?.reviewByEntryId[entry.id]
   if (latchedSteps) return normalizeDisplaySteps(latchedSteps.revokeSteps)
   const review = entry.review as unknown as ReviewWithSteps | undefined
   return isExternalProtocolMigrationReview(review)
@@ -135,7 +135,11 @@ const getEntryPostSteps = (entry: typeof entries.value[number]): DisplayStep[] =
 const stepsByEntryId = computed<Record<string, DisplayStep[]>>(() => {
   const out: Record<string, DisplayStep[]> = {}
   for (const entry of entries.value) {
-    const plan = (entry.review as unknown as ReviewWithSteps | undefined)?.displayPlan ?? entryPlans.value[entry.id]
+    const plan = getBatchReviewDisplayPlan(
+      bundledExecutionRef.value?.reviewByEntryId[entry.id]?.plan,
+      (entry.review as unknown as ReviewWithSteps | undefined)?.displayPlan,
+      entryPlans.value[entry.id],
+    )
     const ctx = entry.review as unknown as StepDecodingContext | undefined
     if (!plan?.length || !ctx) continue
     try {

--- a/components/BatchReviewModal.vue
+++ b/components/BatchReviewModal.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref } from 'vue'
-import { encodeFunctionData, getAddress } from 'viem'
+import { computed, onMounted, onUnmounted, ref, shallowRef } from 'vue'
+import { getAddress } from 'viem'
 import { flattenBatchEntries, getSubAccountId, type TransactionPlan } from '@eulerxyz/euler-v2-sdk'
 import { getEulerSdkForChain } from '~/composables/useEulerSdk'
-import { buildModifiedPositionKeySets, buildRemovedPositionKeySets, filterPositionKeysByOwner, useTxBatch } from '~/composables/useTxBatch'
+import { buildModifiedPositionKeySets, buildRemovedPositionKeySets, filterPositionKeysByOwner, type PreparedBatchBundledExecution, useTxBatch } from '~/composables/useTxBatch'
 import { useTokenSymbolResolver } from '~/composables/useTokenSymbolResolver'
 import { useVaultRegistry } from '~/composables/useVaultRegistry'
 import { getAssetLogoUrl } from '~/composables/useTokenList'
@@ -15,6 +15,7 @@ import { hasPermit2TokenApproval } from '~/utils/transactionPlanApprovals'
 import { isPlanBundleable } from '~/utils/transaction-plan-calls'
 import type { TrackedExecutionHandle } from '~/composables/useSafeExecutionDetachment'
 import { formatNumber } from '~/utils/string-utils'
+import { buildBatchReviewCalldata } from '~/utils/batchReviewCalldata'
 
 // Whole-batch review: required approvals, then the operations as rows that roll
 // down to their details, the net wallet changes, a Tenderly simulation link,
@@ -47,8 +48,10 @@ const {
   simulateOnTenderly,
   dismissExecutionError,
   prepareBundledExecution,
-  latchedBundledExecution,
+  isBundledExecutionCurrent,
 } = useTxBatch()
+
+const bundledExecutionRef = shallowRef<PreparedBatchBundledExecution | null>(null)
 
 const { isSpyMode, effectiveAddress } = useEffectiveAddress()
 const { chainId: wagmiChainId } = useWagmi()
@@ -90,14 +93,14 @@ type ReviewWithSteps = StepDecodingContext & {
 const isExternalProtocolMigrationReview = (review: ReviewWithSteps | undefined): boolean =>
   review?.type === 'migration'
 
-const normalizeDisplaySteps = (steps: DisplayStep[] | undefined): DisplayStep[] =>
+const normalizeDisplaySteps = (steps: readonly DisplayStep[] | undefined): DisplayStep[] =>
   (steps ?? []).map((step, idx) => ({ ...step, index: idx + 1 }))
 
-// Bundled styling follows the ceremony latched when this modal opened. Live
+// Bundled styling follows the ceremony owned by this modal. Live
 // Safe detection can resolve later, but it cannot change what this review will
 // execute without a fresh review.
 const isBundledEntry = (entry: typeof entries.value[number]): boolean =>
-  isBundledReviewEntry(latchedBundledExecution.value !== null, !!entry.buildBundledExecution)
+  isBundledReviewEntry(bundledExecutionRef.value !== null, !!entry.buildBundledExecution)
 
 const overrideBundled = (steps: DisplayStep[], entry: typeof entries.value[number]): DisplayStep[] =>
   isBundledEntry(entry)
@@ -105,10 +108,10 @@ const overrideBundled = (steps: DisplayStep[], entry: typeof entries.value[numbe
     : steps
 
 const getEntrySignatureSteps = (entry: typeof entries.value[number]): DisplayStep[] => {
-  // A latched bundled ceremony carries its own rows, derived from the SAME
+  // A bundled ceremony carries its own rows, derived from the SAME
   // authorization resolution the proposal executes — the add-time captures
   // can be stale (authorization state drifts between add and review).
-  const latchedSteps = latchedBundledExecution.value?.stepsByEntryId[entry.id]
+  const latchedSteps = bundledExecutionRef.value?.stepsByEntryId[entry.id]
   if (latchedSteps) return normalizeDisplaySteps(latchedSteps.grantSteps)
   const review = entry.review as unknown as ReviewWithSteps | undefined
   return isExternalProtocolMigrationReview(review)
@@ -117,7 +120,7 @@ const getEntrySignatureSteps = (entry: typeof entries.value[number]): DisplaySte
 }
 
 const getEntryPostSteps = (entry: typeof entries.value[number]): DisplayStep[] => {
-  const latchedSteps = latchedBundledExecution.value?.stepsByEntryId[entry.id]
+  const latchedSteps = bundledExecutionRef.value?.stepsByEntryId[entry.id]
   if (latchedSteps) return normalizeDisplaySteps(latchedSteps.revokeSteps)
   const review = entry.review as unknown as ReviewWithSteps | undefined
   return isExternalProtocolMigrationReview(review)
@@ -369,7 +372,12 @@ const hasPermit2Approval = computed(() =>
 // Mirrors execution eligibility: only claim bundling when the merged plan
 // would actually submit as one Safe bundle.
 const bundlesApprovals = computed(() =>
-  isSafeWallet.value && !!preparedPlanRef.value && isPlanBundleable(preparedPlanRef.value),
+  (bundledExecutionRef.value !== null || isSafeWallet.value)
+  && !!preparedPlanRef.value
+  && isPlanBundleable(preparedPlanRef.value),
+)
+const isReviewCurrent = computed(() =>
+  !bundledExecutionRef.value || isBundledExecutionCurrent(bundledExecutionRef.value),
 )
 
 onMounted(async () => {
@@ -382,8 +390,9 @@ onMounted(async () => {
   try {
     // Resolve the bundled ceremony once for this review session: the same
     // resolution drives the rows, Copy calldata, and execution.
-    await prepareBundledExecution()
-    const prepared = await prepareBatchPlan()
+    const bundledExecution = await prepareBundledExecution()
+    bundledExecutionRef.value = bundledExecution
+    const prepared = bundledExecution?.prepared ?? await prepareBatchPlan()
     preparedPlanRef.value = prepared?.plan
     const known = buildKnownSymbols()
     const out: Array<{ kind: 'approve' | 'permit', symbol: string }> = []
@@ -415,47 +424,23 @@ onUnmounted(() => {
 // batch), matching the per-operation review modals. This requires the prepared
 // plan so approval txs are included.
 const isCalldataCopyDisabled = computed(() =>
-  isPreparing.value || !!prepareError.value || !preparedPlanRef.value?.length,
+  isPreparing.value || !!prepareError.value || !isReviewCurrent.value || !preparedPlanRef.value?.length,
 )
 const copyCalldata = async () => {
-  const plan = preparedPlanRef.value
+  const bundledExecution = bundledExecutionRef.value
+  const plan = bundledExecution?.prepared.plan ?? preparedPlanRef.value
   if (!plan?.length) return
   try {
-    const cid = chainId.value
+    if (bundledExecution && !isBundledExecutionCurrent(bundledExecution)) return
+    const cid = bundledExecution?.chainId ?? chainId.value
     const sdk = await getEulerSdkForChain(cid)
-    const out: { to: string, data: string, value: string }[] = []
-    // The latched Safe proposal wraps the plan with grants/revocations —
-    // the copied JSON must match the actual submission.
-    const latched = latchedBundledExecution.value
-    for (const call of latched?.grants ?? []) {
-      out.push({ to: call.to, data: call.data, value: (call.value ?? 0n).toString() })
-    }
-    for (const item of plan) {
-      if (item.type === 'requiredApproval') {
-        for (const r of item.resolved ?? []) {
-          if (r.type === 'approve') out.push({ to: r.token, data: r.data, value: '0' })
-        }
-        continue
-      }
-      if (item.type === 'evcBatch' && cid) {
-        const items = flattenBatchEntries(item.items)
-        const evc = sdk.deploymentService.getDeployment(cid).addresses.coreAddrs.evc
-        const data = sdk.executionService.encodeBatch(items)
-        const value = items.reduce((sum, it) => sum + it.value, 0n)
-        out.push({ to: evc, data, value: value.toString() })
-        continue
-      }
-      if (item.type === 'contractCall') {
-        out.push({
-          to: item.to,
-          data: encodeFunctionData({ abi: item.abi, functionName: item.functionName, args: item.args }),
-          value: item.value.toString(),
-        })
-      }
-    }
-    for (const call of latched?.revokes ?? []) {
-      out.push({ to: call.to, data: call.data, value: (call.value ?? 0n).toString() })
-    }
+    const out = buildBatchReviewCalldata({
+      plan,
+      before: bundledExecution?.grants,
+      after: bundledExecution?.revokes,
+      sdk,
+      chainId: cid,
+    })
     copyToClipboard(JSON.stringify(out, null, 2), 'calldata')
   }
   catch (error) {
@@ -466,10 +451,11 @@ const copyCalldata = async () => {
 const hasTenderlyFailed = computed(() => Boolean(tenderlyUrl.value && tenderlyError.value))
 
 const isConfirmDisabled = computed(() =>
-  isSpyMode.value || isExecuting.value || hasPendingDetachedExecution.value || isPreparing.value || isSimulating.value || !canExecuteBatch.value || !!prepareError.value,
+  isSpyMode.value || isExecuting.value || hasPendingDetachedExecution.value || isPreparing.value || isSimulating.value || !canExecuteBatch.value || !!prepareError.value || !isReviewCurrent.value,
 )
 const blockedReason = computed(() => {
   if (isSpyMode.value) return 'Connect a wallet to execute — disabled in spy mode'
+  if (!isReviewCurrent.value) return 'Batch or wallet changed — reopen review to continue'
   if (hasFailedOps.value) return 'Resolve the reverting operation to execute'
   if (hasInsufficientBalance.value) return insufficientBalanceMessage.value || 'Not enough balance to execute this batch'
   if (simError.value) return 'This batch would revert — resolve the flagged error'
@@ -487,7 +473,7 @@ const handleExecute = async () => {
   // rejects new submissions while a detached proposal is pending.
   const handle = beginTrackedExecution({ safeAtSubmit: isSafeWallet.value })
   if (!handle) return
-  const run = executeBatch(handle.scope)
+  const run = executeBatch(handle.scope, bundledExecutionRef.value ?? undefined)
   pendingBatchExecution = run
   executionHandle = handle
   try {

--- a/components/BatchReviewModal.vue
+++ b/components/BatchReviewModal.vue
@@ -3,7 +3,7 @@ import { computed, onMounted, onUnmounted, ref, shallowRef } from 'vue'
 import { getAddress } from 'viem'
 import { flattenBatchEntries, getSubAccountId, type TransactionPlan } from '@eulerxyz/euler-v2-sdk'
 import { getEulerSdkForChain } from '~/composables/useEulerSdk'
-import { buildModifiedPositionKeySets, buildRemovedPositionKeySets, filterPositionKeysByOwner, type PreparedBatchBundledExecution, useTxBatch } from '~/composables/useTxBatch'
+import { buildModifiedPositionKeySets, buildRemovedPositionKeySets, filterPositionKeysByOwner, type PreparedBatchExecution, useTxBatch } from '~/composables/useTxBatch'
 import { useTokenSymbolResolver } from '~/composables/useTokenSymbolResolver'
 import { useVaultRegistry } from '~/composables/useVaultRegistry'
 import { getAssetLogoUrl } from '~/composables/useTokenList'
@@ -37,7 +37,6 @@ const {
   hasInsufficientBalance,
   insufficientBalanceMessage,
   executeBatch,
-  prepareBatchPlan,
   entryPlans,
   marketByEntryId,
   tenderlyEnabled,
@@ -47,21 +46,19 @@ const {
   fetchTenderlyEnabled,
   simulateOnTenderly,
   dismissExecutionError,
-  prepareBundledExecution,
-  isBundledExecutionCurrent,
+  prepareBatchExecution,
+  isBatchExecutionCurrent,
 } = useTxBatch()
 
-const bundledExecutionRef = shallowRef<PreparedBatchBundledExecution | null>(null)
+const executionCeremonyRef = shallowRef<PreparedBatchExecution | null>(null)
 
 const { isSpyMode, effectiveAddress } = useEffectiveAddress()
-const { chainId: wagmiChainId } = useWagmi()
 const { isSafeWallet } = useSafeWallet()
-const { chainId: addressesChainId, eulerCoreAddresses } = useEulerAddresses()
+const { eulerCoreAddresses } = useEulerAddresses()
 const { buildKnownSymbols, resolveSymbol } = useTokenSymbolResolver()
 const { getVault, isVerifiedVault } = useVaultRegistry()
 const { copied, copyToClipboard } = useClipboardCopy()
 const owner = computed(() => effectiveAddress.value || '')
-const chainId = computed(() => wagmiChainId.value ?? addressesChainId.value)
 const ownerSubAccountKey = computed(() => {
   try {
     return owner.value ? getAddress(owner.value).toLowerCase() : undefined
@@ -100,7 +97,7 @@ const normalizeDisplaySteps = (steps: readonly DisplayStep[] | undefined): Displ
 // Safe detection can resolve later, but it cannot change what this review will
 // execute without a fresh review.
 const isBundledEntry = (entry: typeof entries.value[number]): boolean =>
-  isBundledReviewEntry(bundledExecutionRef.value !== null, !!entry.buildBundledExecution)
+  isBundledReviewEntry(executionCeremonyRef.value?.mode === 'safe-bundled', !!entry.buildBundledExecution)
 
 const overrideBundled = (steps: DisplayStep[], entry: typeof entries.value[number]): DisplayStep[] =>
   isBundledEntry(entry)
@@ -111,7 +108,7 @@ const getEntrySignatureSteps = (entry: typeof entries.value[number]): DisplaySte
   // A bundled ceremony carries its own rows, derived from the SAME
   // authorization resolution the proposal executes — the add-time captures
   // can be stale (authorization state drifts between add and review).
-  const latchedSteps = bundledExecutionRef.value?.reviewByEntryId[entry.id]
+  const latchedSteps = executionCeremonyRef.value?.reviewByEntryId[entry.id]
   if (latchedSteps) return normalizeDisplaySteps(latchedSteps.grantSteps)
   const review = entry.review as unknown as ReviewWithSteps | undefined
   return isExternalProtocolMigrationReview(review)
@@ -120,7 +117,7 @@ const getEntrySignatureSteps = (entry: typeof entries.value[number]): DisplaySte
 }
 
 const getEntryPostSteps = (entry: typeof entries.value[number]): DisplayStep[] => {
-  const latchedSteps = bundledExecutionRef.value?.reviewByEntryId[entry.id]
+  const latchedSteps = executionCeremonyRef.value?.reviewByEntryId[entry.id]
   if (latchedSteps) return normalizeDisplaySteps(latchedSteps.revokeSteps)
   const review = entry.review as unknown as ReviewWithSteps | undefined
   return isExternalProtocolMigrationReview(review)
@@ -136,7 +133,7 @@ const stepsByEntryId = computed<Record<string, DisplayStep[]>>(() => {
   const out: Record<string, DisplayStep[]> = {}
   for (const entry of entries.value) {
     const plan = getBatchReviewDisplayPlan(
-      bundledExecutionRef.value?.reviewByEntryId[entry.id]?.plan,
+      executionCeremonyRef.value?.reviewByEntryId[entry.id]?.plan,
       (entry.review as unknown as ReviewWithSteps | undefined)?.displayPlan,
       entryPlans.value[entry.id],
     )
@@ -376,12 +373,12 @@ const hasPermit2Approval = computed(() =>
 // Mirrors execution eligibility: only claim bundling when the merged plan
 // would actually submit as one Safe bundle.
 const bundlesApprovals = computed(() =>
-  (bundledExecutionRef.value !== null || isSafeWallet.value)
+  (executionCeremonyRef.value?.safeWallet ?? isSafeWallet.value)
   && !!preparedPlanRef.value
   && isPlanBundleable(preparedPlanRef.value),
 )
 const isReviewCurrent = computed(() =>
-  !bundledExecutionRef.value || isBundledExecutionCurrent(bundledExecutionRef.value),
+  !!executionCeremonyRef.value && isBatchExecutionCurrent(executionCeremonyRef.value),
 )
 
 onMounted(async () => {
@@ -392,11 +389,11 @@ onMounted(async () => {
   isPreparing.value = true
   prepareError.value = ''
   try {
-    // Resolve the bundled ceremony once for this review session: the same
-    // resolution drives the rows, Copy calldata, and execution.
-    const bundledExecution = await prepareBundledExecution()
-    bundledExecutionRef.value = bundledExecution
-    const prepared = bundledExecution?.prepared ?? await prepareBatchPlan()
+    // Resolve one ceremony for this review session. Its exact prepared core,
+    // prerequisite calls, rows, calldata export, and execution stay together.
+    const executionCeremony = await prepareBatchExecution()
+    executionCeremonyRef.value = executionCeremony
+    const prepared = executionCeremony.prepared
     preparedPlanRef.value = prepared?.plan
     const known = buildKnownSymbols()
     const out: Array<{ kind: 'approve' | 'permit', symbol: string }> = []
@@ -431,17 +428,17 @@ const isCalldataCopyDisabled = computed(() =>
   isPreparing.value || !!prepareError.value || !isReviewCurrent.value || !preparedPlanRef.value?.length,
 )
 const copyCalldata = async () => {
-  const bundledExecution = bundledExecutionRef.value
-  const plan = bundledExecution?.prepared.plan ?? preparedPlanRef.value
+  const executionCeremony = executionCeremonyRef.value
+  const plan = executionCeremony?.prepared.plan ?? preparedPlanRef.value
   if (!plan?.length) return
   try {
-    if (bundledExecution && !isBundledExecutionCurrent(bundledExecution)) return
-    const cid = bundledExecution?.chainId ?? chainId.value
+    if (!executionCeremony || !isBatchExecutionCurrent(executionCeremony)) return
+    const cid = executionCeremony.chainId
     const sdk = await getEulerSdkForChain(cid)
     const out = buildBatchReviewCalldata({
       plan,
-      before: bundledExecution?.grants,
-      after: bundledExecution?.revokes,
+      before: executionCeremony.grants,
+      after: executionCeremony.revokes,
       sdk,
       chainId: cid,
     })
@@ -477,7 +474,7 @@ const handleExecute = async () => {
   // rejects new submissions while a detached proposal is pending.
   const handle = beginTrackedExecution({ safeAtSubmit: isSafeWallet.value })
   if (!handle) return
-  const run = executeBatch(handle.scope, bundledExecutionRef.value ?? undefined)
+  const run = executeBatch(handle.scope, executionCeremonyRef.value ?? undefined)
   pendingBatchExecution = run
   executionHandle = handle
   try {

--- a/components/BatchReviewModal.vue
+++ b/components/BatchReviewModal.vue
@@ -97,7 +97,7 @@ const normalizeDisplaySteps = (steps: readonly DisplayStep[] | undefined): Displ
 // Safe detection can resolve later, but it cannot change what this review will
 // execute without a fresh review.
 const isBundledEntry = (entry: typeof entries.value[number]): boolean =>
-  isBundledReviewEntry(executionCeremonyRef.value?.mode === 'safe-bundled', !!entry.buildBundledExecution)
+  isBundledReviewEntry(executionCeremonyRef.value?.mode === 'safe-bundled', entry.bundleExecutionCeremony === true)
 
 const overrideBundled = (steps: DisplayStep[], entry: typeof entries.value[number]): DisplayStep[] =>
   isBundledEntry(entry)
@@ -105,11 +105,9 @@ const overrideBundled = (steps: DisplayStep[], entry: typeof entries.value[numbe
     : steps
 
 const getEntrySignatureSteps = (entry: typeof entries.value[number]): DisplayStep[] => {
-  // A bundled ceremony carries its own rows, derived from the SAME
-  // authorization resolution the proposal executes — the add-time captures
-  // can be stale (authorization state drifts between add and review).
-  const latchedSteps = executionCeremonyRef.value?.reviewByEntryId[entry.id]
-  if (latchedSteps) return normalizeDisplaySteps(latchedSteps.grantSteps)
+  // Ceremony-owned rows and execution calls share one authorization resolution.
+  const ceremonySteps = executionCeremonyRef.value?.reviewByEntryId[entry.id]
+  if (ceremonySteps) return normalizeDisplaySteps(ceremonySteps.grantSteps)
   const review = entry.review as unknown as ReviewWithSteps | undefined
   return isExternalProtocolMigrationReview(review)
     ? overrideBundled(normalizeDisplaySteps(review?.signatureSteps), entry)
@@ -117,8 +115,8 @@ const getEntrySignatureSteps = (entry: typeof entries.value[number]): DisplaySte
 }
 
 const getEntryPostSteps = (entry: typeof entries.value[number]): DisplayStep[] => {
-  const latchedSteps = executionCeremonyRef.value?.reviewByEntryId[entry.id]
-  if (latchedSteps) return normalizeDisplaySteps(latchedSteps.revokeSteps)
+  const ceremonySteps = executionCeremonyRef.value?.reviewByEntryId[entry.id]
+  if (ceremonySteps) return normalizeDisplaySteps(ceremonySteps.revokeSteps)
   const review = entry.review as unknown as ReviewWithSteps | undefined
   return isExternalProtocolMigrationReview(review)
     ? overrideBundled(normalizeDisplaySteps(review?.postSteps), entry)
@@ -228,13 +226,16 @@ const restorationSummaryGroups = computed(() => {
   ]
 })
 
-// Unverified vaults the batch touches — surfaced as a warning. A vault is the
-// target of an op's core action; we read targets off each op's contextual plan
-// and check the registry's verification flag (same source the forms use).
+// Unverified-vault disclosure follows the ceremony plan used by review and
+// execution. The add-time entry plan is only a fallback before preparation.
 const unverifiedVaultNames = computed<string[]>(() => {
   const names = new Set<string>()
   for (const entry of entries.value) {
-    const plan = entryPlans.value[entry.id]
+    const plan = getBatchReviewDisplayPlan(
+      executionCeremonyRef.value?.reviewByEntryId[entry.id]?.plan,
+      (entry.review as unknown as ReviewWithSteps | undefined)?.displayPlan,
+      entryPlans.value[entry.id],
+    )
     if (!plan) continue
     for (const item of plan) {
       if (item.type !== 'evcBatch') continue
@@ -421,9 +422,9 @@ onUnmounted(() => {
   }
 })
 
-// Copy the exact batch calldata (one entry per on-chain tx: approvals + the EVC
-// batch), matching the per-operation review modals. This requires the prepared
-// plan so approval txs are included.
+// Copy the reviewed batch calldata (one entry per on-chain tx: approvals + the
+// EVC batch), matching the per-operation review modals. Signature-mode
+// migrations disclose that their copied authorization bytes are placeholders.
 const isCalldataCopyDisabled = computed(() =>
   isPreparing.value || !!prepareError.value || !isReviewCurrent.value || !preparedPlanRef.value?.length,
 )
@@ -435,6 +436,7 @@ const copyCalldata = async () => {
     if (!executionCeremony || !isBatchExecutionCurrent(executionCeremony)) return
     const cid = executionCeremony.chainId
     const sdk = await getEulerSdkForChain(cid)
+    if (!isBatchExecutionCurrent(executionCeremony)) return
     const out = buildBatchReviewCalldata({
       plan,
       before: executionCeremony.grants,
@@ -442,7 +444,7 @@ const copyCalldata = async () => {
       sdk,
       chainId: cid,
     })
-    copyToClipboard(JSON.stringify(out, null, 2), 'calldata')
+    await copyToClipboard(JSON.stringify(out, null, 2), 'calldata')
   }
   catch (error) {
     logWarn('BatchReviewModal/copyCalldata', error)
@@ -793,6 +795,14 @@ const onCloseRequested = () => {
         size="compact"
         title="Preparation failed"
         :description="prepareError"
+      />
+
+      <UiAlert
+        v-if="executionCeremonyRef?.usesPlaceholderSignatures"
+        variant="info"
+        size="compact"
+        title="Authorization signatures required"
+        description="Copied calldata contains placeholder authorization signatures. Your wallet requests the reviewed signatures only after you confirm the batch."
       />
 
       <!-- Secondary actions: copy calldata + Tenderly -->

--- a/components/BatchReviewModal.vue
+++ b/components/BatchReviewModal.vue
@@ -10,7 +10,7 @@ import { getAssetLogoUrl } from '~/composables/useTokenList'
 import { buildTransactionPlanDisplaySteps, type DisplayStep, type StepDecodingContext } from '~/utils/stepDecoding'
 import { logWarn } from '~/utils/errorHandling'
 import { buildBatchHealthSummary } from '~/utils/batchHealthSummary'
-import { consolidateRestorationSummaryRows, getAuthorizationStepDisplay, getBatchReviewDisplayPlan, groupRestorationSummaryRows, isBundledReviewEntry } from '~/utils/batchReviewDisplay'
+import { getAuthorizationStepDisplay, getBatchReviewDisplayPlan, groupRestorationSummaryRows, isBundledReviewEntry } from '~/utils/batchReviewDisplay'
 import { hasPermit2TokenApproval } from '~/utils/transactionPlanApprovals'
 import { isPlanBundleable } from '~/utils/transaction-plan-calls'
 import type { TrackedExecutionHandle } from '~/composables/useSafeExecutionDetachment'
@@ -18,8 +18,8 @@ import { formatNumber } from '~/utils/string-utils'
 import { buildBatchReviewCalldata } from '~/utils/batchReviewCalldata'
 
 // Whole-batch review: required approvals, then the operations as rows that roll
-// down to their details, the net wallet changes, a Tenderly simulation link,
-// and one atomic Execute. Opened from the "Review batch" button in the drawer
+// down to their details, the net wallet changes, and one atomic Execute. Opened
+// from the "Review batch" button in the drawer
 // (and mobile page). The per-operation detail is the data captured at add-time;
 // execution is delegated to the composable's executeBatch.
 const emit = defineEmits(['close'])
@@ -39,12 +39,6 @@ const {
   executeBatch,
   entryPlans,
   marketByEntryId,
-  tenderlyEnabled,
-  isTenderlySimulating,
-  tenderlyUrl,
-  tenderlyError,
-  fetchTenderlyEnabled,
-  simulateOnTenderly,
   dismissExecutionError,
   prepareBatchExecution,
   isBatchExecutionCurrent,
@@ -203,15 +197,13 @@ const authorizationSummaryGroups = computed(() => {
 //
 // Rows render in EXECUTION order: restorations unwind in reverse entry order
 // (each entry's own steps are already reversed by the encoder). Identical
-// standalone restorations are consolidated because sequential prerequisite
-// resolution sends them once. Bundled Safe restorations are already collected
-// proposal calls, so every call remains visible. Labels are NOT identity: two
-// different aTokens can share a label while representing distinct transactions.
+// standalone and bundled restorations both remain one row per wallet prompt or
+// proposal call. Labels are NOT identity: two different aTokens can share a
+// label while representing distinct transactions.
 const restorationSummaryRows = computed(() => {
-  const rows = [...entries.value].reverse().flatMap(entry =>
+  return [...entries.value].reverse().flatMap(entry =>
     (postStepsByEntryId.value[entry.id] ?? []).map(step => ({ entry, step })),
   )
-  return consolidateRestorationSummaryRows(rows)
 })
 
 const restorationSummaryGroups = computed(() => {
@@ -386,7 +378,6 @@ onMounted(async () => {
   nowTimer = setInterval(() => {
     nowMs.value = Date.now()
   }, 1000)
-  void fetchTenderlyEnabled()
   isPreparing.value = true
   prepareError.value = ''
   try {
@@ -450,8 +441,6 @@ const copyCalldata = async () => {
     logWarn('BatchReviewModal/copyCalldata', error)
   }
 }
-
-const hasTenderlyFailed = computed(() => Boolean(tenderlyUrl.value && tenderlyError.value))
 
 const isConfirmDisabled = computed(() =>
   isSpyMode.value || isExecuting.value || hasPendingDetachedExecution.value || isPreparing.value || isSimulating.value || !canExecuteBatch.value || !!prepareError.value || !isReviewCurrent.value,
@@ -805,7 +794,9 @@ const onCloseRequested = () => {
         description="Copied calldata contains placeholder authorization signatures. Your wallet requests the reviewed signatures only after you confirm the batch."
       />
 
-      <!-- Secondary actions: copy calldata + Tenderly -->
+      <!-- Secondary action: copy the reviewed call vector. Whole-batch
+           third-party simulation is intentionally unavailable because it
+           cannot preserve the complete reviewed wallet ceremony. -->
       <div class="flex items-center justify-center gap-16">
         <button
           type="button"
@@ -820,40 +811,6 @@ const onCloseRequested = () => {
           />
           {{ copied ? 'Copied!' : isPreparing ? 'Preparing calldata…' : 'Copy calldata' }}
         </button>
-        <template v-if="tenderlyEnabled">
-          <a
-            v-if="tenderlyUrl"
-            :href="tenderlyUrl"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="flex items-center gap-6 text-p3 transition-colors"
-            :class="hasTenderlyFailed ? 'text-error-500' : 'text-success-500 hover:text-success-600'"
-          >
-            <SvgIcon
-              :name="hasTenderlyFailed ? 'warning-circle' : 'check-circle'"
-              class="!w-16 !h-16"
-            />
-            {{ hasTenderlyFailed ? 'Simulation reverted — view on Tenderly' : 'View simulation on Tenderly' }}
-            <SvgIcon
-              name="arrow-top-right"
-              class="!w-14 !h-14"
-            />
-          </a>
-          <button
-            v-else
-            type="button"
-            class="flex items-center gap-6 text-p3 text-content-secondary hover:text-content-primary transition-colors disabled:opacity-50"
-            :disabled="isTenderlySimulating"
-            @click="simulateOnTenderly"
-          >
-            <SvgIcon
-              :name="isTenderlySimulating ? 'loading' : 'arrow-top-right'"
-              class="!w-16 !h-16"
-              :class="{ 'animate-spin': isTenderlySimulating }"
-            />
-            {{ isTenderlySimulating ? 'Simulating…' : 'Simulate on Tenderly' }}
-          </button>
-        </template>
       </div>
 
       <div class="flex flex-col items-center gap-8">

--- a/components/PendingSubmissionRecovery.vue
+++ b/components/PendingSubmissionRecovery.vue
@@ -1,0 +1,87 @@
+<script setup lang="ts">
+import { recoverableSubmissionLabel, usePendingSubmissionRecovery } from '~/composables/usePendingSubmissionRecovery'
+
+/**
+ * App-root banner for armed pending-submission records orphaned by a reload
+ * before the wallet answered (direct forms, both migration pages, CoW
+ * orders). They block every send for the wallet/chain and carry no id to
+ * verify on-chain, so the only safe release is the user confirming the
+ * wallet itself shows nothing pending. Mirrors the batch cart's release CTA,
+ * which owns the 'batch' flow.
+ */
+const { entries, releaseError, release } = usePendingSubmissionRecovery()
+</script>
+
+<template>
+  <div
+    v-if="entries.length"
+    class="pending-recovery"
+    data-testid="pending-submission-recovery"
+  >
+    <p class="text-p3">
+      A previous submission was handed to the wallet but no transaction id came
+      back, so it cannot be verified automatically and blocks new transactions
+      from this wallet. If your wallet's pending activity shows nothing
+      pending, you can dismiss it.
+    </p>
+    <div
+      v-for="entry in entries"
+      :key="`${entry.flow}:${entry.chainId}:${entry.owner}`"
+      class="pending-recovery-row"
+    >
+      <span class="text-p3 capitalize">
+        Pending {{ recoverableSubmissionLabel(entry.flow) }} — chain {{ entry.chainId }}
+      </span>
+      <button
+        type="button"
+        class="pending-recovery-release"
+        :data-testid="`release-armed-${entry.flow}`"
+        @click="release(entry)"
+      >
+        My wallet shows nothing pending — dismiss it
+      </button>
+    </div>
+    <p
+      v-if="releaseError"
+      class="text-p3 pending-recovery-error"
+      data-testid="pending-submission-recovery-error"
+    >
+      {{ releaseError }}
+    </p>
+  </div>
+</template>
+
+<style scoped lang="scss">
+.pending-recovery {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px 16px;
+  background-color: var(--bg-surface);
+  color: var(--text-primary);
+  border-bottom: 1px solid var(--border-default);
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.pending-recovery-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.pending-recovery-release {
+  text-decoration: underline;
+  cursor: pointer;
+  white-space: nowrap;
+
+  &:hover {
+    color: var(--text-secondary);
+  }
+}
+
+.pending-recovery-error {
+  color: var(--error-300);
+}
+</style>

--- a/composables/cowswap/useCowSwapExecutionCore.ts
+++ b/composables/cowswap/useCowSwapExecutionCore.ts
@@ -18,6 +18,8 @@ import { invalidateSdkQueries } from '~/utils/sdk-query-cache'
 import { INVALIDATE_AFTER_TX } from '~/utils/sdk-query-policy'
 import { usePortfolioRefresh } from '~/composables/usePortfolioRefresh'
 import { logWarn } from '~/utils/errorHandling'
+import { assertNoConflictingPendingSubmission } from '~/utils/pendingSubmissionGate'
+import type { ReceiptClientLike } from '~/utils/safeWalletTransactions'
 
 /** SDK progress status → lite UI status used by the review modal. */
 const SDK_STATUS_TO_LITE: Record<CowSwapTransactionPlanExecutionStatus, CowSwapExecutionStatus> = {
@@ -120,6 +122,19 @@ export const useCowSwapExecutionCore = () => {
 
     try {
       const sdk = await getEulerSdkFresh()
+      // Cross-surface quarantine: the CoW executor sends approval
+      // transactions and signs the order permit directly through the wallet
+      // callbacks below, without passing any plan-executor gate — an
+      // unresolved value-moving submission from any flow must block it here,
+      // before anything reaches the wallet. CoW execution is EOA-only
+      // (assertTransactionsEnabled rejects Safes), so no Safe provider
+      // lookup is needed to resolve proposal records.
+      await assertNoConflictingPendingSubmission({
+        owner: userAddress,
+        chainId: flow.chainId,
+        provider: sdk.providerService?.getProvider(flow.chainId) as ReceiptClientLike | undefined,
+        getSafeWalletProvider: async () => undefined,
+      })
       const result = await sdk.executionService.executeCowSwapTransactionPlan({
         plan: flow.plan,
         chainId: flow.chainId,
@@ -151,6 +166,9 @@ export const useCowSwapExecutionCore = () => {
     }
   }
 
+  // Deliberately not gated on pending submissions: cancellation strictly
+  // reduces exposure (it invalidates a standing order) and must stay
+  // available while an ambiguous submission is quarantined.
   const cancelOrder = async (): Promise<void> => {
     assertTransactionsEnabled()
     const uid = orderUid.value

--- a/composables/cowswap/useCowSwapExecutionCore.ts
+++ b/composables/cowswap/useCowSwapExecutionCore.ts
@@ -1,7 +1,10 @@
 import { computed, ref } from 'vue'
 import type { Address, Hex } from 'viem'
-import { useSendTransaction, useSignTypedData } from '@wagmi/vue'
+import { useConfig, useSendTransaction, useSignTypedData } from '@wagmi/vue'
+import { getAccount } from '@wagmi/vue/actions'
 import {
+  COWSWAP_ORDER_POLL_INTERVAL_MS,
+  COWSWAP_ORDER_POLL_MAX_DURATION_MS,
   type CowSwapCancellationMode,
   type CowSwapCancellationStatus,
   type CowSwapExecutionStatus,
@@ -11,6 +14,7 @@ import {
   type CowSwapTransactionPlanExecutionStatus,
   cancelCowSwapOrder,
   getCowSwapOrderExplorerUrl,
+  pollCowSwapOrderStatus,
 } from '~/entities/cowswap'
 import type { TransactionPlan } from '@eulerxyz/euler-v2-sdk'
 import { getEulerSdkFresh } from '~/composables/useEulerSdk'
@@ -19,6 +23,16 @@ import { INVALIDATE_AFTER_TX } from '~/utils/sdk-query-policy'
 import { usePortfolioRefresh } from '~/composables/usePortfolioRefresh'
 import { logWarn } from '~/utils/errorHandling'
 import { assertNoConflictingPendingSubmission } from '~/utils/pendingSubmissionGate'
+import {
+  armPendingSubmission,
+  createPendingSubmissionAttemptId,
+  registerActiveSubmissionAttempt,
+  releasePendingSubmission,
+  unregisterActiveSubmissionAttempt,
+  upgradePendingSubmissionToSubmitted,
+  walletNeverAcceptedSubmission,
+} from '~/utils/pendingSubmissions'
+import { WALLET_CHANGED_SINCE_REVIEW_ERROR, assertWalletExecutionContext } from '~/utils/walletExecutionContext'
 import type { ReceiptClientLike } from '~/utils/safeWalletTransactions'
 
 /** SDK progress status → lite UI status used by the review modal. */
@@ -43,8 +57,12 @@ export type CowSwapPlanFlow = {
   settlementContract?: Address
 }
 
+const connectorKeyOf = (connector: { id: string, uid: string } | undefined): string | undefined =>
+  connector ? `${connector.id}:${connector.uid}` : undefined
+
 export const useCowSwapExecutionCore = () => {
   const { address } = useWagmi()
+  const config = useConfig()
   const { signTypedDataAsync } = useSignTypedData()
   const { sendTransactionAsync } = useSendTransaction()
   const { isSpyMode } = useSpyMode()
@@ -54,6 +72,7 @@ export const useCowSwapExecutionCore = () => {
   const status = ref<CowSwapExecutionStatus>('idle')
   const orderUid = ref<CowSwapOrderUid | undefined>()
   const submissionChainId = ref<number | undefined>()
+  const submissionOwner = ref<Address | undefined>()
   const error = ref<Error | null>(null)
   const locallyCancelled = ref(false)
   const cancellationStatus = ref<CowSwapCancellationStatus>('none')
@@ -85,12 +104,74 @@ export const useCowSwapExecutionCore = () => {
     return userAddress as Address
   }
 
-  const sendTransaction = ({ to, data, value }: { to: Address, data: Hex, value?: bigint }) =>
-    sendTransactionAsync({ to, data, value: value ?? 0n })
-
-  const signTypedData = async (typedData: { domain: Record<string, unknown>, types: Record<string, unknown>, primaryType: string, message: Record<string, unknown> }) => {
-    const sig = await signTypedDataAsync(typedData as unknown as Parameters<typeof signTypedDataAsync>[0])
-    return sig as Hex
+  /**
+   * Pin every wallet callback handed to the SDK to the context captured at
+   * ceremony entry: account, chain, and the connector itself. The SDK awaits
+   * between callbacks (approval receipts, inbox preparation, orderbook
+   * calls), and a wallet switched during those awaits — including a
+   * same-address connector switch, which account/chain checks cannot see —
+   * must not receive the next approval or signature request. Each request is
+   * also dispatched with the pinned account/chain/connector explicitly, so
+   * wagmi cannot silently route it to whatever is current.
+   */
+  const createPinnedWalletCallbacks = (
+    expected: { owner: Address, chainId: number },
+    hooks?: { onSignatureOutcome?: (artifactPossible: boolean) => void },
+  ) => {
+    const entry = getAccount(config)
+    const pinnedConnector = entry.connector
+    const pinnedConnectorKey = connectorKeyOf(pinnedConnector)
+    assertWalletExecutionContext({
+      expectedAccount: expected.owner,
+      expectedChainId: expected.chainId,
+      currentAccount: entry.address,
+      currentChainId: entry.chainId,
+    })
+    if (!pinnedConnector || !pinnedConnectorKey) {
+      throw new Error(WALLET_CHANGED_SINCE_REVIEW_ERROR)
+    }
+    const assertPinnedContext = () => {
+      const current = getAccount(config)
+      assertWalletExecutionContext({
+        expectedAccount: expected.owner,
+        expectedChainId: expected.chainId,
+        currentAccount: current.address,
+        currentChainId: current.chainId,
+      })
+      if (connectorKeyOf(current.connector) !== pinnedConnectorKey) {
+        throw new Error(WALLET_CHANGED_SINCE_REVIEW_ERROR)
+      }
+    }
+    const sendTransaction = ({ to, data, value }: { to: Address, data: Hex, value?: bigint }) => {
+      assertPinnedContext()
+      return sendTransactionAsync({
+        account: expected.owner,
+        chainId: expected.chainId,
+        connector: pinnedConnector,
+        to,
+        data,
+        value: value ?? 0n,
+      })
+    }
+    const signTypedData = async (typedData: { domain: Record<string, unknown>, types: Record<string, unknown>, primaryType: string, message: Record<string, unknown> }) => {
+      assertPinnedContext()
+      try {
+        const sig = await signTypedDataAsync({
+          ...typedData,
+          account: expected.owner,
+          connector: pinnedConnector,
+        } as unknown as Parameters<typeof signTypedDataAsync>[0])
+        hooks?.onSignatureOutcome?.(true)
+        return sig as Hex
+      }
+      catch (err) {
+        // A proven wallet-side rejection means no signature exists; anything
+        // else (dropped connection, timeout) leaves one possible.
+        hooks?.onSignatureOutcome?.(!walletNeverAcceptedSubmission(err))
+        throw err
+      }
+    }
+    return { sendTransaction, signTypedData }
   }
 
   const onProgress = (progress: CowSwapTransactionPlanExecutionProgress) => {
@@ -104,9 +185,50 @@ export const useCowSwapExecutionCore = () => {
   }
 
   /**
+   * Background watcher for a submitted order's quarantine record: once the
+   * orderbook reports the order terminal (traded, fulfilled, cancelled, or
+   * expired) the record has nothing ambiguous left to guard and is released.
+   * If this session never observes a terminal state, the record stays and the
+   * pending-submission gate resolves it objectively on the next attempt.
+   */
+  const releaseWhenOrderTerminal = (
+    attempt: { owner: Address, chainId: number, attemptId: string },
+    uid: CowSwapOrderUid,
+    orderbookUrl?: string,
+  ) => {
+    void (async () => {
+      try {
+        const terminal = await pollCowSwapOrderStatus({
+          orderUid: uid,
+          chainId: attempt.chainId,
+          orderbookUrl,
+          intervalMs: COWSWAP_ORDER_POLL_INTERVAL_MS,
+          timeoutMs: COWSWAP_ORDER_POLL_MAX_DURATION_MS,
+        })
+        if (terminal.terminal) {
+          await releasePendingSubmission('cow-order', attempt.owner, attempt.chainId, { attemptId: attempt.attemptId })
+        }
+      }
+      catch (err) {
+        logWarn('cowswap/quarantine-release', err)
+      }
+    })()
+  }
+
+  /**
    * Drive `executeCowSwapTransactionPlan` and surface progress through `status` / `orderUid`.
    * Captures any `permitCancellation` from the plan items so a later EVC-permit hard cancel
    * is available.
+   *
+   * The whole ceremony runs under an owned quarantine attempt: replay
+   * protection is armed before the first approval/signature boundary, the
+   * record is upgraded with the order uid the moment one is known, and an
+   * ambiguous outcome (a completed or ambiguous signature, or an orderbook
+   * submission whose response was lost) keeps the record so no second live
+   * order can be created against it. Only a failure that provably left no
+   * order artifact — no signature completed, submission never started —
+   * releases the reservation, because the approval transactions that may have
+   * preceded it are idempotent.
    */
   const executePlan = async (flow: CowSwapPlanFlow): Promise<CowSwapOrderUid> => {
     const userAddress = requireWallet()
@@ -114,14 +236,44 @@ export const useCowSwapExecutionCore = () => {
     locallyCancelled.value = false
     cancellationStatus.value = 'none'
     submissionChainId.value = flow.chainId
+    submissionOwner.value = userAddress
     cancelMode.value = flow.cancellationMode
     permitCancellation.value = undefined
     cowApiCancellation.value = flow.cancellationMode === 'cow-api'
       ? { chainId: flow.chainId, orderbookUrl: flow.orderbookUrl, settlementContract: flow.settlementContract }
       : undefined
 
+    const attempt = { owner: userAddress, chainId: flow.chainId, attemptId: createPendingSubmissionAttemptId() }
+    registerActiveSubmissionAttempt(attempt.attemptId)
+    let armed = false
+    let signatureArtifactPossible = false
+    let submissionStarted = false
+    let upgradePromise: ReturnType<typeof upgradePendingSubmissionToSubmitted> | undefined
+
+    const noteOrderUid = (uid: CowSwapOrderUid) => {
+      if (upgradePromise) return
+      submissionStarted = true
+      upgradePromise = upgradePendingSubmissionToSubmitted('cow-order', {
+        owner: attempt.owner,
+        chainId: attempt.chainId,
+        attemptId: attempt.attemptId,
+        kind: 'cow-order',
+        orderUid: uid,
+        orderbookUrl: flow.orderbookUrl,
+        completesPlan: true,
+      })
+      // Awaited explicitly on both the success and failure paths below; this
+      // only stops an earlier SDK throw from turning it into an unhandled
+      // rejection in the meantime.
+      upgradePromise.catch(() => undefined)
+    }
+
     try {
       const sdk = await getEulerSdkFresh()
+      const { sendTransaction, signTypedData } = createPinnedWalletCallbacks(
+        { owner: userAddress, chainId: flow.chainId },
+        { onSignatureOutcome: (artifactPossible) => { signatureArtifactPossible ||= artifactPossible } },
+      )
       // Cross-surface quarantine: the CoW executor sends approval
       // transactions and signs the order permit directly through the wallet
       // callbacks below, without passing any plan-executor gate — an
@@ -135,13 +287,27 @@ export const useCowSwapExecutionCore = () => {
         provider: sdk.providerService?.getProvider(flow.chainId) as ReceiptClientLike | undefined,
         getSafeWalletProvider: async () => undefined,
       })
+      // Atomic check+reserve before the first wallet boundary: an accepted
+      // orderbook submission whose response is lost must leave a durable
+      // record, or a retry would create a second live order.
+      await armPendingSubmission('cow-order', {
+        owner: userAddress,
+        chainId: flow.chainId,
+        completesPlan: true,
+        attemptId: attempt.attemptId,
+      })
+      armed = true
       const result = await sdk.executionService.executeCowSwapTransactionPlan({
         plan: flow.plan,
         chainId: flow.chainId,
         account: userAddress,
         sendTransaction,
         signTypedData,
-        onProgress,
+        onProgress: (progress) => {
+          if (progress.status === 'submitOrder') submissionStarted = true
+          if (progress.orderUid) noteOrderUid(progress.orderUid)
+          onProgress(progress)
+        },
       })
 
       for (const r of result.results) {
@@ -153,22 +319,53 @@ export const useCowSwapExecutionCore = () => {
       const uid = result.orderUids[0]
       if (!uid) throw new Error('CoW order UID missing from execution result')
 
+      noteOrderUid(uid)
+      // Throws when the order uid could not be durably recorded — the order
+      // is live, so that failure must surface instead of reading as success.
+      await upgradePromise
+
       orderUid.value = uid
       status.value = 'submitted'
+      releaseWhenOrderTerminal(attempt, uid, flow.orderbookUrl)
       return uid
     }
     catch (err) {
       const wrapped = err instanceof Error ? err : new Error(String(err))
+      if (upgradePromise) {
+        try {
+          await upgradePromise
+        }
+        catch (upgradeErr) {
+          logWarn('cowswap/quarantine', upgradeErr)
+        }
+      }
+      if (armed && !submissionStarted && !signatureArtifactPossible) {
+        // Provably no order artifact exists: no permit/order signature was
+        // produced and the orderbook was never contacted. Any approval
+        // transactions already sent are idempotent, so the reservation can be
+        // released. Every other failure keeps the record quarantined.
+        try {
+          await releasePendingSubmission('cow-order', attempt.owner, attempt.chainId, { attemptId: attempt.attemptId })
+        }
+        catch (releaseErr) {
+          logWarn('cowswap/quarantine', releaseErr)
+        }
+      }
       error.value = wrapped
       status.value = 'idle'
       logWarn('cowswap/execute', wrapped)
       throw wrapped
     }
+    finally {
+      unregisterActiveSubmissionAttempt(attempt.attemptId)
+    }
   }
 
   // Deliberately not gated on pending submissions: cancellation strictly
   // reduces exposure (it invalidates a standing order) and must stay
-  // available while an ambiguous submission is quarantined.
+  // available while an ambiguous submission is quarantined. Its wallet
+  // callbacks are still pinned to the submitting owner's context — a
+  // cancellation signed by a switched wallet would be invalid anyway.
   const cancelOrder = async (): Promise<void> => {
     assertTransactionsEnabled()
     const uid = orderUid.value
@@ -182,14 +379,18 @@ export const useCowSwapExecutionCore = () => {
 
     try {
       if (cancelMode.value === 'cow-api') {
-        const config = cowApiCancellation.value
-        if (!config) throw new Error('CoW API cancellation data not available')
+        const apiCancellation = cowApiCancellation.value
+        if (!apiCancellation) throw new Error('CoW API cancellation data not available')
 
+        const { signTypedData } = createPinnedWalletCallbacks({
+          owner: submissionOwner.value ?? requireWallet(),
+          chainId: apiCancellation.chainId,
+        })
         await cancelCowSwapOrder({
           orderUid: uid,
-          chainId: config.chainId,
-          orderbookUrl: config.orderbookUrl,
-          settlementContract: config.settlementContract,
+          chainId: apiCancellation.chainId,
+          orderbookUrl: apiCancellation.orderbookUrl,
+          settlementContract: apiCancellation.settlementContract,
           signTypedData,
         })
         cancellationStatus.value = 'soft_submitted'
@@ -207,10 +408,15 @@ export const useCowSwapExecutionCore = () => {
           wrapperAddress: permit.wrapperAddress,
         })
 
+        const account = requireWallet()
+        const { sendTransaction, signTypedData } = createPinnedWalletCallbacks({
+          owner: account,
+          chainId: permit.chainId,
+        })
         await sdk.executionService.executeCowSwapTransactionPlan({
           plan: cancelPlan,
           chainId: permit.chainId,
-          account: requireWallet(),
+          account,
           sendTransaction,
           signTypedData,
           onProgress,
@@ -239,6 +445,7 @@ export const useCowSwapExecutionCore = () => {
     status.value = 'idle'
     orderUid.value = undefined
     submissionChainId.value = undefined
+    submissionOwner.value = undefined
     error.value = null
     locallyCancelled.value = false
     cancellationStatus.value = 'none'

--- a/composables/useEulerTx.ts
+++ b/composables/useEulerTx.ts
@@ -1005,6 +1005,7 @@ export const useEulerTx = () => {
 
   const signMigrationAuthorization = async (
     request: MigrationAuthorizationRequest,
+    options?: { beforeSignature?: () => void },
   ): Promise<SignedMigrationAuthorization> => {
     if (isSpyMode.value) {
       throw new Error('Authorization signatures are disabled in spy mode')
@@ -1019,9 +1020,10 @@ export const useEulerTx = () => {
       currentAccount: currentAccount.address,
       currentChainId: currentAccount.chainId,
     })
+    options?.beforeSignature?.()
     const signature = await signTypedDataAsync(request.typedData as unknown as Parameters<typeof signTypedDataAsync>[0])
     const postMigrationAuthorization = request.postMigrationAuthorization
-      ? await signMigrationAuthorization(request.postMigrationAuthorization)
+      ? await signMigrationAuthorization(request.postMigrationAuthorization, options)
       : undefined
     return {
       request,
@@ -1208,6 +1210,7 @@ export const useEulerTx = () => {
     expectedChainId,
     connector,
     resolveHash,
+    beforeBroadcast,
   }: {
     isOkx: boolean
     expectedAccount: Address
@@ -1220,6 +1223,8 @@ export const useEulerTx = () => {
      */
     connector?: ReturnType<typeof getAccount>['connector']
     resolveHash?: (hash: Hash) => Promise<Hash>
+    /** Final caller-owned freshness check at the wallet submission boundary. */
+    beforeBroadcast?: () => void
   }) => {
     let okxDelayPending = false
     const send = async ({ to, data, value }: { to: Address, data: Hex, value?: bigint }) => {
@@ -1234,6 +1239,7 @@ export const useEulerTx = () => {
         currentAccount: currentAccount.address,
         currentChainId: currentAccount.chainId,
       })
+      beforeBroadcast?.()
       const hash = await sendTransactionAsync({
         account: expectedAccount,
         chainId: expectedChainId,
@@ -1264,6 +1270,7 @@ export const useEulerTx = () => {
     options?: {
       onBroadcast?: (index: number, walletContext: WalletExecutionContext) => void
       walletContext?: WalletExecutionContext
+      beforeBroadcast?: () => void
     },
   ): Promise<TransactionReceipt[]> => {
     if (isSpyMode.value) {
@@ -1293,6 +1300,7 @@ export const useEulerTx = () => {
       expectedAccount: owner,
       expectedChainId: cid,
       connector,
+      beforeBroadcast: options?.beforeBroadcast,
     })
 
     const receipts: TransactionReceipt[] = []
@@ -1421,7 +1429,7 @@ export const useEulerTx = () => {
    * bundling brings no benefit (fewer than two calls) — callers fall back to
    * sequential execution.
    */
-  const executePlanAsSafeBundle = async ({ plan, chainId, owner, provider, connector, safeWalletProvider, sdk, extraCalls, allowSingleCall }: {
+  const executePlanAsSafeBundle = async ({ plan, chainId, owner, provider, connector, safeWalletProvider, sdk, extraCalls, allowSingleCall, beforeBroadcast }: {
     plan: TransactionPlan
     chainId: number
     owner: Address
@@ -1440,6 +1448,8 @@ export const useEulerTx = () => {
      * "no Safe context" — with it set, undefined strictly means the latter.
      */
     allowSingleCall?: boolean
+    /** Final caller-owned freshness check at the Safe submission boundary. */
+    beforeBroadcast?: () => void
   }) => {
     let planCalls
     try {
@@ -1474,6 +1484,7 @@ export const useEulerTx = () => {
       currentAccount: currentAccount.address,
       currentChainId: currentAccount.chainId,
     })
+    beforeBroadcast?.()
 
     // Pin submission to the connector whose provider was identified as Safe.
     // Without it, wagmi resolves the currently-active connector, and a
@@ -1587,7 +1598,10 @@ export const useEulerTx = () => {
     return result
   }
 
-  const executePreparedPlan = async (prepared: TransactionPlanPrepared) => {
+  const executePreparedPlan = async (
+    prepared: TransactionPlanPrepared,
+    options?: { beforeBroadcast?: () => void },
+  ) => {
     if (isSpyMode.value) {
       throw new Error('Transactions are disabled in spy mode')
     }
@@ -1641,6 +1655,7 @@ export const useEulerTx = () => {
         connector,
         safeWalletProvider,
         sdk,
+        beforeBroadcast: options?.beforeBroadcast,
       })
       if (bundled) {
         finalizeExecution(bundled)
@@ -1653,6 +1668,7 @@ export const useEulerTx = () => {
       expectedAccount: preparedOwner,
       expectedChainId: prepared.chainId,
       connector,
+      beforeBroadcast: options?.beforeBroadcast,
       resolveHash: safeWalletProvider
         ? async submittedHash => (await waitForSafeTransactionExecution({
           submittedHash,
@@ -1666,6 +1682,7 @@ export const useEulerTx = () => {
       prepared: effectivePrepared,
       sendTransaction,
       signTypedData: async (typedData) => {
+        options?.beforeBroadcast?.()
         const signature = await signTypedDataAsync(typedData as unknown as Parameters<typeof signTypedDataAsync>[0])
         return signature as Hex
       },
@@ -1694,7 +1711,7 @@ export const useEulerTx = () => {
       before?: readonly PlainTxRequest[]
       after?: readonly PlainTxRequest[]
     },
-    options?: { allowSingleCall?: boolean },
+    options?: { allowSingleCall?: boolean, beforeBroadcast?: () => void },
   ) => {
     if (isSpyMode.value) {
       throw new Error('Transactions are disabled in spy mode')
@@ -1738,6 +1755,7 @@ export const useEulerTx = () => {
       sdk,
       extraCalls,
       allowSingleCall: options?.allowSingleCall,
+      beforeBroadcast: options?.beforeBroadcast,
     })
     if (!bundled) return undefined
     finalizeExecution(bundled)

--- a/composables/useEulerTx.ts
+++ b/composables/useEulerTx.ts
@@ -70,10 +70,10 @@ import {
   assertWalletExecutionContext,
   type WalletExecutionContext,
 } from '~/utils/walletExecutionContext'
+import { PLACEHOLDER_MIGRATION_AUTHORIZATION_SIGNATURE } from '~/utils/migrationAuthorizationSignatures'
 
 const OKX_POST_APPROVE_DELAY_MS = 3000
 const ERC20_APPROVE_SELECTOR = '0x095ea7b3'
-const PLACEHOLDER_AUTHORIZATION_SIGNATURE = `0x${'00'.repeat(65)}` as Hex
 const SUB_ACCOUNT_SNAPSHOT_FETCH_OPTIONS = {
   populateVaults: false,
   populateMarketPrices: false,
@@ -1041,7 +1041,7 @@ export const useEulerTx = () => {
 
     return {
       request,
-      signature: PLACEHOLDER_AUTHORIZATION_SIGNATURE,
+      signature: PLACEHOLDER_MIGRATION_AUTHORIZATION_SIGNATURE,
       ...(postMigrationAuthorization ? { postMigrationAuthorization } : {}),
     }
   }

--- a/composables/useEulerTx.ts
+++ b/composables/useEulerTx.ts
@@ -99,6 +99,16 @@ const isOkxWallet = async (connector?: { id?: string, name?: string, getProvider
   return false
 }
 
+/**
+ * A plan submission the wallet has accepted but whose confirmation is still
+ * pending: an on-chain transaction hash for standard wallets, or a safeTxHash
+ * proposal id for Safes (resolvable only through the Safe wallet provider).
+ */
+export interface PreparedPlanBroadcast {
+  kind: 'transaction' | 'proposal'
+  hash: Hash
+}
+
 export interface PlanDepositInput {
   vaultAddress: Address
   assetAddress: Address
@@ -1217,6 +1227,7 @@ export const useEulerTx = () => {
     connector,
     resolveHash,
     beforeBroadcast,
+    onBroadcast,
   }: {
     isOkx: boolean
     expectedAccount: Address
@@ -1231,6 +1242,13 @@ export const useEulerTx = () => {
     resolveHash?: (hash: Hash) => Promise<Hash>
     /** Final caller-owned freshness check at the wallet submission boundary. */
     beforeBroadcast?: () => void
+    /**
+     * Fires as soon as the wallet accepted the submission, before any
+     * confirmation wait — from here on the transaction may land even if
+     * everything after this point fails, so callers use it to stop treating
+     * a later error as "never sent".
+     */
+    onBroadcast?: (hash: Hash) => void
   }) => {
     let okxDelayPending = false
     const send = async ({ to, data, value }: { to: Address, data: Hex, value?: bigint }) => {
@@ -1258,6 +1276,7 @@ export const useEulerTx = () => {
         okxDelayPending = true
       }
       const submittedHash = hash as Hash
+      onBroadcast?.(submittedHash)
       return resolveHash ? resolveHash(submittedHash) : submittedHash
     }
     return send
@@ -1354,12 +1373,14 @@ export const useEulerTx = () => {
   const executeMigrationAuthorizationGrants = async (
     request: MigrationAuthorizationRequest,
     broadcastRevokes: MigrationAuthorizationRevoke[] = [],
+    options?: { beforeBroadcast?: () => void },
   ): Promise<MigrationAuthorizationRevoke[]> => {
     const { grants, revokesByGrant } = encodeMigrationAuthorizationTxs(request)
     await sendPlainTransactions(grants, {
       // The request was prepared for this exact owner/network. Do not let a
       // wallet switch during the preceding SDK reads retarget the grant.
       walletContext: { account: request.owner, chainId: request.chainId },
+      beforeBroadcast: options?.beforeBroadcast,
       onBroadcast: (index, walletContext) => {
         const revoke = revokesByGrant[index]
         if (revoke) {
@@ -1435,7 +1456,7 @@ export const useEulerTx = () => {
    * bundling brings no benefit (fewer than two calls) — callers fall back to
    * sequential execution.
    */
-  const executePlanAsSafeBundle = async ({ plan, chainId, owner, provider, connector, safeWalletProvider, sdk, extraCalls, allowSingleCall, beforeBroadcast }: {
+  const executePlanAsSafeBundle = async ({ plan, chainId, owner, provider, connector, safeWalletProvider, sdk, extraCalls, allowSingleCall, beforeBroadcast, onBroadcast }: {
     plan: TransactionPlan
     chainId: number
     owner: Address
@@ -1456,6 +1477,13 @@ export const useEulerTx = () => {
     allowSingleCall?: boolean
     /** Final caller-owned freshness check at the Safe submission boundary. */
     beforeBroadcast?: () => void
+    /**
+     * Fires once the Safe accepted the proposal (safeTxHash exists), before
+     * the execution wait — from here on the proposal may execute even if
+     * status polling fails, so callers use it to stop treating a later error
+     * as "never submitted".
+     */
+    onBroadcast?: (safeTxHash: Hash) => void
   }) => {
     let planCalls
     try {
@@ -1508,6 +1536,7 @@ export const useEulerTx = () => {
     if (!/^0x[0-9a-f]{64}$/i.test(id)) {
       throw new Error('Safe wallet returned an unexpected call bundle id')
     }
+    onBroadcast?.(id as Hash)
 
     const execution = await waitForSafeTransactionExecution({
       submittedHash: id as Hash,
@@ -1606,7 +1635,17 @@ export const useEulerTx = () => {
 
   const executePreparedPlan = async (
     prepared: TransactionPlanPrepared,
-    options?: { beforeBroadcast?: () => void },
+    options?: {
+      beforeBroadcast?: () => void
+      /**
+       * Fires as soon as the wallet accepted a plan submission (a transaction
+       * hash for standard wallets, a safeTxHash proposal id for Safes),
+       * before any confirmation wait. From that point the submission may land
+       * even when a later step throws, so callers use it to distinguish
+       * "never sent" from "sent but unconfirmed".
+       */
+      onBroadcast?: (broadcast: PreparedPlanBroadcast) => void
+    },
   ) => {
     if (isSpyMode.value) {
       throw new Error('Transactions are disabled in spy mode')
@@ -1662,6 +1701,7 @@ export const useEulerTx = () => {
         safeWalletProvider,
         sdk,
         beforeBroadcast: options?.beforeBroadcast,
+        onBroadcast: hash => options?.onBroadcast?.({ kind: 'proposal', hash }),
       })
       if (bundled) {
         finalizeExecution(bundled)
@@ -1675,6 +1715,12 @@ export const useEulerTx = () => {
       expectedChainId: prepared.chainId,
       connector,
       beforeBroadcast: options?.beforeBroadcast,
+      // A Safe's sequential fallback submits through the Safe app, so the
+      // wallet returns a safeTxHash proposal id, not an on-chain hash.
+      onBroadcast: hash => options?.onBroadcast?.({
+        kind: safeWalletProvider ? 'proposal' : 'transaction',
+        hash,
+      }),
       resolveHash: safeWalletProvider
         ? async submittedHash => (await waitForSafeTransactionExecution({
           submittedHash,
@@ -1717,7 +1763,12 @@ export const useEulerTx = () => {
       before?: readonly PlainTxRequest[]
       after?: readonly PlainTxRequest[]
     },
-    options?: { allowSingleCall?: boolean, beforeBroadcast?: () => void },
+    options?: {
+      allowSingleCall?: boolean
+      beforeBroadcast?: () => void
+      /** See executePreparedPlan — fires with the safeTxHash proposal id. */
+      onBroadcast?: (broadcast: PreparedPlanBroadcast) => void
+    },
   ) => {
     if (isSpyMode.value) {
       throw new Error('Transactions are disabled in spy mode')
@@ -1762,6 +1813,7 @@ export const useEulerTx = () => {
       extraCalls,
       allowSingleCall: options?.allowSingleCall,
       beforeBroadcast: options?.beforeBroadcast,
+      onBroadcast: hash => options?.onBroadcast?.({ kind: 'proposal', hash }),
     })
     if (!bundled) return undefined
     finalizeExecution(bundled)

--- a/composables/useEulerTx.ts
+++ b/composables/useEulerTx.ts
@@ -100,13 +100,29 @@ const isOkxWallet = async (connector?: { id?: string, name?: string, getProvider
 }
 
 /**
- * A plan submission the wallet has accepted but whose confirmation is still
- * pending: an on-chain transaction hash for standard wallets, or a safeTxHash
- * proposal id for Safes (resolvable only through the Safe wallet provider).
+ * A plan submission the wallet has accepted: an on-chain transaction hash for
+ * standard wallets, or a safeTxHash proposal id for Safes (resolvable only
+ * through the Safe wallet provider).
+ *
+ * The executor waits for each submission's receipt before sending the next,
+ * so it re-fires the same broadcast with status 'confirmed' once the receipt
+ * succeeded — at any failure, at most the single latest 'submitted' broadcast
+ * without a matching 'confirmed' has an unknown outcome.
  */
 export interface PreparedPlanBroadcast {
   kind: 'transaction' | 'proposal'
   hash: Hash
+  /**
+   * Which plan step produced the submission. 'bundle' (one Safe proposal for
+   * the whole plan) and 'evcBatch' move value; 'approval' and 'pluginCall'
+   * (TOS/oracle prerequisites) are idempotent and safe to re-run.
+   */
+  item: 'bundle' | 'evcBatch' | 'approval' | 'pluginCall'
+  /** Zero-based position in this attempt's send order. */
+  index: number
+  /** True when no value-moving submission follows this one in the plan. */
+  completesPlan: boolean
+  status: 'submitted' | 'confirmed'
 }
 
 export interface PlanDepositInput {
@@ -1031,7 +1047,14 @@ export const useEulerTx = () => {
       currentChainId: currentAccount.chainId,
     })
     options?.beforeSignature?.()
-    const signature = await signTypedDataAsync(request.typedData as unknown as Parameters<typeof signTypedDataAsync>[0])
+    // Pin the signature request to the connector that just passed the wallet
+    // context check. Without it wagmi resolves the currently-active connector
+    // at request time, so a connector switched during the check-to-sign gap
+    // would receive the request despite never being validated.
+    const signature = await signTypedDataAsync({
+      ...(request.typedData as unknown as Parameters<typeof signTypedDataAsync>[0]),
+      ...(currentAccount.connector ? { connector: currentAccount.connector } : {}),
+    })
     const postMigrationAuthorization = request.postMigrationAuthorization
       ? await signMigrationAuthorization(request.postMigrationAuthorization, options)
       : undefined
@@ -1623,7 +1646,12 @@ export const useEulerTx = () => {
       usePermit2: isKnownSafe ? false : signaturesEnabled.value,
       sendTransaction,
       signTypedData: async (typedData) => {
-        const signature = await signTypedDataAsync(typedData as unknown as Parameters<typeof signTypedDataAsync>[0])
+        // Same pinning as sendTransaction: sign through the captured
+        // connector, never the currently-active one.
+        const signature = await signTypedDataAsync({
+          ...(typedData as unknown as Parameters<typeof signTypedDataAsync>[0]),
+          ...(connector ? { connector } : {}),
+        })
         return signature as Hex
       },
       onProgress: (_progress: TransactionPlanExecutionProgress) => {},
@@ -1692,6 +1720,7 @@ export const useEulerTx = () => {
 
     if (safeWalletProvider && connector) {
       // Prepared plans already ran plugins and approval resolution.
+      let bundleBroadcast: PreparedPlanBroadcast | undefined
       const bundled = await executePlanAsSafeBundle({
         plan: effectivePrepared.plan,
         chainId: prepared.chainId,
@@ -1701,13 +1730,40 @@ export const useEulerTx = () => {
         safeWalletProvider,
         sdk,
         beforeBroadcast: options?.beforeBroadcast,
-        onBroadcast: hash => options?.onBroadcast?.({ kind: 'proposal', hash }),
+        onBroadcast: (hash) => {
+          bundleBroadcast = {
+            kind: 'proposal',
+            hash,
+            item: 'bundle',
+            index: 0,
+            completesPlan: true,
+            status: 'submitted',
+          }
+          options?.onBroadcast?.(bundleBroadcast)
+        },
       })
       if (bundled) {
+        // A truthy bundle result means the proposal executed with a
+        // successful receipt — the submission's outcome is no longer unknown.
+        if (bundleBroadcast) {
+          options?.onBroadcast?.({ ...bundleBroadcast, status: 'confirmed' })
+        }
         finalizeExecution(bundled)
         return bundled
       }
     }
+
+    // Ordered execution tracking for the sequential path. The executor emits
+    // a pre-send progress event (no hash) naming the item about to be sent,
+    // then waits for the receipt and re-emits with the confirmed hash — so
+    // the item announced by the latest pre-send event classifies the next
+    // wallet submission, and a hash-bearing event confirms it.
+    const planItems = effectivePrepared.plan
+    const lastValueMovingItem = [...planItems].reverse().find(item =>
+      item.type !== 'requiredApproval' && item.type !== 'cowSwap')
+    let pendingSend: { item: PreparedPlanBroadcast['item'], completesPlan: boolean } | undefined
+    let lastSubmitted: PreparedPlanBroadcast | undefined
+    let sendIndex = 0
 
     const sendTransaction = buildSendTransaction({
       isOkx,
@@ -1717,10 +1773,19 @@ export const useEulerTx = () => {
       beforeBroadcast: options?.beforeBroadcast,
       // A Safe's sequential fallback submits through the Safe app, so the
       // wallet returns a safeTxHash proposal id, not an on-chain hash.
-      onBroadcast: hash => options?.onBroadcast?.({
-        kind: safeWalletProvider ? 'proposal' : 'transaction',
-        hash,
-      }),
+      onBroadcast: (hash) => {
+        lastSubmitted = {
+          kind: safeWalletProvider ? 'proposal' : 'transaction',
+          hash,
+          // Fail toward the strict classification: an unattributed send is
+          // treated as the value-moving batch, never as a re-runnable step.
+          item: pendingSend?.item ?? 'evcBatch',
+          index: sendIndex++,
+          completesPlan: pendingSend?.completesPlan ?? true,
+          status: 'submitted',
+        }
+        options?.onBroadcast?.(lastSubmitted)
+      },
       resolveHash: safeWalletProvider
         ? async submittedHash => (await waitForSafeTransactionExecution({
           submittedHash,
@@ -1735,10 +1800,33 @@ export const useEulerTx = () => {
       sendTransaction,
       signTypedData: async (typedData) => {
         options?.beforeBroadcast?.()
-        const signature = await signTypedDataAsync(typedData as unknown as Parameters<typeof signTypedDataAsync>[0])
+        // Same pinning as sendTransaction: sign through the captured
+        // connector, never the currently-active one.
+        const signature = await signTypedDataAsync({
+          ...(typedData as unknown as Parameters<typeof signTypedDataAsync>[0]),
+          ...(connector ? { connector } : {}),
+        })
         return signature as Hex
       },
-      onProgress: (_progress: TransactionPlanExecutionProgress) => {},
+      onProgress: (progress: TransactionPlanExecutionProgress) => {
+        if (progress.hash) {
+          // Receipt confirmed for the outstanding submission.
+          if (lastSubmitted) {
+            options?.onBroadcast?.({ ...lastSubmitted, status: 'confirmed' })
+            lastSubmitted = undefined
+          }
+          return
+        }
+        if (progress.status === 'approval') {
+          pendingSend = { item: 'approval', completesPlan: false }
+        }
+        else if (progress.status === 'evcBatch' || progress.status === 'contractCall') {
+          pendingSend = {
+            item: progress.status === 'evcBatch' ? 'evcBatch' : 'pluginCall',
+            completesPlan: !!progress.item && progress.item === lastValueMovingItem,
+          }
+        }
+      },
     })
 
     finalizeExecution(result)
@@ -1802,6 +1890,7 @@ export const useEulerTx = () => {
       effectivePrepared = { ...prepared, usePermit2: false }
     }
 
+    let bundleBroadcast: PreparedPlanBroadcast | undefined
     const bundled = await executePlanAsSafeBundle({
       plan: effectivePrepared.plan,
       chainId: prepared.chainId,
@@ -1813,9 +1902,24 @@ export const useEulerTx = () => {
       extraCalls,
       allowSingleCall: options?.allowSingleCall,
       beforeBroadcast: options?.beforeBroadcast,
-      onBroadcast: hash => options?.onBroadcast?.({ kind: 'proposal', hash }),
+      onBroadcast: (hash) => {
+        bundleBroadcast = {
+          kind: 'proposal',
+          hash,
+          item: 'bundle',
+          index: 0,
+          completesPlan: true,
+          status: 'submitted',
+        }
+        options?.onBroadcast?.(bundleBroadcast)
+      },
     })
     if (!bundled) return undefined
+    // A truthy bundle result means the proposal executed with a successful
+    // receipt — the submission's outcome is no longer unknown.
+    if (bundleBroadcast) {
+      options?.onBroadcast?.({ ...bundleBroadcast, status: 'confirmed' })
+    }
     finalizeExecution(bundled)
     return bundled
   }

--- a/composables/useEulerTx.ts
+++ b/composables/useEulerTx.ts
@@ -49,6 +49,8 @@ import {
   type PlainTxRequest,
 } from '~/utils/migrationAuthorizationTxs'
 import { logWarn } from '~/utils/errorHandling'
+import { assertNoConflictingPendingSubmission } from '~/utils/pendingSubmissionGate'
+import { walletNeverAcceptedSubmission } from '~/utils/pendingSubmissions'
 import { invalidateSdkQueries } from '~/utils/sdk-query-cache'
 import { INVALIDATE_AFTER_TX } from '~/utils/sdk-query-policy'
 import { waitForSubgraphBlock } from '~/utils/subgraph'
@@ -100,18 +102,24 @@ const isOkxWallet = async (connector?: { id?: string, name?: string, getProvider
 }
 
 /**
- * A plan submission the wallet has accepted: an on-chain transaction hash for
- * standard wallets, or a safeTxHash proposal id for Safes (resolvable only
- * through the Safe wallet provider).
+ * One plan step's lifecycle at the wallet boundary.
+ *
+ * 'armed' fires immediately before the wallet is invoked for the step — the
+ * wallet call is itself an external side-effect: it may accept and submit the
+ * request, then disconnect or fail to return an id. From 'armed' on, the step
+ * must be treated as possibly-sent until a terminal signal. 'submitted' fires
+ * once the wallet returned an id (an on-chain transaction hash for standard
+ * wallets, or a safeTxHash proposal id for Safes, resolvable only through the
+ * Safe wallet provider). 'rejected' fires only when the wallet provably never
+ * accepted the armed request (explicit user rejection or a pre-dispatch
+ * connector failure). 'confirmed' re-fires the submitted broadcast once its
+ * receipt succeeded.
  *
  * The executor waits for each submission's receipt before sending the next,
- * so it re-fires the same broadcast with status 'confirmed' once the receipt
- * succeeded — at any failure, at most the single latest 'submitted' broadcast
- * without a matching 'confirmed' has an unknown outcome.
+ * so at any failure at most the single latest armed/submitted broadcast
+ * without a terminal signal has an unknown outcome.
  */
-export interface PreparedPlanBroadcast {
-  kind: 'transaction' | 'proposal'
-  hash: Hash
+export type PreparedPlanBroadcast = {
   /**
    * Which plan step produced the submission. 'bundle' (one Safe proposal for
    * the whole plan) and 'evcBatch' move value; 'approval' and 'pluginCall'
@@ -122,8 +130,10 @@ export interface PreparedPlanBroadcast {
   index: number
   /** True when no value-moving submission follows this one in the plan. */
   completesPlan: boolean
-  status: 'submitted' | 'confirmed'
-}
+} & (
+  | { status: 'armed' | 'rejected', kind?: undefined, hash?: undefined }
+  | { status: 'submitted' | 'confirmed', kind: 'transaction' | 'proposal', hash: Hash }
+)
 
 export interface PlanDepositInput {
   vaultAddress: Address
@@ -1250,6 +1260,8 @@ export const useEulerTx = () => {
     connector,
     resolveHash,
     beforeBroadcast,
+    onArm,
+    onSubmitError,
     onBroadcast,
   }: {
     isOkx: boolean
@@ -1265,6 +1277,19 @@ export const useEulerTx = () => {
     resolveHash?: (hash: Hash) => Promise<Hash>
     /** Final caller-owned freshness check at the wallet submission boundary. */
     beforeBroadcast?: () => void
+    /**
+     * Fires immediately before the wallet is invoked. The wallet call is
+     * itself an external side-effect — it may accept and dispatch the
+     * request, then fail before returning its id — so callers persist replay
+     * protection here, with no hash yet.
+     */
+    onArm?: () => void
+    /**
+     * Fires when the wallet invocation threw, before the error propagates —
+     * so callers can release the armed state when the error proves the
+     * wallet never accepted the request.
+     */
+    onSubmitError?: (error: unknown) => void
     /**
      * Fires as soon as the wallet accepted the submission, before any
      * confirmation wait — from here on the transaction may land even if
@@ -1287,14 +1312,22 @@ export const useEulerTx = () => {
         currentChainId: currentAccount.chainId,
       })
       beforeBroadcast?.()
-      const hash = await sendTransactionAsync({
-        account: expectedAccount,
-        chainId: expectedChainId,
-        ...(connector ? { connector } : {}),
-        to,
-        data: data as Hex,
-        value: value ?? 0n,
-      })
+      onArm?.()
+      let hash: Hash
+      try {
+        hash = await sendTransactionAsync({
+          account: expectedAccount,
+          chainId: expectedChainId,
+          ...(connector ? { connector } : {}),
+          to,
+          data: data as Hex,
+          value: value ?? 0n,
+        }) as Hash
+      }
+      catch (error) {
+        onSubmitError?.(error)
+        throw error
+      }
       if (isOkx && (data as Hex).toLowerCase().startsWith(ERC20_APPROVE_SELECTOR)) {
         okxDelayPending = true
       }
@@ -1479,7 +1512,7 @@ export const useEulerTx = () => {
    * bundling brings no benefit (fewer than two calls) — callers fall back to
    * sequential execution.
    */
-  const executePlanAsSafeBundle = async ({ plan, chainId, owner, provider, connector, safeWalletProvider, sdk, extraCalls, allowSingleCall, beforeBroadcast, onBroadcast }: {
+  const executePlanAsSafeBundle = async ({ plan, chainId, owner, provider, connector, safeWalletProvider, sdk, extraCalls, allowSingleCall, beforeBroadcast, onArm, onSubmitError, onBroadcast }: {
     plan: TransactionPlan
     chainId: number
     owner: Address
@@ -1500,6 +1533,14 @@ export const useEulerTx = () => {
     allowSingleCall?: boolean
     /** Final caller-owned freshness check at the Safe submission boundary. */
     beforeBroadcast?: () => void
+    /**
+     * Fires immediately before the bundle is handed to the wallet — the
+     * wallet may accept the proposal and then fail to return its id, so
+     * callers persist replay protection here, with no id yet.
+     */
+    onArm?: () => void
+    /** Fires when the wallet invocation threw, before the error propagates. */
+    onSubmitError?: (error: unknown) => void
     /**
      * Fires once the Safe accepted the proposal (safeTxHash exists), before
      * the execution wait — from here on the proposal may execute even if
@@ -1542,20 +1583,30 @@ export const useEulerTx = () => {
       currentChainId: currentAccount.chainId,
     })
     beforeBroadcast?.()
+    onArm?.()
 
     // Pin submission to the connector whose provider was identified as Safe.
     // Without it, wagmi resolves the currently-active connector, and a
     // same-account connector switch would submit through one provider while
     // status polling watches another.
-    const { id } = await sendCalls(config, {
-      account: owner,
-      chainId,
-      connector,
-      forceAtomic: true,
-      calls,
-    })
+    let id: string
+    try {
+      ({ id } = await sendCalls(config, {
+        account: owner,
+        chainId,
+        connector,
+        forceAtomic: true,
+        calls,
+      }))
+    }
+    catch (error) {
+      onSubmitError?.(error)
+      throw error
+    }
     // Safe returns the safeTxHash as the bundle id; the status poller needs
-    // a hash-shaped id to resolve it to the executed transaction.
+    // a hash-shaped id to resolve it to the executed transaction. The wallet
+    // DID respond here, so acceptance cannot be ruled out — the armed state
+    // must survive this failure (no onSubmitError).
     if (!/^0x[0-9a-f]{64}$/i.test(id)) {
       throw new Error('Safe wallet returned an unexpected call bundle id')
     }
@@ -1595,6 +1646,18 @@ export const useEulerTx = () => {
     // Known Safe even when provider acquisition failed — degraded execution
     // must still never take the permit2 path.
     const isKnownSafe = Boolean(safeWalletProvider) || isSafeConnectorIdentity(connector)
+
+    // Cross-surface quarantine: an unresolved value-moving submission from
+    // any flow (batch cart or a direct migration) for this wallet/chain
+    // blocks new sends until it reconciles — switching execution surfaces
+    // must not walk around a flow's own retry gate.
+    await assertNoConflictingPendingSubmission({
+      owner,
+      chainId: cid,
+      provider: provider as ReceiptClientLike,
+      connector,
+      getSafeWalletProvider,
+    })
 
     if (safeWalletProvider && connector) {
       // Mirror what executeTransactionPlan would do to the plan (plugins,
@@ -1696,6 +1759,18 @@ export const useEulerTx = () => {
     // sequential path must still never sign permit2 messages.
     const isKnownSafe = Boolean(safeWalletProvider) || isSafeConnectorIdentity(connector)
 
+    // Cross-surface quarantine: an unresolved value-moving submission from
+    // any flow (batch cart or a direct migration) for this wallet/chain
+    // blocks new sends until it reconciles — switching execution surfaces
+    // must not walk around a flow's own retry gate.
+    await assertNoConflictingPendingSubmission({
+      owner: preparedOwner,
+      chainId: prepared.chainId,
+      provider: provider as ReceiptClientLike,
+      connector,
+      getSafeWalletProvider,
+    })
+
     let effectivePrepared = prepared
     if (isKnownSafe) {
       // A Safe never signs permit2 messages. If the envelope was prepared
@@ -1720,7 +1795,8 @@ export const useEulerTx = () => {
 
     if (safeWalletProvider && connector) {
       // Prepared plans already ran plugins and approval resolution.
-      let bundleBroadcast: PreparedPlanBroadcast | undefined
+      let bundleBroadcast: (PreparedPlanBroadcast & { status: 'submitted' }) | undefined
+      let bundleArmed = false
       const bundled = await executePlanAsSafeBundle({
         plan: effectivePrepared.plan,
         chainId: prepared.chainId,
@@ -1730,6 +1806,18 @@ export const useEulerTx = () => {
         safeWalletProvider,
         sdk,
         beforeBroadcast: options?.beforeBroadcast,
+        onArm: () => {
+          bundleArmed = true
+          options?.onBroadcast?.({ item: 'bundle', index: 0, completesPlan: true, status: 'armed' })
+        },
+        onSubmitError: (error) => {
+          // Only a provable non-acceptance releases the armed state — any
+          // other wallet-boundary failure leaves acceptance possible.
+          if (bundleArmed && walletNeverAcceptedSubmission(error)) {
+            bundleArmed = false
+            options?.onBroadcast?.({ item: 'bundle', index: 0, completesPlan: true, status: 'rejected' })
+          }
+        },
         onBroadcast: (hash) => {
           bundleBroadcast = {
             kind: 'proposal',
@@ -1762,7 +1850,8 @@ export const useEulerTx = () => {
     const lastValueMovingItem = [...planItems].reverse().find(item =>
       item.type !== 'requiredApproval' && item.type !== 'cowSwap')
     let pendingSend: { item: PreparedPlanBroadcast['item'], completesPlan: boolean } | undefined
-    let lastSubmitted: PreparedPlanBroadcast | undefined
+    let lastSubmitted: (PreparedPlanBroadcast & { status: 'submitted' }) | undefined
+    let armedSend: PreparedPlanBroadcast | undefined
     let sendIndex = 0
 
     const sendTransaction = buildSendTransaction({
@@ -1771,14 +1860,40 @@ export const useEulerTx = () => {
       expectedChainId: prepared.chainId,
       connector,
       beforeBroadcast: options?.beforeBroadcast,
+      // Announce the step before crossing the wallet boundary: the wallet
+      // may accept the request and then fail to return its id, and trackers
+      // must already hold replay protection when that happens.
+      onArm: () => {
+        armedSend = {
+          // Fail toward the strict classification: an unattributed send is
+          // treated as the value-moving batch, never as a re-runnable step.
+          item: pendingSend?.item ?? 'evcBatch',
+          index: sendIndex,
+          completesPlan: pendingSend?.completesPlan ?? true,
+          status: 'armed',
+        }
+        options?.onBroadcast?.(armedSend)
+      },
+      onSubmitError: (error) => {
+        // Only a provable non-acceptance releases the armed state — any
+        // other wallet-boundary failure leaves acceptance possible.
+        if (armedSend && walletNeverAcceptedSubmission(error)) {
+          options?.onBroadcast?.({
+            item: armedSend.item,
+            index: armedSend.index,
+            completesPlan: armedSend.completesPlan,
+            status: 'rejected',
+          })
+          armedSend = undefined
+        }
+      },
       // A Safe's sequential fallback submits through the Safe app, so the
       // wallet returns a safeTxHash proposal id, not an on-chain hash.
       onBroadcast: (hash) => {
+        armedSend = undefined
         lastSubmitted = {
           kind: safeWalletProvider ? 'proposal' : 'transaction',
           hash,
-          // Fail toward the strict classification: an unattributed send is
-          // treated as the value-moving batch, never as a re-runnable step.
           item: pendingSend?.item ?? 'evcBatch',
           index: sendIndex++,
           completesPlan: pendingSend?.completesPlan ?? true,
@@ -1874,6 +1989,15 @@ export const useEulerTx = () => {
       ? getAddress(prepared.account)
       : getAddress(prepared.account.owner)
 
+    // Cross-surface quarantine — see executePreparedPlan.
+    await assertNoConflictingPendingSubmission({
+      owner: preparedOwner,
+      chainId: prepared.chainId,
+      provider: provider as ReceiptClientLike,
+      connector,
+      getSafeWalletProvider,
+    })
+
     // Same invariant as executePreparedPlan: an envelope executed for a Safe
     // never carries permit2.
     let effectivePrepared = prepared
@@ -1890,7 +2014,8 @@ export const useEulerTx = () => {
       effectivePrepared = { ...prepared, usePermit2: false }
     }
 
-    let bundleBroadcast: PreparedPlanBroadcast | undefined
+    let bundleBroadcast: (PreparedPlanBroadcast & { status: 'submitted' }) | undefined
+    let bundleArmed = false
     const bundled = await executePlanAsSafeBundle({
       plan: effectivePrepared.plan,
       chainId: prepared.chainId,
@@ -1902,6 +2027,18 @@ export const useEulerTx = () => {
       extraCalls,
       allowSingleCall: options?.allowSingleCall,
       beforeBroadcast: options?.beforeBroadcast,
+      onArm: () => {
+        bundleArmed = true
+        options?.onBroadcast?.({ item: 'bundle', index: 0, completesPlan: true, status: 'armed' })
+      },
+      onSubmitError: (error) => {
+        // Only a provable non-acceptance releases the armed state — any
+        // other wallet-boundary failure leaves acceptance possible.
+        if (bundleArmed && walletNeverAcceptedSubmission(error)) {
+          bundleArmed = false
+          options?.onBroadcast?.({ item: 'bundle', index: 0, completesPlan: true, status: 'rejected' })
+        }
+      },
       onBroadcast: (hash) => {
         bundleBroadcast = {
           kind: 'proposal',

--- a/composables/useEulerTx.ts
+++ b/composables/useEulerTx.ts
@@ -1165,6 +1165,12 @@ export const useEulerTx = () => {
     return sdk.executionService.estimateGasForTransactionPlan(cid, owner, plan)
   }
 
+  /** Estimate the exact prepared envelope without rerunning plan plugins. */
+  const estimateGasForPreparedPlan = async (prepared: TransactionPlanPrepared): Promise<bigint> => {
+    const sdk = await getEulerSdkForChain(prepared.chainId)
+    return sdk.executionService.estimateGasForPreparedTransactionPlan(prepared)
+  }
+
   /**
    * Resolve each plugin's prefetch payload for a representative plan once per
    * form-load. Pass the returned record to prepare/simulate/estimate via the
@@ -1820,6 +1826,7 @@ export const useEulerTx = () => {
     simulatePlan,
     prepareTransactionPlan,
     estimateGasForPlan,
+    estimateGasForPreparedPlan,
     prefetchPluginData,
     simulatePreparedPlan,
     executePreparedPlanWithPlainCalls,

--- a/composables/useEulerTx.ts
+++ b/composables/useEulerTx.ts
@@ -70,10 +70,57 @@ import {
 } from '~/utils/transaction-plan-calls'
 import { hasPermit2Signature } from '~/utils/transactionPlanApprovals'
 import {
+  WALLET_CHANGED_SINCE_REVIEW_ERROR,
   assertWalletExecutionContext,
   type WalletExecutionContext,
 } from '~/utils/walletExecutionContext'
 import { PLACEHOLDER_MIGRATION_AUTHORIZATION_SIGNATURE } from '~/utils/migrationAuthorizationSignatures'
+
+/**
+ * Wallet identity a prepared envelope was reviewed against: the exact
+ * connector instance (id + connection uid, so a same-address reconnect still
+ * differs) and its Safe/EOA classification. Captured by
+ * `prepareTransactionPlan` and enforced by the prepared-plan executors — a
+ * confirmation modal reviews the envelope, so whatever executes it must be
+ * the wallet that reviewed it.
+ */
+export interface ReviewedWalletContext {
+  readonly connectorKey: string | undefined
+  readonly isSafeWallet: boolean
+}
+
+export type ReviewedTransactionPlanPrepared = TransactionPlanPrepared & {
+  readonly reviewedWalletContext?: ReviewedWalletContext
+}
+
+const connectorContextKey = (
+  connector: { id: string, uid: string } | undefined,
+): string | undefined => (connector ? `${connector.id}:${connector.uid}` : undefined)
+
+/**
+ * Fail closed when a bound envelope reaches an executor under a different
+ * wallet identity than it was prepared with. This runs before the Safe
+ * permit2 repair, so a reviewed EOA signature ceremony can never be silently
+ * re-shaped into a Safe approval ceremony (or vice versa) after the user
+ * confirmed — reclassification means the review is stale, not repairable.
+ * Envelopes without a binding (hand-built or legacy callers) keep the
+ * executor's own connector pinning as their only guard.
+ */
+const assertPreparedWalletBinding = (
+  prepared: ReviewedTransactionPlanPrepared,
+  connector: { id: string, uid: string } | undefined,
+  isKnownSafe: boolean,
+) => {
+  const binding = prepared.reviewedWalletContext
+  if (!binding) return
+  if (
+    binding.connectorKey === undefined
+    || connectorContextKey(connector) !== binding.connectorKey
+    || binding.isSafeWallet !== isKnownSafe
+  ) {
+    throw new Error(WALLET_CHANGED_SINCE_REVIEW_ERROR)
+  }
+}
 
 const OKX_POST_APPROVE_DELAY_MS = 3000
 const ERC20_APPROVE_SELECTOR = '0x095ea7b3'
@@ -1326,18 +1373,33 @@ export const useEulerTx = () => {
       prefetch?: PluginPrefetchData
       usePermit2?: boolean
     },
-  ): Promise<TransactionPlanPrepared> => {
+  ): Promise<ReviewedTransactionPlanPrepared> => {
     return profAsync('sdk', 'prepareTransactionPlan', async () => {
       const owner = requireOwner()
       const cid = options?.chainId ?? requireChainId()
+      // Capture the wallet identity under review before any await: the
+      // returned envelope is what confirmation modals show, so it is bound
+      // to the exact connector (and Safe/EOA classification) the review
+      // happens against. The executors refuse the envelope under any other.
+      const connector = getAccount(config).connector
       const sdk = await getEulerSdkForChain(cid)
-      return sdk.executionService.prepareTransactionPlan({
-        plan,
-        chainId: cid,
-        account: options?.account ?? owner,
-        usePermit2: options?.usePermit2 ?? signaturesEnabled.value,
-        prefetch: options?.prefetch,
-      })
+      const [prepared, safeWalletProvider] = await Promise.all([
+        sdk.executionService.prepareTransactionPlan({
+          plan,
+          chainId: cid,
+          account: options?.account ?? owner,
+          usePermit2: options?.usePermit2 ?? signaturesEnabled.value,
+          prefetch: options?.prefetch,
+        }),
+        getSafeWalletProvider(connector),
+      ])
+      return {
+        ...prepared,
+        reviewedWalletContext: {
+          connectorKey: connectorContextKey(connector),
+          isSafeWallet: Boolean(safeWalletProvider) || isSafeConnectorIdentity(connector),
+        },
+      }
     })
   }
 
@@ -1846,91 +1908,97 @@ export const useEulerTx = () => {
     // only on a terminal signal, with no caller wiring required.
     const quarantine = createDirectSubmissionQuarantine({ flow: 'direct', getSafeWalletProvider })
     quarantine.begin({ owner, chainId: cid })
+    // end() in finally: once the attempt is over, any record it left behind
+    // is orphaned from live execution and becomes visible to manual recovery.
+    try {
+      if (safeWalletProvider && connector) {
+        // Mirror what executeTransactionPlan would do to the plan (plugins,
+        // approval resolution), then try to submit it as one Safe proposal.
+        // The provider positively identified a Safe, so permit2 is forced off
+        // here regardless of the (possibly lagging) reactive preference.
+        const processedPlan = await sdk.executionService.processPlanPlugins(plan, owner, cid)
+        const resolvedPlan = await sdk.executionService.resolveRequiredApprovals({
+          plan: processedPlan,
+          chainId: cid,
+          account: owner,
+          usePermit2: false,
+        })
+        const bundleTracker = createBundleBroadcastAdapter(quarantine.track)
+        const bundled = await executePlanAsSafeBundle({
+          plan: resolvedPlan,
+          chainId: cid,
+          owner,
+          provider,
+          connector,
+          safeWalletProvider,
+          sdk,
+          onArm: bundleTracker.onArm,
+          onSubmitError: bundleTracker.onSubmitError,
+          onBroadcast: bundleTracker.onBroadcast,
+        })
+        if (bundled) {
+          await bundleTracker.confirm()
+          finalizeExecution(bundled)
+          return bundled
+        }
+      }
 
-    if (safeWalletProvider && connector) {
-      // Mirror what executeTransactionPlan would do to the plan (plugins,
-      // approval resolution), then try to submit it as one Safe proposal.
-      // The provider positively identified a Safe, so permit2 is forced off
-      // here regardless of the (possibly lagging) reactive preference.
-      const processedPlan = await sdk.executionService.processPlanPlugins(plan, owner, cid)
-      const resolvedPlan = await sdk.executionService.resolveRequiredApprovals({
-        plan: processedPlan,
+      // executeTransactionPlan reprocesses plugins internally, so the progress
+      // items may not be identical to this plan's — completesPlan can then fall
+      // back to its strict default, which is cosmetic for the 'direct' flow
+      // (the gate treats any landed direct record the same way).
+      const tracker = createSequentialBroadcastTracker({
+        plan,
+        isProposal: Boolean(safeWalletProvider),
+        emit: quarantine.track,
+      })
+      const sendTransaction = buildSendTransaction({
+        isOkx,
+        expectedAccount: owner,
+        expectedChainId: cid,
+        connector,
+        onArm: tracker.onArm,
+        onSubmitError: tracker.onSubmitError,
+        onBroadcast: tracker.onBroadcast,
+        resolveHash: safeWalletProvider
+          ? async submittedHash => (await waitForSafeTransactionExecution({
+            submittedHash,
+            walletProvider: safeWalletProvider,
+            publicClient: provider as ReceiptClientLike,
+          })).hash
+          : undefined,
+      })
+
+      const result = await sdk.executionService.executeTransactionPlan({
+        plan,
         chainId: cid,
         account: owner,
-        usePermit2: false,
+        // A known Safe never uses permit2, even on the sequential fallback
+        // and even when its provider could not be acquired.
+        usePermit2: isKnownSafe ? false : signaturesEnabled.value,
+        sendTransaction,
+        signTypedData: async (typedData) => {
+          // Same pinning as sendTransaction: sign through the captured
+          // connector, never the currently-active one.
+          const signature = await signTypedDataAsync({
+            ...(typedData as unknown as Parameters<typeof signTypedDataAsync>[0]),
+            ...(connector ? { connector } : {}),
+          })
+          return signature as Hex
+        },
+        onProgress: tracker.onProgress,
       })
-      const bundleTracker = createBundleBroadcastAdapter(quarantine.track)
-      const bundled = await executePlanAsSafeBundle({
-        plan: resolvedPlan,
-        chainId: cid,
-        owner,
-        provider,
-        connector,
-        safeWalletProvider,
-        sdk,
-        onArm: bundleTracker.onArm,
-        onSubmitError: bundleTracker.onSubmitError,
-        onBroadcast: bundleTracker.onBroadcast,
-      })
-      if (bundled) {
-        await bundleTracker.confirm()
-        finalizeExecution(bundled)
-        return bundled
-      }
+
+      // Terminal releases fire out of band from the executor's synchronous
+      // progress callback — drain them before this attempt's result is
+      // finalized so the released record cannot lag into the next attempt.
+      await tracker.flush()
+      finalizeExecution(result)
+      return result
     }
-
-    // executeTransactionPlan reprocesses plugins internally, so the progress
-    // items may not be identical to this plan's — completesPlan can then fall
-    // back to its strict default, which is cosmetic for the 'direct' flow
-    // (the gate treats any landed direct record the same way).
-    const tracker = createSequentialBroadcastTracker({
-      plan,
-      isProposal: Boolean(safeWalletProvider),
-      emit: quarantine.track,
-    })
-    const sendTransaction = buildSendTransaction({
-      isOkx,
-      expectedAccount: owner,
-      expectedChainId: cid,
-      connector,
-      onArm: tracker.onArm,
-      onSubmitError: tracker.onSubmitError,
-      onBroadcast: tracker.onBroadcast,
-      resolveHash: safeWalletProvider
-        ? async submittedHash => (await waitForSafeTransactionExecution({
-          submittedHash,
-          walletProvider: safeWalletProvider,
-          publicClient: provider as ReceiptClientLike,
-        })).hash
-        : undefined,
-    })
-
-    const result = await sdk.executionService.executeTransactionPlan({
-      plan,
-      chainId: cid,
-      account: owner,
-      // A known Safe never uses permit2, even on the sequential fallback
-      // and even when its provider could not be acquired.
-      usePermit2: isKnownSafe ? false : signaturesEnabled.value,
-      sendTransaction,
-      signTypedData: async (typedData) => {
-        // Same pinning as sendTransaction: sign through the captured
-        // connector, never the currently-active one.
-        const signature = await signTypedDataAsync({
-          ...(typedData as unknown as Parameters<typeof signTypedDataAsync>[0]),
-          ...(connector ? { connector } : {}),
-        })
-        return signature as Hex
-      },
-      onProgress: tracker.onProgress,
-    })
-
-    // Terminal releases fire out of band from the executor's synchronous
-    // progress callback — drain them before this attempt's result is
-    // finalized so the released record cannot lag into the next attempt.
-    await tracker.flush()
-    finalizeExecution(result)
-    return result
+    finally {
+      quarantine.end()
+    }
   }
 
   const executePreparedPlan = async (
@@ -1971,6 +2039,11 @@ export const useEulerTx = () => {
     // sequential path must still never sign permit2 messages.
     const isKnownSafe = Boolean(safeWalletProvider) || isSafeConnectorIdentity(connector)
 
+    // Bound envelopes execute only under the wallet identity they were
+    // reviewed with — checked before the quarantine gate and the permit2
+    // repair so nothing observable happens for a stale review.
+    assertPreparedWalletBinding(prepared, connector, isKnownSafe)
+
     // Cross-surface quarantine: an unresolved value-moving submission from
     // any flow (batch cart or a direct migration) for this wallet/chain
     // blocks new sends until it reconciles — switching execution surfaces
@@ -1993,98 +2066,105 @@ export const useEulerTx = () => {
     internalQuarantine?.begin({ owner: preparedOwner, chainId: prepared.chainId })
     const emitBroadcast: PreparedPlanBroadcastEmit = options?.onBroadcast ?? internalQuarantine!.track
 
-    let effectivePrepared = prepared
-    if (isKnownSafe) {
-      // A Safe never signs permit2 messages. If the envelope was prepared
-      // before Safe detection resolved, re-resolve its approvals with
-      // permit2 off — resolution overwrites `resolved` on each item, so the
-      // repaired plan is used for both the bundle and the fallback.
-      if (hasPermit2Signature(prepared.plan)) {
-        const repairedPlan = await sdk.executionService.resolveRequiredApprovals({
-          plan: prepared.plan,
+    // end() in finally: once the attempt is over, any record it left behind
+    // is orphaned from live execution and becomes visible to manual recovery.
+    try {
+      let effectivePrepared = prepared
+      if (isKnownSafe) {
+        // A Safe never signs permit2 messages. If the envelope was prepared
+        // before Safe detection resolved, re-resolve its approvals with
+        // permit2 off — resolution overwrites `resolved` on each item, so the
+        // repaired plan is used for both the bundle and the fallback.
+        if (hasPermit2Signature(prepared.plan)) {
+          const repairedPlan = await sdk.executionService.resolveRequiredApprovals({
+            plan: prepared.plan,
+            chainId: prepared.chainId,
+            account: preparedOwner,
+            usePermit2: false,
+          })
+          effectivePrepared = { ...prepared, plan: repairedPlan, usePermit2: false }
+        }
+        else if (prepared.usePermit2) {
+          // Invariant: an envelope executed for a Safe never carries
+          // usePermit2, even when no permit2 items happened to resolve.
+          effectivePrepared = { ...prepared, usePermit2: false }
+        }
+      }
+
+      if (safeWalletProvider && connector) {
+        // Prepared plans already ran plugins and approval resolution.
+        const bundleTracker = createBundleBroadcastAdapter(emitBroadcast)
+        const bundled = await executePlanAsSafeBundle({
+          plan: effectivePrepared.plan,
           chainId: prepared.chainId,
-          account: preparedOwner,
-          usePermit2: false,
+          owner: preparedOwner,
+          provider,
+          connector,
+          safeWalletProvider,
+          sdk,
+          beforeBroadcast: options?.beforeBroadcast,
+          onArm: bundleTracker.onArm,
+          onSubmitError: bundleTracker.onSubmitError,
+          onBroadcast: bundleTracker.onBroadcast,
         })
-        effectivePrepared = { ...prepared, plan: repairedPlan, usePermit2: false }
+        if (bundled) {
+          await bundleTracker.confirm()
+          finalizeExecution(bundled)
+          return bundled
+        }
       }
-      else if (prepared.usePermit2) {
-        // Invariant: an envelope executed for a Safe never carries
-        // usePermit2, even when no permit2 items happened to resolve.
-        effectivePrepared = { ...prepared, usePermit2: false }
-      }
-    }
 
-    if (safeWalletProvider && connector) {
-      // Prepared plans already ran plugins and approval resolution.
-      const bundleTracker = createBundleBroadcastAdapter(emitBroadcast)
-      const bundled = await executePlanAsSafeBundle({
+      // A Safe's sequential fallback submits through the Safe app, so the
+      // wallet returns safeTxHash proposal ids, not on-chain hashes.
+      const tracker = createSequentialBroadcastTracker({
         plan: effectivePrepared.plan,
-        chainId: prepared.chainId,
-        owner: preparedOwner,
-        provider,
-        connector,
-        safeWalletProvider,
-        sdk,
-        beforeBroadcast: options?.beforeBroadcast,
-        onArm: bundleTracker.onArm,
-        onSubmitError: bundleTracker.onSubmitError,
-        onBroadcast: bundleTracker.onBroadcast,
+        isProposal: Boolean(safeWalletProvider),
+        emit: emitBroadcast,
       })
-      if (bundled) {
-        await bundleTracker.confirm()
-        finalizeExecution(bundled)
-        return bundled
-      }
+      const sendTransaction = buildSendTransaction({
+        isOkx,
+        expectedAccount: preparedOwner,
+        expectedChainId: prepared.chainId,
+        connector,
+        beforeBroadcast: options?.beforeBroadcast,
+        onArm: tracker.onArm,
+        onSubmitError: tracker.onSubmitError,
+        onBroadcast: tracker.onBroadcast,
+        resolveHash: safeWalletProvider
+          ? async submittedHash => (await waitForSafeTransactionExecution({
+            submittedHash,
+            walletProvider: safeWalletProvider,
+            publicClient: provider as ReceiptClientLike,
+          })).hash
+          : undefined,
+      })
+
+      const result = await sdk.executionService.executePreparedTransactionPlan({
+        prepared: effectivePrepared,
+        sendTransaction,
+        signTypedData: async (typedData) => {
+          options?.beforeBroadcast?.()
+          // Same pinning as sendTransaction: sign through the captured
+          // connector, never the currently-active one.
+          const signature = await signTypedDataAsync({
+            ...(typedData as unknown as Parameters<typeof signTypedDataAsync>[0]),
+            ...(connector ? { connector } : {}),
+          })
+          return signature as Hex
+        },
+        onProgress: tracker.onProgress,
+      })
+
+      // Terminal releases fire out of band from the executor's synchronous
+      // progress callback — drain them before this attempt's result is
+      // finalized so the released record cannot lag into the next attempt.
+      await tracker.flush()
+      finalizeExecution(result)
+      return result
     }
-
-    // A Safe's sequential fallback submits through the Safe app, so the
-    // wallet returns safeTxHash proposal ids, not on-chain hashes.
-    const tracker = createSequentialBroadcastTracker({
-      plan: effectivePrepared.plan,
-      isProposal: Boolean(safeWalletProvider),
-      emit: emitBroadcast,
-    })
-    const sendTransaction = buildSendTransaction({
-      isOkx,
-      expectedAccount: preparedOwner,
-      expectedChainId: prepared.chainId,
-      connector,
-      beforeBroadcast: options?.beforeBroadcast,
-      onArm: tracker.onArm,
-      onSubmitError: tracker.onSubmitError,
-      onBroadcast: tracker.onBroadcast,
-      resolveHash: safeWalletProvider
-        ? async submittedHash => (await waitForSafeTransactionExecution({
-          submittedHash,
-          walletProvider: safeWalletProvider,
-          publicClient: provider as ReceiptClientLike,
-        })).hash
-        : undefined,
-    })
-
-    const result = await sdk.executionService.executePreparedTransactionPlan({
-      prepared: effectivePrepared,
-      sendTransaction,
-      signTypedData: async (typedData) => {
-        options?.beforeBroadcast?.()
-        // Same pinning as sendTransaction: sign through the captured
-        // connector, never the currently-active one.
-        const signature = await signTypedDataAsync({
-          ...(typedData as unknown as Parameters<typeof signTypedDataAsync>[0]),
-          ...(connector ? { connector } : {}),
-        })
-        return signature as Hex
-      },
-      onProgress: tracker.onProgress,
-    })
-
-    // Terminal releases fire out of band from the executor's synchronous
-    // progress callback — drain them before this attempt's result is
-    // finalized so the released record cannot lag into the next attempt.
-    await tracker.flush()
-    finalizeExecution(result)
-    return result
+    finally {
+      internalQuarantine?.end()
+    }
   }
 
   /**
@@ -2124,6 +2204,11 @@ export const useEulerTx = () => {
     const safeWalletProvider = await getSafeWalletProvider(connector)
     if (!safeWalletProvider || !connector) return undefined
 
+    // This path only runs for a live Safe provider, so a bound envelope must
+    // have been reviewed as a Safe under this exact connector — a reviewed
+    // EOA envelope is never repaired into a Safe bundle.
+    assertPreparedWalletBinding(prepared, connector, true)
+
     const preparedOwner = typeof prepared.account === 'string'
       ? getAddress(prepared.account)
       : getAddress(prepared.account.owner)
@@ -2144,42 +2229,49 @@ export const useEulerTx = () => {
     internalQuarantine?.begin({ owner: preparedOwner, chainId: prepared.chainId })
     const emitBroadcast: PreparedPlanBroadcastEmit = options?.onBroadcast ?? internalQuarantine!.track
 
-    // Same invariant as executePreparedPlan: an envelope executed for a Safe
-    // never carries permit2.
-    let effectivePrepared = prepared
-    if (hasPermit2Signature(prepared.plan)) {
-      const repairedPlan = await sdk.executionService.resolveRequiredApprovals({
-        plan: prepared.plan,
-        chainId: prepared.chainId,
-        account: preparedOwner,
-        usePermit2: false,
-      })
-      effectivePrepared = { ...prepared, plan: repairedPlan, usePermit2: false }
-    }
-    else if (prepared.usePermit2) {
-      effectivePrepared = { ...prepared, usePermit2: false }
-    }
+    // end() in finally: once the attempt is over, any record it left behind
+    // is orphaned from live execution and becomes visible to manual recovery.
+    try {
+      // Same invariant as executePreparedPlan: an envelope executed for a Safe
+      // never carries permit2.
+      let effectivePrepared = prepared
+      if (hasPermit2Signature(prepared.plan)) {
+        const repairedPlan = await sdk.executionService.resolveRequiredApprovals({
+          plan: prepared.plan,
+          chainId: prepared.chainId,
+          account: preparedOwner,
+          usePermit2: false,
+        })
+        effectivePrepared = { ...prepared, plan: repairedPlan, usePermit2: false }
+      }
+      else if (prepared.usePermit2) {
+        effectivePrepared = { ...prepared, usePermit2: false }
+      }
 
-    const bundleTracker = createBundleBroadcastAdapter(emitBroadcast)
-    const bundled = await executePlanAsSafeBundle({
-      plan: effectivePrepared.plan,
-      chainId: prepared.chainId,
-      owner: preparedOwner,
-      provider,
-      connector,
-      safeWalletProvider,
-      sdk,
-      extraCalls,
-      allowSingleCall: options?.allowSingleCall,
-      beforeBroadcast: options?.beforeBroadcast,
-      onArm: bundleTracker.onArm,
-      onSubmitError: bundleTracker.onSubmitError,
-      onBroadcast: bundleTracker.onBroadcast,
-    })
-    if (!bundled) return undefined
-    await bundleTracker.confirm()
-    finalizeExecution(bundled)
-    return bundled
+      const bundleTracker = createBundleBroadcastAdapter(emitBroadcast)
+      const bundled = await executePlanAsSafeBundle({
+        plan: effectivePrepared.plan,
+        chainId: prepared.chainId,
+        owner: preparedOwner,
+        provider,
+        connector,
+        safeWalletProvider,
+        sdk,
+        extraCalls,
+        allowSingleCall: options?.allowSingleCall,
+        beforeBroadcast: options?.beforeBroadcast,
+        onArm: bundleTracker.onArm,
+        onSubmitError: bundleTracker.onSubmitError,
+        onBroadcast: bundleTracker.onBroadcast,
+      })
+      if (!bundled) return undefined
+      await bundleTracker.confirm()
+      finalizeExecution(bundled)
+      return bundled
+    }
+    finally {
+      internalQuarantine?.end()
+    }
   }
 
   /**

--- a/composables/useEulerTx.ts
+++ b/composables/useEulerTx.ts
@@ -1,4 +1,4 @@
-import { getAddress, type Address, type Hash, type Hex, type StateOverride, type TransactionReceipt } from 'viem'
+import { getAddress, isHash, type Address, type Hash, type Hex, type StateOverride, type TransactionReceipt } from 'viem'
 import type {
   Account,
   CollateralShareSource,
@@ -50,6 +50,7 @@ import {
 } from '~/utils/migrationAuthorizationTxs'
 import { logWarn } from '~/utils/errorHandling'
 import { assertNoConflictingPendingSubmission } from '~/utils/pendingSubmissionGate'
+import { createDirectSubmissionQuarantine } from '~/utils/directSubmissionQuarantine'
 import { walletNeverAcceptedSubmission } from '~/utils/pendingSubmissions'
 import { invalidateSdkQueries } from '~/utils/sdk-query-cache'
 import { INVALIDATE_AFTER_TX } from '~/utils/sdk-query-policy'
@@ -134,6 +135,148 @@ export type PreparedPlanBroadcast = {
   | { status: 'armed' | 'rejected', kind?: undefined, hash?: undefined }
   | { status: 'submitted' | 'confirmed', kind: 'transaction' | 'proposal', hash: Hash }
 )
+
+/**
+ * Broadcast sinks may persist replay protection (an async, lock-serialized
+ * storage reservation) — the executors await armed/submitted emissions before
+ * crossing the wallet boundary, so a sink that throws stops the wallet call.
+ */
+export type PreparedPlanBroadcastEmit = (broadcast: PreparedPlanBroadcast) => void | Promise<void>
+
+/**
+ * Shared Safe-bundle broadcast lifecycle: armed before the wallet is invoked,
+ * rejected only on provable non-acceptance, submitted once the proposal id
+ * exists, confirmed by the caller once the bundle result proves execution.
+ */
+const createBundleBroadcastAdapter = (emit: PreparedPlanBroadcastEmit) => {
+  let bundleBroadcast: (PreparedPlanBroadcast & { status: 'submitted' }) | undefined
+  let bundleArmed = false
+  return {
+    onArm: async () => {
+      bundleArmed = true
+      await emit({ item: 'bundle', index: 0, completesPlan: true, status: 'armed' })
+    },
+    onSubmitError: async (error: unknown) => {
+      // Only a provable non-acceptance releases the armed state — any other
+      // wallet-boundary failure leaves acceptance possible.
+      if (bundleArmed && walletNeverAcceptedSubmission(error)) {
+        bundleArmed = false
+        await emit({ item: 'bundle', index: 0, completesPlan: true, status: 'rejected' })
+      }
+    },
+    onBroadcast: async (hash: Hash) => {
+      bundleBroadcast = {
+        kind: 'proposal',
+        hash,
+        item: 'bundle',
+        index: 0,
+        completesPlan: true,
+        status: 'submitted',
+      }
+      await emit(bundleBroadcast)
+    },
+    /** A truthy bundle result means the proposal executed with a successful
+     * receipt — the submission's outcome is no longer unknown. */
+    confirm: async () => {
+      if (bundleBroadcast) await emit({ ...bundleBroadcast, status: 'confirmed' })
+    },
+  }
+}
+
+/**
+ * Ordered execution tracking for the sequential path. The SDK executor emits
+ * a pre-send progress event (no hash) naming the item about to be sent, then
+ * waits for the receipt and re-emits with the confirmed hash — so the item
+ * announced by the latest pre-send event classifies the next wallet
+ * submission, and a hash-bearing event confirms it.
+ */
+const createSequentialBroadcastTracker = ({ plan, isProposal, emit }: {
+  plan: TransactionPlan
+  /** A Safe's sequential fallback submits proposal ids, not on-chain hashes. */
+  isProposal: boolean
+  emit: PreparedPlanBroadcastEmit
+}) => {
+  const lastValueMovingItem = [...plan].reverse().find(item =>
+    item.type !== 'requiredApproval' && item.type !== 'cowSwap')
+  let pendingSend: { item: PreparedPlanBroadcast['item'], completesPlan: boolean } | undefined
+  let lastSubmitted: (PreparedPlanBroadcast & { status: 'submitted' }) | undefined
+  let armedSend: PreparedPlanBroadcast | undefined
+  let sendIndex = 0
+  // Terminal emissions fired from the executor's synchronous progress
+  // callback; awaited via flush() before the executor result is finalized so
+  // a released record cannot lag into the next attempt's gate check.
+  const inFlightEmits: Promise<void>[] = []
+  return {
+    // Announce the step before crossing the wallet boundary: the wallet may
+    // accept the request and then fail to return its id, and trackers must
+    // already hold replay protection when that happens.
+    onArm: async () => {
+      armedSend = {
+        // Fail toward the strict classification: an unattributed send is
+        // treated as the value-moving batch, never as a re-runnable step.
+        item: pendingSend?.item ?? 'evcBatch',
+        index: sendIndex,
+        completesPlan: pendingSend?.completesPlan ?? true,
+        status: 'armed',
+      }
+      await emit(armedSend)
+    },
+    onSubmitError: async (error: unknown) => {
+      // Only a provable non-acceptance releases the armed state — any other
+      // wallet-boundary failure leaves acceptance possible.
+      if (armedSend && walletNeverAcceptedSubmission(error)) {
+        const rejected = {
+          item: armedSend.item,
+          index: armedSend.index,
+          completesPlan: armedSend.completesPlan,
+          status: 'rejected' as const,
+        }
+        armedSend = undefined
+        await emit(rejected)
+      }
+    },
+    onBroadcast: async (hash: Hash) => {
+      armedSend = undefined
+      lastSubmitted = {
+        kind: isProposal ? 'proposal' : 'transaction',
+        hash,
+        item: pendingSend?.item ?? 'evcBatch',
+        index: sendIndex++,
+        completesPlan: pendingSend?.completesPlan ?? true,
+        status: 'submitted',
+      }
+      await emit(lastSubmitted)
+    },
+    onProgress: (progress: TransactionPlanExecutionProgress) => {
+      if (progress.hash) {
+        // Receipt confirmed for the outstanding submission. onProgress is
+        // synchronous, so the terminal release runs out of band — the
+        // per-wallet lock orders it before any later reservation, and
+        // flush() drains it before the attempt result is returned.
+        if (lastSubmitted) {
+          const confirmed = { ...lastSubmitted, status: 'confirmed' as const }
+          lastSubmitted = undefined
+          inFlightEmits.push(Promise.resolve(emit(confirmed)).catch((err) => {
+            logWarn('useEulerTx/broadcastTracker', err)
+          }))
+        }
+        return
+      }
+      if (progress.status === 'approval') {
+        pendingSend = { item: 'approval', completesPlan: false }
+      }
+      else if (progress.status === 'evcBatch' || progress.status === 'contractCall') {
+        pendingSend = {
+          item: progress.status === 'evcBatch' ? 'evcBatch' : 'pluginCall',
+          completesPlan: !!progress.item && progress.item === lastValueMovingItem,
+        }
+      }
+    },
+    flush: async () => {
+      await Promise.all(inFlightEmits.splice(0))
+    },
+  }
+}
 
 export interface PlanDepositInput {
   vaultAddress: Address
@@ -1278,25 +1421,26 @@ export const useEulerTx = () => {
     /** Final caller-owned freshness check at the wallet submission boundary. */
     beforeBroadcast?: () => void
     /**
-     * Fires immediately before the wallet is invoked. The wallet call is
-     * itself an external side-effect — it may accept and dispatch the
-     * request, then fail before returning its id — so callers persist replay
-     * protection here, with no hash yet.
+     * Fires immediately before the wallet is invoked, and is awaited: the
+     * wallet call is itself an external side-effect — it may accept and
+     * dispatch the request, then fail before returning its id — so callers
+     * persist replay protection here, with no hash yet. A throw here
+     * (reservation conflict, storage not durable) stops the wallet call.
      */
-    onArm?: () => void
+    onArm?: () => void | Promise<void>
     /**
      * Fires when the wallet invocation threw, before the error propagates —
      * so callers can release the armed state when the error proves the
      * wallet never accepted the request.
      */
-    onSubmitError?: (error: unknown) => void
+    onSubmitError?: (error: unknown) => void | Promise<void>
     /**
      * Fires as soon as the wallet accepted the submission, before any
      * confirmation wait — from here on the transaction may land even if
      * everything after this point fails, so callers use it to stop treating
      * a later error as "never sent".
      */
-    onBroadcast?: (hash: Hash) => void
+    onBroadcast?: (hash: Hash) => void | Promise<void>
   }) => {
     let okxDelayPending = false
     const send = async ({ to, data, value }: { to: Address, data: Hex, value?: bigint }) => {
@@ -1312,27 +1456,35 @@ export const useEulerTx = () => {
         currentChainId: currentAccount.chainId,
       })
       beforeBroadcast?.()
-      onArm?.()
-      let hash: Hash
+      await onArm?.()
+      let submittedHash: Hash
       try {
-        hash = await sendTransactionAsync({
+        const result: unknown = await sendTransactionAsync({
           account: expectedAccount,
           chainId: expectedChainId,
           ...(connector ? { connector } : {}),
           to,
           data: data as Hex,
           value: value ?? 0n,
-        }) as Hash
+        })
+        // The connector's return value is untyped at runtime. The wallet DID
+        // respond, so acceptance cannot be ruled out — a malformed id must
+        // not reach onBroadcast (it would corrupt the armed replay-protection
+        // record into an unverifiable submitted one); the armed state stands
+        // (walletNeverAcceptedSubmission does not match this error).
+        if (typeof result !== 'string' || !isHash(result)) {
+          throw new Error('Wallet returned an unexpected transaction id')
+        }
+        submittedHash = result
       }
       catch (error) {
-        onSubmitError?.(error)
+        await onSubmitError?.(error)
         throw error
       }
       if (isOkx && (data as Hex).toLowerCase().startsWith(ERC20_APPROVE_SELECTOR)) {
         okxDelayPending = true
       }
-      const submittedHash = hash as Hash
-      onBroadcast?.(submittedHash)
+      await onBroadcast?.(submittedHash)
       return resolveHash ? resolveHash(submittedHash) : submittedHash
     }
     return send
@@ -1352,6 +1504,15 @@ export const useEulerTx = () => {
       onBroadcast?: (index: number, walletContext: WalletExecutionContext) => void
       walletContext?: WalletExecutionContext
       beforeBroadcast?: () => void
+      /**
+       * Skip the conflicting-pending-submission gate. Reserved for sends
+       * that strictly reduce standing authorization (migration revokes):
+       * they must run during abort cleanup even while an ambiguous
+       * submission is quarantined — blocking them would leave live grants
+       * behind. Never set this for anything that moves value or grants
+       * authority.
+       */
+      bypassPendingSubmissionGate?: boolean
     },
   ): Promise<TransactionReceipt[]> => {
     if (isSpyMode.value) {
@@ -1376,6 +1537,20 @@ export const useEulerTx = () => {
       isOkxWallet(connector),
       getSafeWalletProvider(connector),
     ])
+
+    // Cross-surface quarantine: standalone sends (migration authorization
+    // grants, batch prerequisites) reach the wallet before any plan executor
+    // gate, so an unresolved value-moving submission must block them here.
+    if (!options?.bypassPendingSubmissionGate) {
+      await assertNoConflictingPendingSubmission({
+        owner,
+        chainId: cid,
+        provider: provider as ReceiptClientLike,
+        connector,
+        getSafeWalletProvider,
+      })
+    }
+
     const send = buildSendTransaction({
       isOkx,
       expectedAccount: owner,
@@ -1460,6 +1635,10 @@ export const useEulerTx = () => {
       try {
         await sendPlainTransactions([revoke.transaction], {
           walletContext: revoke.walletContext,
+          // Revokes strictly reduce standing authorization and run during
+          // abort cleanup — possibly while the aborted submission itself is
+          // quarantined. Blocking them would leave live grants behind.
+          bypassPendingSubmissionGate: true,
         })
         restored.push(revoke)
       }
@@ -1534,20 +1713,22 @@ export const useEulerTx = () => {
     /** Final caller-owned freshness check at the Safe submission boundary. */
     beforeBroadcast?: () => void
     /**
-     * Fires immediately before the bundle is handed to the wallet — the
-     * wallet may accept the proposal and then fail to return its id, so
-     * callers persist replay protection here, with no id yet.
+     * Fires immediately before the bundle is handed to the wallet, and is
+     * awaited — the wallet may accept the proposal and then fail to return
+     * its id, so callers persist replay protection here, with no id yet. A
+     * throw here (reservation conflict, storage not durable) stops the
+     * wallet call.
      */
-    onArm?: () => void
+    onArm?: () => void | Promise<void>
     /** Fires when the wallet invocation threw, before the error propagates. */
-    onSubmitError?: (error: unknown) => void
+    onSubmitError?: (error: unknown) => void | Promise<void>
     /**
      * Fires once the Safe accepted the proposal (safeTxHash exists), before
      * the execution wait — from here on the proposal may execute even if
      * status polling fails, so callers use it to stop treating a later error
      * as "never submitted".
      */
-    onBroadcast?: (safeTxHash: Hash) => void
+    onBroadcast?: (safeTxHash: Hash) => void | Promise<void>
   }) => {
     let planCalls
     try {
@@ -1583,7 +1764,7 @@ export const useEulerTx = () => {
       currentChainId: currentAccount.chainId,
     })
     beforeBroadcast?.()
-    onArm?.()
+    await onArm?.()
 
     // Pin submission to the connector whose provider was identified as Safe.
     // Without it, wagmi resolves the currently-active connector, and a
@@ -1600,7 +1781,7 @@ export const useEulerTx = () => {
       }))
     }
     catch (error) {
-      onSubmitError?.(error)
+      await onSubmitError?.(error)
       throw error
     }
     // Safe returns the safeTxHash as the bundle id; the status poller needs
@@ -1610,7 +1791,7 @@ export const useEulerTx = () => {
     if (!/^0x[0-9a-f]{64}$/i.test(id)) {
       throw new Error('Safe wallet returned an unexpected call bundle id')
     }
-    onBroadcast?.(id as Hash)
+    await onBroadcast?.(id as Hash)
 
     const execution = await waitForSafeTransactionExecution({
       submittedHash: id as Hash,
@@ -1659,6 +1840,13 @@ export const useEulerTx = () => {
       getSafeWalletProvider,
     })
 
+    // Built-in reservation ownership: this executor has no caller-supplied
+    // broadcast sink, so it owns a durable 'direct' quarantine itself — every
+    // value-moving submission is reserved at the wallet boundary and released
+    // only on a terminal signal, with no caller wiring required.
+    const quarantine = createDirectSubmissionQuarantine({ flow: 'direct', getSafeWalletProvider })
+    quarantine.begin({ owner, chainId: cid })
+
     if (safeWalletProvider && connector) {
       // Mirror what executeTransactionPlan would do to the plan (plugins,
       // approval resolution), then try to submit it as one Safe proposal.
@@ -1671,6 +1859,7 @@ export const useEulerTx = () => {
         account: owner,
         usePermit2: false,
       })
+      const bundleTracker = createBundleBroadcastAdapter(quarantine.track)
       const bundled = await executePlanAsSafeBundle({
         plan: resolvedPlan,
         chainId: cid,
@@ -1679,18 +1868,34 @@ export const useEulerTx = () => {
         connector,
         safeWalletProvider,
         sdk,
+        onArm: bundleTracker.onArm,
+        onSubmitError: bundleTracker.onSubmitError,
+        onBroadcast: bundleTracker.onBroadcast,
       })
       if (bundled) {
+        await bundleTracker.confirm()
         finalizeExecution(bundled)
         return bundled
       }
     }
 
+    // executeTransactionPlan reprocesses plugins internally, so the progress
+    // items may not be identical to this plan's — completesPlan can then fall
+    // back to its strict default, which is cosmetic for the 'direct' flow
+    // (the gate treats any landed direct record the same way).
+    const tracker = createSequentialBroadcastTracker({
+      plan,
+      isProposal: Boolean(safeWalletProvider),
+      emit: quarantine.track,
+    })
     const sendTransaction = buildSendTransaction({
       isOkx,
       expectedAccount: owner,
       expectedChainId: cid,
       connector,
+      onArm: tracker.onArm,
+      onSubmitError: tracker.onSubmitError,
+      onBroadcast: tracker.onBroadcast,
       resolveHash: safeWalletProvider
         ? async submittedHash => (await waitForSafeTransactionExecution({
           submittedHash,
@@ -1717,9 +1922,13 @@ export const useEulerTx = () => {
         })
         return signature as Hex
       },
-      onProgress: (_progress: TransactionPlanExecutionProgress) => {},
+      onProgress: tracker.onProgress,
     })
 
+    // Terminal releases fire out of band from the executor's synchronous
+    // progress callback — drain them before this attempt's result is
+    // finalized so the released record cannot lag into the next attempt.
+    await tracker.flush()
     finalizeExecution(result)
     return result
   }
@@ -1733,9 +1942,12 @@ export const useEulerTx = () => {
        * hash for standard wallets, a safeTxHash proposal id for Safes),
        * before any confirmation wait. From that point the submission may land
        * even when a later step throws, so callers use it to distinguish
-       * "never sent" from "sent but unconfirmed".
+       * "never sent" from "sent but unconfirmed". Callers that pass this own
+       * the durable replay protection for the plan (armed emissions are
+       * awaited before the wallet is invoked); without it the executor
+       * quarantines value-moving submissions itself under the 'direct' flow.
        */
-      onBroadcast?: (broadcast: PreparedPlanBroadcast) => void
+      onBroadcast?: PreparedPlanBroadcastEmit
     },
   ) => {
     if (isSpyMode.value) {
@@ -1771,6 +1983,16 @@ export const useEulerTx = () => {
       getSafeWalletProvider,
     })
 
+    // Built-in reservation ownership: when no caller-supplied sink owns the
+    // replay protection, the executor quarantines value-moving submissions
+    // itself under the 'direct' flow — the guarantee cannot depend on
+    // optional caller wiring.
+    const internalQuarantine = options?.onBroadcast
+      ? undefined
+      : createDirectSubmissionQuarantine({ flow: 'direct', getSafeWalletProvider })
+    internalQuarantine?.begin({ owner: preparedOwner, chainId: prepared.chainId })
+    const emitBroadcast: PreparedPlanBroadcastEmit = options?.onBroadcast ?? internalQuarantine!.track
+
     let effectivePrepared = prepared
     if (isKnownSafe) {
       // A Safe never signs permit2 messages. If the envelope was prepared
@@ -1795,8 +2017,7 @@ export const useEulerTx = () => {
 
     if (safeWalletProvider && connector) {
       // Prepared plans already ran plugins and approval resolution.
-      let bundleBroadcast: (PreparedPlanBroadcast & { status: 'submitted' }) | undefined
-      let bundleArmed = false
+      const bundleTracker = createBundleBroadcastAdapter(emitBroadcast)
       const bundled = await executePlanAsSafeBundle({
         plan: effectivePrepared.plan,
         chainId: prepared.chainId,
@@ -1806,101 +2027,33 @@ export const useEulerTx = () => {
         safeWalletProvider,
         sdk,
         beforeBroadcast: options?.beforeBroadcast,
-        onArm: () => {
-          bundleArmed = true
-          options?.onBroadcast?.({ item: 'bundle', index: 0, completesPlan: true, status: 'armed' })
-        },
-        onSubmitError: (error) => {
-          // Only a provable non-acceptance releases the armed state — any
-          // other wallet-boundary failure leaves acceptance possible.
-          if (bundleArmed && walletNeverAcceptedSubmission(error)) {
-            bundleArmed = false
-            options?.onBroadcast?.({ item: 'bundle', index: 0, completesPlan: true, status: 'rejected' })
-          }
-        },
-        onBroadcast: (hash) => {
-          bundleBroadcast = {
-            kind: 'proposal',
-            hash,
-            item: 'bundle',
-            index: 0,
-            completesPlan: true,
-            status: 'submitted',
-          }
-          options?.onBroadcast?.(bundleBroadcast)
-        },
+        onArm: bundleTracker.onArm,
+        onSubmitError: bundleTracker.onSubmitError,
+        onBroadcast: bundleTracker.onBroadcast,
       })
       if (bundled) {
-        // A truthy bundle result means the proposal executed with a
-        // successful receipt — the submission's outcome is no longer unknown.
-        if (bundleBroadcast) {
-          options?.onBroadcast?.({ ...bundleBroadcast, status: 'confirmed' })
-        }
+        await bundleTracker.confirm()
         finalizeExecution(bundled)
         return bundled
       }
     }
 
-    // Ordered execution tracking for the sequential path. The executor emits
-    // a pre-send progress event (no hash) naming the item about to be sent,
-    // then waits for the receipt and re-emits with the confirmed hash — so
-    // the item announced by the latest pre-send event classifies the next
-    // wallet submission, and a hash-bearing event confirms it.
-    const planItems = effectivePrepared.plan
-    const lastValueMovingItem = [...planItems].reverse().find(item =>
-      item.type !== 'requiredApproval' && item.type !== 'cowSwap')
-    let pendingSend: { item: PreparedPlanBroadcast['item'], completesPlan: boolean } | undefined
-    let lastSubmitted: (PreparedPlanBroadcast & { status: 'submitted' }) | undefined
-    let armedSend: PreparedPlanBroadcast | undefined
-    let sendIndex = 0
-
+    // A Safe's sequential fallback submits through the Safe app, so the
+    // wallet returns safeTxHash proposal ids, not on-chain hashes.
+    const tracker = createSequentialBroadcastTracker({
+      plan: effectivePrepared.plan,
+      isProposal: Boolean(safeWalletProvider),
+      emit: emitBroadcast,
+    })
     const sendTransaction = buildSendTransaction({
       isOkx,
       expectedAccount: preparedOwner,
       expectedChainId: prepared.chainId,
       connector,
       beforeBroadcast: options?.beforeBroadcast,
-      // Announce the step before crossing the wallet boundary: the wallet
-      // may accept the request and then fail to return its id, and trackers
-      // must already hold replay protection when that happens.
-      onArm: () => {
-        armedSend = {
-          // Fail toward the strict classification: an unattributed send is
-          // treated as the value-moving batch, never as a re-runnable step.
-          item: pendingSend?.item ?? 'evcBatch',
-          index: sendIndex,
-          completesPlan: pendingSend?.completesPlan ?? true,
-          status: 'armed',
-        }
-        options?.onBroadcast?.(armedSend)
-      },
-      onSubmitError: (error) => {
-        // Only a provable non-acceptance releases the armed state — any
-        // other wallet-boundary failure leaves acceptance possible.
-        if (armedSend && walletNeverAcceptedSubmission(error)) {
-          options?.onBroadcast?.({
-            item: armedSend.item,
-            index: armedSend.index,
-            completesPlan: armedSend.completesPlan,
-            status: 'rejected',
-          })
-          armedSend = undefined
-        }
-      },
-      // A Safe's sequential fallback submits through the Safe app, so the
-      // wallet returns a safeTxHash proposal id, not an on-chain hash.
-      onBroadcast: (hash) => {
-        armedSend = undefined
-        lastSubmitted = {
-          kind: safeWalletProvider ? 'proposal' : 'transaction',
-          hash,
-          item: pendingSend?.item ?? 'evcBatch',
-          index: sendIndex++,
-          completesPlan: pendingSend?.completesPlan ?? true,
-          status: 'submitted',
-        }
-        options?.onBroadcast?.(lastSubmitted)
-      },
+      onArm: tracker.onArm,
+      onSubmitError: tracker.onSubmitError,
+      onBroadcast: tracker.onBroadcast,
       resolveHash: safeWalletProvider
         ? async submittedHash => (await waitForSafeTransactionExecution({
           submittedHash,
@@ -1923,27 +2076,13 @@ export const useEulerTx = () => {
         })
         return signature as Hex
       },
-      onProgress: (progress: TransactionPlanExecutionProgress) => {
-        if (progress.hash) {
-          // Receipt confirmed for the outstanding submission.
-          if (lastSubmitted) {
-            options?.onBroadcast?.({ ...lastSubmitted, status: 'confirmed' })
-            lastSubmitted = undefined
-          }
-          return
-        }
-        if (progress.status === 'approval') {
-          pendingSend = { item: 'approval', completesPlan: false }
-        }
-        else if (progress.status === 'evcBatch' || progress.status === 'contractCall') {
-          pendingSend = {
-            item: progress.status === 'evcBatch' ? 'evcBatch' : 'pluginCall',
-            completesPlan: !!progress.item && progress.item === lastValueMovingItem,
-          }
-        }
-      },
+      onProgress: tracker.onProgress,
     })
 
+    // Terminal releases fire out of band from the executor's synchronous
+    // progress callback — drain them before this attempt's result is
+    // finalized so the released record cannot lag into the next attempt.
+    await tracker.flush()
     finalizeExecution(result)
     return result
   }
@@ -1970,7 +2109,7 @@ export const useEulerTx = () => {
       allowSingleCall?: boolean
       beforeBroadcast?: () => void
       /** See executePreparedPlan — fires with the safeTxHash proposal id. */
-      onBroadcast?: (broadcast: PreparedPlanBroadcast) => void
+      onBroadcast?: PreparedPlanBroadcastEmit
     },
   ) => {
     if (isSpyMode.value) {
@@ -1998,6 +2137,13 @@ export const useEulerTx = () => {
       getSafeWalletProvider,
     })
 
+    // Built-in reservation ownership — see executePreparedPlan.
+    const internalQuarantine = options?.onBroadcast
+      ? undefined
+      : createDirectSubmissionQuarantine({ flow: 'direct', getSafeWalletProvider })
+    internalQuarantine?.begin({ owner: preparedOwner, chainId: prepared.chainId })
+    const emitBroadcast: PreparedPlanBroadcastEmit = options?.onBroadcast ?? internalQuarantine!.track
+
     // Same invariant as executePreparedPlan: an envelope executed for a Safe
     // never carries permit2.
     let effectivePrepared = prepared
@@ -2014,8 +2160,7 @@ export const useEulerTx = () => {
       effectivePrepared = { ...prepared, usePermit2: false }
     }
 
-    let bundleBroadcast: (PreparedPlanBroadcast & { status: 'submitted' }) | undefined
-    let bundleArmed = false
+    const bundleTracker = createBundleBroadcastAdapter(emitBroadcast)
     const bundled = await executePlanAsSafeBundle({
       plan: effectivePrepared.plan,
       chainId: prepared.chainId,
@@ -2027,36 +2172,12 @@ export const useEulerTx = () => {
       extraCalls,
       allowSingleCall: options?.allowSingleCall,
       beforeBroadcast: options?.beforeBroadcast,
-      onArm: () => {
-        bundleArmed = true
-        options?.onBroadcast?.({ item: 'bundle', index: 0, completesPlan: true, status: 'armed' })
-      },
-      onSubmitError: (error) => {
-        // Only a provable non-acceptance releases the armed state — any
-        // other wallet-boundary failure leaves acceptance possible.
-        if (bundleArmed && walletNeverAcceptedSubmission(error)) {
-          bundleArmed = false
-          options?.onBroadcast?.({ item: 'bundle', index: 0, completesPlan: true, status: 'rejected' })
-        }
-      },
-      onBroadcast: (hash) => {
-        bundleBroadcast = {
-          kind: 'proposal',
-          hash,
-          item: 'bundle',
-          index: 0,
-          completesPlan: true,
-          status: 'submitted',
-        }
-        options?.onBroadcast?.(bundleBroadcast)
-      },
+      onArm: bundleTracker.onArm,
+      onSubmitError: bundleTracker.onSubmitError,
+      onBroadcast: bundleTracker.onBroadcast,
     })
     if (!bundled) return undefined
-    // A truthy bundle result means the proposal executed with a successful
-    // receipt — the submission's outcome is no longer unknown.
-    if (bundleBroadcast) {
-      options?.onBroadcast?.({ ...bundleBroadcast, status: 'confirmed' })
-    }
+    await bundleTracker.confirm()
     finalizeExecution(bundled)
     return bundled
   }

--- a/composables/useMigrationAuthorizationFlow.ts
+++ b/composables/useMigrationAuthorizationFlow.ts
@@ -62,15 +62,23 @@ export const useMigrationAuthorizationFlow = () => {
     return false
   }
 
-  const revokeAfterSuccess = async (revokes: readonly MigrationAuthorizationRevoke[]) => {
+  const revokeAfterSuccess = async (
+    revokes: readonly MigrationAuthorizationRevoke[],
+    options?: { shouldNotify?: () => boolean },
+  ) => {
     queueRevokes(revokes)
     if (await restorePendingRevokes()) return
+    if (options?.shouldNotify?.() === false) return
     showWarning('Migration succeeded, but restoring your previous authorization failed or was cancelled. You can restore it manually later.')
   }
 
-  const revokeAfterAbort = async (revokes: readonly MigrationAuthorizationRevoke[]) => {
+  const revokeAfterAbort = async (
+    revokes: readonly MigrationAuthorizationRevoke[],
+    options?: { shouldNotify?: () => boolean },
+  ) => {
     queueRevokes(revokes)
     if (await restorePendingRevokes()) return
+    if (options?.shouldNotify?.() === false) return
     showWarning('The temporary authorization granted for this migration is still standing. Retry the migration or restore your previous authorization manually.')
   }
 

--- a/composables/usePendingSubmissionRecovery.ts
+++ b/composables/usePendingSubmissionRecovery.ts
@@ -1,0 +1,106 @@
+import { onMounted, onUnmounted, ref, shallowRef, watch } from 'vue'
+import {
+  listReleasableArmedSubmissions,
+  releaseUnverifiablePendingSubmission,
+  subscribeToPendingSubmissionChanges,
+  type PendingSubmissionFlow,
+  type ReleasableArmedSubmission,
+} from '~/utils/pendingSubmissions'
+import { logWarn } from '~/utils/errorHandling'
+
+/**
+ * Flows whose armed records have no owning recovery surface of their own: a
+ * reload while the wallet prompt was open orphans the record, and the page
+ * that armed it holds no state to offer the release from. The batch flow is
+ * excluded — the batch cart drawer persists across navigation and owns its
+ * own release CTA over the exact entries the record covers.
+ */
+export const RECOVERABLE_SUBMISSION_FLOWS: readonly PendingSubmissionFlow[] = [
+  'direct',
+  'outgoing-migration',
+  'inbound-migration',
+  'cow-order',
+]
+
+export const recoverableSubmissionLabel = (flow: PendingSubmissionFlow): string =>
+  flow === 'cow-order'
+    ? 'CoW Swap order'
+    : flow === 'outgoing-migration' || flow === 'inbound-migration'
+      ? 'migration'
+      : 'transaction'
+
+/**
+ * App-root recovery for armed pending-submission records orphaned by a reload
+ * before the wallet answered. Such records have no transaction id, so they
+ * can never resolve on-chain by themselves — they block every executor for
+ * the wallet/chain until the user explicitly confirms the wallet itself shows
+ * nothing pending and dismisses them. Records that carry any verifiable id
+ * (submitted, or armed with an observed id) are never listed: they resolve
+ * objectively and must not be dismissable.
+ */
+export const usePendingSubmissionRecovery = () => {
+  const { address } = useWagmi()
+  // shallowRef: entries are immutable snapshots replaced wholesale on every
+  // refresh — deep reactivity would only mangle the readonly record types.
+  const entries = shallowRef<ReleasableArmedSubmission[]>([])
+  const releaseError = ref('')
+
+  const refresh = () => {
+    const owner = address.value
+    if (!owner) {
+      entries.value = []
+      return
+    }
+    try {
+      // Both sides are EIP-55 checksummed (the listing via getAddress, the
+      // connected address via useWagmi's normalization).
+      entries.value = listReleasableArmedSubmissions(RECOVERABLE_SUBMISSION_FLOWS)
+        .filter(entry => entry.owner === owner)
+    }
+    catch (err) {
+      // Recovery is best-effort UI — it must never break the app shell. The
+      // executors' own gates keep failing closed regardless.
+      logWarn('pendingSubmissionRecovery/list', err)
+      entries.value = []
+    }
+  }
+
+  /**
+   * Risk-labelled manual release. Callers must only invoke this from a
+   * control whose copy states the user checked the wallet's pending activity
+   * and found nothing pending — the acknowledgement flag asserts exactly
+   * that. A refusal (e.g. the record gained an id meanwhile) surfaces as
+   * `releaseError` and the listing refreshes either way.
+   */
+  const release = async (entry: ReleasableArmedSubmission) => {
+    releaseError.value = ''
+    try {
+      await releaseUnverifiablePendingSubmission(entry.flow, entry.owner, entry.chainId, {
+        userConfirmedWalletShowsNoPendingSubmission: true,
+      })
+    }
+    catch (err) {
+      releaseError.value = err instanceof Error ? err.message : 'This record could not be dismissed.'
+      logWarn('pendingSubmissionRecovery/release', err)
+    }
+    finally {
+      refresh()
+    }
+  }
+
+  let unsubscribe: (() => void) | undefined
+  onMounted(() => {
+    unsubscribe = subscribeToPendingSubmissionChanges(refresh)
+    // Same-key writes from other tabs arrive as storage events.
+    window.addEventListener('storage', refresh)
+    refresh()
+  })
+  onUnmounted(() => {
+    unsubscribe?.()
+    unsubscribe = undefined
+    window.removeEventListener('storage', refresh)
+  })
+  watch(address, refresh)
+
+  return { entries, releaseError, refresh, release }
+}

--- a/composables/useTxBatch.ts
+++ b/composables/useTxBatch.ts
@@ -36,12 +36,16 @@ import type { WalletExecutionContext } from '~/utils/walletExecutionContext'
 import type { PreparedPlanBroadcast } from '~/composables/useEulerTx'
 import { getSafeWalletProvider, type ReceiptClientLike } from '~/utils/safeWalletTransactions'
 import {
+  armPendingSubmission,
   clearPendingSubmission,
+  createPendingSubmissionAttemptId,
   listPendingSubmissions,
   pendingSubmissionStorageKeyPrefix,
   readPendingSubmission,
+  releasePendingSubmission,
+  releaseUnverifiablePendingSubmission,
   resolvePendingSubmissionOutcome,
-  writePendingSubmission,
+  upgradePendingSubmissionToSubmitted,
   type PendingSubmissionRecord,
 } from '~/utils/pendingSubmissions'
 import { registerLandedBatchSubmissionHandler } from '~/utils/pendingSubmissionGate'
@@ -348,14 +352,26 @@ const setPendingCoreSubmission = (record: PendingSubmissionRecord, context?: { c
   pendingCoreSubmissions.value = next
 }
 
-/** Remove the wallet's record from the mirror AND its durable storage. */
-const removePendingCoreSubmission = (owner: Address, chainId: number) => {
-  clearPendingSubmission('batch', owner, chainId)
-  const key = pendingSubmissionMirrorKey(owner, chainId)
-  if (!pendingCoreSubmissions.value.has(key)) return
-  const next = new Map(pendingCoreSubmissions.value)
-  next.delete(key)
-  pendingCoreSubmissions.value = next
+/**
+ * Remove the wallet's record from durable storage and refresh the mirror.
+ * The delete is guarded: with `attemptId` it is ownership-checked (a stale
+ * completion cannot delete a reservation a newer attempt holds), and with
+ * `ifMatches` it is compare-and-delete against the exact reconciled record.
+ * The mirror is rebuilt from storage afterwards, so a refused delete keeps
+ * the surviving record visible.
+ */
+const removePendingCoreSubmission = async (
+  owner: Address,
+  chainId: number,
+  guard: { attemptId: string } | { ifMatches: PendingSubmissionRecord },
+) => {
+  if ('attemptId' in guard) {
+    await releasePendingSubmission('batch', owner, chainId, guard)
+  }
+  else {
+    await clearPendingSubmission('batch', owner, chainId, guard)
+  }
+  hydratePendingBatchSubmissionFromStorage()
 }
 
 /**
@@ -2971,16 +2987,27 @@ export const useTxBatch = () => {
   ): Promise<boolean> => {
     hydratePendingBatchSubmissionFromStorage()
     if (!attempt.owner || !attempt.chainId) return true
-    const record = readPendingSubmission('batch', attempt.owner, attempt.chainId)
-    if (!record) return true
-    const context = pendingCoreSubmissions.value
-      .get(pendingSubmissionMirrorKey(record.owner, record.chainId))?.context
-
-    const releaseQuarantine = () => {
-      removePendingCoreSubmission(record.owner, record.chainId)
+    let record: PendingSubmissionRecord | undefined
+    try {
+      record = readPendingSubmission('batch', attempt.owner, attempt.chainId)
     }
+    catch (error) {
+      // Unreadable or corrupt state: a previous submission cannot be ruled
+      // out, so the attempt is blocked — never treated as "no quarantine".
+      execError.value = error instanceof Error ? error.message : String(error)
+      return false
+    }
+    if (!record) return true
+    const reconciled = record
+    const context = pendingCoreSubmissions.value
+      .get(pendingSubmissionMirrorKey(reconciled.owner, reconciled.chainId))?.context
+
+    // Compare-and-delete: only the exact reconciled record is released — a
+    // record another attempt reserved during the on-chain check survives.
+    const releaseQuarantine = () =>
+      removePendingCoreSubmission(reconciled.owner, reconciled.chainId, { ifMatches: reconciled })
     const keepQuarantined = () => {
-      execError.value = record.phase === 'armed'
+      execError.value = reconciled.phase === 'armed'
         ? 'A previous batch submission was handed to the wallet but no transaction id came back, so it cannot be verified automatically. Check the wallet\'s pending activity and let it resolve before executing again.'
         : 'A previous batch submission may still confirm on-chain and could not be verified yet. Wait a moment and execute again — the submission is re-checked before anything is re-sent.'
       return false
@@ -3000,12 +3027,12 @@ export const useTxBatch = () => {
     }
     if (outcome === 'not-landed') {
       // Definitively cancelled/reverted — a retry cannot duplicate anything.
-      releaseQuarantine()
+      await releaseQuarantine()
       return true
     }
 
     // Landed: on-chain state moved under any standing review.
-    releaseQuarantine()
+    await releaseQuarantine()
     invalidateBatchReview()
     if (!record.completesPlan) {
       // Defensive: a landed intermediate submission means part of the plan
@@ -3088,36 +3115,56 @@ export const useTxBatch = () => {
     // definitively confirmed — a failure after this point must not allow the
     // covered entries to be executed again.
     let confirmedValueMovingBroadcast: PreparedPlanBroadcast | undefined
-    const trackBroadcast = (broadcast: PreparedPlanBroadcast) => {
+    // Identity of this attempt's reservation: upgrades and terminal releases
+    // are ownership-checked against it, so a stale completion from this
+    // attempt can never delete a reservation a newer attempt holds.
+    const attemptId = createPendingSubmissionAttemptId()
+    const trackBroadcast = async (broadcast: PreparedPlanBroadcast) => {
       const valueMoving = broadcast.item === 'bundle' || broadcast.item === 'evcBatch'
       if (broadcast.status === 'armed' || broadcast.status === 'submitted') {
-        unconfirmedBroadcast = broadcast
+        // A submitted broadcast is ambiguous no matter what happens below —
+        // the wallet already returned an id. An armed one becomes ambiguous
+        // only once the reservation succeeded: an arm that throws aborts the
+        // attempt before the wallet is invoked, so nothing is outstanding.
+        if (broadcast.status === 'submitted') unconfirmedBroadcast = broadcast
         if (valueMoving && execution) {
-          // Persist the quarantine synchronously at the wallet boundary — a
-          // reload or crash between here and the receipt must still find the
-          // record, and the wallet may accept a request yet never return its
-          // id. The armed record upgrades to the submitted hash in place.
+          // Persist the quarantine at the wallet boundary — the executor
+          // awaits this emission before invoking the wallet, so a
+          // reservation another attempt holds, or one that cannot be proven
+          // durable, throws here and the wallet is never invoked. A reload
+          // or crash after this point still finds the record; the armed
+          // record upgrades to its submitted hash in place.
           const owner = getAddress(execution.owner)
-          const record: PendingSubmissionRecord = {
-            ...(broadcast.status === 'armed'
-              ? { phase: 'armed' as const }
-              : { phase: 'submitted' as const, kind: broadcast.kind, hash: broadcast.hash }),
-            chainId: execution.chainId,
-            owner,
-            completesPlan: broadcast.completesPlan,
-            refreshExternalPositions: entries.value.some(entry =>
-              entry.refreshExternalMigrationPositions && entry.id in execution!.reviewByEntryId),
-            submittedAt: Date.now(),
-          }
-          writePendingSubmission('batch', record)
-          setPendingCoreSubmission(record, { ceremony: execution })
+          const refreshExternalPositions = entries.value.some(entry =>
+            entry.refreshExternalMigrationPositions && entry.id in execution!.reviewByEntryId)
+          const record = broadcast.status === 'armed'
+            ? await armPendingSubmission('batch', {
+                owner,
+                chainId: execution.chainId,
+                completesPlan: broadcast.completesPlan,
+                refreshExternalPositions,
+                attemptId,
+              })
+            : await upgradePendingSubmissionToSubmitted('batch', {
+                owner,
+                chainId: execution.chainId,
+                attemptId,
+                kind: broadcast.kind,
+                hash: broadcast.hash,
+                completesPlan: broadcast.completesPlan,
+                refreshExternalPositions,
+              })
+          // A refused upgrade (ownership lost, storage failure) leaves the
+          // stored record authoritative; only mirror what actually stuck.
+          if (record) setPendingCoreSubmission(record, { ceremony: execution })
         }
+        if (broadcast.status === 'armed') unconfirmedBroadcast = broadcast
         return
       }
       // 'rejected' and 'confirmed' are both terminal for the record.
       unconfirmedBroadcast = undefined
       if (valueMoving && execution) {
-        removePendingCoreSubmission(getAddress(execution.owner), execution.chainId)
+        await removePendingCoreSubmission(getAddress(execution.owner), execution.chainId, { attemptId })
       }
       if (broadcast.status === 'confirmed' && valueMoving) {
         confirmedValueMovingBroadcast = broadcast
@@ -3363,7 +3410,10 @@ export const useTxBatch = () => {
   registerLandedBatchSubmissionHandler((record) => {
     const context = pendingCoreSubmissions.value
       .get(pendingSubmissionMirrorKey(record.owner, record.chainId))?.context
-    removePendingCoreSubmission(record.owner, record.chainId)
+    // Compare-and-delete of the exact landed record; the handler contract is
+    // synchronous and the gate throws right after, so the lock-serialized
+    // delete completes out of band.
+    void removePendingCoreSubmission(record.owner, record.chainId, { ifMatches: record })
     invalidateBatchReview()
     if (record.completesPlan && context) {
       retireExecutedEntries(context.ceremony)
@@ -3375,6 +3425,51 @@ export const useTxBatch = () => {
     }
     if (record.refreshExternalPositions) scheduleExternalMigrationRefreshes()
   })
+
+  /**
+   * The current wallet/chain holds an armed batch record and no attempt is
+   * running — after a reload the attempt that armed it is gone, no id will
+   * ever arrive, and only a manual wallet check can resolve it. Drives the
+   * visibility of the manual release action.
+   */
+  const hasReleasableArmedSubmission = computed(() => {
+    if (isExecuting.value) return false
+    const currentOwner = owner.value
+    const currentChainId = chainId.value
+    if (!currentOwner || !currentChainId) return false
+    try {
+      const entry = pendingCoreSubmissions.value
+        .get(pendingSubmissionMirrorKey(currentOwner, currentChainId))
+      return entry?.record.phase === 'armed'
+    }
+    catch {
+      return false
+    }
+  })
+
+  /**
+   * Risk-labelled manual recovery for an armed record orphaned by a reload:
+   * call sites must present the user a "the wallet shows nothing pending"
+   * confirmation before invoking this. Submitted records are refused by the
+   * underlying release — they carry an id and are verified on-chain instead.
+   */
+  const releaseArmedQuarantineAfterManualCheck = async (): Promise<boolean> => {
+    const currentOwner = owner.value
+    const currentChainId = chainId.value
+    if (!currentOwner || !currentChainId) return false
+    try {
+      const released = await releaseUnverifiablePendingSubmission('batch', getAddress(currentOwner), currentChainId, {
+        userConfirmedWalletShowsNoPendingSubmission: true,
+      })
+      hydratePendingBatchSubmissionFromStorage()
+      if (released) execError.value = undefined
+      return released
+    }
+    catch (error) {
+      execError.value = error instanceof Error ? error.message : String(error)
+      return false
+    }
+  }
 
   return {
     entries,
@@ -3388,6 +3483,8 @@ export const useTxBatch = () => {
     isExecuting,
     execError,
     hasPendingCoreSubmission: computed(() => pendingCoreSubmissions.value.size > 0),
+    hasReleasableArmedSubmission,
+    releaseArmedQuarantineAfterManualCheck,
     hasFailedOps,
     canExecuteBatch,
     hasInsufficientBalance,

--- a/composables/useTxBatch.ts
+++ b/composables/useTxBatch.ts
@@ -37,11 +37,14 @@ import type { PreparedPlanBroadcast } from '~/composables/useEulerTx'
 import { getSafeWalletProvider, type ReceiptClientLike } from '~/utils/safeWalletTransactions'
 import {
   clearPendingSubmission,
+  listPendingSubmissions,
+  pendingSubmissionStorageKeyPrefix,
   readPendingSubmission,
   resolvePendingSubmissionOutcome,
   writePendingSubmission,
   type PendingSubmissionRecord,
 } from '~/utils/pendingSubmissions'
+import { registerLandedBatchSubmissionHandler } from '~/utils/pendingSubmissionGate'
 import {
   assertPreparedPlanSignatureParity,
   type PreparedPlanSignatureSubstitution,
@@ -314,35 +317,78 @@ const simError = ref<string | undefined>(undefined)
 const isExecuting = ref(false)
 const execError = ref<string | undefined>(undefined)
 /**
- * A core batch submission the wallet accepted but whose confirmation failed —
- * it may still land. While set, execution for the record's wallet/chain is
- * quarantined against blind replays (re-executing could duplicate every entry
- * the submission covered): the next execute attempt first reconciles this
- * submission on-chain, and proceeds only when it definitively did not land.
- * Landed submissions retire their entries.
+ * Core batch submissions the wallet was invoked for but whose outcome is
+ * unknown — armed (no id returned yet) or submitted but unconfirmed. While a
+ * record exists, execution for its wallet/chain is quarantined against blind
+ * replays (re-executing could duplicate every entry the submission covered):
+ * the next execute attempt first reconciles the submission on-chain, and
+ * proceeds only when it definitively did not land. Landed submissions retire
+ * their entries.
  *
- * The record itself is durable (localStorage) so cart clearing, account
- * switches, and page reloads cannot erase the unknown outcome — only a
- * terminal reconcile verdict releases it. The ceremony context exists only
- * while the submitting session is alive; a record hydrated after a reload has
- * no ceremony, so a landed verdict then resets the cart instead of retiring
- * the exact covered entries.
+ * The records are durable (localStorage, keyed per wallet and chain) so cart
+ * clearing, account switches, and page reloads cannot erase the unknown
+ * outcome — only a terminal verdict releases one. This map is a same-session
+ * mirror; durable storage stays the source of truth and is re-read before
+ * every attempt, because another tab can add a record long after this one
+ * hydrated. The ceremony context exists only while the submitting session is
+ * alive; a record hydrated after a reload has no ceremony, so a landed
+ * verdict then resets the cart instead of retiring the exact covered entries.
  */
-const pendingCoreSubmission = shallowRef<{
+const pendingCoreSubmissions = shallowRef<ReadonlyMap<string, {
   record: PendingSubmissionRecord
   context?: { ceremony: PreparedBatchExecution }
-} | null>(null)
+}>>(new Map())
+
+const pendingSubmissionMirrorKey = (owner: Address, chainId: number) =>
+  `${chainId}:${getAddress(owner)}`
+
+const setPendingCoreSubmission = (record: PendingSubmissionRecord, context?: { ceremony: PreparedBatchExecution }) => {
+  const next = new Map(pendingCoreSubmissions.value)
+  next.set(pendingSubmissionMirrorKey(record.owner, record.chainId), { record, context })
+  pendingCoreSubmissions.value = next
+}
+
+/** Remove the wallet's record from the mirror AND its durable storage. */
+const removePendingCoreSubmission = (owner: Address, chainId: number) => {
+  clearPendingSubmission('batch', owner, chainId)
+  const key = pendingSubmissionMirrorKey(owner, chainId)
+  if (!pendingCoreSubmissions.value.has(key)) return
+  const next = new Map(pendingCoreSubmissions.value)
+  next.delete(key)
+  pendingCoreSubmissions.value = next
+}
 
 /**
- * Rehydrate the quarantine mirror from its durable record. Runs once at
- * module init (covering reloads and reconnects); tests re-run it after
- * seeding or clearing storage to simulate those lifecycles.
+ * Rebuild the quarantine mirror from its durable records. Runs at module
+ * init (covering reloads and reconnects), on cross-tab storage events, and
+ * before every execute attempt — an already-open tab must see a quarantine
+ * another tab stored after this one initialized. Ceremony contexts are
+ * preserved only while they still describe the stored submission (same
+ * attempt: an armed record upgrading to its submitted hash keeps its
+ * ceremony; a different hash means a different submission).
  */
 export const hydratePendingBatchSubmissionFromStorage = () => {
-  const record = readPendingSubmission('batch')
-  pendingCoreSubmission.value = record ? { record } : null
+  const previous = pendingCoreSubmissions.value
+  const next = new Map<string, { record: PendingSubmissionRecord, context?: { ceremony: PreparedBatchExecution } }>()
+  for (const record of listPendingSubmissions('batch')) {
+    const key = pendingSubmissionMirrorKey(record.owner, record.chainId)
+    const prior = previous.get(key)
+    const sameAttempt = !!prior
+      && (prior.record.phase === 'armed' || prior.record.hash === record.hash)
+    next.set(key, { record, context: sameAttempt ? prior.context : undefined })
+  }
+  pendingCoreSubmissions.value = next
 }
 hydratePendingBatchSubmissionFromStorage()
+if (typeof window !== 'undefined') {
+  // Storage events only fire in OTHER tabs, which is exactly the gap: a tab
+  // that hydrated before another tab quarantined a submission.
+  window.addEventListener('storage', (event) => {
+    if (event.key === null || event.key.startsWith(pendingSubmissionStorageKeyPrefix('batch'))) {
+      hydratePendingBatchSubmissionFromStorage()
+    }
+  })
+}
 // Drawer expanded/collapsed state, shared so the mobile nav's "Batch" item and
 // the drawer header toggle the same thing. On laptop this collapses the body; on
 // mobile it shows/hides the whole bottom sheet (the nav item is the entry point).
@@ -2907,32 +2953,36 @@ export const useTxBatch = () => {
 
   /**
    * Resolve a quarantined core submission before anything new is sent.
-   * Returns true when this attempt may proceed: no quarantine exists, the
-   * record belongs to a different wallet/chain (nothing this attempt sends
-   * can duplicate it, so the record is kept for the wallet that owns it), or
-   * the submission definitively did not land. A landed submission retires the
-   * entries it covered and stops the attempt; an unverifiable one keeps the
-   * quarantine — replaying while the original may still confirm would
-   * duplicate every entry it covered.
+   * Returns true when this attempt may proceed: no quarantine exists for the
+   * attempting wallet/chain (records are keyed per wallet, so another
+   * wallet's record stays quarantined for the wallet that owns it without
+   * blocking this one), or the submission definitively did not land. A landed
+   * submission retires the entries it covered and stops the attempt; an
+   * unverifiable one keeps the quarantine — replaying while the original may
+   * still confirm would duplicate every entry it covered.
+   *
+   * The durable record is re-read here, never trusted from the in-memory
+   * mirror: another tab may have quarantined a submission long after this
+   * tab hydrated.
    */
   const reconcilePendingCoreSubmission = async (
     scope: TrackedExecutionScope | undefined,
     attempt: { owner?: Address, chainId?: number },
   ): Promise<boolean> => {
-    const submission = pendingCoreSubmission.value
-    if (!submission) return true
-    const { record, context } = submission
-
-    const matchesAttempt = !!attempt.owner
-      && attempt.owner === record.owner
-      && attempt.chainId === record.chainId
+    hydratePendingBatchSubmissionFromStorage()
+    if (!attempt.owner || !attempt.chainId) return true
+    const record = readPendingSubmission('batch', attempt.owner, attempt.chainId)
+    if (!record) return true
+    const context = pendingCoreSubmissions.value
+      .get(pendingSubmissionMirrorKey(record.owner, record.chainId))?.context
 
     const releaseQuarantine = () => {
-      pendingCoreSubmission.value = null
-      clearPendingSubmission('batch')
+      removePendingCoreSubmission(record.owner, record.chainId)
     }
     const keepQuarantined = () => {
-      execError.value = 'A previous batch submission may still confirm on-chain and could not be verified yet. Wait a moment and execute again — the submission is re-checked before anything is re-sent.'
+      execError.value = record.phase === 'armed'
+        ? 'A previous batch submission was handed to the wallet but no transaction id came back, so it cannot be verified automatically. Check the wallet\'s pending activity and let it resolve before executing again.'
+        : 'A previous batch submission may still confirm on-chain and could not be verified yet. Wait a moment and execute again — the submission is re-checked before anything is re-sent.'
       return false
     }
 
@@ -2946,9 +2996,7 @@ export const useTxBatch = () => {
     })
 
     if (outcome === 'unknown') {
-      // Fail closed only for the wallet/chain that owns the record — a
-      // different wallet's attempt cannot duplicate it and may proceed.
-      return matchesAttempt ? keepQuarantined() : true
+      return keepQuarantined()
     }
     if (outcome === 'not-landed') {
       // Definitively cancelled/reverted — a retry cannot duplicate anything.
@@ -2974,14 +3022,13 @@ export const useTxBatch = () => {
     if (context) {
       retireExecutedEntries(context.ceremony)
     }
-    else if (matchesAttempt) {
-      // No ceremony survives a reload, so the exact covered entries are
-      // unknown — reset the cart rather than leave already-executed entries
-      // queued to run again.
+    else {
+      // No ceremony survives a reload (or the record came from another tab),
+      // so the exact covered entries are unknown — reset the cart rather
+      // than leave already-executed entries queued to run again.
       clearBatch()
     }
     if (record.refreshExternalPositions) scheduleExternalMigrationRefreshes()
-    if (!matchesAttempt) return true
     scope?.markSucceeded()
     if (entries.value.length > 0) {
       execError.value = 'The previous batch submission confirmed on-chain. The operations it covered were removed — review the remaining ones before executing again.'
@@ -3030,22 +3077,49 @@ export const useTxBatch = () => {
     }
     const grantedRevokes: MigrationAuthorizationRevoke[] = []
     let execution = reviewedExecution
-    // Ordered execution tracking. The executor waits for each submission's
-    // receipt before the next send and re-fires the broadcast as 'confirmed'
-    // once that receipt lands, so at most the single latest 'submitted'
-    // broadcast has an unknown outcome at any failure.
+    // Ordered execution tracking. The executor announces each step before
+    // crossing the wallet boundary ('armed'), re-fires with the id the wallet
+    // returned ('submitted'), and terminally with 'confirmed' (receipt landed)
+    // or 'rejected' (the wallet provably never accepted the request) — so at
+    // most the single latest armed/submitted broadcast has an unknown outcome
+    // at any failure.
     let unconfirmedBroadcast: PreparedPlanBroadcast | undefined
     // The value-moving submission (Safe bundle or EVC batch) whose receipt
     // definitively confirmed — a failure after this point must not allow the
     // covered entries to be executed again.
     let confirmedValueMovingBroadcast: PreparedPlanBroadcast | undefined
     const trackBroadcast = (broadcast: PreparedPlanBroadcast) => {
-      if (broadcast.status === 'submitted') {
+      const valueMoving = broadcast.item === 'bundle' || broadcast.item === 'evcBatch'
+      if (broadcast.status === 'armed' || broadcast.status === 'submitted') {
         unconfirmedBroadcast = broadcast
+        if (valueMoving && execution) {
+          // Persist the quarantine synchronously at the wallet boundary — a
+          // reload or crash between here and the receipt must still find the
+          // record, and the wallet may accept a request yet never return its
+          // id. The armed record upgrades to the submitted hash in place.
+          const owner = getAddress(execution.owner)
+          const record: PendingSubmissionRecord = {
+            ...(broadcast.status === 'armed'
+              ? { phase: 'armed' as const }
+              : { phase: 'submitted' as const, kind: broadcast.kind, hash: broadcast.hash }),
+            chainId: execution.chainId,
+            owner,
+            completesPlan: broadcast.completesPlan,
+            refreshExternalPositions: entries.value.some(entry =>
+              entry.refreshExternalMigrationPositions && entry.id in execution!.reviewByEntryId),
+            submittedAt: Date.now(),
+          }
+          writePendingSubmission('batch', record)
+          setPendingCoreSubmission(record, { ceremony: execution })
+        }
         return
       }
+      // 'rejected' and 'confirmed' are both terminal for the record.
       unconfirmedBroadcast = undefined
-      if (broadcast.item === 'bundle' || broadcast.item === 'evcBatch') {
+      if (valueMoving && execution) {
+        removePendingCoreSubmission(getAddress(execution.owner), execution.chainId)
+      }
+      if (broadcast.status === 'confirmed' && valueMoving) {
         confirmedValueMovingBroadcast = broadcast
       }
     }
@@ -3145,24 +3219,13 @@ export const useTxBatch = () => {
         ? unconfirmedBroadcast
         : undefined
       if (ambiguousValueMoving && execution) {
-        // The wallet accepted a value-moving submission but its confirmation
-        // failed — it may still land. Quarantine durably (the record survives
-        // cart clearing, account switches, and reloads) and force on-chain
-        // reconciliation before anything is re-sent. Ambiguous approval or
+        // A value-moving submission is armed or accepted with an unknown
+        // outcome — it may still land. The durable quarantine record was
+        // already written when the broadcast fired (persistence must not
+        // wait for this catch: a reload in between would lose it); here only
+        // force a fresh review before any retry. Ambiguous approval or
         // plugin submissions are idempotent prerequisites and need none of
         // this — an ordinary retry re-runs them safely.
-        const record: PendingSubmissionRecord = {
-          kind: ambiguousValueMoving.kind,
-          hash: ambiguousValueMoving.hash,
-          chainId: execution.chainId,
-          owner: getAddress(execution.owner),
-          completesPlan: ambiguousValueMoving.completesPlan,
-          refreshExternalPositions: entries.value.some(entry =>
-            entry.refreshExternalMigrationPositions && entry.id in execution!.reviewByEntryId),
-          submittedAt: Date.now(),
-        }
-        pendingCoreSubmission.value = { record, context: { ceremony: execution } }
-        writePendingSubmission('batch', record)
         ceremonyInvalidatedForRetry = true
         invalidateBatchReview()
       }
@@ -3183,7 +3246,9 @@ export const useTxBatch = () => {
       })
       let decodedError = await describeExecError(error)
       if (ambiguousValueMoving) {
-        decodedError = `${decodedError} The submission may still confirm — executing again first verifies it on-chain before anything is re-sent.`
+        decodedError = ambiguousValueMoving.status === 'armed'
+          ? `${decodedError} The wallet may have accepted the submission without returning its id — it stays treated as pending until it can be ruled out.`
+          : `${decodedError} The submission may still confirm — executing again first verifies it on-chain before anything is re-sent.`
       }
       else if (confirmedValueMovingBroadcast && execution) {
         decodedError = `${decodedError} The batch itself confirmed on-chain; the operations it covered were removed from the cart.`
@@ -3288,6 +3353,29 @@ export const useTxBatch = () => {
   const modifiedBalanceKeys = computed(() => modifiedPositionKeySets.value.balance)
   const modifiedDebtKeys = computed(() => modifiedPositionKeySets.value.debt)
 
+  // When another execution surface (a direct form or migration page)
+  // discovers that a quarantined batch submission LANDED, the cart must
+  // reconcile it exactly like its own pre-attempt check would — the cart's
+  // own reconcile can never run for an emptied cart (executeBatch
+  // early-returns on zero entries), so without this a landed record would
+  // block every surface forever. State is module-level, so re-registering on
+  // each composable call is idempotent.
+  registerLandedBatchSubmissionHandler((record) => {
+    const context = pendingCoreSubmissions.value
+      .get(pendingSubmissionMirrorKey(record.owner, record.chainId))?.context
+    removePendingCoreSubmission(record.owner, record.chainId)
+    invalidateBatchReview()
+    if (record.completesPlan && context) {
+      retireExecutedEntries(context.ceremony)
+    }
+    else {
+      // No ceremony (reload/another tab) or a partial landing — the exact
+      // covered entries are unknown; reset the cart.
+      clearBatch()
+    }
+    if (record.refreshExternalPositions) scheduleExternalMigrationRefreshes()
+  })
+
   return {
     entries,
     layers,
@@ -3299,7 +3387,7 @@ export const useTxBatch = () => {
     simError,
     isExecuting,
     execError,
-    hasPendingCoreSubmission: computed(() => !!pendingCoreSubmission.value),
+    hasPendingCoreSubmission: computed(() => pendingCoreSubmissions.value.size > 0),
     hasFailedOps,
     canExecuteBatch,
     hasInsufficientBalance,

--- a/composables/useTxBatch.ts
+++ b/composables/useTxBatch.ts
@@ -111,6 +111,20 @@ export interface BatchEntryBundledExecution {
   revokeSteps: DisplayStep[]
 }
 
+/** One immutable Safe review ceremony used for display, export, and execution. */
+export interface PreparedBatchBundledExecution {
+  readonly generation: number
+  readonly owner: Address
+  readonly chainId: number
+  readonly prepared: TransactionPlanPrepared
+  readonly grants: readonly BatchEntryExternalTx[]
+  readonly revokes: readonly BatchEntryExternalTx[]
+  readonly stepsByEntryId: Readonly<Record<string, {
+    readonly grantSteps: readonly DisplayStep[]
+    readonly revokeSteps: readonly DisplayStep[]
+  }>>
+}
+
 export interface BatchEntry {
   id: string
   label: string
@@ -227,22 +241,16 @@ export interface WalletShortfall {
 // --- module-scoped state (single shared cart for the session) ---
 const entries: Ref<BatchEntry[]> = ref([])
 const layers = shallowRef<BatchLayer[]>([])
-/**
- * Bundled ceremony resolved ONCE when the review modal opens, displayed,
- * copied, and executed verbatim — the latch that keeps the reviewed
- * ceremony, the copied payload, and the submitted proposal identical. A
- * cart edit or account/chain reset clears it; executeBatch treats its
- * presence as the reviewed promise of ONE proposal. Module-scoped like the
- * rest of the cart state so every component instance shares it.
- */
-const latchedBundledExecution = shallowRef<{
-  /** Prepared core envelope shared by review export and Safe execution. */
-  prepared: TransactionPlanPrepared
-  grants: BatchEntryExternalTx[]
-  revokes: BatchEntryExternalTx[]
-  /** Per-entry review rows from the same resolution, for the modal to render. */
-  stepsByEntryId: Record<string, { grantSteps: DisplayStep[], revokeSteps: DisplayStep[] }>
-} | null>(null)
+const batchGeneration = ref(0)
+let bundledPreparation: {
+  generation: number
+  promise: Promise<PreparedBatchBundledExecution>
+} | null = null
+
+const invalidateBatchReview = () => {
+  batchGeneration.value++
+  bundledPreparation = null
+}
 // Per-entry fixed plan (keyed by entry id), used by the review modal and by the
 // merged whole-batch plan. These are captured once when the entry is added.
 const entryPlans = computed<Record<string, TransactionPlan>>(() =>
@@ -2136,18 +2144,15 @@ export const useTxBatch = () => {
       watch(entries, () => {
         logBatchDiag('watch:entries-changed')
         tenderly.clearSimulation()
-        // A cart edit invalidates the latched bundled ceremony — the modal
-        // re-latches on next open.
-        latchedBundledExecution.value = null
         void runResimulate()
       })
       watch([activeLayer, layers], syncOverlay)
       // Reset the cart when the account or chain changes — layers would be stale.
       watch([owner, chainId], () => {
         logBatchDiag('watch:owner-or-chain-reset', {}, 'error')
+        invalidateBatchReview()
         resimToken++
         entries.value = []
-        latchedBundledExecution.value = null
         layers.value = []
         activeLayer.value = 0
         isSimulating.value = false
@@ -2245,6 +2250,9 @@ export const useTxBatch = () => {
     const signature = `${entry.subAccount ?? ''}|${entry.label}`
     if (pendingAddSignatures.has(signature)) return
     pendingAddSignatures.add(signature)
+    // Invalidate synchronously when the edit starts, not after its async plan
+    // build finishes, so an open review cannot execute while an add is pending.
+    invalidateBatchReview()
 
     const add = async () => {
       execError.value = undefined
@@ -2321,6 +2329,8 @@ export const useTxBatch = () => {
   const removeEntry = (id: string) => {
     const nextEntries = entries.value.filter(entry => entry.id !== id)
     execError.value = undefined
+    if (nextEntries.length === entries.value.length) return
+    invalidateBatchReview()
     entries.value = nextEntries
     if (nextEntries.length === 0) {
       resimToken++
@@ -2339,6 +2349,7 @@ export const useTxBatch = () => {
   }
 
   const clearBatch = () => {
+    invalidateBatchReview()
     resimToken++
     entries.value = []
     layers.value = []
@@ -2416,7 +2427,6 @@ export const useTxBatch = () => {
   /** Resolve approvals/permits/plugins for the merged batch plan, so the review
    *  modal can list the approvals the user will be asked to sign. */
   const prepareBatchPlan = async () => {
-    if (latchedBundledExecution.value) return latchedBundledExecution.value.prepared
     if (!lastMerged) return null
     return prepareTransactionPlan(lastMerged)
   }
@@ -2467,25 +2477,69 @@ export const useTxBatch = () => {
     && entries.value.every(entry => !entry.buildExecutionPrerequisites || entry.buildBundledExecution),
   )
 
-  /**
-   * Bundled ceremony resolved ONCE when the review modal opens, displayed,
-   * copied, and executed verbatim — the latch that keeps the reviewed
-   * ceremony, the copied payload, and the submitted proposal identical. A
-   * cart edit or account/chain reset clears it; executeBatch treats its
-   * presence as the reviewed promise of ONE proposal.
-   */
-  const prepareBundledExecution = async () => {
-    if (!willBundlePrerequisites.value) {
-      latchedBundledExecution.value = null
-      return null
+  const isBundledExecutionCurrent = (ceremony: PreparedBatchBundledExecution): boolean => {
+    if (ceremony.generation !== batchGeneration.value || ceremony.chainId !== chainId.value || !owner.value) {
+      return false
     }
-    const { plans, ...ceremony } = await collectBundledExecution()
-    const sdk = await getEulerSdkFresh()
-    const executionPlan = sdk.executionService.mergePlans(plans)
-    const prepared = await prepareTransactionPlan(executionPlan)
-    const latched = { ...ceremony, prepared }
-    latchedBundledExecution.value = latched
-    return latched
+    try {
+      return getAddress(owner.value) === ceremony.owner
+    }
+    catch {
+      return false
+    }
+  }
+
+  const assertBundledExecutionCurrent = (ceremony: PreparedBatchBundledExecution) => {
+    if (!isBundledExecutionCurrent(ceremony)) {
+      throw new Error('Batch or wallet changed since review preparation — reopen review and try again.')
+    }
+  }
+
+  /**
+   * Resolve one ceremony per cart generation. Concurrent review modals share
+   * the same in-flight promise and immutable result; stale work can finish but
+   * cannot be used after a cart, account, or chain change.
+   */
+  const prepareBundledExecution = (): Promise<PreparedBatchBundledExecution | null> => {
+    if (!willBundlePrerequisites.value) return Promise.resolve(null)
+
+    const generation = batchGeneration.value
+    if (bundledPreparation?.generation === generation) return bundledPreparation.promise
+
+    const currentOwner = owner.value
+    const currentChainId = chainId.value
+    if (!currentOwner || !currentChainId) return Promise.reject(new Error('Account not loaded'))
+    const reviewOwner = getAddress(currentOwner)
+
+    const preparationPromise = (async (): Promise<PreparedBatchBundledExecution> => {
+      const { plans, grants, revokes, stepsByEntryId } = await collectBundledExecution()
+      const sdk = await getEulerSdkFresh()
+      const executionPlan = sdk.executionService.mergePlans(plans)
+      const prepared = await prepareTransactionPlan(executionPlan)
+      const frozenSteps = Object.freeze(Object.fromEntries(
+        Object.entries(stepsByEntryId).map(([entryId, steps]) => [entryId, Object.freeze({
+          grantSteps: Object.freeze([...steps.grantSteps]),
+          revokeSteps: Object.freeze([...steps.revokeSteps]),
+        })]),
+      ))
+      const ceremony: PreparedBatchBundledExecution = Object.freeze({
+        generation,
+        owner: reviewOwner,
+        chainId: currentChainId,
+        prepared,
+        grants: Object.freeze([...grants]),
+        revokes: Object.freeze([...revokes]),
+        stepsByEntryId: frozenSteps,
+      })
+      assertBundledExecutionCurrent(ceremony)
+      return ceremony
+    })()
+
+    const trackedPromise = preparationPromise.finally(() => {
+      if (bundledPreparation?.promise === trackedPromise) bundledPreparation = null
+    })
+    bundledPreparation = { generation, promise: trackedPromise }
+    return trackedPromise
   }
 
   /**
@@ -2563,7 +2617,10 @@ export const useTxBatch = () => {
    * the preview plan; entries with simulation-only preview state can rebuild a
    * signed execution plan before the merged batch is prepared and sent.
    */
-  const executeBatch = async (scope?: TrackedExecutionScope) => {
+  const executeBatch = async (
+    scope?: TrackedExecutionScope,
+    bundledExecution?: PreparedBatchBundledExecution,
+  ) => {
     if (isExecuting.value || entries.value.length === 0 || !lastMerged) return
     // simError covers both a top-level EVC revert and a deferred status-check
     // failure; walletShortfalls covers an under-funded wallet. Either way the
@@ -2579,34 +2636,35 @@ export const useTxBatch = () => {
       // the last simulation), surface the decoded reason and don't send.
       const shouldRefreshExternalMigrationPositions = entries.value.some(entry => entry.refreshExternalMigrationPositions)
 
-      if (latchedBundledExecution.value) {
-        // The review modal latched and displayed ONE atomic proposal built
-        // from this exact resolution — execute it verbatim (payload
-        // identity), even when the grants resolved empty: the provider-bound
-        // Safe path must not silently degrade into anything else.
+      if (bundledExecution) {
+        // Execute the exact immutable ceremony owned by this review modal.
+        // Never combine its prepared core with wrappers from another review.
+        assertBundledExecutionCurrent(bundledExecution)
         if (!isSafeWallet.value) {
           throw new Error('Wallet changed since review — please review the batch again.')
         }
-        const collected = latchedBundledExecution.value
         // No standalone gas estimate — grants are unmined until the
         // proposal executes; the cart's continuous simulation (which runs
         // with the entries' authorization state overrides) is the
         // pre-flight validation. Atomicity also removes the unwind
         // bookkeeping: a failed proposal reverts its grants with it.
-        const result = await executePreparedPlanWithPlainCalls(collected.prepared, {
-          before: collected.grants,
-          after: collected.revokes,
+        const result = await executePreparedPlanWithPlainCalls(bundledExecution.prepared, {
+          before: bundledExecution.grants,
+          after: bundledExecution.revokes,
         }, { allowSingleCall: true })
         if (!result) {
           // The review described ONE proposal; never silently degrade to
           // the sequential multi-proposal ceremony.
           throw new Error('Safe connection unavailable — the reviewed single-proposal submission cannot run. Reconnect your Safe and retry.')
         }
-        latchedBundledExecution.value = null
         clearBatch()
         if (shouldRefreshExternalMigrationPositions) scheduleExternalMigrationRefreshes()
         await redirectAfterBatchExecution(scope)
         return
+      }
+
+      if (willBundlePrerequisites.value) {
+        throw new Error('Safe batch review expired — reopen review before submitting.')
       }
 
       await sendExecutionPrerequisites(grantedRevokes)
@@ -2751,7 +2809,7 @@ export const useTxBatch = () => {
     executeBatch,
     willBundlePrerequisites,
     prepareBundledExecution,
-    latchedBundledExecution,
+    isBundledExecutionCurrent,
     // Tenderly "Simulate on Tenderly" for the whole batch.
     tenderlyEnabled,
     isTenderlySimulating: tenderly.isSimulating,

--- a/composables/useTxBatch.ts
+++ b/composables/useTxBatch.ts
@@ -2464,6 +2464,40 @@ export const useTxBatch = () => {
     syncOverlay()
   }
 
+  /**
+   * Remove exactly the entries a landed execution covered, keeping any the
+   * user added while the broadcast was in flight. Runs when execution
+   * succeeded but the cart is no longer the reviewed generation for the same
+   * wallet: clearing everything would discard unexecuted work, while keeping
+   * everything would leave already-executed entries queued to run again. The
+   * ceremony's review index carries the executed entry ids. A wallet-context
+   * change is already handled by the owner/chain watcher emptying the cart, so
+   * this only ever filters same-wallet successors, and the surviving entries
+   * resimulate through the entries watcher.
+   */
+  const retireExecutedEntries = (ceremony: PreparedBatchExecution) => {
+    const executedIds = new Set(Object.keys(ceremony.reviewByEntryId))
+    const nextEntries = entries.value.filter(entry => !executedIds.has(entry.id))
+    if (nextEntries.length === entries.value.length) return
+    execError.value = undefined
+    invalidatePendingAddContext()
+    invalidateBatchReview()
+    entries.value = nextEntries
+    if (nextEntries.length === 0) {
+      resimToken++
+      layers.value = []
+      activeLayer.value = 0
+      isSimulating.value = false
+      simError.value = undefined
+      walletShortfalls.value = []
+      lastMerged = null
+      baseAccountSnapshot = null
+      batchSlotHints = {}
+      resimulatePromise = null
+      syncOverlay()
+    }
+  }
+
   const setActiveLayer = (layer: number) => {
     activeLayer.value = Math.max(0, Math.min(layer, layers.value.length - 1))
     syncOverlay()
@@ -2883,6 +2917,7 @@ export const useTxBatch = () => {
           throw new Error('Safe connection unavailable — the reviewed single-proposal submission cannot run. Reconnect your Safe and retry.')
         }
         if (!isBatchExecutionCurrent(execution)) {
+          retireExecutedEntries(execution)
           scope?.markSucceeded()
           return
         }
@@ -2906,6 +2941,7 @@ export const useTxBatch = () => {
         shouldNotify: () => isBatchExecutionWalletCurrent(execution!),
       })
       if (!isBatchExecutionCurrent(execution)) {
+        retireExecutedEntries(execution)
         scope?.markSucceeded()
         return
       }

--- a/composables/useTxBatch.ts
+++ b/composables/useTxBatch.ts
@@ -1,5 +1,5 @@
 import { computed, effectScope, ref, shallowRef, watch, type EffectScope, type Ref } from 'vue'
-import { formatUnits, getAddress, type Address, type Hex, type StateOverride } from 'viem'
+import { formatUnits, getAddress, type Address, type Hash, type Hex, type StateOverride } from 'viem'
 import { Account, fetchErc20SlotHints, getEulerLabelProductByVault, mergeStateOverrides } from '@eulerxyz/euler-v2-sdk'
 import type {
   IHasVaultAddress,
@@ -33,6 +33,13 @@ import { logWarn } from '~/utils/errorHandling'
 import { buildVisiblePortfolioPositionFilter } from '~/utils/portfolioPositionFilter'
 import type { MigrationAuthorizationRevoke } from '~/utils/migrationAuthorizationTxs'
 import type { WalletExecutionContext } from '~/utils/walletExecutionContext'
+import type { PreparedPlanBroadcast } from '~/composables/useEulerTx'
+import {
+  getSafeWalletProvider,
+  SafeTransactionStatusUnknownError,
+  waitForSafeTransactionExecution,
+  type ReceiptClientLike,
+} from '~/utils/safeWalletTransactions'
 import {
   assertPreparedPlanSignatureParity,
   type PreparedPlanSignatureSubstitution,
@@ -118,6 +125,15 @@ export interface BatchEntryExecutionCeremony {
   }>
   /** The review/copy plan contains placeholder authorization signatures. */
   usesPlaceholderSignatures?: boolean
+  /**
+   * Re-resolve this entry's prerequisite authorization against current chain
+   * state and throw when it no longer matches what the review displayed.
+   * The ceremony's prerequisites are frozen at review time, so on-chain drift
+   * (an allowance granted or revoked elsewhere) would otherwise broadcast
+   * grant/revoke calls the user never reviewed. Invoked at the last
+   * pre-broadcast boundary of the batch execution.
+   */
+  revalidatePrerequisites?: () => Promise<void>
 }
 
 /** One immutable batch review ceremony used for display, export, and execution. */
@@ -135,6 +151,8 @@ export interface PreparedBatchExecution {
   readonly grants: readonly BatchEntryExternalTx[]
   readonly revokes: readonly BatchEntryExternalTx[]
   readonly prerequisites: readonly Readonly<BatchEntryExecutionPrerequisites>[]
+  /** Per-entry prerequisite drift checks, run before anything irreversible. */
+  readonly prerequisiteRevalidations: readonly (() => Promise<void>)[]
   readonly reviewByEntryId: Readonly<Record<string, {
     readonly plan: TransactionPlan
     readonly grantSteps: readonly DisplayStep[]
@@ -293,6 +311,20 @@ const isSimulating = ref(false)
 const simError = ref<string | undefined>(undefined)
 const isExecuting = ref(false)
 const execError = ref<string | undefined>(undefined)
+/**
+ * A core batch submission the wallet accepted but whose confirmation failed —
+ * it may still land. While set, the cart is quarantined against blind replays
+ * (re-executing could duplicate every entry the submission covered): the next
+ * execute attempt first reconciles this submission on-chain, and proceeds only
+ * when it definitively did not land. Landed submissions retire their entries.
+ */
+const pendingCoreSubmission = shallowRef<{
+  kind: PreparedPlanBroadcast['kind']
+  hash: Hash
+  chainId: number
+  ceremony: PreparedBatchExecution
+  shouldRefreshExternalMigrationPositions: boolean
+} | null>(null)
 // Drawer expanded/collapsed state, shared so the mobile nav's "Batch" item and
 // the drawer header toggle the same thing. On laptop this collapses the body; on
 // mobile it shows/hides the whole bottom sheet (the nav item is the entry point).
@@ -2449,6 +2481,9 @@ export const useTxBatch = () => {
   const clearBatch = () => {
     invalidatePendingAddContext()
     invalidateBatchReview()
+    // Emptying the cart discards the entries a quarantined submission covered,
+    // so a replay can no longer duplicate them — the quarantine is moot.
+    pendingCoreSubmission.value = null
     resimToken++
     entries.value = []
     layers.value = []
@@ -2623,7 +2658,7 @@ export const useTxBatch = () => {
     const mode = willBundlePrerequisites.value ? 'safe-bundled' : 'standard'
 
     const preparationPromise = (async (): Promise<PreparedBatchExecution> => {
-      const { plans, planResolvers, usesPlaceholderSignatures, grants, revokes, prerequisites, reviewByEntryId } = mode === 'safe-bundled'
+      const { plans, planResolvers, usesPlaceholderSignatures, grants, revokes, prerequisites, prerequisiteRevalidations, reviewByEntryId } = mode === 'safe-bundled'
         ? await collectBundledExecution()
         : await collectStandardExecution()
       const sdk = await getEulerSdkFresh()
@@ -2687,6 +2722,7 @@ export const useTxBatch = () => {
         grants: Object.freeze(grants.map(tx => Object.freeze({ ...tx }))),
         revokes: Object.freeze(revokes.map(tx => Object.freeze({ ...tx }))),
         prerequisites: frozenPrerequisites,
+        prerequisiteRevalidations: Object.freeze([...prerequisiteRevalidations]),
         reviewByEntryId: frozenReview,
       })
       assertBatchExecutionCurrent(ceremony)
@@ -2714,6 +2750,7 @@ export const useTxBatch = () => {
     const grants: BatchEntryExternalTx[] = []
     const revokes: BatchEntryExternalTx[] = []
     const prerequisites: BatchEntryExecutionPrerequisites[] = []
+    const prerequisiteRevalidations: Array<() => Promise<void>> = []
     const reviewByEntryId: Record<string, {
       plan: TransactionPlan
       grantSteps: DisplayStep[]
@@ -2727,6 +2764,7 @@ export const useTxBatch = () => {
         plans.push(execution.plan)
         planResolvers.push(execution.resolveExecutionPlan)
         usesPlaceholderSignatures ||= execution.usesPlaceholderSignatures === true
+        if (execution.revalidatePrerequisites) prerequisiteRevalidations.push(execution.revalidatePrerequisites)
         if (prerequisite) {
           prerequisites.push(prerequisite)
           grants.push(...prerequisite.preTxs)
@@ -2759,7 +2797,7 @@ export const useTxBatch = () => {
       reviewByEntryId[entry.id] = { plan, grantSteps: [], revokeSteps: [] }
     }
 
-    return { plans, planResolvers, usesPlaceholderSignatures, grants, revokes, prerequisites, reviewByEntryId }
+    return { plans, planResolvers, usesPlaceholderSignatures, grants, revokes, prerequisites, prerequisiteRevalidations, reviewByEntryId }
   }
 
   /**
@@ -2773,6 +2811,7 @@ export const useTxBatch = () => {
     let usesPlaceholderSignatures = false
     const grants: BatchEntryExternalTx[] = []
     const revokesByEntry: BatchEntryExternalTx[][] = []
+    const prerequisiteRevalidations: Array<() => Promise<void>> = []
     const reviewByEntryId: Record<string, {
       plan: TransactionPlan
       grantSteps: DisplayStep[]
@@ -2785,6 +2824,7 @@ export const useTxBatch = () => {
         plans.push(bundled.plan)
         planResolvers.push(bundled.resolveExecutionPlan)
         usesPlaceholderSignatures ||= bundled.usesPlaceholderSignatures === true
+        if (bundled.revalidatePrerequisites) prerequisiteRevalidations.push(bundled.revalidatePrerequisites)
         grants.push(...(prerequisite?.preTxs ?? []))
         revokesByEntry.push(prerequisite?.postTxs ?? [])
         reviewByEntryId[entry.id] = {
@@ -2802,7 +2842,7 @@ export const useTxBatch = () => {
       revokesByEntry.push([])
       reviewByEntryId[entry.id] = { plan, grantSteps: [], revokeSteps: [] }
     }
-    return { plans, planResolvers, usesPlaceholderSignatures, grants, revokes: revokesByEntry.reverse().flat(), prerequisites: [], reviewByEntryId }
+    return { plans, planResolvers, usesPlaceholderSignatures, grants, revokes: revokesByEntry.reverse().flat(), prerequisites: [], prerequisiteRevalidations, reviewByEntryId }
   }
 
   /**
@@ -2843,6 +2883,79 @@ export const useTxBatch = () => {
           walletContext: grantWalletContext,
         })))
       }
+    }
+  }
+
+  /**
+   * Resolve a quarantined core submission before anything new is sent.
+   * Returns true only when the submission definitively did not land (or none
+   * exists). A landed submission retires its entries here instead; an
+   * unverifiable one keeps the quarantine — replaying while the original may
+   * still confirm would duplicate every entry it covered.
+   */
+  const reconcilePendingCoreSubmission = async (scope?: TrackedExecutionScope): Promise<boolean> => {
+    const submission = pendingCoreSubmission.value
+    if (!submission) return true
+
+    const finalizeLandedSubmission = () => {
+      pendingCoreSubmission.value = null
+      execError.value = undefined
+      retireExecutedEntries(submission.ceremony)
+      if (submission.shouldRefreshExternalMigrationPositions) scheduleExternalMigrationRefreshes()
+      scope?.markSucceeded()
+    }
+    const keepQuarantined = () => {
+      execError.value = 'A previous batch submission may still confirm on-chain and could not be verified yet. Wait a moment and execute again — the submission is re-checked before anything is re-sent.'
+      return false
+    }
+
+    const sdk = await getEulerSdkFresh()
+    const provider = sdk.providerService?.getProvider(submission.chainId) as ReceiptClientLike | undefined
+    if (!provider) return keepQuarantined()
+
+    if (submission.kind === 'transaction') {
+      const receipt = await provider.getTransactionReceipt({ hash: submission.hash }).catch(() => undefined)
+      if (!receipt) return keepQuarantined()
+      if (receipt.status === 'success') {
+        finalizeLandedSubmission()
+        return false
+      }
+      // Definitively reverted on-chain — the retry cannot duplicate anything.
+      pendingCoreSubmission.value = null
+      return true
+    }
+
+    // Safe proposal: only the Safe app knows whether the proposal executed
+    // and under which final transaction hash.
+    const walletProvider = await getSafeWalletProvider(connector.value)
+    if (!walletProvider) return keepQuarantined()
+    try {
+      const { receipt } = await waitForSafeTransactionExecution({
+        submittedHash: submission.hash,
+        walletProvider,
+        publicClient: provider,
+        timeoutMs: 8_000,
+      })
+      if (receipt.status === 'success') {
+        finalizeLandedSubmission()
+        return false
+      }
+      pendingCoreSubmission.value = null
+      return true
+    }
+    catch (error) {
+      if (error instanceof SafeTransactionStatusUnknownError) return keepQuarantined()
+      if (error instanceof Error && (
+        error.message === 'Safe transaction was cancelled'
+        || error.message === 'Safe transaction failed'
+      )) {
+        pendingCoreSubmission.value = null
+        return true
+      }
+      // Anything else is not a definitive verdict — fail closed and keep the
+      // quarantine rather than risk a duplicate submission.
+      logWarn('useTxBatch/reconcilePendingCoreSubmission', error)
+      return keepQuarantined()
     }
   }
 
@@ -2887,11 +3000,37 @@ export const useTxBatch = () => {
     }
     const grantedRevokes: MigrationAuthorizationRevoke[] = []
     let execution = reviewedExecution
+    // Set once the wallet accepts the core submission — from that point a
+    // failure no longer means "nothing was sent".
+    let coreBroadcast: PreparedPlanBroadcast | undefined
+    // Set when this attempt itself invalidated the review (quarantine or
+    // prerequisite drift): the error must still surface even though the
+    // ceremony's generation check now fails.
+    let ceremonyInvalidatedForRetry = false
     try {
       if (!await restorePendingBeforeRetry()) return
+      if (!await reconcilePendingCoreSubmission(scope)) return
       execution ??= await prepareBatchExecution()
       assertBatchExecutionCurrent(execution)
       const shouldRefreshExternalMigrationPositions = entries.value.some(entry => entry.refreshExternalMigrationPositions)
+      // Prerequisite requirements were captured at review time; on-chain state
+      // (granted operators, existing approvals) can drift during the wallet
+      // waits above. Re-derive them immediately before anything irreversible
+      // and force a fresh review on any mismatch.
+      const revalidateCeremonyPrerequisites = async () => {
+        for (const revalidate of execution!.prerequisiteRevalidations) {
+          assertBatchExecutionCurrent(execution!)
+          try {
+            await revalidate()
+          }
+          catch (error) {
+            ceremonyInvalidatedForRetry = true
+            invalidateBatchReview()
+            throw error
+          }
+          assertBatchExecutionCurrent(execution!)
+        }
+      }
       const prepared = execution.resolvePreparedPlan
         ? await execution.resolvePreparedPlan(() => assertBatchExecutionCurrent(execution!))
         : execution.prepared
@@ -2904,12 +3043,16 @@ export const useTxBatch = () => {
         // pre-flight validation. Atomicity also removes the unwind
         // bookkeeping: a failed proposal reverts its grants with it.
         assertBatchExecutionCurrent(execution)
+        await revalidateCeremonyPrerequisites()
         const result = await executePreparedPlanWithPlainCalls(prepared, {
           before: execution.grants,
           after: execution.revokes,
         }, {
           allowSingleCall: true,
           beforeBroadcast: () => assertBatchExecutionCurrent(execution),
+          onBroadcast: (broadcast) => {
+            coreBroadcast = broadcast
+          },
         })
         if (!result) {
           // The review described ONE proposal; never silently degrade to
@@ -2927,6 +3070,7 @@ export const useTxBatch = () => {
         return
       }
 
+      await revalidateCeremonyPrerequisites()
       await sendExecutionPrerequisites(execution, grantedRevokes)
       assertBatchExecutionCurrent(execution)
       // Final on-chain gas estimate before the irreversible core broadcast. If
@@ -2936,6 +3080,9 @@ export const useTxBatch = () => {
       assertBatchExecutionCurrent(execution)
       await executePreparedPlan(prepared, {
         beforeBroadcast: () => assertBatchExecutionCurrent(execution),
+        onBroadcast: (broadcast) => {
+          coreBroadcast = broadcast
+        },
       })
       await revokeAfterSuccess(grantedRevokes, {
         shouldNotify: () => isBatchExecutionWalletCurrent(execution!),
@@ -2951,13 +3098,38 @@ export const useTxBatch = () => {
     }
     catch (error) {
       logWarn('useTxBatch/executeBatch', error)
-      // The batch never landed, so no granted authorization should be left
-      // standing. Entries stay in the cart for a retry, which re-grants.
+      if (coreBroadcast && execution) {
+        // The wallet accepted the core submission but confirmation failed —
+        // it may still land. Quarantine the cart against a blind replay (it
+        // would duplicate every covered entry) and force reconciliation on
+        // the next execute attempt.
+        pendingCoreSubmission.value = {
+          kind: coreBroadcast.kind,
+          hash: coreBroadcast.hash,
+          chainId: execution.chainId,
+          ceremony: execution,
+          shouldRefreshExternalMigrationPositions: entries.value.some(entry =>
+            entry.refreshExternalMigrationPositions && entry.id in execution!.reviewByEntryId),
+        }
+        ceremonyInvalidatedForRetry = true
+        invalidateBatchReview()
+      }
+      // Unwinding granted authorizations is safe regardless of whether the
+      // core landed: after a landed core it is the normal success-order
+      // cleanup, and before a still-pending core it cleanly reverts that
+      // core, resolving the ambiguity in the safe direction.
       await revokeAfterAbort(grantedRevokes, {
         shouldNotify: () => !execution || isBatchExecutionWalletCurrent(execution),
       })
-      const decodedError = await describeExecError(error)
-      if (execution ? isBatchExecutionCurrent(execution) : isAttemptCurrent()) {
+      let decodedError = await describeExecError(error)
+      if (coreBroadcast && execution) {
+        decodedError = `${decodedError} The submission may still confirm — executing again first verifies it on-chain before anything is re-sent.`
+      }
+      const shouldSurfaceError = execution
+        ? isBatchExecutionCurrent(execution)
+        || (ceremonyInvalidatedForRetry && isBatchExecutionWalletCurrent(execution))
+        : isAttemptCurrent()
+      if (shouldSurfaceError) {
         execError.value = decodedError
       }
     }
@@ -3064,6 +3236,7 @@ export const useTxBatch = () => {
     simError,
     isExecuting,
     execError,
+    hasPendingCoreSubmission: computed(() => !!pendingCoreSubmission.value),
     hasFailedOps,
     canExecuteBatch,
     hasInsufficientBalance,

--- a/composables/useTxBatch.ts
+++ b/composables/useTxBatch.ts
@@ -80,7 +80,7 @@ export interface BatchEntryExternalTx {
 }
 
 export interface BatchEntryExecutionPrerequisites {
-  /** Sent and mined before the merged plan is built. */
+  /** Sent and mined before the reviewed prepared core is executed. */
   preTxs: BatchEntryExternalTx[]
   /** Wallet context used to build the prerequisite request. */
   walletContext: WalletExecutionContext
@@ -111,14 +111,17 @@ export interface BatchEntryBundledExecution {
   revokeSteps: DisplayStep[]
 }
 
-/** One immutable Safe review ceremony used for display, export, and execution. */
-export interface PreparedBatchBundledExecution {
+/** One immutable batch review ceremony used for display, export, and execution. */
+export interface PreparedBatchExecution {
   readonly generation: number
   readonly owner: Address
   readonly chainId: number
+  readonly safeWallet: boolean
+  readonly mode: 'standard' | 'safe-bundled'
   readonly prepared: TransactionPlanPrepared
   readonly grants: readonly BatchEntryExternalTx[]
   readonly revokes: readonly BatchEntryExternalTx[]
+  readonly prerequisites: readonly Readonly<BatchEntryExecutionPrerequisites>[]
   readonly reviewByEntryId: Readonly<Record<string, {
     readonly plan: TransactionPlan
     readonly grantSteps: readonly DisplayStep[]
@@ -134,8 +137,9 @@ export interface BatchEntry {
   /** Optional real execution payload builder for entries whose preview plan uses simulation-only state. */
   buildExecutionPlan?: (account: Account<IHasVaultAddress>) => Promise<TransactionPlan>
   /** Standalone transactions this entry needs around the merged batch, resolved
-   *  at execution time. Migrations without message signatures use this to grant
-   *  their authorization before the batch and revoke it after: the grants cannot
+   *  when the review ceremony is prepared. Migrations without message signatures
+   *  use this to grant their authorization before the batch and revoke it after:
+   *  the grants cannot
    *  be plan items (`mergePlans` rejects contractCall, and the EVC would be the
    *  msg.sender), and must be mined before the plan is built. */
   buildExecutionPrerequisites?: (
@@ -245,14 +249,14 @@ const layers = shallowRef<BatchLayer[]>([])
 const batchGeneration = ref(0)
 const pendingAddCount = ref(0)
 let addContextGeneration = 0
-let bundledPreparation: {
+let batchPreparation: {
   generation: number
-  promise: Promise<PreparedBatchBundledExecution>
+  promise: Promise<PreparedBatchExecution>
 } | null = null
 
 const invalidateBatchReview = () => {
   batchGeneration.value++
-  bundledPreparation = null
+  batchPreparation = null
 }
 
 const invalidatePendingAddContext = () => {
@@ -1817,6 +1821,17 @@ export const useTxBatch = () => {
       return
     }
 
+    const ownerAddr = getAddress(o)
+    const isResimulationContextCurrent = (): boolean => {
+      if (token !== resimToken || chainId.value !== cid || !owner.value) return false
+      try {
+        return getAddress(owner.value) === ownerAddr
+      }
+      catch {
+        return false
+      }
+    }
+
     isSimulating.value = true
     // NOTE: deliberately do NOT clear simError / walletShortfalls here. A new
     // simulation runs on every add/remove/reorder; clearing up-front would make a
@@ -1824,13 +1839,16 @@ export const useTxBatch = () => {
     // atomically on completion below (and cleared on the empty-batch path above).
     try {
       const sdk = await getEulerSdkFresh()
-      const ownerAddr = getAddress(o)
       // Keep the real base state fixed for the lifetime of the cart. Entry plans
       // are immutable add-time payloads; later real-state drift should not cause
       // the whole batch to rebuild around a different base account.
       const baseAccount = baseAccountSnapshot
         ?? resolvePrefetchedAccounts(cid, ownerAddr).baseAccount
         ?? await fetchBaseAccountSnapshot(sdk, cid, ownerAddr)
+      if (!isResimulationContextCurrent()) {
+        logBatchDiag('resimulate:superseded-after-base-fetch', { token, supersededBy: resimToken }, 'error')
+        return
+      }
       baseAccountSnapshot = baseAccount
 
       const plans = entries.value.map(entry => entry.plan)
@@ -1842,7 +1860,6 @@ export const useTxBatch = () => {
       // operation and returns simulatedAccounts = [base, afterOp0, afterOp1, …]
       // plus per-operation revert attribution via failedBatchItems.
       const merged = sdk.executionService.mergePlans(plans)
-      lastMerged = merged
       const sim = await sdk.executionService.simulateTransactionPlan(
         cid,
         ownerAddr,
@@ -1863,7 +1880,7 @@ export const useTxBatch = () => {
         },
       )
 
-      if (token !== resimToken) {
+      if (!isResimulationContextCurrent()) {
         // A newer resimulation superseded this one after the sim resolved, so this
         // run bails before populating layers. When that happens during a plan-time
         // await it's exactly what surfaces as the misleading "Batch simulation not
@@ -1872,6 +1889,7 @@ export const useTxBatch = () => {
         logBatchDiag('resimulate:superseded-after-sim', { token, supersededBy: resimToken }, 'error')
         return
       }
+      lastMerged = merged
 
       // Two distinct failure shapes, both blocking but handled differently:
       //  - simulationError: the EVC call reverted at the top level (couldn't even
@@ -2032,7 +2050,7 @@ export const useTxBatch = () => {
           logWarn('useTxBatch/fetchWallet', error)
         }
       }
-      if (token !== resimToken) {
+      if (!isResimulationContextCurrent()) {
         // Superseded during the post-sim wallet fetch — same race as above, just a
         // later checkpoint. Bails before populating layers.
         logBatchDiag('resimulate:superseded-after-wallet-fetch', { token, supersededBy: resimToken }, 'error')
@@ -2130,7 +2148,7 @@ export const useTxBatch = () => {
       )
     }
     catch (error) {
-      if (token !== resimToken) {
+      if (!isResimulationContextCurrent()) {
         logBatchDiag('resimulate:superseded-in-catch', { token, supersededBy: resimToken }, 'error')
         return
       }
@@ -2140,7 +2158,7 @@ export const useTxBatch = () => {
       simError.value = error instanceof Error ? error.message : String(error)
     }
     finally {
-      if (token === resimToken) isSimulating.value = false
+      if (isResimulationContextCurrent()) isSimulating.value = false
     }
   }
 
@@ -2512,11 +2530,8 @@ export const useTxBatch = () => {
   /** Resolve approvals/permits/plugins for the merged batch plan, so the review
    *  modal can list the approvals the user will be asked to sign. */
   const prepareBatchPlan = async () => {
-    if (pendingAddCount.value > 0) {
-      throw new Error('An operation is still being added — wait for the batch to finish updating.')
-    }
     if (!lastMerged) return null
-    return prepareTransactionPlan(lastMerged)
+    return (await prepareBatchExecution()).prepared
   }
 
   const getExecutionPlanningAccount = async (entryIndex: number): Promise<Account<IHasVaultAddress>> => {
@@ -2537,27 +2552,25 @@ export const useTxBatch = () => {
     const o = owner.value
     const cid = chainId.value
     if (!o || !cid) throw new Error('Account not loaded')
+    const executionOwner = getAddress(o)
+    const executionGeneration = batchGeneration.value
     const sdk = await getEulerSdkFresh()
-    baseAccountSnapshot = await fetchBaseAccountSnapshot(sdk, cid, getAddress(o))
-    return baseAccountSnapshot
-  }
-
-  const buildMergedExecutionPlan = async (): Promise<TransactionPlan> => {
-    const sdk = await getEulerSdkFresh()
-    const plans: TransactionPlan[] = []
-    for (const [index, entry] of entries.value.entries()) {
-      plans.push(entry.buildExecutionPlan
-        ? await entry.buildExecutionPlan(await getExecutionPlanningAccount(index))
-        : entry.plan)
+    const fetched = await fetchBaseAccountSnapshot(sdk, cid, executionOwner)
+    if (
+      executionGeneration !== batchGeneration.value
+      || chainId.value !== cid
+      || !owner.value
+      || getAddress(owner.value) !== executionOwner
+    ) {
+      throw new Error('Batch or wallet changed since review preparation — reopen review and try again.')
     }
-    return sdk.executionService.mergePlans(plans)
+    baseAccountSnapshot = fetched
+    return fetched
   }
 
   /**
    * A Safe executes the cart's prerequisites inside the batch proposal when
-   * every prerequisite-bearing entry provides a bundled builder — mixed
-   * carts (a prerequisite entry without bundled support) keep the sequential
-   * ceremony for all entries, so the review never half-describes it.
+   * every prerequisite-bearing entry provides a bundled builder.
    */
   const willBundlePrerequisites = computed(() =>
     isSafeWallet.value
@@ -2565,12 +2578,12 @@ export const useTxBatch = () => {
     && entries.value.every(entry => !entry.buildExecutionPrerequisites || entry.buildBundledExecution),
   )
 
-  const isBundledExecutionCurrent = (ceremony: PreparedBatchBundledExecution): boolean => {
+  const isBatchExecutionCurrent = (ceremony: PreparedBatchExecution): boolean => {
     if (
       pendingAddCount.value > 0
-      || !isSafeWallet.value
       || ceremony.generation !== batchGeneration.value
       || ceremony.chainId !== chainId.value
+      || ceremony.safeWallet !== isSafeWallet.value
       || !owner.value
     ) {
       return false
@@ -2583,33 +2596,40 @@ export const useTxBatch = () => {
     }
   }
 
-  const assertBundledExecutionCurrent = (ceremony: PreparedBatchBundledExecution) => {
-    if (!isBundledExecutionCurrent(ceremony)) {
+  const assertBatchExecutionCurrent = (ceremony: PreparedBatchExecution) => {
+    if (!isBatchExecutionCurrent(ceremony)) {
       throw new Error('Batch or wallet changed since review preparation — reopen review and try again.')
     }
   }
 
   /**
-   * Resolve one ceremony per cart generation. Concurrent review modals share
-   * the same in-flight promise and immutable result; stale work can finish but
-   * cannot be used after a cart, account, or chain change.
+   * Resolve one ceremony per cart generation for every wallet/execution mode.
+   * Concurrent review modals share the same in-flight promise and immutable
+   * result; stale work can finish but cannot be used after a cart or wallet
+   * context change.
    */
-  const prepareBundledExecution = (): Promise<PreparedBatchBundledExecution | null> => {
+  const prepareBatchExecution = (): Promise<PreparedBatchExecution> => {
     if (pendingAddCount.value > 0) {
       return Promise.reject(new Error('An operation is still being added — wait for the batch to finish updating.'))
     }
-    if (!willBundlePrerequisites.value) return Promise.resolve(null)
+    if (!lastMerged || entries.value.length === 0) {
+      return Promise.reject(new Error('Batch simulation not loaded'))
+    }
 
     const generation = batchGeneration.value
-    if (bundledPreparation?.generation === generation) return bundledPreparation.promise
+    if (batchPreparation?.generation === generation) return batchPreparation.promise
 
     const currentOwner = owner.value
     const currentChainId = chainId.value
     if (!currentOwner || !currentChainId) return Promise.reject(new Error('Account not loaded'))
     const reviewOwner = getAddress(currentOwner)
+    const reviewSafeWallet = isSafeWallet.value
+    const mode = willBundlePrerequisites.value ? 'safe-bundled' : 'standard'
 
-    const preparationPromise = (async (): Promise<PreparedBatchBundledExecution> => {
-      const { plans, grants, revokes, reviewByEntryId } = await collectBundledExecution()
+    const preparationPromise = (async (): Promise<PreparedBatchExecution> => {
+      const { plans, grants, revokes, prerequisites, reviewByEntryId } = mode === 'safe-bundled'
+        ? await collectBundledExecution()
+        : await collectStandardExecution()
       const sdk = await getEulerSdkFresh()
       const executionPlan = sdk.executionService.mergePlans(plans)
       const prepared = await prepareTransactionPlan(executionPlan)
@@ -2620,25 +2640,93 @@ export const useTxBatch = () => {
           revokeSteps: Object.freeze([...review.revokeSteps]),
         })]),
       ))
-      const ceremony: PreparedBatchBundledExecution = Object.freeze({
+      const frozenPrerequisites = Object.freeze(prerequisites.map(prerequisite => Object.freeze({
+        ...prerequisite,
+        preTxs: Object.freeze(prerequisite.preTxs.map(tx => Object.freeze({ ...tx }))),
+        postTxs: Object.freeze(prerequisite.postTxs.map(tx => Object.freeze({ ...tx }))),
+        postTxsByPreTx: prerequisite.postTxsByPreTx
+          ? Object.freeze(prerequisite.postTxsByPreTx.map(tx => tx ? Object.freeze({ ...tx }) : undefined))
+          : undefined,
+        walletContext: Object.freeze({ ...prerequisite.walletContext }),
+      })))
+      const ceremony: PreparedBatchExecution = Object.freeze({
         generation,
         owner: reviewOwner,
         chainId: currentChainId,
+        safeWallet: reviewSafeWallet,
+        mode,
         prepared,
-        grants: Object.freeze([...grants]),
-        revokes: Object.freeze([...revokes]),
+        grants: Object.freeze(grants.map(tx => Object.freeze({ ...tx }))),
+        revokes: Object.freeze(revokes.map(tx => Object.freeze({ ...tx }))),
+        prerequisites: frozenPrerequisites,
         reviewByEntryId: frozenReview,
       })
-      assertBundledExecutionCurrent(ceremony)
+      assertBatchExecutionCurrent(ceremony)
       return ceremony
     })()
 
     const trackedPromise = preparationPromise.catch((error) => {
-      if (bundledPreparation?.promise === trackedPromise) bundledPreparation = null
+      if (batchPreparation?.promise === trackedPromise) batchPreparation = null
       throw error
     })
-    bundledPreparation = { generation, promise: trackedPromise }
+    batchPreparation = { generation, promise: trackedPromise }
     return trackedPromise
+  }
+
+  /**
+   * Build the exact standard ceremony. Prerequisite-bearing entries use their
+   * simulation variant for the prepared core and freeze the standalone grants
+   * that make that core executable. Entries without prerequisites resolve their
+   * ordinary execution plan during review.
+   */
+  const collectStandardExecution = async () => {
+    const plans: TransactionPlan[] = []
+    const grants: BatchEntryExternalTx[] = []
+    const revokes: BatchEntryExternalTx[] = []
+    const prerequisites: BatchEntryExecutionPrerequisites[] = []
+    const reviewByEntryId: Record<string, {
+      plan: TransactionPlan
+      grantSteps: DisplayStep[]
+      revokeSteps: DisplayStep[]
+    }> = {}
+
+    for (const [index, entry] of entries.value.entries()) {
+      if (entry.buildExecutionPrerequisites) {
+        if (!entry.buildBundledExecution) {
+          throw new Error('This operation cannot produce an exact reviewable execution plan.')
+        }
+        const account = await getExecutionPlanningAccount(index)
+        const prerequisite = await entry.buildExecutionPrerequisites(account)
+        const execution = await entry.buildBundledExecution(account)
+        plans.push(execution.plan)
+        if (prerequisite) {
+          prerequisites.push(prerequisite)
+          grants.push(...prerequisite.preTxs)
+          if (prerequisite.postTxsByPreTx) {
+            for (const revoke of prerequisite.postTxsByPreTx) {
+              if (revoke) revokes.unshift(revoke)
+            }
+          }
+          else {
+            revokes.push(...prerequisite.postTxs)
+          }
+        }
+        reviewByEntryId[entry.id] = {
+          plan: execution.plan,
+          grantSteps: execution.grantSteps.map(step => ({ ...step, isSeparateTx: true })),
+          revokeSteps: execution.revokeSteps.map(step => ({ ...step, isSeparateTx: true })),
+        }
+        continue
+      }
+
+      const plan = entry.buildExecutionPlan
+        ? await entry.buildExecutionPlan(await getExecutionPlanningAccount(index))
+        : entry.plan
+      plans.push(plan)
+      reviewByEntryId[entry.id] = { plan, grantSteps: [], revokeSteps: [] }
+    }
+
+    return { plans, grants, revokes, prerequisites, reviewByEntryId }
   }
 
   /**
@@ -2675,29 +2763,25 @@ export const useTxBatch = () => {
       revokesByEntry.push([])
       reviewByEntryId[entry.id] = { plan, grantSteps: [], revokeSteps: [] }
     }
-    return { plans, grants, revokes: revokesByEntry.reverse().flat(), reviewByEntryId }
+    return { plans, grants, revokes: revokesByEntry.reverse().flat(), prerequisites: [], reviewByEntryId }
   }
 
   /**
-   * Send each entry's prerequisite grants, mined, before the merged plan is
-   * built — plan builders read live on-chain allowances to decide whether their
-   * batch still needs an authorization item.
-   *
-   * Sequential on purpose: a later entry needing the same grant sees the earlier
-   * one already on-chain and resolves to no prerequisite at all.
+   * Send the ceremony's frozen prerequisite grants before its prepared core.
+   * Each call is sent separately so ceremony freshness is checked immediately
+   * before and after every irreversible broadcast.
    */
   const sendExecutionPrerequisites = async (
+    ceremony: PreparedBatchExecution,
     grantedRevokes: MigrationAuthorizationRevoke[],
   ): Promise<void> => {
-    for (const [index, entry] of entries.value.entries()) {
-      if (!entry.buildExecutionPrerequisites) continue
-      const prerequisites = await entry.buildExecutionPrerequisites(await getExecutionPlanningAccount(index))
-      if (!prerequisites) continue
+    for (const prerequisites of ceremony.prerequisites) {
       let grantWalletContext: WalletExecutionContext | undefined
-      if (prerequisites.preTxs.length) {
-        await sendPlainTransactions(prerequisites.preTxs, {
+      for (const [preTxIndex, preTx] of prerequisites.preTxs.entries()) {
+        assertBatchExecutionCurrent(ceremony)
+        await sendPlainTransactions([preTx], {
           walletContext: prerequisites.walletContext,
-          onBroadcast: (preTxIndex, walletContext) => {
+          onBroadcast: (_index, walletContext) => {
             grantWalletContext = walletContext
             const revoke = prerequisites.postTxsByPreTx?.[preTxIndex]
             if (revoke) {
@@ -2705,6 +2789,7 @@ export const useTxBatch = () => {
             }
           },
         })
+        assertBatchExecutionCurrent(ceremony)
       }
       // Entries without a one-to-one mapping retain the original all-or-nothing
       // behavior. Migration entries always provide postTxsByPreTx so partial or
@@ -2721,14 +2806,10 @@ export const useTxBatch = () => {
     }
   }
 
-  /**
-   * Execute the whole batch as one atomic transaction. Entries normally reuse
-   * the preview plan; entries with simulation-only preview state can rebuild a
-   * signed execution plan before the merged batch is prepared and sent.
-   */
+  /** Execute the immutable ceremony produced for the current batch review. */
   const executeBatch = async (
     scope?: TrackedExecutionScope,
-    bundledExecution?: PreparedBatchBundledExecution,
+    reviewedExecution?: PreparedBatchExecution,
   ) => {
     if (pendingAddCount.value > 0) {
       execError.value = 'An operation is still being added — wait for the batch to finish updating.'
@@ -2744,26 +2825,20 @@ export const useTxBatch = () => {
     const grantedRevokes: MigrationAuthorizationRevoke[] = []
     try {
       if (!await restorePendingBeforeRetry()) return
-      // Final on-chain gas estimate before asking the user to sign. If the batch
-      // would revert (against the current chain state, which may have moved since
-      // the last simulation), surface the decoded reason and don't send.
+      const execution = reviewedExecution ?? await prepareBatchExecution()
+      assertBatchExecutionCurrent(execution)
       const shouldRefreshExternalMigrationPositions = entries.value.some(entry => entry.refreshExternalMigrationPositions)
 
-      if (bundledExecution) {
-        // Execute the exact immutable ceremony owned by this review modal.
-        // Never combine its prepared core with wrappers from another review.
-        assertBundledExecutionCurrent(bundledExecution)
-        if (!isSafeWallet.value) {
-          throw new Error('Wallet changed since review — please review the batch again.')
-        }
+      if (execution.mode === 'safe-bundled') {
         // No standalone gas estimate — grants are unmined until the
         // proposal executes; the cart's continuous simulation (which runs
         // with the entries' authorization state overrides) is the
         // pre-flight validation. Atomicity also removes the unwind
         // bookkeeping: a failed proposal reverts its grants with it.
-        const result = await executePreparedPlanWithPlainCalls(bundledExecution.prepared, {
-          before: bundledExecution.grants,
-          after: bundledExecution.revokes,
+        assertBatchExecutionCurrent(execution)
+        const result = await executePreparedPlanWithPlainCalls(execution.prepared, {
+          before: execution.grants,
+          after: execution.revokes,
         }, { allowSingleCall: true })
         if (!result) {
           // The review described ONE proposal; never silently degrade to
@@ -2776,15 +2851,14 @@ export const useTxBatch = () => {
         return
       }
 
-      if (willBundlePrerequisites.value) {
-        throw new Error('Safe batch review expired — reopen review before submitting.')
-      }
-
-      await sendExecutionPrerequisites(grantedRevokes)
-      const executionPlan = await buildMergedExecutionPlan()
-      await estimateGasForPlan(executionPlan)
-      const prepared = await prepareTransactionPlan(executionPlan)
-      await executePreparedPlan(prepared)
+      await sendExecutionPrerequisites(execution, grantedRevokes)
+      assertBatchExecutionCurrent(execution)
+      // Final on-chain gas estimate before the irreversible core broadcast. If
+      // chain state moved since review, surface the decoded reason and retain
+      // the cart. A pending edit during this await invalidates the ceremony.
+      await estimateGasForPlan(execution.prepared.plan)
+      assertBatchExecutionCurrent(execution)
+      await executePreparedPlan(execution.prepared)
       clearBatch()
       if (shouldRefreshExternalMigrationPositions) scheduleExternalMigrationRefreshes()
       await revokeAfterSuccess(grantedRevokes)
@@ -2923,8 +2997,10 @@ export const useTxBatch = () => {
     setActiveLayer,
     executeBatch,
     willBundlePrerequisites,
-    prepareBundledExecution,
-    isBundledExecutionCurrent,
+    prepareBatchExecution,
+    isBatchExecutionCurrent,
+    prepareBundledExecution: prepareBatchExecution,
+    isBundledExecutionCurrent: isBatchExecutionCurrent,
     // Tenderly "Simulate on Tenderly" for the whole batch.
     tenderlyEnabled,
     isTenderlySimulating: tenderly.isSimulating,

--- a/composables/useTxBatch.ts
+++ b/composables/useTxBatch.ts
@@ -243,6 +243,8 @@ export interface WalletShortfall {
 const entries: Ref<BatchEntry[]> = ref([])
 const layers = shallowRef<BatchLayer[]>([])
 const batchGeneration = ref(0)
+const pendingAddCount = ref(0)
+let addContextGeneration = 0
 let bundledPreparation: {
   generation: number
   promise: Promise<PreparedBatchBundledExecution>
@@ -251,6 +253,23 @@ let bundledPreparation: {
 const invalidateBatchReview = () => {
   batchGeneration.value++
   bundledPreparation = null
+}
+
+const invalidatePendingAddContext = () => {
+  addContextGeneration++
+}
+
+interface BatchAddContext {
+  generation: number
+  owner?: Address
+  chainId?: number
+}
+
+class BatchAddContextChangedError extends Error {
+  constructor() {
+    super('Wallet or batch changed while adding this operation — add it again.')
+    this.name = 'BatchAddContextChangedError'
+  }
 }
 // Per-entry fixed plan (keyed by entry id), used by the review modal and by the
 // merged whole-batch plan. These are captured once when the entry is added.
@@ -489,7 +508,11 @@ const collectRequiredApprovalTokens = (plan: TransactionPlan): Address[] => {
   return tokens
 }
 
-const primeBatchSlotHintsFor = async (chainId: number, tokens: Address[]): Promise<void> => {
+const primeBatchSlotHintsFor = async (
+  chainId: number,
+  tokens: Address[],
+  isCurrent: () => boolean = () => true,
+): Promise<void> => {
   if (!tokens.length) return
   try {
     const sdk = await getEulerSdkFresh()
@@ -507,8 +530,10 @@ const primeBatchSlotHintsFor = async (chainId: number, tokens: Address[]): Promi
         logWarn('useTxBatch/primeBatchSlotHintsFor', error)
       }
     }))
-    batchSlotHints = next
-    mergeBatchPrefetchedSlotHints(chainId, next)
+    if (isCurrent()) {
+      batchSlotHints = next
+      mergeBatchPrefetchedSlotHints(chainId, next)
+    }
   }
   catch (error) {
     logWarn('useTxBatch/primeBatchSlotHintsFor', error)
@@ -2151,6 +2176,7 @@ export const useTxBatch = () => {
       // Reset the cart when the account or chain changes — layers would be stale.
       watch([owner, chainId], () => {
         logBatchDiag('watch:owner-or-chain-reset', {}, 'error')
+        invalidatePendingAddContext()
         invalidateBatchReview()
         resimToken++
         entries.value = []
@@ -2167,10 +2193,17 @@ export const useTxBatch = () => {
         tenderly.clearSimulation()
         syncOverlay()
       })
+      // Safe classification is part of a bundled ceremony's wallet context.
+      // Connector detection can change without changing the owner or chain.
+      watch(isSafeWallet, () => {
+        invalidateBatchReview()
+      })
     })
   }
 
-  const getEntryPlanningAccount = async (): Promise<Account<IHasVaultAddress>> => {
+  const getEntryPlanningAccount = async (
+    isAddContextCurrent: () => boolean,
+  ): Promise<Account<IHasVaultAddress>> => {
     const getCurrentFinalLayer = () => (
       entries.value.length > 0 && layers.value.length === entries.value.length + 1
         ? layers.value[layers.value.length - 1]?.account
@@ -2240,22 +2273,57 @@ export const useTxBatch = () => {
 
     logBatchDiag('getEntryPlanningAccount:base-snapshot-fetch', { owner: o, chainId: cid })
     const sdk = await getEulerSdkFresh()
-    baseAccountSnapshot = await fetchBaseAccountSnapshot(sdk, cid, ownerAddress)
-    return baseAccountSnapshot
+    const fetched = await fetchBaseAccountSnapshot(sdk, cid, ownerAddress)
+    if (!isAddContextCurrent()) throw new BatchAddContextChangedError()
+    baseAccountSnapshot = fetched
+    return fetched
+  }
+
+  const captureAddContext = (): BatchAddContext => {
+    let currentOwner: Address | undefined
+    try {
+      currentOwner = owner.value ? getAddress(owner.value) : undefined
+    }
+    catch {
+      currentOwner = undefined
+    }
+    return {
+      generation: addContextGeneration,
+      owner: currentOwner,
+      chainId: chainId.value,
+    }
+  }
+
+  const isAddContextCurrent = (context: BatchAddContext): boolean => {
+    if (context.generation !== addContextGeneration || context.chainId !== chainId.value) return false
+    try {
+      const currentOwner = owner.value ? getAddress(owner.value) : undefined
+      return currentOwner === context.owner
+    }
+    catch {
+      return context.owner === undefined
+    }
+  }
+
+  const assertAddContextCurrent = (context: BatchAddContext) => {
+    if (!isAddContextCurrent(context)) throw new BatchAddContextChangedError()
   }
 
   const addEntry = async (entry: BatchEntryInput) => {
+    const addContext = captureAddContext()
     // Ignore a rapid duplicate click while an identical add is still in flight
     // (same target sub-account + label). Sequential re-adds are unaffected — the
     // signature is released once the add settles.
-    const signature = `${entry.subAccount ?? ''}|${entry.label}`
+    const signature = `${addContext.generation}|${addContext.owner ?? ''}|${addContext.chainId ?? ''}|${entry.subAccount ?? ''}|${entry.label}`
     if (pendingAddSignatures.has(signature)) return
     pendingAddSignatures.add(signature)
+    pendingAddCount.value++
     // Invalidate synchronously when the edit starts, not after its async plan
     // build finishes, so an open review cannot execute while an add is pending.
     invalidateBatchReview()
 
     const add = async () => {
+      assertAddContextCurrent(addContext)
       execError.value = undefined
       logBatchDiag('addEntry:building', {
         label: entry.label,
@@ -2276,9 +2344,15 @@ export const useTxBatch = () => {
           // The simulator will surface the normal account-loading error later.
         }
       }
+      let planningAccount: Account<IHasVaultAddress> | undefined
+      if (entry.requiresPlanningAccount !== false) {
+        planningAccount = await getEntryPlanningAccount(() => isAddContextCurrent(addContext))
+        assertAddContextCurrent(addContext)
+      }
       const buildResult = entry.requiresPlanningAccount === false
         ? await entry.buildPlan()
-        : await entry.buildPlan(await getEntryPlanningAccount())
+        : await entry.buildPlan(planningAccount!)
+      assertAddContextCurrent(addContext)
       const plan = Array.isArray(buildResult) ? buildResult : buildResult.plan
       const builtStateOverrides = Array.isArray(buildResult) ? undefined : buildResult.stateOverrides
       const cid = chainId.value
@@ -2290,8 +2364,9 @@ export const useTxBatch = () => {
         // Probe only what no form or earlier batch entry has resolved yet.
         const missingSlotHintTokens = collectRequiredApprovalTokens(plan)
           .filter(token => batchSlotHints[token] === undefined)
-        await primeBatchSlotHintsFor(cid, missingSlotHintTokens)
+        await primeBatchSlotHintsFor(cid, missingSlotHintTokens, () => isAddContextCurrent(addContext))
       }
+      assertAddContextCurrent(addContext)
       const {
         buildPlan: _buildPlan,
         requiresPlanningAccount: _requiresPlanningAccount,
@@ -2323,11 +2398,14 @@ export const useTxBatch = () => {
         error: error instanceof Error ? error.message : String(error),
       }, 'error')
       logWarn('useTxBatch/addEntry', error)
-      simError.value = error instanceof Error ? error.message : String(error)
+      if (!(error instanceof BatchAddContextChangedError)) {
+        simError.value = error instanceof Error ? error.message : String(error)
+      }
       throw error
     }
     finally {
       pendingAddSignatures.delete(signature)
+      pendingAddCount.value = Math.max(0, pendingAddCount.value - 1)
     }
   }
 
@@ -2335,6 +2413,7 @@ export const useTxBatch = () => {
     const nextEntries = entries.value.filter(entry => entry.id !== id)
     execError.value = undefined
     if (nextEntries.length === entries.value.length) return
+    invalidatePendingAddContext()
     invalidateBatchReview()
     entries.value = nextEntries
     if (nextEntries.length === 0) {
@@ -2354,6 +2433,7 @@ export const useTxBatch = () => {
   }
 
   const clearBatch = () => {
+    invalidatePendingAddContext()
     invalidateBatchReview()
     resimToken++
     entries.value = []
@@ -2432,6 +2512,9 @@ export const useTxBatch = () => {
   /** Resolve approvals/permits/plugins for the merged batch plan, so the review
    *  modal can list the approvals the user will be asked to sign. */
   const prepareBatchPlan = async () => {
+    if (pendingAddCount.value > 0) {
+      throw new Error('An operation is still being added — wait for the batch to finish updating.')
+    }
     if (!lastMerged) return null
     return prepareTransactionPlan(lastMerged)
   }
@@ -2483,7 +2566,13 @@ export const useTxBatch = () => {
   )
 
   const isBundledExecutionCurrent = (ceremony: PreparedBatchBundledExecution): boolean => {
-    if (ceremony.generation !== batchGeneration.value || ceremony.chainId !== chainId.value || !owner.value) {
+    if (
+      pendingAddCount.value > 0
+      || !isSafeWallet.value
+      || ceremony.generation !== batchGeneration.value
+      || ceremony.chainId !== chainId.value
+      || !owner.value
+    ) {
       return false
     }
     try {
@@ -2506,6 +2595,9 @@ export const useTxBatch = () => {
    * cannot be used after a cart, account, or chain change.
    */
   const prepareBundledExecution = (): Promise<PreparedBatchBundledExecution | null> => {
+    if (pendingAddCount.value > 0) {
+      return Promise.reject(new Error('An operation is still being added — wait for the batch to finish updating.'))
+    }
     if (!willBundlePrerequisites.value) return Promise.resolve(null)
 
     const generation = batchGeneration.value
@@ -2638,6 +2730,10 @@ export const useTxBatch = () => {
     scope?: TrackedExecutionScope,
     bundledExecution?: PreparedBatchBundledExecution,
   ) => {
+    if (pendingAddCount.value > 0) {
+      execError.value = 'An operation is still being added — wait for the batch to finish updating.'
+      return
+    }
     if (isExecuting.value || entries.value.length === 0 || !lastMerged) return
     // simError covers both a top-level EVC revert and a deferred status-check
     // failure; walletShortfalls covers an under-funded wallet. Either way the
@@ -2729,6 +2825,7 @@ export const useTxBatch = () => {
   // when this is false — this only gates the Execute action.
   const canExecuteBatch = computed(() =>
     entries.value.length > 0
+    && pendingAddCount.value === 0
     && !isSimulating.value
     && !isExecuting.value
     && !hasFailedOps.value
@@ -2814,6 +2911,7 @@ export const useTxBatch = () => {
     removedKeys: activeLayerRemovedKeysRef,
     walletChanges,
     entryCount,
+    hasPendingAdds: computed(() => pendingAddCount.value > 0),
     marketByEntryId,
     isDrawerOpen: drawerOpen,
     toggleDrawer: () => { drawerOpen.value = !drawerOpen.value },

--- a/composables/useTxBatch.ts
+++ b/composables/useTxBatch.ts
@@ -1782,7 +1782,7 @@ export const useTxBatch = () => {
     () => effectiveAddress.value as Address | undefined,
   )
   const chainId = computed(() => wagmiChainId.value ?? addressesChainId.value)
-  const { prepareTransactionPlan, executePreparedPlan, executePreparedPlanWithPlainCalls, estimateGasForPlan, sendPlainTransactions } = useEulerTx()
+  const { prepareTransactionPlan, executePreparedPlan, executePreparedPlanWithPlainCalls, estimateGasForPreparedPlan, sendPlainTransactions } = useEulerTx()
   const { isSafeWallet, isSafeWalletResolved } = useSafeWallet()
   const connectorKey = computed(() => {
     const current = connector.value
@@ -2897,7 +2897,7 @@ export const useTxBatch = () => {
       // Final on-chain gas estimate before the irreversible core broadcast. If
       // chain state moved since review, surface the decoded reason and retain
       // the cart. A pending edit during this await invalidates the ceremony.
-      await estimateGasForPlan(prepared.plan)
+      await estimateGasForPreparedPlan(prepared)
       assertBatchExecutionCurrent(execution)
       await executePreparedPlan(prepared, {
         beforeBroadcast: () => assertBatchExecutionCurrent(execution),

--- a/composables/useTxBatch.ts
+++ b/composables/useTxBatch.ts
@@ -20,14 +20,12 @@ import {
 } from '~/composables/batchPrefetchState'
 import { getCurrentEulerLabelsData } from '~/composables/useEulerLabels'
 import type { TrackedExecutionScope } from '~/composables/useSafeExecutionDetachment'
-import { useTenderlySimulation } from '~/composables/useTenderlySimulation'
 import {
   activeLayerVaultsRef,
   collectAccountVaults,
   mergeLayeredVaults,
   type LayeredVaultMap,
 } from '~/composables/useLayeredVaults'
-import { buildTenderlySimulationPayload } from '~/utils/tenderly-plan'
 import { buildPlanMarketLabel, type DisplayStep } from '~/utils/stepDecoding'
 import { formatSmartAmount } from '~/utils/string-utils'
 import { formatSimulationFailure, getTxErrorMessage } from '~/utils/tx-errors'
@@ -35,6 +33,10 @@ import { logWarn } from '~/utils/errorHandling'
 import { buildVisiblePortfolioPositionFilter } from '~/utils/portfolioPositionFilter'
 import type { MigrationAuthorizationRevoke } from '~/utils/migrationAuthorizationTxs'
 import type { WalletExecutionContext } from '~/utils/walletExecutionContext'
+import {
+  assertPreparedPlanSignatureParity,
+  type PreparedPlanSignatureSubstitution,
+} from '~/utils/preparedPlanParity'
 
 export interface BatchWalletChange {
   token: string
@@ -110,7 +112,10 @@ export interface BatchEntryExecutionCeremony {
    * ceremony. The callback receives the ceremony freshness guard and returns
    * the same plan with real signature bytes.
    */
-  resolveExecutionPlan?: (beforeWalletAction: () => void) => Promise<TransactionPlan>
+  resolveExecutionPlan?: (beforeWalletAction: () => void) => Promise<{
+    plan: TransactionPlan
+    signatureSubstitutions: readonly PreparedPlanSignatureSubstitution[]
+  }>
   /** The review/copy plan contains placeholder authorization signatures. */
   usesPlaceholderSignatures?: boolean
 }
@@ -296,15 +301,6 @@ const drawerOpen = ref(true)
 // executeBatch so the executed batch is exactly what was simulated.
 let lastMerged: TransactionPlan | null = null
 let baseAccountSnapshot: Account<IHasVaultAddress> | null = null
-
-// "Simulate on Tenderly" for the whole batch — runs the exact merged plan
-// through the server-side Tenderly endpoint and returns a shareable dashboard
-// URL. Shared (module-level) so the result persists across the laptop drawer
-// and the mobile full-page view. Mirrors the per-operation flow in
-// OperationReviewModal, just fed the batch's merged plan instead of one op.
-const tenderly = useTenderlySimulation()
-const tenderlyEnabled = ref(false)
-let tenderlyEnabledFetched = false
 
 /**
  * Module-level overlay ref read by `useEulerAccount` so the portfolio is
@@ -2188,11 +2184,8 @@ export const useTxBatch = () => {
   if (!scope) {
     scope = effectScope(true)
     scope.run(() => {
-      // Any edit to the cart invalidates a prior Tenderly run (it simulated a
-      // different fixed plan list), so drop the stale URL before re-simulating.
       watch(entries, () => {
         logBatchDiag('watch:entries-changed')
-        tenderly.clearSimulation()
         void runResimulate()
       })
       watch([activeLayer, layers], syncOverlay)
@@ -2213,7 +2206,6 @@ export const useTxBatch = () => {
         baseAccountSnapshot = null
         batchSlotHints = {}
         resimulatePromise = null
-        tenderly.clearSimulation()
         syncOverlay()
       })
       // Safe classification is part of a bundled ceremony's wallet context.
@@ -2450,7 +2442,6 @@ export const useTxBatch = () => {
       baseAccountSnapshot = null
       batchSlotHints = {}
       resimulatePromise = null
-      tenderly.clearSimulation()
       syncOverlay()
     }
   }
@@ -2470,7 +2461,6 @@ export const useTxBatch = () => {
     baseAccountSnapshot = null
     batchSlotHints = {}
     resimulatePromise = null
-    tenderly.clearSimulation()
     syncOverlay()
   }
 
@@ -2481,51 +2471,6 @@ export const useTxBatch = () => {
 
   const dismissExecutionError = () => {
     execError.value = undefined
-  }
-
-  /** Lazily check (once) whether the server has Tenderly credentials configured,
-   *  so the UI can hide the button when simulation isn't available. */
-  const fetchTenderlyEnabled = async (): Promise<boolean> => {
-    if (tenderlyEnabledFetched) return tenderlyEnabled.value
-    tenderlyEnabledFetched = true
-    tenderlyEnabled.value = await tenderly.fetchEnabled()
-    return tenderlyEnabled.value
-  }
-
-  /**
-   * Run the whole batch through Tenderly using the preview plan and the SDK's
-   * derived state overrides (so approvals/permits don't make it revert). Returns
-   * a dashboard URL surfaced via `tenderlyUrl`. Works in spy mode too — it's a
-   * read-only simulation, no signature required.
-   */
-  const simulateOnTenderly = async (): Promise<void> => {
-    if (!lastMerged) return
-    const o = owner.value
-    const cid = chainId.value
-    if (!o || !cid) return
-    tenderly.clearSimulation()
-    try {
-      const sdk = await getEulerSdkFresh()
-      const extraStateOverrides = mergeStateOverrides(
-        entries.value.flatMap(entry => entry.stateOverrides ?? []),
-      )
-      const payload = await buildTenderlySimulationPayload({
-        plan: lastMerged,
-        owner: getAddress(o),
-        chainId: cid,
-        sdk,
-        extraStateOverrides,
-      })
-      if (!payload) {
-        tenderly.simulationError.value = 'Tenderly simulation is not available for this batch.'
-        return
-      }
-      await tenderly.simulate(payload)
-    }
-    catch (error) {
-      logWarn('useTxBatch/simulateOnTenderly', error)
-      tenderly.simulationError.value = 'Tenderly simulation failed.'
-    }
   }
 
   /** The latest merged preview plan (null until a successful simulation).
@@ -2653,15 +2598,28 @@ export const useTxBatch = () => {
       const resolvePreparedPlan = planResolvers.some(Boolean)
         ? async (beforeWalletAction: () => void): Promise<TransactionPlanPrepared> => {
           const resolvedPlans: TransactionPlan[] = []
+          const signatureSubstitutions: PreparedPlanSignatureSubstitution[] = []
           for (const [index, plan] of plans.entries()) {
             beforeWalletAction()
             const resolver = planResolvers[index]
-            resolvedPlans.push(resolver ? await resolver(beforeWalletAction) : plan)
+            if (resolver) {
+              const resolved = await resolver(beforeWalletAction)
+              resolvedPlans.push(resolved.plan)
+              signatureSubstitutions.push(...resolved.signatureSubstitutions)
+            }
+            else {
+              resolvedPlans.push(plan)
+            }
             beforeWalletAction()
           }
           const resolvedPlan = sdk.executionService.mergePlans(resolvedPlans)
           const resolvedPrepared = await prepareTransactionPlan(resolvedPlan)
           beforeWalletAction()
+          assertPreparedPlanSignatureParity({
+            reviewed: prepared,
+            resolved: resolvedPrepared,
+            substitutions: signatureSubstitutions,
+          })
           return resolvedPrepared
         }
         : undefined
@@ -2870,6 +2828,29 @@ export const useTxBatch = () => {
     if (simError.value || walletShortfalls.value.length > 0 || hasFailedOps.value) return
     execError.value = undefined
     isExecuting.value = true
+    const attemptGeneration = batchGeneration.value
+    const attemptOwner = owner.value ? getAddress(owner.value) : undefined
+    const attemptChainId = chainId.value
+    const attemptConnectorKey = connectorKey.value
+    const attemptSafeWallet = isSafeWallet.value
+    const attemptSafeWalletResolved = isSafeWalletResolved.value
+    const isAttemptCurrent = () => {
+      if (
+        attemptGeneration !== batchGeneration.value
+        || attemptChainId !== chainId.value
+        || attemptConnectorKey !== connectorKey.value
+        || attemptSafeWallet !== isSafeWallet.value
+        || attemptSafeWalletResolved !== isSafeWalletResolved.value
+        || !attemptOwner
+        || !owner.value
+      ) return false
+      try {
+        return attemptOwner === getAddress(owner.value)
+      }
+      catch {
+        return false
+      }
+    }
     const grantedRevokes: MigrationAuthorizationRevoke[] = []
     let execution = reviewedExecution
     try {
@@ -2939,8 +2920,9 @@ export const useTxBatch = () => {
       await revokeAfterAbort(grantedRevokes, {
         shouldNotify: () => !execution || isBatchExecutionWalletCurrent(execution),
       })
-      if (!execution || isBatchExecutionCurrent(execution)) {
-        execError.value = await describeExecError(error)
+      const decodedError = await describeExecError(error)
+      if (execution ? isBatchExecutionCurrent(execution) : isAttemptCurrent()) {
+        execError.value = decodedError
       }
     }
     finally {
@@ -3073,13 +3055,6 @@ export const useTxBatch = () => {
     isBatchExecutionCurrent,
     prepareBundledExecution: prepareBatchExecution,
     isBundledExecutionCurrent: isBatchExecutionCurrent,
-    // Tenderly "Simulate on Tenderly" for the whole batch.
-    tenderlyEnabled,
-    isTenderlySimulating: tenderly.isSimulating,
-    tenderlyUrl: tenderly.simulationUrl,
-    tenderlyError: tenderly.simulationError,
-    fetchTenderlyEnabled,
-    simulateOnTenderly,
     // For the Review batch modal.
     getMergedPlan,
     prepareBatchPlan,

--- a/composables/useTxBatch.ts
+++ b/composables/useTxBatch.ts
@@ -8,6 +8,7 @@ import type {
   PortfolioSavingsPosition,
   SlotHints,
   TransactionPlan,
+  TransactionPlanPrepared,
   VaultEntity,
 } from '@eulerxyz/euler-v2-sdk'
 import { getEulerSdkFresh } from '~/composables/useEulerSdk'
@@ -235,7 +236,8 @@ const layers = shallowRef<BatchLayer[]>([])
  * rest of the cart state so every component instance shares it.
  */
 const latchedBundledExecution = shallowRef<{
-  plans: TransactionPlan[]
+  /** Prepared core envelope shared by review export and Safe execution. */
+  prepared: TransactionPlanPrepared
   grants: BatchEntryExternalTx[]
   revokes: BatchEntryExternalTx[]
   /** Per-entry review rows from the same resolution, for the modal to render. */
@@ -2414,6 +2416,7 @@ export const useTxBatch = () => {
   /** Resolve approvals/permits/plugins for the merged batch plan, so the review
    *  modal can list the approvals the user will be asked to sign. */
   const prepareBatchPlan = async () => {
+    if (latchedBundledExecution.value) return latchedBundledExecution.value.prepared
     if (!lastMerged) return null
     return prepareTransactionPlan(lastMerged)
   }
@@ -2476,9 +2479,13 @@ export const useTxBatch = () => {
       latchedBundledExecution.value = null
       return null
     }
-    const collected = await collectBundledExecution()
-    latchedBundledExecution.value = collected
-    return collected
+    const { plans, ...ceremony } = await collectBundledExecution()
+    const sdk = await getEulerSdkFresh()
+    const executionPlan = sdk.executionService.mergePlans(plans)
+    const prepared = await prepareTransactionPlan(executionPlan)
+    const latched = { ...ceremony, prepared }
+    latchedBundledExecution.value = latched
+    return latched
   }
 
   /**
@@ -2586,10 +2593,7 @@ export const useTxBatch = () => {
         // with the entries' authorization state overrides) is the
         // pre-flight validation. Atomicity also removes the unwind
         // bookkeeping: a failed proposal reverts its grants with it.
-        const sdk = await getEulerSdkFresh()
-        const executionPlan = sdk.executionService.mergePlans(collected.plans)
-        const prepared = await prepareTransactionPlan(executionPlan)
-        const result = await executePreparedPlanWithPlainCalls(prepared, {
+        const result = await executePreparedPlanWithPlainCalls(collected.prepared, {
           before: collected.grants,
           after: collected.revokes,
         }, { allowSingleCall: true })

--- a/composables/useTxBatch.ts
+++ b/composables/useTxBatch.ts
@@ -2298,6 +2298,10 @@ export const useTxBatch = () => {
         ...fixedEntry
       } = entry
       registerReviewAssetMeta(fixedEntry.review)
+      // A ceremony can be prepared while this async add is building against
+      // the prior cart. Advance again at the commit edge so that ceremony is
+      // stale before the completed entry becomes visible.
+      invalidateBatchReview()
       entries.value = [...entries.value, {
         ...fixedEntry,
         ...(builtStateOverrides ? { stateOverrides: builtStateOverrides } : {}),

--- a/composables/useTxBatch.ts
+++ b/composables/useTxBatch.ts
@@ -379,9 +379,11 @@ const removePendingCoreSubmission = async (
  * init (covering reloads and reconnects), on cross-tab storage events, and
  * before every execute attempt — an already-open tab must see a quarantine
  * another tab stored after this one initialized. Ceremony contexts are
- * preserved only while they still describe the stored submission (same
- * attempt: an armed record upgrading to its submitted hash keeps its
- * ceremony; a different hash means a different submission).
+ * preserved only while the stored record still belongs to the exact attempt
+ * the context describes — the same attemptId. Phase or hash alone is not
+ * identity: another tab can release this tab's armed record and arm its own,
+ * and attaching this tab's ceremony to that foreign attempt would let a
+ * landed verdict retire entries the foreign submission never covered.
  */
 export const hydratePendingBatchSubmissionFromStorage = () => {
   const previous = pendingCoreSubmissions.value
@@ -390,7 +392,8 @@ export const hydratePendingBatchSubmissionFromStorage = () => {
     const key = pendingSubmissionMirrorKey(record.owner, record.chainId)
     const prior = previous.get(key)
     const sameAttempt = !!prior
-      && (prior.record.phase === 'armed' || prior.record.hash === record.hash)
+      && prior.record.attemptId !== undefined
+      && prior.record.attemptId === record.attemptId
     next.set(key, { record, context: sameAttempt ? prior.context : undefined })
   }
   pendingCoreSubmissions.value = next

--- a/composables/useTxBatch.ts
+++ b/composables/useTxBatch.ts
@@ -90,25 +90,29 @@ export interface BatchEntryExecutionPrerequisites {
   postTxsByPreTx?: Array<BatchEntryExternalTx | undefined>
 }
 
-export interface BatchEntryBundledExecution {
+export interface BatchEntryExecutionCeremony {
   /**
-   * Execution payload built WITHOUT live authorization reads (the
-   * simulation-variant plan) — the grants ride in the same Safe proposal
-   * and are not mined when this plan is built.
+   * Execution payload built from the same authorization resolution as the
+   * prerequisite calls and review rows.
    */
   plan: TransactionPlan
-  /** Grant calls to prepend to the proposal, in dependency order. */
-  grants: BatchEntryExternalTx[]
-  /** Revocation calls to append, already in unwind order for this entry. */
-  revokes: BatchEntryExternalTx[]
+  /** One authorization resolution shared by standard and Safe execution. */
+  prerequisites?: BatchEntryExecutionPrerequisites
   /**
-   * Review rows for the grants above, derived from the SAME authorization
-   * resolution — the modal renders these, never the add-time captures, so
-   * the displayed ceremony cannot drift from the executed one.
+   * Review rows for the prerequisite grants, derived from this ceremony's
+   * authorization resolution.
    */
   grantSteps: DisplayStep[]
-  /** Review rows for the revocations above, same resolution. */
+  /** Review rows for the prerequisite revocations, from the same resolution. */
   revokeSteps: DisplayStep[]
+  /**
+   * Resolve wallet signatures only after the user confirms this reviewed
+   * ceremony. The callback receives the ceremony freshness guard and returns
+   * the same plan with real signature bytes.
+   */
+  resolveExecutionPlan?: (beforeWalletAction: () => void) => Promise<TransactionPlan>
+  /** The review/copy plan contains placeholder authorization signatures. */
+  usesPlaceholderSignatures?: boolean
 }
 
 /** One immutable batch review ceremony used for display, export, and execution. */
@@ -117,8 +121,12 @@ export interface PreparedBatchExecution {
   readonly owner: Address
   readonly chainId: number
   readonly safeWallet: boolean
+  readonly safeWalletResolved: boolean
+  readonly connectorKey?: string
   readonly mode: 'standard' | 'safe-bundled'
   readonly prepared: TransactionPlanPrepared
+  readonly resolvePreparedPlan?: (beforeWalletAction: () => void) => Promise<TransactionPlanPrepared>
+  readonly usesPlaceholderSignatures: boolean
   readonly grants: readonly BatchEntryExternalTx[]
   readonly revokes: readonly BatchEntryExternalTx[]
   readonly prerequisites: readonly Readonly<BatchEntryExecutionPrerequisites>[]
@@ -136,21 +144,14 @@ export interface BatchEntry {
   plan: TransactionPlan
   /** Optional real execution payload builder for entries whose preview plan uses simulation-only state. */
   buildExecutionPlan?: (account: Account<IHasVaultAddress>) => Promise<TransactionPlan>
-  /** Standalone transactions this entry needs around the merged batch, resolved
-   *  when the review ceremony is prepared. Migrations without message signatures
-   *  use this to grant their authorization before the batch and revoke it after:
-   *  the grants cannot
-   *  be plan items (`mergePlans` rejects contractCall, and the EVC would be the
-   *  msg.sender), and must be mined before the plan is built. */
-  buildExecutionPrerequisites?: (
+  /** Resolve the execution plan, authorization calls, and review rows together.
+   *  Standard wallets broadcast the prerequisite calls around the prepared core;
+   *  Safe wallets include the same calls in one atomic proposal. */
+  buildExecutionCeremony?: (
     account: Account<IHasVaultAddress>,
-  ) => Promise<BatchEntryExecutionPrerequisites | undefined>
-  /** Bundled-mode counterpart of the two builders above: plan + grant/revoke
-   *  calls for ONE atomic Safe proposal. Entries providing this let the cart
-   *  skip the standalone grant broadcasts entirely when a Safe executes. */
-  buildBundledExecution?: (
-    account: Account<IHasVaultAddress>,
-  ) => Promise<BatchEntryBundledExecution>
+  ) => Promise<BatchEntryExecutionCeremony>
+  /** This entry's prerequisite calls belong inside one atomic Safe proposal. */
+  bundleExecutionCeremony?: boolean
   /** Extra simulation-only overrides required by this entry, e.g. migration authorization. */
   stateOverrides?: StateOverride
   /** Props for the per-operation review modal (OperationReviewModal), captured at
@@ -1776,7 +1777,7 @@ export const awaitFinalPlanningLayer = async <T>(opts: {
 }
 
 export const useTxBatch = () => {
-  const { chainId: wagmiChainId } = useWagmi()
+  const { chainId: wagmiChainId, connector } = useWagmi()
   const { effectiveAddress } = useEffectiveAddress()
   const { chainId: addressesChainId } = useEulerAddresses()
   const { scheduleExternalMigrationRefreshes } = useExternalMigrationRefresh()
@@ -1786,7 +1787,11 @@ export const useTxBatch = () => {
   )
   const chainId = computed(() => wagmiChainId.value ?? addressesChainId.value)
   const { prepareTransactionPlan, executePreparedPlan, executePreparedPlanWithPlainCalls, estimateGasForPlan, sendPlainTransactions } = useEulerTx()
-  const { isSafeWallet } = useSafeWallet()
+  const { isSafeWallet, isSafeWalletResolved } = useSafeWallet()
+  const connectorKey = computed(() => {
+    const current = connector.value
+    return current ? `${current.id}:${current.uid}` : undefined
+  })
   const { restorePendingBeforeRetry, revokeAfterSuccess, revokeAfterAbort } = useMigrationAuthorizationFlow()
   const { getTokenByAddress } = useTokenList()
   const ownerSubAccountKey = computed(() => {
@@ -2213,7 +2218,7 @@ export const useTxBatch = () => {
       })
       // Safe classification is part of a bundled ceremony's wallet context.
       // Connector detection can change without changing the owner or chain.
-      watch(isSafeWallet, () => {
+      watch([isSafeWallet, isSafeWalletResolved, connectorKey], () => {
         invalidateBatchReview()
       })
     })
@@ -2569,25 +2574,32 @@ export const useTxBatch = () => {
   }
 
   /**
-   * A Safe executes the cart's prerequisites inside the batch proposal when
-   * every prerequisite-bearing entry provides a bundled builder.
+   * A Safe executes ceremony prerequisites inside the batch proposal.
    */
   const willBundlePrerequisites = computed(() =>
     isSafeWallet.value
-    && entries.value.some(entry => entry.buildBundledExecution)
-    && entries.value.every(entry => !entry.buildExecutionPrerequisites || entry.buildBundledExecution),
+    && entries.value.some(entry => entry.bundleExecutionCeremony),
   )
 
   const isBatchExecutionCurrent = (ceremony: PreparedBatchExecution): boolean => {
     if (
       pendingAddCount.value > 0
       || ceremony.generation !== batchGeneration.value
-      || ceremony.chainId !== chainId.value
-      || ceremony.safeWallet !== isSafeWallet.value
-      || !owner.value
     ) {
       return false
     }
+    return isBatchExecutionWalletCurrent(ceremony)
+  }
+
+  const isBatchExecutionWalletCurrent = (ceremony: PreparedBatchExecution): boolean => {
+    if (
+      ceremony.chainId !== chainId.value
+      || ceremony.safeWallet !== isSafeWallet.value
+      || !isSafeWalletResolved.value
+      || ceremony.safeWalletResolved !== isSafeWalletResolved.value
+      || ceremony.connectorKey !== connectorKey.value
+      || !owner.value
+    ) return false
     try {
       return getAddress(owner.value) === ceremony.owner
     }
@@ -2615,6 +2627,9 @@ export const useTxBatch = () => {
     if (!lastMerged || entries.value.length === 0) {
       return Promise.reject(new Error('Batch simulation not loaded'))
     }
+    if (!isSafeWalletResolved.value) {
+      return Promise.reject(new Error('Wallet type is still loading — wait before reviewing the batch.'))
+    }
 
     const generation = batchGeneration.value
     if (batchPreparation?.generation === generation) return batchPreparation.promise
@@ -2624,15 +2639,32 @@ export const useTxBatch = () => {
     if (!currentOwner || !currentChainId) return Promise.reject(new Error('Account not loaded'))
     const reviewOwner = getAddress(currentOwner)
     const reviewSafeWallet = isSafeWallet.value
+    const reviewSafeWalletResolved = isSafeWalletResolved.value
+    const reviewConnectorKey = connectorKey.value
     const mode = willBundlePrerequisites.value ? 'safe-bundled' : 'standard'
 
     const preparationPromise = (async (): Promise<PreparedBatchExecution> => {
-      const { plans, grants, revokes, prerequisites, reviewByEntryId } = mode === 'safe-bundled'
+      const { plans, planResolvers, usesPlaceholderSignatures, grants, revokes, prerequisites, reviewByEntryId } = mode === 'safe-bundled'
         ? await collectBundledExecution()
         : await collectStandardExecution()
       const sdk = await getEulerSdkFresh()
       const executionPlan = sdk.executionService.mergePlans(plans)
       const prepared = await prepareTransactionPlan(executionPlan)
+      const resolvePreparedPlan = planResolvers.some(Boolean)
+        ? async (beforeWalletAction: () => void): Promise<TransactionPlanPrepared> => {
+          const resolvedPlans: TransactionPlan[] = []
+          for (const [index, plan] of plans.entries()) {
+            beforeWalletAction()
+            const resolver = planResolvers[index]
+            resolvedPlans.push(resolver ? await resolver(beforeWalletAction) : plan)
+            beforeWalletAction()
+          }
+          const resolvedPlan = sdk.executionService.mergePlans(resolvedPlans)
+          const resolvedPrepared = await prepareTransactionPlan(resolvedPlan)
+          beforeWalletAction()
+          return resolvedPrepared
+        }
+        : undefined
       const frozenReview = Object.freeze(Object.fromEntries(
         Object.entries(reviewByEntryId).map(([entryId, review]) => [entryId, Object.freeze({
           plan: review.plan,
@@ -2654,8 +2686,12 @@ export const useTxBatch = () => {
         owner: reviewOwner,
         chainId: currentChainId,
         safeWallet: reviewSafeWallet,
+        safeWalletResolved: reviewSafeWalletResolved,
+        connectorKey: reviewConnectorKey,
         mode,
         prepared,
+        resolvePreparedPlan,
+        usesPlaceholderSignatures,
         grants: Object.freeze(grants.map(tx => Object.freeze({ ...tx }))),
         revokes: Object.freeze(revokes.map(tx => Object.freeze({ ...tx }))),
         prerequisites: frozenPrerequisites,
@@ -2681,6 +2717,8 @@ export const useTxBatch = () => {
    */
   const collectStandardExecution = async () => {
     const plans: TransactionPlan[] = []
+    const planResolvers: Array<BatchEntryExecutionCeremony['resolveExecutionPlan']> = []
+    let usesPlaceholderSignatures = false
     const grants: BatchEntryExternalTx[] = []
     const revokes: BatchEntryExternalTx[] = []
     const prerequisites: BatchEntryExecutionPrerequisites[] = []
@@ -2691,14 +2729,12 @@ export const useTxBatch = () => {
     }> = {}
 
     for (const [index, entry] of entries.value.entries()) {
-      if (entry.buildExecutionPrerequisites) {
-        if (!entry.buildBundledExecution) {
-          throw new Error('This operation cannot produce an exact reviewable execution plan.')
-        }
-        const account = await getExecutionPlanningAccount(index)
-        const prerequisite = await entry.buildExecutionPrerequisites(account)
-        const execution = await entry.buildBundledExecution(account)
+      if (entry.buildExecutionCeremony) {
+        const execution = await entry.buildExecutionCeremony(await getExecutionPlanningAccount(index))
+        const prerequisite = execution.prerequisites
         plans.push(execution.plan)
+        planResolvers.push(execution.resolveExecutionPlan)
+        usesPlaceholderSignatures ||= execution.usesPlaceholderSignatures === true
         if (prerequisite) {
           prerequisites.push(prerequisite)
           grants.push(...prerequisite.preTxs)
@@ -2713,8 +2749,12 @@ export const useTxBatch = () => {
         }
         reviewByEntryId[entry.id] = {
           plan: execution.plan,
-          grantSteps: execution.grantSteps.map(step => ({ ...step, isSeparateTx: true })),
-          revokeSteps: execution.revokeSteps.map(step => ({ ...step, isSeparateTx: true })),
+          grantSteps: prerequisite
+            ? execution.grantSteps.map(step => ({ ...step, isSeparateTx: true }))
+            : execution.grantSteps,
+          revokeSteps: prerequisite
+            ? execution.revokeSteps.map(step => ({ ...step, isSeparateTx: true }))
+            : execution.revokeSteps,
         }
         continue
       }
@@ -2723,10 +2763,11 @@ export const useTxBatch = () => {
         ? await entry.buildExecutionPlan(await getExecutionPlanningAccount(index))
         : entry.plan
       plans.push(plan)
+      planResolvers.push(undefined)
       reviewByEntryId[entry.id] = { plan, grantSteps: [], revokeSteps: [] }
     }
 
-    return { plans, grants, revokes, prerequisites, reviewByEntryId }
+    return { plans, planResolvers, usesPlaceholderSignatures, grants, revokes, prerequisites, reviewByEntryId }
   }
 
   /**
@@ -2736,6 +2777,8 @@ export const useTxBatch = () => {
    */
   const collectBundledExecution = async () => {
     const plans: TransactionPlan[] = []
+    const planResolvers: Array<BatchEntryExecutionCeremony['resolveExecutionPlan']> = []
+    let usesPlaceholderSignatures = false
     const grants: BatchEntryExternalTx[] = []
     const revokesByEntry: BatchEntryExternalTx[][] = []
     const reviewByEntryId: Record<string, {
@@ -2744,11 +2787,14 @@ export const useTxBatch = () => {
       revokeSteps: DisplayStep[]
     }> = {}
     for (const [index, entry] of entries.value.entries()) {
-      if (entry.buildBundledExecution) {
-        const bundled = await entry.buildBundledExecution(await getExecutionPlanningAccount(index))
+      if (entry.buildExecutionCeremony) {
+        const bundled = await entry.buildExecutionCeremony(await getExecutionPlanningAccount(index))
+        const prerequisite = bundled.prerequisites
         plans.push(bundled.plan)
-        grants.push(...bundled.grants)
-        revokesByEntry.push(bundled.revokes)
+        planResolvers.push(bundled.resolveExecutionPlan)
+        usesPlaceholderSignatures ||= bundled.usesPlaceholderSignatures === true
+        grants.push(...(prerequisite?.preTxs ?? []))
+        revokesByEntry.push(prerequisite?.postTxs ?? [])
         reviewByEntryId[entry.id] = {
           plan: bundled.plan,
           grantSteps: bundled.grantSteps,
@@ -2760,10 +2806,11 @@ export const useTxBatch = () => {
         ? await entry.buildExecutionPlan(await getExecutionPlanningAccount(index))
         : entry.plan
       plans.push(plan)
+      planResolvers.push(undefined)
       revokesByEntry.push([])
       reviewByEntryId[entry.id] = { plan, grantSteps: [], revokeSteps: [] }
     }
-    return { plans, grants, revokes: revokesByEntry.reverse().flat(), prerequisites: [], reviewByEntryId }
+    return { plans, planResolvers, usesPlaceholderSignatures, grants, revokes: revokesByEntry.reverse().flat(), prerequisites: [], reviewByEntryId }
   }
 
   /**
@@ -2781,6 +2828,7 @@ export const useTxBatch = () => {
         assertBatchExecutionCurrent(ceremony)
         await sendPlainTransactions([preTx], {
           walletContext: prerequisites.walletContext,
+          beforeBroadcast: () => assertBatchExecutionCurrent(ceremony),
           onBroadcast: (_index, walletContext) => {
             grantWalletContext = walletContext
             const revoke = prerequisites.postTxsByPreTx?.[preTxIndex]
@@ -2823,11 +2871,16 @@ export const useTxBatch = () => {
     execError.value = undefined
     isExecuting.value = true
     const grantedRevokes: MigrationAuthorizationRevoke[] = []
+    let execution = reviewedExecution
     try {
       if (!await restorePendingBeforeRetry()) return
-      const execution = reviewedExecution ?? await prepareBatchExecution()
+      execution ??= await prepareBatchExecution()
       assertBatchExecutionCurrent(execution)
       const shouldRefreshExternalMigrationPositions = entries.value.some(entry => entry.refreshExternalMigrationPositions)
+      const prepared = execution.resolvePreparedPlan
+        ? await execution.resolvePreparedPlan(() => assertBatchExecutionCurrent(execution!))
+        : execution.prepared
+      assertBatchExecutionCurrent(execution)
 
       if (execution.mode === 'safe-bundled') {
         // No standalone gas estimate — grants are unmined until the
@@ -2836,14 +2889,21 @@ export const useTxBatch = () => {
         // pre-flight validation. Atomicity also removes the unwind
         // bookkeeping: a failed proposal reverts its grants with it.
         assertBatchExecutionCurrent(execution)
-        const result = await executePreparedPlanWithPlainCalls(execution.prepared, {
+        const result = await executePreparedPlanWithPlainCalls(prepared, {
           before: execution.grants,
           after: execution.revokes,
-        }, { allowSingleCall: true })
+        }, {
+          allowSingleCall: true,
+          beforeBroadcast: () => assertBatchExecutionCurrent(execution),
+        })
         if (!result) {
           // The review described ONE proposal; never silently degrade to
           // the sequential multi-proposal ceremony.
           throw new Error('Safe connection unavailable — the reviewed single-proposal submission cannot run. Reconnect your Safe and retry.')
+        }
+        if (!isBatchExecutionCurrent(execution)) {
+          scope?.markSucceeded()
+          return
         }
         clearBatch()
         if (shouldRefreshExternalMigrationPositions) scheduleExternalMigrationRefreshes()
@@ -2856,20 +2916,32 @@ export const useTxBatch = () => {
       // Final on-chain gas estimate before the irreversible core broadcast. If
       // chain state moved since review, surface the decoded reason and retain
       // the cart. A pending edit during this await invalidates the ceremony.
-      await estimateGasForPlan(execution.prepared.plan)
+      await estimateGasForPlan(prepared.plan)
       assertBatchExecutionCurrent(execution)
-      await executePreparedPlan(execution.prepared)
+      await executePreparedPlan(prepared, {
+        beforeBroadcast: () => assertBatchExecutionCurrent(execution),
+      })
+      await revokeAfterSuccess(grantedRevokes, {
+        shouldNotify: () => isBatchExecutionWalletCurrent(execution!),
+      })
+      if (!isBatchExecutionCurrent(execution)) {
+        scope?.markSucceeded()
+        return
+      }
       clearBatch()
       if (shouldRefreshExternalMigrationPositions) scheduleExternalMigrationRefreshes()
-      await revokeAfterSuccess(grantedRevokes)
       await redirectAfterBatchExecution(scope)
     }
     catch (error) {
       logWarn('useTxBatch/executeBatch', error)
       // The batch never landed, so no granted authorization should be left
       // standing. Entries stay in the cart for a retry, which re-grants.
-      await revokeAfterAbort(grantedRevokes)
-      execError.value = await describeExecError(error)
+      await revokeAfterAbort(grantedRevokes, {
+        shouldNotify: () => !execution || isBatchExecutionWalletCurrent(execution),
+      })
+      if (!execution || isBatchExecutionCurrent(execution)) {
+        execError.value = await describeExecError(error)
+      }
     }
     finally {
       isExecuting.value = false

--- a/composables/useTxBatch.ts
+++ b/composables/useTxBatch.ts
@@ -119,7 +119,8 @@ export interface PreparedBatchBundledExecution {
   readonly prepared: TransactionPlanPrepared
   readonly grants: readonly BatchEntryExternalTx[]
   readonly revokes: readonly BatchEntryExternalTx[]
-  readonly stepsByEntryId: Readonly<Record<string, {
+  readonly reviewByEntryId: Readonly<Record<string, {
+    readonly plan: TransactionPlan
     readonly grantSteps: readonly DisplayStep[]
     readonly revokeSteps: readonly DisplayStep[]
   }>>
@@ -2512,14 +2513,15 @@ export const useTxBatch = () => {
     const reviewOwner = getAddress(currentOwner)
 
     const preparationPromise = (async (): Promise<PreparedBatchBundledExecution> => {
-      const { plans, grants, revokes, stepsByEntryId } = await collectBundledExecution()
+      const { plans, grants, revokes, reviewByEntryId } = await collectBundledExecution()
       const sdk = await getEulerSdkFresh()
       const executionPlan = sdk.executionService.mergePlans(plans)
       const prepared = await prepareTransactionPlan(executionPlan)
-      const frozenSteps = Object.freeze(Object.fromEntries(
-        Object.entries(stepsByEntryId).map(([entryId, steps]) => [entryId, Object.freeze({
-          grantSteps: Object.freeze([...steps.grantSteps]),
-          revokeSteps: Object.freeze([...steps.revokeSteps]),
+      const frozenReview = Object.freeze(Object.fromEntries(
+        Object.entries(reviewByEntryId).map(([entryId, review]) => [entryId, Object.freeze({
+          plan: review.plan,
+          grantSteps: Object.freeze([...review.grantSteps]),
+          revokeSteps: Object.freeze([...review.revokeSteps]),
         })]),
       ))
       const ceremony: PreparedBatchBundledExecution = Object.freeze({
@@ -2529,14 +2531,15 @@ export const useTxBatch = () => {
         prepared,
         grants: Object.freeze([...grants]),
         revokes: Object.freeze([...revokes]),
-        stepsByEntryId: frozenSteps,
+        reviewByEntryId: frozenReview,
       })
       assertBundledExecutionCurrent(ceremony)
       return ceremony
     })()
 
-    const trackedPromise = preparationPromise.finally(() => {
+    const trackedPromise = preparationPromise.catch((error) => {
       if (bundledPreparation?.promise === trackedPromise) bundledPreparation = null
+      throw error
     })
     bundledPreparation = { generation, promise: trackedPromise }
     return trackedPromise
@@ -2551,22 +2554,32 @@ export const useTxBatch = () => {
     const plans: TransactionPlan[] = []
     const grants: BatchEntryExternalTx[] = []
     const revokesByEntry: BatchEntryExternalTx[][] = []
-    const stepsByEntryId: Record<string, { grantSteps: DisplayStep[], revokeSteps: DisplayStep[] }> = {}
+    const reviewByEntryId: Record<string, {
+      plan: TransactionPlan
+      grantSteps: DisplayStep[]
+      revokeSteps: DisplayStep[]
+    }> = {}
     for (const [index, entry] of entries.value.entries()) {
       if (entry.buildBundledExecution) {
         const bundled = await entry.buildBundledExecution(await getExecutionPlanningAccount(index))
         plans.push(bundled.plan)
         grants.push(...bundled.grants)
         revokesByEntry.push(bundled.revokes)
-        stepsByEntryId[entry.id] = { grantSteps: bundled.grantSteps, revokeSteps: bundled.revokeSteps }
+        reviewByEntryId[entry.id] = {
+          plan: bundled.plan,
+          grantSteps: bundled.grantSteps,
+          revokeSteps: bundled.revokeSteps,
+        }
         continue
       }
-      plans.push(entry.buildExecutionPlan
+      const plan = entry.buildExecutionPlan
         ? await entry.buildExecutionPlan(await getExecutionPlanningAccount(index))
-        : entry.plan)
+        : entry.plan
+      plans.push(plan)
       revokesByEntry.push([])
+      reviewByEntryId[entry.id] = { plan, grantSteps: [], revokeSteps: [] }
     }
-    return { plans, grants, revokes: revokesByEntry.reverse().flat(), stepsByEntryId }
+    return { plans, grants, revokes: revokesByEntry.reverse().flat(), reviewByEntryId }
   }
 
   /**

--- a/composables/useTxBatch.ts
+++ b/composables/useTxBatch.ts
@@ -1,5 +1,5 @@
-import { computed, effectScope, ref, shallowRef, watch, type EffectScope, type Ref } from 'vue'
-import { formatUnits, getAddress, type Address, type Hash, type Hex, type StateOverride } from 'viem'
+import { computed, effectScope, nextTick, ref, shallowRef, watch, type EffectScope, type Ref } from 'vue'
+import { formatUnits, getAddress, type Address, type Hex, type StateOverride } from 'viem'
 import { Account, fetchErc20SlotHints, getEulerLabelProductByVault, mergeStateOverrides } from '@eulerxyz/euler-v2-sdk'
 import type {
   IHasVaultAddress,
@@ -34,12 +34,14 @@ import { buildVisiblePortfolioPositionFilter } from '~/utils/portfolioPositionFi
 import type { MigrationAuthorizationRevoke } from '~/utils/migrationAuthorizationTxs'
 import type { WalletExecutionContext } from '~/utils/walletExecutionContext'
 import type { PreparedPlanBroadcast } from '~/composables/useEulerTx'
+import { getSafeWalletProvider, type ReceiptClientLike } from '~/utils/safeWalletTransactions'
 import {
-  getSafeWalletProvider,
-  SafeTransactionStatusUnknownError,
-  waitForSafeTransactionExecution,
-  type ReceiptClientLike,
-} from '~/utils/safeWalletTransactions'
+  clearPendingSubmission,
+  readPendingSubmission,
+  resolvePendingSubmissionOutcome,
+  writePendingSubmission,
+  type PendingSubmissionRecord,
+} from '~/utils/pendingSubmissions'
 import {
   assertPreparedPlanSignatureParity,
   type PreparedPlanSignatureSubstitution,
@@ -313,18 +315,34 @@ const isExecuting = ref(false)
 const execError = ref<string | undefined>(undefined)
 /**
  * A core batch submission the wallet accepted but whose confirmation failed —
- * it may still land. While set, the cart is quarantined against blind replays
- * (re-executing could duplicate every entry the submission covered): the next
- * execute attempt first reconciles this submission on-chain, and proceeds only
- * when it definitively did not land. Landed submissions retire their entries.
+ * it may still land. While set, execution for the record's wallet/chain is
+ * quarantined against blind replays (re-executing could duplicate every entry
+ * the submission covered): the next execute attempt first reconciles this
+ * submission on-chain, and proceeds only when it definitively did not land.
+ * Landed submissions retire their entries.
+ *
+ * The record itself is durable (localStorage) so cart clearing, account
+ * switches, and page reloads cannot erase the unknown outcome — only a
+ * terminal reconcile verdict releases it. The ceremony context exists only
+ * while the submitting session is alive; a record hydrated after a reload has
+ * no ceremony, so a landed verdict then resets the cart instead of retiring
+ * the exact covered entries.
  */
 const pendingCoreSubmission = shallowRef<{
-  kind: PreparedPlanBroadcast['kind']
-  hash: Hash
-  chainId: number
-  ceremony: PreparedBatchExecution
-  shouldRefreshExternalMigrationPositions: boolean
+  record: PendingSubmissionRecord
+  context?: { ceremony: PreparedBatchExecution }
 } | null>(null)
+
+/**
+ * Rehydrate the quarantine mirror from its durable record. Runs once at
+ * module init (covering reloads and reconnects); tests re-run it after
+ * seeding or clearing storage to simulate those lifecycles.
+ */
+export const hydratePendingBatchSubmissionFromStorage = () => {
+  const record = readPendingSubmission('batch')
+  pendingCoreSubmission.value = record ? { record } : null
+}
+hydratePendingBatchSubmissionFromStorage()
 // Drawer expanded/collapsed state, shared so the mobile nav's "Batch" item and
 // the drawer header toggle the same thing. On laptop this collapses the body; on
 // mobile it shows/hides the whole bottom sheet (the nav item is the entry point).
@@ -2481,9 +2499,10 @@ export const useTxBatch = () => {
   const clearBatch = () => {
     invalidatePendingAddContext()
     invalidateBatchReview()
-    // Emptying the cart discards the entries a quarantined submission covered,
-    // so a replay can no longer duplicate them — the quarantine is moot.
-    pendingCoreSubmission.value = null
+    // A quarantined core submission deliberately survives cart clearing: the
+    // on-chain outcome of what was already sent does not change because the
+    // local cart emptied, and the next execute attempt for that wallet/chain
+    // must still reconcile it before anything new is sent.
     resimToken++
     entries.value = []
     layers.value = []
@@ -2888,21 +2907,29 @@ export const useTxBatch = () => {
 
   /**
    * Resolve a quarantined core submission before anything new is sent.
-   * Returns true only when the submission definitively did not land (or none
-   * exists). A landed submission retires its entries here instead; an
-   * unverifiable one keeps the quarantine — replaying while the original may
-   * still confirm would duplicate every entry it covered.
+   * Returns true when this attempt may proceed: no quarantine exists, the
+   * record belongs to a different wallet/chain (nothing this attempt sends
+   * can duplicate it, so the record is kept for the wallet that owns it), or
+   * the submission definitively did not land. A landed submission retires the
+   * entries it covered and stops the attempt; an unverifiable one keeps the
+   * quarantine — replaying while the original may still confirm would
+   * duplicate every entry it covered.
    */
-  const reconcilePendingCoreSubmission = async (scope?: TrackedExecutionScope): Promise<boolean> => {
+  const reconcilePendingCoreSubmission = async (
+    scope: TrackedExecutionScope | undefined,
+    attempt: { owner?: Address, chainId?: number },
+  ): Promise<boolean> => {
     const submission = pendingCoreSubmission.value
     if (!submission) return true
+    const { record, context } = submission
 
-    const finalizeLandedSubmission = () => {
+    const matchesAttempt = !!attempt.owner
+      && attempt.owner === record.owner
+      && attempt.chainId === record.chainId
+
+    const releaseQuarantine = () => {
       pendingCoreSubmission.value = null
-      execError.value = undefined
-      retireExecutedEntries(submission.ceremony)
-      if (submission.shouldRefreshExternalMigrationPositions) scheduleExternalMigrationRefreshes()
-      scope?.markSucceeded()
+      clearPendingSubmission('batch')
     }
     const keepQuarantined = () => {
       execError.value = 'A previous batch submission may still confirm on-chain and could not be verified yet. Wait a moment and execute again — the submission is re-checked before anything is re-sent.'
@@ -2910,53 +2937,56 @@ export const useTxBatch = () => {
     }
 
     const sdk = await getEulerSdkFresh()
-    const provider = sdk.providerService?.getProvider(submission.chainId) as ReceiptClientLike | undefined
-    if (!provider) return keepQuarantined()
+    const provider = sdk.providerService?.getProvider(record.chainId) as ReceiptClientLike | undefined
+    const outcome = await resolvePendingSubmissionOutcome(record, {
+      provider,
+      getSafeWalletProvider,
+      connector: connector.value,
+      safeStatusTimeoutMs: 8_000,
+    })
 
-    if (submission.kind === 'transaction') {
-      const receipt = await provider.getTransactionReceipt({ hash: submission.hash }).catch(() => undefined)
-      if (!receipt) return keepQuarantined()
-      if (receipt.status === 'success') {
-        finalizeLandedSubmission()
-        return false
-      }
-      // Definitively reverted on-chain — the retry cannot duplicate anything.
-      pendingCoreSubmission.value = null
+    if (outcome === 'unknown') {
+      // Fail closed only for the wallet/chain that owns the record — a
+      // different wallet's attempt cannot duplicate it and may proceed.
+      return matchesAttempt ? keepQuarantined() : true
+    }
+    if (outcome === 'not-landed') {
+      // Definitively cancelled/reverted — a retry cannot duplicate anything.
+      releaseQuarantine()
       return true
     }
 
-    // Safe proposal: only the Safe app knows whether the proposal executed
-    // and under which final transaction hash.
-    const walletProvider = await getSafeWalletProvider(connector.value)
-    if (!walletProvider) return keepQuarantined()
-    try {
-      const { receipt } = await waitForSafeTransactionExecution({
-        submittedHash: submission.hash,
-        walletProvider,
-        publicClient: provider,
-        timeoutMs: 8_000,
-      })
-      if (receipt.status === 'success') {
-        finalizeLandedSubmission()
-        return false
-      }
-      pendingCoreSubmission.value = null
-      return true
+    // Landed: on-chain state moved under any standing review.
+    releaseQuarantine()
+    invalidateBatchReview()
+    if (!record.completesPlan) {
+      // Defensive: a landed intermediate submission means part of the plan
+      // executed and part did not. The layered cart cannot represent that
+      // split — reset it and require rebuilding what remains.
+      clearBatch()
+      // The entries watcher runs an empty-batch resimulate reset on the next
+      // flush that wipes execError — let it settle so the explanation stays.
+      await nextTick()
+      execError.value = 'A previous batch submission confirmed on-chain but did not complete the reviewed batch. The cart was reset — review your positions and rebuild the remaining operations.'
+      return false
     }
-    catch (error) {
-      if (error instanceof SafeTransactionStatusUnknownError) return keepQuarantined()
-      if (error instanceof Error && (
-        error.message === 'Safe transaction was cancelled'
-        || error.message === 'Safe transaction failed'
-      )) {
-        pendingCoreSubmission.value = null
-        return true
-      }
-      // Anything else is not a definitive verdict — fail closed and keep the
-      // quarantine rather than risk a duplicate submission.
-      logWarn('useTxBatch/reconcilePendingCoreSubmission', error)
-      return keepQuarantined()
+    execError.value = undefined
+    if (context) {
+      retireExecutedEntries(context.ceremony)
     }
+    else if (matchesAttempt) {
+      // No ceremony survives a reload, so the exact covered entries are
+      // unknown — reset the cart rather than leave already-executed entries
+      // queued to run again.
+      clearBatch()
+    }
+    if (record.refreshExternalPositions) scheduleExternalMigrationRefreshes()
+    if (!matchesAttempt) return true
+    scope?.markSucceeded()
+    if (entries.value.length > 0) {
+      execError.value = 'The previous batch submission confirmed on-chain. The operations it covered were removed — review the remaining ones before executing again.'
+    }
+    return false
   }
 
   /** Execute the immutable ceremony produced for the current batch review. */
@@ -3000,16 +3030,32 @@ export const useTxBatch = () => {
     }
     const grantedRevokes: MigrationAuthorizationRevoke[] = []
     let execution = reviewedExecution
-    // Set once the wallet accepts the core submission — from that point a
-    // failure no longer means "nothing was sent".
-    let coreBroadcast: PreparedPlanBroadcast | undefined
+    // Ordered execution tracking. The executor waits for each submission's
+    // receipt before the next send and re-fires the broadcast as 'confirmed'
+    // once that receipt lands, so at most the single latest 'submitted'
+    // broadcast has an unknown outcome at any failure.
+    let unconfirmedBroadcast: PreparedPlanBroadcast | undefined
+    // The value-moving submission (Safe bundle or EVC batch) whose receipt
+    // definitively confirmed — a failure after this point must not allow the
+    // covered entries to be executed again.
+    let confirmedValueMovingBroadcast: PreparedPlanBroadcast | undefined
+    const trackBroadcast = (broadcast: PreparedPlanBroadcast) => {
+      if (broadcast.status === 'submitted') {
+        unconfirmedBroadcast = broadcast
+        return
+      }
+      unconfirmedBroadcast = undefined
+      if (broadcast.item === 'bundle' || broadcast.item === 'evcBatch') {
+        confirmedValueMovingBroadcast = broadcast
+      }
+    }
     // Set when this attempt itself invalidated the review (quarantine or
     // prerequisite drift): the error must still surface even though the
     // ceremony's generation check now fails.
     let ceremonyInvalidatedForRetry = false
     try {
       if (!await restorePendingBeforeRetry()) return
-      if (!await reconcilePendingCoreSubmission(scope)) return
+      if (!await reconcilePendingCoreSubmission(scope, { owner: attemptOwner, chainId: attemptChainId })) return
       execution ??= await prepareBatchExecution()
       assertBatchExecutionCurrent(execution)
       const shouldRefreshExternalMigrationPositions = entries.value.some(entry => entry.refreshExternalMigrationPositions)
@@ -3050,9 +3096,7 @@ export const useTxBatch = () => {
         }, {
           allowSingleCall: true,
           beforeBroadcast: () => assertBatchExecutionCurrent(execution),
-          onBroadcast: (broadcast) => {
-            coreBroadcast = broadcast
-          },
+          onBroadcast: trackBroadcast,
         })
         if (!result) {
           // The review described ONE proposal; never silently degrade to
@@ -3080,9 +3124,7 @@ export const useTxBatch = () => {
       assertBatchExecutionCurrent(execution)
       await executePreparedPlan(prepared, {
         beforeBroadcast: () => assertBatchExecutionCurrent(execution),
-        onBroadcast: (broadcast) => {
-          coreBroadcast = broadcast
-        },
+        onBroadcast: trackBroadcast,
       })
       await revokeAfterSuccess(grantedRevokes, {
         shouldNotify: () => isBatchExecutionWalletCurrent(execution!),
@@ -3098,19 +3140,37 @@ export const useTxBatch = () => {
     }
     catch (error) {
       logWarn('useTxBatch/executeBatch', error)
-      if (coreBroadcast && execution) {
-        // The wallet accepted the core submission but confirmation failed —
-        // it may still land. Quarantine the cart against a blind replay (it
-        // would duplicate every covered entry) and force reconciliation on
-        // the next execute attempt.
-        pendingCoreSubmission.value = {
-          kind: coreBroadcast.kind,
-          hash: coreBroadcast.hash,
+      const ambiguousValueMoving = unconfirmedBroadcast && execution
+        && (unconfirmedBroadcast.item === 'bundle' || unconfirmedBroadcast.item === 'evcBatch')
+        ? unconfirmedBroadcast
+        : undefined
+      if (ambiguousValueMoving && execution) {
+        // The wallet accepted a value-moving submission but its confirmation
+        // failed — it may still land. Quarantine durably (the record survives
+        // cart clearing, account switches, and reloads) and force on-chain
+        // reconciliation before anything is re-sent. Ambiguous approval or
+        // plugin submissions are idempotent prerequisites and need none of
+        // this — an ordinary retry re-runs them safely.
+        const record: PendingSubmissionRecord = {
+          kind: ambiguousValueMoving.kind,
+          hash: ambiguousValueMoving.hash,
           chainId: execution.chainId,
-          ceremony: execution,
-          shouldRefreshExternalMigrationPositions: entries.value.some(entry =>
+          owner: getAddress(execution.owner),
+          completesPlan: ambiguousValueMoving.completesPlan,
+          refreshExternalPositions: entries.value.some(entry =>
             entry.refreshExternalMigrationPositions && entry.id in execution!.reviewByEntryId),
+          submittedAt: Date.now(),
         }
+        pendingCoreSubmission.value = { record, context: { ceremony: execution } }
+        writePendingSubmission('batch', record)
+        ceremonyInvalidatedForRetry = true
+        invalidateBatchReview()
+      }
+      else if (confirmedValueMovingBroadcast && execution) {
+        // The value-moving submission definitively landed and a later step
+        // (revoke, cleanup) failed. Retire the covered entries so a retry
+        // cannot execute them a second time.
+        retireExecutedEntries(execution)
         ceremonyInvalidatedForRetry = true
         invalidateBatchReview()
       }
@@ -3122,8 +3182,11 @@ export const useTxBatch = () => {
         shouldNotify: () => !execution || isBatchExecutionWalletCurrent(execution),
       })
       let decodedError = await describeExecError(error)
-      if (coreBroadcast && execution) {
+      if (ambiguousValueMoving) {
         decodedError = `${decodedError} The submission may still confirm — executing again first verifies it on-chain before anything is re-sent.`
+      }
+      else if (confirmedValueMovingBroadcast && execution) {
+        decodedError = `${decodedError} The batch itself confirmed on-chain; the operations it covered were removed from the cart.`
       }
       const shouldSurfaceError = execution
         ? isBatchExecutionCurrent(execution)

--- a/docs/batch-review-modal-handoff.md
+++ b/docs/batch-review-modal-handoff.md
@@ -218,19 +218,33 @@ Execute is `UiButton variant="primary" size="xlarge" rounded` full-width.
   requirement immediately before anything irreversible is sent; if the grant/revoke set no
   longer matches what was reviewed (an allowance granted or revoked elsewhere), execution
   aborts, the review is invalidated, and the error asks the user to reopen review.
-- **Submitted but unconfirmed** → every wallet acceptance during execution is classified
+- **Submitted but unconfirmed** → every wallet interaction during execution is classified
   by the plan step that produced it (prerequisite approval/plugin call vs. the value-moving
-  batch transaction or Safe proposal). A failure after an accepted *prerequisite* retries
-  plainly — those steps are idempotent. A failure after the accepted *core* submission
-  quarantines the cart with the submitted hash, durably in `localStorage`: clearing the
-  cart, switching wallets, or reloading does not drop it. The next Execute press for that
-  wallet/chain first verifies the submission on-chain — a landed submission retires its
-  entries (or resets the cart when it landed mid-plan or the ceremony did not survive a
-  reload), a reverted/cancelled one releases the retry, an unverifiable one keeps the
-  quarantine and explains why. Once the core submission's receipt confirmed, a later
-  failure (for example a revoke) retires the covered entries instead of quarantining.
-  The direct migration pages (`migrate.vue`, `borrow/swap.vue`) apply the same quarantine
-  per flow via `utils/directSubmissionQuarantine.ts`.
+  batch transaction or Safe proposal). Replay protection *arms* before the value-moving
+  step crosses the wallet boundary: an `armed` record is persisted durably before the
+  wallet is invoked, upgraded to `submitted` when a transaction hash or Safe proposal id
+  comes back, and released only when the wallet provably rejected the request (user
+  rejection / connector error). A wallet failure that returns no id — or a malformed
+  bundle id — leaves the armed record standing, because acceptance cannot be disproved.
+  A failure after an accepted *prerequisite* retries plainly — those steps are idempotent.
+  Records live in `localStorage` keyed per flow, wallet, and chain
+  (`utils/pendingSubmissions.ts`), so one wallet's quarantine never blocks or overwrites
+  another's; when durable storage is unavailable or lies about writes, an in-memory
+  fail-closed fallback keeps the quarantine for the session. Clearing the cart, switching
+  wallets, or reloading does not drop a record. Before every Execute press the durable
+  record is re-read (so a quarantine placed by another tab is enforced, and a `storage`
+  event listener syncs already-open tabs), then verified on-chain — a landed submission
+  retires its entries (or resets the cart when it landed mid-plan or the ceremony did not
+  survive a reload), a reverted/cancelled one releases the retry, an unverifiable or
+  still-armed one keeps the quarantine and explains why. Once the core submission's
+  receipt confirmed, a later failure (for example a revoke) retires the covered entries
+  instead of quarantining. The direct migration pages (`migrate.vue`, `borrow/swap.vue`)
+  apply the same arming and quarantine per flow via `utils/directSubmissionQuarantine.ts`.
+  The quarantine is also enforced *across surfaces*: every plan executor in
+  `useEulerTx.ts` runs `utils/pendingSubmissionGate.ts` before anything reaches a wallet,
+  so an unresolved batch submission blocks an equivalent direct operation for that
+  wallet/chain (and vice versa); a landed batch record discovered from another surface is
+  retired through a handler the cart registers.
 
 ## Accessibility
 - Row header is a real `<button>`; expose `aria-expanded` bound to the open state and

--- a/docs/batch-review-modal-handoff.md
+++ b/docs/batch-review-modal-handoff.md
@@ -221,30 +221,47 @@ Execute is `UiButton variant="primary" size="xlarge" rounded` full-width.
 - **Submitted but unconfirmed** → every wallet interaction during execution is classified
   by the plan step that produced it (prerequisite approval/plugin call vs. the value-moving
   batch transaction or Safe proposal). Replay protection *arms* before the value-moving
-  step crosses the wallet boundary: an `armed` record is persisted durably before the
-  wallet is invoked, upgraded to `submitted` when a transaction hash or Safe proposal id
-  comes back, and released only when the wallet provably rejected the request (user
-  rejection / connector error). A wallet failure that returns no id — or a malformed
-  bundle id — leaves the armed record standing, because acceptance cannot be disproved.
-  A failure after an accepted *prerequisite* retries plainly — those steps are idempotent.
-  Records live in `localStorage` keyed per flow, wallet, and chain
-  (`utils/pendingSubmissions.ts`), so one wallet's quarantine never blocks or overwrites
-  another's; when durable storage is unavailable or lies about writes, an in-memory
-  fail-closed fallback keeps the quarantine for the session. Clearing the cart, switching
-  wallets, or reloading does not drop a record. Before every Execute press the durable
-  record is re-read (so a quarantine placed by another tab is enforced, and a `storage`
-  event listener syncs already-open tabs), then verified on-chain — a landed submission
-  retires its entries (or resets the cart when it landed mid-plan or the ceremony did not
-  survive a reload), a reverted/cancelled one releases the retry, an unverifiable or
-  still-armed one keeps the quarantine and explains why. Once the core submission's
+  step crosses the wallet boundary: an `armed` record is reserved atomically (check +
+  reserve serialized per wallet/chain under a Web Lock, stamped with the attempt's id)
+  and persisted durably before the wallet is invoked, upgraded to `submitted` when a
+  transaction hash or Safe proposal id comes back, and released only when the wallet
+  provably rejected the request (user rejection / connector error). Reservation writes
+  are durable-or-abort: if the `localStorage` write fails or does not read back, the
+  attempt aborts *before* the wallet is invoked (an in-realm memory copy still blocks
+  same-session retries while storage stays broken), and an unreadable record fails
+  closed rather than reading as empty. All upgrades and releases are ownership-checked
+  against the reserving attempt's id, so a stale attempt can never release or overwrite
+  a reservation a newer attempt holds. A wallet failure that returns no id — or a
+  malformed transaction/bundle id — leaves the armed record standing, because acceptance
+  cannot be disproved. A failure after an accepted *prerequisite* retries plainly —
+  those steps are idempotent. Records live in `localStorage` keyed per flow, wallet, and
+  chain (`utils/pendingSubmissions.ts`), so one wallet's quarantine never blocks or
+  overwrites another's. Clearing the cart, switching wallets, or reloading does not drop
+  a record. Before every Execute press the durable record is re-read (so a quarantine
+  placed by another tab is enforced, and a `storage` event listener syncs already-open
+  tabs), then verified on-chain — a landed submission retires its entries (or resets the
+  cart when it landed mid-plan or the ceremony did not survive a reload), a
+  reverted/cancelled one releases the retry, an unverifiable or still-armed one keeps
+  the quarantine and explains why. An `armed` record orphaned by a reload has no id and
+  can never verify on its own: the cart offers a risk-labelled manual release
+  (`BatchContents.vue` → `releaseArmedQuarantineAfterManualCheck`) that only applies
+  after the user confirms the wallet itself shows nothing pending, and refuses
+  `submitted` records (those are verified on-chain instead). Once the core submission's
   receipt confirmed, a later failure (for example a revoke) retires the covered entries
   instead of quarantining. The direct migration pages (`migrate.vue`, `borrow/swap.vue`)
-  apply the same arming and quarantine per flow via `utils/directSubmissionQuarantine.ts`.
-  The quarantine is also enforced *across surfaces*: every plan executor in
-  `useEulerTx.ts` runs `utils/pendingSubmissionGate.ts` before anything reaches a wallet,
-  so an unresolved batch submission blocks an equivalent direct operation for that
-  wallet/chain (and vice versa); a landed batch record discovered from another surface is
-  retired through a handler the cart registers.
+  apply the same arming and quarantine per flow via `utils/directSubmissionQuarantine.ts`,
+  and the ordinary executors (`executePlan`, callback-less `executePreparedPlan`)
+  quarantine value-moving submissions themselves under a shared `direct` flow — replay
+  protection never depends on optional caller wiring. The quarantine is also enforced
+  *across surfaces*: every wallet/signature boundary in `useEulerTx.ts` — the plan
+  executors, standalone plain sends, and migration authorization grants — plus the CoW
+  executor (`useCowSwapExecutionCore.ts`) runs `utils/pendingSubmissionGate.ts` before
+  anything reaches a wallet, so an unresolved batch submission blocks an equivalent
+  direct operation for that wallet/chain (and vice versa); a landed batch record
+  discovered from another surface is retired through a handler the cart registers. Two
+  deliberate, strictly risk-reducing bypasses: migration authorization *revokes* (they
+  run during abort cleanup — blocking them would leave live grants behind) and CoW order
+  *cancellation* (it only invalidates a standing order).
 
 ## Accessibility
 - Row header is a real `<button>`; expose `aria-expanded` bound to the open state and

--- a/docs/batch-review-modal-handoff.md
+++ b/docs/batch-review-modal-handoff.md
@@ -211,6 +211,9 @@ Execute is `UiButton variant="primary" size="xlarge" rounded` full-width.
 - **Fresh-position deposit** → no `subAccount` → no Position tag (by design).
 - **Many operations** → `BaseModalWrapper` handles scroll; do not add a nested scroll.
 - **Spy mode** → everything renders; only Execute is disabled.
+- **Cart edited during broadcast** → a same-wallet add while the execution is in flight
+  makes the ceremony stale; on success only the executed entries are removed from the
+  cart (the mid-flight addition survives and resimulates), instead of clearing everything.
 
 ## Accessibility
 - Row header is a real `<button>`; expose `aria-expanded` bound to the open state and

--- a/docs/batch-review-modal-handoff.md
+++ b/docs/batch-review-modal-handoff.md
@@ -218,11 +218,19 @@ Execute is `UiButton variant="primary" size="xlarge" rounded` full-width.
   requirement immediately before anything irreversible is sent; if the grant/revoke set no
   longer matches what was reviewed (an allowance granted or revoked elsewhere), execution
   aborts, the review is invalidated, and the error asks the user to reopen review.
-- **Submitted but unconfirmed** → once the wallet accepts the core submission (the batch
-  transaction or the Safe proposal), a confirmation failure no longer offers a blind
-  replay. The cart is quarantined with the submitted hash; the next Execute press first
-  verifies it on-chain — a landed submission retires its entries, a reverted/cancelled one
-  releases the retry, an unverifiable one keeps the quarantine and explains why.
+- **Submitted but unconfirmed** → every wallet acceptance during execution is classified
+  by the plan step that produced it (prerequisite approval/plugin call vs. the value-moving
+  batch transaction or Safe proposal). A failure after an accepted *prerequisite* retries
+  plainly — those steps are idempotent. A failure after the accepted *core* submission
+  quarantines the cart with the submitted hash, durably in `localStorage`: clearing the
+  cart, switching wallets, or reloading does not drop it. The next Execute press for that
+  wallet/chain first verifies the submission on-chain — a landed submission retires its
+  entries (or resets the cart when it landed mid-plan or the ceremony did not survive a
+  reload), a reverted/cancelled one releases the retry, an unverifiable one keeps the
+  quarantine and explains why. Once the core submission's receipt confirmed, a later
+  failure (for example a revoke) retires the covered entries instead of quarantining.
+  The direct migration pages (`migrate.vue`, `borrow/swap.vue`) apply the same quarantine
+  per flow via `utils/directSubmissionQuarantine.ts`.
 
 ## Accessibility
 - Row header is a real `<button>`; expose `aria-expanded` bound to the open state and

--- a/docs/batch-review-modal-handoff.md
+++ b/docs/batch-review-modal-handoff.md
@@ -17,8 +17,7 @@ transaction. It must show, in order:
    permit2 signatures the user will be asked to sign.
 2. **Operations** — each queued op as a row that **rolls down** to reveal that op's details.
 3. **Wallet changes** — the net effect of the whole batch on the wallet.
-4. **Simulate on Tenderly** — a link/button (Tenderly lives ONLY here, not in the drawer).
-5. **Execute batch** — one atomic execute, with a disabled reason when it can't run.
+4. **Execute batch** — execute the reviewed ceremony, with a disabled reason when it can't run.
 
 It is opened via `useModal().open(BatchReviewModal)` and dismisses by emitting `close`.
 
@@ -50,7 +49,6 @@ below (never hardcode hex). Values shown are the **dark theme** for reference on
 | `text-content-primary` | `#f7f7f8` | Primary labels (op title, amounts) |
 | `text-content-secondary` | `#ddfbf4` | Secondary text (asset symbol, position tag) |
 | `text-content-tertiary` | `#a1acb8` | Section labels, muted meta, disabled reason |
-| `text-success-500` | `#62ad4f` | Tenderly "view simulation" success link |
 | `text-error-500` / `bg-error-100` | `#c02723` / `rgba(192,39,35,.2)` | Revert chip text / fill |
 | Radius `rounded-8` / `rounded-12` / `rounded-16` | 8 / 12 / 16px | Rows / cards / modal |
 | Type `text-p2` / `text-p3` / `text-h6` | 16/400, 14/400, 14/600 | Body / meta / row title |
@@ -69,7 +67,6 @@ width). Pass `title="Review batch"`. Body content is a single vertical stack:
     [Operations]            always (≥1 entry)
     [Wallet changes]        v-if walletChanges.length
     [Top-level batch error] v-if simError || execError
-    [Tenderly]              v-if tenderlyEnabled
     [Execute + reason]      always
   </div>
 </BaseModalWrapper>
@@ -93,7 +90,6 @@ All data comes from `useTxBatch()`. The composable already exposes everything ne
 | `executeBatch()` | `() => Promise` | Atomic execute (clears batch on success) |
 | `prepareBatchPlan()` | `() => Promise<TransactionPlanPrepared\|null>` | Resolve approvals for the approvals section |
 | `getMergedPlan()` | `() => TransactionPlan\|null` | The exact plan that will execute |
-| `tenderlyEnabled`, `isTenderlySimulating`, `tenderlyUrl`, `tenderlyError`, `fetchTenderlyEnabled()`, `simulateOnTenderly()` | — | Tenderly section |
 
 `BatchEntry` (see `composables/useTxBatch.ts`) carries:
 `label`, `review?` (`{ type, asset:{symbol}, amount, swapToAsset:{symbol} }`), and
@@ -179,13 +175,11 @@ text-content-tertiary mb-6`). One row per token: symbol left (`text-content-seco
 signed amount right (`tabular-nums`), positive `text-accent-500`, negative `text-error-500`.
 Format `−`/`+` + `formatSmartAmount(formatUnits(abs, decimals))` + symbol.
 
-## Tenderly
-Centered. Before run: button "Simulate on Tenderly" (`arrow-top-right` icon, swap to
-spinning `loading` while `isTenderlySimulating`) → `simulateOnTenderly()`. After run: link to
-`tenderlyUrl` (`target=_blank rel=noopener`). If `tenderlyUrl && tenderlyError` →
-"Simulation reverted — view on Tenderly" in `text-error-500` with `warning-circle`; else
-"View simulation on Tenderly" in `text-success-500` with `check-circle` + `arrow-top-right`.
-Call `fetchTenderlyEnabled()` on mount; hide the whole section when `!tenderlyEnabled`.
+## External simulation
+Whole-batch Tenderly simulation is not exposed from this modal. The reviewed ceremony can
+contain sequential authorization transactions, prepared plugin/approval/core calls, and
+restorations. The single-transaction simulation endpoint cannot preserve that complete call
+vector, so presenting its result as a whole-batch simulation would be misleading.
 
 ## States & interactions
 
@@ -216,25 +210,22 @@ Execute is `UiButton variant="primary" size="xlarge" rounded` full-width.
 - **Long asset symbol / op label** → row title `truncate`; never let it push the chevron.
 - **Fresh-position deposit** → no `subAccount` → no Position tag (by design).
 - **Many operations** → `BaseModalWrapper` handles scroll; do not add a nested scroll.
-- **Spy mode** → everything renders; only Execute is disabled (read-only review still works,
-  including Tenderly which is a read-only simulation).
+- **Spy mode** → everything renders; only Execute is disabled.
 
 ## Accessibility
 - Row header is a real `<button>`; expose `aria-expanded` bound to the open state and
   `aria-controls` pointing at the detail region id.
-- Focus order: close → (approvals are static text) → operation row buttons in order →
-  Tenderly → Execute.
-- Tenderly link: `rel="noopener noreferrer"`, descriptive text (already states pass/fail).
+- Focus order: close → (approvals are static text) → operation row buttons in order → Execute.
 - Revert chips are persistent text (not hover-only) so they're announced.
 - Icon-only controls (close, chevrons) need `aria-label` / `title`.
 
 ## Files
 - `components/BatchReviewModal.vue` — the modal (exists; extend detail fields per the gap).
-- `composables/useTxBatch.ts` — data + `prepareBatchPlan` / `getMergedPlan` / tenderly API.
+- `composables/useTxBatch.ts` — ceremony preparation, review data, and execution.
 - `components/BatchContents.vue` — opens the modal via the "Review batch" button.
 - Reference for tokens/patterns: `components/entities/portfolio/PortfolioBorrowItem.vue`
   (position tag), `components/entities/operation/OperationReviewModal.vue` (approvals
-  decode, Tenderly, `UiButton` usage), `assets/styles/variables.scss` (token values).
+  decode and `UiButton` usage), `assets/styles/variables.scss` (token values).
 
 ## Definition of done
 - Borders/dividers use `*-line-default` (no white borders anywhere).
@@ -242,5 +233,5 @@ Execute is `UiButton variant="primary" size="xlarge" rounded` full-width.
 - Operation rows roll down; first row open by default; detail includes at least Amount +
   Vault (+ Receive for swaps, + Position when applicable).
 - Approvals appear only when the prepared plan requires them, with resolved token symbols.
-- Wallet changes, Tenderly, and the gated Execute (with reason) all behave per the tables.
+- Wallet changes and the gated Execute (with reason) behave per the tables.
 - Spy-mode, revert, preparing, and success states all verified live in the running app.

--- a/docs/batch-review-modal-handoff.md
+++ b/docs/batch-review-modal-handoff.md
@@ -214,6 +214,15 @@ Execute is `UiButton variant="primary" size="xlarge" rounded` full-width.
 - **Cart edited during broadcast** → a same-wallet add while the execution is in flight
   makes the ceremony stale; on success only the executed entries are removed from the
   cart (the mid-flight addition survives and resimulates), instead of clearing everything.
+- **Prerequisite drift** → non-signature migration entries re-derive their authorization
+  requirement immediately before anything irreversible is sent; if the grant/revoke set no
+  longer matches what was reviewed (an allowance granted or revoked elsewhere), execution
+  aborts, the review is invalidated, and the error asks the user to reopen review.
+- **Submitted but unconfirmed** → once the wallet accepts the core submission (the batch
+  transaction or the Safe proposal), a confirmation failure no longer offers a blind
+  replay. The cart is quarantined with the submitted hash; the next Execute press first
+  verifies it on-chain — a landed submission retires its entries, a reverted/cancelled one
+  releases the retry, an unverifiable one keeps the quarantine and explains why.
 
 ## Accessibility
 - Row header is a real `<button>`; expose `aria-expanded` bound to the open state and

--- a/docs/batch-review-modal-handoff.md
+++ b/docs/batch-review-modal-handoff.md
@@ -222,10 +222,15 @@ Execute is `UiButton variant="primary" size="xlarge" rounded` full-width.
   by the plan step that produced it (prerequisite approval/plugin call vs. the value-moving
   batch transaction or Safe proposal). Replay protection *arms* before the value-moving
   step crosses the wallet boundary: an `armed` record is reserved atomically (check +
-  reserve serialized per wallet/chain under a Web Lock, stamped with the attempt's id)
-  and persisted durably before the wallet is invoked, upgraded to `submitted` when a
-  transaction hash or Safe proposal id comes back, and released only when the wallet
-  provably rejected the request (user rejection / connector error). Reservation writes
+  reserve serialized per wallet/chain under a Web Lock, falling back to a storage-token
+  mutex — token claimed in `localStorage`, verified after a settle delay — when the Web
+  Locks API is unavailable, so the reservation stays cross-tab-exclusive either way;
+  stamped with the attempt's id) and persisted durably before the wallet is invoked,
+  upgraded to `submitted` when a transaction hash or Safe proposal id comes back, and
+  released only when the wallet provably rejected the request (user rejection /
+  connector error). If the upgrade write fails after an id was observed, the id is
+  preserved on the armed record and the attempt aborts fail-closed — the record then
+  verifies on-chain like a `submitted` one and is never manually dismissable. Reservation writes
   are durable-or-abort: if the `localStorage` write fails or does not read back, the
   attempt aborts *before* the wallet is invoked (an in-realm memory copy still blocks
   same-session retries while storage stays broken), and an unreadable record fails
@@ -242,11 +247,20 @@ Execute is `UiButton variant="primary" size="xlarge" rounded` full-width.
   tabs), then verified on-chain — a landed submission retires its entries (or resets the
   cart when it landed mid-plan or the ceremony did not survive a reload), a
   reverted/cancelled one releases the retry, an unverifiable or still-armed one keeps
-  the quarantine and explains why. An `armed` record orphaned by a reload has no id and
-  can never verify on its own: the cart offers a risk-labelled manual release
-  (`BatchContents.vue` → `releaseArmedQuarantineAfterManualCheck`) that only applies
-  after the user confirms the wallet itself shows nothing pending, and refuses
-  `submitted` records (those are verified on-chain instead). Once the core submission's
+  the quarantine and explains why. A hydrated record only re-attaches this tab's held
+  ceremony when the record's attempt id matches the one the ceremony was captured for —
+  phase or hash alone is not identity, so a record re-armed by another tab can never
+  retire entries its submission did not cover. An `armed` record orphaned by a reload
+  has no id and can never verify on its own: the cart offers a risk-labelled manual
+  release (`BatchContents.vue` → `releaseArmedQuarantineAfterManualCheck`) that only
+  applies after the user confirms the wallet itself shows nothing pending, and refuses
+  `submitted` records (those are verified on-chain instead). For the non-batch flows
+  (direct, migrations, CoW orders) the app root renders
+  `components/PendingSubmissionRecovery.vue` (backed by
+  `composables/usePendingSubmissionRecovery.ts`), which lists the connected wallet's
+  orphaned armed records and offers the same acknowledged manual release; records whose
+  arming attempt is still live in this realm, and records carrying any verifiable id,
+  are never listed. Once the core submission's
   receipt confirmed, a later failure (for example a revoke) retires the covered entries
   instead of quarantining. The direct migration pages (`migrate.vue`, `borrow/swap.vue`)
   apply the same arming and quarantine per flow via `utils/directSubmissionQuarantine.ts`,
@@ -258,10 +272,19 @@ Execute is `UiButton variant="primary" size="xlarge" rounded` full-width.
   executor (`useCowSwapExecutionCore.ts`) runs `utils/pendingSubmissionGate.ts` before
   anything reaches a wallet, so an unresolved batch submission blocks an equivalent
   direct operation for that wallet/chain (and vice versa); a landed batch record
-  discovered from another surface is retired through a handler the cart registers. Two
-  deliberate, strictly risk-reducing bypasses: migration authorization *revokes* (they
-  run during abort cleanup — blocking them would leave live grants behind) and CoW order
-  *cancellation* (it only invalidates a standing order).
+  discovered from another surface is retired through a handler the cart registers. The
+  CoW executor additionally owns its own quarantine under the `cow-order` flow — order
+  placement arms before the order signature is requested and releases only on a
+  provable wallet refusal — and it resolves the signing account, chain, and connector
+  once at review time and pins every subsequent wallet callback to that snapshot, so a
+  wallet or chain switched mid-ceremony aborts instead of signing from the new context.
+  Prepared plan envelopes are likewise stamped at review with the reviewing connector
+  session and its Safe/EOA classification; execution refuses an envelope whose live
+  connector session or wallet classification differs from the review (including
+  re-shaping an EOA-reviewed plan into a Safe ceremony), asking the user to review
+  again. Two deliberate, strictly risk-reducing bypasses: migration authorization
+  *revokes* (they run during abort cleanup — blocking them would leave live grants
+  behind) and CoW order *cancellation* (it only invalidates a standing order).
 
 ## Accessibility
 - Row header is a real `<button>`; expose `aria-expanded` bound to the open state and

--- a/docs/transaction-building.md
+++ b/docs/transaction-building.md
@@ -69,6 +69,8 @@ The wrapper supplies the current SDK `Account`, wallet/sub-account owner, chain 
 
 The review modal is fail-closed: if preparation does not produce a plan, it shows an error and disables confirmation.
 
+Prepared plans are additionally stamped at preparation time with the reviewing connector session and its Safe/EOA classification. Execution refuses a prepared envelope when the live connector session or wallet classification no longer matches the review (including attempting to execute an EOA-reviewed plan through a Safe ceremony) and asks the user to review again. Replay protection for value-moving submissions — durable armed/submitted records per flow, wallet, and chain, with cross-surface gating — is documented in `docs/batch-review-modal-handoff.md` ("Submitted but unconfirmed").
+
 ## Approvals and Permit2
 
 Plans may include `requiredApproval` items. During review and execution, `resolveRequiredApprovals` resolves each approval to either:

--- a/entities/cowswap/index.ts
+++ b/entities/cowswap/index.ts
@@ -17,5 +17,6 @@ export {
   formatCowSwapExecutionErrorMessage,
   getCowSwapOrderExplorerUrl,
   isCowSwapTerminalOrderStatus,
+  pollCowSwapOrderStatus,
   resolveCowSwapOrderStatusType,
 } from '@eulerxyz/euler-v2-sdk'

--- a/pages/position/[number]/borrow/swap.vue
+++ b/pages/position/[number]/borrow/swap.vue
@@ -83,7 +83,7 @@ import {
 import { logWarn } from '~/utils/errorHandling'
 import { isOperationBlocked, registerOperationBlocker, unregisterOperationBlocker } from '~/utils/operationGuardRegistry'
 import { BATCH_ACTIVE_REASON } from '~/utils/tx-batch-messages'
-import { assertWalletExecutionContext } from '~/utils/walletExecutionContext'
+import { assertWalletExecutionContext, createSafeBundleBroadcastGuard } from '~/utils/walletExecutionContext'
 import type { CollateralOption } from '~/types/collateral-option'
 import { getMigrationAuthorizationSignatureSubstitutions } from '~/utils/migrationAuthorizationSignatures'
 import {
@@ -3492,23 +3492,15 @@ const sendInboundExternalMigration = async (execution: TrackedExecutionScope, pr
           inboundExternalMigrationPreview.value = null
           throw new Error('Authorization requirements changed since review — please review the migration again.')
         }
-        // The wallet/Safe checks above ran at confirm entry; authorization
-        // lookup, planning, preparation, and simulation all await in between,
-        // so re-assert the full reviewed context (including the connector —
-        // a same-account Safe connector switch changes who submits) right
-        // before the irreversible proposal broadcast.
-        const confirmedConnectorKey = walletConnectorContextKey()
-        const outcome = await sendInboundExternalMigrationAsSafeBundle(input, authorizationRequest, account, useSignatures, preview.authorizationDeadline, () => {
-          assertWalletExecutionContext({
-            expectedAccount: input.owner,
-            expectedChainId: migrationChainId,
-            currentAccount: address.value as Address | undefined,
-            currentChainId: walletChainId.value,
-          })
-          if (!isSafeWallet.value || walletConnectorContextKey() !== confirmedConnectorKey) {
-            throw new Error('Wallet changed since review — please review the migration again.')
-          }
+        const beforeBroadcast = createSafeBundleBroadcastGuard({
+          expectedAccount: input.owner,
+          expectedChainId: migrationChainId,
+          currentAccount: () => address.value as Address | undefined,
+          currentChainId: () => walletChainId.value,
+          isSafeWallet: () => isSafeWallet.value,
+          connectorContextKey: walletConnectorContextKey,
         })
+        const outcome = await sendInboundExternalMigrationAsSafeBundle(input, authorizationRequest, account, useSignatures, preview.authorizationDeadline, beforeBroadcast)
         if (outcome === 'aborted') return
         finishInboundExternalMigrationSuccess(execution, input)
         return

--- a/pages/position/[number]/borrow/swap.vue
+++ b/pages/position/[number]/borrow/swap.vue
@@ -2651,6 +2651,13 @@ type InboundExternalMigrationPreview = {
    * plan's verifier calldata (so a re-mint diverges from the reviewed plan).
    */
   authorizationDeadline: bigint
+  /**
+   * The connector identity (`id:uid`) the review was built under. The direct
+   * Safe-bundle broadcast guard validates against this reviewed key — never a
+   * snapshot taken inside the confirmation flow, which would accept a
+   * connector swapped during an earlier confirmation await as its baseline.
+   */
+  connectorContextKey: string | undefined
   tenderlySimulation: PreparedMigrationTenderlySimulation
   calldataPrepared: TransactionPlanPrepared
   authorizationRequest?: MigrationAuthorizationRequest
@@ -2984,6 +2991,7 @@ const prepareInboundExternalMigrationPreview = async (): Promise<InboundExternal
       input,
       account,
       authorizationDeadline,
+      connectorContextKey: walletConnectorContextKey(),
       tenderlySimulation: {
         plan: simulationResult.plan,
         prepared: tenderlyPrepared,
@@ -3495,6 +3503,7 @@ const sendInboundExternalMigration = async (execution: TrackedExecutionScope, pr
         const beforeBroadcast = createSafeBundleBroadcastGuard({
           expectedAccount: input.owner,
           expectedChainId: migrationChainId,
+          expectedConnectorKey: preview.connectorContextKey,
           currentAccount: () => address.value as Address | undefined,
           currentChainId: () => walletChainId.value,
           isSafeWallet: () => isSafeWallet.value,

--- a/pages/position/[number]/borrow/swap.vue
+++ b/pages/position/[number]/borrow/swap.vue
@@ -87,6 +87,11 @@ import { assertWalletExecutionContext } from '~/utils/walletExecutionContext'
 import type { CollateralOption } from '~/types/collateral-option'
 import { getMigrationAuthorizationSignatureSubstitutions } from '~/utils/migrationAuthorizationSignatures'
 import {
+  isMigrationCeremonyDeadlineExpired,
+  mintMigrationCeremonyDeadline,
+  pinInboundMigrationCeremonyDeadline,
+} from '~/utils/migrationCeremonyDeadline'
+import {
   getProjectedYieldState,
   mergeProjectedRewardCampaigns,
   type ProjectedYieldCampaignInput,
@@ -100,7 +105,7 @@ const route = useRoute()
 const router = useRouter()
 const modal = useModal()
 const { error: showError } = useToast()
-const { isConnected, address, chainId: walletChainId } = useWagmi()
+const { isConnected, address, chainId: walletChainId, connector: walletConnector } = useWagmi()
 const { isSpyMode, spyAddress } = useSpyMode()
 const { isPositionsLoaded, isPositionsLoading, getPositionBySubAccountIndex, refreshAllPositions } = useEulerAccount()
 const { chainId: currentChainId, eulerPeripheryAddresses } = useEulerAddresses()
@@ -2639,6 +2644,13 @@ type InboundExternalMigrationPreview = {
   bundledReview: boolean
   input: InboundExternalMigrationInput
   account: Account<IHasVaultAddress>
+  /**
+   * The verifier/authorization deadline every build of this preview pinned.
+   * Confirmation must reuse it: the deadline is embedded in the EIP-712
+   * payload (so a re-mint always fails the payload-equality gate) and in the
+   * plan's verifier calldata (so a re-mint diverges from the reviewed plan).
+   */
+  authorizationDeadline: bigint
   tenderlySimulation: PreparedMigrationTenderlySimulation
   calldataPrepared: TransactionPlanPrepared
   authorizationRequest?: MigrationAuthorizationRequest
@@ -2750,23 +2762,19 @@ const buildInboundExternalMigrationInput = async (): Promise<InboundExternalMigr
 const shouldRemoveInboundExternalAuthorization = (connectorId: string, useSignatures: boolean) =>
   connectorId === MORPHO_CONNECTOR_ID && useSignatures
 
-const mintInboundMigrationDeadline = (): bigint => BigInt(Math.floor(Date.now() / 1000) + 60 * 60)
-
-// A supplied plan deadline replaces the quote-derived verifier deadlines the
-// connectors would otherwise use, so clamp it to the quotes' own bounds —
-// pinning a ceremony deadline must never extend how long a reviewed swap
-// stays executable on-chain.
-const pinInboundMigrationCeremonyDeadline = (input: InboundExternalMigrationInput): bigint =>
-  [input.collateralSwapQuote, input.debtSwapQuote]
-    .map(quote => quote?.verify.deadline)
-    .filter((deadline): deadline is number => typeof deadline === 'number' && deadline > 0)
-    .map(deadline => BigInt(deadline))
-    .reduce((earliest, deadline) => (deadline < earliest ? deadline : earliest), mintInboundMigrationDeadline())
+// Identity of the wallet connector a Safe proposal would submit through.
+// Account and chain checks cannot see a same-account connector switch, so the
+// direct Safe-bundle flow captures this at confirmation and re-asserts it
+// immediately before the irreversible proposal broadcast.
+const walletConnectorContextKey = (): string | undefined => {
+  const current = walletConnector.value
+  return current ? `${current.id}:${current.uid}` : undefined
+}
 
 const getInboundExternalMigrationAuthorizationRequest = async (
   input: InboundExternalMigrationInput,
   useSignatures = signaturesEnabled.value,
-  deadline: bigint = mintInboundMigrationDeadline(),
+  deadline: bigint = mintMigrationCeremonyDeadline(),
 ): Promise<MigrationAuthorizationRequest | undefined> => {
   if (!chainId.value) {
     throw new Error('Migration inputs are incomplete')
@@ -2827,6 +2835,7 @@ const buildInboundExternalMigrationCalldataPreview = async (
   authorizationRequest: MigrationAuthorizationRequest | undefined,
   useSignatures: boolean,
   prefetch?: PluginPrefetchData,
+  deadline?: bigint,
 ): Promise<TransactionPlanPrepared> => {
   if (!chainId.value) {
     throw new Error('Migration inputs are incomplete')
@@ -2848,6 +2857,7 @@ const buildInboundExternalMigrationCalldataPreview = async (
     collateralSwapQuote: input.collateralSwapQuote,
     debtSwapQuote: input.debtSwapQuote,
     operationName: `${input.source.connectorId}ToEulerMigration`,
+    deadline,
   })
   return prepareTransactionPlan(plan, {
     account,
@@ -2940,8 +2950,12 @@ const prepareInboundExternalMigrationPreview = async (): Promise<InboundExternal
     const input = await buildInboundExternalMigrationInput()
     const account = currentPlanAccount()
     if (!account) throw new Error('Migration inputs are incomplete')
-    const authorizationRequest = await getInboundExternalMigrationAuthorizationRequest(input, useSignatures)
-    const simulationResult = await buildInboundExternalMigrationSimulationResult(input, authorizationRequest, account, useSignatures)
+    // Pinned once for the preview's whole lifetime: every build here and the
+    // confirm-time rebuild must embed this same deadline, or the payload and
+    // plan gates reject the confirmation as drift.
+    const authorizationDeadline = pinInboundMigrationCeremonyDeadline(input)
+    const authorizationRequest = await getInboundExternalMigrationAuthorizationRequest(input, useSignatures, authorizationDeadline)
+    const simulationResult = await buildInboundExternalMigrationSimulationResult(input, authorizationRequest, account, useSignatures, authorizationDeadline)
     const prefetch = await prefetchInboundExternalMigrationPlugins(simulationResult.plan, account)
     // Without signatures the authorization is granted by a standalone tx, so the
     // simulation plan (authorization item filtered out) is already the exact
@@ -2954,7 +2968,7 @@ const prepareInboundExternalMigrationPreview = async (): Promise<InboundExternal
         usePermit2: useSignatures,
       }),
       useSignatures
-        ? buildInboundExternalMigrationCalldataPreview(input, account, authorizationRequest, useSignatures, prefetch)
+        ? buildInboundExternalMigrationCalldataPreview(input, account, authorizationRequest, useSignatures, prefetch, authorizationDeadline)
         : Promise.resolve(undefined),
     ])
     const calldataPrepared = previewPrepared ?? tenderlyPrepared
@@ -2969,6 +2983,7 @@ const prepareInboundExternalMigrationPreview = async (): Promise<InboundExternal
       bundledReview: !useSignatures && isSafeWallet.value && !!authorizationRequest,
       input,
       account,
+      authorizationDeadline,
       tenderlySimulation: {
         plan: simulationResult.plan,
         prepared: tenderlyPrepared,
@@ -3438,7 +3453,14 @@ const sendInboundExternalMigration = async (execution: TrackedExecutionScope, pr
     })
     if (!await restorePendingBeforeRetry()) return
     inboundExternalPreparedPlan.value = null
-    const authorizationRequest = await getInboundExternalMigrationAuthorizationRequest(input, useSignatures)
+    // The reviewed deadline is embedded in the displayed payload and plan, so
+    // an expired one can only produce an on-chain revert — force a re-review
+    // that mints a fresh ceremony instead.
+    if (isMigrationCeremonyDeadlineExpired(preview.authorizationDeadline)) {
+      inboundExternalMigrationPreview.value = null
+      throw new Error('The reviewed authorization expired — please review the migration again.')
+    }
+    const authorizationRequest = await getInboundExternalMigrationAuthorizationRequest(input, useSignatures, preview.authorizationDeadline)
     inboundExternalAuthorizationConnector.value = authorizationRequest ? input.source.connectorId : null
 
     // The reviewed ceremony is defined by the authorization payload the modal
@@ -3470,14 +3492,30 @@ const sendInboundExternalMigration = async (execution: TrackedExecutionScope, pr
           inboundExternalMigrationPreview.value = null
           throw new Error('Authorization requirements changed since review — please review the migration again.')
         }
-        const outcome = await sendInboundExternalMigrationAsSafeBundle(input, authorizationRequest, account, useSignatures)
+        // The wallet/Safe checks above ran at confirm entry; authorization
+        // lookup, planning, preparation, and simulation all await in between,
+        // so re-assert the full reviewed context (including the connector —
+        // a same-account Safe connector switch changes who submits) right
+        // before the irreversible proposal broadcast.
+        const confirmedConnectorKey = walletConnectorContextKey()
+        const outcome = await sendInboundExternalMigrationAsSafeBundle(input, authorizationRequest, account, useSignatures, preview.authorizationDeadline, () => {
+          assertWalletExecutionContext({
+            expectedAccount: input.owner,
+            expectedChainId: migrationChainId,
+            currentAccount: address.value as Address | undefined,
+            currentChainId: walletChainId.value,
+          })
+          if (!isSafeWallet.value || walletConnectorContextKey() !== confirmedConnectorKey) {
+            throw new Error('Wallet changed since review — please review the migration again.')
+          }
+        })
         if (outcome === 'aborted') return
         finishInboundExternalMigrationSuccess(execution, input)
         return
       }
 
       const authorization = await resolveInboundExternalMigrationAuthorization(authorizationRequest, revokeTxs, useSignatures)
-      inboundExternalPlan.value = await buildInboundExternalMigrationExecutionPlan(input, authorization, useSignatures)
+      inboundExternalPlan.value = await buildInboundExternalMigrationExecutionPlan(input, authorization, useSignatures, preview.authorizationDeadline)
       inboundExternalPreparedPlan.value = await prepareTransactionPlan(inboundExternalPlan.value, {
         account,
         chainId: migrationChainId,
@@ -3565,9 +3603,11 @@ const sendInboundExternalMigrationAsSafeBundle = async (
   authorizationRequest: MigrationAuthorizationRequest,
   account: Account<IHasVaultAddress> | undefined,
   useSignatures: boolean,
+  deadline: bigint,
+  beforeBroadcast: () => void,
 ): Promise<'executed' | 'aborted'> => {
   const { grants, revokes } = encodeMigrationAuthorizationTxs(authorizationRequest)
-  const simulation = await buildInboundExternalMigrationSimulationResult(input, authorizationRequest, account, useSignatures)
+  const simulation = await buildInboundExternalMigrationSimulationResult(input, authorizationRequest, account, useSignatures, deadline)
   const prepared = await prepareTransactionPlan(simulation.plan, {
     account,
     chainId: input.position.chainId,
@@ -3582,7 +3622,8 @@ const sendInboundExternalMigrationAsSafeBundle = async (
   )
   if (!ok) return 'aborted'
 
-  const result = await executePreparedPlanWithPlainCalls(prepared, { before: grants, after: revokes }, { allowSingleCall: true })
+  beforeBroadcast()
+  const result = await executePreparedPlanWithPlainCalls(prepared, { before: grants, after: revokes }, { allowSingleCall: true, beforeBroadcast })
   if (!result) {
     // The review showed ONE atomic proposal. A Safe whose provider cannot be
     // acquired at confirm time must abort loudly, never silently degrade
@@ -3710,6 +3751,7 @@ const addInboundExternalMigrationToBatch = async () => {
           preview.authorizationRequest,
           account,
           useSignatures,
+          preview.authorizationDeadline,
         )
         return {
           plan: simulationResult.plan,

--- a/pages/position/[number]/borrow/swap.vue
+++ b/pages/position/[number]/borrow/swap.vue
@@ -83,7 +83,8 @@ import {
 import { logWarn } from '~/utils/errorHandling'
 import { isOperationBlocked, registerOperationBlocker, unregisterOperationBlocker } from '~/utils/operationGuardRegistry'
 import { BATCH_ACTIVE_REASON } from '~/utils/tx-batch-messages'
-import { assertWalletExecutionContext, createSafeBundleBroadcastGuard } from '~/utils/walletExecutionContext'
+import { assertPreparedPlanSignatureParity } from '~/utils/preparedPlanParity'
+import { assertWalletExecutionContext, createReviewedWalletContextGuard, createSafeBundleBroadcastGuard } from '~/utils/walletExecutionContext'
 import type { CollateralOption } from '~/types/collateral-option'
 import { getMigrationAuthorizationSignatureSubstitutions } from '~/utils/migrationAuthorizationSignatures'
 import {
@@ -2885,16 +2886,17 @@ const resolveInboundExternalMigrationAuthorization = async (
   authorizationRequest: MigrationAuthorizationRequest | undefined,
   revokeTxs: MigrationAuthorizationRevoke[],
   useSignatures: boolean,
+  beforeWalletAction?: () => void,
 ): Promise<SignedMigrationAuthorization | undefined> => {
   // No request means the grant is already live on-chain: nothing to sign, and
   // nothing of ours to revoke afterwards.
   if (!authorizationRequest) return undefined
   if (useSignatures) {
-    return signMigrationAuthorization(authorizationRequest)
+    return signMigrationAuthorization(authorizationRequest, { beforeSignature: beforeWalletAction })
   }
   // Must be mined before the plan is built: the connector reads the live
   // allowance to decide whether the batch still needs an authorization.
-  await executeMigrationAuthorizationGrants(authorizationRequest, revokeTxs)
+  await executeMigrationAuthorizationGrants(authorizationRequest, revokeTxs, { beforeBroadcast: beforeWalletAction })
   return undefined
 }
 
@@ -3447,6 +3449,30 @@ const reviewInboundExternalMigration = async () => {
   }
 }
 
+/**
+ * Prove the confirm-time prepared plan is byte-identical to the reviewed
+ * calldata outside the authorized signature substitutions. Any other
+ * divergence drops the cached preview and forces a re-review — the wallet
+ * must never receive calldata the modal did not display.
+ */
+const assertInboundMigrationPreparedParity = (
+  preview: InboundExternalMigrationPreview,
+  resolved: TransactionPlanPrepared,
+  authorization: SignedMigrationAuthorization | undefined,
+) => {
+  try {
+    assertPreparedPlanSignatureParity({
+      reviewed: preview.calldataPrepared,
+      resolved,
+      substitutions: getMigrationAuthorizationSignatureSubstitutions(authorization),
+    })
+  }
+  catch (err) {
+    inboundExternalMigrationPreview.value = null
+    throw err
+  }
+}
+
 const sendInboundExternalMigration = async (execution: TrackedExecutionScope, preview: InboundExternalMigrationPreview) => {
   isSubmitting.value = true
   clearSimulationError()
@@ -3509,19 +3535,32 @@ const sendInboundExternalMigration = async (execution: TrackedExecutionScope, pr
           isSafeWallet: () => isSafeWallet.value,
           connectorContextKey: walletConnectorContextKey,
         })
-        const outcome = await sendInboundExternalMigrationAsSafeBundle(input, authorizationRequest, account, useSignatures, preview.authorizationDeadline, beforeBroadcast)
+        const outcome = await sendInboundExternalMigrationAsSafeBundle(preview, authorizationRequest, account, beforeBroadcast)
         if (outcome === 'aborted') return
         finishInboundExternalMigrationSuccess(execution, input)
         return
       }
 
-      const authorization = await resolveInboundExternalMigrationAuthorization(authorizationRequest, revokeTxs, useSignatures)
+      // Every wallet action below (signature request, grant broadcasts, plan
+      // broadcast) re-asserts the reviewed account/chain/connector — the
+      // awaits between them are where a delayed wallet switch can land.
+      const assertReviewedWalletContext = createReviewedWalletContextGuard({
+        expectedAccount: input.owner,
+        expectedChainId: migrationChainId,
+        expectedConnectorKey: preview.connectorContextKey,
+        currentAccount: () => address.value as Address | undefined,
+        currentChainId: () => walletChainId.value,
+        connectorContextKey: walletConnectorContextKey,
+      })
+      const authorization = await resolveInboundExternalMigrationAuthorization(authorizationRequest, revokeTxs, useSignatures, assertReviewedWalletContext)
       inboundExternalPlan.value = await buildInboundExternalMigrationExecutionPlan(input, authorization, useSignatures, preview.authorizationDeadline)
       inboundExternalPreparedPlan.value = await prepareTransactionPlan(inboundExternalPlan.value, {
         account,
         chainId: migrationChainId,
+        prefetch: preview.prefetch,
         usePermit2: useSignatures,
       })
+      assertInboundMigrationPreparedParity(preview, inboundExternalPreparedPlan.value, authorization)
       const ok = await runPreparedSimulation(inboundExternalPreparedPlan.value, buildRefinanceStateOverrideOptions())
       if (!ok) {
         await revokeAfterAbort(revokeTxs)
@@ -3529,7 +3568,7 @@ const sendInboundExternalMigration = async (execution: TrackedExecutionScope, pr
       }
       // executePreparedPlan resolves once the migration tx is mined (it returns
       // receipts), so everything below runs after on-chain confirmation.
-      await executePreparedPlan(inboundExternalPreparedPlan.value)
+      await executePreparedPlan(inboundExternalPreparedPlan.value, { beforeBroadcast: assertReviewedWalletContext })
     }
     catch (err) {
       // Covers a rejected batch, a failed prepare, and a stale grant.
@@ -3600,20 +3639,23 @@ function finishInboundExternalMigrationSuccess(execution: TrackedExecutionScope,
  * is no Safe bundle context — the caller falls back to sequential grants.
  */
 const sendInboundExternalMigrationAsSafeBundle = async (
-  input: InboundExternalMigrationInput,
+  preview: InboundExternalMigrationPreview,
   authorizationRequest: MigrationAuthorizationRequest,
   account: Account<IHasVaultAddress> | undefined,
-  useSignatures: boolean,
-  deadline: bigint,
   beforeBroadcast: () => void,
 ): Promise<'executed' | 'aborted'> => {
+  const { input, useSignatures, authorizationDeadline: deadline } = preview
   const { grants, revokes } = encodeMigrationAuthorizationTxs(authorizationRequest)
   const simulation = await buildInboundExternalMigrationSimulationResult(input, authorizationRequest, account, useSignatures, deadline)
   const prepared = await prepareTransactionPlan(simulation.plan, {
     account,
     chainId: input.position.chainId,
+    prefetch: preview.prefetch,
     usePermit2: false,
   })
+  // Bundled reviews are always no-signature, so the reviewed calldata is the
+  // simulation-variant plan itself: parity holds with zero substitutions.
+  assertInboundMigrationPreparedParity(preview, prepared, undefined)
   inboundExternalPlan.value = simulation.plan
   inboundExternalPreparedPlan.value = prepared
   const ok = await runPreparedSimulation(
@@ -3711,6 +3753,15 @@ const addInboundExternalMigrationToBatch = async () => {
                       postTxsByPreTx: revokesByGrant,
                     }
                   : undefined,
+                // Authorization state can drift between review and execution
+                // (an allowance granted or revoked elsewhere) — the reviewed
+                // grant/revoke set would no longer match what should run.
+                revalidatePrerequisites: async () => {
+                  const fresh = await getInboundExternalMigrationAuthorizationRequest(input, useSignatures)
+                  if (migrationAuthorizationPayloadKey(fresh) !== migrationAuthorizationPayloadKey(request)) {
+                    throw new Error('Authorization requirements changed since review — reopen review and try again.')
+                  }
+                },
                 grantSteps: buildMigrationAuthorizationTxSteps(request, 'grant', 1, { bundled: true }),
                 revokeSteps: buildMigrationAuthorizationTxSteps(request, 'revoke', 1, { bundled: true }),
               }

--- a/pages/position/[number]/borrow/swap.vue
+++ b/pages/position/[number]/borrow/swap.vue
@@ -101,6 +101,9 @@ import {
   type ProjectedYieldState,
 } from '~/utils/projected-yield'
 import { getLayeredVault } from '~/composables/useLayeredVaults'
+import { createDirectSubmissionQuarantine } from '~/utils/directSubmissionQuarantine'
+import { getSafeWalletProvider, type ReceiptClientLike } from '~/utils/safeWalletTransactions'
+import { getEulerSdkFresh } from '~/composables/useEulerSdk'
 
 const route = useRoute()
 const router = useRouter()
@@ -3473,6 +3476,42 @@ const assertInboundMigrationPreparedParity = (
   }
 }
 
+/**
+ * Replay protection for the direct inbound flow: once the wallet accepts the
+ * migration submission, a confirmation failure must not degrade into an
+ * ordinary retry — the accepted hash/proposal id is retained durably and
+ * verified on-chain before another attempt may send anything.
+ */
+const inboundMigrationQuarantine = createDirectSubmissionQuarantine({
+  flow: 'inbound-migration',
+  getSafeWalletProvider,
+})
+
+/**
+ * Returns false (after surfacing what happened) when the attempt must stop:
+ * a previously accepted submission confirmed on-chain, so the position state
+ * the review was built on is gone. It may have been this migration or an
+ * earlier one for the same wallet — never finalize the current attempt on it.
+ * An unresolved outcome throws and blocks the retry.
+ */
+async function reconcileInboundMigrationQuarantine(preview: InboundExternalMigrationPreview): Promise<boolean> {
+  const sdk = await getEulerSdkFresh()
+  const migrationChainId = preview.input.position.chainId
+  const verdict = await inboundMigrationQuarantine.reconcileBeforeAttempt({
+    owner: preview.input.owner,
+    chainId: migrationChainId,
+    provider: sdk.providerService?.getProvider(migrationChainId) as ReceiptClientLike | undefined,
+    connector: walletConnector.value,
+  })
+  if (verdict === 'clear') return true
+  inboundExternalMigrationPreview.value = null
+  schedulePostMigrationRefreshes(preview.input.owner)
+  showError(verdict === 'landed'
+    ? 'A previous migration submission confirmed on-chain. Positions were refreshed — review the migration again before retrying.'
+    : 'A previous migration submission confirmed on-chain but may not have completed its plan. Positions were refreshed — review the migration again before retrying.')
+  return false
+}
+
 const sendInboundExternalMigration = async (execution: TrackedExecutionScope, preview: InboundExternalMigrationPreview) => {
   isSubmitting.value = true
   clearSimulationError()
@@ -3486,6 +3525,7 @@ const sendInboundExternalMigration = async (execution: TrackedExecutionScope, pr
       currentChainId: walletChainId.value,
     })
     if (!await restorePendingBeforeRetry()) return
+    if (!await reconcileInboundMigrationQuarantine(preview)) return
     inboundExternalPreparedPlan.value = null
     // The reviewed deadline is embedded in the displayed payload and plan, so
     // an expired one can only produce an on-chain revert — force a re-review
@@ -3509,6 +3549,7 @@ const sendInboundExternalMigration = async (execution: TrackedExecutionScope, pr
     }
 
     const revokeTxs: MigrationAuthorizationRevoke[] = []
+    inboundMigrationQuarantine.begin({ owner: input.owner, chainId: migrationChainId })
     try {
       if (preview.bundledReview) {
         // The review promised ONE atomic Safe proposal. Revalidate that mode
@@ -3568,12 +3609,23 @@ const sendInboundExternalMigration = async (execution: TrackedExecutionScope, pr
       }
       // executePreparedPlan resolves once the migration tx is mined (it returns
       // receipts), so everything below runs after on-chain confirmation.
-      await executePreparedPlan(inboundExternalPreparedPlan.value, { beforeBroadcast: assertReviewedWalletContext })
+      await executePreparedPlan(inboundExternalPreparedPlan.value, {
+        beforeBroadcast: assertReviewedWalletContext,
+        onBroadcast: inboundMigrationQuarantine.track,
+      })
     }
     catch (err) {
+      // A wallet-accepted submission whose confirmation failed may still land
+      // — retain it durably so the next attempt reconciles it on-chain before
+      // sending anything.
+      const quarantined = inboundMigrationQuarantine.sealFailure()
       // Covers a rejected batch, a failed prepare, and a stale grant.
       await revokeAfterAbort(revokeTxs)
-      throw toMigrationExecutionError(err)
+      const executionError = toMigrationExecutionError(err)
+      if (quarantined && executionError instanceof Error) {
+        throw new Error(`${executionError.message} The submission may still confirm — retrying first verifies it on-chain before anything is re-sent.`, { cause: err })
+      }
+      throw executionError
     }
 
     await revokeAfterSuccess(revokeTxs)
@@ -3666,7 +3718,11 @@ const sendInboundExternalMigrationAsSafeBundle = async (
   if (!ok) return 'aborted'
 
   beforeBroadcast()
-  const result = await executePreparedPlanWithPlainCalls(prepared, { before: grants, after: revokes }, { allowSingleCall: true, beforeBroadcast })
+  const result = await executePreparedPlanWithPlainCalls(prepared, { before: grants, after: revokes }, {
+    allowSingleCall: true,
+    beforeBroadcast,
+    onBroadcast: inboundMigrationQuarantine.track,
+  })
   if (!result) {
     // The review showed ONE atomic proposal. A Safe whose provider cannot be
     // acquired at confirm time must abort loudly, never silently degrade

--- a/pages/position/[number]/borrow/swap.vue
+++ b/pages/position/[number]/borrow/swap.vue
@@ -3627,6 +3627,11 @@ const sendInboundExternalMigration = async (execution: TrackedExecutionScope, pr
       }
       throw executionError
     }
+    finally {
+      // The attempt is over either way — any record it left behind is now
+      // orphaned from live execution and becomes visible to manual recovery.
+      inboundMigrationQuarantine.end()
+    }
 
     await revokeAfterSuccess(revokeTxs)
     finishInboundExternalMigrationSuccess(execution, input)

--- a/pages/position/[number]/borrow/swap.vue
+++ b/pages/position/[number]/borrow/swap.vue
@@ -85,6 +85,7 @@ import { isOperationBlocked, registerOperationBlocker, unregisterOperationBlocke
 import { BATCH_ACTIVE_REASON } from '~/utils/tx-batch-messages'
 import { assertWalletExecutionContext } from '~/utils/walletExecutionContext'
 import type { CollateralOption } from '~/types/collateral-option'
+import { getMigrationAuthorizationSignatureSubstitutions } from '~/utils/migrationAuthorizationSignatures'
 import {
   getProjectedYieldState,
   mergeProjectedRewardCampaigns,
@@ -3615,7 +3616,10 @@ const addInboundExternalMigrationToBatch = async () => {
                     ? await signMigrationAuthorization(request, { beforeSignature: beforeWalletAction })
                     : undefined
                   beforeWalletAction()
-                  return buildInboundExternalMigrationExecutionPlan(input, authorization, useSignatures)
+                  return {
+                    plan: await buildInboundExternalMigrationExecutionPlan(input, authorization, useSignatures),
+                    signatureSubstitutions: getMigrationAuthorizationSignatureSubstitutions(authorization),
+                  }
                 },
                 usesPlaceholderSignatures: !!request,
                 grantSteps: buildInboundExternalMigrationSignatureSteps(request, true, false, input.source.connectorId),

--- a/pages/position/[number]/borrow/swap.vue
+++ b/pages/position/[number]/borrow/swap.vue
@@ -2750,15 +2750,28 @@ const buildInboundExternalMigrationInput = async (): Promise<InboundExternalMigr
 const shouldRemoveInboundExternalAuthorization = (connectorId: string, useSignatures: boolean) =>
   connectorId === MORPHO_CONNECTOR_ID && useSignatures
 
+const mintInboundMigrationDeadline = (): bigint => BigInt(Math.floor(Date.now() / 1000) + 60 * 60)
+
+// A supplied plan deadline replaces the quote-derived verifier deadlines the
+// connectors would otherwise use, so clamp it to the quotes' own bounds —
+// pinning a ceremony deadline must never extend how long a reviewed swap
+// stays executable on-chain.
+const pinInboundMigrationCeremonyDeadline = (input: InboundExternalMigrationInput): bigint =>
+  [input.collateralSwapQuote, input.debtSwapQuote]
+    .map(quote => quote?.verify.deadline)
+    .filter((deadline): deadline is number => typeof deadline === 'number' && deadline > 0)
+    .map(deadline => BigInt(deadline))
+    .reduce((earliest, deadline) => (deadline < earliest ? deadline : earliest), mintInboundMigrationDeadline())
+
 const getInboundExternalMigrationAuthorizationRequest = async (
   input: InboundExternalMigrationInput,
   useSignatures = signaturesEnabled.value,
+  deadline: bigint = mintInboundMigrationDeadline(),
 ): Promise<MigrationAuthorizationRequest | undefined> => {
   if (!chainId.value) {
     throw new Error('Migration inputs are incomplete')
   }
   const migrationChainId = input.position.chainId
-  const deadline = BigInt(Math.floor(Date.now() / 1000) + 60 * 60)
   return getMigrationAuthorization({
     direction: 'external-to-euler',
     connectorId: input.source.connectorId,
@@ -2784,6 +2797,7 @@ const buildInboundExternalMigrationExecutionPlan = async (
   input: InboundExternalMigrationInput,
   authorization?: SignedMigrationAuthorization,
   useSignatures = signaturesEnabled.value,
+  deadline?: bigint,
 ): Promise<TransactionPlan> => {
   if (!chainId.value) {
     throw new Error('Migration inputs are incomplete')
@@ -2803,6 +2817,7 @@ const buildInboundExternalMigrationExecutionPlan = async (
     collateralSwapQuote: input.collateralSwapQuote,
     debtSwapQuote: input.debtSwapQuote,
     operationName: `${input.source.connectorId}ToEulerMigration`,
+    deadline,
   })
 }
 
@@ -2871,6 +2886,7 @@ const buildInboundExternalMigrationSimulationResult = async (
   authorizationRequest?: MigrationAuthorizationRequest,
   account?: Account<IHasVaultAddress>,
   useSignatures = signaturesEnabled.value,
+  deadline?: bigint,
 ) => {
   if (!chainId.value) {
     throw new Error('Migration inputs are incomplete')
@@ -2890,6 +2906,7 @@ const buildInboundExternalMigrationSimulationResult = async (
     debtSwapQuote: input.debtSwapQuote,
     account,
     operationName: `${input.source.connectorId}ToEulerMigration`,
+    deadline,
   })
 }
 
@@ -3607,8 +3624,13 @@ const addInboundExternalMigrationToBatch = async () => {
             // Review uses placeholder signature bytes. Real wallet signatures
             // are requested only after confirmation.
             buildExecutionCeremony: async (account: Account<IHasVaultAddress>) => {
-              const request = await getInboundExternalMigrationAuthorizationRequest(input, useSignatures)
-              const simulation = await buildInboundExternalMigrationSimulationResult(input, request, account, useSignatures)
+              // The confirm-time rebuild must differ from the reviewed preview
+              // plan only in the signature bytes. Connectors mint a wall-clock
+              // verifier deadline on every build unless one is supplied, so the
+              // ceremony pins a single deadline across both builds.
+              const ceremonyDeadline = pinInboundMigrationCeremonyDeadline(input)
+              const request = await getInboundExternalMigrationAuthorizationRequest(input, useSignatures, ceremonyDeadline)
+              const simulation = await buildInboundExternalMigrationSimulationResult(input, request, account, useSignatures, ceremonyDeadline)
               return {
                 plan: simulation.previewPlan,
                 resolveExecutionPlan: async (beforeWalletAction: () => void) => {
@@ -3617,7 +3639,7 @@ const addInboundExternalMigrationToBatch = async () => {
                     : undefined
                   beforeWalletAction()
                   return {
-                    plan: await buildInboundExternalMigrationExecutionPlan(input, authorization, useSignatures),
+                    plan: await buildInboundExternalMigrationExecutionPlan(input, authorization, useSignatures, ceremonyDeadline),
                     signatureSubstitutions: getMigrationAuthorizationSignatureSubstitutions(authorization),
                   }
                 },

--- a/pages/position/[number]/borrow/swap.vue
+++ b/pages/position/[number]/borrow/swap.vue
@@ -3601,47 +3601,48 @@ const addInboundExternalMigrationToBatch = async () => {
     const batchEntry = {
       label: `Migrate ${positionLabel} to Euler`,
       nameOverride: `Migrate ${positionLabel}`,
-      buildExecutionPlan: async () => {
-        const authorizationRequest = useSignatures
-          ? await getInboundExternalMigrationAuthorizationRequest(input, useSignatures)
-          : undefined
-        const authorization = authorizationRequest
-          ? await signMigrationAuthorization(authorizationRequest)
-          : undefined
-        // Without signatures the grant was already mined by the batch's
-        // pre-phase, so the connector omits the authorization item.
-        return buildInboundExternalMigrationExecutionPlan(input, authorization, useSignatures)
-      },
       ...(useSignatures
-        ? {}
-        : {
-            buildExecutionPrerequisites: async () => {
+        ? {
+            // Review uses placeholder signature bytes. Real wallet signatures
+            // are requested only after confirmation.
+            buildExecutionCeremony: async (account: Account<IHasVaultAddress>) => {
               const request = await getInboundExternalMigrationAuthorizationRequest(input, useSignatures)
-              if (!request) return undefined
-              const { grants, revokes, revokesByGrant } = encodeMigrationAuthorizationTxs(request)
+              const simulation = await buildInboundExternalMigrationSimulationResult(input, request, account, useSignatures)
               return {
-                preTxs: grants,
-                walletContext: { account: request.owner, chainId: request.chainId },
-                postTxs: revokes,
-                postTxsByPreTx: revokesByGrant,
+                plan: simulation.previewPlan,
+                resolveExecutionPlan: async (beforeWalletAction: () => void) => {
+                  const authorization = request
+                    ? await signMigrationAuthorization(request, { beforeSignature: beforeWalletAction })
+                    : undefined
+                  beforeWalletAction()
+                  return buildInboundExternalMigrationExecutionPlan(input, authorization, useSignatures)
+                },
+                usesPlaceholderSignatures: !!request,
+                grantSteps: buildInboundExternalMigrationSignatureSteps(request, true, false, input.source.connectorId),
+                revokeSteps: [],
               }
             },
-            // Bundled counterpart for Safe execution: the simulation-variant
-            // plan validates the grant instead of reading the live
-            // allowance, so nothing needs to mine before the proposal is
-            // assembled. The review rows come from the SAME resolution so
-            // the modal cannot display a ceremony other than the one that
-            // executes.
-            buildBundledExecution: async (account: Account<IHasVaultAddress>) => {
+          }
+        : {
+            bundleExecutionCeremony: true,
+            // Resolve authorization once so the reviewed rows, exported calls,
+            // standalone flow, and Safe proposal all describe one ceremony.
+            buildExecutionCeremony: async (account: Account<IHasVaultAddress>) => {
               const request = await getInboundExternalMigrationAuthorizationRequest(input, useSignatures)
-              const { grants, revokes } = request
+              const { grants, revokes, revokesByGrant } = request
                 ? encodeMigrationAuthorizationTxs(request)
-                : { grants: [], revokes: [] }
+                : { grants: [], revokes: [], revokesByGrant: [] }
               const simulation = await buildInboundExternalMigrationSimulationResult(input, request, account, useSignatures)
               return {
                 plan: simulation.plan,
-                grants,
-                revokes,
+                prerequisites: request
+                  ? {
+                      preTxs: grants,
+                      walletContext: { account: request.owner, chainId: request.chainId },
+                      postTxs: revokes,
+                      postTxsByPreTx: revokesByGrant,
+                    }
+                  : undefined,
                 grantSteps: buildMigrationAuthorizationTxSteps(request, 'grant', 1, { bundled: true }),
                 revokeSteps: buildMigrationAuthorizationTxSteps(request, 'revoke', 1, { bundled: true }),
               }
@@ -3654,8 +3655,7 @@ const addInboundExternalMigrationToBatch = async () => {
         type: 'migration',
         asset: reviewAsset,
         amount: formatUnits(reviewAsset.amount, Number(reviewAsset.decimals)),
-        // Add-time rows describe the sequential fallback. A latched Safe review
-        // uses rows from the exact bundled resolution instead.
+        // Ceremony-owned rows replace these captured rows during batch review.
         signatureSteps: buildInboundExternalMigrationSignatureSteps(preview.authorizationRequest, useSignatures, false),
         postSteps: buildInboundExternalMigrationRevokeSteps(preview.authorizationRequest, useSignatures, false),
         displayPlan: preview.calldataPrepared.plan,
@@ -4017,13 +4017,14 @@ function buildInboundExternalMigrationSignatureSteps(
   authorizationRequest: MigrationAuthorizationRequest | undefined,
   useSignatures: boolean,
   bundled: boolean,
+  connectorId = inboundExternalAuthorizationConnector.value,
 ): DisplayStep[] {
   const sourceCollateral = externalCollateralAsset.value
   if (!sourceCollateral) return []
   if (!useSignatures) {
     return buildMigrationAuthorizationTxSteps(authorizationRequest, 'grant', 1, { bundled })
   }
-  if (inboundExternalAuthorizationConnector.value === AAVE_CONNECTOR_ID) {
+  if (connectorId === AAVE_CONNECTOR_ID) {
     const permitValue = getTypedDataAuthorizationValue(authorizationRequest)
     return [{
       index: 1,
@@ -4032,7 +4033,7 @@ function buildInboundExternalMigrationSignatureSteps(
       assetInfo: migrationStepAssetInfo(sourceCollateral, permitValue ?? sourceCollateral.amount),
     }]
   }
-  if (inboundExternalAuthorizationConnector.value === MORPHO_CONNECTOR_ID) {
+  if (connectorId === MORPHO_CONNECTOR_ID) {
     return flattenMigrationAuthorizationRequests(authorizationRequest).map((request, index) => ({
       index: index + 1,
       label: request.kind === 'typedData' && request.typedData.message.isAuthorized === false
@@ -4041,7 +4042,7 @@ function buildInboundExternalMigrationSignatureSteps(
       isSeparateTx: false,
     }))
   }
-  if (inboundExternalAuthorizationConnector.value === METAMORPHO_CONNECTOR_ID) {
+  if (connectorId === METAMORPHO_CONNECTOR_ID) {
     // The permit value is denominated in vault shares, so display the
     // underlying position amount as an estimate instead.
     return [{

--- a/pages/position/[number]/migrate.vue
+++ b/pages/position/[number]/migrate.vue
@@ -1094,46 +1094,48 @@ async function addPreparedMigrationToBatch(preview: OutgoingMigrationPreview) {
   const batchEntry = {
     label: `Migrate ${sourceCollateralSymbol}/${sourceDebtSymbol} to ${targetProtocolDisplay(input.target)}`,
     nameOverride: `Migrate ${sourceCollateralSymbol}/${sourceDebtSymbol}`,
-    buildExecutionPlan: async (account: Account<IHasVaultAddress>) => {
-      const executionAuthorizationRequest = useSignatures
-        ? await getAuthorizationRequest(input, migrationPosition, account, useSignatures)
-        : undefined
-      const authorization = executionAuthorizationRequest
-        ? await signMigrationAuthorization(executionAuthorizationRequest)
-        : undefined
-      // Without signatures the grant was already mined by the batch's pre-phase,
-      // so the connector omits the authorization item from the plan.
-      return buildMigrationPlan(input, authorization, migrationPosition, account)
-    },
     ...(useSignatures
-      ? {}
-      : {
-          buildExecutionPrerequisites: async (account: Account<IHasVaultAddress>) => {
+      ? {
+          // Review uses placeholder signature bytes. Real wallet signatures are
+          // requested only after the user confirms this exact authorization.
+          buildExecutionCeremony: async (account: Account<IHasVaultAddress>) => {
             const request = await getAuthorizationRequest(input, migrationPosition, account, useSignatures)
-            if (!request) return undefined
-            const { grants, revokes, revokesByGrant } = encodeMigrationAuthorizationTxs(request)
+            const simulation = await buildMigrationSimulation(input, migrationPosition, request, account)
             return {
-              preTxs: grants,
-              walletContext: { account: request.owner, chainId: request.chainId },
-              postTxs: revokes,
-              postTxsByPreTx: revokesByGrant,
+              plan: simulation.previewPlan,
+              resolveExecutionPlan: async (beforeWalletAction: () => void) => {
+                const authorization = request
+                  ? await signMigrationAuthorization(request, { beforeSignature: beforeWalletAction })
+                  : undefined
+                beforeWalletAction()
+                return buildMigrationPlan(input, authorization, migrationPosition, account)
+              },
+              usesPlaceholderSignatures: !!request,
+              grantSteps: buildSignatureSteps(input.target, request, true, false),
+              revokeSteps: [],
             }
           },
-          // Bundled counterpart for Safe execution: the simulation-variant
-          // plan validates the grant instead of reading the live allowance,
-          // so nothing needs to mine before the proposal is assembled. The
-          // review rows come from the SAME resolution so the modal cannot
-          // display a ceremony other than the one that executes.
-          buildBundledExecution: async (account: Account<IHasVaultAddress>) => {
+        }
+      : {
+          bundleExecutionCeremony: true,
+          // Resolve authorization once so the reviewed rows, exported calls,
+          // standalone flow, and Safe proposal all describe one ceremony.
+          buildExecutionCeremony: async (account: Account<IHasVaultAddress>) => {
             const request = await getAuthorizationRequest(input, migrationPosition, account, useSignatures)
-            const { grants, revokes } = request
+            const { grants, revokes, revokesByGrant } = request
               ? encodeMigrationAuthorizationTxs(request)
-              : { grants: [], revokes: [] }
+              : { grants: [], revokes: [], revokesByGrant: [] }
             const simulation = await buildMigrationSimulation(input, migrationPosition, request, account)
             return {
               plan: simulation.plan,
-              grants,
-              revokes,
+              prerequisites: request
+                ? {
+                    preTxs: grants,
+                    walletContext: { account: request.owner, chainId: request.chainId },
+                    postTxs: revokes,
+                    postTxsByPreTx: revokesByGrant,
+                  }
+                : undefined,
               grantSteps: buildMigrationAuthorizationTxSteps(request, 'grant', 1, { bundled: true }),
               revokeSteps: buildMigrationAuthorizationTxSteps(request, 'revoke', 1, { bundled: true }),
             }
@@ -1150,8 +1152,7 @@ async function addPreparedMigrationToBatch(preview: OutgoingMigrationPreview) {
       type: 'migration',
       asset: sourceDebtAsset,
       amount: debtAmount,
-      // Add-time rows describe the sequential fallback. A latched Safe review
-      // uses rows from the exact bundled resolution instead.
+      // Ceremony-owned rows replace these captured rows during batch review.
       signatureSteps: buildSignatureSteps(input.target, authorizationRequest, useSignatures, false),
       postSteps: buildRevokeSteps(authorizationRequest, useSignatures, false),
       displayPlan: preview.calldataPrepared.plan,

--- a/pages/position/[number]/migrate.vue
+++ b/pages/position/[number]/migrate.vue
@@ -46,6 +46,7 @@ import { assertWalletExecutionContext } from '~/utils/walletExecutionContext'
 import type { TrackedExecutionScope } from '~/composables/useSafeExecutionDetachment'
 import { useModal } from '~/components/ui/composables/useModal'
 import { useToast } from '~/components/ui/composables/useToast'
+import { getMigrationAuthorizationSignatureSubstitutions } from '~/utils/migrationAuthorizationSignatures'
 
 type AaveOutgoingMigrationTarget = MigrationTarget<AaveMigrationTargetRaw, AavePositionRef, AaveMigrationTargetExtraData>
 
@@ -1108,7 +1109,10 @@ async function addPreparedMigrationToBatch(preview: OutgoingMigrationPreview) {
                   ? await signMigrationAuthorization(request, { beforeSignature: beforeWalletAction })
                   : undefined
                 beforeWalletAction()
-                return buildMigrationPlan(input, authorization, migrationPosition, account)
+                return {
+                  plan: await buildMigrationPlan(input, authorization, migrationPosition, account),
+                  signatureSubstitutions: getMigrationAuthorizationSignatureSubstitutions(authorization),
+                }
               },
               usesPlaceholderSignatures: !!request,
               grantSteps: buildSignatureSteps(input.target, request, true, false),

--- a/pages/position/[number]/migrate.vue
+++ b/pages/position/[number]/migrate.vue
@@ -47,6 +47,7 @@ import type { TrackedExecutionScope } from '~/composables/useSafeExecutionDetach
 import { useModal } from '~/components/ui/composables/useModal'
 import { useToast } from '~/components/ui/composables/useToast'
 import { getMigrationAuthorizationSignatureSubstitutions } from '~/utils/migrationAuthorizationSignatures'
+import { isMigrationCeremonyDeadlineExpired, mintMigrationCeremonyDeadline } from '~/utils/migrationCeremonyDeadline'
 
 type AaveOutgoingMigrationTarget = MigrationTarget<AaveMigrationTargetRaw, AavePositionRef, AaveMigrationTargetExtraData>
 
@@ -84,6 +85,13 @@ type OutgoingMigrationPreview = {
   input: OutgoingMigrationInput
   account: Account<IHasVaultAddress>
   position: MigrationPosition
+  /**
+   * The verifier/authorization deadline every build of this preview pinned.
+   * Confirmation must reuse it: the deadline is embedded in the EIP-712
+   * payload (so a re-mint always fails the payload-equality gate) and in the
+   * plan's verifier calldata (so a re-mint diverges from the reviewed plan).
+   */
+  authorizationDeadline: bigint
   authorizationRequest?: MigrationAuthorizationRequest
   tenderlySimulation: PreparedMigrationTenderlySimulation
   calldataPrepared: TransactionPlanPrepared
@@ -104,7 +112,7 @@ const route = useRoute()
 const router = useRouter()
 const modal = useModal()
 const { error: showError } = useToast()
-const { isConnected, address, chainId: walletChainId } = useWagmi()
+const { isConnected, address, chainId: walletChainId, connector: walletConnector } = useWagmi()
 const { isSpyMode, spyAddress } = useSpyMode()
 const { isPositionsLoading, getPositionBySubAccountIndex, refreshAllPositions } = useEulerAccount()
 const { chainId } = useEulerAddresses()
@@ -610,8 +618,13 @@ function buildMigrationInput(
   }
 }
 
-function mintMigrationDeadline(): bigint {
-  return BigInt(Math.floor(Date.now() / 1000) + 60 * 60)
+// Identity of the wallet connector a Safe proposal would submit through.
+// Account and chain checks cannot see a same-account connector switch, so the
+// direct Safe-bundle flow captures this at confirmation and re-asserts it
+// immediately before the irreversible proposal broadcast.
+function walletConnectorContextKey(): string | undefined {
+  const current = walletConnector.value
+  return current ? `${current.id}:${current.uid}` : undefined
 }
 
 async function getAuthorizationRequest(
@@ -619,7 +632,7 @@ async function getAuthorizationRequest(
   migrationPosition?: MigrationPosition,
   account?: Account<IHasVaultAddress>,
   useSignatures = signaturesEnabled.value,
-  deadline: bigint = mintMigrationDeadline(),
+  deadline: bigint = mintMigrationCeremonyDeadline(),
 ): Promise<MigrationAuthorizationRequest | undefined> {
   return getMigrationAuthorization({
     direction: 'euler-to-external',
@@ -764,6 +777,10 @@ async function prepareOutgoingMigrationPreview(
       positionRef: input.target.ref,
     })
 
+    // Pinned once for the preview's whole lifetime: every build here and the
+    // confirm-time rebuild must embed this same deadline, or the payload and
+    // plan gates reject the confirmation as drift.
+    const authorizationDeadline = mintMigrationCeremonyDeadline()
     // Match the inbound migration flow: resolve the exact authorization form
     // first, then pass it into simulation. In no-signature mode this must be a
     // standalone transaction request so the review can list its grant/revoke
@@ -773,6 +790,7 @@ async function prepareOutgoingMigrationPreview(
       migrationPosition,
       account,
       useSignatures,
+      authorizationDeadline,
     )
     // One batch build returns both plans: the simulation plan (auth item
     // stripped, replaced by state overrides) and the stub-signed preview
@@ -782,6 +800,7 @@ async function prepareOutgoingMigrationPreview(
       migrationPosition,
       authorizationRequest,
       account,
+      authorizationDeadline,
     )
 
     // Resolve plugin payloads (Pyth Hermes pull, Keyring reads, TOS) once,
@@ -821,6 +840,7 @@ async function prepareOutgoingMigrationPreview(
       input,
       account,
       position: migrationPosition,
+      authorizationDeadline,
       tenderlySimulation: {
         plan: simulationResult.plan,
         prepared: tenderlyPrepared,
@@ -922,7 +942,14 @@ async function sendMigration(execution: TrackedExecutionScope, preview: Outgoing
     })
     if (!await restorePendingBeforeRetry()) return
     const input = reviewedInput
-    const authorizationRequest = await getAuthorizationRequest(input, migrationPosition, reviewedAccount, useSignatures)
+    // The reviewed deadline is embedded in the displayed payload and plan, so
+    // an expired one can only produce an on-chain revert — force a re-review
+    // that mints a fresh ceremony instead.
+    if (isMigrationCeremonyDeadlineExpired(preview.authorizationDeadline)) {
+      invalidateOutgoingMigrationPreview(preview.key)
+      throw new Error('The reviewed authorization expired — please review the migration again.')
+    }
+    const authorizationRequest = await getAuthorizationRequest(input, migrationPosition, reviewedAccount, useSignatures, preview.authorizationDeadline)
 
     // The reviewed ceremony is defined by the authorization payload the modal
     // displayed and copied. Authorization state can drift between review and
@@ -956,7 +983,23 @@ async function sendMigration(execution: TrackedExecutionScope, preview: Outgoing
           invalidateOutgoingMigrationPreview(preview.key)
           throw new Error('Authorization requirements changed since review — please review the migration again.')
         }
-        const outcome = await sendMigrationAsSafeBundle(input, migrationPosition, authorizationRequest, reviewedAccount)
+        // The wallet/Safe checks above ran at confirm entry; authorization
+        // lookup, planning, preparation, and simulation all await in between,
+        // so re-assert the full reviewed context (including the connector —
+        // a same-account Safe connector switch changes who submits) right
+        // before the irreversible proposal broadcast.
+        const confirmedConnectorKey = walletConnectorContextKey()
+        const outcome = await sendMigrationAsSafeBundle(input, migrationPosition, authorizationRequest, reviewedAccount, preview.authorizationDeadline, () => {
+          assertWalletExecutionContext({
+            expectedAccount: reviewedInput.owner,
+            expectedChainId: target.chainId,
+            currentAccount: address.value as Address | undefined,
+            currentChainId: walletChainId.value,
+          })
+          if (!isSafeWallet.value || walletConnectorContextKey() !== confirmedConnectorKey) {
+            throw new Error('Wallet changed since review — please review the migration again.')
+          }
+        })
         if (outcome === 'aborted') return
         finishMigrationSuccess(execution)
         return
@@ -972,7 +1015,7 @@ async function sendMigration(execution: TrackedExecutionScope, preview: Outgoing
           await executeMigrationAuthorizationGrants(authorizationRequest, revokeTxs)
         }
       }
-      const plan = await buildMigrationPlan(input, authorization, migrationPosition, reviewedAccount)
+      const plan = await buildMigrationPlan(input, authorization, migrationPosition, reviewedAccount, preview.authorizationDeadline)
       const prepared = await prepareTransactionPlan(plan, {
         account: reviewedAccount,
         chainId: input.target.chainId,
@@ -1050,10 +1093,12 @@ async function sendMigrationAsSafeBundle(
   input: OutgoingMigrationInput,
   migrationPosition: MigrationPosition,
   authorizationRequest: MigrationAuthorizationRequest,
-  account?: Account<IHasVaultAddress>,
+  account: Account<IHasVaultAddress> | undefined,
+  deadline: bigint,
+  beforeBroadcast: () => void,
 ): Promise<'executed' | 'aborted'> {
   const { grants, revokes } = encodeMigrationAuthorizationTxs(authorizationRequest)
-  const simulation = await buildMigrationSimulation(input, migrationPosition, authorizationRequest, account)
+  const simulation = await buildMigrationSimulation(input, migrationPosition, authorizationRequest, account, deadline)
   const prepared = await prepareTransactionPlan(simulation.plan, {
     account,
     chainId: input.target.chainId,
@@ -1066,7 +1111,8 @@ async function sendMigrationAsSafeBundle(
   )
   if (!ok) return 'aborted'
 
-  const result = await executePreparedPlanWithPlainCalls(prepared, { before: grants, after: revokes }, { allowSingleCall: true })
+  beforeBroadcast()
+  const result = await executePreparedPlanWithPlainCalls(prepared, { before: grants, after: revokes }, { allowSingleCall: true, beforeBroadcast })
   if (!result) {
     throw new Error('Safe connection unavailable — the reviewed single-proposal submission cannot run. Reconnect your Safe and retry.')
   }
@@ -1112,7 +1158,7 @@ async function addPreparedMigrationToBatch(preview: OutgoingMigrationPreview) {
             // plan only in the signature bytes. Connectors mint a wall-clock
             // verifier deadline on every build unless one is supplied, so the
             // ceremony pins a single deadline across both builds.
-            const ceremonyDeadline = mintMigrationDeadline()
+            const ceremonyDeadline = mintMigrationCeremonyDeadline()
             const request = await getAuthorizationRequest(input, migrationPosition, account, useSignatures, ceremonyDeadline)
             const simulation = await buildMigrationSimulation(input, migrationPosition, request, account, ceremonyDeadline)
             return {

--- a/pages/position/[number]/migrate.vue
+++ b/pages/position/[number]/migrate.vue
@@ -1131,6 +1131,11 @@ async function sendMigration(execution: TrackedExecutionScope, preview: Outgoing
       }
       throw executionError
     }
+    finally {
+      // The attempt is over either way — any record it left behind is now
+      // orphaned from live execution and becomes visible to manual recovery.
+      migrationQuarantine.end()
+    }
 
     await revokeAfterSuccess(revokeTxs)
     finishMigrationSuccess(execution)

--- a/pages/position/[number]/migrate.vue
+++ b/pages/position/[number]/migrate.vue
@@ -42,7 +42,8 @@ import { logWarn } from '~/utils/errorHandling'
 import { isOperationBlocked } from '~/utils/operationGuardRegistry'
 import { BATCH_ACTIVE_REASON } from '~/utils/tx-batch-messages'
 import { assertReviewedExecutionCurrent } from '~/utils/reviewedExecution'
-import { assertWalletExecutionContext, createSafeBundleBroadcastGuard } from '~/utils/walletExecutionContext'
+import { assertPreparedPlanSignatureParity } from '~/utils/preparedPlanParity'
+import { assertWalletExecutionContext, createReviewedWalletContextGuard, createSafeBundleBroadcastGuard } from '~/utils/walletExecutionContext'
 import type { TrackedExecutionScope } from '~/composables/useSafeExecutionDetachment'
 import { useModal } from '~/components/ui/composables/useModal'
 import { useToast } from '~/components/ui/composables/useToast'
@@ -102,6 +103,12 @@ type OutgoingMigrationPreview = {
   authorizationRequest?: MigrationAuthorizationRequest
   tenderlySimulation: PreparedMigrationTenderlySimulation
   calldataPrepared: TransactionPlanPrepared
+  /**
+   * The plugin payloads the reviewed calldata was prepared with. Confirm-time
+   * rebuilds must prepare with the same payloads so the parity proof compares
+   * plans that differ only in the authorized signature substitutions.
+   */
+  prefetch?: PluginPrefetchData
 }
 
 type MigrationTargetAssetLike = {
@@ -855,6 +862,7 @@ async function prepareOutgoingMigrationPreview(
         stateOverrides: simulationResult.stateOverrides,
       },
       calldataPrepared,
+      ...(prefetch ? { prefetch } : {}),
       ...(authorizationRequest
         ? { authorizationRequest }
         : {}),
@@ -932,6 +940,30 @@ async function reviewMigration(target: OutgoingMigrationTarget) {
   }
 }
 
+/**
+ * Prove the confirm-time prepared plan is byte-identical to the reviewed
+ * calldata outside the authorized signature substitutions. Any other
+ * divergence evicts the cached preview and forces a re-review — the wallet
+ * must never receive calldata the modal did not display.
+ */
+function assertMigrationPreparedParity(
+  preview: OutgoingMigrationPreview,
+  resolved: TransactionPlanPrepared,
+  authorization: SignedMigrationAuthorization | undefined,
+) {
+  try {
+    assertPreparedPlanSignatureParity({
+      reviewed: preview.calldataPrepared,
+      resolved,
+      substitutions: getMigrationAuthorizationSignatureSubstitutions(authorization),
+    })
+  }
+  catch (err) {
+    invalidateOutgoingMigrationPreview(preview.key)
+    throw err
+  }
+}
+
 async function sendMigration(execution: TrackedExecutionScope, preview: OutgoingMigrationPreview) {
   const { input: reviewedInput, account: reviewedAccount, position: migrationPosition, useSignatures } = preview
   const { target } = reviewedInput
@@ -1000,34 +1032,47 @@ async function sendMigration(execution: TrackedExecutionScope, preview: Outgoing
           isSafeWallet: () => isSafeWallet.value,
           connectorContextKey: walletConnectorContextKey,
         })
-        const outcome = await sendMigrationAsSafeBundle(input, migrationPosition, authorizationRequest, reviewedAccount, preview.authorizationDeadline, beforeBroadcast)
+        const outcome = await sendMigrationAsSafeBundle(preview, migrationPosition, authorizationRequest, reviewedAccount, beforeBroadcast)
         if (outcome === 'aborted') return
         finishMigrationSuccess(execution)
         return
       }
 
+      // Every wallet action below (signature request, grant broadcasts, plan
+      // broadcast) re-asserts the reviewed account/chain/connector — the
+      // awaits between them are where a delayed wallet switch can land.
+      const assertReviewedWalletContext = createReviewedWalletContextGuard({
+        expectedAccount: reviewedInput.owner,
+        expectedChainId: target.chainId,
+        expectedConnectorKey: preview.connectorContextKey,
+        currentAccount: () => address.value as Address | undefined,
+        currentChainId: () => walletChainId.value,
+        connectorContextKey: walletConnectorContextKey,
+      })
       if (authorizationRequest) {
         if (useSignatures) {
-          authorization = await signMigrationAuthorization(authorizationRequest)
+          authorization = await signMigrationAuthorization(authorizationRequest, { beforeSignature: assertReviewedWalletContext })
         }
         else {
           // Record each revoke as soon as its grant is broadcast so partial or
           // receipt-ambiguous failures can still unwind what may have landed.
-          await executeMigrationAuthorizationGrants(authorizationRequest, revokeTxs)
+          await executeMigrationAuthorizationGrants(authorizationRequest, revokeTxs, { beforeBroadcast: assertReviewedWalletContext })
         }
       }
       const plan = await buildMigrationPlan(input, authorization, migrationPosition, reviewedAccount, preview.authorizationDeadline)
       const prepared = await prepareTransactionPlan(plan, {
         account: reviewedAccount,
         chainId: input.target.chainId,
+        prefetch: preview.prefetch,
         usePermit2: useSignatures,
       })
+      assertMigrationPreparedParity(preview, prepared, authorization)
       const ok = await runPreparedSimulation(prepared, buildStateOverrideOptions({ noBalanceOverride: true }))
       if (!ok) {
         await revokeAfterAbort(revokeTxs)
         return
       }
-      await executePreparedPlan(prepared)
+      await executePreparedPlan(prepared, { beforeBroadcast: assertReviewedWalletContext })
     }
     catch (err) {
       // Covers a rejected batch, a failed prepare, and a stale grant.
@@ -1091,20 +1136,24 @@ function finishMigrationSuccess(execution: TrackedExecutionScope) {
  * is no Safe bundle context — the caller falls back to sequential grants.
  */
 async function sendMigrationAsSafeBundle(
-  input: OutgoingMigrationInput,
+  preview: OutgoingMigrationPreview,
   migrationPosition: MigrationPosition,
   authorizationRequest: MigrationAuthorizationRequest,
   account: Account<IHasVaultAddress> | undefined,
-  deadline: bigint,
   beforeBroadcast: () => void,
 ): Promise<'executed' | 'aborted'> {
+  const { input, authorizationDeadline: deadline } = preview
   const { grants, revokes } = encodeMigrationAuthorizationTxs(authorizationRequest)
   const simulation = await buildMigrationSimulation(input, migrationPosition, authorizationRequest, account, deadline)
   const prepared = await prepareTransactionPlan(simulation.plan, {
     account,
     chainId: input.target.chainId,
+    prefetch: preview.prefetch,
     usePermit2: false,
   })
+  // Bundled reviews are always no-signature, so the reviewed calldata is the
+  // simulation-variant plan itself: parity holds with zero substitutions.
+  assertMigrationPreparedParity(preview, prepared, undefined)
   const ok = await runPreparedSimulation(
     prepared,
     buildStateOverrideOptions({ noBalanceOverride: true }),
@@ -1200,6 +1249,15 @@ async function addPreparedMigrationToBatch(preview: OutgoingMigrationPreview) {
                     postTxsByPreTx: revokesByGrant,
                   }
                 : undefined,
+              // Authorization state can drift between review and execution
+              // (an allowance granted or revoked elsewhere) — the reviewed
+              // grant/revoke set would no longer match what should run.
+              revalidatePrerequisites: async () => {
+                const fresh = await getAuthorizationRequest(input, migrationPosition, account, useSignatures)
+                if (migrationAuthorizationPayloadKey(fresh) !== migrationAuthorizationPayloadKey(request)) {
+                  throw new Error('Authorization requirements changed since review — reopen review and try again.')
+                }
+              },
               grantSteps: buildMigrationAuthorizationTxSteps(request, 'grant', 1, { bundled: true }),
               revokeSteps: buildMigrationAuthorizationTxSteps(request, 'revoke', 1, { bundled: true }),
             }

--- a/pages/position/[number]/migrate.vue
+++ b/pages/position/[number]/migrate.vue
@@ -42,7 +42,7 @@ import { logWarn } from '~/utils/errorHandling'
 import { isOperationBlocked } from '~/utils/operationGuardRegistry'
 import { BATCH_ACTIVE_REASON } from '~/utils/tx-batch-messages'
 import { assertReviewedExecutionCurrent } from '~/utils/reviewedExecution'
-import { assertWalletExecutionContext } from '~/utils/walletExecutionContext'
+import { assertWalletExecutionContext, createSafeBundleBroadcastGuard } from '~/utils/walletExecutionContext'
 import type { TrackedExecutionScope } from '~/composables/useSafeExecutionDetachment'
 import { useModal } from '~/components/ui/composables/useModal'
 import { useToast } from '~/components/ui/composables/useToast'
@@ -983,23 +983,15 @@ async function sendMigration(execution: TrackedExecutionScope, preview: Outgoing
           invalidateOutgoingMigrationPreview(preview.key)
           throw new Error('Authorization requirements changed since review — please review the migration again.')
         }
-        // The wallet/Safe checks above ran at confirm entry; authorization
-        // lookup, planning, preparation, and simulation all await in between,
-        // so re-assert the full reviewed context (including the connector —
-        // a same-account Safe connector switch changes who submits) right
-        // before the irreversible proposal broadcast.
-        const confirmedConnectorKey = walletConnectorContextKey()
-        const outcome = await sendMigrationAsSafeBundle(input, migrationPosition, authorizationRequest, reviewedAccount, preview.authorizationDeadline, () => {
-          assertWalletExecutionContext({
-            expectedAccount: reviewedInput.owner,
-            expectedChainId: target.chainId,
-            currentAccount: address.value as Address | undefined,
-            currentChainId: walletChainId.value,
-          })
-          if (!isSafeWallet.value || walletConnectorContextKey() !== confirmedConnectorKey) {
-            throw new Error('Wallet changed since review — please review the migration again.')
-          }
+        const beforeBroadcast = createSafeBundleBroadcastGuard({
+          expectedAccount: reviewedInput.owner,
+          expectedChainId: target.chainId,
+          currentAccount: () => address.value as Address | undefined,
+          currentChainId: () => walletChainId.value,
+          isSafeWallet: () => isSafeWallet.value,
+          connectorContextKey: walletConnectorContextKey,
         })
+        const outcome = await sendMigrationAsSafeBundle(input, migrationPosition, authorizationRequest, reviewedAccount, preview.authorizationDeadline, beforeBroadcast)
         if (outcome === 'aborted') return
         finishMigrationSuccess(execution)
         return

--- a/pages/position/[number]/migrate.vue
+++ b/pages/position/[number]/migrate.vue
@@ -43,6 +43,9 @@ import { isOperationBlocked } from '~/utils/operationGuardRegistry'
 import { BATCH_ACTIVE_REASON } from '~/utils/tx-batch-messages'
 import { assertReviewedExecutionCurrent } from '~/utils/reviewedExecution'
 import { assertPreparedPlanSignatureParity } from '~/utils/preparedPlanParity'
+import { createDirectSubmissionQuarantine } from '~/utils/directSubmissionQuarantine'
+import { getSafeWalletProvider, type ReceiptClientLike } from '~/utils/safeWalletTransactions'
+import { getEulerSdkFresh } from '~/composables/useEulerSdk'
 import { assertWalletExecutionContext, createReviewedWalletContextGuard, createSafeBundleBroadcastGuard } from '~/utils/walletExecutionContext'
 import type { TrackedExecutionScope } from '~/composables/useSafeExecutionDetachment'
 import { useModal } from '~/components/ui/composables/useModal'
@@ -964,6 +967,42 @@ function assertMigrationPreparedParity(
   }
 }
 
+/**
+ * Replay protection for the direct outgoing flow: once the wallet accepts the
+ * migration submission, a confirmation failure must not degrade into an
+ * ordinary retry — the accepted hash/proposal id is retained durably and
+ * verified on-chain before another attempt may send anything.
+ */
+const migrationQuarantine = createDirectSubmissionQuarantine({
+  flow: 'outgoing-migration',
+  getSafeWalletProvider,
+})
+
+/**
+ * Returns false (after surfacing what happened) when the attempt must stop:
+ * a previously accepted submission confirmed on-chain, so the position state
+ * the review was built on is gone. It may have been this migration or an
+ * earlier one for the same wallet — never finalize the current attempt on it.
+ * An unresolved outcome throws and blocks the retry.
+ */
+async function reconcileMigrationQuarantine(preview: OutgoingMigrationPreview): Promise<boolean> {
+  const sdk = await getEulerSdkFresh()
+  const targetChainId = preview.input.target.chainId
+  const verdict = await migrationQuarantine.reconcileBeforeAttempt({
+    owner: preview.input.owner,
+    chainId: targetChainId,
+    provider: sdk.providerService?.getProvider(targetChainId) as ReceiptClientLike | undefined,
+    connector: walletConnector.value,
+  })
+  if (verdict === 'clear') return true
+  invalidateOutgoingMigrationPreview(preview.key)
+  schedulePostMigrationRefreshes()
+  showError(verdict === 'landed'
+    ? 'A previous migration submission confirmed on-chain. Positions were refreshed — review the migration again before retrying.'
+    : 'A previous migration submission confirmed on-chain but may not have completed its plan. Positions were refreshed — review the migration again before retrying.')
+  return false
+}
+
 async function sendMigration(execution: TrackedExecutionScope, preview: OutgoingMigrationPreview) {
   const { input: reviewedInput, account: reviewedAccount, position: migrationPosition, useSignatures } = preview
   const { target } = reviewedInput
@@ -981,6 +1020,7 @@ async function sendMigration(execution: TrackedExecutionScope, preview: Outgoing
       currentChainId: walletChainId.value,
     })
     if (!await restorePendingBeforeRetry()) return
+    if (!await reconcileMigrationQuarantine(preview)) return
     const input = reviewedInput
     // The reviewed deadline is embedded in the displayed payload and plan, so
     // an expired one can only produce an on-chain revert — force a re-review
@@ -1006,6 +1046,7 @@ async function sendMigration(execution: TrackedExecutionScope, preview: Outgoing
     // sign, nothing to grant, and nothing of ours to revoke afterwards.
     let authorization: SignedMigrationAuthorization | undefined
     const revokeTxs: MigrationAuthorizationRevoke[] = []
+    migrationQuarantine.begin({ owner: reviewedInput.owner, chainId: target.chainId })
     try {
       if (preview.bundledReview) {
         // The review promised ONE atomic Safe proposal. Revalidate that mode
@@ -1072,12 +1113,23 @@ async function sendMigration(execution: TrackedExecutionScope, preview: Outgoing
         await revokeAfterAbort(revokeTxs)
         return
       }
-      await executePreparedPlan(prepared, { beforeBroadcast: assertReviewedWalletContext })
+      await executePreparedPlan(prepared, {
+        beforeBroadcast: assertReviewedWalletContext,
+        onBroadcast: migrationQuarantine.track,
+      })
     }
     catch (err) {
+      // A wallet-accepted submission whose confirmation failed may still land
+      // — retain it durably so the next attempt reconciles it on-chain before
+      // sending anything.
+      const quarantined = migrationQuarantine.sealFailure()
       // Covers a rejected batch, a failed prepare, and a stale grant.
       await revokeAfterAbort(revokeTxs)
-      throw toMigrationExecutionError(err)
+      const executionError = toMigrationExecutionError(err)
+      if (quarantined && executionError instanceof Error) {
+        throw new Error(`${executionError.message} The submission may still confirm — retrying first verifies it on-chain before anything is re-sent.`, { cause: err })
+      }
+      throw executionError
     }
 
     await revokeAfterSuccess(revokeTxs)
@@ -1162,7 +1214,11 @@ async function sendMigrationAsSafeBundle(
   if (!ok) return 'aborted'
 
   beforeBroadcast()
-  const result = await executePreparedPlanWithPlainCalls(prepared, { before: grants, after: revokes }, { allowSingleCall: true, beforeBroadcast })
+  const result = await executePreparedPlanWithPlainCalls(prepared, { before: grants, after: revokes }, {
+    allowSingleCall: true,
+    beforeBroadcast,
+    onBroadcast: migrationQuarantine.track,
+  })
   if (!result) {
     throw new Error('Safe connection unavailable — the reviewed single-proposal submission cannot run. Reconnect your Safe and retry.')
   }

--- a/pages/position/[number]/migrate.vue
+++ b/pages/position/[number]/migrate.vue
@@ -92,6 +92,13 @@ type OutgoingMigrationPreview = {
    * plan's verifier calldata (so a re-mint diverges from the reviewed plan).
    */
   authorizationDeadline: bigint
+  /**
+   * The connector identity (`id:uid`) the review was built under. The direct
+   * Safe-bundle broadcast guard validates against this reviewed key — never a
+   * snapshot taken inside the confirmation flow, which would accept a
+   * connector swapped during an earlier confirmation await as its baseline.
+   */
+  connectorContextKey: string | undefined
   authorizationRequest?: MigrationAuthorizationRequest
   tenderlySimulation: PreparedMigrationTenderlySimulation
   calldataPrepared: TransactionPlanPrepared
@@ -841,6 +848,7 @@ async function prepareOutgoingMigrationPreview(
       account,
       position: migrationPosition,
       authorizationDeadline,
+      connectorContextKey: walletConnectorContextKey(),
       tenderlySimulation: {
         plan: simulationResult.plan,
         prepared: tenderlyPrepared,
@@ -986,6 +994,7 @@ async function sendMigration(execution: TrackedExecutionScope, preview: Outgoing
         const beforeBroadcast = createSafeBundleBroadcastGuard({
           expectedAccount: reviewedInput.owner,
           expectedChainId: target.chainId,
+          expectedConnectorKey: preview.connectorContextKey,
           currentAccount: () => address.value as Address | undefined,
           currentChainId: () => walletChainId.value,
           isSafeWallet: () => isSafeWallet.value,

--- a/pages/position/[number]/migrate.vue
+++ b/pages/position/[number]/migrate.vue
@@ -610,13 +610,17 @@ function buildMigrationInput(
   }
 }
 
+function mintMigrationDeadline(): bigint {
+  return BigInt(Math.floor(Date.now() / 1000) + 60 * 60)
+}
+
 async function getAuthorizationRequest(
   input: OutgoingMigrationInput,
   migrationPosition?: MigrationPosition,
   account?: Account<IHasVaultAddress>,
   useSignatures = signaturesEnabled.value,
+  deadline: bigint = mintMigrationDeadline(),
 ): Promise<MigrationAuthorizationRequest | undefined> {
-  const deadline = BigInt(Math.floor(Date.now() / 1000) + 60 * 60)
   return getMigrationAuthorization({
     direction: 'euler-to-external',
     connectorId: input.target.connectorId,
@@ -640,6 +644,7 @@ async function buildMigrationPlan(
   authorization?: SignedMigrationAuthorization,
   migrationPosition?: MigrationPosition,
   account: Account<IHasVaultAddress> | undefined = planAccount.value,
+  deadline?: bigint,
 ): Promise<TransactionPlan> {
   return planCrossProtocolMigration({
     direction: 'euler-to-external',
@@ -655,6 +660,7 @@ async function buildMigrationPlan(
     account,
     cleanupEulerPosition: input.cleanupEulerPosition,
     operationName: `${input.target.connectorId}OutgoingMigration`,
+    deadline,
   })
 }
 
@@ -663,6 +669,7 @@ async function buildMigrationSimulation(
   migrationPosition: MigrationPosition,
   authorizationRequest: MigrationAuthorizationRequest | undefined,
   account?: Account<IHasVaultAddress>,
+  deadline?: bigint,
 ) {
   return planCrossProtocolMigrationSimulation({
     direction: 'euler-to-external',
@@ -678,6 +685,7 @@ async function buildMigrationSimulation(
     account,
     cleanupEulerPosition: input.cleanupEulerPosition,
     operationName: `${input.target.connectorId}OutgoingMigration`,
+    deadline,
   })
 }
 
@@ -1100,8 +1108,13 @@ async function addPreparedMigrationToBatch(preview: OutgoingMigrationPreview) {
           // Review uses placeholder signature bytes. Real wallet signatures are
           // requested only after the user confirms this exact authorization.
           buildExecutionCeremony: async (account: Account<IHasVaultAddress>) => {
-            const request = await getAuthorizationRequest(input, migrationPosition, account, useSignatures)
-            const simulation = await buildMigrationSimulation(input, migrationPosition, request, account)
+            // The confirm-time rebuild must differ from the reviewed preview
+            // plan only in the signature bytes. Connectors mint a wall-clock
+            // verifier deadline on every build unless one is supplied, so the
+            // ceremony pins a single deadline across both builds.
+            const ceremonyDeadline = mintMigrationDeadline()
+            const request = await getAuthorizationRequest(input, migrationPosition, account, useSignatures, ceremonyDeadline)
+            const simulation = await buildMigrationSimulation(input, migrationPosition, request, account, ceremonyDeadline)
             return {
               plan: simulation.previewPlan,
               resolveExecutionPlan: async (beforeWalletAction: () => void) => {
@@ -1110,7 +1123,7 @@ async function addPreparedMigrationToBatch(preview: OutgoingMigrationPreview) {
                   : undefined
                 beforeWalletAction()
                 return {
-                  plan: await buildMigrationPlan(input, authorization, migrationPosition, account),
+                  plan: await buildMigrationPlan(input, authorization, migrationPosition, account, ceremonyDeadline),
                   signatureSubstitutions: getMigrationAuthorizationSignatureSubstitutions(authorization),
                 }
               },

--- a/tests/components/batchReviewModal.test.ts
+++ b/tests/components/batchReviewModal.test.ts
@@ -46,4 +46,19 @@ describe('BatchReviewModal ceremony wiring', () => {
     expect(source).toContain('v-if="hasUnverified"')
     expect(source).toContain('unverifiedVaultNames.join(\', \')')
   })
+
+  it('keeps one restoration summary row per reviewed wallet action', () => {
+    const restorationSection = sectionBetween(
+      'const restorationSummaryRows = computed',
+      'const restorationSummaryGroups = computed',
+    )
+
+    expect(restorationSection).toContain('postStepsByEntryId.value[entry.id]')
+    expect(restorationSection).not.toContain('consolidate')
+  })
+
+  it('does not offer a whole-batch simulation for a different call vector', () => {
+    expect(source).not.toContain('simulateOnTenderly')
+    expect(source).not.toContain('Simulate on Tenderly')
+  })
 })

--- a/tests/components/batchReviewModal.test.ts
+++ b/tests/components/batchReviewModal.test.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const source = readFileSync(
+  join(process.cwd(), 'components/BatchReviewModal.vue'),
+  'utf8',
+)
+
+const sectionBetween = (start: string, end: string): string => {
+  const startIndex = source.indexOf(start)
+  const endIndex = source.indexOf(end, startIndex)
+  expect(startIndex, `missing start marker: ${start}`).toBeGreaterThanOrEqual(0)
+  expect(endIndex, `missing end marker: ${end}`).toBeGreaterThan(startIndex)
+  return source.slice(startIndex, endIndex)
+}
+
+const expectCeremonyPlanFirst = (section: string) => {
+  const selectorIndex = section.indexOf('getBatchReviewDisplayPlan(')
+  const ceremonyIndex = section.indexOf('executionCeremonyRef.value?.reviewByEntryId[entry.id]?.plan')
+  const capturedPlanIndex = section.indexOf('entryPlans.value[entry.id]')
+
+  expect(selectorIndex).toBeGreaterThanOrEqual(0)
+  expect(ceremonyIndex).toBeGreaterThan(selectorIndex)
+  expect(capturedPlanIndex).toBeGreaterThan(ceremonyIndex)
+}
+
+describe('BatchReviewModal ceremony wiring', () => {
+  it('derives expanded operation rows from the ceremony plan', () => {
+    const displaySection = sectionBetween(
+      'const stepsByEntryId = computed',
+      'const signatureStepsByEntryId = computed',
+    )
+
+    expectCeremonyPlanFirst(displaySection)
+    expect(source).toContain(':steps="stepsByEntryId[entry.id]"')
+  })
+
+  it('derives unverified-vault disclosure from the ceremony plan', () => {
+    const disclosureSection = sectionBetween(
+      'const unverifiedVaultNames = computed',
+      'const hasUnverified = computed',
+    )
+
+    expectCeremonyPlanFirst(disclosureSection)
+    expect(source).toContain('v-if="hasUnverified"')
+    expect(source).toContain('unverifiedVaultNames.join(\', \')')
+  })
+})

--- a/tests/composables/useCowSwapExecutionCore.test.ts
+++ b/tests/composables/useCowSwapExecutionCore.test.ts
@@ -1,21 +1,34 @@
 import { ref, type Ref } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { getAddress } from 'viem'
 import type { TransactionPlan } from '@eulerxyz/euler-v2-sdk'
+import { readPendingSubmission, resetPendingSubmissionMemoryFallback, writePendingSubmission } from '~/utils/pendingSubmissions'
+
+// Hoisted so the same spy instances survive vi.resetModules() — the mock
+// factories re-run for each fresh module graph but hand back these objects.
+const wagmiMocks = vi.hoisted(() => ({
+  sendTransactionAsync: vi.fn(),
+  signTypedDataAsync: vi.fn(),
+}))
+
+const sdkMocks = vi.hoisted(() => ({
+  getEulerSdkFresh: vi.fn(),
+}))
 
 vi.mock('@wagmi/vue', () => ({
-  useSendTransaction: () => ({ sendTransactionAsync: vi.fn() }),
-  useSignTypedData: () => ({ signTypedDataAsync: vi.fn() }),
+  useSendTransaction: () => ({ sendTransactionAsync: wagmiMocks.sendTransactionAsync }),
+  useSignTypedData: () => ({ signTypedDataAsync: wagmiMocks.signTypedDataAsync }),
 }))
 
 vi.mock('~/composables/useEulerSdk', () => ({
-  getEulerSdkFresh: vi.fn(),
+  getEulerSdkFresh: sdkMocks.getEulerSdkFresh,
 }))
 
 vi.mock('~/composables/usePortfolioRefresh', () => ({
   usePortfolioRefresh: () => ({ triggerPortfolioRefresh: vi.fn() }),
 }))
 
-const OWNER = '0x1000000000000000000000000000000000000000'
+const OWNER = getAddress('0x1000000000000000000000000000000000000000')
 
 describe('useCowSwapExecutionCore Safe backstop', () => {
   let isSafeWallet: Ref<boolean>
@@ -35,6 +48,7 @@ describe('useCowSwapExecutionCore Safe backstop', () => {
 
   beforeEach(() => {
     vi.resetModules()
+    vi.clearAllMocks()
     isSafeWallet = ref(false)
     isSafeWalletResolved = ref(true)
     vi.stubGlobal('useWagmi', () => ({ address: ref(OWNER) }))
@@ -43,6 +57,8 @@ describe('useCowSwapExecutionCore Safe backstop', () => {
     vi.stubGlobal('useCowSwapEligibility', () => ({
       cowSwapForcedOff: computed(() => isSafeWallet.value || !isSafeWalletResolved.value),
     }))
+    // The pending-submission quarantine is module state shared across tests.
+    resetPendingSubmissionMemoryFallback()
   })
 
   it('rejects execution for Safe wallets before any transaction is sent', async () => {
@@ -57,5 +73,41 @@ describe('useCowSwapExecutionCore Safe backstop', () => {
     const core = await setupCore()
 
     await expect(core.executePlan(dummyFlow)).rejects.toThrow('CoW Swap is not available with Safe wallets')
+  })
+
+  it('blocks execution while an ambiguous submission from another surface is unresolved', async () => {
+    // The CoW executor sends approvals and signs the order permit straight
+    // through the wallet callbacks, without passing any plan-executor gate —
+    // a quarantined submission from any flow must stop it before either.
+    writePendingSubmission('batch', {
+      phase: 'armed',
+      chainId: 1,
+      owner: OWNER,
+      completesPlan: true,
+      submittedAt: 1_000,
+    })
+    const executeCowSwapTransactionPlan = vi.fn()
+    sdkMocks.getEulerSdkFresh.mockResolvedValue({
+      providerService: {
+        getProvider: vi.fn(() => ({
+          getTransactionReceipt: vi.fn(async () => {
+            throw new Error('receipt not found')
+          }),
+        })),
+      },
+      executionService: { executeCowSwapTransactionPlan },
+    })
+    const core = await setupCore()
+
+    await expect(core.executePlan(dummyFlow)).rejects.toThrow(
+      'handed to the wallet but no transaction id came back',
+    )
+
+    // Nothing crossed the wallet boundary: no approval transaction was sent
+    // and no order or permit signature was requested.
+    expect(executeCowSwapTransactionPlan).not.toHaveBeenCalled()
+    expect(wagmiMocks.sendTransactionAsync).not.toHaveBeenCalled()
+    expect(wagmiMocks.signTypedDataAsync).not.toHaveBeenCalled()
+    expect(readPendingSubmission('batch', OWNER, 1)).toBeDefined()
   })
 })

--- a/tests/composables/useCowSwapExecutionCore.test.ts
+++ b/tests/composables/useCowSwapExecutionCore.test.ts
@@ -1,6 +1,6 @@
 import { ref, type Ref } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { getAddress } from 'viem'
+import { getAddress, type Address, type Hex } from 'viem'
 import type { TransactionPlan } from '@eulerxyz/euler-v2-sdk'
 import { readPendingSubmission, resetPendingSubmissionMemoryFallback, writePendingSubmission } from '~/utils/pendingSubmissions'
 
@@ -9,15 +9,38 @@ import { readPendingSubmission, resetPendingSubmissionMemoryFallback, writePendi
 const wagmiMocks = vi.hoisted(() => ({
   sendTransactionAsync: vi.fn(),
   signTypedDataAsync: vi.fn(),
+  getAccount: vi.fn(),
+  config: {},
 }))
 
 const sdkMocks = vi.hoisted(() => ({
   getEulerSdkFresh: vi.fn(),
 }))
 
+const cowMocks = vi.hoisted(() => ({
+  pollCowSwapOrderStatus: vi.fn(),
+  fetchCowSwapOrderStatus: vi.fn(),
+  cancelCowSwapOrder: vi.fn(),
+  getCowSwapOrderExplorerUrl: vi.fn(() => 'https://explorer.cow.fi/orders/test'),
+}))
+
 vi.mock('@wagmi/vue', () => ({
+  useConfig: () => wagmiMocks.config,
   useSendTransaction: () => ({ sendTransactionAsync: wagmiMocks.sendTransactionAsync }),
   useSignTypedData: () => ({ signTypedDataAsync: wagmiMocks.signTypedDataAsync }),
+}))
+
+vi.mock('@wagmi/vue/actions', () => ({
+  getAccount: wagmiMocks.getAccount,
+}))
+
+vi.mock('~/entities/cowswap', () => ({
+  pollCowSwapOrderStatus: cowMocks.pollCowSwapOrderStatus,
+  fetchCowSwapOrderStatus: cowMocks.fetchCowSwapOrderStatus,
+  cancelCowSwapOrder: cowMocks.cancelCowSwapOrder,
+  getCowSwapOrderExplorerUrl: cowMocks.getCowSwapOrderExplorerUrl,
+  COWSWAP_ORDER_POLL_INTERVAL_MS: 1,
+  COWSWAP_ORDER_POLL_MAX_DURATION_MS: 50,
 }))
 
 vi.mock('~/composables/useEulerSdk', () => ({
@@ -29,8 +52,48 @@ vi.mock('~/composables/usePortfolioRefresh', () => ({
 }))
 
 const OWNER = getAddress('0x1000000000000000000000000000000000000000')
+const OTHER_OWNER = getAddress('0x2000000000000000000000000000000000000000')
+const APPROVAL_TARGET = getAddress('0x3000000000000000000000000000000000000000')
+const CONNECTOR = { id: 'io.metamask', uid: 'uid-1' }
+const ORDER_UID = `0x${'ab'.repeat(56)}`
+const TX_HASH = `0x${'33'.repeat(32)}`
 
-describe('useCowSwapExecutionCore Safe backstop', () => {
+/** Shape of the argument object the core hands to executeCowSwapTransactionPlan. */
+interface ExecArgs {
+  plan: TransactionPlan
+  chainId: number
+  account: Address
+  sendTransaction: (tx: { to: Address, data: Hex, value?: bigint }) => Promise<unknown>
+  signTypedData: (typedData: {
+    domain: Record<string, unknown>
+    types: Record<string, unknown>
+    primaryType: string
+    message: Record<string, unknown>
+  }) => Promise<unknown>
+  onProgress: (progress: { status?: string, orderUid?: string }) => void
+}
+
+const sdkFor = (executeCowSwapTransactionPlan: (args: ExecArgs) => Promise<unknown>) => ({
+  providerService: {
+    getProvider: vi.fn(() => ({
+      getTransactionReceipt: vi.fn(async () => {
+        throw new Error('receipt not found')
+      }),
+    })),
+  },
+  executionService: { executeCowSwapTransactionPlan },
+})
+
+const successResult = { results: [], orderUids: [ORDER_UID] }
+
+const typedDataStub = {
+  domain: { name: 'Permit2' },
+  types: { Permit: [] },
+  primaryType: 'Permit',
+  message: { spender: APPROVAL_TARGET },
+}
+
+describe('useCowSwapExecutionCore', () => {
   let isSafeWallet: Ref<boolean>
   let isSafeWalletResolved: Ref<boolean>
 
@@ -57,57 +120,311 @@ describe('useCowSwapExecutionCore Safe backstop', () => {
     vi.stubGlobal('useCowSwapEligibility', () => ({
       cowSwapForcedOff: computed(() => isSafeWallet.value || !isSafeWalletResolved.value),
     }))
+    wagmiMocks.getAccount.mockReturnValue({ address: OWNER, chainId: 1, connector: CONNECTOR })
+    wagmiMocks.sendTransactionAsync.mockResolvedValue(TX_HASH)
+    wagmiMocks.signTypedDataAsync.mockResolvedValue('0xsig')
+    // Default: the orderbook never reports the order terminal within this
+    // test, so the background release watcher leaves the record alone.
+    cowMocks.pollCowSwapOrderStatus.mockResolvedValue({ terminal: false })
+    cowMocks.fetchCowSwapOrderStatus.mockResolvedValue({ terminal: false })
     // The pending-submission quarantine is module state shared across tests.
     resetPendingSubmissionMemoryFallback()
   })
 
-  it('rejects execution for Safe wallets before any transaction is sent', async () => {
-    isSafeWallet.value = true
-    const core = await setupCore()
+  describe('Safe backstop and cross-surface gate', () => {
+    it('rejects execution for Safe wallets before any transaction is sent', async () => {
+      isSafeWallet.value = true
+      const core = await setupCore()
 
-    await expect(core.executePlan(dummyFlow)).rejects.toThrow('CoW Swap is not available with Safe wallets')
-  })
-
-  it('rejects execution while Safe detection is pending', async () => {
-    isSafeWalletResolved.value = false
-    const core = await setupCore()
-
-    await expect(core.executePlan(dummyFlow)).rejects.toThrow('CoW Swap is not available with Safe wallets')
-  })
-
-  it('blocks execution while an ambiguous submission from another surface is unresolved', async () => {
-    // The CoW executor sends approvals and signs the order permit straight
-    // through the wallet callbacks, without passing any plan-executor gate —
-    // a quarantined submission from any flow must stop it before either.
-    writePendingSubmission('batch', {
-      phase: 'armed',
-      chainId: 1,
-      owner: OWNER,
-      completesPlan: true,
-      submittedAt: 1_000,
+      await expect(core.executePlan(dummyFlow)).rejects.toThrow('CoW Swap is not available with Safe wallets')
     })
-    const executeCowSwapTransactionPlan = vi.fn()
-    sdkMocks.getEulerSdkFresh.mockResolvedValue({
-      providerService: {
-        getProvider: vi.fn(() => ({
-          getTransactionReceipt: vi.fn(async () => {
-            throw new Error('receipt not found')
-          }),
-        })),
+
+    it('rejects execution while Safe detection is pending', async () => {
+      isSafeWalletResolved.value = false
+      const core = await setupCore()
+
+      await expect(core.executePlan(dummyFlow)).rejects.toThrow('CoW Swap is not available with Safe wallets')
+    })
+
+    it('blocks execution while an ambiguous submission from another surface is unresolved', async () => {
+      // The CoW executor sends approvals and signs the order permit straight
+      // through the wallet callbacks, without passing any plan-executor gate —
+      // a quarantined submission from any flow must stop it before either.
+      writePendingSubmission('batch', {
+        phase: 'armed',
+        chainId: 1,
+        owner: OWNER,
+        completesPlan: true,
+        submittedAt: 1_000,
+      })
+      const executeCowSwapTransactionPlan = vi.fn()
+      sdkMocks.getEulerSdkFresh.mockResolvedValue(sdkFor(executeCowSwapTransactionPlan) as never)
+      const core = await setupCore()
+
+      await expect(core.executePlan(dummyFlow)).rejects.toThrow(
+        'handed to the wallet but no transaction id came back',
+      )
+
+      // Nothing crossed the wallet boundary: no approval transaction was sent
+      // and no order or permit signature was requested.
+      expect(executeCowSwapTransactionPlan).not.toHaveBeenCalled()
+      expect(wagmiMocks.sendTransactionAsync).not.toHaveBeenCalled()
+      expect(wagmiMocks.signTypedDataAsync).not.toHaveBeenCalled()
+      expect(readPendingSubmission('batch', OWNER, 1)).toBeDefined()
+    })
+  })
+
+  describe('owned quarantine lifecycle', () => {
+    it('arms replay protection before the wallet boundary and upgrades it with the order uid', async () => {
+      let recordAtBoundary: unknown
+      const executeCowSwapTransactionPlan = vi.fn(async ({ onProgress }: ExecArgs) => {
+        // The SDK is about to invoke the wallet callbacks — a reload here must
+        // already find the durable reservation.
+        recordAtBoundary = readPendingSubmission('cow-order', OWNER, 1)
+        onProgress({ status: 'submitOrder' })
+        onProgress({ orderUid: ORDER_UID })
+        return successResult
+      })
+      sdkMocks.getEulerSdkFresh.mockResolvedValue(sdkFor(executeCowSwapTransactionPlan) as never)
+      const core = await setupCore()
+
+      await expect(core.executePlan(dummyFlow)).resolves.toBe(ORDER_UID)
+
+      expect(recordAtBoundary).toMatchObject({ phase: 'armed', owner: OWNER, chainId: 1 })
+      expect(readPendingSubmission('cow-order', OWNER, 1)).toMatchObject({
+        phase: 'submitted',
+        kind: 'cow-order',
+        orderUid: ORDER_UID,
+        owner: OWNER,
+        chainId: 1,
+      })
+    })
+
+    it('releases the record once the orderbook reports the order terminal', async () => {
+      cowMocks.pollCowSwapOrderStatus.mockResolvedValue({ terminal: true, status: 'fulfilled' })
+      const executeCowSwapTransactionPlan = vi.fn(async ({ onProgress }: ExecArgs) => {
+        onProgress({ status: 'submitOrder', orderUid: ORDER_UID })
+        return successResult
+      })
+      sdkMocks.getEulerSdkFresh.mockResolvedValue(sdkFor(executeCowSwapTransactionPlan) as never)
+      const core = await setupCore()
+
+      await expect(core.executePlan(dummyFlow)).resolves.toBe(ORDER_UID)
+
+      await vi.waitFor(() => {
+        expect(readPendingSubmission('cow-order', OWNER, 1)).toBeUndefined()
+      })
+      expect(cowMocks.pollCowSwapOrderStatus).toHaveBeenCalledWith(expect.objectContaining({
+        orderUid: ORDER_UID,
+        chainId: 1,
+        orderbookUrl: 'https://api.cow.fi/mainnet',
+      }))
+    })
+
+    it('keeps the armed record when the orderbook accepted the submission but the response was lost, and blocks the retry', async () => {
+      const executeCowSwapTransactionPlan = vi.fn(async ({ onProgress }: ExecArgs) => {
+        // The orderbook request went out; the response never came back, so no
+        // order uid exists — but a live order may.
+        onProgress({ status: 'submitOrder' })
+        throw new Error('Failed to fetch')
+      })
+      sdkMocks.getEulerSdkFresh.mockResolvedValue(sdkFor(executeCowSwapTransactionPlan) as never)
+      const core = await setupCore()
+
+      await expect(core.executePlan(dummyFlow)).rejects.toThrow('Failed to fetch')
+      expect(readPendingSubmission('cow-order', OWNER, 1)).toMatchObject({
+        phase: 'armed',
+        owner: OWNER,
+        chainId: 1,
+      })
+
+      // A retry must not create a second live order: the gate stops it before
+      // the executor or any wallet callback runs.
+      await expect(core.executePlan(dummyFlow)).rejects.toThrow(
+        'handed to the wallet but no transaction id came back',
+      )
+      expect(executeCowSwapTransactionPlan).toHaveBeenCalledTimes(1)
+      expect(wagmiMocks.sendTransactionAsync).not.toHaveBeenCalled()
+      expect(wagmiMocks.signTypedDataAsync).not.toHaveBeenCalled()
+    })
+
+    it('keeps the armed record after an ambiguous signature failure', async () => {
+      wagmiMocks.signTypedDataAsync.mockRejectedValue(new Error('connection lost'))
+      const executeCowSwapTransactionPlan = vi.fn(async ({ signTypedData }: ExecArgs) => {
+        await signTypedData(typedDataStub)
+        return successResult
+      })
+      sdkMocks.getEulerSdkFresh.mockResolvedValue(sdkFor(executeCowSwapTransactionPlan) as never)
+      const core = await setupCore()
+
+      await expect(core.executePlan(dummyFlow)).rejects.toThrow('connection lost')
+
+      // A dropped connection cannot prove the wallet produced no signature —
+      // the order may still be signable/submittable wallet-side.
+      expect(readPendingSubmission('cow-order', OWNER, 1)).toMatchObject({
+        phase: 'armed',
+        owner: OWNER,
+        chainId: 1,
+      })
+    })
+
+    it('releases the record on a proven wallet rejection and allows a fresh attempt', async () => {
+      wagmiMocks.signTypedDataAsync.mockRejectedValueOnce(
+        Object.assign(new Error('User rejected the request.'), { code: 4001 }),
+      )
+      const executeCowSwapTransactionPlan = vi.fn(async ({ signTypedData }: ExecArgs) => {
+        await signTypedData(typedDataStub)
+        return successResult
+      })
+      sdkMocks.getEulerSdkFresh.mockResolvedValue(sdkFor(executeCowSwapTransactionPlan) as never)
+      const core = await setupCore()
+
+      await expect(core.executePlan(dummyFlow)).rejects.toThrow('User rejected the request.')
+      expect(readPendingSubmission('cow-order', OWNER, 1)).toBeUndefined()
+
+      await expect(core.executePlan(dummyFlow)).resolves.toBe(ORDER_UID)
+      expect(executeCowSwapTransactionPlan).toHaveBeenCalledTimes(2)
+    })
+
+    it('preserves the order uid and throws when the submitted upgrade cannot be made durable', async () => {
+      const executeCowSwapTransactionPlan = vi.fn(async ({ onProgress }: ExecArgs) => {
+        onProgress({ status: 'submitOrder', orderUid: ORDER_UID })
+        return successResult
+      })
+      sdkMocks.getEulerSdkFresh.mockResolvedValue(sdkFor(executeCowSwapTransactionPlan) as never)
+      const core = await setupCore()
+
+      // Storage accepts the armed reservation but rejects the submitted
+      // rewrite — the order is live at that point, so the failure must
+      // surface instead of reading as success.
+      const working = globalThis.localStorage
+      vi.stubGlobal('localStorage', {
+        get length() {
+          return working.length
+        },
+        clear: () => working.clear(),
+        key: (index: number) => working.key(index),
+        getItem: (key: string) => working.getItem(key),
+        removeItem: (key: string) => working.removeItem(key),
+        setItem: (key: string, value: string) => {
+          if (value.includes('"phase":"submitted"')) throw new Error('quota exceeded')
+          working.setItem(key, value)
+        },
+      })
+      try {
+        await expect(core.executePlan(dummyFlow)).rejects.toThrow('could not durably record its id')
+      }
+      finally {
+        vi.stubGlobal('localStorage', working)
+      }
+
+      // The known uid was preserved in fail-closed durable form: the record
+      // is armed but carries the observed order id, so it can never be
+      // dismissed manually and resolves objectively via the orderbook.
+      expect(readPendingSubmission('cow-order', OWNER, 1)).toMatchObject({
+        phase: 'armed',
+        owner: OWNER,
+        chainId: 1,
+        observedId: { kind: 'cow-order', orderUid: ORDER_UID },
+      })
+    })
+  })
+
+  describe('pinned wallet callbacks', () => {
+    it('dispatches every approval and signature with the reviewed account, chain, and connector', async () => {
+      const executeCowSwapTransactionPlan = vi.fn(async ({ sendTransaction, signTypedData }: ExecArgs) => {
+        await sendTransaction({ to: APPROVAL_TARGET, data: '0xdead', value: 5n })
+        await signTypedData(typedDataStub)
+        return successResult
+      })
+      sdkMocks.getEulerSdkFresh.mockResolvedValue(sdkFor(executeCowSwapTransactionPlan) as never)
+      const core = await setupCore()
+
+      await expect(core.executePlan(dummyFlow)).resolves.toBe(ORDER_UID)
+
+      expect(wagmiMocks.sendTransactionAsync).toHaveBeenCalledWith({
+        account: OWNER,
+        chainId: 1,
+        connector: CONNECTOR,
+        to: APPROVAL_TARGET,
+        data: '0xdead',
+        value: 5n,
+      })
+      expect(wagmiMocks.signTypedDataAsync).toHaveBeenCalledWith(expect.objectContaining({
+        account: OWNER,
+        connector: CONNECTOR,
+        primaryType: 'Permit',
+      }))
+    })
+
+    it.each([
+      {
+        drift: 'account',
+        current: { address: OTHER_OWNER, chainId: 1, connector: CONNECTOR },
+        message: 'Wallet account changed during execution',
       },
-      executionService: { executeCowSwapTransactionPlan },
+      {
+        drift: 'chain',
+        current: { address: OWNER, chainId: 8453, connector: CONNECTOR },
+        message: 'Wallet network changed during execution',
+      },
+      {
+        drift: 'connector',
+        current: { address: OWNER, chainId: 1, connector: { id: 'io.metamask', uid: 'uid-2' } },
+        message: 'Wallet changed since review',
+      },
+    ])('refuses the next approval when the $drift changed during an SDK await', async ({ current, message }) => {
+      const executeCowSwapTransactionPlan = vi.fn(async ({ sendTransaction }: ExecArgs) => {
+        // The switch happens while the SDK awaits between callbacks — e.g. a
+        // same-address connector swap the account/chain checks cannot see.
+        wagmiMocks.getAccount.mockReturnValue(current)
+        await sendTransaction({ to: APPROVAL_TARGET, data: '0xdead' })
+        return successResult
+      })
+      sdkMocks.getEulerSdkFresh.mockResolvedValue(sdkFor(executeCowSwapTransactionPlan) as never)
+      const core = await setupCore()
+
+      await expect(core.executePlan(dummyFlow)).rejects.toThrow(message)
+
+      expect(wagmiMocks.sendTransactionAsync).not.toHaveBeenCalled()
+      expect(wagmiMocks.signTypedDataAsync).not.toHaveBeenCalled()
+      // The abort happened before anything reached the wallet, so no order
+      // artifact can exist and the reservation was released for the retry.
+      expect(readPendingSubmission('cow-order', OWNER, 1)).toBeUndefined()
     })
-    const core = await setupCore()
 
-    await expect(core.executePlan(dummyFlow)).rejects.toThrow(
-      'handed to the wallet but no transaction id came back',
-    )
+    it('refuses the order signature when the connector changed, without invoking the wallet', async () => {
+      const executeCowSwapTransactionPlan = vi.fn(async ({ signTypedData }: ExecArgs) => {
+        wagmiMocks.getAccount.mockReturnValue({
+          address: OWNER,
+          chainId: 1,
+          connector: { id: 'io.metamask', uid: 'uid-2' },
+        })
+        await signTypedData(typedDataStub)
+        return successResult
+      })
+      sdkMocks.getEulerSdkFresh.mockResolvedValue(sdkFor(executeCowSwapTransactionPlan) as never)
+      const core = await setupCore()
 
-    // Nothing crossed the wallet boundary: no approval transaction was sent
-    // and no order or permit signature was requested.
-    expect(executeCowSwapTransactionPlan).not.toHaveBeenCalled()
-    expect(wagmiMocks.sendTransactionAsync).not.toHaveBeenCalled()
-    expect(wagmiMocks.signTypedDataAsync).not.toHaveBeenCalled()
-    expect(readPendingSubmission('batch', OWNER, 1)).toBeDefined()
+      await expect(core.executePlan(dummyFlow)).rejects.toThrow('Wallet changed since review')
+
+      // The pin check throws before the signing request is built: no
+      // signature was requested, so no artifact is possible and the
+      // reservation was released.
+      expect(wagmiMocks.signTypedDataAsync).not.toHaveBeenCalled()
+      expect(readPendingSubmission('cow-order', OWNER, 1)).toBeUndefined()
+    })
+
+    it('refuses to start the ceremony when no connector is available at entry', async () => {
+      wagmiMocks.getAccount.mockReturnValue({ address: OWNER, chainId: 1, connector: undefined })
+      const executeCowSwapTransactionPlan = vi.fn()
+      sdkMocks.getEulerSdkFresh.mockResolvedValue(sdkFor(executeCowSwapTransactionPlan) as never)
+      const core = await setupCore()
+
+      await expect(core.executePlan(dummyFlow)).rejects.toThrow('Wallet changed since review')
+
+      expect(executeCowSwapTransactionPlan).not.toHaveBeenCalled()
+      expect(readPendingSubmission('cow-order', OWNER, 1)).toBeUndefined()
+    })
   })
 })

--- a/tests/composables/useEulerTx.test.ts
+++ b/tests/composables/useEulerTx.test.ts
@@ -4,7 +4,7 @@ import type { MigrationAuthorizationRequest, TransactionPlan, TransactionPlanPre
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { getAccount } from '@wagmi/vue/actions'
 import { getEulerSdkForChain, getEulerSdkFresh } from '~/composables/useEulerSdk'
-import { useEulerTx, type PreparedPlanBroadcast } from '~/composables/useEulerTx'
+import { useEulerTx, type PreparedPlanBroadcast, type ReviewedTransactionPlanPrepared } from '~/composables/useEulerTx'
 import { createDirectSubmissionQuarantine } from '~/utils/directSubmissionQuarantine'
 import type { MigrationAuthorizationRevoke } from '~/utils/migrationAuthorizationTxs'
 import { registerLandedBatchSubmissionHandler } from '~/utils/pendingSubmissionGate'
@@ -278,6 +278,113 @@ describe('useEulerTx migration authorization cleanup', () => {
     expect(wagmiMocks.signTypedDataAsync).toHaveBeenCalledWith(
       expect.objectContaining({ connector: reviewedConnector }),
     )
+  })
+
+  it('stamps prepared envelopes with the reviewed connector session and wallet classification', async () => {
+    const reviewedConnector = { id: 'io.metamask', uid: 'uid-1', name: 'MetaMask' }
+    vi.mocked(getAccount).mockImplementation(() => ({
+      address: currentAccount,
+      chainId: currentChainId,
+      connector: reviewedConnector,
+    }) as never)
+    const prepare = vi.fn().mockResolvedValue({ __prepared: true, plan: [] })
+    vi.mocked(getEulerSdkForChain).mockResolvedValue({
+      executionService: { prepareTransactionPlan: prepare },
+    } as never)
+    const { prepareTransactionPlan } = useEulerTx()
+
+    const prepared = await prepareTransactionPlan(
+      [] as TransactionPlan, { usePermit2: false },
+    ) as ReviewedTransactionPlanPrepared
+
+    // The uid distinguishes connector sessions, so a same-address reconnect
+    // through the same wallet extension still invalidates the review.
+    expect(prepared.reviewedWalletContext).toEqual({
+      connectorKey: 'io.metamask:uid-1',
+      isSafeWallet: false,
+    })
+  })
+
+  it('refuses a reviewed envelope when a different connector session is live at execution', async () => {
+    const reconnectedConnector = { id: 'io.metamask', uid: 'uid-2', name: 'MetaMask' }
+    vi.mocked(getAccount).mockImplementation(() => ({
+      address: currentAccount,
+      chainId: currentChainId,
+      connector: reconnectedConnector,
+    }) as never)
+    const executePreparedTransactionPlan = vi.fn()
+    vi.mocked(getEulerSdkFresh).mockResolvedValue({
+      providerService: { getProvider: vi.fn(() => ({ waitForTransactionReceipt: vi.fn() })) },
+      executionService: { executePreparedTransactionPlan },
+    } as never)
+    const { executePreparedPlan } = useEulerTx()
+    const prepared = {
+      __prepared: true,
+      plan: [],
+      chainId: 1,
+      account: OWNER,
+      usePermit2: false,
+      unlimitedApproval: false,
+      reviewedWalletContext: { connectorKey: 'io.metamask:uid-1', isSafeWallet: false },
+    } as ReviewedTransactionPlanPrepared
+
+    await expect(executePreparedPlan(prepared)).rejects.toThrow('Wallet changed since review')
+    expect(executePreparedTransactionPlan).not.toHaveBeenCalled()
+    expect(wagmiMocks.sendTransactionAsync).not.toHaveBeenCalled()
+    // The refusal fires before the executor arms its own quarantine.
+    expect(readPendingSubmission('direct', OWNER, 1)).toBeUndefined()
+  })
+
+  it('refuses a bound envelope whose review captured no connector', async () => {
+    const executePreparedTransactionPlan = vi.fn()
+    vi.mocked(getEulerSdkFresh).mockResolvedValue({
+      providerService: { getProvider: vi.fn(() => ({ waitForTransactionReceipt: vi.fn() })) },
+      executionService: { executePreparedTransactionPlan },
+    } as never)
+    const { executePreparedPlan } = useEulerTx()
+    const prepared = {
+      __prepared: true,
+      plan: [],
+      chainId: 1,
+      account: OWNER,
+      usePermit2: false,
+      unlimitedApproval: false,
+      // Review-time connector was missing: continuity is unprovable, so the
+      // binding must fail closed instead of matching "undefined === undefined".
+      reviewedWalletContext: { connectorKey: undefined, isSafeWallet: false },
+    } as ReviewedTransactionPlanPrepared
+
+    await expect(executePreparedPlan(prepared)).rejects.toThrow('Wallet changed since review')
+    expect(executePreparedTransactionPlan).not.toHaveBeenCalled()
+    expect(wagmiMocks.sendTransactionAsync).not.toHaveBeenCalled()
+  })
+
+  it('executes a bound envelope when the live connector session matches the review', async () => {
+    const reviewedConnector = { id: 'io.metamask', uid: 'uid-1', name: 'MetaMask' }
+    vi.mocked(getAccount).mockImplementation(() => ({
+      address: currentAccount,
+      chainId: currentChainId,
+      connector: reviewedConnector,
+    }) as never)
+    const executePreparedTransactionPlan = vi.fn(async () => ({ receipts: [] }))
+    vi.mocked(getEulerSdkFresh).mockResolvedValue({
+      providerService: { getProvider: vi.fn(() => ({ waitForTransactionReceipt: vi.fn() })) },
+      executionService: { executePreparedTransactionPlan },
+    } as never)
+    const { executePreparedPlan } = useEulerTx()
+    const prepared = {
+      __prepared: true,
+      plan: [],
+      chainId: 1,
+      account: OWNER,
+      usePermit2: false,
+      unlimitedApproval: false,
+      reviewedWalletContext: { connectorKey: 'io.metamask:uid-1', isSafeWallet: false },
+    } as ReviewedTransactionPlanPrepared
+
+    await executePreparedPlan(prepared)
+
+    expect(executePreparedTransactionPlan).toHaveBeenCalledTimes(1)
   })
 
   it('classifies ordered broadcasts so only the last submission stays unconfirmed on failure', async () => {
@@ -1223,6 +1330,52 @@ describe('useEulerTx Safe wallet bundling', () => {
     expect(result.hashes).toEqual([SAFE_TX_HASH])
   })
 
+  it('refuses to repair an envelope reviewed on an EOA into a Safe ceremony', async () => {
+    const permitPrepared = {
+      ...buildPrepared([
+        {
+          ...approvedPlan[0],
+          resolved: [{ type: 'permit2', token: TOKEN, amount: 100n, owner: OWNER, spender: SWAP_VERIFIER }],
+        },
+        approvedPlan[1],
+      ] as unknown as TransactionPlan),
+      // The user confirmed a permit2 signature ceremony on an EOA session;
+      // the wallet is now a Safe. Reclassification is a stale review, not a
+      // repairable envelope.
+      reviewedWalletContext: { connectorKey: 'io.metamask:uid-1', isSafeWallet: false },
+    } as ReviewedTransactionPlanPrepared
+    const resolveRequiredApprovals = vi.fn(async () => approvedPlan)
+    vi.mocked(getEulerSdkFresh).mockResolvedValue({
+      providerService: { getProvider: vi.fn(() => ({ getTransactionReceipt: vi.fn() })) },
+      deploymentService: { getDeployment: vi.fn(() => ({ addresses: { coreAddrs: { evc: EVC } } })) },
+      executionService: {
+        encodeBatch: vi.fn(() => BATCH_DATA),
+        resolveRequiredApprovals,
+        executePreparedTransactionPlan,
+      },
+    } as never)
+    const { executePreparedPlan } = useEulerTx()
+
+    await expect(executePreparedPlan(permitPrepared)).rejects.toThrow('Wallet changed since review')
+    expect(resolveRequiredApprovals).not.toHaveBeenCalled()
+    expect(wagmiMocks.sendCalls).not.toHaveBeenCalled()
+    expect(wagmiMocks.signTypedDataAsync).not.toHaveBeenCalled()
+    expect(executePreparedTransactionPlan).not.toHaveBeenCalled()
+  })
+
+  it('executes a bound envelope reviewed on this Safe connector session', async () => {
+    const prepared = {
+      ...buildPrepared(approvedPlan),
+      reviewedWalletContext: { connectorKey: 'safe:undefined', isSafeWallet: true },
+    } as ReviewedTransactionPlanPrepared
+    const { executePreparedPlan } = useEulerTx()
+
+    const result = await executePreparedPlan(prepared)
+
+    expect(wagmiMocks.sendCalls).toHaveBeenCalledTimes(1)
+    expect(result.hashes).toEqual([SAFE_TX_HASH])
+  })
+
   it('normalizes the envelope in degraded mode when the Safe provider is unavailable', async () => {
     // Connector identifies as Safe, but getProvider() rejects — no bundle
     // and no status polling are possible, yet permit2 must stay off.
@@ -1368,6 +1521,21 @@ describe('useEulerTx Safe wallet bundling', () => {
     })).rejects.toThrow('handed to the wallet but no transaction id came back')
     expect(wagmiMocks.sendCalls).not.toHaveBeenCalled()
     expect(readPendingSubmission('batch', OWNER, 1)).toBeDefined()
+  })
+
+  it('refuses the plain-calls bundle when the envelope was reviewed on a different wallet', async () => {
+    const prepared = {
+      ...buildPrepared(approvedPlan),
+      reviewedWalletContext: { connectorKey: 'io.metamask:uid-1', isSafeWallet: false },
+    } as ReviewedTransactionPlanPrepared
+    const { executePreparedPlanWithPlainCalls } = useEulerTx()
+
+    await expect(executePreparedPlanWithPlainCalls(prepared, {
+      before: [GRANT_CALL],
+      after: [REVOKE_CALL],
+    })).rejects.toThrow('Wallet changed since review')
+    expect(wagmiMocks.sendCalls).not.toHaveBeenCalled()
+    expect(executePreparedTransactionPlan).not.toHaveBeenCalled()
   })
 
   it('runs the caller freshness guard after Safe provider setup and before submission', async () => {

--- a/tests/composables/useEulerTx.test.ts
+++ b/tests/composables/useEulerTx.test.ts
@@ -5,7 +5,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { getAccount } from '@wagmi/vue/actions'
 import { getEulerSdkForChain, getEulerSdkFresh } from '~/composables/useEulerSdk'
 import { useEulerTx, type PreparedPlanBroadcast } from '~/composables/useEulerTx'
+import { createDirectSubmissionQuarantine } from '~/utils/directSubmissionQuarantine'
 import type { MigrationAuthorizationRevoke } from '~/utils/migrationAuthorizationTxs'
+import { registerLandedBatchSubmissionHandler } from '~/utils/pendingSubmissionGate'
+import { readPendingSubmission, resetPendingSubmissionMemoryFallback, writePendingSubmission } from '~/utils/pendingSubmissions'
 import { WalletExecutionContextChangedError } from '~/utils/walletExecutionContext'
 
 const wagmiMocks = vi.hoisted(() => ({
@@ -105,10 +108,15 @@ describe('useEulerTx migration authorization cleanup', () => {
         transactionHash: hash,
         status: 'success',
       }) as TransactionReceipt),
+      getTransactionReceipt: vi.fn(async () => {
+        throw new Error('receipt not found')
+      }),
     }
     vi.mocked(getEulerSdkFresh).mockResolvedValue({
       providerService: { getProvider: vi.fn(() => provider) },
     } as never)
+    // The pending-submission quarantine is module state shared across tests.
+    resetPendingSubmissionMemoryFallback()
   })
 
   it.each([
@@ -310,11 +318,230 @@ describe('useEulerTx migration authorization cleanup', () => {
 
     // The confirmed approval is retryable history; only the accepted-but-
     // unconfirmed value-moving batch is left ambiguous for quarantine.
+    // Every send arms replay protection before crossing the wallet boundary.
     expect(broadcasts).toEqual([
+      expect.objectContaining({ item: 'approval', index: 0, completesPlan: false, status: 'armed' }),
       expect.objectContaining({ kind: 'transaction', item: 'approval', index: 0, completesPlan: false, status: 'submitted' }),
       expect.objectContaining({ item: 'approval', index: 0, status: 'confirmed' }),
+      expect.objectContaining({ item: 'evcBatch', index: 1, completesPlan: true, status: 'armed' }),
       expect.objectContaining({ kind: 'transaction', item: 'evcBatch', index: 1, completesPlan: true, status: 'submitted' }),
     ])
+  })
+
+  it('fires only an armed broadcast when the wallet fails without disproving acceptance', async () => {
+    const evcBatchItem = { type: 'evcBatch', items: [] }
+    const plan = [evcBatchItem] as unknown as TransactionPlan
+    wagmiMocks.sendTransactionAsync.mockRejectedValue(new Error('wallet connection dropped mid-request'))
+    const executePreparedTransactionPlan = vi.fn(async ({ sendTransaction, onProgress }: {
+      sendTransaction: (tx: { to: Address, data: Hex }) => Promise<Hash>
+      onProgress: (progress: { status: string, item?: unknown }) => void
+    }) => {
+      onProgress({ status: 'evcBatch', item: evcBatchItem })
+      await sendTransaction({ to: TOKEN, data: '0x02' })
+    })
+    vi.mocked(getEulerSdkFresh).mockResolvedValue({
+      providerService: { getProvider: vi.fn(() => ({
+        waitForTransactionReceipt: vi.fn(),
+        getTransactionReceipt: vi.fn(async () => {
+          throw new Error('receipt not found')
+        }),
+      })) },
+      executionService: { executePreparedTransactionPlan },
+    } as never)
+    const quarantine = createDirectSubmissionQuarantine({
+      flow: 'outgoing-migration',
+      getSafeWalletProvider: async () => undefined,
+    })
+    quarantine.begin({ owner: OWNER, chainId: 1 })
+    const { executePreparedPlan } = useEulerTx()
+    const broadcasts: PreparedPlanBroadcast[] = []
+    const prepared = {
+      __prepared: true,
+      plan,
+      chainId: 1,
+      account: OWNER,
+      usePermit2: false,
+      unlimitedApproval: false,
+    } as TransactionPlanPrepared
+
+    await expect(executePreparedPlan(prepared, {
+      onBroadcast: (b) => {
+        broadcasts.push(b)
+        quarantine.track(b)
+      },
+    })).rejects.toThrow('wallet connection dropped mid-request')
+
+    // No id ever reached onBroadcast and the failure does not prove the
+    // wallet rejected the request, so the armed reservation must stand.
+    expect(broadcasts).toEqual([
+      expect.objectContaining({ item: 'evcBatch', index: 0, completesPlan: true, status: 'armed' }),
+    ])
+    expect(readPendingSubmission('outgoing-migration', OWNER, 1)).toMatchObject({ phase: 'armed' })
+
+    // A retry — including one from a fresh session after a reload — is
+    // blocked at the executor gate before the wallet is invoked again.
+    wagmiMocks.sendTransactionAsync.mockClear()
+    await expect(executePreparedPlan(prepared)).rejects.toThrow(
+      'handed to the wallet but no transaction id came back',
+    )
+    expect(wagmiMocks.sendTransactionAsync).not.toHaveBeenCalled()
+    expect(executePreparedTransactionPlan).toHaveBeenCalledTimes(1)
+  })
+
+  it('releases the armed reservation when the wallet provably rejected the request', async () => {
+    const evcBatchItem = { type: 'evcBatch', items: [] }
+    const plan = [evcBatchItem] as unknown as TransactionPlan
+    wagmiMocks.sendTransactionAsync.mockRejectedValue(
+      Object.assign(new Error('User rejected the request.'), { code: 4001 }),
+    )
+    const executePreparedTransactionPlan = vi.fn(async ({ sendTransaction, onProgress }: {
+      sendTransaction: (tx: { to: Address, data: Hex }) => Promise<Hash>
+      onProgress: (progress: { status: string, item?: unknown }) => void
+    }) => {
+      onProgress({ status: 'evcBatch', item: evcBatchItem })
+      await sendTransaction({ to: TOKEN, data: '0x02' })
+    })
+    vi.mocked(getEulerSdkFresh).mockResolvedValue({
+      providerService: { getProvider: vi.fn(() => ({ waitForTransactionReceipt: vi.fn() })) },
+      executionService: { executePreparedTransactionPlan },
+    } as never)
+    const quarantine = createDirectSubmissionQuarantine({
+      flow: 'outgoing-migration',
+      getSafeWalletProvider: async () => undefined,
+    })
+    quarantine.begin({ owner: OWNER, chainId: 1 })
+    const { executePreparedPlan } = useEulerTx()
+    const broadcasts: PreparedPlanBroadcast[] = []
+    const prepared = {
+      __prepared: true,
+      plan,
+      chainId: 1,
+      account: OWNER,
+      usePermit2: false,
+      unlimitedApproval: false,
+    } as TransactionPlanPrepared
+
+    await expect(executePreparedPlan(prepared, {
+      onBroadcast: (b) => {
+        broadcasts.push(b)
+        quarantine.track(b)
+      },
+    })).rejects.toThrow('User rejected the request.')
+
+    expect(broadcasts).toEqual([
+      expect.objectContaining({ item: 'evcBatch', index: 0, status: 'armed' }),
+      expect.objectContaining({ item: 'evcBatch', index: 0, status: 'rejected' }),
+    ])
+    expect(readPendingSubmission('outgoing-migration', OWNER, 1)).toBeUndefined()
+
+    // With the reservation released, a retry reaches the wallet again.
+    await expect(executePreparedPlan(prepared, {
+      onBroadcast: b => quarantine.track(b),
+    })).rejects.toThrow('User rejected the request.')
+    expect(wagmiMocks.sendTransactionAsync).toHaveBeenCalledTimes(2)
+  })
+
+  it('blocks a direct plan while an ambiguous batch submission from this wallet is unresolved', async () => {
+    writePendingSubmission('batch', {
+      phase: 'armed',
+      chainId: 1,
+      owner: OWNER,
+      completesPlan: true,
+      submittedAt: 1_000,
+    })
+    const executePreparedTransactionPlan = vi.fn()
+    vi.mocked(getEulerSdkFresh).mockResolvedValue({
+      providerService: { getProvider: vi.fn(() => ({
+        waitForTransactionReceipt: vi.fn(),
+        getTransactionReceipt: vi.fn(async () => {
+          throw new Error('receipt not found')
+        }),
+      })) },
+      executionService: { executePreparedTransactionPlan },
+    } as never)
+    const { executePreparedPlan } = useEulerTx()
+
+    await expect(executePreparedPlan({
+      __prepared: true,
+      plan: [],
+      chainId: 1,
+      account: OWNER,
+      usePermit2: false,
+      unlimitedApproval: false,
+    } as TransactionPlanPrepared)).rejects.toThrow(
+      'A previous batch submission was handed to the wallet but no transaction id came back',
+    )
+    expect(executePreparedTransactionPlan).not.toHaveBeenCalled()
+    expect(wagmiMocks.sendTransactionAsync).not.toHaveBeenCalled()
+    // The record must survive the refusal so the conflict stays enforced.
+    expect(readPendingSubmission('batch', OWNER, 1)).toBeDefined()
+  })
+
+  it('blocks a direct plan while a submitted batch record cannot be verified on-chain', async () => {
+    writePendingSubmission('batch', {
+      phase: 'submitted',
+      kind: 'transaction',
+      hash: GRANT_HASH,
+      chainId: 1,
+      owner: OWNER,
+      completesPlan: true,
+      submittedAt: 1_000,
+    })
+    const executePreparedTransactionPlan = vi.fn()
+    vi.mocked(getEulerSdkFresh).mockResolvedValue({
+      providerService: { getProvider: vi.fn(() => ({
+        waitForTransactionReceipt: vi.fn(),
+        getTransactionReceipt: vi.fn(async () => {
+          throw new Error('receipt not found')
+        }),
+      })) },
+      executionService: { executePreparedTransactionPlan },
+    } as never)
+    const { executePreparedPlan } = useEulerTx()
+
+    await expect(executePreparedPlan({
+      __prepared: true,
+      plan: [],
+      chainId: 1,
+      account: OWNER,
+      usePermit2: false,
+      unlimitedApproval: false,
+    } as TransactionPlanPrepared)).rejects.toThrow('could not be verified yet')
+    expect(executePreparedTransactionPlan).not.toHaveBeenCalled()
+    expect(readPendingSubmission('batch', OWNER, 1)).toBeDefined()
+  })
+
+  it('does not block a direct plan over another wallet\'s pending submission', async () => {
+    writePendingSubmission('batch', {
+      phase: 'armed',
+      chainId: 1,
+      owner: OTHER_OWNER,
+      completesPlan: true,
+      submittedAt: 1_000,
+    })
+    const executePreparedTransactionPlan = vi.fn(async () => ({ receipts: [] }))
+    vi.mocked(getEulerSdkFresh).mockResolvedValue({
+      providerService: { getProvider: vi.fn(() => ({
+        waitForTransactionReceipt: vi.fn(),
+        getTransactionReceipt: vi.fn(async () => {
+          throw new Error('receipt not found')
+        }),
+      })) },
+      executionService: { executePreparedTransactionPlan },
+    } as never)
+    const { executePreparedPlan } = useEulerTx()
+
+    await executePreparedPlan({
+      __prepared: true,
+      plan: [],
+      chainId: 1,
+      account: OWNER,
+      usePermit2: false,
+      unlimitedApproval: false,
+    } as TransactionPlanPrepared)
+
+    expect(executePreparedTransactionPlan).toHaveBeenCalledTimes(1)
+    expect(readPendingSubmission('batch', OTHER_OWNER, 1)).toBeDefined()
   })
 
   it('runs the caller freshness guard after async setup and before a plain broadcast', async () => {
@@ -480,6 +707,8 @@ describe('useEulerTx Safe wallet bundling', () => {
         executePreparedTransactionPlan,
       },
     } as never)
+    // The pending-submission quarantine is module state shared across tests.
+    resetPendingSubmissionMemoryFallback()
   })
 
   it('submits approve + EVC batch as one Safe call bundle', async () => {
@@ -516,6 +745,8 @@ describe('useEulerTx Safe wallet bundling', () => {
     })
 
     expect(broadcasts).toEqual([
+      // Replay protection arms before the bundle crosses the wallet boundary.
+      expect.objectContaining({ item: 'bundle', index: 0, completesPlan: true, status: 'armed' }),
       expect.objectContaining({ kind: 'proposal', hash: SAFE_TX_HASH, item: 'bundle', completesPlan: true, status: 'submitted' }),
       expect.objectContaining({ kind: 'proposal', hash: SAFE_TX_HASH, item: 'bundle', status: 'confirmed' }),
     ])
@@ -586,6 +817,133 @@ describe('useEulerTx Safe wallet bundling', () => {
 
     await expect(executePreparedPlan(buildPrepared(approvedPlan)))
       .rejects.toThrow('unexpected call bundle id')
+  })
+
+  it('keeps the armed reservation when the Safe returns a malformed bundle id', async () => {
+    wagmiMocks.sendCalls.mockResolvedValue({ id: 'bundle-1' })
+    const quarantine = createDirectSubmissionQuarantine({
+      flow: 'outgoing-migration',
+      getSafeWalletProvider: async () => undefined,
+    })
+    quarantine.begin({ owner: OWNER, chainId: 1 })
+    const { executePreparedPlan } = useEulerTx()
+    const broadcasts: PreparedPlanBroadcast[] = []
+
+    await expect(executePreparedPlan(buildPrepared(approvedPlan), {
+      onBroadcast: (b) => {
+        broadcasts.push(b)
+        quarantine.track(b)
+      },
+    })).rejects.toThrow('unexpected call bundle id')
+
+    // The wallet DID respond, so acceptance cannot be ruled out: only the
+    // armed event fires (no 'rejected') and the durable reservation stands.
+    expect(broadcasts).toEqual([
+      expect.objectContaining({ item: 'bundle', index: 0, completesPlan: true, status: 'armed' }),
+    ])
+    expect(readPendingSubmission('outgoing-migration', OWNER, 1)).toMatchObject({ phase: 'armed' })
+
+    // A retry — including from a fresh session after a reload — is blocked
+    // at the executor gate before the wallet is invoked again.
+    wagmiMocks.sendCalls.mockClear()
+    await expect(executePreparedPlan(buildPrepared(approvedPlan))).rejects.toThrow(
+      'handed to the wallet but no transaction id came back',
+    )
+    expect(wagmiMocks.sendCalls).not.toHaveBeenCalled()
+  })
+
+  it('releases the armed bundle when the Safe wallet provably rejected it', async () => {
+    wagmiMocks.sendCalls.mockRejectedValue(
+      Object.assign(new Error('User rejected the request.'), { name: 'UserRejectedRequestError' }),
+    )
+    const quarantine = createDirectSubmissionQuarantine({
+      flow: 'outgoing-migration',
+      getSafeWalletProvider: async () => undefined,
+    })
+    quarantine.begin({ owner: OWNER, chainId: 1 })
+    const { executePreparedPlan } = useEulerTx()
+    const broadcasts: PreparedPlanBroadcast[] = []
+
+    await expect(executePreparedPlan(buildPrepared(approvedPlan), {
+      onBroadcast: (b) => {
+        broadcasts.push(b)
+        quarantine.track(b)
+      },
+    })).rejects.toThrow('User rejected the request.')
+
+    expect(broadcasts).toEqual([
+      expect.objectContaining({ item: 'bundle', index: 0, status: 'armed' }),
+      expect.objectContaining({ item: 'bundle', index: 0, status: 'rejected' }),
+    ])
+    expect(readPendingSubmission('outgoing-migration', OWNER, 1)).toBeUndefined()
+
+    // With the reservation released, a retry reaches the wallet again.
+    await expect(executePreparedPlan(buildPrepared(approvedPlan), {
+      onBroadcast: b => quarantine.track(b),
+    })).rejects.toThrow('User rejected the request.')
+    expect(wagmiMocks.sendCalls).toHaveBeenCalledTimes(2)
+  })
+
+  it('blocks a Safe bundle while a landed batch record awaits cart reconciliation', async () => {
+    // No cart handler is registered yet: the record must be kept so the cart
+    // can reconcile it when it next runs.
+    writePendingSubmission('batch', {
+      phase: 'submitted',
+      kind: 'transaction',
+      hash: SAFE_TX_HASH,
+      chainId: 1,
+      owner: OWNER,
+      completesPlan: true,
+      submittedAt: 1_000,
+    })
+    const { executePreparedPlan } = useEulerTx()
+
+    await expect(executePreparedPlan(buildPrepared(approvedPlan))).rejects.toThrow(
+      'Open the batch cart to reconcile',
+    )
+    expect(wagmiMocks.sendCalls).not.toHaveBeenCalled()
+    expect(readPendingSubmission('batch', OWNER, 1)).toBeDefined()
+  })
+
+  it('retires a landed batch record through the registered cart handler before executing', async () => {
+    const handler = vi.fn()
+    registerLandedBatchSubmissionHandler(handler)
+    writePendingSubmission('batch', {
+      phase: 'submitted',
+      kind: 'transaction',
+      hash: SAFE_TX_HASH,
+      chainId: 1,
+      owner: OWNER,
+      completesPlan: true,
+      submittedAt: 1_000,
+    })
+    const { executePreparedPlan } = useEulerTx()
+
+    await expect(executePreparedPlan(buildPrepared(approvedPlan))).rejects.toThrow(
+      'the batch cart was reconciled',
+    )
+    expect(handler).toHaveBeenCalledWith(expect.objectContaining({ hash: SAFE_TX_HASH }))
+    expect(wagmiMocks.sendCalls).not.toHaveBeenCalled()
+  })
+
+  it('clears a landed migration record and demands re-review before executing', async () => {
+    writePendingSubmission('outgoing-migration', {
+      phase: 'submitted',
+      kind: 'transaction',
+      hash: SAFE_TX_HASH,
+      chainId: 1,
+      owner: OWNER,
+      completesPlan: true,
+      submittedAt: 1_000,
+    })
+    const { executePreparedPlan } = useEulerTx()
+
+    await expect(executePreparedPlan(buildPrepared(approvedPlan))).rejects.toThrow(
+      'confirmed on-chain. Review your positions',
+    )
+    expect(wagmiMocks.sendCalls).not.toHaveBeenCalled()
+    // Landed migrations are terminal: the record is released after refusal.
+    expect(readPendingSubmission('outgoing-migration', OWNER, 1)).toBeUndefined()
   })
 
   it('throws on a mined-but-reverted Safe bundle instead of finalizing it', async () => {
@@ -776,6 +1134,24 @@ describe('useEulerTx Safe wallet bundling', () => {
     expect(result?.hashes).toEqual([SAFE_TX_HASH])
     expect(result?.receipts[0].transactionHash).toBe(SAFE_TX_HASH)
     expect(executePreparedTransactionPlan).not.toHaveBeenCalled()
+  })
+
+  it('gates the plain-calls bundle on a conflicting pending submission', async () => {
+    writePendingSubmission('batch', {
+      phase: 'armed',
+      chainId: 1,
+      owner: OWNER,
+      completesPlan: true,
+      submittedAt: 1_000,
+    })
+    const { executePreparedPlanWithPlainCalls } = useEulerTx()
+
+    await expect(executePreparedPlanWithPlainCalls(buildPrepared(approvedPlan), {
+      before: [GRANT_CALL],
+      after: [REVOKE_CALL],
+    })).rejects.toThrow('handed to the wallet but no transaction id came back')
+    expect(wagmiMocks.sendCalls).not.toHaveBeenCalled()
+    expect(readPendingSubmission('batch', OWNER, 1)).toBeDefined()
   })
 
   it('runs the caller freshness guard after Safe provider setup and before submission', async () => {

--- a/tests/composables/useEulerTx.test.ts
+++ b/tests/composables/useEulerTx.test.ts
@@ -185,6 +185,31 @@ describe('useEulerTx migration authorization cleanup', () => {
     expect(wagmiMocks.sendTransactionAsync).not.toHaveBeenCalled()
   })
 
+  it('runs the caller freshness guard after async setup and before a plain broadcast', async () => {
+    const provider = {
+      waitForTransactionReceipt: vi.fn(),
+    }
+    let resolveSdk!: (sdk: unknown) => void
+    const sdkPromise = new Promise<unknown>((resolve) => {
+      resolveSdk = resolve
+    })
+    vi.mocked(getEulerSdkFresh).mockReturnValue(sdkPromise as never)
+    let current = true
+    const { sendPlainTransactions } = useEulerTx()
+    const execution = sendPlainTransactions([{ to: TOKEN, data: '0x1234' }], {
+      beforeBroadcast: () => {
+        if (!current) throw new Error('review became stale')
+      },
+    })
+    await vi.waitFor(() => expect(getEulerSdkFresh).toHaveBeenCalledTimes(1))
+
+    current = false
+    resolveSdk({ providerService: { getProvider: vi.fn(() => provider) } })
+
+    await expect(execution).rejects.toThrow('review became stale')
+    expect(wagmiMocks.sendTransactionAsync).not.toHaveBeenCalled()
+  })
+
   it.each([
     ['account', () => { currentAccount = OTHER_OWNER }],
     ['chain', () => { currentChainId = 8453 }],
@@ -582,9 +607,8 @@ describe('useEulerTx Safe wallet bundling', () => {
 
   it('wraps the plan with plain calls inside one Safe bundle in order', async () => {
     const { executePreparedPlanWithPlainCalls } = useEulerTx()
-    const batchOnly = [approvedPlan[1]] as TransactionPlan
 
-    const result = await executePreparedPlanWithPlainCalls(buildPrepared(batchOnly), {
+    const result = await executePreparedPlanWithPlainCalls(buildPrepared(approvedPlan), {
       before: [GRANT_CALL],
       after: [REVOKE_CALL],
     })
@@ -598,6 +622,7 @@ describe('useEulerTx Safe wallet bundling', () => {
       calls: [
         // Grants before the batch, revocations after — one atomic proposal.
         { to: TOKEN, data: '0x11ff', value: 0n },
+        { to: TOKEN, data: APPROVE_DATA, value: 0n },
         { to: EVC, data: BATCH_DATA, value: 0n },
         { to: TOKEN, data: '0x22ff', value: 0n },
       ],
@@ -605,6 +630,42 @@ describe('useEulerTx Safe wallet bundling', () => {
     expect(result?.hashes).toEqual([SAFE_TX_HASH])
     expect(result?.receipts[0].transactionHash).toBe(SAFE_TX_HASH)
     expect(executePreparedTransactionPlan).not.toHaveBeenCalled()
+  })
+
+  it('runs the caller freshness guard after Safe provider setup and before submission', async () => {
+    let resolveSafeProvider!: (provider: { request: ReturnType<typeof vi.fn> }) => void
+    const safeProviderPromise = new Promise<{ request: ReturnType<typeof vi.fn> }>((resolve) => {
+      resolveSafeProvider = resolve
+    })
+    const deferredSafeConnector = {
+      id: 'safe',
+      name: 'Safe',
+      getProvider: vi.fn(() => safeProviderPromise),
+    }
+    vi.mocked(getAccount).mockImplementation(() => ({
+      address: currentAccount,
+      chainId: currentChainId,
+      connector: deferredSafeConnector,
+    }) as never)
+    let current = true
+    const { executePreparedPlanWithPlainCalls } = useEulerTx()
+    const execution = executePreparedPlanWithPlainCalls(
+      buildPrepared([approvedPlan[1]] as TransactionPlan),
+      { before: [GRANT_CALL], after: [REVOKE_CALL] },
+      {
+        allowSingleCall: true,
+        beforeBroadcast: () => {
+          if (!current) throw new Error('review became stale')
+        },
+      },
+    )
+    await vi.waitFor(() => expect(deferredSafeConnector.getProvider).toHaveBeenCalledTimes(1))
+
+    current = false
+    resolveSafeProvider({ request: vi.fn() })
+
+    await expect(execution).rejects.toThrow('review became stale')
+    expect(wagmiMocks.sendCalls).not.toHaveBeenCalled()
   })
 
   it('rejects wrapper calls around a plan that encodes no calls', async () => {

--- a/tests/composables/useEulerTx.test.ts
+++ b/tests/composables/useEulerTx.test.ts
@@ -313,7 +313,7 @@ describe('useEulerTx migration authorization cleanup', () => {
       usePermit2: false,
       unlimitedApproval: false,
     } as TransactionPlanPrepared, {
-      onBroadcast: b => broadcasts.push(b),
+      onBroadcast: (b) => { broadcasts.push(b) },
     })).rejects.toThrow('Receipt polling failed.')
 
     // The confirmed approval is retryable history; only the accepted-but-
@@ -439,6 +439,168 @@ describe('useEulerTx migration authorization cleanup', () => {
       onBroadcast: b => quarantine.track(b),
     })).rejects.toThrow('User rejected the request.')
     expect(wagmiMocks.sendTransactionAsync).toHaveBeenCalledTimes(2)
+  })
+
+  it('quarantines a callback-less ambiguous submission under the shared direct flow', async () => {
+    const evcBatchItem = { type: 'evcBatch', items: [] }
+    const plan = [evcBatchItem] as unknown as TransactionPlan
+    wagmiMocks.sendTransactionAsync.mockRejectedValue(new Error('wallet connection dropped mid-request'))
+    const executePreparedTransactionPlan = vi.fn(async ({ sendTransaction, onProgress }: {
+      sendTransaction: (tx: { to: Address, data: Hex }) => Promise<Hash>
+      onProgress: (progress: { status: string, item?: unknown }) => void
+    }) => {
+      onProgress({ status: 'evcBatch', item: evcBatchItem })
+      await sendTransaction({ to: TOKEN, data: '0x02' })
+    })
+    vi.mocked(getEulerSdkFresh).mockResolvedValue({
+      providerService: { getProvider: vi.fn(() => ({
+        waitForTransactionReceipt: vi.fn(),
+        getTransactionReceipt: vi.fn(async () => {
+          throw new Error('receipt not found')
+        }),
+      })) },
+      executionService: { executePreparedTransactionPlan },
+    } as never)
+    const { executePreparedPlan } = useEulerTx()
+    const prepared = {
+      __prepared: true,
+      plan,
+      chainId: 1,
+      account: OWNER,
+      usePermit2: false,
+      unlimitedApproval: false,
+    } as TransactionPlanPrepared
+
+    // No caller-supplied broadcast sink: the executor's own quarantine must
+    // reserve the durable record before the wallet is invoked.
+    await expect(executePreparedPlan(prepared)).rejects.toThrow('wallet connection dropped mid-request')
+    expect(readPendingSubmission('direct', OWNER, 1)).toMatchObject({ phase: 'armed' })
+
+    // Every retry surface is blocked before the wallet: the callback-less
+    // direct form itself, and a batch-style caller wiring its own sink.
+    wagmiMocks.sendTransactionAsync.mockClear()
+    await expect(executePreparedPlan(prepared)).rejects.toThrow(
+      'handed to the wallet but no transaction id came back',
+    )
+    await expect(executePreparedPlan(prepared, { onBroadcast: () => {} })).rejects.toThrow(
+      'handed to the wallet but no transaction id came back',
+    )
+    expect(wagmiMocks.sendTransactionAsync).not.toHaveBeenCalled()
+    expect(executePreparedTransactionPlan).toHaveBeenCalledTimes(1)
+    expect(readPendingSubmission('direct', OWNER, 1)).toMatchObject({ phase: 'armed' })
+  })
+
+  it('keeps the armed reservation when the wallet returns a malformed transaction id', async () => {
+    const evcBatchItem = { type: 'evcBatch', items: [] }
+    const plan = [evcBatchItem] as unknown as TransactionPlan
+    // The wallet DID respond — just not with a transaction hash. Acceptance
+    // cannot be ruled out, and the malformed value must never replace the
+    // armed record as an unverifiable submitted one.
+    wagmiMocks.sendTransactionAsync.mockResolvedValue('not-a-transaction-hash')
+    const executePreparedTransactionPlan = vi.fn(async ({ sendTransaction, onProgress }: {
+      sendTransaction: (tx: { to: Address, data: Hex }) => Promise<Hash>
+      onProgress: (progress: { status: string, item?: unknown }) => void
+    }) => {
+      onProgress({ status: 'evcBatch', item: evcBatchItem })
+      await sendTransaction({ to: TOKEN, data: '0x02' })
+    })
+    vi.mocked(getEulerSdkFresh).mockResolvedValue({
+      providerService: { getProvider: vi.fn(() => ({
+        waitForTransactionReceipt: vi.fn(),
+        getTransactionReceipt: vi.fn(async () => {
+          throw new Error('receipt not found')
+        }),
+      })) },
+      executionService: { executePreparedTransactionPlan },
+    } as never)
+    const { executePreparedPlan } = useEulerTx()
+    const prepared = {
+      __prepared: true,
+      plan,
+      chainId: 1,
+      account: OWNER,
+      usePermit2: false,
+      unlimitedApproval: false,
+    } as TransactionPlanPrepared
+
+    await expect(executePreparedPlan(prepared)).rejects.toThrow('Wallet returned an unexpected transaction id')
+    expect(readPendingSubmission('direct', OWNER, 1)).toMatchObject({ phase: 'armed' })
+
+    // A retry is blocked at the executor gate before the wallet is invoked.
+    wagmiMocks.sendTransactionAsync.mockClear()
+    await expect(executePreparedPlan(prepared)).rejects.toThrow(
+      'handed to the wallet but no transaction id came back',
+    )
+    expect(wagmiMocks.sendTransactionAsync).not.toHaveBeenCalled()
+  })
+
+  it('blocks standalone plain sends while an ambiguous submission is unresolved', async () => {
+    writePendingSubmission('batch', {
+      phase: 'armed',
+      chainId: 1,
+      owner: OWNER,
+      completesPlan: true,
+      submittedAt: 1_000,
+    })
+    const { sendPlainTransactions } = useEulerTx()
+
+    // Standalone sends reach the wallet without any plan executor in the
+    // path, so they carry the cross-surface gate themselves.
+    await expect(sendPlainTransactions([{ to: TOKEN, data: '0x1234' }])).rejects.toThrow(
+      'handed to the wallet but no transaction id came back',
+    )
+    expect(wagmiMocks.sendTransactionAsync).not.toHaveBeenCalled()
+    expect(readPendingSubmission('batch', OWNER, 1)).toBeDefined()
+  })
+
+  it('blocks migration authorization grants while a submission is quarantined', async () => {
+    writePendingSubmission('outgoing-migration', {
+      phase: 'armed',
+      chainId: 1,
+      owner: OWNER,
+      completesPlan: true,
+      submittedAt: 1_000,
+    })
+    const { executeMigrationAuthorizationGrants } = useEulerTx()
+
+    await expect(executeMigrationAuthorizationGrants(authorizationRequest, [])).rejects.toThrow(
+      'handed to the wallet but no transaction id came back',
+    )
+    expect(wagmiMocks.sendTransactionAsync).not.toHaveBeenCalled()
+    expect(readPendingSubmission('outgoing-migration', OWNER, 1)).toBeDefined()
+  })
+
+  it('still sends migration revokes while a submission is quarantined', async () => {
+    // Revokes strictly reduce standing authorization and run during abort
+    // cleanup — possibly while the aborted submission itself is quarantined.
+    // Blocking them would leave live grants behind.
+    writePendingSubmission('batch', {
+      phase: 'armed',
+      chainId: 1,
+      owner: OWNER,
+      completesPlan: true,
+      submittedAt: 1_000,
+    })
+    const { sendMigrationAuthorizationRevokes } = useEulerTx()
+    const revoke = {
+      transaction: {
+        to: TOKEN,
+        data: encodeFunctionData({
+          abi: erc20Abi,
+          functionName: 'approve',
+          args: [SWAP_VERIFIER, 0n],
+        }),
+      },
+      walletContext: { account: OWNER, chainId: 1 },
+    }
+
+    await expect(sendMigrationAuthorizationRevokes([revoke])).resolves.toEqual({
+      restored: [revoke],
+      failed: [],
+    })
+    expect(wagmiMocks.sendTransactionAsync).toHaveBeenCalledTimes(1)
+    // The quarantine itself is untouched by the bypassed send.
+    expect(readPendingSubmission('batch', OWNER, 1)).toBeDefined()
   })
 
   it('blocks a direct plan while an ambiguous batch submission from this wallet is unresolved', async () => {
@@ -741,7 +903,7 @@ describe('useEulerTx Safe wallet bundling', () => {
     const broadcasts: PreparedPlanBroadcast[] = []
 
     await executePreparedPlan(buildPrepared(approvedPlan), {
-      onBroadcast: b => broadcasts.push(b),
+      onBroadcast: (b) => { broadcasts.push(b) },
     })
 
     expect(broadcasts).toEqual([
@@ -882,6 +1044,60 @@ describe('useEulerTx Safe wallet bundling', () => {
       onBroadcast: b => quarantine.track(b),
     })).rejects.toThrow('User rejected the request.')
     expect(wagmiMocks.sendCalls).toHaveBeenCalledTimes(2)
+  })
+
+  it('quarantines a callback-less ambiguous Safe bundle under the shared direct flow', async () => {
+    wagmiMocks.sendCalls.mockRejectedValue(new Error('wallet connection dropped mid-request'))
+    const { executePreparedPlan } = useEulerTx()
+
+    // No caller-supplied broadcast sink: the executor's own quarantine must
+    // reserve the durable record before the Safe bundle crosses the wallet.
+    await expect(executePreparedPlan(buildPrepared(approvedPlan)))
+      .rejects.toThrow('wallet connection dropped mid-request')
+    expect(readPendingSubmission('direct', OWNER, 1)).toMatchObject({ phase: 'armed' })
+
+    // A retry is blocked at the executor gate before the wallet is invoked.
+    wagmiMocks.sendCalls.mockClear()
+    await expect(executePreparedPlan(buildPrepared(approvedPlan))).rejects.toThrow(
+      'handed to the wallet but no transaction id came back',
+    )
+    expect(wagmiMocks.sendCalls).not.toHaveBeenCalled()
+  })
+
+  it('quarantines an ambiguous raw-plan submission without caller wiring', async () => {
+    wagmiMocks.sendCalls.mockRejectedValue(new Error('wallet connection dropped mid-request'))
+    const processPlanPlugins = vi.fn(async (plan: TransactionPlan) => plan)
+    const resolveRequiredApprovals = vi.fn(async () => approvedPlan)
+    const executeTransactionPlan = vi.fn()
+    const provider = {
+      getTransactionReceipt: vi.fn(async () => {
+        throw new Error('receipt not found')
+      }),
+    }
+    vi.mocked(getEulerSdkFresh).mockResolvedValue({
+      providerService: { getProvider: vi.fn(() => provider) },
+      deploymentService: { getDeployment: vi.fn(() => ({ addresses: { coreAddrs: { evc: EVC } } })) },
+      executionService: {
+        encodeBatch: vi.fn(() => BATCH_DATA),
+        processPlanPlugins,
+        resolveRequiredApprovals,
+        executeTransactionPlan,
+      },
+    } as never)
+    const { executePlan } = useEulerTx()
+
+    // executePlan has no broadcast option at all — replay protection must be
+    // built into the executor itself.
+    await expect(executePlan([approvedPlan[0]] as TransactionPlan))
+      .rejects.toThrow('wallet connection dropped mid-request')
+    expect(readPendingSubmission('direct', OWNER, 1)).toMatchObject({ phase: 'armed' })
+
+    wagmiMocks.sendCalls.mockClear()
+    await expect(executePlan([approvedPlan[0]] as TransactionPlan)).rejects.toThrow(
+      'handed to the wallet but no transaction id came back',
+    )
+    expect(wagmiMocks.sendCalls).not.toHaveBeenCalled()
+    expect(executeTransactionPlan).not.toHaveBeenCalled()
   })
 
   it('blocks a Safe bundle while a landed batch record awaits cart reconciliation', async () => {

--- a/tests/composables/useEulerTx.test.ts
+++ b/tests/composables/useEulerTx.test.ts
@@ -4,7 +4,7 @@ import type { MigrationAuthorizationRequest, TransactionPlan, TransactionPlanPre
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { getAccount } from '@wagmi/vue/actions'
 import { getEulerSdkForChain, getEulerSdkFresh } from '~/composables/useEulerSdk'
-import { useEulerTx } from '~/composables/useEulerTx'
+import { useEulerTx, type PreparedPlanBroadcast } from '~/composables/useEulerTx'
 import type { MigrationAuthorizationRevoke } from '~/utils/migrationAuthorizationTxs'
 import { WalletExecutionContextChangedError } from '~/utils/walletExecutionContext'
 
@@ -144,6 +144,32 @@ describe('useEulerTx migration authorization cleanup', () => {
     expect(wagmiMocks.signTypedDataAsync).not.toHaveBeenCalled()
   })
 
+  it('signs through the connector that passed the context check, not the live one', async () => {
+    const reviewedConnector = { id: 'io.metamask', name: 'MetaMask' }
+    const swappedConnector = { id: 'io.rabby', name: 'Rabby' }
+    let activeConnector: unknown = reviewedConnector
+    vi.mocked(getAccount).mockImplementation(() => ({
+      address: currentAccount,
+      chainId: currentChainId,
+      connector: activeConnector,
+    }) as never)
+    wagmiMocks.signTypedDataAsync.mockResolvedValue(`0x${'ab'.repeat(65)}`)
+    const { signMigrationAuthorization } = useEulerTx()
+
+    await signMigrationAuthorization(typedAuthorizationRequest, {
+      // A connector switch in the check-to-sign gap: the swapped connector
+      // was never validated and must not receive the signature request.
+      beforeSignature: () => {
+        activeConnector = swappedConnector
+      },
+    })
+
+    expect(wagmiMocks.signTypedDataAsync).toHaveBeenCalledTimes(1)
+    expect(wagmiMocks.signTypedDataAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ connector: reviewedConnector }),
+    )
+  })
+
   it('prepares the transaction plan with the caller-pinned signature mode', async () => {
     const prepare = vi.fn().mockResolvedValue({ kind: 'prepared' })
     vi.mocked(getEulerSdkForChain).mockResolvedValue({
@@ -204,6 +230,91 @@ describe('useEulerTx migration authorization cleanup', () => {
     await expect(executePreparedPlan(prepared))
       .rejects.toMatchObject({ name: WalletExecutionContextChangedError.name, kind: 'account' })
     expect(wagmiMocks.sendTransactionAsync).not.toHaveBeenCalled()
+  })
+
+  it('pins mid-plan typed-data signatures to the connector captured at execution start', async () => {
+    const reviewedConnector = { id: 'io.metamask', name: 'MetaMask' }
+    const swappedConnector = { id: 'io.rabby', name: 'Rabby' }
+    let activeConnector: unknown = reviewedConnector
+    vi.mocked(getAccount).mockImplementation(() => ({
+      address: currentAccount,
+      chainId: currentChainId,
+      connector: activeConnector,
+    }) as never)
+    wagmiMocks.signTypedDataAsync.mockResolvedValue(`0x${'ab'.repeat(65)}`)
+    const executePreparedTransactionPlan = vi.fn(async ({ signTypedData }: {
+      signTypedData: (typedData: unknown) => Promise<Hex>
+    }) => {
+      // The wallet switches connectors while the executor is mid-plan; the
+      // permit signature must still go to the connector that was validated.
+      activeConnector = swappedConnector
+      await signTypedData({ domain: {}, types: {}, primaryType: 'PermitSingle', message: {} })
+      return { receipts: [] }
+    })
+    vi.mocked(getEulerSdkFresh).mockResolvedValue({
+      providerService: { getProvider: vi.fn(() => ({ waitForTransactionReceipt: vi.fn() })) },
+      executionService: { executePreparedTransactionPlan },
+    } as never)
+    const { executePreparedPlan } = useEulerTx()
+
+    await executePreparedPlan({
+      __prepared: true,
+      plan: [],
+      chainId: 1,
+      account: OWNER,
+      usePermit2: true,
+      unlimitedApproval: false,
+    } as TransactionPlanPrepared)
+
+    expect(wagmiMocks.signTypedDataAsync).toHaveBeenCalledTimes(1)
+    expect(wagmiMocks.signTypedDataAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ connector: reviewedConnector }),
+    )
+  })
+
+  it('classifies ordered broadcasts so only the last submission stays unconfirmed on failure', async () => {
+    const approvalItem = { type: 'requiredApproval', resolved: [] }
+    const evcBatchItem = { type: 'evcBatch', items: [] }
+    const plan = [approvalItem, evcBatchItem] as unknown as TransactionPlan
+    const executePreparedTransactionPlan = vi.fn(async ({ sendTransaction, onProgress }: {
+      sendTransaction: (tx: { to: Address, data: Hex }) => Promise<Hash>
+      onProgress: (progress: { status: string, item?: unknown, hash?: Hash }) => void
+    }) => {
+      // Mirrors the SDK executor contract: a pre-send progress event names
+      // the item about to be sent, the receipt is awaited, and the same
+      // event re-fires with the confirmed hash before the next send.
+      onProgress({ status: 'approval', item: approvalItem })
+      const approvalHash = await sendTransaction({ to: TOKEN, data: '0x01' })
+      onProgress({ status: 'approval', item: approvalItem, hash: approvalHash })
+      onProgress({ status: 'evcBatch', item: evcBatchItem })
+      await sendTransaction({ to: TOKEN, data: '0x02' })
+      throw new Error('Receipt polling failed.')
+    })
+    vi.mocked(getEulerSdkFresh).mockResolvedValue({
+      providerService: { getProvider: vi.fn(() => ({ waitForTransactionReceipt: vi.fn() })) },
+      executionService: { executePreparedTransactionPlan },
+    } as never)
+    const { executePreparedPlan } = useEulerTx()
+    const broadcasts: PreparedPlanBroadcast[] = []
+
+    await expect(executePreparedPlan({
+      __prepared: true,
+      plan,
+      chainId: 1,
+      account: OWNER,
+      usePermit2: false,
+      unlimitedApproval: false,
+    } as TransactionPlanPrepared, {
+      onBroadcast: b => broadcasts.push(b),
+    })).rejects.toThrow('Receipt polling failed.')
+
+    // The confirmed approval is retryable history; only the accepted-but-
+    // unconfirmed value-moving batch is left ambiguous for quarantine.
+    expect(broadcasts).toEqual([
+      expect.objectContaining({ kind: 'transaction', item: 'approval', index: 0, completesPlan: false, status: 'submitted' }),
+      expect.objectContaining({ item: 'approval', index: 0, status: 'confirmed' }),
+      expect.objectContaining({ kind: 'transaction', item: 'evcBatch', index: 1, completesPlan: true, status: 'submitted' }),
+    ])
   })
 
   it('runs the caller freshness guard after async setup and before a plain broadcast', async () => {
@@ -394,6 +505,20 @@ describe('useEulerTx Safe wallet bundling', () => {
     // The sequential path never runs: no per-transaction sends.
     expect(executePreparedTransactionPlan).not.toHaveBeenCalled()
     expect(wagmiMocks.sendTransactionAsync).not.toHaveBeenCalled()
+  })
+
+  it('reports the Safe bundle as submitted on acceptance and confirmed after its receipt', async () => {
+    const { executePreparedPlan } = useEulerTx()
+    const broadcasts: PreparedPlanBroadcast[] = []
+
+    await executePreparedPlan(buildPrepared(approvedPlan), {
+      onBroadcast: b => broadcasts.push(b),
+    })
+
+    expect(broadcasts).toEqual([
+      expect.objectContaining({ kind: 'proposal', hash: SAFE_TX_HASH, item: 'bundle', completesPlan: true, status: 'submitted' }),
+      expect.objectContaining({ kind: 'proposal', hash: SAFE_TX_HASH, item: 'bundle', status: 'confirmed' }),
+    ])
   })
 
   it('falls back to sequential execution for single-call plans', async () => {

--- a/tests/composables/useEulerTx.test.ts
+++ b/tests/composables/useEulerTx.test.ts
@@ -156,6 +156,27 @@ describe('useEulerTx migration authorization cleanup', () => {
     expect(prepare).toHaveBeenCalledWith(expect.objectContaining({ usePermit2: false }))
   })
 
+  it('estimates a prepared envelope without rerunning the raw plan pipeline', async () => {
+    const estimatePrepared = vi.fn().mockResolvedValue(123n)
+    vi.mocked(getEulerSdkForChain).mockResolvedValue({
+      executionService: { estimateGasForPreparedTransactionPlan: estimatePrepared },
+    } as never)
+    const prepared = {
+      __prepared: true,
+      plan: [],
+      chainId: 8453,
+      account: OWNER,
+      usePermit2: false,
+      unlimitedApproval: false,
+    } as TransactionPlanPrepared
+    const { estimateGasForPreparedPlan } = useEulerTx()
+
+    await expect(estimateGasForPreparedPlan(prepared)).resolves.toBe(123n)
+
+    expect(getEulerSdkForChain).toHaveBeenCalledWith(8453)
+    expect(estimatePrepared).toHaveBeenCalledWith(prepared)
+  })
+
   it('does not broadcast a reviewed migration after account drift', async () => {
     const executePreparedTransactionPlan = vi.fn(async ({ sendTransaction }: {
       sendTransaction: (tx: { to: Address, data: Hex }) => Promise<Hash>

--- a/tests/composables/useMigrationAuthorizationFlow.test.ts
+++ b/tests/composables/useMigrationAuthorizationFlow.test.ts
@@ -58,4 +58,21 @@ describe('useMigrationAuthorizationFlow pending cleanup', () => {
 
     expect(flow.pendingRevokes.value).toEqual([revoke])
   })
+
+  it.each(['revokeAfterSuccess', 'revokeAfterAbort'] as const)(
+    'keeps failed cleanup queued without notifying a successor wallet from %s',
+    async (method) => {
+      mocks.sendMigrationAuthorizationRevokes.mockResolvedValue({
+        restored: [],
+        failed: [revoke],
+      })
+      const flow = useMigrationAuthorizationFlow()
+
+      await flow[method]([revoke], { shouldNotify: () => false })
+
+      expect(mocks.sendMigrationAuthorizationRevokes).toHaveBeenCalledWith([revoke])
+      expect(flow.pendingRevokes.value).toEqual([revoke])
+      expect(mocks.showWarning).not.toHaveBeenCalled()
+    },
+  )
 })

--- a/tests/composables/usePendingSubmissionRecovery.test.ts
+++ b/tests/composables/usePendingSubmissionRecovery.test.ts
@@ -1,0 +1,180 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick, ref } from 'vue'
+import { getAddress, type Address, type Hash } from 'viem'
+import {
+  RECOVERABLE_SUBMISSION_FLOWS,
+  usePendingSubmissionRecovery,
+} from '~/composables/usePendingSubmissionRecovery'
+import {
+  armPendingSubmission,
+  readPendingSubmission,
+  registerActiveSubmissionAttempt,
+  resetPendingSubmissionMemoryFallback,
+  unregisterActiveSubmissionAttempt,
+  writePendingSubmission,
+} from '~/utils/pendingSubmissions'
+
+const OWNER = getAddress('0x1000000000000000000000000000000000000000')
+const OTHER_OWNER = getAddress('0x2000000000000000000000000000000000000000')
+const TX_HASH = `0x${'11'.repeat(32)}` as Hash
+
+const createMemoryStorage = (): Storage => {
+  const store = new Map<string, string>()
+  return {
+    get length() {
+      return store.size
+    },
+    clear: () => store.clear(),
+    getItem: (key: string) => store.get(key) ?? null,
+    key: (index: number) => [...store.keys()][index] ?? null,
+    removeItem: (key: string) => {
+      store.delete(key)
+    },
+    setItem: (key: string, value: string) => {
+      store.set(key, String(value))
+    },
+  }
+}
+
+/** An armed record whose arming attempt died with the page — no id will ever arrive. */
+const orphanedArmed = (owner: Address = OWNER) => ({
+  phase: 'armed' as const,
+  chainId: 1,
+  owner,
+  completesPlan: true,
+  submittedAt: 1_000,
+  attemptId: 'gone-attempt',
+})
+
+const addressRef = ref<Address | undefined>(OWNER)
+
+beforeEach(() => {
+  vi.stubGlobal('localStorage', createMemoryStorage())
+  vi.stubGlobal('useWagmi', () => ({ address: addressRef }))
+  addressRef.value = OWNER
+  resetPendingSubmissionMemoryFallback()
+})
+
+describe('usePendingSubmissionRecovery', () => {
+  it('lists orphaned armed records for every recoverable flow, never the batch flow', () => {
+    for (const flow of RECOVERABLE_SUBMISSION_FLOWS) {
+      writePendingSubmission(flow, orphanedArmed())
+    }
+    // The batch cart drawer owns its own release CTA — the app-root recovery
+    // surface must not offer a second, context-free dismissal for it.
+    writePendingSubmission('batch', orphanedArmed())
+    const { entries, refresh } = usePendingSubmissionRecovery()
+
+    refresh()
+
+    expect(entries.value.map(entry => entry.flow).sort())
+      .toEqual([...RECOVERABLE_SUBMISSION_FLOWS].sort())
+    expect(entries.value).toEqual(RECOVERABLE_SUBMISSION_FLOWS.map(() =>
+      expect.objectContaining({ owner: OWNER, chainId: 1, state: 'armed' }),
+    ))
+  })
+
+  it('shows only the connected wallet\'s records and clears on disconnect', async () => {
+    writePendingSubmission('direct', orphanedArmed())
+    writePendingSubmission('outgoing-migration', orphanedArmed(OTHER_OWNER))
+    const { entries, refresh } = usePendingSubmissionRecovery()
+
+    refresh()
+    expect(entries.value).toEqual([
+      expect.objectContaining({ flow: 'direct', owner: OWNER }),
+    ])
+
+    // The address watcher refreshes the listing on wallet changes.
+    addressRef.value = undefined
+    await nextTick()
+    expect(entries.value).toEqual([])
+  })
+
+  it('leaves records owned by a live attempt to their executor', () => {
+    registerActiveSubmissionAttempt('live-attempt')
+    try {
+      writePendingSubmission('direct', { ...orphanedArmed(), attemptId: 'live-attempt' })
+      const { entries, refresh } = usePendingSubmissionRecovery()
+
+      refresh()
+
+      // The executor that armed this record is still running in this realm;
+      // its own settle/release path resolves it, and offering a manual
+      // dismissal here would race that resolution.
+      expect(entries.value).toEqual([])
+    }
+    finally {
+      unregisterActiveSubmissionAttempt('live-attempt')
+    }
+  })
+
+  it('dismisses an orphaned record after the user checked the wallet, unblocking the executors', async () => {
+    writePendingSubmission('outgoing-migration', orphanedArmed())
+    const { entries, releaseError, refresh, release } = usePendingSubmissionRecovery()
+    refresh()
+    const [entry] = entries.value
+    expect(entry).toBeDefined()
+
+    await release(entry)
+
+    expect(releaseError.value).toBe('')
+    expect(entries.value).toEqual([])
+    expect(readPendingSubmission('outgoing-migration', OWNER, 1)).toBeUndefined()
+    // The wallet/chain is no longer reserved: the next attempt can arm.
+    await expect(armPendingSubmission('outgoing-migration', {
+      owner: OWNER,
+      chainId: 1,
+      completesPlan: true,
+      attemptId: 'new-attempt',
+    })).resolves.toMatchObject({ phase: 'armed', attemptId: 'new-attempt' })
+  })
+
+  it('refuses the dismissal when the record gained a transaction id meanwhile', async () => {
+    writePendingSubmission('direct', orphanedArmed())
+    const { entries, releaseError, refresh, release } = usePendingSubmissionRecovery()
+    refresh()
+    const [entry] = entries.value
+    expect(entry).toBeDefined()
+
+    // Between the listing and the click, the wallet's answer landed (e.g.
+    // relayed through another tab): the record now resolves objectively.
+    writePendingSubmission('direct', {
+      phase: 'submitted',
+      kind: 'transaction',
+      hash: TX_HASH,
+      chainId: 1,
+      owner: OWNER,
+      completesPlan: true,
+      submittedAt: 2_000,
+    })
+
+    await release(entry)
+
+    expect(releaseError.value).toContain('cannot be dismissed')
+    expect(readPendingSubmission('direct', OWNER, 1)).toMatchObject({ phase: 'submitted' })
+    // The refreshed listing no longer offers it either.
+    expect(entries.value).toEqual([])
+  })
+
+  it('never breaks the app shell when the listing itself fails', () => {
+    const working = createMemoryStorage()
+    vi.stubGlobal('localStorage', {
+      ...working,
+      get length(): number {
+        throw new Error('storage unavailable')
+      },
+      key: () => {
+        throw new Error('storage unavailable')
+      },
+      getItem: () => {
+        throw new Error('storage unavailable')
+      },
+    })
+    const { entries, refresh } = usePendingSubmissionRecovery()
+
+    // Recovery is best-effort UI: a throwing storage must degrade to an
+    // empty listing — the executors' own gates keep failing closed.
+    expect(() => refresh()).not.toThrow()
+    expect(entries.value).toEqual([])
+  })
+})

--- a/tests/composables/useTxBatch.test.ts
+++ b/tests/composables/useTxBatch.test.ts
@@ -5,7 +5,7 @@ import { getAddress, type Address, type Hash, type Hex } from 'viem'
 import { getEulerSdkFresh } from '~/composables/useEulerSdk'
 import { awaitFinalPlanningLayer, buildOperationEntryMap, buildWalletBalanceLayers, buildWalletChanges, countPlanOperations, fetchBaseAccountSnapshot, hydratePendingBatchSubmissionFromStorage, normalizeSimulatedVaultLayers, stitchAccount, useTxBatch } from '~/composables/useTxBatch'
 import type { PreparedPlanBroadcast } from '~/composables/useEulerTx'
-import { readPendingSubmission, writePendingSubmission } from '~/utils/pendingSubmissions'
+import { readPendingSubmission, resetPendingSubmissionMemoryFallback, writePendingSubmission } from '~/utils/pendingSubmissions'
 import {
   mergeBatchPrefetchedSlotHints,
   resetBatchPrefetchState,
@@ -381,6 +381,7 @@ beforeEach(() => {
   // Fresh storage plus a hydrate resets the module-level submission
   // quarantine, which deliberately survives clearBatch().
   vi.stubGlobal('localStorage', createMemoryStorage())
+  resetPendingSubmissionMemoryFallback()
   hydratePendingBatchSubmissionFromStorage()
   useTxBatch().clearBatch()
 })
@@ -1387,14 +1388,44 @@ describe('useTxBatch submission quarantine', () => {
   const CORE_HASH = `0x${'ab'.repeat(32)}` as Hash
   const APPROVAL_HASH = `0x${'cd'.repeat(32)}` as Hash
 
-  const coreBroadcast = (overrides: Partial<PreparedPlanBroadcast> = {}): PreparedPlanBroadcast => ({
-    kind: 'transaction',
-    hash: CORE_HASH,
-    item: 'evcBatch',
-    index: 0,
-    completesPlan: true,
+  interface BroadcastOverrides {
+    kind?: 'transaction' | 'proposal'
+    hash?: Hash
+    item?: PreparedPlanBroadcast['item']
+    index?: number
+    completesPlan?: boolean
+  }
+
+  const coreSubmitted = (overrides: BroadcastOverrides = {}): PreparedPlanBroadcast => ({
+    kind: overrides.kind ?? 'transaction',
+    hash: overrides.hash ?? CORE_HASH,
+    item: overrides.item ?? 'evcBatch',
+    index: overrides.index ?? 0,
+    completesPlan: overrides.completesPlan ?? true,
     status: 'submitted',
-    ...overrides,
+  })
+
+  const coreConfirmed = (overrides: BroadcastOverrides = {}): PreparedPlanBroadcast => ({
+    kind: overrides.kind ?? 'transaction',
+    hash: overrides.hash ?? CORE_HASH,
+    item: overrides.item ?? 'evcBatch',
+    index: overrides.index ?? 0,
+    completesPlan: overrides.completesPlan ?? true,
+    status: 'confirmed',
+  })
+
+  const coreArmed = (overrides: Pick<BroadcastOverrides, 'item' | 'index' | 'completesPlan'> = {}): PreparedPlanBroadcast => ({
+    item: overrides.item ?? 'evcBatch',
+    index: overrides.index ?? 0,
+    completesPlan: overrides.completesPlan ?? true,
+    status: 'armed',
+  })
+
+  const coreRejected = (overrides: Pick<BroadcastOverrides, 'item' | 'index' | 'completesPlan'> = {}): PreparedPlanBroadcast => ({
+    item: overrides.item ?? 'evcBatch',
+    index: overrides.index ?? 0,
+    completesPlan: overrides.completesPlan ?? true,
+    status: 'rejected',
   })
 
   /** SDK whose provider resolves the quarantined hash to a receipt verdict. */
@@ -1425,12 +1456,12 @@ describe('useTxBatch submission quarantine', () => {
   /** Run one attempt whose accepted core submission never confirmed. */
   const quarantineOneSubmission = async (
     batch: Awaited<ReturnType<typeof setupExecutableBatch>>,
-    broadcast: PreparedPlanBroadcast = coreBroadcast(),
+    broadcasts: PreparedPlanBroadcast[] = [coreArmed(), coreSubmitted()],
   ) => {
     eulerTxMocks.executePreparedPlan.mockImplementationOnce(async (_prepared, options?: {
       onBroadcast?: (b: PreparedPlanBroadcast) => void
     }) => {
-      options?.onBroadcast?.(broadcast)
+      for (const broadcast of broadcasts) options?.onBroadcast?.(broadcast)
       throw new Error('Receipt polling failed.')
     })
     await batch.executeBatch()
@@ -1445,9 +1476,11 @@ describe('useTxBatch submission quarantine', () => {
       }) => {
         // The approval submission confirmed (the executor re-fires with
         // status 'confirmed' once its receipt landed) — then the wallet
-        // rejected the core submission before accepting it.
-        options?.onBroadcast?.(coreBroadcast({ item: 'approval', hash: APPROVAL_HASH, completesPlan: false }))
-        options?.onBroadcast?.(coreBroadcast({ item: 'approval', hash: APPROVAL_HASH, completesPlan: false, status: 'confirmed' }))
+        // provably rejected the armed core submission before accepting it.
+        options?.onBroadcast?.(coreSubmitted({ item: 'approval', hash: APPROVAL_HASH, completesPlan: false }))
+        options?.onBroadcast?.(coreConfirmed({ item: 'approval', hash: APPROVAL_HASH, completesPlan: false }))
+        options?.onBroadcast?.(coreArmed({ index: 1 }))
+        options?.onBroadcast?.(coreRejected({ index: 1 }))
         throw new Error('User rejected the request.')
       })
       .mockResolvedValueOnce(undefined)
@@ -1457,7 +1490,7 @@ describe('useTxBatch submission quarantine', () => {
     // Nothing value-moving is outstanding: no quarantine, plain error.
     expect(batch.execError.value).toBe('User rejected the request.')
     expect(batch.hasPendingCoreSubmission.value).toBe(false)
-    expect(readPendingSubmission('batch')).toBeUndefined()
+    expect(readPendingSubmission('batch', owner, 1)).toBeUndefined()
     expect(batch.entryCount.value).toBe(1)
 
     // An ordinary retry proceeds without any on-chain reconciliation gate.
@@ -1467,13 +1500,91 @@ describe('useTxBatch submission quarantine', () => {
     expect(batch.entryCount.value).toBe(0)
   })
 
+  it('persists the quarantine the moment the wallet accepts, before the executor settles', async () => {
+    const batch = await setupExecutableBatch()
+    let recordAtBroadcastTime: unknown
+    eulerTxMocks.executePreparedPlan.mockImplementationOnce(async (_prepared, options?: {
+      onBroadcast?: (b: PreparedPlanBroadcast) => void
+    }) => {
+      options?.onBroadcast?.(coreSubmitted())
+      // A reload between the wallet's acceptance and the executor settling
+      // (receipt polling, later steps) must already find the durable record.
+      recordAtBroadcastTime = readPendingSubmission('batch', owner, 1)
+      throw new Error('Receipt polling failed.')
+    })
+
+    await batch.executeBatch()
+
+    expect(recordAtBroadcastTime).toMatchObject({
+      phase: 'submitted',
+      hash: CORE_HASH,
+      owner,
+      chainId: 1,
+    })
+  })
+
+  it('quarantines an armed submission whose id never came back', async () => {
+    const batch = await setupExecutableBatch()
+    let recordAtArmTime: unknown
+    eulerTxMocks.executePreparedPlan.mockImplementationOnce(async (_prepared, options?: {
+      onBroadcast?: (b: PreparedPlanBroadcast) => void
+    }) => {
+      options?.onBroadcast?.(coreArmed())
+      recordAtArmTime = readPendingSubmission('batch', owner, 1)
+      // The wallet boundary failed without returning an id and without a
+      // provable rejection — acceptance cannot be ruled out.
+      throw new Error('Wallet request failed.')
+    })
+
+    await batch.executeBatch()
+
+    // The record was durable before the wallet was even invoked.
+    expect(recordAtArmTime).toMatchObject({ phase: 'armed', owner, chainId: 1 })
+    expect(batch.hasPendingCoreSubmission.value).toBe(true)
+    expect(batch.execError.value).toBe('Wallet request failed. The wallet may have accepted the submission without returning its id — it stays treated as pending until it can be ruled out.')
+    expect(readPendingSubmission('batch', owner, 1)).toMatchObject({ phase: 'armed' })
+
+    // With no id there is nothing to verify on-chain: the retry stays
+    // blocked even though a provider could resolve receipts.
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdkWithReceipt('success') as never)
+    await batch.executeBatch()
+
+    expect(eulerTxMocks.executePreparedPlan).toHaveBeenCalledTimes(1)
+    expect(batch.execError.value).toBe('A previous batch submission was handed to the wallet but no transaction id came back, so it cannot be verified automatically. Check the wallet\'s pending activity and let it resolve before executing again.')
+    expect(readPendingSubmission('batch', owner, 1)).toBeDefined()
+  })
+
+  it('releases an armed submission the wallet provably never accepted', async () => {
+    const batch = await setupExecutableBatch()
+    eulerTxMocks.executePreparedPlan
+      .mockImplementationOnce(async (_prepared, options?: {
+        onBroadcast?: (b: PreparedPlanBroadcast) => void
+      }) => {
+        options?.onBroadcast?.(coreArmed())
+        options?.onBroadcast?.(coreRejected())
+        throw new Error('User rejected the request.')
+      })
+      .mockResolvedValueOnce(undefined)
+
+    await batch.executeBatch()
+
+    expect(batch.hasPendingCoreSubmission.value).toBe(false)
+    expect(readPendingSubmission('batch', owner, 1)).toBeUndefined()
+    expect(batch.execError.value).toBe('User rejected the request.')
+
+    // The rejection is terminal — an ordinary retry proceeds.
+    await batch.executeBatch()
+    expect(eulerTxMocks.executePreparedPlan).toHaveBeenCalledTimes(2)
+  })
+
   it('quarantines an accepted core submission durably across cart clearing', async () => {
     const batch = await setupExecutableBatch()
 
     await quarantineOneSubmission(batch)
 
     expect(batch.execError.value).toBe('Receipt polling failed. The submission may still confirm — executing again first verifies it on-chain before anything is re-sent.')
-    expect(readPendingSubmission('batch')).toMatchObject({
+    expect(readPendingSubmission('batch', owner, 1)).toMatchObject({
+      phase: 'submitted',
       kind: 'transaction',
       hash: CORE_HASH,
       chainId: 1,
@@ -1484,7 +1595,7 @@ describe('useTxBatch submission quarantine', () => {
     // Clearing the cart and rebuilding it must not drop the quarantine.
     batch.clearBatch()
     expect(batch.hasPendingCoreSubmission.value).toBe(true)
-    expect(readPendingSubmission('batch')).toBeDefined()
+    expect(readPendingSubmission('batch', owner, 1)).toBeDefined()
     await batch.addEntry({ label: 'Rebuilt operation', buildPlan: async () => [] })
 
     // The default SDK mock has no provider — the outcome is unverifiable, so
@@ -1493,7 +1604,27 @@ describe('useTxBatch submission quarantine', () => {
 
     expect(eulerTxMocks.executePreparedPlan).toHaveBeenCalledTimes(1)
     expect(batch.execError.value).toBe('A previous batch submission may still confirm on-chain and could not be verified yet. Wait a moment and execute again — the submission is re-checked before anything is re-sent.')
-    expect(readPendingSubmission('batch')).toBeDefined()
+    expect(readPendingSubmission('batch', owner, 1)).toBeDefined()
+  })
+
+  it('keeps the quarantine fail-closed when durable storage rejects the write', async () => {
+    vi.stubGlobal('localStorage', {
+      ...createMemoryStorage(),
+      setItem: () => {
+        throw new Error('quota exceeded')
+      },
+    })
+    const batch = await setupExecutableBatch()
+
+    await quarantineOneSubmission(batch)
+
+    // Nothing durable was written, but the in-memory fallback must still
+    // block this session's retry while the outcome is unknown.
+    expect(readPendingSubmission('batch', owner, 1)).toMatchObject({ phase: 'submitted', hash: CORE_HASH })
+    await batch.executeBatch()
+
+    expect(eulerTxMocks.executePreparedPlan).toHaveBeenCalledTimes(1)
+    expect(batch.execError.value).toContain('could not be verified yet')
   })
 
   it('releases the quarantine and retries once the submission definitively did not land', async () => {
@@ -1507,7 +1638,7 @@ describe('useTxBatch submission quarantine', () => {
 
     expect(eulerTxMocks.executePreparedPlan).toHaveBeenCalledTimes(2)
     expect(batch.hasPendingCoreSubmission.value).toBe(false)
-    expect(readPendingSubmission('batch')).toBeUndefined()
+    expect(readPendingSubmission('batch', owner, 1)).toBeUndefined()
     expect(batch.entryCount.value).toBe(0)
   })
 
@@ -1523,13 +1654,13 @@ describe('useTxBatch submission quarantine', () => {
     expect(eulerTxMocks.executePreparedPlan).toHaveBeenCalledTimes(1)
     expect(batch.entryCount.value).toBe(0)
     expect(batch.hasPendingCoreSubmission.value).toBe(false)
-    expect(readPendingSubmission('batch')).toBeUndefined()
+    expect(readPendingSubmission('batch', owner, 1)).toBeUndefined()
     expect(batch.execError.value).toBeUndefined()
   })
 
   it('resets the cart when a landed submission did not complete the reviewed batch', async () => {
     const batch = await setupExecutableBatch()
-    await quarantineOneSubmission(batch, coreBroadcast({ completesPlan: false }))
+    await quarantineOneSubmission(batch, [coreArmed({ completesPlan: false }), coreSubmitted({ completesPlan: false })])
 
     vi.mocked(getEulerSdkFresh).mockResolvedValue(sdkWithReceipt('success') as never)
 
@@ -1538,7 +1669,7 @@ describe('useTxBatch submission quarantine', () => {
     expect(eulerTxMocks.executePreparedPlan).toHaveBeenCalledTimes(1)
     expect(batch.entryCount.value).toBe(0)
     expect(batch.execError.value).toBe('A previous batch submission confirmed on-chain but did not complete the reviewed batch. The cart was reset — review your positions and rebuild the remaining operations.')
-    expect(readPendingSubmission('batch')).toBeUndefined()
+    expect(readPendingSubmission('batch', owner, 1)).toBeUndefined()
   })
 
   it('blocks execution after a reload while the hydrated submission is unverifiable', async () => {
@@ -1546,6 +1677,7 @@ describe('useTxBatch submission quarantine', () => {
     // Simulated reload: only the durable record survives — no ceremony
     // context, no in-memory tracking.
     writePendingSubmission('batch', {
+      phase: 'submitted',
       kind: 'transaction',
       hash: CORE_HASH,
       chainId: 1,
@@ -1560,12 +1692,32 @@ describe('useTxBatch submission quarantine', () => {
 
     expect(eulerTxMocks.executePreparedPlan).not.toHaveBeenCalled()
     expect(batch.execError.value).toContain('could not be verified yet')
-    expect(readPendingSubmission('batch')).toBeDefined()
+    expect(readPendingSubmission('batch', owner, 1)).toBeDefined()
+  })
+
+  it('blocks execution after a reload while the hydrated record is still armed', async () => {
+    const batch = await setupExecutableBatch()
+    writePendingSubmission('batch', {
+      phase: 'armed',
+      chainId: 1,
+      owner,
+      completesPlan: true,
+      submittedAt: 1_000,
+    })
+    hydratePendingBatchSubmissionFromStorage()
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdkWithReceipt('success') as never)
+
+    await batch.executeBatch()
+
+    expect(eulerTxMocks.executePreparedPlan).not.toHaveBeenCalled()
+    expect(batch.execError.value).toContain('no transaction id came back')
+    expect(readPendingSubmission('batch', owner, 1)).toBeDefined()
   })
 
   it('resets the cart when a hydrated post-reload submission landed without ceremony context', async () => {
     const batch = await setupExecutableBatch()
     writePendingSubmission('batch', {
+      phase: 'submitted',
       kind: 'transaction',
       hash: CORE_HASH,
       chainId: 1,
@@ -1583,7 +1735,7 @@ describe('useTxBatch submission quarantine', () => {
     // cart resets rather than leaving executed entries queued to run again.
     expect(eulerTxMocks.executePreparedPlan).not.toHaveBeenCalled()
     expect(batch.entryCount.value).toBe(0)
-    expect(readPendingSubmission('batch')).toBeUndefined()
+    expect(readPendingSubmission('batch', owner, 1)).toBeUndefined()
     expect(scheduleExternalMigrationRefreshes).toHaveBeenCalledTimes(1)
   })
 
@@ -1591,6 +1743,7 @@ describe('useTxBatch submission quarantine', () => {
     const batch = await setupExecutableBatch()
     const otherOwner = getAddress('0x9999999999999999999999999999999999999999')
     writePendingSubmission('batch', {
+      phase: 'submitted',
       kind: 'transaction',
       hash: CORE_HASH,
       chainId: 1,
@@ -1607,7 +1760,70 @@ describe('useTxBatch submission quarantine', () => {
     // it executes normally; the record stays for the wallet that owns it.
     expect(eulerTxMocks.executePreparedPlan).toHaveBeenCalledTimes(1)
     expect(batch.entryCount.value).toBe(0)
-    expect(readPendingSubmission('batch')).toMatchObject({ owner: otherOwner })
+    expect(readPendingSubmission('batch', otherOwner, 1)).toMatchObject({ owner: otherOwner })
+  })
+
+  it('reconciles both wallets\' coexisting records independently', async () => {
+    const batch = await setupExecutableBatch()
+    const otherOwner = getAddress('0x9999999999999999999999999999999999999999')
+    // Wallet A quarantined a submission, then the user switched to wallet B
+    // whose earlier submission is also unresolved — B's record must not have
+    // been overwritten by A's.
+    await quarantineOneSubmission(batch)
+    writePendingSubmission('batch', {
+      phase: 'submitted',
+      kind: 'transaction',
+      hash: APPROVAL_HASH,
+      chainId: 1,
+      owner: otherOwner,
+      completesPlan: true,
+      submittedAt: 1_000,
+    })
+    hydratePendingBatchSubmissionFromStorage()
+
+    expect(readPendingSubmission('batch', owner, 1)).toMatchObject({ hash: CORE_HASH })
+    expect(readPendingSubmission('batch', otherOwner, 1)).toMatchObject({ hash: APPROVAL_HASH })
+
+    // Wallet A's record resolves as reverted and is released — wallet B's
+    // record must survive that reconciliation untouched.
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdkWithReceipt('reverted') as never)
+    eulerTxMocks.executePreparedPlan.mockResolvedValueOnce(undefined)
+    await batch.executeBatch()
+
+    expect(readPendingSubmission('batch', owner, 1)).toBeUndefined()
+    expect(readPendingSubmission('batch', otherOwner, 1)).toMatchObject({ hash: APPROVAL_HASH })
+  })
+
+  it('blocks a second tab whose in-memory mirror predates another tab\'s quarantine', async () => {
+    // Tab B: a fresh module instance initialized over the same storage
+    // BEFORE anything is quarantined — its hydrated mirror is empty and no
+    // storage event fires in this environment to refresh it.
+    vi.resetModules()
+    vi.doMock('~/composables/useEulerSdk', () => ({
+      getEulerSdkFresh: vi.fn(async () => createMockSdk()),
+    }))
+    try {
+      const moduleB = await import('~/composables/useTxBatch')
+      const tabB = moduleB.useTxBatch()
+      tabB.clearBatch()
+      await tabB.addEntry({ label: 'Tab B operation', buildPlan: async () => [] })
+
+      // Tab A quarantines an accepted, unresolved submission.
+      const tabA = await setupExecutableBatch()
+      await quarantineOneSubmission(tabA)
+      const callsAfterTabA = eulerTxMocks.executePreparedPlan.mock.calls.length
+
+      // Tab B re-reads durable records at the attempt boundary, so its stale
+      // mirror must not let it broadcast anything.
+      await tabB.executeBatch()
+
+      expect(eulerTxMocks.executePreparedPlan.mock.calls.length).toBe(callsAfterTabA)
+      expect(tabB.execError.value).toContain('could not be verified yet')
+      expect(readPendingSubmission('batch', owner, 1)).toBeDefined()
+    }
+    finally {
+      vi.doUnmock('~/composables/useEulerSdk')
+    }
   })
 
   it('retires entries when the core submission confirmed but a later step failed', async () => {
@@ -1615,8 +1831,9 @@ describe('useTxBatch submission quarantine', () => {
     eulerTxMocks.executePreparedPlan.mockImplementationOnce(async (_prepared, options?: {
       onBroadcast?: (b: PreparedPlanBroadcast) => void
     }) => {
-      options?.onBroadcast?.(coreBroadcast())
-      options?.onBroadcast?.(coreBroadcast({ status: 'confirmed' }))
+      options?.onBroadcast?.(coreArmed())
+      options?.onBroadcast?.(coreSubmitted())
+      options?.onBroadcast?.(coreConfirmed())
       return undefined
     })
     migrationFlowMocks.revokeAfterSuccess.mockRejectedValueOnce(new Error('Revoke failed.'))
@@ -1627,7 +1844,7 @@ describe('useTxBatch submission quarantine', () => {
     // must not stay queued for a duplicate replay.
     expect(batch.entryCount.value).toBe(0)
     expect(batch.hasPendingCoreSubmission.value).toBe(false)
-    expect(readPendingSubmission('batch')).toBeUndefined()
+    expect(readPendingSubmission('batch', owner, 1)).toBeUndefined()
     expect(batch.execError.value).toBe('Revoke failed. The batch itself confirmed on-chain; the operations it covered were removed from the cart.')
   })
 })

--- a/tests/composables/useTxBatch.test.ts
+++ b/tests/composables/useTxBatch.test.ts
@@ -5,7 +5,7 @@ import { getAddress, type Address, type Hash, type Hex } from 'viem'
 import { getEulerSdkFresh } from '~/composables/useEulerSdk'
 import { awaitFinalPlanningLayer, buildOperationEntryMap, buildWalletBalanceLayers, buildWalletChanges, countPlanOperations, fetchBaseAccountSnapshot, hydratePendingBatchSubmissionFromStorage, normalizeSimulatedVaultLayers, stitchAccount, useTxBatch } from '~/composables/useTxBatch'
 import type { PreparedPlanBroadcast } from '~/composables/useEulerTx'
-import { readPendingSubmission, resetPendingSubmissionMemoryFallback, writePendingSubmission } from '~/utils/pendingSubmissions'
+import { clearPendingSubmission, readPendingSubmission, resetPendingSubmissionMemoryFallback, writePendingSubmission } from '~/utils/pendingSubmissions'
 import {
   mergeBatchPrefetchedSlotHints,
   resetBatchPrefetchState,
@@ -1800,6 +1800,48 @@ describe('useTxBatch submission quarantine', () => {
     expect(batch.entryCount.value).toBe(0)
     expect(readPendingSubmission('batch', owner, 1)).toBeUndefined()
     expect(scheduleExternalMigrationRefreshes).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not attach this tab\'s ceremony to a record another attempt re-keyed', async () => {
+    const batch = await setupExecutableBatch()
+    // This tab quarantines its own submission — its in-memory mirror retains
+    // the ceremony context for the single entry the submission covered.
+    await quarantineOneSubmission(batch)
+    // The cart grows past what that ceremony covered.
+    await batch.addEntry({
+      label: 'Second operation',
+      buildPlan: async () => [],
+    })
+    expect(batch.entryCount.value).toBe(2)
+
+    // Another tab releases this tab's record and quarantines its OWN
+    // submission — same wallet, same flow, even the same hash. Only the
+    // attemptId distinguishes it from the attempt this tab's ceremony
+    // describes.
+    await clearPendingSubmission('batch', owner, 1)
+    writePendingSubmission('batch', {
+      phase: 'submitted',
+      kind: 'transaction',
+      hash: CORE_HASH,
+      chainId: 1,
+      owner,
+      completesPlan: true,
+      attemptId: 'attempt-tab-b',
+      submittedAt: 2_000,
+    })
+    hydratePendingBatchSubmissionFromStorage()
+
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdkWithReceipt('success') as never)
+    await batch.executeBatch()
+
+    // The foreign submission landed, but this tab's ceremony must not have
+    // been attached to it: the exact covered entries are unknowable, so the
+    // cart resets instead of retiring only the ceremony's entry and leaving
+    // the second one queued behind a stale "covered operations" error.
+    expect(eulerTxMocks.executePreparedPlan).toHaveBeenCalledTimes(1)
+    expect(batch.entryCount.value).toBe(0)
+    expect(batch.execError.value).toBeUndefined()
+    expect(readPendingSubmission('batch', owner, 1)).toBeUndefined()
   })
 
   it('keeps another wallet\'s record without blocking the current wallet', async () => {

--- a/tests/composables/useTxBatch.test.ts
+++ b/tests/composables/useTxBatch.test.ts
@@ -37,6 +37,8 @@ const eulerTxMocks = {
   sendPlainTransactions: vi.fn(),
 }
 const isSafeWalletRef = ref(false)
+const isSafeWalletResolvedRef = ref(true)
+const walletConnectorRef = ref({ id: 'mock', uid: 'mock:1' })
 const walletAddressRef = ref<Address | undefined>(owner)
 const walletChainIdRef = ref<number | undefined>(1)
 const effectiveAddressRef = ref<Address | undefined>(owner)
@@ -44,12 +46,16 @@ const grantWalletContext: WalletExecutionContext = { account: owner, chainId: 1 
 type PlainTxSendOptions = {
   onBroadcast?: (index: number, walletContext: WalletExecutionContext) => void
   walletContext?: WalletExecutionContext
+  beforeBroadcast?: () => void
 }
 const broadcastAllTransactions = async (
   txs: Array<{ data: Hex }>,
   options?: PlainTxSendOptions,
 ) => {
-  txs.forEach((_tx, index) => options?.onBroadcast?.(index, options?.walletContext ?? grantWalletContext))
+  txs.forEach((_tx, index) => {
+    options?.beforeBroadcast?.()
+    options?.onBroadcast?.(index, options?.walletContext ?? grantWalletContext)
+  })
   return []
 }
 const migrationFlowMocks = {
@@ -267,7 +273,7 @@ const accountWithPositions = (
 })
 
 const stubBatchComposableGlobals = () => {
-  vi.stubGlobal('useWagmi', () => ({ address: walletAddressRef, chainId: walletChainIdRef }))
+  vi.stubGlobal('useWagmi', () => ({ address: walletAddressRef, chainId: walletChainIdRef, connector: walletConnectorRef }))
   vi.stubGlobal('useSpyMode', () => ({ isSpyMode: ref(false), spyAddress: ref(undefined) }))
   vi.stubGlobal('useEffectiveAddress', () => ({
     address: effectiveAddressRef,
@@ -279,7 +285,8 @@ const stubBatchComposableGlobals = () => {
   vi.stubGlobal('useEulerAddresses', () => ({ chainId: ref(1) }))
   vi.stubGlobal('useEulerTx', () => eulerTxMocks)
   isSafeWalletRef.value = false
-  vi.stubGlobal('useSafeWallet', () => ({ isSafeWallet: isSafeWalletRef, isSafeWalletResolved: ref(true) }))
+  isSafeWalletResolvedRef.value = true
+  vi.stubGlobal('useSafeWallet', () => ({ isSafeWallet: isSafeWalletRef, isSafeWalletResolved: isSafeWalletResolvedRef }))
   vi.stubGlobal('useMigrationAuthorizationFlow', () => migrationFlowMocks)
   vi.stubGlobal('useExternalMigrationRefresh', () => ({ scheduleExternalMigrationRefreshes }))
   vi.stubGlobal('useRouter', () => ({ replace: routerReplace }))
@@ -332,6 +339,7 @@ beforeEach(() => {
   walletAddressRef.value = owner
   walletChainIdRef.value = 1
   effectiveAddressRef.value = owner
+  walletConnectorRef.value = { id: 'mock', uid: 'mock:1' }
   stubBatchComposableGlobals()
   vi.mocked(getEulerSdkFresh).mockResolvedValue(createMockSdk() as never)
   resetBatchPrefetchState()
@@ -1265,7 +1273,9 @@ describe('useTxBatch execution errors', () => {
     })
     await batch.executeBatch()
 
-    expect(eulerTxMocks.executePreparedPlan).toHaveBeenCalledWith(prepared)
+    expect(eulerTxMocks.executePreparedPlan).toHaveBeenCalledWith(prepared, {
+      beforeBroadcast: expect.any(Function),
+    })
     expect(scheduleExternalMigrationRefreshes).toHaveBeenCalledTimes(1)
     expect(batch.entryCount.value).toBe(0)
     expect(routerReplace).toHaveBeenCalledWith({
@@ -1352,11 +1362,10 @@ describe('useTxBatch execution prerequisites', () => {
     await batch.addEntry({
       label: 'Migrate Aave position',
       buildPlan: async () => [] as TransactionPlan,
-      buildExecutionPrerequisites: async () => prerequisites,
-      buildBundledExecution: async () => ({
+      bundleExecutionCeremony: true,
+      buildExecutionCeremony: async () => ({
         plan: [] as TransactionPlan,
-        grants: prerequisites?.preTxs ?? [],
-        revokes: prerequisites?.postTxs ?? [],
+        prerequisites,
         grantSteps: [],
         revokeSteps: [],
       }),
@@ -1389,21 +1398,262 @@ describe('useTxBatch execution prerequisites', () => {
     batch.addEntry({
       label: 'Migrate Aave position',
       buildPlan: async () => singleOpBundledPlan,
-      buildExecutionPrerequisites: async () => ({
-        preTxs: [grantTx],
-        walletContext: grantWalletContext,
-        postTxs: [revokeTx],
-        postTxsByPreTx: [revokeTx],
-      }),
-      buildBundledExecution: async () => ({
+      bundleExecutionCeremony: true,
+      buildExecutionCeremony: async () => ({
         plan: singleOpBundledPlan,
-        grants: [grantTx],
-        revokes: [revokeTx],
+        prerequisites: {
+          preTxs: [grantTx],
+          walletContext: grantWalletContext,
+          postTxs: [revokeTx],
+          postTxsByPreTx: [revokeTx],
+        },
         grantSteps: [bundledGrantStep],
         revokeSteps: [bundledRevokeStep],
       }),
       refreshExternalMigrationPositions: true,
     })
+
+  it('resolves an authorization-bearing entry once for plan, calls, and review rows', async () => {
+    const sdk = createMockSdk()
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    isSafeWalletRef.value = false
+    const prepared = { kind: 'prepared', plan: singleOpBundledPlan, chainId: 1, account: owner }
+    eulerTxMocks.prepareTransactionPlan.mockResolvedValue(prepared)
+    const buildExecutionCeremony = vi.fn(async () => ({
+      plan: singleOpBundledPlan,
+      prerequisites: {
+        preTxs: [grantTx],
+        walletContext: grantWalletContext,
+        postTxs: [revokeTx],
+        postTxsByPreTx: [revokeTx],
+      },
+      grantSteps: [bundledGrantStep],
+      revokeSteps: [bundledRevokeStep],
+    }))
+
+    const batch = useTxBatch()
+    await batch.addEntry({
+      label: 'Migrate Aave position',
+      buildPlan: async () => singleOpBundledPlan,
+      bundleExecutionCeremony: true,
+      buildExecutionCeremony,
+    })
+    const ceremony = await batch.prepareBatchExecution()
+    const entryId = batch.entries.value[0]!.id
+
+    expect(buildExecutionCeremony).toHaveBeenCalledTimes(1)
+    expect(ceremony.prepared).toBe(prepared)
+    expect(ceremony.grants).toEqual([grantTx])
+    expect(ceremony.revokes).toEqual([revokeTx])
+    expect(ceremony.reviewByEntryId[entryId]).toEqual({
+      plan: singleOpBundledPlan,
+      grantSteps: [{ ...bundledGrantStep, isSeparateTx: true }],
+      revokeSteps: [{ ...bundledRevokeStep, isSeparateTx: true }],
+    })
+  })
+
+  it('reviews placeholder migration signatures and requests the real signatures only after confirmation', async () => {
+    const sdk = createMockSdk()
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    const placeholderPlan = [{
+      type: 'evcBatch',
+      items: [{ type: 'operation', name: 'placeholder-signature', items: [] }],
+    }] as unknown as TransactionPlan
+    const signedPlan = [{
+      type: 'evcBatch',
+      items: [{ type: 'operation', name: 'signed-authorization', items: [] }],
+    }] as unknown as TransactionPlan
+    const signatureStep = { index: 1, label: 'Sign migration authorization', isSeparateTx: false }
+    const requestWalletSignature = vi.fn()
+    const resolveExecutionPlan = vi.fn(async (beforeWalletAction: () => void) => {
+      beforeWalletAction()
+      requestWalletSignature()
+      return signedPlan
+    })
+    eulerTxMocks.prepareTransactionPlan.mockImplementation(async plan => ({ plan, chainId: 1, account: owner }))
+    eulerTxMocks.estimateGasForPlan.mockResolvedValue(undefined)
+    eulerTxMocks.executePreparedPlan.mockResolvedValue(undefined)
+
+    const batch = useTxBatch()
+    await batch.addEntry({
+      label: 'Signature migration',
+      buildPlan: async () => placeholderPlan,
+      buildExecutionCeremony: async () => ({
+        plan: placeholderPlan,
+        resolveExecutionPlan,
+        usesPlaceholderSignatures: true,
+        grantSteps: [signatureStep],
+        revokeSteps: [],
+      }),
+      requiresPlanningAccount: false,
+    })
+    await vi.waitFor(() => expect(batch.layers.value).toHaveLength(2))
+
+    const ceremony = await batch.prepareBatchExecution()
+    const entryId = batch.entries.value[0]!.id
+
+    expect(requestWalletSignature).not.toHaveBeenCalled()
+    expect(resolveExecutionPlan).not.toHaveBeenCalled()
+    expect(ceremony.usesPlaceholderSignatures).toBe(true)
+    expect(ceremony.reviewByEntryId[entryId]).toEqual({
+      plan: placeholderPlan,
+      grantSteps: [signatureStep],
+      revokeSteps: [],
+    })
+
+    await batch.executeBatch(undefined, ceremony)
+
+    expect(requestWalletSignature).toHaveBeenCalledTimes(1)
+    expect(resolveExecutionPlan).toHaveBeenCalledTimes(1)
+    expect(eulerTxMocks.prepareTransactionPlan).toHaveBeenNthCalledWith(1, placeholderPlan)
+    expect(eulerTxMocks.prepareTransactionPlan).toHaveBeenNthCalledWith(2, signedPlan)
+    expect(eulerTxMocks.executePreparedPlan).toHaveBeenCalledWith(
+      expect.objectContaining({ plan: signedPlan }),
+      { beforeBroadcast: expect.any(Function) },
+    )
+  })
+
+  it('requires resolved wallet classification and invalidates review on connector changes', async () => {
+    const sdk = createMockSdk()
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    eulerTxMocks.prepareTransactionPlan.mockResolvedValue({ kind: 'prepared' })
+
+    const batch = useTxBatch()
+    await addBundledMigrationEntry(batch)
+    isSafeWalletResolvedRef.value = false
+    await nextTick()
+    await expect(batch.prepareBatchExecution()).rejects.toThrow('Wallet type is still loading')
+
+    isSafeWalletResolvedRef.value = true
+    await nextTick()
+    const ceremony = await batch.prepareBatchExecution()
+    expect(batch.isBatchExecutionCurrent(ceremony)).toBe(true)
+
+    walletConnectorRef.value = { id: 'safe', uid: 'safe:2' }
+    expect(batch.isBatchExecutionCurrent(ceremony)).toBe(false)
+    await batch.executeBatch(undefined, ceremony)
+    expect(eulerTxMocks.executePreparedPlan).not.toHaveBeenCalled()
+    expect(eulerTxMocks.executePreparedPlanWithPlainCalls).not.toHaveBeenCalled()
+  })
+
+  it('rechecks standard ceremony freshness at the helper broadcast boundary', async () => {
+    const sdk = createMockSdk()
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    const prepared = { kind: 'prepared', plan: singleOpBundledPlan, chainId: 1, account: owner }
+    eulerTxMocks.prepareTransactionPlan.mockResolvedValue(prepared)
+    eulerTxMocks.estimateGasForPlan.mockResolvedValue(undefined)
+    let releaseHelper!: () => void
+    const helperGate = new Promise<void>((resolve) => {
+      releaseHelper = resolve
+    })
+    let broadcasted = false
+    eulerTxMocks.executePreparedPlan.mockImplementation(async (_prepared, options) => {
+      await helperGate
+      options.beforeBroadcast()
+      broadcasted = true
+      return { receipts: [] }
+    })
+
+    const batch = useTxBatch()
+    await batch.addEntry({
+      label: 'Standard operation',
+      buildPlan: async () => singleOpBundledPlan,
+      requiresPlanningAccount: false,
+    })
+    await vi.waitFor(() => expect(batch.layers.value).toHaveLength(2))
+    const ceremony = await batch.prepareBatchExecution()
+    const execution = batch.executeBatch(undefined, ceremony)
+    await vi.waitFor(() => expect(eulerTxMocks.executePreparedPlan).toHaveBeenCalledTimes(1))
+
+    batch.clearBatch()
+    releaseHelper()
+    await execution
+
+    expect(broadcasted).toBe(false)
+    expect(batch.execError.value).toBeUndefined()
+  })
+
+  it('rechecks prerequisite freshness at the helper broadcast boundary', async () => {
+    const sdk = createMockSdk()
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    const prepared = { kind: 'prepared', plan: singleOpBundledPlan, chainId: 1, account: owner }
+    eulerTxMocks.prepareTransactionPlan.mockResolvedValue(prepared)
+    eulerTxMocks.estimateGasForPlan.mockResolvedValue(undefined)
+    let releaseHelper!: () => void
+    const helperGate = new Promise<void>((resolve) => {
+      releaseHelper = resolve
+    })
+    let broadcasted = false
+    eulerTxMocks.sendPlainTransactions.mockImplementation(async (_txs, options) => {
+      await helperGate
+      options?.beforeBroadcast?.()
+      broadcasted = true
+      return []
+    })
+
+    const batch = useTxBatch()
+    await addBundledMigrationEntry(batch)
+    const ceremony = await batch.prepareBatchExecution()
+    const execution = batch.executeBatch(undefined, ceremony)
+    await vi.waitFor(() => expect(eulerTxMocks.sendPlainTransactions).toHaveBeenCalledTimes(1))
+
+    batch.clearBatch()
+    releaseHelper()
+    await execution
+
+    expect(broadcasted).toBe(false)
+    expect(eulerTxMocks.executePreparedPlan).not.toHaveBeenCalled()
+    expect(batch.execError.value).toBeUndefined()
+  })
+
+  it.each([
+    ['successful', undefined],
+    ['failed', new Error('old wallet execution failed')],
+  ])('does not let a late %s execution completion mutate a successor wallet cart', async (_outcome, completionError) => {
+    const sdk = createMockSdk()
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    const prepared = { kind: 'prepared', plan: singleOpBundledPlan, chainId: 1, account: owner }
+    eulerTxMocks.prepareTransactionPlan.mockResolvedValue(prepared)
+    eulerTxMocks.estimateGasForPlan.mockResolvedValue(undefined)
+    let releaseCompletion!: () => void
+    const completionGate = new Promise<void>((resolve) => {
+      releaseCompletion = resolve
+    })
+    eulerTxMocks.executePreparedPlan.mockImplementation(async (_prepared, options) => {
+      options.beforeBroadcast()
+      await completionGate
+      if (completionError) throw completionError
+      return { receipts: [] }
+    })
+
+    const batch = useTxBatch()
+    await batch.addEntry({
+      label: 'Old wallet operation',
+      buildPlan: async () => singleOpBundledPlan,
+      requiresPlanningAccount: false,
+    })
+    await vi.waitFor(() => expect(batch.layers.value).toHaveLength(2))
+    const ceremony = await batch.prepareBatchExecution()
+    const execution = batch.executeBatch(undefined, ceremony)
+    await vi.waitFor(() => expect(eulerTxMocks.executePreparedPlan).toHaveBeenCalledTimes(1))
+
+    const successor = getAddress('0x2000000000000000000000000000000000000000')
+    effectiveAddressRef.value = successor
+    walletAddressRef.value = successor
+    await nextTick()
+    await batch.addEntry({
+      label: 'Successor wallet operation',
+      buildPlan: async () => singleOpBundledPlan,
+      requiresPlanningAccount: false,
+    })
+    expect(batch.entries.value.map(entry => entry.label)).toEqual(['Successor wallet operation'])
+
+    releaseCompletion()
+    await execution
+
+    expect(batch.entries.value.map(entry => entry.label)).toEqual(['Successor wallet operation'])
+    expect(batch.execError.value).toBeUndefined()
+  })
 
   it('bundles grants + batch + revokes into one safe proposal', async () => {
     const sdk = createMockSdk()
@@ -1425,7 +1675,10 @@ describe('useTxBatch execution prerequisites', () => {
     expect(eulerTxMocks.executePreparedPlanWithPlainCalls).toHaveBeenCalledWith(prepared, {
       before: [grantTx],
       after: [revokeTx],
-    }, { allowSingleCall: true })
+    }, {
+      allowSingleCall: true,
+      beforeBroadcast: expect.any(Function),
+    })
     expect(eulerTxMocks.executePreparedPlan).not.toHaveBeenCalled()
     // Revokes rode in the proposal — nothing standalone to send afterwards.
     expect(migrationFlowMocks.revokeAfterSuccess).not.toHaveBeenCalled()
@@ -1439,31 +1692,39 @@ describe('useTxBatch execution prerequisites', () => {
     eulerTxMocks.prepareTransactionPlan.mockResolvedValue({ kind: 'prepared' })
     let resolveBundled!: (value: {
       plan: TransactionPlan
-      grants: typeof grantTx[]
-      revokes: typeof revokeTx[]
+      prerequisites?: {
+        preTxs: typeof grantTx[]
+        walletContext: WalletExecutionContext
+        postTxs: typeof revokeTx[]
+        postTxsByPreTx: typeof revokeTx[]
+      }
       grantSteps: typeof bundledGrantStep[]
       revokeSteps: typeof bundledRevokeStep[]
     }) => void
     const bundledResult = new Promise<Parameters<typeof resolveBundled>[0]>((resolve) => {
       resolveBundled = resolve
     })
-    const buildBundledExecution = vi.fn(() => bundledResult)
+    const buildExecutionCeremony = vi.fn(() => bundledResult)
 
     const batch = useTxBatch()
     await batch.addEntry({
       label: 'Migrate Aave position',
       buildPlan: async () => singleOpBundledPlan,
-      buildExecutionPrerequisites: async () => undefined,
-      buildBundledExecution,
+      bundleExecutionCeremony: true,
+      buildExecutionCeremony,
     })
 
     const preparationA = batch.prepareBundledExecution()
     const preparationB = batch.prepareBundledExecution()
-    await vi.waitFor(() => expect(buildBundledExecution).toHaveBeenCalledTimes(1))
+    await vi.waitFor(() => expect(buildExecutionCeremony).toHaveBeenCalledTimes(1))
     resolveBundled({
       plan: singleOpBundledPlan,
-      grants: [grantTx],
-      revokes: [revokeTx],
+      prerequisites: {
+        preTxs: [grantTx],
+        walletContext: grantWalletContext,
+        postTxs: [revokeTx],
+        postTxsByPreTx: [revokeTx],
+      },
       grantSteps: [bundledGrantStep],
       revokeSteps: [bundledRevokeStep],
     })
@@ -1507,11 +1768,9 @@ describe('useTxBatch execution prerequisites', () => {
     const pendingAdd = batch.addEntry({
       label: 'Second migration',
       buildPlan: buildSecondPlan,
-      buildExecutionPrerequisites: async () => undefined,
-      buildBundledExecution: async () => ({
+      bundleExecutionCeremony: true,
+      buildExecutionCeremony: async () => ({
         plan: singleOpBundledPlan,
-        grants: [],
-        revokes: [],
         grantSteps: [],
         revokeSteps: [],
       }),
@@ -1529,7 +1788,7 @@ describe('useTxBatch execution prerequisites', () => {
     expect(batch.isBundledExecutionCurrent(oldCartCeremony!)).toBe(false)
     await batch.executeBatch(undefined, oldCartCeremony!)
     expect(eulerTxMocks.executePreparedPlanWithPlainCalls).not.toHaveBeenCalled()
-    expect(batch.execError.value).toContain('Batch or wallet changed since review preparation')
+    expect(batch.execError.value).toBeUndefined()
   })
 
   it('keeps review unavailable until every queued add settles', async () => {
@@ -1559,8 +1818,6 @@ describe('useTxBatch execution prerequisites', () => {
     const buildSecondPlan = vi.fn(() => secondPlan)
     const bundled = async () => ({
       plan: singleOpBundledPlan,
-      grants: [],
-      revokes: [],
       grantSteps: [],
       revokeSteps: [],
     })
@@ -1570,16 +1827,16 @@ describe('useTxBatch execution prerequisites', () => {
       label: 'First migration',
       buildPlan: buildFirstPlan,
       requiresPlanningAccount: false,
-      buildExecutionPrerequisites: async () => undefined,
-      buildBundledExecution: bundled,
+      bundleExecutionCeremony: true,
+      buildExecutionCeremony: bundled,
     })
     await vi.waitFor(() => expect(buildFirstPlan).toHaveBeenCalledTimes(1))
     const secondAdd = batch.addEntry({
       label: 'Second migration',
       buildPlan: buildSecondPlan,
       requiresPlanningAccount: false,
-      buildExecutionPrerequisites: async () => undefined,
-      buildBundledExecution: bundled,
+      bundleExecutionCeremony: true,
+      buildExecutionCeremony: bundled,
     })
 
     resolveFirstPlan(singleOpBundledPlan)
@@ -1639,7 +1896,7 @@ describe('useTxBatch execution prerequisites', () => {
     await execution
 
     expect(eulerTxMocks.executePreparedPlan).not.toHaveBeenCalled()
-    expect(batch.execError.value).toContain('Batch or wallet changed since review preparation')
+    expect(batch.execError.value).toBeUndefined()
 
     resolvePendingPlan(singleOpBundledPlan)
     await pendingAdd
@@ -1680,7 +1937,7 @@ describe('useTxBatch execution prerequisites', () => {
     await execution
 
     expect(eulerTxMocks.executePreparedPlan).not.toHaveBeenCalled()
-    expect(batch.execError.value).toContain('Batch or wallet changed since review preparation')
+    expect(batch.execError.value).toBeUndefined()
 
     resolvePendingPlan(singleOpBundledPlan)
     await pendingAdd
@@ -1755,8 +2012,12 @@ describe('useTxBatch execution prerequisites', () => {
     eulerTxMocks.prepareTransactionPlan.mockImplementation(async plan => ({ plan }))
     let resolveOld!: (value: {
       plan: TransactionPlan
-      grants: typeof grantTx[]
-      revokes: typeof revokeTx[]
+      prerequisites?: {
+        preTxs: typeof grantTx[]
+        walletContext: WalletExecutionContext
+        postTxs: typeof revokeTx[]
+        postTxsByPreTx: typeof revokeTx[]
+      }
       grantSteps: typeof bundledGrantStep[]
       revokeSteps: typeof bundledRevokeStep[]
     }) => void
@@ -1769,8 +2030,8 @@ describe('useTxBatch execution prerequisites', () => {
     await batch.addEntry({
       label: 'Old migration',
       buildPlan: async () => singleOpBundledPlan,
-      buildExecutionPrerequisites: async () => undefined,
-      buildBundledExecution: buildOld,
+      bundleExecutionCeremony: true,
+      buildExecutionCeremony: buildOld,
     })
     const oldPreparation = batch.prepareBundledExecution()
     await vi.waitFor(() => expect(buildOld).toHaveBeenCalledTimes(1))
@@ -1780,11 +2041,15 @@ describe('useTxBatch execution prerequisites', () => {
     await batch.addEntry({
       label: 'New migration',
       buildPlan: async () => singleOpBundledPlan,
-      buildExecutionPrerequisites: async () => undefined,
-      buildBundledExecution: async () => ({
+      bundleExecutionCeremony: true,
+      buildExecutionCeremony: async () => ({
         plan: singleOpBundledPlan,
-        grants: [newGrant],
-        revokes: [],
+        prerequisites: {
+          preTxs: [newGrant],
+          walletContext: grantWalletContext,
+          postTxs: [],
+          postTxsByPreTx: [],
+        },
         grantSteps: [],
         revokeSteps: [],
       }),
@@ -1793,8 +2058,12 @@ describe('useTxBatch execution prerequisites', () => {
 
     resolveOld({
       plan: singleOpBundledPlan,
-      grants: [grantTx],
-      revokes: [revokeTx],
+      prerequisites: {
+        preTxs: [grantTx],
+        walletContext: grantWalletContext,
+        postTxs: [revokeTx],
+        postTxsByPreTx: [revokeTx],
+      },
       grantSteps: [bundledGrantStep],
       revokeSteps: [bundledRevokeStep],
     })
@@ -1811,33 +2080,41 @@ describe('useTxBatch execution prerequisites', () => {
     eulerTxMocks.prepareTransactionPlan.mockResolvedValue({ kind: 'prepared' })
     let resolveBundled!: (value: {
       plan: TransactionPlan
-      grants: typeof grantTx[]
-      revokes: typeof revokeTx[]
+      prerequisites?: {
+        preTxs: typeof grantTx[]
+        walletContext: WalletExecutionContext
+        postTxs: typeof revokeTx[]
+        postTxsByPreTx: typeof revokeTx[]
+      }
       grantSteps: typeof bundledGrantStep[]
       revokeSteps: typeof bundledRevokeStep[]
     }) => void
     const bundledResult = new Promise<Parameters<typeof resolveBundled>[0]>((resolve) => {
       resolveBundled = resolve
     })
-    const buildBundledExecution = vi.fn(() => bundledResult)
+    const buildExecutionCeremony = vi.fn(() => bundledResult)
 
     const batch = useTxBatch()
     await batch.addEntry({
       label: 'Migrate Aave position',
       buildPlan: async () => singleOpBundledPlan,
-      buildExecutionPrerequisites: async () => undefined,
-      buildBundledExecution,
+      bundleExecutionCeremony: true,
+      buildExecutionCeremony,
     })
     const preparation = batch.prepareBundledExecution()
-    await vi.waitFor(() => expect(buildBundledExecution).toHaveBeenCalledTimes(1))
+    await vi.waitFor(() => expect(buildExecutionCeremony).toHaveBeenCalledTimes(1))
 
     const nextOwner = getAddress('0x9000000000000000000000000000000000000009')
     effectiveAddressRef.value = nextOwner
     walletAddressRef.value = nextOwner
     resolveBundled({
       plan: singleOpBundledPlan,
-      grants: [grantTx],
-      revokes: [revokeTx],
+      prerequisites: {
+        preTxs: [grantTx],
+        walletContext: grantWalletContext,
+        postTxs: [revokeTx],
+        postTxsByPreTx: [revokeTx],
+      },
       grantSteps: [bundledGrantStep],
       revokeSteps: [bundledRevokeStep],
     })
@@ -1875,7 +2152,9 @@ describe('useTxBatch execution prerequisites', () => {
     expect(ceremony.mode).toBe('standard')
     expect(ceremony.safeWallet).toBe(safeWallet)
     expect(eulerTxMocks.prepareTransactionPlan).toHaveBeenCalledTimes(1)
-    expect(eulerTxMocks.executePreparedPlan).toHaveBeenCalledWith(reviewedPrepared)
+    expect(eulerTxMocks.executePreparedPlan).toHaveBeenCalledWith(reviewedPrepared, {
+      beforeBroadcast: expect.any(Function),
+    })
   })
 
   it('uses one prepared core plan for review export and safe execution', async () => {
@@ -1898,16 +2177,15 @@ describe('useTxBatch execution prerequisites', () => {
     await batch.addEntry({
       label: 'Migrate Aave position',
       buildPlan: async () => previewPlan,
-      buildExecutionPrerequisites: async () => ({
-        preTxs: [grantTx],
-        walletContext: grantWalletContext,
-        postTxs: [revokeTx],
-        postTxsByPreTx: [revokeTx],
-      }),
-      buildBundledExecution: async () => ({
+      bundleExecutionCeremony: true,
+      buildExecutionCeremony: async () => ({
         plan: latchedPlan,
-        grants: [grantTx],
-        revokes: [revokeTx],
+        prerequisites: {
+          preTxs: [grantTx],
+          walletContext: grantWalletContext,
+          postTxs: [revokeTx],
+          postTxsByPreTx: [revokeTx],
+        },
         grantSteps: [bundledGrantStep],
         revokeSteps: [bundledRevokeStep],
       }),
@@ -1924,7 +2202,10 @@ describe('useTxBatch execution prerequisites', () => {
     expect(eulerTxMocks.executePreparedPlanWithPlainCalls).toHaveBeenCalledWith(latchedPrepared, {
       before: [grantTx],
       after: [revokeTx],
-    }, { allowSingleCall: true })
+    }, {
+      allowSingleCall: true,
+      beforeBroadcast: expect.any(Function),
+    })
   })
 
   it('keeps copied and submitted before, prepared plugin/approval/core, after vectors identical', async () => {
@@ -2015,7 +2296,9 @@ describe('useTxBatch execution prerequisites', () => {
     expect(batch.execError.value).toBeTruthy()
     // Nothing broadcast standalone, nothing to unwind, cart retained.
     expect(eulerTxMocks.sendPlainTransactions).not.toHaveBeenCalled()
-    expect(migrationFlowMocks.revokeAfterAbort).toHaveBeenCalledWith([])
+    expect(migrationFlowMocks.revokeAfterAbort).toHaveBeenCalledWith([], {
+      shouldNotify: expect.any(Function),
+    })
     expect(batch.entryCount.value).toBe(1)
   })
 
@@ -2031,11 +2314,10 @@ describe('useTxBatch execution prerequisites', () => {
     await batch.addEntry({
       label: 'Migrate Aave position',
       buildPlan: async () => singleOpBundledPlan,
-      buildExecutionPrerequisites: async () => undefined,
-      // Grant already live: nothing to wrap — but the reviewed ceremony is
-      // still ONE provider-bound proposal, never a silent executePreparedPlan
-      // whose internals could degrade to sequential sends.
-      buildBundledExecution: async () => ({ plan: singleOpBundledPlan, grants: [], revokes: [], grantSteps: [], revokeSteps: [] }),
+      bundleExecutionCeremony: true,
+      // A ceremony remains one provider-bound proposal even when its
+      // authorization calls are empty.
+      buildExecutionCeremony: async () => ({ plan: singleOpBundledPlan, grantSteps: [], revokeSteps: [] }),
     })
     const ceremony = await batch.prepareBundledExecution()
     await batch.executeBatch(undefined, ceremony ?? undefined)
@@ -2043,7 +2325,10 @@ describe('useTxBatch execution prerequisites', () => {
     expect(eulerTxMocks.executePreparedPlanWithPlainCalls).toHaveBeenCalledWith(prepared, {
       before: [],
       after: [],
-    }, { allowSingleCall: true })
+    }, {
+      allowSingleCall: true,
+      beforeBroadcast: expect.any(Function),
+    })
     expect(eulerTxMocks.executePreparedPlan).not.toHaveBeenCalled()
   })
 
@@ -2095,7 +2380,62 @@ describe('useTxBatch execution prerequisites', () => {
     ])
   })
 
-  it('throws a re-review error when the wallet stopped being a safe after latching', async () => {
+  it('submits grants in entry order and restorations in exact reverse entry order', async () => {
+    const sdk = createMockSdk()
+    sdk.executionService.simulateTransactionPlan.mockImplementation(async (...args: unknown[]) => ({
+      simulatedAccounts: Array.from(
+        { length: countPlanOperations(args[2] as TransactionPlan) },
+        (_, index) => accountWithPosition(subAccount, subAccount, BigInt(index + 2)),
+      ),
+      simulatedWalletBalances: [],
+      simulatedVaults: [],
+      failedBatchItems: [],
+      insufficientWalletAssets: [],
+    }))
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    isSafeWalletRef.value = true
+    const secondGrant = { to: morphoBlue, data: '0xgrant2' as Hex }
+    const secondRevoke = { to: morphoBlue, data: '0xrevoke2' as Hex }
+    const prepared = { kind: 'prepared', plan: singleOpBundledPlan, chainId: 1, account: owner }
+    eulerTxMocks.prepareTransactionPlan.mockResolvedValue(prepared)
+    eulerTxMocks.executePreparedPlanWithPlainCalls.mockResolvedValue({ receipts: [] })
+
+    const batch = useTxBatch()
+    await addBundledMigrationEntry(batch)
+    await batch.addEntry({
+      label: 'Second migration',
+      buildPlan: async () => singleOpBundledPlan,
+      bundleExecutionCeremony: true,
+      buildExecutionCeremony: async () => ({
+        plan: singleOpBundledPlan,
+        prerequisites: {
+          preTxs: [secondGrant],
+          walletContext: grantWalletContext,
+          postTxs: [secondRevoke],
+          postTxsByPreTx: [secondRevoke],
+        },
+        grantSteps: [],
+        revokeSteps: [],
+      }),
+    })
+    await vi.waitFor(() => expect(batch.layers.value).toHaveLength(3))
+
+    const ceremony = await batch.prepareBundledExecution()
+    expect(ceremony?.grants).toEqual([grantTx, secondGrant])
+    expect(ceremony?.revokes).toEqual([secondRevoke, revokeTx])
+
+    await batch.executeBatch(undefined, ceremony)
+
+    expect(eulerTxMocks.executePreparedPlanWithPlainCalls).toHaveBeenCalledWith(prepared, {
+      before: [grantTx, secondGrant],
+      after: [secondRevoke, revokeTx],
+    }, {
+      allowSingleCall: true,
+      beforeBroadcast: expect.any(Function),
+    })
+  })
+
+  it('rejects the ceremony when the wallet stopped being a safe after review', async () => {
     const sdk = createMockSdk()
     vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
     isSafeWalletRef.value = true
@@ -2111,7 +2451,7 @@ describe('useTxBatch execution prerequisites', () => {
     expect(batch.isBundledExecutionCurrent(ceremony!)).toBe(false)
     await batch.executeBatch(undefined, ceremony ?? undefined)
 
-    expect(batch.execError.value).toBeTruthy()
+    expect(batch.execError.value).toBeUndefined()
     expect(eulerTxMocks.executePreparedPlanWithPlainCalls).not.toHaveBeenCalled()
     expect(eulerTxMocks.sendPlainTransactions).not.toHaveBeenCalled()
   })
@@ -2143,7 +2483,9 @@ describe('useTxBatch execution prerequisites', () => {
       [grantTx],
       expect.objectContaining({ walletContext: grantWalletContext }),
     )
-    expect(eulerTxMocks.executePreparedPlan).toHaveBeenCalledWith(prepared)
+    expect(eulerTxMocks.executePreparedPlan).toHaveBeenCalledWith(prepared, {
+      beforeBroadcast: expect.any(Function),
+    })
   })
 
   it('revokes an already-granted entry when a later entry\'s grant is rejected', async () => {
@@ -2187,7 +2529,9 @@ describe('useTxBatch execution prerequisites', () => {
 
     // The first grant is mined and standing. Leaving it would orphan the
     // allowance: a retry sees it already granted, so it registers no revoke.
-    expect(migrationFlowMocks.revokeAfterAbort).toHaveBeenCalledWith([trackedRevoke(revokeTx)])
+    expect(migrationFlowMocks.revokeAfterAbort).toHaveBeenCalledWith([trackedRevoke(revokeTx)], {
+      shouldNotify: expect.any(Function),
+    })
     expect(eulerTxMocks.executePreparedPlan).not.toHaveBeenCalled()
     expect(batch.entryCount.value).toBe(2)
   })
@@ -2237,7 +2581,9 @@ describe('useTxBatch execution prerequisites', () => {
         onBroadcast: expect.any(Function),
       }),
     )
-    expect(migrationFlowMocks.revokeAfterSuccess).toHaveBeenCalledWith([trackedRevoke(revokeTx)])
+    expect(migrationFlowMocks.revokeAfterSuccess).toHaveBeenCalledWith([trackedRevoke(revokeTx)], {
+      shouldNotify: expect.any(Function),
+    })
     expect(migrationFlowMocks.revokeAfterAbort).not.toHaveBeenCalled()
   })
 
@@ -2252,7 +2598,9 @@ describe('useTxBatch execution prerequisites', () => {
     expect(batch.entryCount.value).toBe(1)
     expect(batch.execError.value).toBeDefined()
     // Nothing landed, so there is nothing of ours to revoke.
-    expect(migrationFlowMocks.revokeAfterAbort).toHaveBeenCalledWith([])
+    expect(migrationFlowMocks.revokeAfterAbort).toHaveBeenCalledWith([], {
+      shouldNotify: expect.any(Function),
+    })
   })
 
   it('revokes a broadcast grant when receipt confirmation fails before later grants', async () => {
@@ -2272,7 +2620,9 @@ describe('useTxBatch execution prerequisites', () => {
     })
     await batch.executeBatch()
 
-    expect(migrationFlowMocks.revokeAfterAbort).toHaveBeenCalledWith([trackedRevoke(revokeTx)])
+    expect(migrationFlowMocks.revokeAfterAbort).toHaveBeenCalledWith([trackedRevoke(revokeTx)], {
+      shouldNotify: expect.any(Function),
+    })
     expect(eulerTxMocks.executePreparedPlan).not.toHaveBeenCalled()
     expect(batch.entryCount.value).toBe(1)
   })
@@ -2289,7 +2639,9 @@ describe('useTxBatch execution prerequisites', () => {
       await addGrantingMigrationEntry(batch)
       await batch.executeBatch()
 
-      expect(migrationFlowMocks.revokeAfterAbort).toHaveBeenCalledWith([trackedRevoke(revokeTx)])
+      expect(migrationFlowMocks.revokeAfterAbort).toHaveBeenCalledWith([trackedRevoke(revokeTx)], {
+        shouldNotify: expect.any(Function),
+      })
       expect(batch.entryCount.value).toBe(1)
     },
   )
@@ -2311,7 +2663,9 @@ describe('useTxBatch execution prerequisites', () => {
     expect(migrationFlowMocks.restorePendingBeforeRetry).toHaveBeenCalledTimes(2)
     expect(eulerTxMocks.sendPlainTransactions).toHaveBeenCalledTimes(1)
     expect(eulerTxMocks.executePreparedPlan).toHaveBeenCalledTimes(1)
-    expect(migrationFlowMocks.revokeAfterAbort).toHaveBeenCalledWith([trackedRevoke(revokeTx)])
+    expect(migrationFlowMocks.revokeAfterAbort).toHaveBeenCalledWith([trackedRevoke(revokeTx)], {
+      shouldNotify: expect.any(Function),
+    })
     expect(batch.entryCount.value).toBe(1)
   })
 
@@ -2327,7 +2681,9 @@ describe('useTxBatch execution prerequisites', () => {
     await batch.executeBatch()
 
     expect(eulerTxMocks.sendPlainTransactions).not.toHaveBeenCalled()
-    expect(migrationFlowMocks.revokeAfterSuccess).toHaveBeenCalledWith([])
+    expect(migrationFlowMocks.revokeAfterSuccess).toHaveBeenCalledWith([], {
+      shouldNotify: expect.any(Function),
+    })
     expect(batch.entryCount.value).toBe(0)
   })
 

--- a/tests/composables/useTxBatch.test.ts
+++ b/tests/composables/useTxBatch.test.ts
@@ -1426,6 +1426,60 @@ describe('useTxBatch execution prerequisites', () => {
     expect(Object.isFrozen(ceremonyA?.grants)).toBe(true)
   })
 
+  it('invalidates a ceremony prepared while another entry is still building', async () => {
+    const sdk = createMockSdk()
+    sdk.executionService.simulateTransactionPlan.mockImplementation(async (...args: unknown[]) => ({
+      simulatedAccounts: Array.from(
+        { length: countPlanOperations(args[2] as TransactionPlan) },
+        (_, index) => accountWithPosition(subAccount, subAccount, BigInt(index + 2)),
+      ),
+      simulatedWalletBalances: [],
+      simulatedVaults: [],
+      failedBatchItems: [],
+      insufficientWalletAssets: [],
+    }))
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    isSafeWalletRef.value = true
+    eulerTxMocks.prepareTransactionPlan.mockImplementation(async plan => ({ plan, chainId: 1, account: owner }))
+    eulerTxMocks.executePreparedPlanWithPlainCalls.mockResolvedValue({ receipts: [] })
+
+    const batch = useTxBatch()
+    await addBundledMigrationEntry(batch)
+
+    let resolveSecondPlan!: (plan: TransactionPlan) => void
+    const secondPlan = new Promise<TransactionPlan>((resolve) => {
+      resolveSecondPlan = resolve
+    })
+    const buildSecondPlan = vi.fn(() => secondPlan)
+    const pendingAdd = batch.addEntry({
+      label: 'Second migration',
+      buildPlan: buildSecondPlan,
+      buildExecutionPrerequisites: async () => undefined,
+      buildBundledExecution: async () => ({
+        plan: singleOpBundledPlan,
+        grants: [],
+        revokes: [],
+        grantSteps: [],
+        revokeSteps: [],
+      }),
+    })
+    await vi.waitFor(() => expect(buildSecondPlan).toHaveBeenCalledTimes(1))
+
+    const oldCartCeremony = await batch.prepareBundledExecution()
+    expect(oldCartCeremony?.reviewByEntryId).toHaveProperty(batch.entries.value[0]!.id)
+    expect(Object.keys(oldCartCeremony?.reviewByEntryId ?? {})).toHaveLength(1)
+
+    resolveSecondPlan(singleOpBundledPlan)
+    await pendingAdd
+    await vi.waitFor(() => expect(batch.layers.value).toHaveLength(3))
+
+    expect(batch.entryCount.value).toBe(2)
+    expect(batch.isBundledExecutionCurrent(oldCartCeremony!)).toBe(false)
+    await batch.executeBatch(undefined, oldCartCeremony!)
+    expect(eulerTxMocks.executePreparedPlanWithPlainCalls).not.toHaveBeenCalled()
+    expect(batch.execError.value).toContain('Batch or wallet changed since review preparation')
+  })
+
   it('rejects an older preparation that resolves after a new cart ceremony', async () => {
     const sdk = createMockSdk()
     vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)

--- a/tests/composables/useTxBatch.test.ts
+++ b/tests/composables/useTxBatch.test.ts
@@ -1738,6 +1738,89 @@ describe('useTxBatch execution prerequisites', () => {
     expect(batch.execError.value).toBeUndefined()
   })
 
+  it('retires executed entries but keeps a same-wallet entry added during the broadcast', async () => {
+    const sdk = createMockSdk()
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    eulerTxMocks.prepareTransactionPlan.mockImplementation(async plan => ({ plan, chainId: 1, account: owner }))
+    eulerTxMocks.estimateGasForPreparedPlan.mockResolvedValue(undefined)
+    let releaseCompletion!: () => void
+    const completionGate = new Promise<void>((resolve) => {
+      releaseCompletion = resolve
+    })
+    eulerTxMocks.executePreparedPlan.mockImplementation(async (_prepared, options) => {
+      options.beforeBroadcast()
+      await completionGate
+      return { receipts: [] }
+    })
+
+    const batch = useTxBatch()
+    await batch.addEntry({
+      label: 'Executed operation',
+      buildPlan: async () => singleOpBundledPlan,
+      requiresPlanningAccount: false,
+    })
+    await vi.waitFor(() => expect(batch.layers.value).toHaveLength(2))
+    const executedId = batch.entries.value[0]!.id
+    const ceremony = await batch.prepareBatchExecution()
+    const execution = batch.executeBatch(undefined, ceremony)
+    await vi.waitFor(() => expect(eulerTxMocks.executePreparedPlan).toHaveBeenCalledTimes(1))
+
+    // Same wallet, cart edited while the broadcast is in flight: the ceremony
+    // goes stale, but the executed entry still lands on-chain.
+    await batch.addEntry({
+      label: 'Added during broadcast',
+      buildPlan: async () => singleOpBundledPlan,
+      requiresPlanningAccount: false,
+    })
+    expect(batch.entries.value.map(entry => entry.label)).toEqual(['Executed operation', 'Added during broadcast'])
+
+    releaseCompletion()
+    await execution
+
+    // Only the executed entry retires — leaving it queued would re-execute it
+    // on the next send; clearing everything would discard the new entry.
+    expect(batch.entries.value.map(entry => entry.label)).toEqual(['Added during broadcast'])
+    expect(batch.entries.value.some(entry => entry.id === executedId)).toBe(false)
+    expect(batch.execError.value).toBeUndefined()
+  })
+
+  it('retires executed entries after a stale safe-bundled proposal lands', async () => {
+    const sdk = createMockSdk()
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    isSafeWalletRef.value = true
+    eulerTxMocks.prepareTransactionPlan.mockImplementation(async plan => ({ plan, chainId: 1, account: owner }))
+    let releaseCompletion!: () => void
+    const completionGate = new Promise<void>((resolve) => {
+      releaseCompletion = resolve
+    })
+    eulerTxMocks.executePreparedPlanWithPlainCalls.mockImplementation(async (_prepared, _wrappers, options) => {
+      options?.beforeBroadcast?.()
+      await completionGate
+      return { receipts: [] }
+    })
+
+    const batch = useTxBatch()
+    await addBundledMigrationEntry(batch)
+    const executedId = batch.entries.value[0]!.id
+    const ceremony = await batch.prepareBatchExecution()
+    const execution = batch.executeBatch(undefined, ceremony)
+    await vi.waitFor(() => expect(eulerTxMocks.executePreparedPlanWithPlainCalls).toHaveBeenCalledTimes(1))
+
+    await batch.addEntry({
+      label: 'Added during proposal',
+      buildPlan: async () => singleOpBundledPlan,
+      requiresPlanningAccount: false,
+    })
+    expect(batch.entries.value).toHaveLength(2)
+
+    releaseCompletion()
+    await execution
+
+    expect(batch.entries.value.map(entry => entry.label)).toEqual(['Added during proposal'])
+    expect(batch.entries.value.some(entry => entry.id === executedId)).toBe(false)
+    expect(batch.execError.value).toBeUndefined()
+  })
+
   it('does not publish a decoded execution error after the wallet context changes', async () => {
     const sdk = createMockSdk()
     vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)

--- a/tests/composables/useTxBatch.test.ts
+++ b/tests/composables/useTxBatch.test.ts
@@ -926,6 +926,49 @@ describe('useTxBatch execution errors', () => {
     expect(buildAccount?.owner).toBe(owner)
   })
 
+  it('does not publish a stale resimulation snapshot after an account reset', async () => {
+    const sdk = createMockSdk()
+    const oldAccount = accountWithPosition(subAccount, subAccount, 11n)
+    const nextOwner = getAddress('0x2000000000000000000000000000000000000002')
+    const nextAccount = accountWithPosition(subAccount, subAccount, 22n)
+    nextAccount.owner = nextOwner
+    let resolveOldFetch!: (value: { result: Account<IHasVaultAddress>, errors: never[] }) => void
+    const oldFetch = new Promise<{ result: Account<IHasVaultAddress>, errors: never[] }>((resolve) => {
+      resolveOldFetch = resolve
+    })
+    sdk.accountService.fetchAccount
+      .mockImplementationOnce(() => oldFetch)
+      .mockResolvedValueOnce({ result: nextAccount, errors: [] })
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+
+    const batch = useTxBatch()
+    await batch.addEntry({
+      label: 'Account A operation',
+      buildPlan: async () => [] as TransactionPlan,
+      requiresPlanningAccount: false,
+    })
+    await vi.waitFor(() => expect(sdk.accountService.fetchAccount).toHaveBeenCalledTimes(1))
+
+    effectiveAddressRef.value = nextOwner
+    walletAddressRef.value = nextOwner
+    await nextTick()
+    resolveOldFetch({ result: oldAccount, errors: [] })
+    await Promise.resolve()
+
+    let planningAccount: Account<IHasVaultAddress> | undefined
+    await batch.addEntry({
+      label: 'Account B operation',
+      buildPlan: async (account) => {
+        planningAccount = account
+        return [] as TransactionPlan
+      },
+    })
+
+    expect(sdk.accountService.fetchAccount).toHaveBeenCalledTimes(2)
+    expect(planningAccount).toBe(nextAccount)
+    expect(planningAccount).not.toBe(oldAccount)
+  })
+
   it('publishes per-layer simulated vault state even without an enriched account position', async () => {
     const sdk = createMockSdk()
     const simulatedVault = {
@@ -1310,6 +1353,13 @@ describe('useTxBatch execution prerequisites', () => {
       label: 'Migrate Aave position',
       buildPlan: async () => [] as TransactionPlan,
       buildExecutionPrerequisites: async () => prerequisites,
+      buildBundledExecution: async () => ({
+        plan: [] as TransactionPlan,
+        grants: prerequisites?.preTxs ?? [],
+        revokes: prerequisites?.postTxs ?? [],
+        grantSteps: [],
+        revokeSteps: [],
+      }),
       refreshExternalMigrationPositions: true,
     })
   }
@@ -1554,6 +1604,88 @@ describe('useTxBatch execution prerequisites', () => {
     expect(Object.keys(ceremony?.reviewByEntryId ?? {})).toHaveLength(2)
   })
 
+  it('does not execute an old ceremony when an add starts during retry restoration', async () => {
+    const sdk = createMockSdk()
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    eulerTxMocks.prepareTransactionPlan.mockImplementation(async plan => ({ plan, chainId: 1, account: owner }))
+    eulerTxMocks.executePreparedPlan.mockResolvedValue(undefined)
+    let releaseRestore!: (value: boolean) => void
+    migrationFlowMocks.restorePendingBeforeRetry.mockImplementation(() => new Promise<boolean>((resolve) => {
+      releaseRestore = resolve
+    }))
+
+    const batch = useTxBatch()
+    await batch.addEntry({
+      label: 'Reviewed operation',
+      buildPlan: async () => singleOpBundledPlan,
+      requiresPlanningAccount: false,
+    })
+    await vi.waitFor(() => expect(batch.layers.value).toHaveLength(2))
+    const ceremony = await batch.prepareBatchExecution()
+    const execution = batch.executeBatch(undefined, ceremony)
+    await vi.waitFor(() => expect(migrationFlowMocks.restorePendingBeforeRetry).toHaveBeenCalledTimes(1))
+
+    let resolvePendingPlan!: (plan: TransactionPlan) => void
+    const pendingPlan = new Promise<TransactionPlan>((resolve) => {
+      resolvePendingPlan = resolve
+    })
+    const pendingAdd = batch.addEntry({
+      label: 'Pending operation',
+      buildPlan: () => pendingPlan,
+      requiresPlanningAccount: false,
+    })
+    await vi.waitFor(() => expect(batch.hasPendingAdds.value).toBe(true))
+    releaseRestore(true)
+    await execution
+
+    expect(eulerTxMocks.executePreparedPlan).not.toHaveBeenCalled()
+    expect(batch.execError.value).toContain('Batch or wallet changed since review preparation')
+
+    resolvePendingPlan(singleOpBundledPlan)
+    await pendingAdd
+  })
+
+  it('rechecks ceremony freshness after the final gas-estimate await', async () => {
+    const sdk = createMockSdk()
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    eulerTxMocks.prepareTransactionPlan.mockImplementation(async plan => ({ plan, chainId: 1, account: owner }))
+    let releaseEstimate!: () => void
+    eulerTxMocks.estimateGasForPlan.mockImplementation(() => new Promise<void>((resolve) => {
+      releaseEstimate = resolve
+    }))
+    eulerTxMocks.executePreparedPlan.mockResolvedValue(undefined)
+
+    const batch = useTxBatch()
+    await batch.addEntry({
+      label: 'Reviewed operation',
+      buildPlan: async () => singleOpBundledPlan,
+      requiresPlanningAccount: false,
+    })
+    await vi.waitFor(() => expect(batch.layers.value).toHaveLength(2))
+    const ceremony = await batch.prepareBatchExecution()
+    const execution = batch.executeBatch(undefined, ceremony)
+    await vi.waitFor(() => expect(eulerTxMocks.estimateGasForPlan).toHaveBeenCalledTimes(1))
+
+    let resolvePendingPlan!: (plan: TransactionPlan) => void
+    const pendingPlan = new Promise<TransactionPlan>((resolve) => {
+      resolvePendingPlan = resolve
+    })
+    const pendingAdd = batch.addEntry({
+      label: 'Pending operation',
+      buildPlan: () => pendingPlan,
+      requiresPlanningAccount: false,
+    })
+    await vi.waitFor(() => expect(batch.hasPendingAdds.value).toBe(true))
+    releaseEstimate()
+    await execution
+
+    expect(eulerTxMocks.executePreparedPlan).not.toHaveBeenCalled()
+    expect(batch.execError.value).toContain('Batch or wallet changed since review preparation')
+
+    resolvePendingPlan(singleOpBundledPlan)
+    await pendingAdd
+  })
+
   it.each([
     ['account', async () => {
       effectiveAddressRef.value = getAddress('0x2000000000000000000000000000000000000000')
@@ -1711,6 +1843,39 @@ describe('useTxBatch execution prerequisites', () => {
     })
 
     await expect(preparation).rejects.toThrow('Batch or wallet changed since review preparation')
+  })
+
+  it.each([
+    ['ordinary Safe', true],
+    ['EOA', false],
+  ])('executes the exact reviewed prepared core for %s batches', async (_label, safeWallet) => {
+    const sdk = createMockSdk()
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    isSafeWalletRef.value = safeWallet
+    const reviewedPlan = [{
+      type: 'evcBatch',
+      items: [{ type: 'operation', name: 'reviewed-standard-core', items: [] }],
+    }] as unknown as TransactionPlan
+    const reviewedPrepared = { kind: 'reviewed', plan: reviewedPlan, chainId: 1, account: owner }
+    eulerTxMocks.prepareTransactionPlan.mockResolvedValue(reviewedPrepared)
+    eulerTxMocks.estimateGasForPlan.mockResolvedValue(undefined)
+    eulerTxMocks.executePreparedPlan.mockResolvedValue(undefined)
+
+    const batch = useTxBatch()
+    await batch.addEntry({
+      label: 'Standard operation',
+      buildPlan: async () => reviewedPlan,
+      requiresPlanningAccount: false,
+    })
+    await vi.waitFor(() => expect(batch.layers.value).toHaveLength(2))
+
+    const ceremony = await batch.prepareBatchExecution()
+    await batch.executeBatch(undefined, ceremony)
+
+    expect(ceremony.mode).toBe('standard')
+    expect(ceremony.safeWallet).toBe(safeWallet)
+    expect(eulerTxMocks.prepareTransactionPlan).toHaveBeenCalledTimes(1)
+    expect(eulerTxMocks.executePreparedPlan).toHaveBeenCalledWith(reviewedPrepared)
   })
 
   it('uses one prepared core plan for review export and safe execution', async () => {
@@ -1955,7 +2120,9 @@ describe('useTxBatch execution prerequisites', () => {
     const sdk = createMockSdk()
     vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
     isSafeWalletRef.value = false
-    eulerTxMocks.prepareTransactionPlan.mockResolvedValue({ kind: 'prepared' })
+    const prepared = { kind: 'prepared', plan: singleOpBundledPlan, chainId: 1, account: owner }
+    eulerTxMocks.prepareTransactionPlan.mockResolvedValue(prepared)
+    eulerTxMocks.estimateGasForPlan.mockResolvedValue(undefined)
     eulerTxMocks.executePreparedPlan.mockResolvedValue(undefined)
     eulerTxMocks.sendPlainTransactions.mockImplementation(async (txs: { data: Hex }[], options?: PlainTxSendOptions) => {
       txs.forEach((_tx, index) => options?.onBroadcast?.(index, grantWalletContext))
@@ -1964,12 +2131,19 @@ describe('useTxBatch execution prerequisites', () => {
 
     const batch = useTxBatch()
     await addBundledMigrationEntry(batch)
-    await batch.prepareBundledExecution()
-    await batch.executeBatch()
+    const ceremony = await batch.prepareBatchExecution()
+    await batch.executeBatch(undefined, ceremony)
 
+    expect(ceremony.mode).toBe('standard')
+    expect(ceremony.grants).toEqual([grantTx])
+    expect(ceremony.revokes).toEqual([revokeTx])
+    expect(eulerTxMocks.prepareTransactionPlan).toHaveBeenCalledTimes(1)
     expect(eulerTxMocks.executePreparedPlanWithPlainCalls).not.toHaveBeenCalled()
-    expect(eulerTxMocks.sendPlainTransactions).toHaveBeenCalled()
-    expect(eulerTxMocks.executePreparedPlan).toHaveBeenCalled()
+    expect(eulerTxMocks.sendPlainTransactions).toHaveBeenCalledWith(
+      [grantTx],
+      expect.objectContaining({ walletContext: grantWalletContext }),
+    )
+    expect(eulerTxMocks.executePreparedPlan).toHaveBeenCalledWith(prepared)
   })
 
   it('revokes an already-granted entry when a later entry\'s grant is rejected', async () => {
@@ -2046,12 +2220,12 @@ describe('useTxBatch execution prerequisites', () => {
     calls.length = 0
     await batch.executeBatch()
 
-    // The grant must be mined before the plan is built: the connector reads the
-    // live allowance to decide whether the batch needs an authorization item.
+    // The exact core is prepared once, then its prerequisite grant is mined
+    // before that reviewed core is estimated and executed.
     expect(calls).toEqual([
       'restorePendingBeforeRetry',
-      'sendPlainTransactions',
       'mergePlans',
+      'sendPlainTransactions',
       'estimateGasForPlan',
       'executePreparedPlan',
       'revokeAfterSuccess',

--- a/tests/composables/useTxBatch.test.ts
+++ b/tests/composables/useTxBatch.test.ts
@@ -13,6 +13,7 @@ import {
 import { activeLayerVaultsRef } from '~/composables/useLayeredVaults'
 import { WalletExecutionContextChangedError } from '~/utils/walletExecutionContext'
 import type { WalletExecutionContext } from '~/utils/walletExecutionContext'
+import { buildBatchReviewCalldata } from '~/utils/batchReviewCalldata'
 
 vi.mock('~/composables/useEulerSdk', () => ({
   getEulerSdkFresh: vi.fn(),
@@ -36,6 +37,9 @@ const eulerTxMocks = {
   sendPlainTransactions: vi.fn(),
 }
 const isSafeWalletRef = ref(false)
+const walletAddressRef = ref<Address | undefined>(owner)
+const walletChainIdRef = ref<number | undefined>(1)
+const effectiveAddressRef = ref<Address | undefined>(owner)
 const grantWalletContext: WalletExecutionContext = { account: owner, chainId: 1 }
 type PlainTxSendOptions = {
   onBroadcast?: (index: number, walletContext: WalletExecutionContext) => void
@@ -263,14 +267,14 @@ const accountWithPositions = (
 })
 
 const stubBatchComposableGlobals = () => {
-  vi.stubGlobal('useWagmi', () => ({ address: ref(owner), chainId: ref(1) }))
+  vi.stubGlobal('useWagmi', () => ({ address: walletAddressRef, chainId: walletChainIdRef }))
   vi.stubGlobal('useSpyMode', () => ({ isSpyMode: ref(false), spyAddress: ref(undefined) }))
   vi.stubGlobal('useEffectiveAddress', () => ({
-    address: ref(owner),
+    address: effectiveAddressRef,
     isConnected: ref(true),
     isSpyMode: ref(false),
     spyAddress: ref(undefined),
-    effectiveAddress: ref(owner),
+    effectiveAddress: effectiveAddressRef,
   }))
   vi.stubGlobal('useEulerAddresses', () => ({ chainId: ref(1) }))
   vi.stubGlobal('useEulerTx', () => eulerTxMocks)
@@ -325,6 +329,9 @@ beforeEach(() => {
   scheduleExternalMigrationRefreshes.mockReset()
   routerReplace.mockReset()
   routeQuery.network = '1'
+  walletAddressRef.value = owner
+  walletChainIdRef.value = 1
+  effectiveAddressRef.value = owner
   stubBatchComposableGlobals()
   vi.mocked(getEulerSdkFresh).mockResolvedValue(createMockSdk() as never)
   resetBatchPrefetchState()
@@ -1358,9 +1365,8 @@ describe('useTxBatch execution prerequisites', () => {
 
     const batch = useTxBatch()
     await addBundledMigrationEntry(batch)
-    // The review modal latches the ceremony at open; execution consumes it.
-    await batch.prepareBundledExecution()
-    await batch.executeBatch()
+    const ceremony = await batch.prepareBundledExecution()
+    await batch.executeBatch(undefined, ceremony ?? undefined)
 
     // Grants ride in the proposal — no standalone broadcasts, no unwind
     // bookkeeping, no standalone gas estimate against unmined grants.
@@ -1376,7 +1382,146 @@ describe('useTxBatch execution prerequisites', () => {
     expect(batch.entryCount.value).toBe(0)
   })
 
-  it('reuses the latched prepared core plan for review export and safe execution', async () => {
+  it('deduplicates overlapping review preparations for one cart generation', async () => {
+    const sdk = createMockSdk()
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    isSafeWalletRef.value = true
+    eulerTxMocks.prepareTransactionPlan.mockResolvedValue({ kind: 'prepared' })
+    let resolveBundled!: (value: {
+      plan: TransactionPlan
+      grants: typeof grantTx[]
+      revokes: typeof revokeTx[]
+      grantSteps: typeof bundledGrantStep[]
+      revokeSteps: typeof bundledRevokeStep[]
+    }) => void
+    const bundledResult = new Promise<Parameters<typeof resolveBundled>[0]>((resolve) => {
+      resolveBundled = resolve
+    })
+    const buildBundledExecution = vi.fn(() => bundledResult)
+
+    const batch = useTxBatch()
+    await batch.addEntry({
+      label: 'Migrate Aave position',
+      buildPlan: async () => singleOpBundledPlan,
+      buildExecutionPrerequisites: async () => undefined,
+      buildBundledExecution,
+    })
+
+    const preparationA = batch.prepareBundledExecution()
+    const preparationB = batch.prepareBundledExecution()
+    await vi.waitFor(() => expect(buildBundledExecution).toHaveBeenCalledTimes(1))
+    resolveBundled({
+      plan: singleOpBundledPlan,
+      grants: [grantTx],
+      revokes: [revokeTx],
+      grantSteps: [bundledGrantStep],
+      revokeSteps: [bundledRevokeStep],
+    })
+
+    const [ceremonyA, ceremonyB] = await Promise.all([preparationA, preparationB])
+    expect(ceremonyA).toBe(ceremonyB)
+    expect(Object.isFrozen(ceremonyA)).toBe(true)
+    expect(Object.isFrozen(ceremonyA?.grants)).toBe(true)
+  })
+
+  it('rejects an older preparation that resolves after a new cart ceremony', async () => {
+    const sdk = createMockSdk()
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    isSafeWalletRef.value = true
+    eulerTxMocks.prepareTransactionPlan.mockImplementation(async plan => ({ plan }))
+    let resolveOld!: (value: {
+      plan: TransactionPlan
+      grants: typeof grantTx[]
+      revokes: typeof revokeTx[]
+      grantSteps: typeof bundledGrantStep[]
+      revokeSteps: typeof bundledRevokeStep[]
+    }) => void
+    const oldResult = new Promise<Parameters<typeof resolveOld>[0]>((resolve) => {
+      resolveOld = resolve
+    })
+    const buildOld = vi.fn(() => oldResult)
+
+    const batch = useTxBatch()
+    await batch.addEntry({
+      label: 'Old migration',
+      buildPlan: async () => singleOpBundledPlan,
+      buildExecutionPrerequisites: async () => undefined,
+      buildBundledExecution: buildOld,
+    })
+    const oldPreparation = batch.prepareBundledExecution()
+    await vi.waitFor(() => expect(buildOld).toHaveBeenCalledTimes(1))
+
+    batch.clearBatch()
+    const newGrant = { to: morphoBlue, data: '0xnewgrant' as Hex }
+    await batch.addEntry({
+      label: 'New migration',
+      buildPlan: async () => singleOpBundledPlan,
+      buildExecutionPrerequisites: async () => undefined,
+      buildBundledExecution: async () => ({
+        plan: singleOpBundledPlan,
+        grants: [newGrant],
+        revokes: [],
+        grantSteps: [],
+        revokeSteps: [],
+      }),
+    })
+    const newCeremony = await batch.prepareBundledExecution()
+
+    resolveOld({
+      plan: singleOpBundledPlan,
+      grants: [grantTx],
+      revokes: [revokeTx],
+      grantSteps: [bundledGrantStep],
+      revokeSteps: [bundledRevokeStep],
+    })
+
+    await expect(oldPreparation).rejects.toThrow('Batch or wallet changed since review preparation')
+    expect(newCeremony?.grants).toEqual([newGrant])
+    expect(batch.isBundledExecutionCurrent(newCeremony!)).toBe(true)
+  })
+
+  it('rejects preparation that finishes after the account changes', async () => {
+    const sdk = createMockSdk()
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    isSafeWalletRef.value = true
+    eulerTxMocks.prepareTransactionPlan.mockResolvedValue({ kind: 'prepared' })
+    let resolveBundled!: (value: {
+      plan: TransactionPlan
+      grants: typeof grantTx[]
+      revokes: typeof revokeTx[]
+      grantSteps: typeof bundledGrantStep[]
+      revokeSteps: typeof bundledRevokeStep[]
+    }) => void
+    const bundledResult = new Promise<Parameters<typeof resolveBundled>[0]>((resolve) => {
+      resolveBundled = resolve
+    })
+    const buildBundledExecution = vi.fn(() => bundledResult)
+
+    const batch = useTxBatch()
+    await batch.addEntry({
+      label: 'Migrate Aave position',
+      buildPlan: async () => singleOpBundledPlan,
+      buildExecutionPrerequisites: async () => undefined,
+      buildBundledExecution,
+    })
+    const preparation = batch.prepareBundledExecution()
+    await vi.waitFor(() => expect(buildBundledExecution).toHaveBeenCalledTimes(1))
+
+    const nextOwner = getAddress('0x9000000000000000000000000000000000000009')
+    effectiveAddressRef.value = nextOwner
+    walletAddressRef.value = nextOwner
+    resolveBundled({
+      plan: singleOpBundledPlan,
+      grants: [grantTx],
+      revokes: [revokeTx],
+      grantSteps: [bundledGrantStep],
+      revokeSteps: [bundledRevokeStep],
+    })
+
+    await expect(preparation).rejects.toThrow('Batch or wallet changed since review preparation')
+  })
+
+  it('uses one prepared core plan for review export and safe execution', async () => {
     const sdk = createMockSdk()
     vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
     isSafeWalletRef.value = true
@@ -1411,18 +1556,89 @@ describe('useTxBatch execution prerequisites', () => {
       }),
     })
 
-    const latched = await batch.prepareBundledExecution()
-    const reviewPrepared = await batch.prepareBatchPlan()
-    await batch.executeBatch()
+    const ceremony = await batch.prepareBundledExecution()
+    await batch.executeBatch(undefined, ceremony ?? undefined)
 
     expect(eulerTxMocks.prepareTransactionPlan).toHaveBeenCalledTimes(1)
     expect(eulerTxMocks.prepareTransactionPlan).toHaveBeenCalledWith(latchedPlan)
-    expect(reviewPrepared).toBe(latchedPrepared)
-    expect(latched?.prepared).toBe(latchedPrepared)
+    expect(ceremony?.prepared).toBe(latchedPrepared)
     expect(eulerTxMocks.executePreparedPlanWithPlainCalls).toHaveBeenCalledWith(latchedPrepared, {
       before: [grantTx],
       after: [revokeTx],
     }, { allowSingleCall: true })
+  })
+
+  it('keeps copied and submitted before, prepared plugin/approval/core, after vectors identical', async () => {
+    const sdk = createMockSdk()
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    isSafeWalletRef.value = true
+    const plugin = getAddress('0x2000000000000000000000000000000000000002')
+    const pingAbi = [{
+      type: 'function',
+      name: 'ping',
+      inputs: [],
+      outputs: [],
+      stateMutability: 'payable',
+    }] as const
+    const preparedPlan = [{
+      type: 'contractCall',
+      chainId: 1,
+      to: plugin,
+      abi: pingAbi,
+      functionName: 'ping',
+      args: [],
+      value: 7n,
+    }, {
+      type: 'requiredApproval',
+      token: aToken,
+      owner,
+      spender: vault,
+      amount: 9n,
+      resolved: [{ type: 'approve', token: aToken, data: '0xapprove' as Hex }],
+    }, {
+      type: 'evcBatch',
+      items: [{ targetContract: vault, onBehalfOfAccount: owner, value: 11n, data: '0xcore' as Hex }],
+    }] as unknown as TransactionPlan
+    const prepared = { plan: preparedPlan, chainId: 1, account: owner }
+    const encodingSdk = {
+      deploymentService: {
+        getDeployment: () => ({ addresses: { coreAddrs: { evc: vault } } }),
+      },
+      executionService: { encodeBatch: () => '0xbatch' as Hex },
+    }
+    eulerTxMocks.prepareTransactionPlan.mockResolvedValue(prepared)
+    let submittedVector: ReturnType<typeof buildBatchReviewCalldata> | undefined
+    eulerTxMocks.executePreparedPlanWithPlainCalls.mockImplementation(async (submittedPrepared, wrappers) => {
+      submittedVector = buildBatchReviewCalldata({
+        plan: submittedPrepared.plan,
+        before: wrappers.before,
+        after: wrappers.after,
+        sdk: encodingSdk,
+        chainId: 1,
+      })
+      return { receipts: [] }
+    })
+
+    const batch = useTxBatch()
+    await addBundledMigrationEntry(batch)
+    const ceremony = await batch.prepareBundledExecution()
+    const copiedVector = buildBatchReviewCalldata({
+      plan: ceremony!.prepared.plan,
+      before: ceremony!.grants,
+      after: ceremony!.revokes,
+      sdk: encodingSdk,
+      chainId: 1,
+    })
+    await batch.executeBatch(undefined, ceremony!)
+
+    expect(submittedVector).toEqual(copiedVector)
+    expect(submittedVector?.map(call => call.to)).toEqual([
+      grantTx.to,
+      plugin,
+      aToken,
+      vault,
+      revokeTx.to,
+    ])
   })
 
   it('throws instead of degrading when the safe bundle context is unavailable', async () => {
@@ -1434,15 +1650,14 @@ describe('useTxBatch execution prerequisites', () => {
 
     const batch = useTxBatch()
     await addBundledMigrationEntry(batch)
-    await batch.prepareBundledExecution()
-    await batch.executeBatch()
+    const ceremony = await batch.prepareBundledExecution()
+    await batch.executeBatch(undefined, ceremony ?? undefined)
 
     expect(batch.execError.value).toBeTruthy()
     // Nothing broadcast standalone, nothing to unwind, cart retained.
     expect(eulerTxMocks.sendPlainTransactions).not.toHaveBeenCalled()
     expect(migrationFlowMocks.revokeAfterAbort).toHaveBeenCalledWith([])
     expect(batch.entryCount.value).toBe(1)
-    batch.latchedBundledExecution.value = null
   })
 
   it('bundles a latched ceremony even when its grants resolved empty', async () => {
@@ -1463,8 +1678,8 @@ describe('useTxBatch execution prerequisites', () => {
       // whose internals could degrade to sequential sends.
       buildBundledExecution: async () => ({ plan: singleOpBundledPlan, grants: [], revokes: [], grantSteps: [], revokeSteps: [] }),
     })
-    await batch.prepareBundledExecution()
-    await batch.executeBatch()
+    const ceremony = await batch.prepareBundledExecution()
+    await batch.executeBatch(undefined, ceremony ?? undefined)
 
     expect(eulerTxMocks.executePreparedPlanWithPlainCalls).toHaveBeenCalledWith(prepared, {
       before: [],
@@ -1490,7 +1705,6 @@ describe('useTxBatch execution prerequisites', () => {
       grantSteps: [bundledGrantStep],
       revokeSteps: [bundledRevokeStep],
     })
-    batch.latchedBundledExecution.value = null
   })
 
   it('keeps duplicate bundled restoration rows in parity with proposal calls', async () => {
@@ -1519,7 +1733,6 @@ describe('useTxBatch execution prerequisites', () => {
       bundledRevokeStep,
       bundledRevokeStep,
     ])
-    batch.latchedBundledExecution.value = null
   })
 
   it('throws a re-review error when the wallet stopped being a safe after latching', async () => {
@@ -1530,15 +1743,14 @@ describe('useTxBatch execution prerequisites', () => {
 
     const batch = useTxBatch()
     await addBundledMigrationEntry(batch)
-    await batch.prepareBundledExecution()
+    const ceremony = await batch.prepareBundledExecution()
     // Safe disconnected between review and confirm.
     isSafeWalletRef.value = false
-    await batch.executeBatch()
+    await batch.executeBatch(undefined, ceremony ?? undefined)
 
     expect(batch.execError.value).toBeTruthy()
     expect(eulerTxMocks.executePreparedPlanWithPlainCalls).not.toHaveBeenCalled()
     expect(eulerTxMocks.sendPlainTransactions).not.toHaveBeenCalled()
-    batch.latchedBundledExecution.value = null
   })
 
   it('keeps the sequential ceremony for non-safe wallets', async () => {

--- a/tests/composables/useTxBatch.test.ts
+++ b/tests/composables/useTxBatch.test.ts
@@ -1419,7 +1419,9 @@ describe('useTxBatch execution prerequisites', () => {
     })
 
     const [ceremonyA, ceremonyB] = await Promise.all([preparationA, preparationB])
+    const ceremonyC = await batch.prepareBundledExecution()
     expect(ceremonyA).toBe(ceremonyB)
+    expect(ceremonyC).toBe(ceremonyA)
     expect(Object.isFrozen(ceremonyA)).toBe(true)
     expect(Object.isFrozen(ceremonyA?.grants)).toBe(true)
   })
@@ -1557,11 +1559,13 @@ describe('useTxBatch execution prerequisites', () => {
     })
 
     const ceremony = await batch.prepareBundledExecution()
+    const entryId = batch.entries.value[0]!.id
     await batch.executeBatch(undefined, ceremony ?? undefined)
 
     expect(eulerTxMocks.prepareTransactionPlan).toHaveBeenCalledTimes(1)
     expect(eulerTxMocks.prepareTransactionPlan).toHaveBeenCalledWith(latchedPlan)
     expect(ceremony?.prepared).toBe(latchedPrepared)
+    expect(ceremony?.reviewByEntryId[entryId]?.plan).toBe(latchedPlan)
     expect(eulerTxMocks.executePreparedPlanWithPlainCalls).toHaveBeenCalledWith(latchedPrepared, {
       before: [grantTx],
       after: [revokeTx],
@@ -1701,7 +1705,8 @@ describe('useTxBatch execution prerequisites', () => {
     // resolution the proposal executes — never the add-time captures, which
     // can be stale by the time the review opens.
     const entryId = batch.entries.value[0]!.id
-    expect(latched?.stepsByEntryId[entryId]).toEqual({
+    expect(latched?.reviewByEntryId[entryId]).toEqual({
+      plan: singleOpBundledPlan,
       grantSteps: [bundledGrantStep],
       revokeSteps: [bundledRevokeStep],
     })
@@ -1729,7 +1734,7 @@ describe('useTxBatch execution prerequisites', () => {
     const latched = await batch.prepareBundledExecution()
 
     expect(latched?.revokes).toEqual([revokeTx, revokeTx])
-    expect(Object.values(latched?.stepsByEntryId ?? {}).flatMap(steps => steps.revokeSteps)).toEqual([
+    expect(Object.values(latched?.reviewByEntryId ?? {}).flatMap(review => review.revokeSteps)).toEqual([
       bundledRevokeStep,
       bundledRevokeStep,
     ])

--- a/tests/composables/useTxBatch.test.ts
+++ b/tests/composables/useTxBatch.test.ts
@@ -1291,6 +1291,7 @@ describe('useTxBatch execution errors', () => {
     expect(eulerTxMocks.estimateGasForPreparedPlan).toHaveBeenCalledWith(prepared)
     expect(eulerTxMocks.executePreparedPlan).toHaveBeenCalledWith(prepared, {
       beforeBroadcast: expect.any(Function),
+      onBroadcast: expect.any(Function),
     })
     expect(scheduleExternalMigrationRefreshes).toHaveBeenCalledTimes(1)
     expect(batch.entryCount.value).toBe(0)
@@ -1539,7 +1540,7 @@ describe('useTxBatch execution prerequisites', () => {
     expect(eulerTxMocks.prepareTransactionPlan).toHaveBeenNthCalledWith(2, signedPlan)
     expect(eulerTxMocks.executePreparedPlan).toHaveBeenCalledWith(
       expect.objectContaining({ plan: signedPlan }),
-      { beforeBroadcast: expect.any(Function) },
+      { beforeBroadcast: expect.any(Function), onBroadcast: expect.any(Function) },
     )
   })
 
@@ -1884,6 +1885,7 @@ describe('useTxBatch execution prerequisites', () => {
     }, {
       allowSingleCall: true,
       beforeBroadcast: expect.any(Function),
+      onBroadcast: expect.any(Function),
     })
     expect(eulerTxMocks.executePreparedPlan).not.toHaveBeenCalled()
     // Revokes rode in the proposal — nothing standalone to send afterwards.
@@ -2360,6 +2362,7 @@ describe('useTxBatch execution prerequisites', () => {
     expect(eulerTxMocks.prepareTransactionPlan).toHaveBeenCalledTimes(1)
     expect(eulerTxMocks.executePreparedPlan).toHaveBeenCalledWith(reviewedPrepared, {
       beforeBroadcast: expect.any(Function),
+      onBroadcast: expect.any(Function),
     })
   })
 
@@ -2411,6 +2414,7 @@ describe('useTxBatch execution prerequisites', () => {
     }, {
       allowSingleCall: true,
       beforeBroadcast: expect.any(Function),
+      onBroadcast: expect.any(Function),
     })
   })
 
@@ -2534,6 +2538,7 @@ describe('useTxBatch execution prerequisites', () => {
     }, {
       allowSingleCall: true,
       beforeBroadcast: expect.any(Function),
+      onBroadcast: expect.any(Function),
     })
     expect(eulerTxMocks.executePreparedPlan).not.toHaveBeenCalled()
   })
@@ -2638,6 +2643,7 @@ describe('useTxBatch execution prerequisites', () => {
     }, {
       allowSingleCall: true,
       beforeBroadcast: expect.any(Function),
+      onBroadcast: expect.any(Function),
     })
   })
 
@@ -2691,6 +2697,7 @@ describe('useTxBatch execution prerequisites', () => {
     )
     expect(eulerTxMocks.executePreparedPlan).toHaveBeenCalledWith(prepared, {
       beforeBroadcast: expect.any(Function),
+      onBroadcast: expect.any(Function),
     })
   })
 

--- a/tests/composables/useTxBatch.test.ts
+++ b/tests/composables/useTxBatch.test.ts
@@ -1,9 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, ref } from 'vue'
 import { Account, Portfolio, type IAccountPosition, type IHasVaultAddress, type IAccountLiquidity, type TransactionPlan } from '@eulerxyz/euler-v2-sdk'
-import { getAddress, type Address, type Hex } from 'viem'
+import { getAddress, type Address, type Hash, type Hex } from 'viem'
 import { getEulerSdkFresh } from '~/composables/useEulerSdk'
-import { awaitFinalPlanningLayer, buildOperationEntryMap, buildWalletBalanceLayers, buildWalletChanges, countPlanOperations, fetchBaseAccountSnapshot, normalizeSimulatedVaultLayers, stitchAccount, useTxBatch } from '~/composables/useTxBatch'
+import { awaitFinalPlanningLayer, buildOperationEntryMap, buildWalletBalanceLayers, buildWalletChanges, countPlanOperations, fetchBaseAccountSnapshot, hydratePendingBatchSubmissionFromStorage, normalizeSimulatedVaultLayers, stitchAccount, useTxBatch } from '~/composables/useTxBatch'
+import type { PreparedPlanBroadcast } from '~/composables/useEulerTx'
+import { readPendingSubmission, writePendingSubmission } from '~/utils/pendingSubmissions'
 import {
   mergeBatchPrefetchedSlotHints,
   resetBatchPrefetchState,
@@ -285,6 +287,24 @@ const accountWithPositions = (
   populated: { vaults: true, marketPrices: true, userRewards: true },
 })
 
+const createMemoryStorage = (): Storage => {
+  const store = new Map<string, string>()
+  return {
+    get length() {
+      return store.size
+    },
+    clear: () => store.clear(),
+    getItem: (key: string) => store.get(key) ?? null,
+    key: (index: number) => [...store.keys()][index] ?? null,
+    removeItem: (key: string) => {
+      store.delete(key)
+    },
+    setItem: (key: string, value: string) => {
+      store.set(key, String(value))
+    },
+  }
+}
+
 const stubBatchComposableGlobals = () => {
   vi.stubGlobal('useWagmi', () => ({ address: walletAddressRef, chainId: walletChainIdRef, connector: walletConnectorRef }))
   vi.stubGlobal('useSpyMode', () => ({ isSpyMode: ref(false), spyAddress: ref(undefined) }))
@@ -358,6 +378,10 @@ beforeEach(() => {
   stubBatchComposableGlobals()
   vi.mocked(getEulerSdkFresh).mockResolvedValue(createMockSdk() as never)
   resetBatchPrefetchState()
+  // Fresh storage plus a hydrate resets the module-level submission
+  // quarantine, which deliberately survives clearBatch().
+  vi.stubGlobal('localStorage', createMemoryStorage())
+  hydratePendingBatchSubmissionFromStorage()
   useTxBatch().clearBatch()
 })
 
@@ -1356,6 +1380,255 @@ describe('useTxBatch execution errors', () => {
 
     expect(executionAccount?.getSubAccount(subAccount)?.positions[0]?.shares).toBe(42n)
     expect(sdk.executionService.mergePlans).toHaveBeenLastCalledWith([borrowPlan, migrationExecutionPlan])
+  })
+})
+
+describe('useTxBatch submission quarantine', () => {
+  const CORE_HASH = `0x${'ab'.repeat(32)}` as Hash
+  const APPROVAL_HASH = `0x${'cd'.repeat(32)}` as Hash
+
+  const coreBroadcast = (overrides: Partial<PreparedPlanBroadcast> = {}): PreparedPlanBroadcast => ({
+    kind: 'transaction',
+    hash: CORE_HASH,
+    item: 'evcBatch',
+    index: 0,
+    completesPlan: true,
+    status: 'submitted',
+    ...overrides,
+  })
+
+  /** SDK whose provider resolves the quarantined hash to a receipt verdict. */
+  const sdkWithReceipt = (status: 'success' | 'reverted' | undefined) => {
+    const sdk = createMockSdk() as ReturnType<typeof createMockSdk> & { providerService?: unknown }
+    sdk.providerService = {
+      getProvider: vi.fn(() => ({
+        getTransactionReceipt: vi.fn(async () => {
+          if (!status) throw new Error('receipt not found')
+          return { status }
+        }),
+      })),
+    }
+    return sdk
+  }
+
+  const setupExecutableBatch = async () => {
+    const batch = useTxBatch()
+    eulerTxMocks.estimateGasForPreparedPlan.mockResolvedValue(undefined)
+    eulerTxMocks.prepareTransactionPlan.mockResolvedValue({ kind: 'prepared' })
+    await batch.addEntry({
+      label: 'Migrate Aave position',
+      buildPlan: async () => [],
+    })
+    return batch
+  }
+
+  /** Run one attempt whose accepted core submission never confirmed. */
+  const quarantineOneSubmission = async (
+    batch: Awaited<ReturnType<typeof setupExecutableBatch>>,
+    broadcast: PreparedPlanBroadcast = coreBroadcast(),
+  ) => {
+    eulerTxMocks.executePreparedPlan.mockImplementationOnce(async (_prepared, options?: {
+      onBroadcast?: (b: PreparedPlanBroadcast) => void
+    }) => {
+      options?.onBroadcast?.(broadcast)
+      throw new Error('Receipt polling failed.')
+    })
+    await batch.executeBatch()
+    expect(batch.hasPendingCoreSubmission.value).toBe(true)
+  }
+
+  it('retries cleanly after a confirmed prerequisite broadcast and a pre-acceptance core rejection', async () => {
+    const batch = await setupExecutableBatch()
+    eulerTxMocks.executePreparedPlan
+      .mockImplementationOnce(async (_prepared, options?: {
+        onBroadcast?: (b: PreparedPlanBroadcast) => void
+      }) => {
+        // The approval submission confirmed (the executor re-fires with
+        // status 'confirmed' once its receipt landed) — then the wallet
+        // rejected the core submission before accepting it.
+        options?.onBroadcast?.(coreBroadcast({ item: 'approval', hash: APPROVAL_HASH, completesPlan: false }))
+        options?.onBroadcast?.(coreBroadcast({ item: 'approval', hash: APPROVAL_HASH, completesPlan: false, status: 'confirmed' }))
+        throw new Error('User rejected the request.')
+      })
+      .mockResolvedValueOnce(undefined)
+
+    await batch.executeBatch()
+
+    // Nothing value-moving is outstanding: no quarantine, plain error.
+    expect(batch.execError.value).toBe('User rejected the request.')
+    expect(batch.hasPendingCoreSubmission.value).toBe(false)
+    expect(readPendingSubmission('batch')).toBeUndefined()
+    expect(batch.entryCount.value).toBe(1)
+
+    // An ordinary retry proceeds without any on-chain reconciliation gate.
+    await batch.executeBatch()
+
+    expect(eulerTxMocks.executePreparedPlan).toHaveBeenCalledTimes(2)
+    expect(batch.entryCount.value).toBe(0)
+  })
+
+  it('quarantines an accepted core submission durably across cart clearing', async () => {
+    const batch = await setupExecutableBatch()
+
+    await quarantineOneSubmission(batch)
+
+    expect(batch.execError.value).toBe('Receipt polling failed. The submission may still confirm — executing again first verifies it on-chain before anything is re-sent.')
+    expect(readPendingSubmission('batch')).toMatchObject({
+      kind: 'transaction',
+      hash: CORE_HASH,
+      chainId: 1,
+      owner,
+      completesPlan: true,
+    })
+
+    // Clearing the cart and rebuilding it must not drop the quarantine.
+    batch.clearBatch()
+    expect(batch.hasPendingCoreSubmission.value).toBe(true)
+    expect(readPendingSubmission('batch')).toBeDefined()
+    await batch.addEntry({ label: 'Rebuilt operation', buildPlan: async () => [] })
+
+    // The default SDK mock has no provider — the outcome is unverifiable, so
+    // the retry is blocked before anything is re-sent.
+    await batch.executeBatch()
+
+    expect(eulerTxMocks.executePreparedPlan).toHaveBeenCalledTimes(1)
+    expect(batch.execError.value).toBe('A previous batch submission may still confirm on-chain and could not be verified yet. Wait a moment and execute again — the submission is re-checked before anything is re-sent.')
+    expect(readPendingSubmission('batch')).toBeDefined()
+  })
+
+  it('releases the quarantine and retries once the submission definitively did not land', async () => {
+    const batch = await setupExecutableBatch()
+    await quarantineOneSubmission(batch)
+
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdkWithReceipt('reverted') as never)
+    eulerTxMocks.executePreparedPlan.mockResolvedValueOnce(undefined)
+
+    await batch.executeBatch()
+
+    expect(eulerTxMocks.executePreparedPlan).toHaveBeenCalledTimes(2)
+    expect(batch.hasPendingCoreSubmission.value).toBe(false)
+    expect(readPendingSubmission('batch')).toBeUndefined()
+    expect(batch.entryCount.value).toBe(0)
+  })
+
+  it('retires the covered entries instead of re-executing when the quarantined submission landed', async () => {
+    const batch = await setupExecutableBatch()
+    await quarantineOneSubmission(batch)
+
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdkWithReceipt('success') as never)
+
+    await batch.executeBatch()
+
+    // Nothing was re-sent — the previous submission already executed the plan.
+    expect(eulerTxMocks.executePreparedPlan).toHaveBeenCalledTimes(1)
+    expect(batch.entryCount.value).toBe(0)
+    expect(batch.hasPendingCoreSubmission.value).toBe(false)
+    expect(readPendingSubmission('batch')).toBeUndefined()
+    expect(batch.execError.value).toBeUndefined()
+  })
+
+  it('resets the cart when a landed submission did not complete the reviewed batch', async () => {
+    const batch = await setupExecutableBatch()
+    await quarantineOneSubmission(batch, coreBroadcast({ completesPlan: false }))
+
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdkWithReceipt('success') as never)
+
+    await batch.executeBatch()
+
+    expect(eulerTxMocks.executePreparedPlan).toHaveBeenCalledTimes(1)
+    expect(batch.entryCount.value).toBe(0)
+    expect(batch.execError.value).toBe('A previous batch submission confirmed on-chain but did not complete the reviewed batch. The cart was reset — review your positions and rebuild the remaining operations.')
+    expect(readPendingSubmission('batch')).toBeUndefined()
+  })
+
+  it('blocks execution after a reload while the hydrated submission is unverifiable', async () => {
+    const batch = await setupExecutableBatch()
+    // Simulated reload: only the durable record survives — no ceremony
+    // context, no in-memory tracking.
+    writePendingSubmission('batch', {
+      kind: 'transaction',
+      hash: CORE_HASH,
+      chainId: 1,
+      owner,
+      completesPlan: true,
+      submittedAt: 1_000,
+    })
+    hydratePendingBatchSubmissionFromStorage()
+    expect(batch.hasPendingCoreSubmission.value).toBe(true)
+
+    await batch.executeBatch()
+
+    expect(eulerTxMocks.executePreparedPlan).not.toHaveBeenCalled()
+    expect(batch.execError.value).toContain('could not be verified yet')
+    expect(readPendingSubmission('batch')).toBeDefined()
+  })
+
+  it('resets the cart when a hydrated post-reload submission landed without ceremony context', async () => {
+    const batch = await setupExecutableBatch()
+    writePendingSubmission('batch', {
+      kind: 'transaction',
+      hash: CORE_HASH,
+      chainId: 1,
+      owner,
+      completesPlan: true,
+      refreshExternalPositions: true,
+      submittedAt: 1_000,
+    })
+    hydratePendingBatchSubmissionFromStorage()
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdkWithReceipt('success') as never)
+
+    await batch.executeBatch()
+
+    // The exact covered entries are unknowable without the ceremony — the
+    // cart resets rather than leaving executed entries queued to run again.
+    expect(eulerTxMocks.executePreparedPlan).not.toHaveBeenCalled()
+    expect(batch.entryCount.value).toBe(0)
+    expect(readPendingSubmission('batch')).toBeUndefined()
+    expect(scheduleExternalMigrationRefreshes).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps another wallet\'s record without blocking the current wallet', async () => {
+    const batch = await setupExecutableBatch()
+    const otherOwner = getAddress('0x9999999999999999999999999999999999999999')
+    writePendingSubmission('batch', {
+      kind: 'transaction',
+      hash: CORE_HASH,
+      chainId: 1,
+      owner: otherOwner,
+      completesPlan: true,
+      submittedAt: 1_000,
+    })
+    hydratePendingBatchSubmissionFromStorage()
+    eulerTxMocks.executePreparedPlan.mockResolvedValueOnce(undefined)
+
+    await batch.executeBatch()
+
+    // The current wallet cannot duplicate the other wallet's submission, so
+    // it executes normally; the record stays for the wallet that owns it.
+    expect(eulerTxMocks.executePreparedPlan).toHaveBeenCalledTimes(1)
+    expect(batch.entryCount.value).toBe(0)
+    expect(readPendingSubmission('batch')).toMatchObject({ owner: otherOwner })
+  })
+
+  it('retires entries when the core submission confirmed but a later step failed', async () => {
+    const batch = await setupExecutableBatch()
+    eulerTxMocks.executePreparedPlan.mockImplementationOnce(async (_prepared, options?: {
+      onBroadcast?: (b: PreparedPlanBroadcast) => void
+    }) => {
+      options?.onBroadcast?.(coreBroadcast())
+      options?.onBroadcast?.(coreBroadcast({ status: 'confirmed' }))
+      return undefined
+    })
+    migrationFlowMocks.revokeAfterSuccess.mockRejectedValueOnce(new Error('Revoke failed.'))
+
+    await batch.executeBatch()
+
+    // The batch definitively landed: no quarantine, but the covered entries
+    // must not stay queued for a duplicate replay.
+    expect(batch.entryCount.value).toBe(0)
+    expect(batch.hasPendingCoreSubmission.value).toBe(false)
+    expect(readPendingSubmission('batch')).toBeUndefined()
+    expect(batch.execError.value).toBe('Revoke failed. The batch itself confirmed on-chain; the operations it covered were removed from the cart.')
   })
 })
 

--- a/tests/composables/useTxBatch.test.ts
+++ b/tests/composables/useTxBatch.test.ts
@@ -14,10 +14,23 @@ import { activeLayerVaultsRef } from '~/composables/useLayeredVaults'
 import { WalletExecutionContextChangedError } from '~/utils/walletExecutionContext'
 import type { WalletExecutionContext } from '~/utils/walletExecutionContext'
 import { buildBatchReviewCalldata } from '~/utils/batchReviewCalldata'
+import { PLACEHOLDER_MIGRATION_AUTHORIZATION_SIGNATURE } from '~/utils/migrationAuthorizationSignatures'
 
 vi.mock('~/composables/useEulerSdk', () => ({
   getEulerSdkFresh: vi.fn(),
 }))
+
+const txErrorMocks = vi.hoisted(() => ({
+  getTxErrorMessage: vi.fn(async (error: unknown) => error instanceof Error ? error.message : String(error)),
+}))
+
+vi.mock('~/utils/tx-errors', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return {
+    ...actual,
+    getTxErrorMessage: txErrorMocks.getTxErrorMessage,
+  }
+})
 
 const owner = getAddress('0x1000000000000000000000000000000000000000')
 const subAccount = getAddress('0x8A54C278D117854486db0F6460D901a180Fff517')
@@ -329,6 +342,8 @@ beforeEach(() => {
   eulerTxMocks.estimateGasForPlan.mockReset()
   eulerTxMocks.sendPlainTransactions.mockReset()
   eulerTxMocks.sendPlainTransactions.mockImplementation(broadcastAllTransactions)
+  txErrorMocks.getTxErrorMessage.mockReset()
+  txErrorMocks.getTxErrorMessage.mockImplementation(async error => error instanceof Error ? error.message : String(error))
   migrationFlowMocks.revokeAfterSuccess.mockReset()
   migrationFlowMocks.revokeAfterAbort.mockReset()
   migrationFlowMocks.restorePendingBeforeRetry.mockReset()
@@ -1455,20 +1470,34 @@ describe('useTxBatch execution prerequisites', () => {
   it('reviews placeholder migration signatures and requests the real signatures only after confirmation', async () => {
     const sdk = createMockSdk()
     vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
-    const placeholderPlan = [{
+    const signedAuthorization = `0x${'11'.repeat(65)}` as Hex
+    const buildSignaturePlan = (authorization: Hex) => [{
       type: 'evcBatch',
-      items: [{ type: 'operation', name: 'placeholder-signature', items: [] }],
+      items: [{
+        type: 'operation',
+        name: 'migration-authorization',
+        items: [{
+          targetContract: vault,
+          onBehalfOfAccount: owner,
+          value: 0n,
+          data: `0x1234${authorization.slice(2)}` as Hex,
+        }],
+      }],
     }] as unknown as TransactionPlan
-    const signedPlan = [{
-      type: 'evcBatch',
-      items: [{ type: 'operation', name: 'signed-authorization', items: [] }],
-    }] as unknown as TransactionPlan
+    const placeholderPlan = buildSignaturePlan(PLACEHOLDER_MIGRATION_AUTHORIZATION_SIGNATURE)
+    const signedPlan = buildSignaturePlan(signedAuthorization)
     const signatureStep = { index: 1, label: 'Sign migration authorization', isSeparateTx: false }
     const requestWalletSignature = vi.fn()
     const resolveExecutionPlan = vi.fn(async (beforeWalletAction: () => void) => {
       beforeWalletAction()
       requestWalletSignature()
-      return signedPlan
+      return {
+        plan: signedPlan,
+        signatureSubstitutions: [{
+          placeholder: PLACEHOLDER_MIGRATION_AUTHORIZATION_SIGNATURE,
+          signature: signedAuthorization,
+        }],
+      }
     })
     eulerTxMocks.prepareTransactionPlan.mockImplementation(async plan => ({ plan, chainId: 1, account: owner }))
     eulerTxMocks.estimateGasForPlan.mockResolvedValue(undefined)
@@ -1511,6 +1540,59 @@ describe('useTxBatch execution prerequisites', () => {
       expect.objectContaining({ plan: signedPlan }),
       { beforeBroadcast: expect.any(Function) },
     )
+  })
+
+  it('rejects a confirm-time migration plan that changes beyond reviewed signature bytes', async () => {
+    const sdk = createMockSdk()
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    const signedAuthorization = `0x${'22'.repeat(65)}` as Hex
+    const placeholderPlan = [{
+      type: 'evcBatch',
+      items: [{
+        targetContract: vault,
+        onBehalfOfAccount: owner,
+        value: 0n,
+        data: `0x1234${PLACEHOLDER_MIGRATION_AUTHORIZATION_SIGNATURE.slice(2)}` as Hex,
+      }],
+    }] as unknown as TransactionPlan
+    const changedPlan = [{
+      type: 'evcBatch',
+      items: [{
+        targetContract: targetVault,
+        onBehalfOfAccount: owner,
+        value: 1n,
+        data: `0x1234${signedAuthorization.slice(2)}` as Hex,
+      }],
+    }] as unknown as TransactionPlan
+    eulerTxMocks.prepareTransactionPlan.mockImplementation(async plan => ({ plan, chainId: 1, account: owner }))
+
+    const batch = useTxBatch()
+    await batch.addEntry({
+      label: 'Signature migration',
+      buildPlan: async () => placeholderPlan,
+      buildExecutionCeremony: async () => ({
+        plan: placeholderPlan,
+        resolveExecutionPlan: async () => ({
+          plan: changedPlan,
+          signatureSubstitutions: [{
+            placeholder: PLACEHOLDER_MIGRATION_AUTHORIZATION_SIGNATURE,
+            signature: signedAuthorization,
+          }],
+        }),
+        usesPlaceholderSignatures: true,
+        grantSteps: [],
+        revokeSteps: [],
+      }),
+      requiresPlanningAccount: false,
+    })
+    await vi.waitFor(() => expect(batch.layers.value).toHaveLength(2))
+    const ceremony = await batch.prepareBatchExecution()
+
+    await batch.executeBatch(undefined, ceremony)
+
+    expect(eulerTxMocks.executePreparedPlan).not.toHaveBeenCalled()
+    expect(eulerTxMocks.executePreparedPlanWithPlainCalls).not.toHaveBeenCalled()
+    expect(batch.execError.value).toContain('transaction plan changed after review')
   })
 
   it('requires resolved wallet classification and invalidates review on connector changes', async () => {
@@ -1649,6 +1731,46 @@ describe('useTxBatch execution prerequisites', () => {
     expect(batch.entries.value.map(entry => entry.label)).toEqual(['Successor wallet operation'])
 
     releaseCompletion()
+    await execution
+
+    expect(batch.entries.value.map(entry => entry.label)).toEqual(['Successor wallet operation'])
+    expect(batch.execError.value).toBeUndefined()
+  })
+
+  it('does not publish a decoded execution error after the wallet context changes', async () => {
+    const sdk = createMockSdk()
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    const prepared = { kind: 'prepared', plan: singleOpBundledPlan, chainId: 1, account: owner }
+    eulerTxMocks.prepareTransactionPlan.mockResolvedValue(prepared)
+    eulerTxMocks.estimateGasForPlan.mockResolvedValue(undefined)
+    eulerTxMocks.executePreparedPlan.mockRejectedValue(new Error('old wallet execution failed'))
+    let resolveDecodedError!: (message: string) => void
+    txErrorMocks.getTxErrorMessage.mockReturnValue(new Promise<string>((resolve) => {
+      resolveDecodedError = resolve
+    }))
+
+    const batch = useTxBatch()
+    await batch.addEntry({
+      label: 'Old wallet operation',
+      buildPlan: async () => singleOpBundledPlan,
+      requiresPlanningAccount: false,
+    })
+    await vi.waitFor(() => expect(batch.layers.value).toHaveLength(2))
+    const ceremony = await batch.prepareBatchExecution()
+    const execution = batch.executeBatch(undefined, ceremony)
+    await vi.waitFor(() => expect(txErrorMocks.getTxErrorMessage).toHaveBeenCalledTimes(1))
+
+    const successor = getAddress('0x2000000000000000000000000000000000000000')
+    effectiveAddressRef.value = successor
+    walletAddressRef.value = successor
+    await nextTick()
+    await batch.addEntry({
+      label: 'Successor wallet operation',
+      buildPlan: async () => singleOpBundledPlan,
+      requiresPlanningAccount: false,
+    })
+
+    resolveDecodedError('decoded old-wallet revert')
     await execution
 
     expect(batch.entries.value.map(entry => entry.label)).toEqual(['Successor wallet operation'])
@@ -2485,6 +2607,51 @@ describe('useTxBatch execution prerequisites', () => {
     )
     expect(eulerTxMocks.executePreparedPlan).toHaveBeenCalledWith(prepared, {
       beforeBroadcast: expect.any(Function),
+    })
+  })
+
+  it('keeps duplicate standalone authorization prompts in parity with execution', async () => {
+    const sdk = createMockSdk()
+    sdk.executionService.simulateTransactionPlan.mockImplementation(async (...args: unknown[]) => ({
+      simulatedAccounts: Array.from(
+        { length: countPlanOperations(args[2] as TransactionPlan) },
+        (_, index) => accountWithPosition(subAccount, subAccount, BigInt(index + 2)),
+      ),
+      simulatedWalletBalances: [],
+      simulatedVaults: [],
+      failedBatchItems: [],
+      insufficientWalletAssets: [],
+    }))
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    isSafeWalletRef.value = false
+    const prepared = { kind: 'prepared', plan: singleOpBundledPlan, chainId: 1, account: owner }
+    eulerTxMocks.prepareTransactionPlan.mockResolvedValue(prepared)
+    eulerTxMocks.estimateGasForPlan.mockResolvedValue(undefined)
+    eulerTxMocks.executePreparedPlan.mockResolvedValue(undefined)
+
+    const batch = useTxBatch()
+    await addBundledMigrationEntry(batch)
+    await addBundledMigrationEntry(batch)
+    await vi.waitFor(() => expect(batch.layers.value).toHaveLength(3))
+    const ceremony = await batch.prepareBatchExecution()
+    const entryIds = batch.entries.value.map(entry => entry.id)
+
+    expect(entryIds).toHaveLength(2)
+    expect(entryIds.map(id => ceremony.reviewByEntryId[id]?.revokeSteps)).toEqual([
+      [{ ...bundledRevokeStep, isSeparateTx: true }],
+      [{ ...bundledRevokeStep, isSeparateTx: true }],
+    ])
+
+    await batch.executeBatch(undefined, ceremony)
+
+    expect(eulerTxMocks.sendPlainTransactions).toHaveBeenCalledTimes(2)
+    expect(eulerTxMocks.sendPlainTransactions).toHaveBeenNthCalledWith(1, [grantTx], expect.any(Object))
+    expect(eulerTxMocks.sendPlainTransactions).toHaveBeenNthCalledWith(2, [grantTx], expect.any(Object))
+    expect(migrationFlowMocks.revokeAfterSuccess).toHaveBeenCalledWith([
+      trackedRevoke(revokeTx),
+      trackedRevoke(revokeTx),
+    ], {
+      shouldNotify: expect.any(Function),
     })
   })
 

--- a/tests/composables/useTxBatch.test.ts
+++ b/tests/composables/useTxBatch.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
+import { nextTick, ref } from 'vue'
 import { Account, Portfolio, type IAccountPosition, type IHasVaultAddress, type IAccountLiquidity, type TransactionPlan } from '@eulerxyz/euler-v2-sdk'
 import { getAddress, type Address, type Hex } from 'viem'
 import { getEulerSdkFresh } from '~/composables/useEulerSdk'
@@ -1426,7 +1426,7 @@ describe('useTxBatch execution prerequisites', () => {
     expect(Object.isFrozen(ceremonyA?.grants)).toBe(true)
   })
 
-  it('invalidates a ceremony prepared while another entry is still building', async () => {
+  it('invalidates the current ceremony while another entry is building', async () => {
     const sdk = createMockSdk()
     sdk.executionService.simulateTransactionPlan.mockImplementation(async (...args: unknown[]) => ({
       simulatedAccounts: Array.from(
@@ -1445,6 +1445,9 @@ describe('useTxBatch execution prerequisites', () => {
 
     const batch = useTxBatch()
     await addBundledMigrationEntry(batch)
+    const oldCartCeremony = await batch.prepareBundledExecution()
+    expect(oldCartCeremony?.reviewByEntryId).toHaveProperty(batch.entries.value[0]!.id)
+    expect(Object.keys(oldCartCeremony?.reviewByEntryId ?? {})).toHaveLength(1)
 
     let resolveSecondPlan!: (plan: TransactionPlan) => void
     const secondPlan = new Promise<TransactionPlan>((resolve) => {
@@ -1465,9 +1468,8 @@ describe('useTxBatch execution prerequisites', () => {
     })
     await vi.waitFor(() => expect(buildSecondPlan).toHaveBeenCalledTimes(1))
 
-    const oldCartCeremony = await batch.prepareBundledExecution()
-    expect(oldCartCeremony?.reviewByEntryId).toHaveProperty(batch.entries.value[0]!.id)
-    expect(Object.keys(oldCartCeremony?.reviewByEntryId ?? {})).toHaveLength(1)
+    expect(batch.isBundledExecutionCurrent(oldCartCeremony!)).toBe(false)
+    await expect(batch.prepareBundledExecution()).rejects.toThrow('still being added')
 
     resolveSecondPlan(singleOpBundledPlan)
     await pendingAdd
@@ -1478,6 +1480,140 @@ describe('useTxBatch execution prerequisites', () => {
     await batch.executeBatch(undefined, oldCartCeremony!)
     expect(eulerTxMocks.executePreparedPlanWithPlainCalls).not.toHaveBeenCalled()
     expect(batch.execError.value).toContain('Batch or wallet changed since review preparation')
+  })
+
+  it('keeps review unavailable until every queued add settles', async () => {
+    const sdk = createMockSdk()
+    sdk.executionService.simulateTransactionPlan.mockImplementation(async (...args: unknown[]) => ({
+      simulatedAccounts: Array.from(
+        { length: countPlanOperations(args[2] as TransactionPlan) },
+        (_, index) => accountWithPosition(subAccount, subAccount, BigInt(index + 2)),
+      ),
+      simulatedWalletBalances: [],
+      simulatedVaults: [],
+      failedBatchItems: [],
+      insufficientWalletAssets: [],
+    }))
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    isSafeWalletRef.value = true
+
+    let resolveFirstPlan!: (plan: TransactionPlan) => void
+    let resolveSecondPlan!: (plan: TransactionPlan) => void
+    const firstPlan = new Promise<TransactionPlan>((resolve) => {
+      resolveFirstPlan = resolve
+    })
+    const secondPlan = new Promise<TransactionPlan>((resolve) => {
+      resolveSecondPlan = resolve
+    })
+    const buildFirstPlan = vi.fn(() => firstPlan)
+    const buildSecondPlan = vi.fn(() => secondPlan)
+    const bundled = async () => ({
+      plan: singleOpBundledPlan,
+      grants: [],
+      revokes: [],
+      grantSteps: [],
+      revokeSteps: [],
+    })
+
+    const batch = useTxBatch()
+    const firstAdd = batch.addEntry({
+      label: 'First migration',
+      buildPlan: buildFirstPlan,
+      requiresPlanningAccount: false,
+      buildExecutionPrerequisites: async () => undefined,
+      buildBundledExecution: bundled,
+    })
+    await vi.waitFor(() => expect(buildFirstPlan).toHaveBeenCalledTimes(1))
+    const secondAdd = batch.addEntry({
+      label: 'Second migration',
+      buildPlan: buildSecondPlan,
+      requiresPlanningAccount: false,
+      buildExecutionPrerequisites: async () => undefined,
+      buildBundledExecution: bundled,
+    })
+
+    resolveFirstPlan(singleOpBundledPlan)
+    await firstAdd
+    await vi.waitFor(() => expect(buildSecondPlan).toHaveBeenCalledTimes(1))
+    await vi.waitFor(() => expect(batch.layers.value).toHaveLength(2))
+
+    expect(batch.entryCount.value).toBe(1)
+    expect(batch.hasPendingAdds.value).toBe(true)
+    expect(batch.canExecuteBatch.value).toBe(false)
+    await expect(batch.prepareBundledExecution()).rejects.toThrow('still being added')
+    await batch.executeBatch()
+    expect(eulerTxMocks.executePreparedPlanWithPlainCalls).not.toHaveBeenCalled()
+    expect(eulerTxMocks.executePreparedPlan).not.toHaveBeenCalled()
+
+    resolveSecondPlan(singleOpBundledPlan)
+    await secondAdd
+    await vi.waitFor(() => expect(batch.layers.value).toHaveLength(3))
+
+    expect(batch.hasPendingAdds.value).toBe(false)
+    const ceremony = await batch.prepareBundledExecution()
+    expect(Object.keys(ceremony?.reviewByEntryId ?? {})).toHaveLength(2)
+  })
+
+  it.each([
+    ['account', async () => {
+      effectiveAddressRef.value = getAddress('0x2000000000000000000000000000000000000000')
+      await nextTick()
+    }],
+    ['chain', async () => {
+      walletChainIdRef.value = 2
+      await nextTick()
+    }],
+    ['account switch away and back', async () => {
+      effectiveAddressRef.value = getAddress('0x2000000000000000000000000000000000000000')
+      await nextTick()
+      effectiveAddressRef.value = owner
+      await nextTick()
+    }],
+  ])('rejects a plan built across an %s change', async (_label, changeContext) => {
+    let resolvePlan!: (plan: TransactionPlan) => void
+    const deferredPlan = new Promise<TransactionPlan>((resolve) => {
+      resolvePlan = resolve
+    })
+    const buildPlan = vi.fn(() => deferredPlan)
+    const batch = useTxBatch()
+    const pendingAdd = batch.addEntry({
+      label: 'Context-bound operation',
+      buildPlan,
+      requiresPlanningAccount: false,
+    })
+    await vi.waitFor(() => expect(buildPlan).toHaveBeenCalledTimes(1))
+
+    await changeContext()
+    resolvePlan(singleOpBundledPlan)
+
+    await expect(pendingAdd).rejects.toThrow('Wallet or batch changed while adding this operation')
+    expect(batch.entryCount.value).toBe(0)
+    expect(batch.hasPendingAdds.value).toBe(false)
+  })
+
+  it.each(['clear', 'remove'] as const)('rejects a pending plan after a cart %s', async (edit) => {
+    const batch = useTxBatch()
+    await addBundledMigrationEntry(batch)
+
+    let resolvePlan!: (plan: TransactionPlan) => void
+    const deferredPlan = new Promise<TransactionPlan>((resolve) => {
+      resolvePlan = resolve
+    })
+    const buildPlan = vi.fn(() => deferredPlan)
+    const pendingAdd = batch.addEntry({
+      label: 'Pending migration',
+      buildPlan,
+      requiresPlanningAccount: false,
+    })
+    await vi.waitFor(() => expect(buildPlan).toHaveBeenCalledTimes(1))
+
+    if (edit === 'clear') batch.clearBatch()
+    else batch.removeEntry(batch.entries.value[0]!.id)
+    resolvePlan(singleOpBundledPlan)
+
+    await expect(pendingAdd).rejects.toThrow('Wallet or batch changed while adding this operation')
+    expect(batch.entryCount.value).toBe(0)
+    expect(batch.hasPendingAdds.value).toBe(false)
   })
 
   it('rejects an older preparation that resolves after a new cart ceremony', async () => {
@@ -1805,6 +1941,9 @@ describe('useTxBatch execution prerequisites', () => {
     const ceremony = await batch.prepareBundledExecution()
     // Safe disconnected between review and confirm.
     isSafeWalletRef.value = false
+    await nextTick()
+
+    expect(batch.isBundledExecutionCurrent(ceremony!)).toBe(false)
     await batch.executeBatch(undefined, ceremony ?? undefined)
 
     expect(batch.execError.value).toBeTruthy()

--- a/tests/composables/useTxBatch.test.ts
+++ b/tests/composables/useTxBatch.test.ts
@@ -1376,6 +1376,55 @@ describe('useTxBatch execution prerequisites', () => {
     expect(batch.entryCount.value).toBe(0)
   })
 
+  it('reuses the latched prepared core plan for review export and safe execution', async () => {
+    const sdk = createMockSdk()
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    isSafeWalletRef.value = true
+    const previewPlan = [{
+      type: 'evcBatch',
+      items: [{ type: 'operation', name: 'stale-preview', items: [] }],
+    }] as unknown as TransactionPlan
+    const latchedPlan = [{
+      type: 'evcBatch',
+      items: [{ type: 'operation', name: 'fresh-latched-execution', items: [] }],
+    }] as unknown as TransactionPlan
+    const latchedPrepared = { plan: latchedPlan, chainId: 1, account: owner }
+    eulerTxMocks.prepareTransactionPlan.mockResolvedValue(latchedPrepared)
+    eulerTxMocks.executePreparedPlanWithPlainCalls.mockResolvedValue({ receipts: [] })
+
+    const batch = useTxBatch()
+    await batch.addEntry({
+      label: 'Migrate Aave position',
+      buildPlan: async () => previewPlan,
+      buildExecutionPrerequisites: async () => ({
+        preTxs: [grantTx],
+        walletContext: grantWalletContext,
+        postTxs: [revokeTx],
+        postTxsByPreTx: [revokeTx],
+      }),
+      buildBundledExecution: async () => ({
+        plan: latchedPlan,
+        grants: [grantTx],
+        revokes: [revokeTx],
+        grantSteps: [bundledGrantStep],
+        revokeSteps: [bundledRevokeStep],
+      }),
+    })
+
+    const latched = await batch.prepareBundledExecution()
+    const reviewPrepared = await batch.prepareBatchPlan()
+    await batch.executeBatch()
+
+    expect(eulerTxMocks.prepareTransactionPlan).toHaveBeenCalledTimes(1)
+    expect(eulerTxMocks.prepareTransactionPlan).toHaveBeenCalledWith(latchedPlan)
+    expect(reviewPrepared).toBe(latchedPrepared)
+    expect(latched?.prepared).toBe(latchedPrepared)
+    expect(eulerTxMocks.executePreparedPlanWithPlainCalls).toHaveBeenCalledWith(latchedPrepared, {
+      before: [grantTx],
+      after: [revokeTx],
+    }, { allowSingleCall: true })
+  })
+
   it('throws instead of degrading when the safe bundle context is unavailable', async () => {
     const sdk = createMockSdk()
     vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)

--- a/tests/composables/useTxBatch.test.ts
+++ b/tests/composables/useTxBatch.test.ts
@@ -1459,9 +1459,9 @@ describe('useTxBatch submission quarantine', () => {
     broadcasts: PreparedPlanBroadcast[] = [coreArmed(), coreSubmitted()],
   ) => {
     eulerTxMocks.executePreparedPlan.mockImplementationOnce(async (_prepared, options?: {
-      onBroadcast?: (b: PreparedPlanBroadcast) => void
+      onBroadcast?: (b: PreparedPlanBroadcast) => void | Promise<void>
     }) => {
-      for (const broadcast of broadcasts) options?.onBroadcast?.(broadcast)
+      for (const broadcast of broadcasts) await options?.onBroadcast?.(broadcast)
       throw new Error('Receipt polling failed.')
     })
     await batch.executeBatch()
@@ -1472,15 +1472,15 @@ describe('useTxBatch submission quarantine', () => {
     const batch = await setupExecutableBatch()
     eulerTxMocks.executePreparedPlan
       .mockImplementationOnce(async (_prepared, options?: {
-        onBroadcast?: (b: PreparedPlanBroadcast) => void
+        onBroadcast?: (b: PreparedPlanBroadcast) => void | Promise<void>
       }) => {
         // The approval submission confirmed (the executor re-fires with
         // status 'confirmed' once its receipt landed) — then the wallet
         // provably rejected the armed core submission before accepting it.
-        options?.onBroadcast?.(coreSubmitted({ item: 'approval', hash: APPROVAL_HASH, completesPlan: false }))
-        options?.onBroadcast?.(coreConfirmed({ item: 'approval', hash: APPROVAL_HASH, completesPlan: false }))
-        options?.onBroadcast?.(coreArmed({ index: 1 }))
-        options?.onBroadcast?.(coreRejected({ index: 1 }))
+        await options?.onBroadcast?.(coreSubmitted({ item: 'approval', hash: APPROVAL_HASH, completesPlan: false }))
+        await options?.onBroadcast?.(coreConfirmed({ item: 'approval', hash: APPROVAL_HASH, completesPlan: false }))
+        await options?.onBroadcast?.(coreArmed({ index: 1 }))
+        await options?.onBroadcast?.(coreRejected({ index: 1 }))
         throw new Error('User rejected the request.')
       })
       .mockResolvedValueOnce(undefined)
@@ -1504,9 +1504,10 @@ describe('useTxBatch submission quarantine', () => {
     const batch = await setupExecutableBatch()
     let recordAtBroadcastTime: unknown
     eulerTxMocks.executePreparedPlan.mockImplementationOnce(async (_prepared, options?: {
-      onBroadcast?: (b: PreparedPlanBroadcast) => void
+      onBroadcast?: (b: PreparedPlanBroadcast) => void | Promise<void>
     }) => {
-      options?.onBroadcast?.(coreSubmitted())
+      await options?.onBroadcast?.(coreArmed())
+      await options?.onBroadcast?.(coreSubmitted())
       // A reload between the wallet's acceptance and the executor settling
       // (receipt polling, later steps) must already find the durable record.
       recordAtBroadcastTime = readPendingSubmission('batch', owner, 1)
@@ -1527,9 +1528,9 @@ describe('useTxBatch submission quarantine', () => {
     const batch = await setupExecutableBatch()
     let recordAtArmTime: unknown
     eulerTxMocks.executePreparedPlan.mockImplementationOnce(async (_prepared, options?: {
-      onBroadcast?: (b: PreparedPlanBroadcast) => void
+      onBroadcast?: (b: PreparedPlanBroadcast) => void | Promise<void>
     }) => {
-      options?.onBroadcast?.(coreArmed())
+      await options?.onBroadcast?.(coreArmed())
       recordAtArmTime = readPendingSubmission('batch', owner, 1)
       // The wallet boundary failed without returning an id and without a
       // provable rejection — acceptance cannot be ruled out.
@@ -1558,10 +1559,10 @@ describe('useTxBatch submission quarantine', () => {
     const batch = await setupExecutableBatch()
     eulerTxMocks.executePreparedPlan
       .mockImplementationOnce(async (_prepared, options?: {
-        onBroadcast?: (b: PreparedPlanBroadcast) => void
+        onBroadcast?: (b: PreparedPlanBroadcast) => void | Promise<void>
       }) => {
-        options?.onBroadcast?.(coreArmed())
-        options?.onBroadcast?.(coreRejected())
+        await options?.onBroadcast?.(coreArmed())
+        await options?.onBroadcast?.(coreRejected())
         throw new Error('User rejected the request.')
       })
       .mockResolvedValueOnce(undefined)
@@ -1607,7 +1608,7 @@ describe('useTxBatch submission quarantine', () => {
     expect(readPendingSubmission('batch', owner, 1)).toBeDefined()
   })
 
-  it('keeps the quarantine fail-closed when durable storage rejects the write', async () => {
+  it('aborts before the wallet when the reservation cannot be proven durable', async () => {
     vi.stubGlobal('localStorage', {
       ...createMemoryStorage(),
       setItem: () => {
@@ -1615,16 +1616,27 @@ describe('useTxBatch submission quarantine', () => {
       },
     })
     const batch = await setupExecutableBatch()
+    let walletInvoked = false
+    eulerTxMocks.executePreparedPlan.mockImplementationOnce(async (_prepared, options?: {
+      onBroadcast?: (b: PreparedPlanBroadcast) => void | Promise<void>
+    }) => {
+      // The executor awaits the armed emission before the wallet call — the
+      // reservation write fails, so the throw must land here.
+      await options?.onBroadcast?.(coreArmed())
+      walletInvoked = true
+    })
 
-    await quarantineOneSubmission(batch)
-
-    // Nothing durable was written, but the in-memory fallback must still
-    // block this session's retry while the outcome is unknown.
-    expect(readPendingSubmission('batch', owner, 1)).toMatchObject({ phase: 'submitted', hash: CORE_HASH })
     await batch.executeBatch()
 
+    // Durable-or-abort: nothing reached the wallet without a reservation.
+    expect(walletInvoked).toBe(false)
+    expect(batch.execError.value).toContain('nothing was handed to the wallet')
+
+    // The in-realm copy written on the failure path still blocks retries
+    // while the storage stays broken — the outcome could not be recorded.
+    await batch.executeBatch()
     expect(eulerTxMocks.executePreparedPlan).toHaveBeenCalledTimes(1)
-    expect(batch.execError.value).toContain('could not be verified yet')
+    expect(batch.execError.value).toContain('no transaction id came back')
   })
 
   it('releases the quarantine and retries once the submission definitively did not land', async () => {
@@ -1712,6 +1724,57 @@ describe('useTxBatch submission quarantine', () => {
     expect(eulerTxMocks.executePreparedPlan).not.toHaveBeenCalled()
     expect(batch.execError.value).toContain('no transaction id came back')
     expect(readPendingSubmission('batch', owner, 1)).toBeDefined()
+  })
+
+  it('offers manual release for an armed record orphaned by a reload and unblocks execution', async () => {
+    const batch = await setupExecutableBatch()
+    // Simulated reload: the attempt that armed the record is gone, no id
+    // will ever arrive, and no on-chain verification is possible.
+    writePendingSubmission('batch', {
+      phase: 'armed',
+      chainId: 1,
+      owner,
+      completesPlan: true,
+      submittedAt: 1_000,
+    })
+    hydratePendingBatchSubmissionFromStorage()
+
+    await batch.executeBatch()
+    expect(eulerTxMocks.executePreparedPlan).not.toHaveBeenCalled()
+    expect(batch.execError.value).toContain('no transaction id came back')
+    // Only the manual, risk-labelled path can resolve this state.
+    expect(batch.hasReleasableArmedSubmission.value).toBe(true)
+
+    // The user confirmed the wallet shows nothing pending.
+    await expect(batch.releaseArmedQuarantineAfterManualCheck()).resolves.toBe(true)
+    expect(batch.hasReleasableArmedSubmission.value).toBe(false)
+    expect(batch.execError.value).toBeUndefined()
+    expect(readPendingSubmission('batch', owner, 1)).toBeUndefined()
+
+    eulerTxMocks.executePreparedPlan.mockResolvedValueOnce(undefined)
+    await batch.executeBatch()
+    expect(eulerTxMocks.executePreparedPlan).toHaveBeenCalledTimes(1)
+  })
+
+  it('refuses manual release for a submitted record and keeps it for on-chain verification', async () => {
+    const batch = await setupExecutableBatch()
+    writePendingSubmission('batch', {
+      phase: 'submitted',
+      kind: 'transaction',
+      hash: CORE_HASH,
+      chainId: 1,
+      owner,
+      completesPlan: true,
+      submittedAt: 1_000,
+    })
+    hydratePendingBatchSubmissionFromStorage()
+
+    // A submitted record has an id and is verified automatically — the
+    // manual release must never be offered for it, nor honor a call.
+    expect(batch.hasReleasableArmedSubmission.value).toBe(false)
+    await expect(batch.releaseArmedQuarantineAfterManualCheck()).resolves.toBe(false)
+    expect(batch.execError.value).toContain('cannot be dismissed')
+    expect(readPendingSubmission('batch', owner, 1)).toMatchObject({ phase: 'submitted' })
   })
 
   it('resets the cart when a hydrated post-reload submission landed without ceremony context', async () => {
@@ -1829,11 +1892,11 @@ describe('useTxBatch submission quarantine', () => {
   it('retires entries when the core submission confirmed but a later step failed', async () => {
     const batch = await setupExecutableBatch()
     eulerTxMocks.executePreparedPlan.mockImplementationOnce(async (_prepared, options?: {
-      onBroadcast?: (b: PreparedPlanBroadcast) => void
+      onBroadcast?: (b: PreparedPlanBroadcast) => void | Promise<void>
     }) => {
-      options?.onBroadcast?.(coreArmed())
-      options?.onBroadcast?.(coreSubmitted())
-      options?.onBroadcast?.(coreConfirmed())
+      await options?.onBroadcast?.(coreArmed())
+      await options?.onBroadcast?.(coreSubmitted())
+      await options?.onBroadcast?.(coreConfirmed())
       return undefined
     })
     migrationFlowMocks.revokeAfterSuccess.mockRejectedValueOnce(new Error('Revoke failed.'))

--- a/tests/composables/useTxBatch.test.ts
+++ b/tests/composables/useTxBatch.test.ts
@@ -46,7 +46,7 @@ const eulerTxMocks = {
   prepareTransactionPlan: vi.fn(),
   executePreparedPlan: vi.fn(),
   executePreparedPlanWithPlainCalls: vi.fn(),
-  estimateGasForPlan: vi.fn(),
+  estimateGasForPreparedPlan: vi.fn(),
   sendPlainTransactions: vi.fn(),
 }
 const isSafeWalletRef = ref(false)
@@ -339,7 +339,7 @@ beforeEach(() => {
   eulerTxMocks.prepareTransactionPlan.mockReset()
   eulerTxMocks.executePreparedPlan.mockReset()
   eulerTxMocks.executePreparedPlanWithPlainCalls.mockReset()
-  eulerTxMocks.estimateGasForPlan.mockReset()
+  eulerTxMocks.estimateGasForPreparedPlan.mockReset()
   eulerTxMocks.sendPlainTransactions.mockReset()
   eulerTxMocks.sendPlainTransactions.mockImplementation(broadcastAllTransactions)
   txErrorMocks.getTxErrorMessage.mockReset()
@@ -1277,7 +1277,7 @@ describe('useTxBatch execution errors', () => {
     const prepared = { kind: 'prepared' }
     const plan: TransactionPlan = []
     routeQuery.network = '8453'
-    eulerTxMocks.estimateGasForPlan.mockResolvedValue(undefined)
+    eulerTxMocks.estimateGasForPreparedPlan.mockResolvedValue(undefined)
     eulerTxMocks.prepareTransactionPlan.mockResolvedValue(prepared)
     eulerTxMocks.executePreparedPlan.mockResolvedValue(undefined)
 
@@ -1288,6 +1288,7 @@ describe('useTxBatch execution errors', () => {
     })
     await batch.executeBatch()
 
+    expect(eulerTxMocks.estimateGasForPreparedPlan).toHaveBeenCalledWith(prepared)
     expect(eulerTxMocks.executePreparedPlan).toHaveBeenCalledWith(prepared, {
       beforeBroadcast: expect.any(Function),
     })
@@ -1330,7 +1331,7 @@ describe('useTxBatch execution errors', () => {
     const migrationPreviewPlan = singleOpPlan('migration-preview')
     const migrationExecutionPlan = singleOpPlan('migration-execution')
     let executionAccount: Account<IHasVaultAddress> | undefined
-    eulerTxMocks.estimateGasForPlan.mockResolvedValue(undefined)
+    eulerTxMocks.estimateGasForPreparedPlan.mockResolvedValue(undefined)
     eulerTxMocks.prepareTransactionPlan.mockResolvedValue(prepared)
     eulerTxMocks.executePreparedPlan.mockResolvedValue(undefined)
 
@@ -1500,7 +1501,7 @@ describe('useTxBatch execution prerequisites', () => {
       }
     })
     eulerTxMocks.prepareTransactionPlan.mockImplementation(async plan => ({ plan, chainId: 1, account: owner }))
-    eulerTxMocks.estimateGasForPlan.mockResolvedValue(undefined)
+    eulerTxMocks.estimateGasForPreparedPlan.mockResolvedValue(undefined)
     eulerTxMocks.executePreparedPlan.mockResolvedValue(undefined)
 
     const batch = useTxBatch()
@@ -1623,7 +1624,7 @@ describe('useTxBatch execution prerequisites', () => {
     vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
     const prepared = { kind: 'prepared', plan: singleOpBundledPlan, chainId: 1, account: owner }
     eulerTxMocks.prepareTransactionPlan.mockResolvedValue(prepared)
-    eulerTxMocks.estimateGasForPlan.mockResolvedValue(undefined)
+    eulerTxMocks.estimateGasForPreparedPlan.mockResolvedValue(undefined)
     let releaseHelper!: () => void
     const helperGate = new Promise<void>((resolve) => {
       releaseHelper = resolve
@@ -1660,7 +1661,7 @@ describe('useTxBatch execution prerequisites', () => {
     vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
     const prepared = { kind: 'prepared', plan: singleOpBundledPlan, chainId: 1, account: owner }
     eulerTxMocks.prepareTransactionPlan.mockResolvedValue(prepared)
-    eulerTxMocks.estimateGasForPlan.mockResolvedValue(undefined)
+    eulerTxMocks.estimateGasForPreparedPlan.mockResolvedValue(undefined)
     let releaseHelper!: () => void
     const helperGate = new Promise<void>((resolve) => {
       releaseHelper = resolve
@@ -1696,7 +1697,7 @@ describe('useTxBatch execution prerequisites', () => {
     vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
     const prepared = { kind: 'prepared', plan: singleOpBundledPlan, chainId: 1, account: owner }
     eulerTxMocks.prepareTransactionPlan.mockResolvedValue(prepared)
-    eulerTxMocks.estimateGasForPlan.mockResolvedValue(undefined)
+    eulerTxMocks.estimateGasForPreparedPlan.mockResolvedValue(undefined)
     let releaseCompletion!: () => void
     const completionGate = new Promise<void>((resolve) => {
       releaseCompletion = resolve
@@ -1742,7 +1743,7 @@ describe('useTxBatch execution prerequisites', () => {
     vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
     const prepared = { kind: 'prepared', plan: singleOpBundledPlan, chainId: 1, account: owner }
     eulerTxMocks.prepareTransactionPlan.mockResolvedValue(prepared)
-    eulerTxMocks.estimateGasForPlan.mockResolvedValue(undefined)
+    eulerTxMocks.estimateGasForPreparedPlan.mockResolvedValue(undefined)
     eulerTxMocks.executePreparedPlan.mockRejectedValue(new Error('old wallet execution failed'))
     let resolveDecodedError!: (message: string) => void
     txErrorMocks.getTxErrorMessage.mockReturnValue(new Promise<string>((resolve) => {
@@ -1793,7 +1794,7 @@ describe('useTxBatch execution prerequisites', () => {
     // Grants ride in the proposal — no standalone broadcasts, no unwind
     // bookkeeping, no standalone gas estimate against unmined grants.
     expect(eulerTxMocks.sendPlainTransactions).not.toHaveBeenCalled()
-    expect(eulerTxMocks.estimateGasForPlan).not.toHaveBeenCalled()
+    expect(eulerTxMocks.estimateGasForPreparedPlan).not.toHaveBeenCalled()
     expect(eulerTxMocks.executePreparedPlanWithPlainCalls).toHaveBeenCalledWith(prepared, {
       before: [grantTx],
       after: [revokeTx],
@@ -2029,7 +2030,7 @@ describe('useTxBatch execution prerequisites', () => {
     vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
     eulerTxMocks.prepareTransactionPlan.mockImplementation(async plan => ({ plan, chainId: 1, account: owner }))
     let releaseEstimate!: () => void
-    eulerTxMocks.estimateGasForPlan.mockImplementation(() => new Promise<void>((resolve) => {
+    eulerTxMocks.estimateGasForPreparedPlan.mockImplementation(() => new Promise<void>((resolve) => {
       releaseEstimate = resolve
     }))
     eulerTxMocks.executePreparedPlan.mockResolvedValue(undefined)
@@ -2043,7 +2044,7 @@ describe('useTxBatch execution prerequisites', () => {
     await vi.waitFor(() => expect(batch.layers.value).toHaveLength(2))
     const ceremony = await batch.prepareBatchExecution()
     const execution = batch.executeBatch(undefined, ceremony)
-    await vi.waitFor(() => expect(eulerTxMocks.estimateGasForPlan).toHaveBeenCalledTimes(1))
+    await vi.waitFor(() => expect(eulerTxMocks.estimateGasForPreparedPlan).toHaveBeenCalledTimes(1))
 
     let resolvePendingPlan!: (plan: TransactionPlan) => void
     const pendingPlan = new Promise<TransactionPlan>((resolve) => {
@@ -2257,7 +2258,7 @@ describe('useTxBatch execution prerequisites', () => {
     }] as unknown as TransactionPlan
     const reviewedPrepared = { kind: 'reviewed', plan: reviewedPlan, chainId: 1, account: owner }
     eulerTxMocks.prepareTransactionPlan.mockResolvedValue(reviewedPrepared)
-    eulerTxMocks.estimateGasForPlan.mockResolvedValue(undefined)
+    eulerTxMocks.estimateGasForPreparedPlan.mockResolvedValue(undefined)
     eulerTxMocks.executePreparedPlan.mockResolvedValue(undefined)
 
     const batch = useTxBatch()
@@ -2584,7 +2585,7 @@ describe('useTxBatch execution prerequisites', () => {
     isSafeWalletRef.value = false
     const prepared = { kind: 'prepared', plan: singleOpBundledPlan, chainId: 1, account: owner }
     eulerTxMocks.prepareTransactionPlan.mockResolvedValue(prepared)
-    eulerTxMocks.estimateGasForPlan.mockResolvedValue(undefined)
+    eulerTxMocks.estimateGasForPreparedPlan.mockResolvedValue(undefined)
     eulerTxMocks.executePreparedPlan.mockResolvedValue(undefined)
     eulerTxMocks.sendPlainTransactions.mockImplementation(async (txs: { data: Hex }[], options?: PlainTxSendOptions) => {
       txs.forEach((_tx, index) => options?.onBroadcast?.(index, grantWalletContext))
@@ -2626,7 +2627,7 @@ describe('useTxBatch execution prerequisites', () => {
     isSafeWalletRef.value = false
     const prepared = { kind: 'prepared', plan: singleOpBundledPlan, chainId: 1, account: owner }
     eulerTxMocks.prepareTransactionPlan.mockResolvedValue(prepared)
-    eulerTxMocks.estimateGasForPlan.mockResolvedValue(undefined)
+    eulerTxMocks.estimateGasForPreparedPlan.mockResolvedValue(undefined)
     eulerTxMocks.executePreparedPlan.mockResolvedValue(undefined)
 
     const batch = useTxBatch()
@@ -2717,7 +2718,7 @@ describe('useTxBatch execution prerequisites', () => {
       txs.forEach((_tx, index) => options?.onBroadcast?.(index, grantWalletContext))
       return []
     })
-    eulerTxMocks.estimateGasForPlan.mockImplementation(async () => void calls.push('estimateGasForPlan'))
+    eulerTxMocks.estimateGasForPreparedPlan.mockImplementation(async () => void calls.push('estimateGasForPreparedPlan'))
     eulerTxMocks.prepareTransactionPlan.mockResolvedValue({ kind: 'prepared' })
     eulerTxMocks.executePreparedPlan.mockImplementation(async () => void calls.push('executePreparedPlan'))
     migrationFlowMocks.restorePendingBeforeRetry.mockImplementation(async () => {
@@ -2737,7 +2738,7 @@ describe('useTxBatch execution prerequisites', () => {
       'restorePendingBeforeRetry',
       'mergePlans',
       'sendPlainTransactions',
-      'estimateGasForPlan',
+      'estimateGasForPreparedPlan',
       'executePreparedPlan',
       'revokeAfterSuccess',
     ])
@@ -2799,7 +2800,7 @@ describe('useTxBatch execution prerequisites', () => {
     async (kind) => {
       const batch = useTxBatch()
       eulerTxMocks.sendPlainTransactions.mockImplementation(broadcastAllTransactions)
-      eulerTxMocks.estimateGasForPlan.mockResolvedValue(undefined)
+      eulerTxMocks.estimateGasForPreparedPlan.mockResolvedValue(undefined)
       eulerTxMocks.prepareTransactionPlan.mockResolvedValue({ kind: 'prepared' })
       eulerTxMocks.executePreparedPlan.mockRejectedValue(new WalletExecutionContextChangedError(kind))
 
@@ -2819,7 +2820,7 @@ describe('useTxBatch execution prerequisites', () => {
       .mockResolvedValueOnce(true)
       .mockResolvedValueOnce(false)
     eulerTxMocks.sendPlainTransactions.mockImplementation(broadcastAllTransactions)
-    eulerTxMocks.estimateGasForPlan.mockResolvedValue(undefined)
+    eulerTxMocks.estimateGasForPreparedPlan.mockResolvedValue(undefined)
     eulerTxMocks.prepareTransactionPlan.mockResolvedValue({ kind: 'prepared' })
     eulerTxMocks.executePreparedPlan.mockRejectedValue(new Error('User rejected the request.'))
 
@@ -2838,7 +2839,7 @@ describe('useTxBatch execution prerequisites', () => {
 
   it('sends no transactions when an entry reports no prerequisites', async () => {
     const batch = useTxBatch()
-    eulerTxMocks.estimateGasForPlan.mockResolvedValue(undefined)
+    eulerTxMocks.estimateGasForPreparedPlan.mockResolvedValue(undefined)
     eulerTxMocks.prepareTransactionPlan.mockResolvedValue({ kind: 'prepared' })
     eulerTxMocks.executePreparedPlan.mockResolvedValue(undefined)
 
@@ -2857,7 +2858,7 @@ describe('useTxBatch execution prerequisites', () => {
   it('still clears the batch when the revoke fails after a successful execution', async () => {
     const batch = useTxBatch()
     eulerTxMocks.sendPlainTransactions.mockImplementation(broadcastAllTransactions)
-    eulerTxMocks.estimateGasForPlan.mockResolvedValue(undefined)
+    eulerTxMocks.estimateGasForPreparedPlan.mockResolvedValue(undefined)
     eulerTxMocks.prepareTransactionPlan.mockResolvedValue({ kind: 'prepared' })
     eulerTxMocks.executePreparedPlan.mockResolvedValue(undefined)
     // revokeAfterSuccess swallows failures internally; it must never throw.

--- a/tests/pages/directMigrationQuarantineBinding.test.ts
+++ b/tests/pages/directMigrationQuarantineBinding.test.ts
@@ -1,0 +1,64 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+// The direct migration flows have no component harness, so this pins the
+// quarantine wiring as source text: both directions must reconcile any
+// previously accepted submission on-chain before sending, classify every
+// broadcast through the quarantine's ordered tracker (standard and Safe-bundle
+// paths alike), and durably retain an accepted-but-unconfirmed submission when
+// the attempt fails. The quarantine behavior itself is covered by
+// tests/utils/directSubmissionQuarantine.test.ts — this guards the call sites.
+const FLOWS = [
+  {
+    direction: 'outgoing',
+    path: 'pages/position/[number]/migrate.vue',
+    flow: 'outgoing-migration',
+    quarantine: 'migrationQuarantine',
+    reconcile: 'reconcileMigrationQuarantine(preview)',
+  },
+  {
+    direction: 'inbound',
+    path: 'pages/position/[number]/borrow/swap.vue',
+    flow: 'inbound-migration',
+    quarantine: 'inboundMigrationQuarantine',
+    reconcile: 'reconcileInboundMigrationQuarantine(preview)',
+  },
+] as const
+
+const sourceOf = (path: string) => readFileSync(join(process.cwd(), path), 'utf8')
+
+describe('direct migration submission quarantine binding', () => {
+  it.each(FLOWS)('$direction: creates a flow-scoped durable quarantine', ({ path, flow, quarantine }) => {
+    const source = sourceOf(path)
+    expect(source).toContain(`const ${quarantine} = createDirectSubmissionQuarantine({`)
+    expect(source).toContain(`flow: '${flow}',`)
+  })
+
+  it.each(FLOWS)('$direction: reconciles the quarantine before any wallet action', ({ path, reconcile }) => {
+    const source = sourceOf(path)
+    // The gate sits right after the pending-signature restore, before the
+    // deadline check, authorization work, and every broadcast.
+    expect(source).toContain('if (!await restorePendingBeforeRetry()) return\n'
+      + `    if (!await ${reconcile}) return`)
+  })
+
+  it.each(FLOWS)('$direction: arms attempt tracking before the wallet ceremony', ({ path, quarantine }) => {
+    const source = sourceOf(path)
+    expect(source).toContain(`${quarantine}.begin({ owner:`)
+  })
+
+  it.each(FLOWS)('$direction: tracks broadcasts on both execution paths', ({ path, quarantine }) => {
+    const source = sourceOf(path)
+    // Standard sequential path AND the Safe-bundle path: both value-moving
+    // submissions must flow through the same ordered tracker.
+    const trackBindings = source.split(`onBroadcast: ${quarantine}.track`).length - 1
+    expect(trackBindings).toBe(2)
+  })
+
+  it.each(FLOWS)('$direction: seals an ambiguous submission when the attempt fails', ({ path, quarantine }) => {
+    const source = sourceOf(path)
+    expect(source).toContain(`const quarantined = ${quarantine}.sealFailure()`)
+    expect(source).toContain('The submission may still confirm — retrying first verifies it on-chain before anything is re-sent.')
+  })
+})

--- a/tests/pages/safeBundleBroadcastGuardBinding.test.ts
+++ b/tests/pages/safeBundleBroadcastGuardBinding.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+// The direct Safe-bundle flows have no component harness, so this pins the
+// call-site binding as source text: the broadcast guard's expected connector
+// key must come from the reviewed preview (captured when the preview was
+// built), never from a snapshot taken inside the confirmation flow — a
+// confirmation-time snapshot runs after awaits the wallet can change under,
+// so a connector swapped during those awaits would become the guard's
+// accepted baseline.
+const FLOWS = [
+  {
+    direction: 'outgoing',
+    path: 'pages/position/[number]/migrate.vue',
+  },
+  {
+    direction: 'inbound',
+    path: 'pages/position/[number]/borrow/swap.vue',
+  },
+] as const
+
+describe('direct Safe-bundle broadcast guard binding', () => {
+  it.each(FLOWS)('$direction: the preview captures the connector key at build time', ({ path }) => {
+    const source = readFileSync(join(process.cwd(), path), 'utf8')
+    expect(source).toContain('connectorContextKey: walletConnectorContextKey(),')
+  })
+
+  it.each(FLOWS)('$direction: the guard validates against the reviewed preview key', ({ path }) => {
+    const source = readFileSync(join(process.cwd(), path), 'utf8')
+    expect(source).toContain('expectedConnectorKey: preview.connectorContextKey,')
+    // The live-state reader stays a thunk for the broadcast-time comparison;
+    // an invoked form here would reintroduce the confirmation-time snapshot.
+    expect(source).not.toContain('expectedConnectorKey: walletConnectorContextKey()')
+  })
+})

--- a/tests/pages/safeBundleBroadcastGuardBinding.test.ts
+++ b/tests/pages/safeBundleBroadcastGuardBinding.test.ts
@@ -33,4 +33,11 @@ describe('direct Safe-bundle broadcast guard binding', () => {
     // an invoked form here would reintroduce the confirmation-time snapshot.
     expect(source).not.toContain('expectedConnectorKey: walletConnectorContextKey()')
   })
+
+  it.each(FLOWS)('$direction: the standard direct flow binds the reviewed-context guard', ({ path }) => {
+    const source = readFileSync(join(process.cwd(), path), 'utf8')
+    // The standard (non-bundled) confirmation must also guard its signature
+    // requests, grant broadcasts, and plan broadcast against the reviewed key.
+    expect(source).toContain('createReviewedWalletContextGuard({')
+  })
 })

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -46,3 +46,38 @@ if (!g.useState) {
     return entry
   }
 }
+
+// Pending-submission replay protection is durable-or-abort: without a working
+// localStorage every wallet-boundary reservation would throw. Node exposes a
+// `localStorage` accessor that can exist yet return undefined, so install a
+// Map-backed polyfill via defineProperty when no usable storage is present.
+const hasUsableLocalStorage = (() => {
+  try {
+    return typeof globalThis.localStorage?.setItem === 'function'
+  }
+  catch {
+    return false
+  }
+})()
+if (!hasUsableLocalStorage) {
+  const backing = new Map<string, string>()
+  const storagePolyfill: Storage = {
+    get length() {
+      return backing.size
+    },
+    clear: () => backing.clear(),
+    getItem: (key: string) => backing.get(key) ?? null,
+    key: (index: number) => [...backing.keys()][index] ?? null,
+    removeItem: (key: string) => {
+      backing.delete(key)
+    },
+    setItem: (key: string, value: string) => {
+      backing.set(key, String(value))
+    },
+  }
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: storagePolyfill,
+    configurable: true,
+    writable: true,
+  })
+}

--- a/tests/utils/batchReviewCalldata.test.ts
+++ b/tests/utils/batchReviewCalldata.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+import { encodeFunctionData, type Address, type Hex } from 'viem'
+import type { TransactionPlan } from '@eulerxyz/euler-v2-sdk'
+import { buildBatchReviewCalldata } from '~/utils/batchReviewCalldata'
+
+const BEFORE = '0x1000000000000000000000000000000000000001' as Address
+const PLUGIN = '0x2000000000000000000000000000000000000002' as Address
+const TOKEN = '0x3000000000000000000000000000000000000003' as Address
+const EVC = '0x4000000000000000000000000000000000000004' as Address
+const AFTER = '0x5000000000000000000000000000000000000005' as Address
+const ACCOUNT = '0x6000000000000000000000000000000000000006' as Address
+const BATCH_TARGET = '0x7000000000000000000000000000000000000007' as Address
+
+const pingAbi = [{
+  type: 'function',
+  name: 'ping',
+  inputs: [],
+  outputs: [],
+  stateMutability: 'payable',
+}] as const
+
+describe('buildBatchReviewCalldata', () => {
+  it('preserves the exact before, prepared plugin/approval/core, after vector', () => {
+    const pluginData = encodeFunctionData({ abi: pingAbi, functionName: 'ping' })
+    const plan = [{
+      type: 'contractCall',
+      chainId: 1,
+      to: PLUGIN,
+      abi: pingAbi,
+      functionName: 'ping',
+      args: [],
+      value: 7n,
+    }, {
+      type: 'requiredApproval',
+      token: TOKEN,
+      owner: ACCOUNT,
+      spender: BATCH_TARGET,
+      amount: 9n,
+      resolved: [{
+        type: 'approve',
+        token: TOKEN,
+        owner: ACCOUNT,
+        spender: BATCH_TARGET,
+        amount: 9n,
+        data: '0xapprove' as Hex,
+      }],
+    }, {
+      type: 'evcBatch',
+      items: [{
+        targetContract: BATCH_TARGET,
+        onBehalfOfAccount: ACCOUNT,
+        value: 11n,
+        data: '0xcore' as Hex,
+      }],
+    }] as unknown as TransactionPlan
+
+    const calldata = buildBatchReviewCalldata({
+      plan,
+      before: [{ to: BEFORE, data: '0xbefore' as Hex, value: 3n }],
+      after: [{ to: AFTER, data: '0xafter' as Hex }],
+      sdk: {
+        deploymentService: {
+          getDeployment: () => ({ addresses: { coreAddrs: { evc: EVC } } }),
+        },
+        executionService: { encodeBatch: () => '0xbatch' as Hex },
+      },
+      chainId: 1,
+    })
+
+    expect(calldata).toEqual([
+      { to: BEFORE, data: '0xbefore', value: '3' },
+      { to: PLUGIN, data: pluginData, value: '7' },
+      { to: TOKEN, data: '0xapprove', value: '0' },
+      { to: EVC, data: '0xbatch', value: '11' },
+      { to: AFTER, data: '0xafter', value: '0' },
+    ])
+  })
+})

--- a/tests/utils/batchReviewDisplay.test.ts
+++ b/tests/utils/batchReviewDisplay.test.ts
@@ -29,7 +29,7 @@ describe('isBundledReviewEntry', () => {
 })
 
 describe('getBatchReviewDisplayPlan', () => {
-  it('shows the ceremony plan instead of a stale captured preview', () => {
+  it('uses the ceremony plan for display and disclosure instead of a stale captured preview', () => {
     const freshCeremonyPlan = [{ type: 'evcBatch', items: [{ name: 'fresh-execution' }] }] as unknown as TransactionPlan
     const stalePreviewPlan = [{ type: 'evcBatch', items: [{ name: 'stale-preview' }] }] as unknown as TransactionPlan
     const entryPlan = [{ type: 'evcBatch', items: [{ name: 'entry-plan' }] }] as unknown as TransactionPlan

--- a/tests/utils/batchReviewDisplay.test.ts
+++ b/tests/utils/batchReviewDisplay.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { TransactionPlan } from '@eulerxyz/euler-v2-sdk'
-import { consolidateRestorationSummaryRows, getAuthorizationStepDisplay, getBatchReviewDisplayPlan, groupRestorationSummaryRows, isBundledReviewEntry } from '~/utils/batchReviewDisplay'
+import { getAuthorizationStepDisplay, getBatchReviewDisplayPlan, groupRestorationSummaryRows, isBundledReviewEntry } from '~/utils/batchReviewDisplay'
 
 describe('getAuthorizationStepDisplay', () => {
   it('describes signature-mode authorization rows as signatures', () => {
@@ -54,21 +54,5 @@ describe('groupRestorationSummaryRows', () => {
       bundled: [],
       postExecution: [],
     })
-  })
-})
-
-describe('consolidateRestorationSummaryRows', () => {
-  it('keeps every bundled Safe call visible', () => {
-    const first = { id: 'first', step: { isSeparateTx: false, txKey: 'same-transaction' } }
-    const second = { id: 'second', step: { isSeparateTx: false, txKey: 'same-transaction' } }
-
-    expect(consolidateRestorationSummaryRows([first, second])).toEqual([first, second])
-  })
-
-  it('consolidates identical standalone restorations resolved sequentially', () => {
-    const first = { id: 'first', step: { isSeparateTx: true, txKey: 'same-transaction' } }
-    const second = { id: 'second', step: { isSeparateTx: true, txKey: 'same-transaction' } }
-
-    expect(consolidateRestorationSummaryRows([first, second])).toEqual([first])
   })
 })

--- a/tests/utils/batchReviewDisplay.test.ts
+++ b/tests/utils/batchReviewDisplay.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import { consolidateRestorationSummaryRows, getAuthorizationStepDisplay, groupRestorationSummaryRows, isBundledReviewEntry } from '~/utils/batchReviewDisplay'
+import type { TransactionPlan } from '@eulerxyz/euler-v2-sdk'
+import { consolidateRestorationSummaryRows, getAuthorizationStepDisplay, getBatchReviewDisplayPlan, groupRestorationSummaryRows, isBundledReviewEntry } from '~/utils/batchReviewDisplay'
 
 describe('getAuthorizationStepDisplay', () => {
   it('describes signature-mode authorization rows as signatures', () => {
@@ -24,6 +25,16 @@ describe('isBundledReviewEntry', () => {
     expect(isBundledReviewEntry(true, true)).toBe(true)
     expect(isBundledReviewEntry(false, true)).toBe(false)
     expect(isBundledReviewEntry(true, false)).toBe(false)
+  })
+})
+
+describe('getBatchReviewDisplayPlan', () => {
+  it('shows the ceremony plan instead of a stale captured preview', () => {
+    const freshCeremonyPlan = [{ type: 'evcBatch', items: [{ name: 'fresh-execution' }] }] as unknown as TransactionPlan
+    const stalePreviewPlan = [{ type: 'evcBatch', items: [{ name: 'stale-preview' }] }] as unknown as TransactionPlan
+    const entryPlan = [{ type: 'evcBatch', items: [{ name: 'entry-plan' }] }] as unknown as TransactionPlan
+
+    expect(getBatchReviewDisplayPlan(freshCeremonyPlan, stalePreviewPlan, entryPlan)).toBe(freshCeremonyPlan)
   })
 })
 

--- a/tests/utils/directSubmissionQuarantine.test.ts
+++ b/tests/utils/directSubmissionQuarantine.test.ts
@@ -7,6 +7,8 @@ import {
   PENDING_SUBMISSION_UNRESOLVED_ERROR,
 } from '~/utils/directSubmissionQuarantine'
 import {
+  PendingSubmissionConflictError,
+  PendingSubmissionStorageError,
   readPendingSubmission,
   resetPendingSubmissionMemoryFallback,
   writePendingSubmission,
@@ -102,10 +104,26 @@ beforeEach(() => {
 })
 
 describe('track', () => {
-  it('persists the quarantine the moment the wallet accepts an EOA submission', () => {
+  it('reserves the quarantine at the wallet boundary, before an id exists', async () => {
     const quarantine = createQuarantine()
     quarantine.begin({ owner: OWNER, chainId: 1 })
-    quarantine.track(submitted())
+    await quarantine.track(armed())
+
+    // The wallet was invoked but returned nothing yet — a reload here must
+    // still find the quarantine even though there is no hash.
+    expect(readPendingSubmission('outgoing-migration', OWNER, 1)).toMatchObject({
+      phase: 'armed',
+      owner: OWNER,
+      chainId: 1,
+    })
+    expect(quarantine.sealFailure()).toBe(true)
+  })
+
+  it('upgrades the armed record the moment the wallet returns the id', async () => {
+    const quarantine = createQuarantine()
+    quarantine.begin({ owner: OWNER, chainId: 1 })
+    await quarantine.track(armed())
+    await quarantine.track(submitted())
 
     // The record must be durable BEFORE the executor settles: a reload
     // between the submitted callback and settlement must still find it.
@@ -120,47 +138,21 @@ describe('track', () => {
     expect(quarantine.sealFailure()).toBe(true)
   })
 
-  it('persists an armed record before an id exists', () => {
+  it('releases an armed record when the wallet provably never accepted it', async () => {
     const quarantine = createQuarantine()
     quarantine.begin({ owner: OWNER, chainId: 1 })
-    quarantine.track(armed())
-
-    // The wallet was invoked but returned nothing yet — a reload here must
-    // still find the quarantine even though there is no hash.
-    expect(readPendingSubmission('outgoing-migration', OWNER, 1)).toMatchObject({
-      phase: 'armed',
-      owner: OWNER,
-      chainId: 1,
-    })
-    expect(quarantine.sealFailure()).toBe(true)
-  })
-
-  it('upgrades an armed record once the wallet returns the id', () => {
-    const quarantine = createQuarantine()
-    quarantine.begin({ owner: OWNER, chainId: 1 })
-    quarantine.track(armed())
-    quarantine.track(submitted())
-
-    expect(readPendingSubmission('outgoing-migration', OWNER, 1)).toMatchObject({
-      phase: 'submitted',
-      hash: TX_HASH,
-    })
-  })
-
-  it('releases an armed record when the wallet provably never accepted it', () => {
-    const quarantine = createQuarantine()
-    quarantine.begin({ owner: OWNER, chainId: 1 })
-    quarantine.track(armed())
-    quarantine.track(rejected())
+    await quarantine.track(armed())
+    await quarantine.track(rejected())
 
     expect(readPendingSubmission('outgoing-migration', OWNER, 1)).toBeUndefined()
     expect(quarantine.sealFailure()).toBe(false)
   })
 
-  it('persists the quarantine for an accepted Safe bundle proposal', () => {
+  it('persists the quarantine for an accepted Safe bundle proposal', async () => {
     const quarantine = createQuarantine()
     quarantine.begin({ owner: OWNER, chainId: 1 })
-    quarantine.track(submitted({ kind: 'proposal', hash: SAFE_TX_HASH, item: 'bundle' }))
+    await quarantine.track(armed({ item: 'bundle' }))
+    await quarantine.track(submitted({ kind: 'proposal', hash: SAFE_TX_HASH, item: 'bundle' }))
 
     expect(readPendingSubmission('outgoing-migration', OWNER, 1)).toMatchObject({
       phase: 'submitted',
@@ -170,26 +162,48 @@ describe('track', () => {
     expect(quarantine.sealFailure()).toBe(true)
   })
 
-  it.each(['approval', 'pluginCall'] as const)('does not quarantine an idempotent ambiguous %s', (item) => {
+  it.each(['approval', 'pluginCall'] as const)('does not quarantine an idempotent ambiguous %s', async (item) => {
     const quarantine = createQuarantine()
     quarantine.begin({ owner: OWNER, chainId: 1 })
-    quarantine.track(submitted({ item, completesPlan: false }))
+    await quarantine.track(armed({ item, completesPlan: false }))
+    await quarantine.track(submitted({ item, completesPlan: false }))
 
     expect(quarantine.sealFailure()).toBe(false)
     expect(readPendingSubmission('outgoing-migration', OWNER, 1)).toBeUndefined()
   })
 
-  it('releases the record once the submission confirmed', () => {
+  it('releases the record once the submission confirmed', async () => {
     const quarantine = createQuarantine()
     quarantine.begin({ owner: OWNER, chainId: 1 })
-    quarantine.track(submitted())
-    quarantine.track(confirmed())
+    await quarantine.track(armed())
+    await quarantine.track(submitted())
+    await quarantine.track(confirmed())
 
     expect(quarantine.sealFailure()).toBe(false)
     expect(readPendingSubmission('outgoing-migration', OWNER, 1)).toBeUndefined()
   })
 
-  it('fails closed to the in-memory fallback when durable storage rejects the write', async () => {
+  it('throws at the arm boundary when a reservation another attempt holds exists', async () => {
+    // Another surface already handed a submission to the wallet.
+    writePendingSubmission('outgoing-migration', {
+      phase: 'armed',
+      chainId: 1,
+      owner: OWNER,
+      completesPlan: true,
+      submittedAt: 1_000,
+      attemptId: 'other-attempt',
+    })
+
+    const quarantine = createQuarantine()
+    quarantine.begin({ owner: OWNER, chainId: 1 })
+    // The executor awaits this before invoking the wallet — the throw is what
+    // keeps the second wallet call from ever happening.
+    await expect(quarantine.track(armed())).rejects.toThrow(PendingSubmissionConflictError)
+    // The existing reservation is untouched.
+    expect(readPendingSubmission('outgoing-migration', OWNER, 1)).toMatchObject({ attemptId: 'other-attempt' })
+  })
+
+  it('throws at the arm boundary when the reservation cannot be proven durable', async () => {
     vi.stubGlobal('localStorage', {
       ...createMemoryStorage(),
       setItem: () => {
@@ -198,20 +212,34 @@ describe('track', () => {
     })
     const quarantine = createQuarantine()
     quarantine.begin({ owner: OWNER, chainId: 1 })
-    quarantine.track(submitted())
 
-    // Even though nothing durable was written, the retry in this session
-    // must still be blocked while the outcome is unknown.
-    const provider = {
-      getTransactionReceipt: vi.fn(async () => {
-        throw new Error('receipt not found')
-      }),
-    }
+    // Durable-or-abort: the executor awaits this before the wallet call, so
+    // nothing reaches the wallet without a durable reservation…
+    await expect(quarantine.track(armed())).rejects.toThrow(PendingSubmissionStorageError)
+
+    // …and the in-realm copy written on the failure path still blocks this
+    // session's retries while the storage stays broken.
     await expect(createQuarantine().reconcileBeforeAttempt({
       owner: OWNER,
       chainId: 1,
-      provider: provider as never,
-    })).rejects.toThrow(PENDING_SUBMISSION_UNRESOLVED_ERROR)
+      provider: { getTransactionReceipt: vi.fn() } as never,
+    })).rejects.toThrow(PENDING_SUBMISSION_ARMED_ERROR)
+  })
+
+  it('cannot upgrade or release a reservation it does not own', async () => {
+    const first = createQuarantine()
+    first.begin({ owner: OWNER, chainId: 1 })
+    await first.track(armed())
+
+    // A stale attempt (different begin → different attemptId) reports a
+    // submitted id and then a confirmation — neither may touch the
+    // reservation the first attempt still holds.
+    const stale = createQuarantine()
+    stale.begin({ owner: OWNER, chainId: 1 })
+    await stale.track(submitted())
+    expect(readPendingSubmission('outgoing-migration', OWNER, 1)).toMatchObject({ phase: 'armed' })
+    await stale.track(confirmed())
+    expect(readPendingSubmission('outgoing-migration', OWNER, 1)).toMatchObject({ phase: 'armed' })
   })
 
   it('does not report a quarantine when nothing was broadcast', () => {
@@ -221,10 +249,11 @@ describe('track', () => {
     expect(quarantine.sealFailure()).toBe(false)
   })
 
-  it('resets in-attempt tracking on the next attempt', () => {
+  it('resets in-attempt tracking on the next attempt', async () => {
     const quarantine = createQuarantine()
     quarantine.begin({ owner: OWNER, chainId: 1 })
-    quarantine.track(submitted())
+    await quarantine.track(armed())
+    await quarantine.track(submitted())
     quarantine.begin({ owner: OWNER, chainId: 1 })
 
     // The stale broadcast belongs to the previous attempt — but the durable
@@ -235,10 +264,13 @@ describe('track', () => {
 })
 
 describe('reconcileBeforeAttempt', () => {
-  const seal = (broadcast: PreparedPlanBroadcast = submitted()) => {
+  const seal = async (broadcast: PreparedPlanBroadcast = submitted()) => {
     const quarantine = createQuarantine()
     quarantine.begin({ owner: OWNER, chainId: 1 })
-    quarantine.track(broadcast)
+    await quarantine.track(armed({ item: broadcast.item, completesPlan: broadcast.completesPlan }))
+    if (broadcast.status !== 'armed') {
+      await quarantine.track(broadcast)
+    }
     expect(quarantine.sealFailure()).toBe(true)
     return quarantine
   }
@@ -255,7 +287,7 @@ describe('reconcileBeforeAttempt', () => {
     ['wallet', { owner: OTHER_OWNER, chainId: 1 }],
     ['chain', { owner: OWNER, chainId: 8453 }],
   ] as const)('lets a different %s proceed while keeping the record', async (_label, attempt) => {
-    const quarantine = seal()
+    const quarantine = await seal()
 
     await expect(quarantine.reconcileBeforeAttempt({
       ...attempt,
@@ -267,7 +299,7 @@ describe('reconcileBeforeAttempt', () => {
   })
 
   it('blocks the retry while an EOA submission has no receipt', async () => {
-    const quarantine = seal()
+    const quarantine = await seal()
     const provider = {
       getTransactionReceipt: vi.fn(async () => {
         throw new Error('receipt not found')
@@ -283,7 +315,7 @@ describe('reconcileBeforeAttempt', () => {
   })
 
   it('blocks the retry forever while a record is still armed — there is no id to verify', async () => {
-    const quarantine = seal(armed())
+    const quarantine = await seal(armed())
     const provider = {
       getTransactionReceipt: vi.fn(async () => ({ status: 'success' })),
     }
@@ -298,7 +330,7 @@ describe('reconcileBeforeAttempt', () => {
   })
 
   it('blocks the retry while a Safe proposal status is unknown', async () => {
-    const quarantine = seal(submitted({ kind: 'proposal', hash: SAFE_TX_HASH, item: 'bundle' }))
+    const quarantine = await seal(submitted({ kind: 'proposal', hash: SAFE_TX_HASH, item: 'bundle' }))
     getSafeWalletProvider.mockResolvedValue({ request: vi.fn() })
     safeMocks.waitForSafeTransactionExecution.mockRejectedValue(
       new SafeTransactionStatusUnknownError(SAFE_TX_HASH, 'timeout'),
@@ -312,8 +344,20 @@ describe('reconcileBeforeAttempt', () => {
     expect(readPendingSubmission('outgoing-migration', OWNER, 1)).toBeDefined()
   })
 
+  it('fails closed when the stored record cannot be read', async () => {
+    localStorage.setItem(`euler_pending_submission:outgoing-migration:1:${OWNER}`, 'not json')
+
+    await expect(createQuarantine().reconcileBeforeAttempt({
+      owner: OWNER,
+      chainId: 1,
+      provider: { getTransactionReceipt: vi.fn() } as never,
+    })).rejects.toThrow(PendingSubmissionStorageError)
+    // The corrupt record is kept, not silently dropped.
+    expect(localStorage.getItem(`euler_pending_submission:outgoing-migration:1:${OWNER}`)).toBe('not json')
+  })
+
   it('clears the quarantine once the submission definitively did not land', async () => {
-    const quarantine = seal()
+    const quarantine = await seal()
     const provider = {
       getTransactionReceipt: vi.fn(async () => ({ status: 'reverted' })),
     }
@@ -330,7 +374,7 @@ describe('reconcileBeforeAttempt', () => {
     [true, 'landed'],
     [false, 'landed-partial'],
   ] as const)('reports a landed submission (completesPlan %s) as %s', async (completesPlan, expected) => {
-    const quarantine = seal(submitted({ completesPlan }))
+    const quarantine = await seal(submitted({ completesPlan }))
     const provider = {
       getTransactionReceipt: vi.fn(async () => ({ status: 'success' })),
     }
@@ -374,7 +418,8 @@ describe('reconcileBeforeAttempt', () => {
     // instance must still block the retry from storage alone.
     const previousSession = createQuarantine()
     previousSession.begin({ owner: OWNER, chainId: 1 })
-    previousSession.track(submitted())
+    await previousSession.track(armed())
+    await previousSession.track(submitted())
 
     const provider = {
       getTransactionReceipt: vi.fn(async () => {
@@ -391,12 +436,48 @@ describe('reconcileBeforeAttempt', () => {
   it('blocks a fresh session after a reload while the record is still armed', async () => {
     const previousSession = createQuarantine()
     previousSession.begin({ owner: OWNER, chainId: 1 })
-    previousSession.track(armed())
+    await previousSession.track(armed())
 
     await expect(createQuarantine().reconcileBeforeAttempt({
       owner: OWNER,
       chainId: 1,
       provider: { getTransactionReceipt: vi.fn() } as never,
     })).rejects.toThrow(PENDING_SUBMISSION_ARMED_ERROR)
+  })
+})
+
+describe('releaseArmedAfterManualCheck', () => {
+  it('recovers an armed record orphaned by a reload once the user checked the wallet', async () => {
+    const previousSession = createQuarantine()
+    previousSession.begin({ owner: OWNER, chainId: 1 })
+    await previousSession.track(armed())
+
+    // Reload: a fresh session can neither verify nor upgrade the record…
+    const fresh = createQuarantine()
+    await expect(fresh.reconcileBeforeAttempt({
+      owner: OWNER,
+      chainId: 1,
+      provider: { getTransactionReceipt: vi.fn() } as never,
+    })).rejects.toThrow(PENDING_SUBMISSION_ARMED_ERROR)
+
+    // …until the user confirms the wallet itself shows nothing pending.
+    await expect(fresh.releaseArmedAfterManualCheck({ owner: OWNER, chainId: 1 })).resolves.toBe(true)
+    expect(readPendingSubmission('outgoing-migration', OWNER, 1)).toBeUndefined()
+    await expect(fresh.reconcileBeforeAttempt({
+      owner: OWNER,
+      chainId: 1,
+      provider: { getTransactionReceipt: vi.fn() } as never,
+    })).resolves.toBe('clear')
+  })
+
+  it('refuses to dismiss a submitted record — it is verified on-chain instead', async () => {
+    const previousSession = createQuarantine()
+    previousSession.begin({ owner: OWNER, chainId: 1 })
+    await previousSession.track(armed())
+    await previousSession.track(submitted())
+
+    await expect(createQuarantine().releaseArmedAfterManualCheck({ owner: OWNER, chainId: 1 }))
+      .rejects.toThrow('cannot be dismissed')
+    expect(readPendingSubmission('outgoing-migration', OWNER, 1)).toMatchObject({ phase: 'submitted' })
   })
 })

--- a/tests/utils/directSubmissionQuarantine.test.ts
+++ b/tests/utils/directSubmissionQuarantine.test.ts
@@ -1,0 +1,249 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { getAddress, type Hash } from 'viem'
+import type { PreparedPlanBroadcast } from '~/composables/useEulerTx'
+import {
+  createDirectSubmissionQuarantine,
+  PENDING_SUBMISSION_UNRESOLVED_ERROR,
+} from '~/utils/directSubmissionQuarantine'
+import { readPendingSubmission, writePendingSubmission } from '~/utils/pendingSubmissions'
+import { SafeTransactionStatusUnknownError } from '~/utils/safeWalletTransactions'
+
+const safeMocks = vi.hoisted(() => ({
+  waitForSafeTransactionExecution: vi.fn(),
+}))
+
+vi.mock('~/utils/safeWalletTransactions', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return {
+    ...actual,
+    waitForSafeTransactionExecution: safeMocks.waitForSafeTransactionExecution,
+  }
+})
+
+const OWNER = getAddress('0x1000000000000000000000000000000000000000')
+const OTHER_OWNER = getAddress('0x2000000000000000000000000000000000000000')
+const TX_HASH = `0x${'11'.repeat(32)}` as Hash
+const SAFE_TX_HASH = `0x${'22'.repeat(32)}` as Hash
+
+const createMemoryStorage = (): Storage => {
+  const store = new Map<string, string>()
+  return {
+    get length() {
+      return store.size
+    },
+    clear: () => store.clear(),
+    getItem: (key: string) => store.get(key) ?? null,
+    key: (index: number) => [...store.keys()][index] ?? null,
+    removeItem: (key: string) => {
+      store.delete(key)
+    },
+    setItem: (key: string, value: string) => {
+      store.set(key, String(value))
+    },
+  }
+}
+
+const broadcast = (overrides: Partial<PreparedPlanBroadcast> = {}): PreparedPlanBroadcast => ({
+  kind: 'transaction',
+  hash: TX_HASH,
+  item: 'evcBatch',
+  index: 0,
+  completesPlan: true,
+  status: 'submitted',
+  ...overrides,
+})
+
+const getSafeWalletProvider = vi.fn()
+
+const createQuarantine = () => createDirectSubmissionQuarantine({
+  flow: 'outgoing-migration',
+  getSafeWalletProvider,
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.stubGlobal('localStorage', createMemoryStorage())
+})
+
+describe('sealFailure', () => {
+  it('quarantines an accepted EOA batch submission after a failed attempt', () => {
+    const quarantine = createQuarantine()
+    quarantine.begin({ owner: OWNER, chainId: 1 })
+    quarantine.track(broadcast())
+
+    expect(quarantine.sealFailure()).toBe(true)
+    expect(readPendingSubmission('outgoing-migration')).toMatchObject({
+      kind: 'transaction',
+      hash: TX_HASH,
+      chainId: 1,
+      owner: OWNER,
+      completesPlan: true,
+    })
+  })
+
+  it('quarantines an accepted Safe bundle proposal after a failed attempt', () => {
+    const quarantine = createQuarantine()
+    quarantine.begin({ owner: OWNER, chainId: 1 })
+    quarantine.track(broadcast({ kind: 'proposal', hash: SAFE_TX_HASH, item: 'bundle' }))
+
+    expect(quarantine.sealFailure()).toBe(true)
+    expect(readPendingSubmission('outgoing-migration')).toMatchObject({
+      kind: 'proposal',
+      hash: SAFE_TX_HASH,
+    })
+  })
+
+  it.each(['approval', 'pluginCall'] as const)('does not quarantine an idempotent ambiguous %s', (item) => {
+    const quarantine = createQuarantine()
+    quarantine.begin({ owner: OWNER, chainId: 1 })
+    quarantine.track(broadcast({ item, completesPlan: false }))
+
+    expect(quarantine.sealFailure()).toBe(false)
+    expect(readPendingSubmission('outgoing-migration')).toBeUndefined()
+  })
+
+  it('does not quarantine once the submission confirmed', () => {
+    const quarantine = createQuarantine()
+    quarantine.begin({ owner: OWNER, chainId: 1 })
+    quarantine.track(broadcast())
+    quarantine.track(broadcast({ status: 'confirmed' }))
+
+    expect(quarantine.sealFailure()).toBe(false)
+  })
+
+  it('does not quarantine when nothing was broadcast', () => {
+    const quarantine = createQuarantine()
+    quarantine.begin({ owner: OWNER, chainId: 1 })
+
+    expect(quarantine.sealFailure()).toBe(false)
+  })
+
+  it('resets tracking on the next attempt', () => {
+    const quarantine = createQuarantine()
+    quarantine.begin({ owner: OWNER, chainId: 1 })
+    quarantine.track(broadcast())
+    quarantine.begin({ owner: OWNER, chainId: 1 })
+
+    // The stale broadcast belongs to the previous attempt.
+    expect(quarantine.sealFailure()).toBe(false)
+  })
+})
+
+describe('reconcileBeforeAttempt', () => {
+  const seal = (overrides: Partial<PreparedPlanBroadcast> = {}) => {
+    const quarantine = createQuarantine()
+    quarantine.begin({ owner: OWNER, chainId: 1 })
+    quarantine.track(broadcast(overrides))
+    expect(quarantine.sealFailure()).toBe(true)
+    return quarantine
+  }
+
+  it('is clear when no submission is quarantined', async () => {
+    await expect(createQuarantine().reconcileBeforeAttempt({
+      owner: OWNER,
+      chainId: 1,
+      provider: undefined,
+    })).resolves.toBe('clear')
+  })
+
+  it.each([
+    ['wallet', { owner: OTHER_OWNER, chainId: 1 }],
+    ['chain', { owner: OWNER, chainId: 8453 }],
+  ] as const)('lets a different %s proceed while keeping the record', async (_label, attempt) => {
+    const quarantine = seal()
+
+    await expect(quarantine.reconcileBeforeAttempt({
+      ...attempt,
+      provider: undefined,
+    })).resolves.toBe('clear')
+    // Nothing that attempt sends can duplicate the record — it stays for the
+    // wallet/chain that owns it.
+    expect(readPendingSubmission('outgoing-migration')).toBeDefined()
+  })
+
+  it('blocks the retry while an EOA submission has no receipt', async () => {
+    const quarantine = seal()
+    const provider = {
+      getTransactionReceipt: vi.fn(async () => {
+        throw new Error('receipt not found')
+      }),
+    }
+
+    await expect(quarantine.reconcileBeforeAttempt({
+      owner: OWNER,
+      chainId: 1,
+      provider: provider as never,
+    })).rejects.toThrow(PENDING_SUBMISSION_UNRESOLVED_ERROR)
+    expect(readPendingSubmission('outgoing-migration')).toBeDefined()
+  })
+
+  it('blocks the retry while a Safe proposal status is unknown', async () => {
+    const quarantine = seal({ kind: 'proposal', hash: SAFE_TX_HASH, item: 'bundle' })
+    getSafeWalletProvider.mockResolvedValue({ request: vi.fn() })
+    safeMocks.waitForSafeTransactionExecution.mockRejectedValue(
+      new SafeTransactionStatusUnknownError(SAFE_TX_HASH, 'timeout'),
+    )
+
+    await expect(quarantine.reconcileBeforeAttempt({
+      owner: OWNER,
+      chainId: 1,
+      provider: { getTransactionReceipt: vi.fn() } as never,
+    })).rejects.toThrow(PENDING_SUBMISSION_UNRESOLVED_ERROR)
+    expect(readPendingSubmission('outgoing-migration')).toBeDefined()
+  })
+
+  it('clears the quarantine once the submission definitively did not land', async () => {
+    const quarantine = seal()
+    const provider = {
+      getTransactionReceipt: vi.fn(async () => ({ status: 'reverted' })),
+    }
+
+    await expect(quarantine.reconcileBeforeAttempt({
+      owner: OWNER,
+      chainId: 1,
+      provider: provider as never,
+    })).resolves.toBe('clear')
+    expect(readPendingSubmission('outgoing-migration')).toBeUndefined()
+  })
+
+  it.each([
+    [true, 'landed'],
+    [false, 'landed-partial'],
+  ] as const)('reports a landed submission (completesPlan %s) as %s', async (completesPlan, expected) => {
+    const quarantine = seal({ completesPlan })
+    const provider = {
+      getTransactionReceipt: vi.fn(async () => ({ status: 'success' })),
+    }
+
+    await expect(quarantine.reconcileBeforeAttempt({
+      owner: OWNER,
+      chainId: 1,
+      provider: provider as never,
+    })).resolves.toBe(expected)
+    // Landed is terminal — the record is released.
+    expect(readPendingSubmission('outgoing-migration')).toBeUndefined()
+  })
+
+  it('reconciles a record that survived a reload', async () => {
+    // No begin/track/sealFailure this session — the record was written by a
+    // previous one and only storage carries it.
+    writePendingSubmission('outgoing-migration', {
+      kind: 'transaction',
+      hash: TX_HASH,
+      chainId: 1,
+      owner: OWNER,
+      completesPlan: true,
+      submittedAt: 1_000,
+    })
+    const provider = {
+      getTransactionReceipt: vi.fn(async () => ({ status: 'success' })),
+    }
+
+    await expect(createQuarantine().reconcileBeforeAttempt({
+      owner: OWNER,
+      chainId: 1,
+      provider: provider as never,
+    })).resolves.toBe('landed')
+    expect(readPendingSubmission('outgoing-migration')).toBeUndefined()
+  })
+})

--- a/tests/utils/directSubmissionQuarantine.test.ts
+++ b/tests/utils/directSubmissionQuarantine.test.ts
@@ -7,6 +7,7 @@ import {
   PENDING_SUBMISSION_UNRESOLVED_ERROR,
 } from '~/utils/directSubmissionQuarantine'
 import {
+  listReleasableArmedSubmissions,
   PendingSubmissionConflictError,
   PendingSubmissionStorageError,
   readPendingSubmission,
@@ -443,6 +444,49 @@ describe('reconcileBeforeAttempt', () => {
       chainId: 1,
       provider: { getTransactionReceipt: vi.fn() } as never,
     })).rejects.toThrow(PENDING_SUBMISSION_ARMED_ERROR)
+  })
+})
+
+describe('attempt liveness registry', () => {
+  it('keeps an armed record off the recovery list while its attempt is live', async () => {
+    const quarantine = createQuarantine()
+    quarantine.begin({ owner: OWNER, chainId: 1 })
+    await quarantine.track(armed())
+
+    // The executor is still mid-flight: its own resolution path owns the
+    // record, and the recovery UI must not offer to dismiss it.
+    expect(listReleasableArmedSubmissions(['outgoing-migration'])).toEqual([])
+  })
+
+  it('surfaces the armed record to the recovery list once the attempt ended', async () => {
+    const quarantine = createQuarantine()
+    quarantine.begin({ owner: OWNER, chainId: 1 })
+    await quarantine.track(armed())
+    quarantine.end()
+
+    // The attempt settled without an id and without a provable rejection —
+    // exactly the orphaned state only the manual, risk-labelled path resolves.
+    expect(listReleasableArmedSubmissions(['outgoing-migration'])).toEqual([
+      expect.objectContaining({
+        flow: 'outgoing-migration',
+        chainId: 1,
+        owner: OWNER,
+        state: 'armed',
+      }),
+    ])
+  })
+
+  it('keeps reporting the sealed failure after end, and end stays idempotent', async () => {
+    const quarantine = createQuarantine()
+    quarantine.begin({ owner: OWNER, chainId: 1 })
+    await quarantine.track(armed())
+    quarantine.end()
+    quarantine.end()
+
+    // Late error handling (sealFailure runs in a catch after the finally
+    // that ended the attempt) still sees the quarantined broadcast.
+    expect(quarantine.sealFailure()).toBe(true)
+    expect(listReleasableArmedSubmissions(['outgoing-migration'])).toHaveLength(1)
   })
 })
 

--- a/tests/utils/directSubmissionQuarantine.test.ts
+++ b/tests/utils/directSubmissionQuarantine.test.ts
@@ -3,9 +3,14 @@ import { getAddress, type Hash } from 'viem'
 import type { PreparedPlanBroadcast } from '~/composables/useEulerTx'
 import {
   createDirectSubmissionQuarantine,
+  PENDING_SUBMISSION_ARMED_ERROR,
   PENDING_SUBMISSION_UNRESOLVED_ERROR,
 } from '~/utils/directSubmissionQuarantine'
-import { readPendingSubmission, writePendingSubmission } from '~/utils/pendingSubmissions'
+import {
+  readPendingSubmission,
+  resetPendingSubmissionMemoryFallback,
+  writePendingSubmission,
+} from '~/utils/pendingSubmissions'
 import { SafeTransactionStatusUnknownError } from '~/utils/safeWalletTransactions'
 
 const safeMocks = vi.hoisted(() => ({
@@ -43,14 +48,44 @@ const createMemoryStorage = (): Storage => {
   }
 }
 
-const broadcast = (overrides: Partial<PreparedPlanBroadcast> = {}): PreparedPlanBroadcast => ({
-  kind: 'transaction',
-  hash: TX_HASH,
-  item: 'evcBatch',
-  index: 0,
-  completesPlan: true,
+interface WithIdOverrides {
+  kind?: 'transaction' | 'proposal'
+  hash?: Hash
+  item?: PreparedPlanBroadcast['item']
+  index?: number
+  completesPlan?: boolean
+}
+
+const submitted = (overrides: WithIdOverrides = {}): PreparedPlanBroadcast => ({
+  kind: overrides.kind ?? 'transaction',
+  hash: overrides.hash ?? TX_HASH,
+  item: overrides.item ?? 'evcBatch',
+  index: overrides.index ?? 0,
+  completesPlan: overrides.completesPlan ?? true,
   status: 'submitted',
-  ...overrides,
+})
+
+const confirmed = (overrides: WithIdOverrides = {}): PreparedPlanBroadcast => ({
+  kind: overrides.kind ?? 'transaction',
+  hash: overrides.hash ?? TX_HASH,
+  item: overrides.item ?? 'evcBatch',
+  index: overrides.index ?? 0,
+  completesPlan: overrides.completesPlan ?? true,
+  status: 'confirmed',
+})
+
+const armed = (overrides: Pick<WithIdOverrides, 'item' | 'index' | 'completesPlan'> = {}): PreparedPlanBroadcast => ({
+  item: overrides.item ?? 'evcBatch',
+  index: overrides.index ?? 0,
+  completesPlan: overrides.completesPlan ?? true,
+  status: 'armed',
+})
+
+const rejected = (overrides: Pick<WithIdOverrides, 'item' | 'index' | 'completesPlan'> = {}): PreparedPlanBroadcast => ({
+  item: overrides.item ?? 'evcBatch',
+  index: overrides.index ?? 0,
+  completesPlan: overrides.completesPlan ?? true,
+  status: 'rejected',
 })
 
 const getSafeWalletProvider = vi.fn()
@@ -63,77 +98,147 @@ const createQuarantine = () => createDirectSubmissionQuarantine({
 beforeEach(() => {
   vi.clearAllMocks()
   vi.stubGlobal('localStorage', createMemoryStorage())
+  resetPendingSubmissionMemoryFallback()
 })
 
-describe('sealFailure', () => {
-  it('quarantines an accepted EOA batch submission after a failed attempt', () => {
+describe('track', () => {
+  it('persists the quarantine the moment the wallet accepts an EOA submission', () => {
     const quarantine = createQuarantine()
     quarantine.begin({ owner: OWNER, chainId: 1 })
-    quarantine.track(broadcast())
+    quarantine.track(submitted())
 
-    expect(quarantine.sealFailure()).toBe(true)
-    expect(readPendingSubmission('outgoing-migration')).toMatchObject({
+    // The record must be durable BEFORE the executor settles: a reload
+    // between the submitted callback and settlement must still find it.
+    expect(readPendingSubmission('outgoing-migration', OWNER, 1)).toMatchObject({
+      phase: 'submitted',
       kind: 'transaction',
       hash: TX_HASH,
       chainId: 1,
       owner: OWNER,
       completesPlan: true,
     })
+    expect(quarantine.sealFailure()).toBe(true)
   })
 
-  it('quarantines an accepted Safe bundle proposal after a failed attempt', () => {
+  it('persists an armed record before an id exists', () => {
     const quarantine = createQuarantine()
     quarantine.begin({ owner: OWNER, chainId: 1 })
-    quarantine.track(broadcast({ kind: 'proposal', hash: SAFE_TX_HASH, item: 'bundle' }))
+    quarantine.track(armed())
 
+    // The wallet was invoked but returned nothing yet — a reload here must
+    // still find the quarantine even though there is no hash.
+    expect(readPendingSubmission('outgoing-migration', OWNER, 1)).toMatchObject({
+      phase: 'armed',
+      owner: OWNER,
+      chainId: 1,
+    })
     expect(quarantine.sealFailure()).toBe(true)
-    expect(readPendingSubmission('outgoing-migration')).toMatchObject({
+  })
+
+  it('upgrades an armed record once the wallet returns the id', () => {
+    const quarantine = createQuarantine()
+    quarantine.begin({ owner: OWNER, chainId: 1 })
+    quarantine.track(armed())
+    quarantine.track(submitted())
+
+    expect(readPendingSubmission('outgoing-migration', OWNER, 1)).toMatchObject({
+      phase: 'submitted',
+      hash: TX_HASH,
+    })
+  })
+
+  it('releases an armed record when the wallet provably never accepted it', () => {
+    const quarantine = createQuarantine()
+    quarantine.begin({ owner: OWNER, chainId: 1 })
+    quarantine.track(armed())
+    quarantine.track(rejected())
+
+    expect(readPendingSubmission('outgoing-migration', OWNER, 1)).toBeUndefined()
+    expect(quarantine.sealFailure()).toBe(false)
+  })
+
+  it('persists the quarantine for an accepted Safe bundle proposal', () => {
+    const quarantine = createQuarantine()
+    quarantine.begin({ owner: OWNER, chainId: 1 })
+    quarantine.track(submitted({ kind: 'proposal', hash: SAFE_TX_HASH, item: 'bundle' }))
+
+    expect(readPendingSubmission('outgoing-migration', OWNER, 1)).toMatchObject({
+      phase: 'submitted',
       kind: 'proposal',
       hash: SAFE_TX_HASH,
     })
+    expect(quarantine.sealFailure()).toBe(true)
   })
 
   it.each(['approval', 'pluginCall'] as const)('does not quarantine an idempotent ambiguous %s', (item) => {
     const quarantine = createQuarantine()
     quarantine.begin({ owner: OWNER, chainId: 1 })
-    quarantine.track(broadcast({ item, completesPlan: false }))
+    quarantine.track(submitted({ item, completesPlan: false }))
 
     expect(quarantine.sealFailure()).toBe(false)
-    expect(readPendingSubmission('outgoing-migration')).toBeUndefined()
+    expect(readPendingSubmission('outgoing-migration', OWNER, 1)).toBeUndefined()
   })
 
-  it('does not quarantine once the submission confirmed', () => {
+  it('releases the record once the submission confirmed', () => {
     const quarantine = createQuarantine()
     quarantine.begin({ owner: OWNER, chainId: 1 })
-    quarantine.track(broadcast())
-    quarantine.track(broadcast({ status: 'confirmed' }))
+    quarantine.track(submitted())
+    quarantine.track(confirmed())
+
+    expect(quarantine.sealFailure()).toBe(false)
+    expect(readPendingSubmission('outgoing-migration', OWNER, 1)).toBeUndefined()
+  })
+
+  it('fails closed to the in-memory fallback when durable storage rejects the write', async () => {
+    vi.stubGlobal('localStorage', {
+      ...createMemoryStorage(),
+      setItem: () => {
+        throw new Error('quota exceeded')
+      },
+    })
+    const quarantine = createQuarantine()
+    quarantine.begin({ owner: OWNER, chainId: 1 })
+    quarantine.track(submitted())
+
+    // Even though nothing durable was written, the retry in this session
+    // must still be blocked while the outcome is unknown.
+    const provider = {
+      getTransactionReceipt: vi.fn(async () => {
+        throw new Error('receipt not found')
+      }),
+    }
+    await expect(createQuarantine().reconcileBeforeAttempt({
+      owner: OWNER,
+      chainId: 1,
+      provider: provider as never,
+    })).rejects.toThrow(PENDING_SUBMISSION_UNRESOLVED_ERROR)
+  })
+
+  it('does not report a quarantine when nothing was broadcast', () => {
+    const quarantine = createQuarantine()
+    quarantine.begin({ owner: OWNER, chainId: 1 })
 
     expect(quarantine.sealFailure()).toBe(false)
   })
 
-  it('does not quarantine when nothing was broadcast', () => {
+  it('resets in-attempt tracking on the next attempt', () => {
     const quarantine = createQuarantine()
     quarantine.begin({ owner: OWNER, chainId: 1 })
-
-    expect(quarantine.sealFailure()).toBe(false)
-  })
-
-  it('resets tracking on the next attempt', () => {
-    const quarantine = createQuarantine()
-    quarantine.begin({ owner: OWNER, chainId: 1 })
-    quarantine.track(broadcast())
+    quarantine.track(submitted())
     quarantine.begin({ owner: OWNER, chainId: 1 })
 
-    // The stale broadcast belongs to the previous attempt.
+    // The stale broadcast belongs to the previous attempt — but the durable
+    // record it wrote survives until reconciliation resolves it.
     expect(quarantine.sealFailure()).toBe(false)
+    expect(readPendingSubmission('outgoing-migration', OWNER, 1)).toBeDefined()
   })
 })
 
 describe('reconcileBeforeAttempt', () => {
-  const seal = (overrides: Partial<PreparedPlanBroadcast> = {}) => {
+  const seal = (broadcast: PreparedPlanBroadcast = submitted()) => {
     const quarantine = createQuarantine()
     quarantine.begin({ owner: OWNER, chainId: 1 })
-    quarantine.track(broadcast(overrides))
+    quarantine.track(broadcast)
     expect(quarantine.sealFailure()).toBe(true)
     return quarantine
   }
@@ -158,7 +263,7 @@ describe('reconcileBeforeAttempt', () => {
     })).resolves.toBe('clear')
     // Nothing that attempt sends can duplicate the record — it stays for the
     // wallet/chain that owns it.
-    expect(readPendingSubmission('outgoing-migration')).toBeDefined()
+    expect(readPendingSubmission('outgoing-migration', OWNER, 1)).toBeDefined()
   })
 
   it('blocks the retry while an EOA submission has no receipt', async () => {
@@ -174,11 +279,26 @@ describe('reconcileBeforeAttempt', () => {
       chainId: 1,
       provider: provider as never,
     })).rejects.toThrow(PENDING_SUBMISSION_UNRESOLVED_ERROR)
-    expect(readPendingSubmission('outgoing-migration')).toBeDefined()
+    expect(readPendingSubmission('outgoing-migration', OWNER, 1)).toBeDefined()
+  })
+
+  it('blocks the retry forever while a record is still armed — there is no id to verify', async () => {
+    const quarantine = seal(armed())
+    const provider = {
+      getTransactionReceipt: vi.fn(async () => ({ status: 'success' })),
+    }
+
+    await expect(quarantine.reconcileBeforeAttempt({
+      owner: OWNER,
+      chainId: 1,
+      provider: provider as never,
+    })).rejects.toThrow(PENDING_SUBMISSION_ARMED_ERROR)
+    expect(provider.getTransactionReceipt).not.toHaveBeenCalled()
+    expect(readPendingSubmission('outgoing-migration', OWNER, 1)).toBeDefined()
   })
 
   it('blocks the retry while a Safe proposal status is unknown', async () => {
-    const quarantine = seal({ kind: 'proposal', hash: SAFE_TX_HASH, item: 'bundle' })
+    const quarantine = seal(submitted({ kind: 'proposal', hash: SAFE_TX_HASH, item: 'bundle' }))
     getSafeWalletProvider.mockResolvedValue({ request: vi.fn() })
     safeMocks.waitForSafeTransactionExecution.mockRejectedValue(
       new SafeTransactionStatusUnknownError(SAFE_TX_HASH, 'timeout'),
@@ -189,7 +309,7 @@ describe('reconcileBeforeAttempt', () => {
       chainId: 1,
       provider: { getTransactionReceipt: vi.fn() } as never,
     })).rejects.toThrow(PENDING_SUBMISSION_UNRESOLVED_ERROR)
-    expect(readPendingSubmission('outgoing-migration')).toBeDefined()
+    expect(readPendingSubmission('outgoing-migration', OWNER, 1)).toBeDefined()
   })
 
   it('clears the quarantine once the submission definitively did not land', async () => {
@@ -203,14 +323,14 @@ describe('reconcileBeforeAttempt', () => {
       chainId: 1,
       provider: provider as never,
     })).resolves.toBe('clear')
-    expect(readPendingSubmission('outgoing-migration')).toBeUndefined()
+    expect(readPendingSubmission('outgoing-migration', OWNER, 1)).toBeUndefined()
   })
 
   it.each([
     [true, 'landed'],
     [false, 'landed-partial'],
   ] as const)('reports a landed submission (completesPlan %s) as %s', async (completesPlan, expected) => {
-    const quarantine = seal({ completesPlan })
+    const quarantine = seal(submitted({ completesPlan }))
     const provider = {
       getTransactionReceipt: vi.fn(async () => ({ status: 'success' })),
     }
@@ -221,13 +341,14 @@ describe('reconcileBeforeAttempt', () => {
       provider: provider as never,
     })).resolves.toBe(expected)
     // Landed is terminal — the record is released.
-    expect(readPendingSubmission('outgoing-migration')).toBeUndefined()
+    expect(readPendingSubmission('outgoing-migration', OWNER, 1)).toBeUndefined()
   })
 
   it('reconciles a record that survived a reload', async () => {
     // No begin/track/sealFailure this session — the record was written by a
     // previous one and only storage carries it.
     writePendingSubmission('outgoing-migration', {
+      phase: 'submitted',
       kind: 'transaction',
       hash: TX_HASH,
       chainId: 1,
@@ -244,6 +365,38 @@ describe('reconcileBeforeAttempt', () => {
       chainId: 1,
       provider: provider as never,
     })).resolves.toBe('landed')
-    expect(readPendingSubmission('outgoing-migration')).toBeUndefined()
+    expect(readPendingSubmission('outgoing-migration', OWNER, 1)).toBeUndefined()
+  })
+
+  it('blocks a fresh session after a reload that interrupted mid-flight tracking', async () => {
+    // Simulate: wallet accepted, the record was written at the boundary, and
+    // the page reloaded before the executor settled. A brand-new quarantine
+    // instance must still block the retry from storage alone.
+    const previousSession = createQuarantine()
+    previousSession.begin({ owner: OWNER, chainId: 1 })
+    previousSession.track(submitted())
+
+    const provider = {
+      getTransactionReceipt: vi.fn(async () => {
+        throw new Error('receipt not found')
+      }),
+    }
+    await expect(createQuarantine().reconcileBeforeAttempt({
+      owner: OWNER,
+      chainId: 1,
+      provider: provider as never,
+    })).rejects.toThrow(PENDING_SUBMISSION_UNRESOLVED_ERROR)
+  })
+
+  it('blocks a fresh session after a reload while the record is still armed', async () => {
+    const previousSession = createQuarantine()
+    previousSession.begin({ owner: OWNER, chainId: 1 })
+    previousSession.track(armed())
+
+    await expect(createQuarantine().reconcileBeforeAttempt({
+      owner: OWNER,
+      chainId: 1,
+      provider: { getTransactionReceipt: vi.fn() } as never,
+    })).rejects.toThrow(PENDING_SUBMISSION_ARMED_ERROR)
   })
 })

--- a/tests/utils/migrationCeremonyDeadline.test.ts
+++ b/tests/utils/migrationCeremonyDeadline.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { MigrationAuthorizationRequest } from '@eulerxyz/euler-v2-sdk'
+import {
+  isMigrationCeremonyDeadlineExpired,
+  mintMigrationCeremonyDeadline,
+  pinInboundMigrationCeremonyDeadline,
+} from '~/utils/migrationCeremonyDeadline'
+import { migrationAuthorizationPayloadKey } from '~/utils/migrationAuthorizationTxs'
+
+const NOW_SECONDS = 1_800_000_000
+
+describe('migrationCeremonyDeadline', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(NOW_SECONDS * 1000)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('mints a wall-clock deadline one hour out', () => {
+    expect(mintMigrationCeremonyDeadline()).toBe(BigInt(NOW_SECONDS + 3600))
+  })
+
+  it('pins exactly the collateral quote deadline, ignoring an earlier debt quote expiry', () => {
+    // Regression: clamping to the earliest quote deadline fails the SDK's
+    // exact-equality check against the collateral quote's immutable embedded
+    // verifier data ("SwapVerifier data mismatch").
+    const deadline = pinInboundMigrationCeremonyDeadline({
+      collateralSwapQuote: { verify: { deadline: 2000 } },
+      debtSwapQuote: { verify: { deadline: 1000 } },
+    })
+    expect(deadline).toBe(2000n)
+  })
+
+  it('pins the collateral quote deadline even when later builds would mint fresher ones', () => {
+    const quotes = { collateralSwapQuote: { verify: { deadline: NOW_SECONDS + 120 } } }
+    const first = pinInboundMigrationCeremonyDeadline(quotes)
+    vi.setSystemTime((NOW_SECONDS + 90) * 1000)
+    const second = pinInboundMigrationCeremonyDeadline(quotes)
+    expect(first).toBe(BigInt(NOW_SECONDS + 120))
+    expect(second).toBe(first)
+  })
+
+  it('mints only when no collateral quote governs the verifier', () => {
+    expect(pinInboundMigrationCeremonyDeadline({
+      debtSwapQuote: { verify: { deadline: 1000 } },
+    })).toBe(BigInt(NOW_SECONDS + 3600))
+    expect(pinInboundMigrationCeremonyDeadline({})).toBe(BigInt(NOW_SECONDS + 3600))
+  })
+
+  it('falls back to the SDK sentinel when the collateral quote carries no deadline', () => {
+    expect(pinInboundMigrationCeremonyDeadline({
+      collateralSwapQuote: { verify: {} },
+    })).toBe(0n)
+  })
+
+  it('reports expiry once the deadline is no longer executable', () => {
+    const deadline = mintMigrationCeremonyDeadline()
+    expect(isMigrationCeremonyDeadlineExpired(deadline)).toBe(false)
+    vi.setSystemTime((NOW_SECONDS + 3599) * 1000)
+    expect(isMigrationCeremonyDeadlineExpired(deadline)).toBe(false)
+    vi.setSystemTime((NOW_SECONDS + 3600) * 1000)
+    expect(isMigrationCeremonyDeadlineExpired(deadline)).toBe(true)
+  })
+
+  it('keeps the authorization payload key stable across builds only under a pinned deadline', () => {
+    // Signature-form requests embed the deadline in the typed-data message, so
+    // the review/confirm payload-equality gate can only pass when both builds
+    // received the same pinned deadline. A re-minted deadline changes the key
+    // and would reject every confirmation once the clock advances.
+    const requestWithDeadline = (deadline: bigint): MigrationAuthorizationRequest => ({
+      kind: 'typedData',
+      name: 'morphoAuthorization',
+      owner: '0x1000000000000000000000000000000000000000',
+      chainId: 1,
+      typedData: {
+        domain: { name: 'Morpho', chainId: 1 },
+        types: { Authorization: [{ name: 'deadline', type: 'uint256' }] },
+        primaryType: 'Authorization',
+        message: { deadline },
+      },
+    } as unknown as MigrationAuthorizationRequest)
+
+    const pinned = mintMigrationCeremonyDeadline()
+    const reviewKey = migrationAuthorizationPayloadKey(requestWithDeadline(pinned))
+
+    vi.setSystemTime((NOW_SECONDS + 30) * 1000)
+    expect(migrationAuthorizationPayloadKey(requestWithDeadline(pinned))).toBe(reviewKey)
+    expect(migrationAuthorizationPayloadKey(requestWithDeadline(mintMigrationCeremonyDeadline()))).not.toBe(reviewKey)
+  })
+})

--- a/tests/utils/pendingSubmissions.test.ts
+++ b/tests/utils/pendingSubmissions.test.ts
@@ -5,13 +5,16 @@ import {
   clearPendingSubmission,
   createPendingSubmissionAttemptId,
   listPendingSubmissions,
+  listReleasableArmedSubmissions,
   PendingSubmissionConflictError,
   PendingSubmissionStorageError,
   readPendingSubmission,
+  registerActiveSubmissionAttempt,
   releasePendingSubmission,
   releaseUnverifiablePendingSubmission,
   resetPendingSubmissionMemoryFallback,
   resolvePendingSubmissionOutcome,
+  unregisterActiveSubmissionAttempt,
   upgradePendingSubmissionToSubmitted,
   walletNeverAcceptedSubmission,
   writePendingSubmission,
@@ -407,21 +410,156 @@ describe('upgradePendingSubmissionToSubmitted', () => {
     expect(readPendingSubmission('direct', OWNER, 1)).toBeUndefined()
   })
 
-  it('keeps the armed record when the upgraded write fails', async () => {
-    const armed = await armPendingSubmission('direct', { owner: OWNER, chainId: 1, completesPlan: true, attemptId: 'attempt-1' })
+  /**
+   * Storage stub that accepts every write except a submitted-phase record —
+   * simulating a quota-bound storage that held the armed reservation but
+   * refuses the larger rewrite. Everything else delegates to `working`.
+   */
+  const submittedWriteRefusingStorage = (working: Storage): Storage => ({
+    get length() {
+      return working.length
+    },
+    clear: () => working.clear(),
+    key: (index: number) => working.key(index),
+    getItem: (key: string) => working.getItem(key),
+    removeItem: (key: string) => working.removeItem(key),
+    setItem: (key: string, value: string) => {
+      if (value.includes('"phase":"submitted"')) throw new Error('quota exceeded')
+      working.setItem(key, value)
+    },
+  })
+
+  it('preserves the observed id durably and throws when the submitted rewrite cannot be made durable', async () => {
+    await armPendingSubmission('direct', { owner: OWNER, chainId: 1, completesPlan: true, attemptId: 'attempt-1' })
+    const working = globalThis.localStorage
+    vi.stubGlobal('localStorage', submittedWriteRefusingStorage(working))
+
+    try {
+      // The wallet already returned the hash — silently keeping a hashless
+      // armed record would let a manual release dismiss a mined transaction.
+      await expect(upgradePendingSubmissionToSubmitted('direct', upgradeInput('attempt-1')))
+        .rejects.toThrow('could not durably record its id')
+    }
+    finally {
+      vi.stubGlobal('localStorage', working)
+    }
+    expect(readPendingSubmission('direct', OWNER, 1)).toMatchObject({
+      phase: 'armed',
+      attemptId: 'attempt-1',
+      observedId: { kind: 'transaction', hash: TX_HASH },
+    })
+  })
+
+  it('after a failed upgrade the preserved id blocks re-arming and manual release, and verifies objectively', async () => {
+    await armPendingSubmission('direct', { owner: OWNER, chainId: 1, completesPlan: true, attemptId: 'attempt-1' })
+    const working = globalThis.localStorage
+    vi.stubGlobal('localStorage', submittedWriteRefusingStorage(working))
+    try {
+      await expect(upgradePendingSubmissionToSubmitted('direct', upgradeInput('attempt-1')))
+        .rejects.toThrow(PendingSubmissionStorageError)
+    }
+    finally {
+      vi.stubGlobal('localStorage', working)
+    }
+    // The observedId record was written durably, which drops the in-realm
+    // copy — everything below therefore behaves exactly as after a reload.
+
+    // A fresh attempt cannot take over the reservation.
+    await expect(armPendingSubmission('direct', { owner: OWNER, chainId: 1, completesPlan: true, attemptId: 'attempt-2' }))
+      .rejects.toThrow(PendingSubmissionConflictError)
+    // The hashless manual-release path refuses it, and the recovery listing
+    // never offers it.
+    await expect(releaseUnverifiablePendingSubmission('direct', OWNER, 1, { userConfirmedWalletShowsNoPendingSubmission: true }))
+      .rejects.toThrow('cannot be dismissed')
+    expect(listReleasableArmedSubmissions(['direct'])).toEqual([])
+    // Reconciliation verifies the record through the observed hash like any
+    // submitted record.
+    const stored = readPendingSubmission('direct', OWNER, 1)
+    const provider = {
+      getTransactionReceipt: vi.fn(async () => ({ status: 'success' })),
+    }
+    await expect(resolvePendingSubmissionOutcome(stored as PendingSubmissionRecord, {
+      provider: provider as never,
+      getSafeWalletProvider: vi.fn(),
+    })).resolves.toBe('landed')
+    expect(provider.getTransactionReceipt).toHaveBeenCalledWith({ hash: TX_HASH })
+  })
+
+  it('refuses the hashless manual release even when the id could only be kept in memory', async () => {
+    await armPendingSubmission('direct', { owner: OWNER, chainId: 1, completesPlan: true, attemptId: 'attempt-1' })
     const working = globalThis.localStorage
     vi.stubGlobal('localStorage', {
-      ...createMemoryStorage(),
+      get length() {
+        return working.length
+      },
+      clear: () => working.clear(),
+      key: (index: number) => working.key(index),
       getItem: (key: string) => working.getItem(key),
+      removeItem: (key: string) => working.removeItem(key),
       setItem: () => {
         throw new Error('quota exceeded')
       },
     })
 
-    await expect(upgradePendingSubmissionToSubmitted('direct', upgradeInput('attempt-1')))
-      .resolves.toBeUndefined()
-    vi.stubGlobal('localStorage', working)
-    expect(readPendingSubmission('direct', OWNER, 1)).toEqual(armed)
+    try {
+      await expect(upgradePendingSubmissionToSubmitted('direct', upgradeInput('attempt-1')))
+        .rejects.toThrow('could not durably record its id')
+      // The durable record still looks hashless-armed — only the in-realm
+      // copy carries the observed id — yet the release must still refuse.
+      expect(readPendingSubmission('direct', OWNER, 1)).toMatchObject({ phase: 'armed', attemptId: 'attempt-1' })
+      await expect(releaseUnverifiablePendingSubmission('direct', OWNER, 1, { userConfirmedWalletShowsNoPendingSubmission: true }))
+        .rejects.toThrow('cannot be dismissed')
+      expect(readPendingSubmission('direct', OWNER, 1)).toBeDefined()
+    }
+    finally {
+      vi.stubGlobal('localStorage', working)
+    }
+  })
+})
+
+describe('listReleasableArmedSubmissions', () => {
+  it('lists an armed record whose owning attempt is no longer live', () => {
+    writePendingSubmission('batch', { ...armedRecord(), attemptId: 'gone-attempt' })
+
+    expect(listReleasableArmedSubmissions(['batch'])).toEqual([{
+      flow: 'batch',
+      chainId: 1,
+      owner: OWNER,
+      state: 'armed',
+      record: expect.objectContaining({ phase: 'armed', attemptId: 'gone-attempt' }),
+    }])
+  })
+
+  it('never offers records that are live, submitted, or carry an observed id', () => {
+    registerActiveSubmissionAttempt('live-attempt')
+    try {
+      // Live attempt: its wallet prompt may be open right now.
+      writePendingSubmission('batch', { ...armedRecord(), attemptId: 'live-attempt' })
+      // Submitted: has an id, resolves objectively.
+      writePendingSubmission('direct', record())
+      // Armed with an observed id: the failed-upgrade case, also objective.
+      writePendingSubmission('outgoing-migration', {
+        ...armedRecord(),
+        attemptId: 'gone-attempt',
+        observedId: { kind: 'transaction', hash: TX_HASH },
+      } as PendingSubmissionRecord)
+
+      expect(listReleasableArmedSubmissions(['batch', 'direct', 'outgoing-migration'])).toEqual([])
+    }
+    finally {
+      unregisterActiveSubmissionAttempt('live-attempt')
+    }
+  })
+
+  it('reports an unparseable entry as corrupt so recovery can offer the acknowledged release', () => {
+    localStorage.setItem(BATCH_KEY, 'not json')
+
+    expect(listReleasableArmedSubmissions(['batch'])).toEqual([{
+      flow: 'batch',
+      chainId: 1,
+      owner: OWNER,
+      state: 'corrupt',
+    }])
   })
 })
 

--- a/tests/utils/pendingSubmissions.test.ts
+++ b/tests/utils/pendingSubmissions.test.ts
@@ -2,10 +2,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { getAddress, type Hash } from 'viem'
 import {
   clearPendingSubmission,
+  listPendingSubmissions,
   readPendingSubmission,
+  resetPendingSubmissionMemoryFallback,
   resolvePendingSubmissionOutcome,
+  walletNeverAcceptedSubmission,
   writePendingSubmission,
   type PendingSubmissionRecord,
+  type SubmittedPendingSubmission,
 } from '~/utils/pendingSubmissions'
 import { SafeTransactionStatusUnknownError } from '~/utils/safeWalletTransactions'
 
@@ -22,8 +26,10 @@ vi.mock('~/utils/safeWalletTransactions', async (importOriginal) => {
 })
 
 const OWNER = getAddress('0x1000000000000000000000000000000000000000')
+const OTHER_OWNER = getAddress('0x2000000000000000000000000000000000000000')
 const TX_HASH = `0x${'11'.repeat(32)}` as Hash
 const SAFE_TX_HASH = `0x${'22'.repeat(32)}` as Hash
+const BATCH_KEY = `euler_pending_submission:batch:1:${OWNER}`
 
 const createMemoryStorage = (): Storage => {
   const store = new Map<string, string>()
@@ -43,7 +49,8 @@ const createMemoryStorage = (): Storage => {
   }
 }
 
-const record = (overrides: Partial<PendingSubmissionRecord> = {}): PendingSubmissionRecord => ({
+const record = (overrides: Partial<SubmittedPendingSubmission> = {}): PendingSubmissionRecord => ({
+  phase: 'submitted',
   kind: 'transaction',
   hash: TX_HASH,
   chainId: 1,
@@ -53,39 +60,80 @@ const record = (overrides: Partial<PendingSubmissionRecord> = {}): PendingSubmis
   ...overrides,
 })
 
+const armedRecord = (): PendingSubmissionRecord => ({
+  phase: 'armed',
+  chainId: 1,
+  owner: OWNER,
+  completesPlan: true,
+  submittedAt: 1_000,
+})
+
 beforeEach(() => {
   vi.clearAllMocks()
   vi.stubGlobal('localStorage', createMemoryStorage())
+  resetPendingSubmissionMemoryFallback()
 })
 
 describe('pending submission storage', () => {
   it('round-trips a record through storage', () => {
     writePendingSubmission('batch', record({ refreshExternalPositions: true }))
 
-    expect(readPendingSubmission('batch')).toEqual(record({ refreshExternalPositions: true }))
+    expect(readPendingSubmission('batch', OWNER, 1)).toEqual(record({ refreshExternalPositions: true }))
     // Flows are isolated: the batch record must not leak into direct flows.
-    expect(readPendingSubmission('outgoing-migration')).toBeUndefined()
+    expect(readPendingSubmission('outgoing-migration', OWNER, 1)).toBeUndefined()
+  })
+
+  it('round-trips an armed record without an id', () => {
+    writePendingSubmission('batch', armedRecord())
+
+    expect(readPendingSubmission('batch', OWNER, 1)).toEqual(armedRecord())
+  })
+
+  it('keys records per wallet and chain so one wallet cannot overwrite another', () => {
+    writePendingSubmission('batch', record())
+    writePendingSubmission('batch', record({ owner: OTHER_OWNER, hash: SAFE_TX_HASH }))
+    writePendingSubmission('batch', record({ chainId: 8453 }))
+
+    // All three coexist and each is independently readable/reconcilable.
+    expect(readPendingSubmission('batch', OWNER, 1)).toEqual(record())
+    expect(readPendingSubmission('batch', OTHER_OWNER, 1)).toEqual(record({ owner: OTHER_OWNER, hash: SAFE_TX_HASH }))
+    expect(readPendingSubmission('batch', OWNER, 8453)).toEqual(record({ chainId: 8453 }))
+    expect(listPendingSubmissions('batch')).toHaveLength(3)
+
+    // Clearing one wallet's record leaves the others quarantined.
+    clearPendingSubmission('batch', OWNER, 1)
+    expect(readPendingSubmission('batch', OWNER, 1)).toBeUndefined()
+    expect(readPendingSubmission('batch', OTHER_OWNER, 1)).toBeDefined()
+    expect(readPendingSubmission('batch', OWNER, 8453)).toBeDefined()
   })
 
   it('clears a stored record', () => {
     writePendingSubmission('outgoing-migration', record())
 
-    clearPendingSubmission('outgoing-migration')
+    clearPendingSubmission('outgoing-migration', OWNER, 1)
 
-    expect(readPendingSubmission('outgoing-migration')).toBeUndefined()
+    expect(readPendingSubmission('outgoing-migration', OWNER, 1)).toBeUndefined()
+  })
+
+  it('normalizes owners to checksum form for keying and reading', () => {
+    writePendingSubmission('batch', record())
+
+    expect(readPendingSubmission('batch', OWNER.toLowerCase() as typeof OWNER, 1)).toEqual(record())
   })
 
   it('normalizes the stored owner to checksum form', () => {
-    localStorage.setItem('euler_pending_submission:batch', JSON.stringify({
+    localStorage.setItem(BATCH_KEY, JSON.stringify({
       ...record(),
       owner: OWNER.toLowerCase(),
     }))
 
-    expect(readPendingSubmission('batch')?.owner).toBe(OWNER)
+    expect(readPendingSubmission('batch', OWNER, 1)?.owner).toBe(OWNER)
   })
 
   it.each([
     ['unparseable JSON', 'not json'],
+    ['wrong phase', JSON.stringify({ ...record(), phase: 'other' })],
+    ['missing phase', JSON.stringify({ ...record(), phase: undefined })],
     ['wrong kind', JSON.stringify({ ...record(), kind: 'other' })],
     ['malformed hash', JSON.stringify({ ...record(), hash: '0x1234' })],
     ['malformed owner', JSON.stringify({ ...record(), owner: '0xnope' })],
@@ -93,24 +141,114 @@ describe('pending submission storage', () => {
     ['non-numeric submittedAt', JSON.stringify({ ...record(), submittedAt: 'now' })],
     ['non-positive chainId', JSON.stringify({ ...record(), chainId: 0 })],
   ])('drops a corrupt record (%s) instead of blocking the flow forever', (_label, raw) => {
-    localStorage.setItem('euler_pending_submission:batch', raw)
+    localStorage.setItem(BATCH_KEY, raw)
 
-    expect(readPendingSubmission('batch')).toBeUndefined()
+    expect(readPendingSubmission('batch', OWNER, 1)).toBeUndefined()
     // The corrupt payload was removed, not left to fail on every read.
-    expect(localStorage.getItem('euler_pending_submission:batch')).toBeNull()
+    expect(localStorage.getItem(BATCH_KEY)).toBeNull()
   })
 
-  it('degrades to no-ops without browser storage', () => {
+  it('drops a record whose content disagrees with its storage key', () => {
+    localStorage.setItem(BATCH_KEY, JSON.stringify(record({ owner: OTHER_OWNER })))
+
+    expect(readPendingSubmission('batch', OWNER, 1)).toBeUndefined()
+    expect(localStorage.getItem(BATCH_KEY)).toBeNull()
+  })
+
+  it('fails closed to the in-memory fallback without browser storage', () => {
     vi.stubGlobal('localStorage', undefined)
 
-    expect(() => writePendingSubmission('batch', record())).not.toThrow()
-    expect(readPendingSubmission('batch')).toBeUndefined()
-    expect(() => clearPendingSubmission('batch')).not.toThrow()
+    // No durable storage exists, but the quarantine must still block this
+    // session's retries rather than silently degrade to "no quarantine".
+    writePendingSubmission('batch', record())
+    expect(readPendingSubmission('batch', OWNER, 1)).toEqual(record())
+    expect(listPendingSubmissions('batch')).toEqual([record()])
+
+    clearPendingSubmission('batch', OWNER, 1)
+    expect(readPendingSubmission('batch', OWNER, 1)).toBeUndefined()
+  })
+
+  it('fails closed to the in-memory fallback when the storage write throws', () => {
+    const storage = createMemoryStorage()
+    vi.stubGlobal('localStorage', {
+      ...storage,
+      setItem: () => {
+        throw new Error('quota exceeded')
+      },
+    })
+
+    writePendingSubmission('batch', record())
+
+    expect(readPendingSubmission('batch', OWNER, 1)).toEqual(record())
+  })
+
+  it('fails closed to the in-memory fallback when the storage write does not stick', () => {
+    const storage = createMemoryStorage()
+    vi.stubGlobal('localStorage', {
+      ...storage,
+      // A lying storage: accepts the write, returns nothing on read-back.
+      setItem: () => {},
+      getItem: () => null,
+      get length() {
+        return 0
+      },
+    })
+
+    writePendingSubmission('batch', record())
+
+    expect(readPendingSubmission('batch', OWNER, 1)).toEqual(record())
+    expect(listPendingSubmissions('batch')).toEqual([record()])
+  })
+
+  it('lists records across storage and the in-memory fallback together', () => {
+    const storage = globalThis.localStorage
+    writePendingSubmission('batch', record())
+    vi.stubGlobal('localStorage', undefined)
+    writePendingSubmission('batch', record({ owner: OTHER_OWNER }))
+    vi.stubGlobal('localStorage', storage)
+
+    expect(listPendingSubmissions('batch')).toEqual(expect.arrayContaining([
+      record(),
+      record({ owner: OTHER_OWNER }),
+    ]))
+    expect(listPendingSubmissions('batch')).toHaveLength(2)
+  })
+})
+
+describe('walletNeverAcceptedSubmission', () => {
+  it.each([
+    ['EIP-1193 user rejection code', { code: 4001 }],
+    ['viem user rejection', { name: 'UserRejectedRequestError' }],
+    ['connector not connected', { name: 'ConnectorNotConnectedError' }],
+    ['nested cause chain', new Error('outer', { cause: { cause: { code: 4001 } } })],
+  ])('recognizes a provable non-acceptance (%s)', (_label, error) => {
+    expect(walletNeverAcceptedSubmission(error)).toBe(true)
+  })
+
+  it.each([
+    ['plain error', new Error('Failed to fetch')],
+    ['timeout-ish error', { name: 'TimeoutError', code: -32603 }],
+    ['malformed response', new Error('Safe wallet returned an unexpected call bundle id.')],
+    ['nothing', undefined],
+  ])('treats anything else as possibly accepted (%s)', (_label, error) => {
+    expect(walletNeverAcceptedSubmission(error)).toBe(false)
   })
 })
 
 describe('resolvePendingSubmissionOutcome', () => {
   const getSafeWalletProvider = vi.fn()
+
+  it('always stays unknown for an armed record — there is no id to verify', async () => {
+    const provider = {
+      getTransactionReceipt: vi.fn(async () => ({ status: 'success' })),
+    }
+
+    await expect(resolvePendingSubmissionOutcome(armedRecord(), {
+      provider: provider as never,
+      getSafeWalletProvider,
+    })).resolves.toBe('unknown')
+    expect(provider.getTransactionReceipt).not.toHaveBeenCalled()
+  })
 
   it('stays unknown without a provider to verify against', async () => {
     await expect(resolvePendingSubmissionOutcome(record(), {

--- a/tests/utils/pendingSubmissions.test.ts
+++ b/tests/utils/pendingSubmissions.test.ts
@@ -1,11 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { getAddress, type Hash } from 'viem'
 import {
+  armPendingSubmission,
   clearPendingSubmission,
+  createPendingSubmissionAttemptId,
   listPendingSubmissions,
+  PendingSubmissionConflictError,
+  PendingSubmissionStorageError,
   readPendingSubmission,
+  releasePendingSubmission,
+  releaseUnverifiablePendingSubmission,
   resetPendingSubmissionMemoryFallback,
   resolvePendingSubmissionOutcome,
+  upgradePendingSubmissionToSubmitted,
   walletNeverAcceptedSubmission,
   writePendingSubmission,
   type PendingSubmissionRecord,
@@ -89,7 +96,7 @@ describe('pending submission storage', () => {
     expect(readPendingSubmission('batch', OWNER, 1)).toEqual(armedRecord())
   })
 
-  it('keys records per wallet and chain so one wallet cannot overwrite another', () => {
+  it('keys records per wallet and chain so one wallet cannot overwrite another', async () => {
     writePendingSubmission('batch', record())
     writePendingSubmission('batch', record({ owner: OTHER_OWNER, hash: SAFE_TX_HASH }))
     writePendingSubmission('batch', record({ chainId: 8453 }))
@@ -101,18 +108,34 @@ describe('pending submission storage', () => {
     expect(listPendingSubmissions('batch')).toHaveLength(3)
 
     // Clearing one wallet's record leaves the others quarantined.
-    clearPendingSubmission('batch', OWNER, 1)
+    await clearPendingSubmission('batch', OWNER, 1)
     expect(readPendingSubmission('batch', OWNER, 1)).toBeUndefined()
     expect(readPendingSubmission('batch', OTHER_OWNER, 1)).toBeDefined()
     expect(readPendingSubmission('batch', OWNER, 8453)).toBeDefined()
   })
 
-  it('clears a stored record', () => {
+  it('clears a stored record', async () => {
     writePendingSubmission('outgoing-migration', record())
 
-    clearPendingSubmission('outgoing-migration', OWNER, 1)
+    await clearPendingSubmission('outgoing-migration', OWNER, 1)
 
     expect(readPendingSubmission('outgoing-migration', OWNER, 1)).toBeUndefined()
+  })
+
+  it('compare-and-delete keeps a record another attempt wrote in the meantime', async () => {
+    const reconciled = record({ attemptId: 'attempt-old' })
+    writePendingSubmission('batch', reconciled)
+    // Another attempt replaced the record between reconcile and clear.
+    const replacement = record({ attemptId: 'attempt-new', submittedAt: 2_000 })
+    writePendingSubmission('batch', replacement)
+
+    await clearPendingSubmission('batch', OWNER, 1, { ifMatches: reconciled })
+
+    expect(readPendingSubmission('batch', OWNER, 1)).toEqual(replacement)
+
+    // With the exact record still in place the clear goes through.
+    await clearPendingSubmission('batch', OWNER, 1, { ifMatches: replacement })
+    expect(readPendingSubmission('batch', OWNER, 1)).toBeUndefined()
   })
 
   it('normalizes owners to checksum form for keying and reading', () => {
@@ -140,35 +163,61 @@ describe('pending submission storage', () => {
     ['non-boolean completesPlan', JSON.stringify({ ...record(), completesPlan: 'yes' })],
     ['non-numeric submittedAt', JSON.stringify({ ...record(), submittedAt: 'now' })],
     ['non-positive chainId', JSON.stringify({ ...record(), chainId: 0 })],
-  ])('drops a corrupt record (%s) instead of blocking the flow forever', (_label, raw) => {
+  ])('fails closed on a corrupt record (%s) instead of silently dropping it', (_label, raw) => {
     localStorage.setItem(BATCH_KEY, raw)
 
-    expect(readPendingSubmission('batch', OWNER, 1)).toBeUndefined()
-    // The corrupt payload was removed, not left to fail on every read.
-    expect(localStorage.getItem(BATCH_KEY)).toBeNull()
+    // A corrupt record may still describe a live submission — deleting it
+    // would reopen the exact replay the quarantine exists to block.
+    expect(() => readPendingSubmission('batch', OWNER, 1)).toThrow(PendingSubmissionStorageError)
+    expect(() => readPendingSubmission('batch', OWNER, 1)).toThrow('could not be read')
+    expect(localStorage.getItem(BATCH_KEY)).toBe(raw)
   })
 
-  it('drops a record whose content disagrees with its storage key', () => {
-    localStorage.setItem(BATCH_KEY, JSON.stringify(record({ owner: OTHER_OWNER })))
+  it('fails closed on a record whose content disagrees with its storage key', () => {
+    const raw = JSON.stringify(record({ owner: OTHER_OWNER }))
+    localStorage.setItem(BATCH_KEY, raw)
 
-    expect(readPendingSubmission('batch', OWNER, 1)).toBeUndefined()
-    expect(localStorage.getItem(BATCH_KEY)).toBeNull()
+    expect(() => readPendingSubmission('batch', OWNER, 1)).toThrow(PendingSubmissionStorageError)
+    expect(localStorage.getItem(BATCH_KEY)).toBe(raw)
   })
 
-  it('fails closed to the in-memory fallback without browser storage', () => {
+  it('fails closed when the storage read itself throws', () => {
+    const storage = createMemoryStorage()
+    vi.stubGlobal('localStorage', {
+      ...storage,
+      getItem: () => {
+        throw new Error('storage read failed')
+      },
+    })
+
+    // An existing durable record may be invisible behind the failing read —
+    // that must block the attempt, never fall through to "no quarantine".
+    expect(() => readPendingSubmission('batch', OWNER, 1)).toThrow(PendingSubmissionStorageError)
+    expect(() => readPendingSubmission('batch', OWNER, 1)).toThrow('could not be read to verify')
+  })
+
+  it('skips unreadable entries when listing for display', () => {
+    writePendingSubmission('batch', record({ owner: OTHER_OWNER }))
+    localStorage.setItem(BATCH_KEY, 'not json')
+
+    // Listing is display/mirror only — it must not crash hydration. The
+    // corrupt entry still blocks at attempt time via readPendingSubmission.
+    expect(listPendingSubmissions('batch')).toEqual([record({ owner: OTHER_OWNER })])
+    expect(() => readPendingSubmission('batch', OWNER, 1)).toThrow(PendingSubmissionStorageError)
+  })
+
+  it('aborts the reservation without browser storage while still blocking this realm', () => {
     vi.stubGlobal('localStorage', undefined)
 
-    // No durable storage exists, but the quarantine must still block this
-    // session's retries rather than silently degrade to "no quarantine".
-    writePendingSubmission('batch', record())
+    // No durable storage: the write must throw so nothing reaches the wallet…
+    expect(() => writePendingSubmission('batch', record())).toThrow(PendingSubmissionStorageError)
+    expect(() => writePendingSubmission('batch', record())).toThrow('nothing was handed to the wallet')
+    // …but the in-realm copy still blocks this session's retries.
     expect(readPendingSubmission('batch', OWNER, 1)).toEqual(record())
     expect(listPendingSubmissions('batch')).toEqual([record()])
-
-    clearPendingSubmission('batch', OWNER, 1)
-    expect(readPendingSubmission('batch', OWNER, 1)).toBeUndefined()
   })
 
-  it('fails closed to the in-memory fallback when the storage write throws', () => {
+  it('aborts the reservation when the storage write throws', () => {
     const storage = createMemoryStorage()
     vi.stubGlobal('localStorage', {
       ...storage,
@@ -177,12 +226,11 @@ describe('pending submission storage', () => {
       },
     })
 
-    writePendingSubmission('batch', record())
-
+    expect(() => writePendingSubmission('batch', record())).toThrow(PendingSubmissionStorageError)
     expect(readPendingSubmission('batch', OWNER, 1)).toEqual(record())
   })
 
-  it('fails closed to the in-memory fallback when the storage write does not stick', () => {
+  it('aborts the reservation when the storage write does not stick', () => {
     const storage = createMemoryStorage()
     vi.stubGlobal('localStorage', {
       ...storage,
@@ -194,8 +242,7 @@ describe('pending submission storage', () => {
       },
     })
 
-    writePendingSubmission('batch', record())
-
+    expect(() => writePendingSubmission('batch', record())).toThrow(PendingSubmissionStorageError)
     expect(readPendingSubmission('batch', OWNER, 1)).toEqual(record())
     expect(listPendingSubmissions('batch')).toEqual([record()])
   })
@@ -204,7 +251,9 @@ describe('pending submission storage', () => {
     const storage = globalThis.localStorage
     writePendingSubmission('batch', record())
     vi.stubGlobal('localStorage', undefined)
-    writePendingSubmission('batch', record({ owner: OTHER_OWNER }))
+    // The storage-less write throws (nothing durable), but its in-realm copy
+    // must still show up so the UI mirrors everything that blocks.
+    expect(() => writePendingSubmission('batch', record({ owner: OTHER_OWNER }))).toThrow(PendingSubmissionStorageError)
     vi.stubGlobal('localStorage', storage)
 
     expect(listPendingSubmissions('batch')).toEqual(expect.arrayContaining([
@@ -212,6 +261,228 @@ describe('pending submission storage', () => {
       record({ owner: OTHER_OWNER }),
     ]))
     expect(listPendingSubmissions('batch')).toHaveLength(2)
+  })
+})
+
+describe('armPendingSubmission', () => {
+  const armInput = (attemptId: string, overrides: Partial<Parameters<typeof armPendingSubmission>[1]> = {}) => ({
+    owner: OWNER,
+    chainId: 1,
+    completesPlan: true,
+    attemptId,
+    ...overrides,
+  })
+
+  it('reserves atomically and returns the durable armed record', async () => {
+    const armed = await armPendingSubmission('direct', armInput('attempt-1'))
+
+    expect(armed).toMatchObject({ phase: 'armed', owner: OWNER, chainId: 1, attemptId: 'attempt-1' })
+    expect(readPendingSubmission('direct', OWNER, 1)).toEqual(armed)
+  })
+
+  it('refuses when any flow already holds a reservation for this wallet/chain', async () => {
+    writePendingSubmission('batch', record({ attemptId: 'other-attempt' }))
+
+    await expect(armPendingSubmission('direct', armInput('attempt-1')))
+      .rejects.toThrow(PendingSubmissionConflictError)
+    // The existing reservation is untouched.
+    expect(readPendingSubmission('batch', OWNER, 1)).toEqual(record({ attemptId: 'other-attempt' }))
+    expect(readPendingSubmission('direct', OWNER, 1)).toBeUndefined()
+  })
+
+  it('lets exactly one of two simultaneous arms win from an empty read', async () => {
+    // Both attempts passed the read-only gate on an empty store; the atomic
+    // check+reserve under the per-wallet lock must let only one proceed to
+    // the wallet.
+    const results = await Promise.allSettled([
+      armPendingSubmission('direct', armInput('attempt-a')),
+      armPendingSubmission('batch', armInput('attempt-b')),
+    ])
+
+    const fulfilled = results.filter(r => r.status === 'fulfilled')
+    const rejected = results.filter(r => r.status === 'rejected')
+    expect(fulfilled).toHaveLength(1)
+    expect(rejected).toHaveLength(1)
+    expect((rejected[0] as PromiseRejectedResult).reason).toBeInstanceOf(PendingSubmissionConflictError)
+  })
+
+  it('does not conflict across different wallets or chains', async () => {
+    await armPendingSubmission('direct', armInput('attempt-1'))
+
+    await expect(armPendingSubmission('direct', armInput('attempt-2', { owner: OTHER_OWNER })))
+      .resolves.toMatchObject({ owner: OTHER_OWNER })
+    await expect(armPendingSubmission('direct', armInput('attempt-3', { chainId: 8453 })))
+      .resolves.toMatchObject({ chainId: 8453 })
+  })
+
+  it('lets the same attempt re-arm its own armed reservation', async () => {
+    await armPendingSubmission('direct', armInput('attempt-1'))
+
+    await expect(armPendingSubmission('direct', armInput('attempt-1', { completesPlan: false })))
+      .resolves.toMatchObject({ attemptId: 'attempt-1', completesPlan: false })
+  })
+
+  it('refuses to re-arm over its own submitted record — the hash must survive', async () => {
+    await armPendingSubmission('direct', armInput('attempt-1'))
+    await upgradePendingSubmissionToSubmitted('direct', {
+      owner: OWNER,
+      chainId: 1,
+      attemptId: 'attempt-1',
+      kind: 'transaction',
+      hash: TX_HASH,
+      completesPlan: true,
+    })
+
+    await expect(armPendingSubmission('direct', armInput('attempt-1')))
+      .rejects.toThrow(PendingSubmissionConflictError)
+    expect(readPendingSubmission('direct', OWNER, 1)).toMatchObject({ phase: 'submitted', hash: TX_HASH })
+  })
+
+  it('refuses a reservation left by a dead attempt (reload) — no silent takeover', async () => {
+    // A record without this attempt's id (e.g. armed before a reload) blocks.
+    writePendingSubmission('direct', { ...armedRecord(), attemptId: 'gone-attempt' })
+
+    await expect(armPendingSubmission('direct', armInput('attempt-new')))
+      .rejects.toThrow(PendingSubmissionConflictError)
+  })
+
+  it('throws before the wallet when the reservation cannot be proven durable', async () => {
+    const storage = createMemoryStorage()
+    vi.stubGlobal('localStorage', {
+      ...storage,
+      setItem: () => {
+        throw new Error('quota exceeded')
+      },
+    })
+
+    await expect(armPendingSubmission('direct', armInput('attempt-1')))
+      .rejects.toThrow(PendingSubmissionStorageError)
+  })
+
+  it('throws before the wallet when existing state cannot be read', async () => {
+    const storage = createMemoryStorage()
+    vi.stubGlobal('localStorage', {
+      ...storage,
+      getItem: () => {
+        throw new Error('storage read failed')
+      },
+    })
+
+    await expect(armPendingSubmission('direct', armInput('attempt-1')))
+      .rejects.toThrow(PendingSubmissionStorageError)
+  })
+})
+
+describe('upgradePendingSubmissionToSubmitted', () => {
+  const upgradeInput = (attemptId: string) => ({
+    owner: OWNER,
+    chainId: 1,
+    attemptId,
+    kind: 'transaction' as const,
+    hash: TX_HASH,
+    completesPlan: true,
+  })
+
+  it('upgrades the attempt\'s own armed reservation', async () => {
+    await armPendingSubmission('direct', { owner: OWNER, chainId: 1, completesPlan: true, attemptId: 'attempt-1' })
+
+    const upgraded = await upgradePendingSubmissionToSubmitted('direct', upgradeInput('attempt-1'))
+
+    expect(upgraded).toMatchObject({ phase: 'submitted', hash: TX_HASH, attemptId: 'attempt-1' })
+    expect(readPendingSubmission('direct', OWNER, 1)).toEqual(upgraded)
+  })
+
+  it('refuses to upgrade a reservation another attempt owns', async () => {
+    await armPendingSubmission('direct', { owner: OWNER, chainId: 1, completesPlan: true, attemptId: 'attempt-owner' })
+
+    await expect(upgradePendingSubmissionToSubmitted('direct', upgradeInput('attempt-stale')))
+      .resolves.toBeUndefined()
+    // The owner's armed reservation is untouched.
+    expect(readPendingSubmission('direct', OWNER, 1)).toMatchObject({ phase: 'armed', attemptId: 'attempt-owner' })
+  })
+
+  it('refuses to create a record when none exists', async () => {
+    await expect(upgradePendingSubmissionToSubmitted('direct', upgradeInput('attempt-1')))
+      .resolves.toBeUndefined()
+    expect(readPendingSubmission('direct', OWNER, 1)).toBeUndefined()
+  })
+
+  it('keeps the armed record when the upgraded write fails', async () => {
+    const armed = await armPendingSubmission('direct', { owner: OWNER, chainId: 1, completesPlan: true, attemptId: 'attempt-1' })
+    const working = globalThis.localStorage
+    vi.stubGlobal('localStorage', {
+      ...createMemoryStorage(),
+      getItem: (key: string) => working.getItem(key),
+      setItem: () => {
+        throw new Error('quota exceeded')
+      },
+    })
+
+    await expect(upgradePendingSubmissionToSubmitted('direct', upgradeInput('attempt-1')))
+      .resolves.toBeUndefined()
+    vi.stubGlobal('localStorage', working)
+    expect(readPendingSubmission('direct', OWNER, 1)).toEqual(armed)
+  })
+})
+
+describe('releasePendingSubmission', () => {
+  it('releases the attempt\'s own record', async () => {
+    await armPendingSubmission('direct', { owner: OWNER, chainId: 1, completesPlan: true, attemptId: 'attempt-1' })
+
+    await expect(releasePendingSubmission('direct', OWNER, 1, { attemptId: 'attempt-1' })).resolves.toBe(true)
+    expect(readPendingSubmission('direct', OWNER, 1)).toBeUndefined()
+  })
+
+  it('is a no-op for a stale completion after another attempt reserved anew', async () => {
+    // Tab A armed, tab B took over the key with a fresh reservation; tab A's
+    // terminal callback must not delete tab B's record.
+    writePendingSubmission('direct', { ...armedRecord(), attemptId: 'attempt-b' })
+
+    await expect(releasePendingSubmission('direct', OWNER, 1, { attemptId: 'attempt-a' })).resolves.toBe(false)
+    expect(readPendingSubmission('direct', OWNER, 1)).toMatchObject({ attemptId: 'attempt-b' })
+  })
+
+  it('keeps an unreadable record blocking — ownership is unprovable', async () => {
+    localStorage.setItem(`euler_pending_submission:direct:1:${OWNER}`, 'not json')
+
+    await expect(releasePendingSubmission('direct', OWNER, 1, { attemptId: 'attempt-1' })).resolves.toBe(false)
+    expect(localStorage.getItem(`euler_pending_submission:direct:1:${OWNER}`)).toBe('not json')
+  })
+})
+
+describe('releaseUnverifiablePendingSubmission', () => {
+  const acknowledgement = { userConfirmedWalletShowsNoPendingSubmission: true as const }
+
+  it('releases an armed record after the user checked the wallet', async () => {
+    writePendingSubmission('batch', { ...armedRecord(), attemptId: 'gone' })
+
+    await expect(releaseUnverifiablePendingSubmission('batch', OWNER, 1, acknowledgement)).resolves.toBe(true)
+    expect(readPendingSubmission('batch', OWNER, 1)).toBeUndefined()
+  })
+
+  it('releases a corrupt record after the user checked the wallet', async () => {
+    localStorage.setItem(BATCH_KEY, 'not json')
+
+    await expect(releaseUnverifiablePendingSubmission('batch', OWNER, 1, acknowledgement)).resolves.toBe(true)
+    expect(localStorage.getItem(BATCH_KEY)).toBeNull()
+  })
+
+  it('refuses to dismiss a submitted record — it has an id and can still confirm', async () => {
+    writePendingSubmission('batch', record())
+
+    await expect(releaseUnverifiablePendingSubmission('batch', OWNER, 1, acknowledgement))
+      .rejects.toThrow('verified automatically and cannot be dismissed')
+    expect(readPendingSubmission('batch', OWNER, 1)).toEqual(record())
+  })
+
+  it('reports false when nothing is quarantined', async () => {
+    await expect(releaseUnverifiablePendingSubmission('batch', OWNER, 1, acknowledgement)).resolves.toBe(false)
+  })
+})
+
+describe('createPendingSubmissionAttemptId', () => {
+  it('produces a distinct id per attempt', () => {
+    expect(createPendingSubmissionAttemptId()).not.toBe(createPendingSubmissionAttemptId())
   })
 })
 

--- a/tests/utils/pendingSubmissions.test.ts
+++ b/tests/utils/pendingSubmissions.test.ts
@@ -1,0 +1,220 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { getAddress, type Hash } from 'viem'
+import {
+  clearPendingSubmission,
+  readPendingSubmission,
+  resolvePendingSubmissionOutcome,
+  writePendingSubmission,
+  type PendingSubmissionRecord,
+} from '~/utils/pendingSubmissions'
+import { SafeTransactionStatusUnknownError } from '~/utils/safeWalletTransactions'
+
+const safeMocks = vi.hoisted(() => ({
+  waitForSafeTransactionExecution: vi.fn(),
+}))
+
+vi.mock('~/utils/safeWalletTransactions', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return {
+    ...actual,
+    waitForSafeTransactionExecution: safeMocks.waitForSafeTransactionExecution,
+  }
+})
+
+const OWNER = getAddress('0x1000000000000000000000000000000000000000')
+const TX_HASH = `0x${'11'.repeat(32)}` as Hash
+const SAFE_TX_HASH = `0x${'22'.repeat(32)}` as Hash
+
+const createMemoryStorage = (): Storage => {
+  const store = new Map<string, string>()
+  return {
+    get length() {
+      return store.size
+    },
+    clear: () => store.clear(),
+    getItem: (key: string) => store.get(key) ?? null,
+    key: (index: number) => [...store.keys()][index] ?? null,
+    removeItem: (key: string) => {
+      store.delete(key)
+    },
+    setItem: (key: string, value: string) => {
+      store.set(key, String(value))
+    },
+  }
+}
+
+const record = (overrides: Partial<PendingSubmissionRecord> = {}): PendingSubmissionRecord => ({
+  kind: 'transaction',
+  hash: TX_HASH,
+  chainId: 1,
+  owner: OWNER,
+  completesPlan: true,
+  submittedAt: 1_000,
+  ...overrides,
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.stubGlobal('localStorage', createMemoryStorage())
+})
+
+describe('pending submission storage', () => {
+  it('round-trips a record through storage', () => {
+    writePendingSubmission('batch', record({ refreshExternalPositions: true }))
+
+    expect(readPendingSubmission('batch')).toEqual(record({ refreshExternalPositions: true }))
+    // Flows are isolated: the batch record must not leak into direct flows.
+    expect(readPendingSubmission('outgoing-migration')).toBeUndefined()
+  })
+
+  it('clears a stored record', () => {
+    writePendingSubmission('outgoing-migration', record())
+
+    clearPendingSubmission('outgoing-migration')
+
+    expect(readPendingSubmission('outgoing-migration')).toBeUndefined()
+  })
+
+  it('normalizes the stored owner to checksum form', () => {
+    localStorage.setItem('euler_pending_submission:batch', JSON.stringify({
+      ...record(),
+      owner: OWNER.toLowerCase(),
+    }))
+
+    expect(readPendingSubmission('batch')?.owner).toBe(OWNER)
+  })
+
+  it.each([
+    ['unparseable JSON', 'not json'],
+    ['wrong kind', JSON.stringify({ ...record(), kind: 'other' })],
+    ['malformed hash', JSON.stringify({ ...record(), hash: '0x1234' })],
+    ['malformed owner', JSON.stringify({ ...record(), owner: '0xnope' })],
+    ['non-boolean completesPlan', JSON.stringify({ ...record(), completesPlan: 'yes' })],
+    ['non-numeric submittedAt', JSON.stringify({ ...record(), submittedAt: 'now' })],
+    ['non-positive chainId', JSON.stringify({ ...record(), chainId: 0 })],
+  ])('drops a corrupt record (%s) instead of blocking the flow forever', (_label, raw) => {
+    localStorage.setItem('euler_pending_submission:batch', raw)
+
+    expect(readPendingSubmission('batch')).toBeUndefined()
+    // The corrupt payload was removed, not left to fail on every read.
+    expect(localStorage.getItem('euler_pending_submission:batch')).toBeNull()
+  })
+
+  it('degrades to no-ops without browser storage', () => {
+    vi.stubGlobal('localStorage', undefined)
+
+    expect(() => writePendingSubmission('batch', record())).not.toThrow()
+    expect(readPendingSubmission('batch')).toBeUndefined()
+    expect(() => clearPendingSubmission('batch')).not.toThrow()
+  })
+})
+
+describe('resolvePendingSubmissionOutcome', () => {
+  const getSafeWalletProvider = vi.fn()
+
+  it('stays unknown without a provider to verify against', async () => {
+    await expect(resolvePendingSubmissionOutcome(record(), {
+      provider: undefined,
+      getSafeWalletProvider,
+    })).resolves.toBe('unknown')
+  })
+
+  it.each([
+    ['success', 'landed'],
+    ['reverted', 'not-landed'],
+  ] as const)('maps a %s transaction receipt to %s', async (status, expected) => {
+    const provider = {
+      getTransactionReceipt: vi.fn(async () => ({ status })),
+    }
+
+    await expect(resolvePendingSubmissionOutcome(record(), {
+      provider: provider as never,
+      getSafeWalletProvider,
+    })).resolves.toBe(expected)
+    expect(provider.getTransactionReceipt).toHaveBeenCalledWith({ hash: TX_HASH })
+  })
+
+  it('stays unknown when the transaction has no receipt yet', async () => {
+    // No receipt covers both a pending transaction and a dropped one that a
+    // mempool copy could still re-broadcast — neither is a terminal verdict.
+    const provider = {
+      getTransactionReceipt: vi.fn(async () => {
+        throw new Error('receipt not found')
+      }),
+    }
+
+    await expect(resolvePendingSubmissionOutcome(record(), {
+      provider: provider as never,
+      getSafeWalletProvider,
+    })).resolves.toBe('unknown')
+  })
+
+  const proposal = record({ kind: 'proposal', hash: SAFE_TX_HASH })
+  const provider = { getTransactionReceipt: vi.fn() }
+
+  it('stays unknown when no Safe provider can be acquired', async () => {
+    getSafeWalletProvider.mockResolvedValueOnce(undefined)
+
+    await expect(resolvePendingSubmissionOutcome(proposal, {
+      provider: provider as never,
+      getSafeWalletProvider,
+    })).resolves.toBe('unknown')
+    expect(safeMocks.waitForSafeTransactionExecution).not.toHaveBeenCalled()
+  })
+
+  it('stays unknown when Safe provider acquisition throws', async () => {
+    getSafeWalletProvider.mockRejectedValueOnce(new Error('no session'))
+
+    await expect(resolvePendingSubmissionOutcome(proposal, {
+      provider: provider as never,
+      getSafeWalletProvider,
+    })).resolves.toBe('unknown')
+  })
+
+  it.each([
+    ['success', 'landed'],
+    ['reverted', 'not-landed'],
+  ] as const)('maps a %s Safe execution receipt to %s', async (status, expected) => {
+    getSafeWalletProvider.mockResolvedValueOnce({ request: vi.fn() })
+    safeMocks.waitForSafeTransactionExecution.mockResolvedValueOnce({
+      hash: SAFE_TX_HASH,
+      receipt: { status },
+    })
+
+    await expect(resolvePendingSubmissionOutcome(proposal, {
+      provider: provider as never,
+      getSafeWalletProvider,
+      safeStatusTimeoutMs: 5_000,
+    })).resolves.toBe(expected)
+    expect(safeMocks.waitForSafeTransactionExecution).toHaveBeenCalledWith(expect.objectContaining({
+      submittedHash: SAFE_TX_HASH,
+      timeoutMs: 5_000,
+    }))
+  })
+
+  it.each([
+    ['Safe transaction was cancelled', 'not-landed'],
+    ['Safe transaction failed', 'not-landed'],
+    ['network exploded', 'unknown'],
+  ] as const)('maps a "%s" Safe status error to %s', async (message, expected) => {
+    getSafeWalletProvider.mockResolvedValueOnce({ request: vi.fn() })
+    safeMocks.waitForSafeTransactionExecution.mockRejectedValueOnce(new Error(message))
+
+    await expect(resolvePendingSubmissionOutcome(proposal, {
+      provider: provider as never,
+      getSafeWalletProvider,
+    })).resolves.toBe(expected)
+  })
+
+  it('stays unknown while the Safe status itself is unknown', async () => {
+    getSafeWalletProvider.mockResolvedValueOnce({ request: vi.fn() })
+    safeMocks.waitForSafeTransactionExecution.mockRejectedValueOnce(
+      new SafeTransactionStatusUnknownError(SAFE_TX_HASH, 'timeout'),
+    )
+
+    await expect(resolvePendingSubmissionOutcome(proposal, {
+      provider: provider as never,
+      getSafeWalletProvider,
+    })).resolves.toBe('unknown')
+  })
+})

--- a/tests/utils/pendingSubmissionsCrossTab.test.ts
+++ b/tests/utils/pendingSubmissionsCrossTab.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { getAddress } from 'viem'
+
+/**
+ * Cross-context serialization of the pending-submission critical section when
+ * the Web Locks API is unavailable. Each "tab" is a separate module graph of
+ * '~/utils/pendingSubmissions' (separate realm-local FIFO queues and memory
+ * maps) sharing one localStorage object — the storage-token mutex is the only
+ * thing that can serialize them, exactly like two real browser tabs without
+ * navigator.locks. The module under test is therefore only ever imported
+ * dynamically, after the globals are stubbed.
+ */
+
+type PendingSubmissionsModule = typeof import('~/utils/pendingSubmissions')
+
+const OWNER = getAddress('0x1000000000000000000000000000000000000000')
+const LOCK_KEY = `euler_pending_submission:lock:1:${OWNER}`
+const DIRECT_KEY = `euler_pending_submission:direct:1:${OWNER}`
+
+const createMemoryStorage = (): Storage => {
+  const store = new Map<string, string>()
+  return {
+    get length() {
+      return store.size
+    },
+    clear: () => store.clear(),
+    getItem: (key: string) => store.get(key) ?? null,
+    key: (index: number) => [...store.keys()][index] ?? null,
+    removeItem: (key: string) => {
+      store.delete(key)
+    },
+    setItem: (key: string, value: string) => {
+      store.set(key, String(value))
+    },
+  }
+}
+
+const loadTab = async (): Promise<PendingSubmissionsModule> => {
+  vi.resetModules()
+  return import('~/utils/pendingSubmissions')
+}
+
+const armInput = (attemptId: string) => ({
+  owner: OWNER,
+  chainId: 1,
+  completesPlan: true,
+  attemptId,
+})
+
+beforeEach(() => {
+  vi.stubGlobal('localStorage', createMemoryStorage())
+  // No Web Locks API: the storage-token mutex must carry serialization.
+  vi.stubGlobal('navigator', {})
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('pending submission lock without Web Locks', () => {
+  it('lets exactly one of two concurrent tabs reach the wallet boundary', async () => {
+    const tabA = await loadTab()
+    const tabB = await loadTab()
+
+    // Both tabs passed their read-only gates and race check+reserve for the
+    // same wallet/chain from different flows (and different module graphs).
+    const walletCalls: string[] = []
+    const outcomes = await Promise.allSettled([
+      tabA.armPendingSubmission('direct', armInput('attempt-a')).then(() => walletCalls.push('tab-a')),
+      tabB.armPendingSubmission('batch', armInput('attempt-b')).then(() => walletCalls.push('tab-b')),
+    ])
+
+    expect(walletCalls).toHaveLength(1)
+    const rejections = outcomes.filter(outcome => outcome.status === 'rejected')
+    expect(rejections).toHaveLength(1)
+    // Compared by name: each module graph has its own class identity.
+    const reason = (rejections[0] as PromiseRejectedResult).reason as Error
+    expect(reason.constructor.name).toBe('PendingSubmissionConflictError')
+    expect(reason.message).toContain('Another transaction from this wallet')
+  })
+
+  it('releases the mutex after the critical section and keeps blocking on the record itself', async () => {
+    const tabA = await loadTab()
+    const tabB = await loadTab()
+
+    await tabA.armPendingSubmission('direct', armInput('attempt-a'))
+    // The mutex protects only the critical section — it must not stay held
+    // while the reservation blocks other tabs.
+    expect(localStorage.getItem(LOCK_KEY)).toBeNull()
+
+    await expect(tabB.armPendingSubmission('batch', armInput('attempt-b')))
+      .rejects.toThrow('Another transaction from this wallet')
+
+    await expect(tabA.releasePendingSubmission('direct', OWNER, 1, { attemptId: 'attempt-a' }))
+      .resolves.toBe(true)
+    await expect(tabB.armPendingSubmission('batch', armInput('attempt-b')))
+      .resolves.toMatchObject({ phase: 'armed', attemptId: 'attempt-b' })
+  })
+
+  it('fails closed — nothing is reserved and nothing may reach the wallet — while another context holds the mutex', async () => {
+    const tab = await loadTab()
+    vi.useFakeTimers()
+    try {
+      localStorage.setItem(LOCK_KEY, JSON.stringify({
+        token: 'held-by-another-context',
+        expiresAt: Date.now() + 60_000,
+      }))
+
+      const attempt = tab.armPendingSubmission('direct', armInput('attempt-a'))
+      const outcome = expect(attempt).rejects.toThrow('could not take the cross-tab submission lock')
+      await vi.advanceTimersByTimeAsync(11_000)
+      await outcome
+
+      expect(localStorage.getItem(DIRECT_KEY)).toBeNull()
+    }
+    finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('reclaims a mutex left behind by a crashed holder once its TTL expired', async () => {
+    const tab = await loadTab()
+    localStorage.setItem(LOCK_KEY, JSON.stringify({ token: 'crashed-holder', expiresAt: Date.now() - 1 }))
+
+    await expect(tab.armPendingSubmission('direct', armInput('attempt-a')))
+      .resolves.toMatchObject({ phase: 'armed', attemptId: 'attempt-a' })
+    expect(localStorage.getItem(LOCK_KEY)).toBeNull()
+  })
+})

--- a/tests/utils/preparedPlanParity.test.ts
+++ b/tests/utils/preparedPlanParity.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest'
+import type { Address, Hex } from 'viem'
+import type { TransactionPlan, TransactionPlanPrepared } from '@eulerxyz/euler-v2-sdk'
+import { assertPreparedPlanSignatureParity } from '~/utils/preparedPlanParity'
+
+const owner = '0x1000000000000000000000000000000000000000' as Address
+const target = '0x2000000000000000000000000000000000000000' as Address
+const otherTarget = '0x3000000000000000000000000000000000000000' as Address
+const placeholder = `0x${'00'.repeat(65)}` as Hex
+const signature = `0x${'11'.repeat(65)}` as Hex
+
+const planWithSignature = (authorization: Hex): TransactionPlan => [{
+  type: 'evcBatch',
+  items: [{
+    type: 'operation',
+    name: 'migration',
+    items: [{
+      targetContract: target,
+      onBehalfOfAccount: owner,
+      value: 7n,
+      data: `0x1234${authorization.slice(2)}abcd` as Hex,
+    }],
+  }],
+}]
+
+const prepared = (plan: TransactionPlan): TransactionPlanPrepared => ({
+  __prepared: true,
+  plan,
+  chainId: 1,
+  account: owner,
+  usePermit2: true,
+  unlimitedApproval: false,
+})
+
+const assertParity = (resolvedPlan: TransactionPlan) => assertPreparedPlanSignatureParity({
+  reviewed: prepared(planWithSignature(placeholder)),
+  resolved: prepared(resolvedPlan),
+  substitutions: [{ placeholder, signature }],
+})
+
+describe('assertPreparedPlanSignatureParity', () => {
+  it('accepts exactly one reviewed placeholder-to-signature substitution', () => {
+    expect(() => assertParity(planWithSignature(signature))).not.toThrow()
+  })
+
+  it.each([
+    ['target', () => {
+      const plan = planWithSignature(signature)
+      const operation = plan[0] as Extract<TransactionPlan[number], { type: 'evcBatch' }>
+      const item = operation.items[0]
+      if ('items' in item) item.items[0]!.targetContract = otherTarget
+      return plan
+    }],
+    ['value', () => {
+      const plan = planWithSignature(signature)
+      const operation = plan[0] as Extract<TransactionPlan[number], { type: 'evcBatch' }>
+      const item = operation.items[0]
+      if ('items' in item) item.items[0]!.value = 8n
+      return plan
+    }],
+    ['order', () => {
+      const plan = planWithSignature(signature)
+      const operation = plan[0] as Extract<TransactionPlan[number], { type: 'evcBatch' }>
+      const item = operation.items[0]
+      if ('items' in item) {
+        item.items.push({ ...item.items[0]!, data: '0xbeef' })
+        item.items.reverse()
+      }
+      return plan
+    }],
+    ['approval', () => [{
+      type: 'requiredApproval',
+      token: target,
+      owner,
+      spender: otherTarget,
+      amount: 1n,
+      resolved: [{ type: 'approve', token: target, data: '0x1234' }],
+    }, ...planWithSignature(signature)] as TransactionPlan],
+    ['plugin call', () => [{
+      type: 'contractCall',
+      chainId: 1,
+      to: otherTarget,
+      abi: [],
+      functionName: 'unexpected',
+      args: [],
+      value: 0n,
+    }, ...planWithSignature(signature)] as TransactionPlan],
+  ])('rejects a confirm-time %s change', (_label, mutate) => {
+    expect(() => assertParity(mutate())).toThrow('transaction plan changed after review')
+  })
+
+  it('rejects a missing or extra signature occurrence', () => {
+    expect(() => assertParity(planWithSignature(placeholder))).toThrow('transaction plan changed after review')
+    const duplicated = planWithSignature(signature)
+    const batch = duplicated[0] as Extract<TransactionPlan[number], { type: 'evcBatch' }>
+    const operation = batch.items[0]
+    if ('items' in operation) operation.items.push({ ...operation.items[0]! })
+    expect(() => assertParity(duplicated)).toThrow('transaction plan changed after review')
+  })
+})

--- a/tests/utils/preparedPlanParity.test.ts
+++ b/tests/utils/preparedPlanParity.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import type { Address, Hex } from 'viem'
+import { encodeFunctionData, type Address, type Hex } from 'viem'
 import type { TransactionPlan, TransactionPlanPrepared } from '@eulerxyz/euler-v2-sdk'
 import { assertPreparedPlanSignatureParity } from '~/utils/preparedPlanParity'
 
@@ -7,7 +7,33 @@ const owner = '0x1000000000000000000000000000000000000000' as Address
 const target = '0x2000000000000000000000000000000000000000' as Address
 const otherTarget = '0x3000000000000000000000000000000000000000' as Address
 const placeholder = `0x${'00'.repeat(65)}` as Hex
-const signature = `0x${'11'.repeat(65)}` as Hex
+const signature = `0x${'11'.repeat(32)}${'22'.repeat(32)}01` as Hex
+
+const permitAbi = [{
+  type: 'function',
+  name: 'permit',
+  inputs: [
+    { name: 'owner', type: 'address' },
+    { name: 'spender', type: 'address' },
+    { name: 'value', type: 'uint256' },
+    { name: 'deadline', type: 'uint256' },
+    { name: 'v', type: 'uint8' },
+    { name: 'r', type: 'bytes32' },
+    { name: 's', type: 'bytes32' },
+  ],
+  outputs: [],
+  stateMutability: 'nonpayable',
+}] as const
+
+const splitSignature = (authorization: Hex) => {
+  let v = Number.parseInt(authorization.slice(130, 132), 16)
+  if (v < 27) v += 27
+  return {
+    r: authorization.slice(0, 66) as Hex,
+    s: `0x${authorization.slice(66, 130)}` as Hex,
+    v,
+  }
+}
 
 const planWithSignature = (authorization: Hex): TransactionPlan => [{
   type: 'evcBatch',
@@ -22,6 +48,27 @@ const planWithSignature = (authorization: Hex): TransactionPlan => [{
     }],
   }],
 }]
+
+const planWithAbiSignature = (authorization: Hex): TransactionPlan => {
+  const { r, s, v } = splitSignature(authorization)
+  return [{
+    type: 'evcBatch',
+    items: [{
+      type: 'operation',
+      name: 'aave-migration',
+      items: [{
+        targetContract: target,
+        onBehalfOfAccount: owner,
+        value: 0n,
+        data: encodeFunctionData({
+          abi: permitAbi,
+          functionName: 'permit',
+          args: [owner, otherTarget, 7n, 123n, v, r, s],
+        }),
+      }],
+    }],
+  }]
+}
 
 const prepared = (plan: TransactionPlan): TransactionPlanPrepared => ({
   __prepared: true,
@@ -41,6 +88,27 @@ const assertParity = (resolvedPlan: TransactionPlan) => assertPreparedPlanSignat
 describe('assertPreparedPlanSignatureParity', () => {
   it('accepts exactly one reviewed placeholder-to-signature substitution', () => {
     expect(() => assertParity(planWithSignature(signature))).not.toThrow()
+  })
+
+  it('accepts the production ABI v/r/s encoding at the reviewed offsets', () => {
+    expect(() => assertPreparedPlanSignatureParity({
+      reviewed: prepared(planWithAbiSignature(placeholder)),
+      resolved: prepared(planWithAbiSignature(signature)),
+      substitutions: [{ placeholder, signature }],
+    })).not.toThrow()
+  })
+
+  it('rejects an unrelated change beside a production ABI v/r/s substitution', () => {
+    const resolved = planWithAbiSignature(signature)
+    const batch = resolved[0] as Extract<TransactionPlan[number], { type: 'evcBatch' }>
+    const operation = batch.items[0]
+    if ('items' in operation) operation.items[0]!.value = 1n
+
+    expect(() => assertPreparedPlanSignatureParity({
+      reviewed: prepared(planWithAbiSignature(placeholder)),
+      resolved: prepared(resolved),
+      substitutions: [{ placeholder, signature }],
+    })).toThrow('transaction plan changed after review')
   })
 
   it.each([

--- a/tests/utils/preparedPlanParity.test.ts
+++ b/tests/utils/preparedPlanParity.test.ts
@@ -8,6 +8,7 @@ const target = '0x2000000000000000000000000000000000000000' as Address
 const otherTarget = '0x3000000000000000000000000000000000000000' as Address
 const placeholder = `0x${'00'.repeat(65)}` as Hex
 const signature = `0x${'11'.repeat(32)}${'22'.repeat(32)}01` as Hex
+const secondSignature = `0x${'33'.repeat(32)}${'44'.repeat(32)}1c` as Hex
 
 const permitAbi = [{
   type: 'function',
@@ -46,6 +47,30 @@ const planWithSignature = (authorization: Hex): TransactionPlan => [{
       value: 7n,
       data: `0x1234${authorization.slice(2)}abcd` as Hex,
     }],
+  }],
+}]
+
+// Two structurally identical placeholder sites: only the signature bytes can
+// tell the resolved items apart.
+const planWithTwoSignatures = (first: Hex, second: Hex): TransactionPlan => [{
+  type: 'evcBatch',
+  items: [{
+    type: 'operation',
+    name: 'migration',
+    items: [
+      {
+        targetContract: target,
+        onBehalfOfAccount: owner,
+        value: 7n,
+        data: `0x1234${first.slice(2)}abcd` as Hex,
+      },
+      {
+        targetContract: target,
+        onBehalfOfAccount: owner,
+        value: 7n,
+        data: `0x1234${second.slice(2)}abcd` as Hex,
+      },
+    ],
   }],
 }]
 
@@ -155,6 +180,58 @@ describe('assertPreparedPlanSignatureParity', () => {
     }, ...planWithSignature(signature)] as TransactionPlan],
   ])('rejects a confirm-time %s change', (_label, mutate) => {
     expect(() => assertParity(mutate())).toThrow('transaction plan changed after review')
+  })
+
+  it('accepts two ordered substitutions across identical placeholder sites', () => {
+    expect(() => assertPreparedPlanSignatureParity({
+      reviewed: prepared(planWithTwoSignatures(placeholder, placeholder)),
+      resolved: prepared(planWithTwoSignatures(signature, secondSignature)),
+      substitutions: [
+        { placeholder, signature },
+        { placeholder, signature: secondSignature },
+      ],
+    })).not.toThrow()
+  })
+
+  it('rejects signatures transposed between identical placeholder sites', () => {
+    expect(() => assertPreparedPlanSignatureParity({
+      reviewed: prepared(planWithTwoSignatures(placeholder, placeholder)),
+      resolved: prepared(planWithTwoSignatures(secondSignature, signature)),
+      substitutions: [
+        { placeholder, signature },
+        { placeholder, signature: secondSignature },
+      ],
+    })).toThrow('transaction plan changed after review')
+  })
+
+  it('binds substitution order within a single calldata string', () => {
+    const dataWith = (first: Hex, second: Hex): TransactionPlan => [{
+      type: 'evcBatch',
+      items: [{
+        type: 'operation',
+        name: 'migration',
+        items: [{
+          targetContract: target,
+          onBehalfOfAccount: owner,
+          value: 7n,
+          data: `0x${first.slice(2)}${second.slice(2)}` as Hex,
+        }],
+      }],
+    }]
+    const substitutions = [
+      { placeholder, signature },
+      { placeholder, signature: secondSignature },
+    ]
+    expect(() => assertPreparedPlanSignatureParity({
+      reviewed: prepared(dataWith(placeholder, placeholder)),
+      resolved: prepared(dataWith(signature, secondSignature)),
+      substitutions,
+    })).not.toThrow()
+    expect(() => assertPreparedPlanSignatureParity({
+      reviewed: prepared(dataWith(placeholder, placeholder)),
+      resolved: prepared(dataWith(secondSignature, signature)),
+      substitutions,
+    })).toThrow('transaction plan changed after review')
   })
 
   it('rejects a missing or extra signature occurrence', () => {

--- a/tests/utils/walletExecutionContext.test.ts
+++ b/tests/utils/walletExecutionContext.test.ts
@@ -1,6 +1,6 @@
 import type { Address } from 'viem'
 import { describe, expect, it } from 'vitest'
-import { assertWalletExecutionContext, createSafeBundleBroadcastGuard } from '~/utils/walletExecutionContext'
+import { assertWalletExecutionContext, createReviewedWalletContextGuard, createSafeBundleBroadcastGuard } from '~/utils/walletExecutionContext'
 import type { WalletExecutionContextChangedError } from '~/utils/walletExecutionContext'
 
 const OWNER = '0x1111111111111111111111111111111111111111' as Address
@@ -35,6 +35,88 @@ describe('assertWalletExecutionContext', () => {
       currentAccount: OWNER,
       currentChainId: 8453,
     })).toThrow(expect.objectContaining<Partial<WalletExecutionContextChangedError>>({
+      name: 'WalletExecutionContextChangedError',
+      kind: 'chain',
+    }))
+  })
+})
+
+describe('createReviewedWalletContextGuard', () => {
+  const REVIEWED_CONNECTOR_KEY = 'metamask:uid-1'
+  const WALLET_CHANGED = 'Wallet changed since review — please review the migration again.'
+
+  const walletState = () => ({
+    account: OWNER as Address | undefined,
+    chainId: 1 as number | undefined,
+    connectorKey: REVIEWED_CONNECTOR_KEY as string | undefined,
+  })
+
+  const guardFor = (
+    state: ReturnType<typeof walletState>,
+    expectedConnectorKey: string | undefined = REVIEWED_CONNECTOR_KEY,
+  ) => createReviewedWalletContextGuard({
+    expectedAccount: OWNER,
+    expectedChainId: 1,
+    expectedConnectorKey,
+    currentAccount: () => state.account,
+    currentChainId: () => state.chainId,
+    connectorContextKey: () => state.connectorKey,
+  })
+
+  it('passes when the reviewed context is intact at the wallet-action boundary', () => {
+    const state = walletState()
+    const guard = guardFor(state)
+    expect(() => guard()).not.toThrow()
+  })
+
+  it('rejects a connector switch completed before guard construction (delayed authorization lookup)', () => {
+    const state = walletState()
+    // The switch lands while confirmation awaits pending restoration or the
+    // fresh authorization lookup — BEFORE the guard exists. Because the
+    // expected key comes from the reviewed preview, the replacement connector
+    // can never become the guard's accepted baseline.
+    state.connectorKey = 'walletconnect:uid-2'
+    const guard = guardFor(state)
+    expect(() => guard()).toThrow(WALLET_CHANGED)
+  })
+
+  it('rejects a same-account connector switch between wallet actions', () => {
+    const state = walletState()
+    const guard = guardFor(state)
+    expect(() => guard()).not.toThrow()
+    // Same owner, same chain — only the connector changed while a signature
+    // request or grant broadcast was in flight.
+    state.connectorKey = 'walletconnect:uid-2'
+    expect(() => guard()).toThrow(WALLET_CHANGED)
+  })
+
+  it('rejects a disconnected connector during delayed planning', () => {
+    const state = walletState()
+    const guard = guardFor(state)
+    state.connectorKey = undefined
+    expect(() => guard()).toThrow(WALLET_CHANGED)
+  })
+
+  it('fails closed when the review captured no connector key', () => {
+    const state = walletState()
+    state.connectorKey = undefined
+    const guard = guardFor(state, undefined)
+    expect(() => guard()).toThrow(WALLET_CHANGED)
+  })
+
+  it('still rejects account and chain drift through the wallet context assertion', () => {
+    const accountState = walletState()
+    const accountGuard = guardFor(accountState)
+    accountState.account = OTHER_OWNER
+    expect(() => accountGuard()).toThrow(expect.objectContaining<Partial<WalletExecutionContextChangedError>>({
+      name: 'WalletExecutionContextChangedError',
+      kind: 'account',
+    }))
+
+    const chainState = walletState()
+    const chainGuard = guardFor(chainState)
+    chainState.chainId = 8453
+    expect(() => chainGuard()).toThrow(expect.objectContaining<Partial<WalletExecutionContextChangedError>>({
       name: 'WalletExecutionContextChangedError',
       kind: 'chain',
     }))

--- a/tests/utils/walletExecutionContext.test.ts
+++ b/tests/utils/walletExecutionContext.test.ts
@@ -1,6 +1,6 @@
 import type { Address } from 'viem'
 import { describe, expect, it } from 'vitest'
-import { assertWalletExecutionContext } from '~/utils/walletExecutionContext'
+import { assertWalletExecutionContext, createSafeBundleBroadcastGuard } from '~/utils/walletExecutionContext'
 import type { WalletExecutionContextChangedError } from '~/utils/walletExecutionContext'
 
 const OWNER = '0x1111111111111111111111111111111111111111' as Address
@@ -35,6 +35,74 @@ describe('assertWalletExecutionContext', () => {
       currentAccount: OWNER,
       currentChainId: 8453,
     })).toThrow(expect.objectContaining<Partial<WalletExecutionContextChangedError>>({
+      name: 'WalletExecutionContextChangedError',
+      kind: 'chain',
+    }))
+  })
+})
+
+describe('createSafeBundleBroadcastGuard', () => {
+  // Mutable wallet state standing in for the reactive refs the pages read;
+  // the guard is created at confirmation and invoked after the flow's
+  // authorization/planning/preparation/simulation awaits.
+  const walletState = () => ({
+    account: OWNER as Address | undefined,
+    chainId: 1 as number | undefined,
+    safeWallet: true,
+    connectorKey: 'safe:uid-1' as string | undefined,
+  })
+
+  const guardFor = (state: ReturnType<typeof walletState>) => createSafeBundleBroadcastGuard({
+    expectedAccount: OWNER,
+    expectedChainId: 1,
+    currentAccount: () => state.account,
+    currentChainId: () => state.chainId,
+    isSafeWallet: () => state.safeWallet,
+    connectorContextKey: () => state.connectorKey,
+  })
+
+  it('passes when the reviewed context is intact at the broadcast boundary', () => {
+    const state = walletState()
+    const guard = guardFor(state)
+    expect(() => guard()).not.toThrow()
+  })
+
+  it('rejects a same-account connector switch during delayed preparation', () => {
+    const state = walletState()
+    const guard = guardFor(state)
+    // Same owner, same chain, still classified as a Safe — only the connector
+    // submitting the proposal changed while preparation was in flight.
+    state.connectorKey = 'safe:uid-2'
+    expect(() => guard()).toThrow('Wallet changed since review — please review the migration again.')
+  })
+
+  it('rejects a wallet that lost its Safe classification during the awaits', () => {
+    const state = walletState()
+    const guard = guardFor(state)
+    state.safeWallet = false
+    expect(() => guard()).toThrow('Wallet changed since review — please review the migration again.')
+  })
+
+  it('rejects a disconnected connector during delayed preparation', () => {
+    const state = walletState()
+    const guard = guardFor(state)
+    state.connectorKey = undefined
+    expect(() => guard()).toThrow('Wallet changed since review — please review the migration again.')
+  })
+
+  it('still rejects account and chain drift through the wallet context assertion', () => {
+    const accountState = walletState()
+    const accountGuard = guardFor(accountState)
+    accountState.account = OTHER_OWNER
+    expect(() => accountGuard()).toThrow(expect.objectContaining<Partial<WalletExecutionContextChangedError>>({
+      name: 'WalletExecutionContextChangedError',
+      kind: 'account',
+    }))
+
+    const chainState = walletState()
+    const chainGuard = guardFor(chainState)
+    chainState.chainId = 8453
+    expect(() => chainGuard()).toThrow(expect.objectContaining<Partial<WalletExecutionContextChangedError>>({
       name: 'WalletExecutionContextChangedError',
       kind: 'chain',
     }))

--- a/tests/utils/walletExecutionContext.test.ts
+++ b/tests/utils/walletExecutionContext.test.ts
@@ -42,19 +42,27 @@ describe('assertWalletExecutionContext', () => {
 })
 
 describe('createSafeBundleBroadcastGuard', () => {
-  // Mutable wallet state standing in for the reactive refs the pages read;
-  // the guard is created at confirmation and invoked after the flow's
-  // authorization/planning/preparation/simulation awaits.
+  const REVIEWED_CONNECTOR_KEY = 'safe:uid-1'
+  const WALLET_CHANGED = 'Wallet changed since review — please review the migration again.'
+
+  // Mutable wallet state standing in for the reactive refs the pages read.
+  // The reviewed connector key is captured when the preview is built; the
+  // guard is constructed inside the confirmation flow — after awaits the
+  // wallet can change under — and invoked at the broadcast boundary.
   const walletState = () => ({
     account: OWNER as Address | undefined,
     chainId: 1 as number | undefined,
     safeWallet: true,
-    connectorKey: 'safe:uid-1' as string | undefined,
+    connectorKey: REVIEWED_CONNECTOR_KEY as string | undefined,
   })
 
-  const guardFor = (state: ReturnType<typeof walletState>) => createSafeBundleBroadcastGuard({
+  const guardFor = (
+    state: ReturnType<typeof walletState>,
+    expectedConnectorKey: string | undefined = REVIEWED_CONNECTOR_KEY,
+  ) => createSafeBundleBroadcastGuard({
     expectedAccount: OWNER,
     expectedChainId: 1,
+    expectedConnectorKey,
     currentAccount: () => state.account,
     currentChainId: () => state.chainId,
     isSafeWallet: () => state.safeWallet,
@@ -67,27 +75,45 @@ describe('createSafeBundleBroadcastGuard', () => {
     expect(() => guard()).not.toThrow()
   })
 
+  it('rejects a connector switch completed before guard construction (delayed authorization lookup)', () => {
+    const state = walletState()
+    // The switch lands while confirmation awaits pending restoration or the
+    // fresh authorization lookup — BEFORE the guard exists. Because the
+    // expected key comes from the reviewed preview, the replacement connector
+    // can never become the guard's accepted baseline.
+    state.connectorKey = 'safe:uid-2'
+    const guard = guardFor(state)
+    expect(() => guard()).toThrow(WALLET_CHANGED)
+  })
+
   it('rejects a same-account connector switch during delayed preparation', () => {
     const state = walletState()
     const guard = guardFor(state)
     // Same owner, same chain, still classified as a Safe — only the connector
     // submitting the proposal changed while preparation was in flight.
     state.connectorKey = 'safe:uid-2'
-    expect(() => guard()).toThrow('Wallet changed since review — please review the migration again.')
+    expect(() => guard()).toThrow(WALLET_CHANGED)
   })
 
   it('rejects a wallet that lost its Safe classification during the awaits', () => {
     const state = walletState()
     const guard = guardFor(state)
     state.safeWallet = false
-    expect(() => guard()).toThrow('Wallet changed since review — please review the migration again.')
+    expect(() => guard()).toThrow(WALLET_CHANGED)
   })
 
   it('rejects a disconnected connector during delayed preparation', () => {
     const state = walletState()
     const guard = guardFor(state)
     state.connectorKey = undefined
-    expect(() => guard()).toThrow('Wallet changed since review — please review the migration again.')
+    expect(() => guard()).toThrow(WALLET_CHANGED)
+  })
+
+  it('fails closed when the review captured no connector key', () => {
+    const state = walletState()
+    state.connectorKey = undefined
+    const guard = guardFor(state, undefined)
+    expect(() => guard()).toThrow(WALLET_CHANGED)
   })
 
   it('still rejects account and chain drift through the wallet context assertion', () => {

--- a/utils/batchReviewCalldata.ts
+++ b/utils/batchReviewCalldata.ts
@@ -1,0 +1,41 @@
+import type { TransactionPlan } from '@eulerxyz/euler-v2-sdk'
+import type { BatchEntryExternalTx } from '~/composables/useTxBatch'
+import { transactionPlanToCalls, type PlanEncodingSdk } from '~/utils/transaction-plan-calls'
+
+export interface BatchReviewCalldataEntry {
+  to: string
+  data: string
+  value: string
+}
+
+interface BuildBatchReviewCalldataOptions {
+  plan: TransactionPlan
+  before?: readonly BatchEntryExternalTx[]
+  after?: readonly BatchEntryExternalTx[]
+  sdk: PlanEncodingSdk
+  chainId: number
+}
+
+const plainCallToCalldata = (call: BatchEntryExternalTx): BatchReviewCalldataEntry => ({
+  to: call.to,
+  data: call.data,
+  value: (call.value ?? 0n).toString(),
+})
+
+/** Build the exact ordered call vector shown by Copy calldata. */
+export const buildBatchReviewCalldata = ({
+  plan,
+  before = [],
+  after = [],
+  sdk,
+  chainId,
+}: BuildBatchReviewCalldataOptions): BatchReviewCalldataEntry[] => {
+  const out = before.map(plainCallToCalldata)
+  out.push(...transactionPlanToCalls(plan, sdk, chainId).map(call => ({
+    to: call.to,
+    data: call.data,
+    value: call.value.toString(),
+  })))
+  out.push(...after.map(plainCallToCalldata))
+  return out
+}

--- a/utils/batchReviewDisplay.ts
+++ b/utils/batchReviewDisplay.ts
@@ -1,4 +1,5 @@
 import type { DisplayStep } from '~/utils/stepDecoding'
+import type { TransactionPlan } from '@eulerxyz/euler-v2-sdk'
 
 export interface AuthorizationStepsDisplay {
   detailHeading: 'Authorization transactions' | 'Signatures'
@@ -10,6 +11,13 @@ export const isBundledReviewEntry = (
   hasLatchedBundledExecution: boolean,
   hasBundledExecutionBuilder: boolean,
 ): boolean => hasLatchedBundledExecution && hasBundledExecutionBuilder
+
+/** Prefer the fresh per-entry plan owned by the Safe review ceremony. */
+export const getBatchReviewDisplayPlan = (
+  ceremonyPlan: TransactionPlan | undefined,
+  capturedDisplayPlan: TransactionPlan | undefined,
+  entryPlan: TransactionPlan | undefined,
+): TransactionPlan | undefined => ceremonyPlan ?? capturedDisplayPlan ?? entryPlan
 
 export const groupRestorationSummaryRows = <TRow extends { step: Pick<DisplayStep, 'isSeparateTx'> }>(
   rows: readonly TRow[],

--- a/utils/batchReviewDisplay.ts
+++ b/utils/batchReviewDisplay.ts
@@ -41,24 +41,3 @@ export const getAuthorizationStepDisplay = (
         itemCountLabel: '1 signature',
       }
 }
-
-type RestorationSummaryRow = {
-  step: Pick<DisplayStep, 'isSeparateTx' | 'txKey'>
-}
-
-/**
- * Standalone prerequisites resolve sequentially, so a repeated restoration
- * transaction is sent only once. Bundled Safe calls are already resolved and
- * every collected call remains in the proposal, so every row stays visible.
- */
-export const consolidateRestorationSummaryRows = <TRow extends RestorationSummaryRow>(
-  rows: readonly TRow[],
-): TRow[] => {
-  const seenStandaloneTransactions = new Set<string>()
-  return rows.filter(({ step }) => {
-    if (!step.isSeparateTx || !step.txKey) return true
-    if (seenStandaloneTransactions.has(step.txKey)) return false
-    seenStandaloneTransactions.add(step.txKey)
-    return true
-  })
-}

--- a/utils/directSubmissionQuarantine.ts
+++ b/utils/directSubmissionQuarantine.ts
@@ -13,6 +13,9 @@ import {
 export const PENDING_SUBMISSION_UNRESOLVED_ERROR
   = 'A previous migration submission may still confirm on-chain and could not be verified yet. Wait a moment and try again — it is re-checked before anything is re-sent.'
 
+export const PENDING_SUBMISSION_ARMED_ERROR
+  = 'A previous attempt handed a submission to the wallet but no transaction id came back, so it cannot be verified automatically. Check the wallet\'s pending activity and let it resolve before trying again.'
+
 /**
  * 'clear'          — no unresolved submission for this wallet/chain; proceed.
  * 'landed'         — a quarantined submission confirmed on-chain. It may be
@@ -24,14 +27,24 @@ export const PENDING_SUBMISSION_UNRESOLVED_ERROR
  */
 export type DirectQuarantineVerdict = 'clear' | 'landed' | 'landed-partial'
 
+const isValueMoving = (broadcast: PreparedPlanBroadcast) =>
+  broadcast.item === 'bundle' || broadcast.item === 'evcBatch'
+
 /**
- * Replay protection for the direct (non-cart) migration flows. Once a wallet
- * accepts a value-moving submission (an EOA transaction or a Safe proposal),
- * a receipt or Safe-status failure no longer means "nothing happened" — the
- * submission can still confirm later. `sealFailure` retains its hash/proposal
- * id durably, keyed by wallet and chain, and `reconcileBeforeAttempt`
- * resolves that record on-chain before the next attempt is allowed to send
- * anything: an unresolved outcome throws and blocks the retry.
+ * Replay protection for the direct (non-cart) migration flows. The record is
+ * persisted at the wallet boundary, not after the failure:
+ *
+ * - 'armed' is written before the wallet is invoked for a value-moving send —
+ *   the wallet may accept the request and then fail to return its id, and a
+ *   reload in that window must still find the quarantine.
+ * - the record upgrades to 'submitted' the moment an id exists, and is
+ *   released only on a terminal signal: the receipt confirmed, or the wallet
+ *   definitively rejected the request before dispatching it.
+ *
+ * `reconcileBeforeAttempt` resolves the durable record on-chain before the
+ * next attempt is allowed to send anything: an unresolved outcome throws and
+ * blocks the retry. `sealFailure` merely reports whether the failed attempt
+ * left a quarantined submission behind — persistence already happened.
  */
 export const createDirectSubmissionQuarantine = (options: {
   flow: PendingSubmissionFlow
@@ -40,7 +53,8 @@ export const createDirectSubmissionQuarantine = (options: {
 }) => {
   let attempt: { owner: Address, chainId: number } | undefined
   // The executor re-fires each broadcast as 'confirmed' once its receipt
-  // landed, so at most the single latest 'submitted' broadcast is ambiguous.
+  // landed (and as 'rejected' when the wallet provably never accepted it),
+  // so at most the single latest armed/submitted broadcast is ambiguous.
   let unconfirmed: PreparedPlanBroadcast | undefined
 
   const reconcileBeforeAttempt = async (input: {
@@ -49,13 +63,10 @@ export const createDirectSubmissionQuarantine = (options: {
     provider: ReceiptClientLike | undefined
     connector?: WalletConnectorLike
   }): Promise<DirectQuarantineVerdict> => {
-    const record = readPendingSubmission(options.flow)
+    // Records are keyed by wallet and chain — a different wallet's record is
+    // invisible here and stays quarantined for the wallet that owns it.
+    const record = readPendingSubmission(options.flow, input.owner, input.chainId)
     if (!record) return 'clear'
-    if (record.owner !== getAddress(input.owner) || record.chainId !== input.chainId) {
-      // A different wallet/chain owns the record — nothing this attempt sends
-      // can duplicate it. The record stays for the wallet that owns it.
-      return 'clear'
-    }
     const outcome = await resolvePendingSubmissionOutcome(record, {
       provider: input.provider,
       getSafeWalletProvider: options.getSafeWalletProvider,
@@ -63,9 +74,9 @@ export const createDirectSubmissionQuarantine = (options: {
       safeStatusTimeoutMs: options.safeStatusTimeoutMs ?? 8_000,
     })
     if (outcome === 'unknown') {
-      throw new Error(PENDING_SUBMISSION_UNRESOLVED_ERROR)
+      throw new Error(record.phase === 'armed' ? PENDING_SUBMISSION_ARMED_ERROR : PENDING_SUBMISSION_UNRESOLVED_ERROR)
     }
-    clearPendingSubmission(options.flow)
+    clearPendingSubmission(options.flow, record.owner, record.chainId)
     if (outcome === 'not-landed') return 'clear'
     return record.completesPlan ? 'landed' : 'landed-partial'
   }
@@ -76,29 +87,44 @@ export const createDirectSubmissionQuarantine = (options: {
     unconfirmed = undefined
   }
 
-  /** onBroadcast sink for executePreparedPlan / …WithPlainCalls. */
+  /**
+   * onBroadcast sink for executePreparedPlan / …WithPlainCalls. Persists the
+   * quarantine synchronously at the wallet boundary; only value-moving items
+   * (the Safe bundle or the EVC batch) quarantine — ambiguous approvals and
+   * plugin prerequisites are idempotent and safe to re-run.
+   */
   const track = (broadcast: PreparedPlanBroadcast) => {
-    unconfirmed = broadcast.status === 'submitted' ? broadcast : undefined
+    if (broadcast.status === 'armed' || broadcast.status === 'submitted') {
+      unconfirmed = broadcast
+      if (attempt && isValueMoving(broadcast)) {
+        writePendingSubmission(options.flow, {
+          ...(broadcast.status === 'armed'
+            ? { phase: 'armed' as const }
+            : { phase: 'submitted' as const, kind: broadcast.kind, hash: broadcast.hash }),
+          chainId: attempt.chainId,
+          owner: attempt.owner,
+          completesPlan: broadcast.completesPlan,
+          submittedAt: Date.now(),
+        })
+      }
+      return
+    }
+    // 'rejected' (the wallet provably never accepted the armed request) and
+    // 'confirmed' (the receipt landed) are both terminal for the record.
+    if (attempt && isValueMoving(broadcast)) {
+      clearPendingSubmission(options.flow, attempt.owner, attempt.chainId)
+    }
+    unconfirmed = undefined
   }
 
   /**
-   * Persist the ambiguous submission after a failed attempt. Returns true
-   * when something was quarantined — only a value-moving submission (the
-   * Safe bundle or the EVC batch) qualifies; ambiguous approvals and plugin
-   * prerequisites are idempotent and safe to re-run.
+   * Report whether the failed attempt left a quarantined submission behind.
+   * The durable record was already written when the broadcast fired — this
+   * only tells the caller which error message applies.
    */
   const sealFailure = (): boolean => {
     if (!attempt || !unconfirmed) return false
-    if (unconfirmed.item !== 'bundle' && unconfirmed.item !== 'evcBatch') return false
-    writePendingSubmission(options.flow, {
-      kind: unconfirmed.kind,
-      hash: unconfirmed.hash,
-      chainId: attempt.chainId,
-      owner: attempt.owner,
-      completesPlan: unconfirmed.completesPlan,
-      submittedAt: Date.now(),
-    })
-    return true
+    return isValueMoving(unconfirmed)
   }
 
   return { reconcileBeforeAttempt, begin, track, sealFailure }

--- a/utils/directSubmissionQuarantine.ts
+++ b/utils/directSubmissionQuarantine.ts
@@ -1,0 +1,105 @@
+import type { Address } from 'viem'
+import { getAddress } from 'viem'
+import type { PreparedPlanBroadcast } from '~/composables/useEulerTx'
+import type { ReceiptClientLike, WalletConnectorLike, WalletProviderLike } from '~/utils/safeWalletTransactions'
+import {
+  clearPendingSubmission,
+  readPendingSubmission,
+  resolvePendingSubmissionOutcome,
+  writePendingSubmission,
+  type PendingSubmissionFlow,
+} from '~/utils/pendingSubmissions'
+
+export const PENDING_SUBMISSION_UNRESOLVED_ERROR
+  = 'A previous migration submission may still confirm on-chain and could not be verified yet. Wait a moment and try again — it is re-checked before anything is re-sent.'
+
+/**
+ * 'clear'          — no unresolved submission for this wallet/chain; proceed.
+ * 'landed'         — a quarantined submission confirmed on-chain. It may be
+ *                    this migration or an earlier one for the same wallet, so
+ *                    the caller must refresh and force a fresh review, never
+ *                    finalize the current attempt on it.
+ * 'landed-partial' — it confirmed but was not the plan's final value-moving
+ *                    item; the remainder needs a fresh review.
+ */
+export type DirectQuarantineVerdict = 'clear' | 'landed' | 'landed-partial'
+
+/**
+ * Replay protection for the direct (non-cart) migration flows. Once a wallet
+ * accepts a value-moving submission (an EOA transaction or a Safe proposal),
+ * a receipt or Safe-status failure no longer means "nothing happened" — the
+ * submission can still confirm later. `sealFailure` retains its hash/proposal
+ * id durably, keyed by wallet and chain, and `reconcileBeforeAttempt`
+ * resolves that record on-chain before the next attempt is allowed to send
+ * anything: an unresolved outcome throws and blocks the retry.
+ */
+export const createDirectSubmissionQuarantine = (options: {
+  flow: PendingSubmissionFlow
+  getSafeWalletProvider: (connector?: WalletConnectorLike) => Promise<WalletProviderLike | undefined>
+  safeStatusTimeoutMs?: number
+}) => {
+  let attempt: { owner: Address, chainId: number } | undefined
+  // The executor re-fires each broadcast as 'confirmed' once its receipt
+  // landed, so at most the single latest 'submitted' broadcast is ambiguous.
+  let unconfirmed: PreparedPlanBroadcast | undefined
+
+  const reconcileBeforeAttempt = async (input: {
+    owner: Address
+    chainId: number
+    provider: ReceiptClientLike | undefined
+    connector?: WalletConnectorLike
+  }): Promise<DirectQuarantineVerdict> => {
+    const record = readPendingSubmission(options.flow)
+    if (!record) return 'clear'
+    if (record.owner !== getAddress(input.owner) || record.chainId !== input.chainId) {
+      // A different wallet/chain owns the record — nothing this attempt sends
+      // can duplicate it. The record stays for the wallet that owns it.
+      return 'clear'
+    }
+    const outcome = await resolvePendingSubmissionOutcome(record, {
+      provider: input.provider,
+      getSafeWalletProvider: options.getSafeWalletProvider,
+      connector: input.connector,
+      safeStatusTimeoutMs: options.safeStatusTimeoutMs ?? 8_000,
+    })
+    if (outcome === 'unknown') {
+      throw new Error(PENDING_SUBMISSION_UNRESOLVED_ERROR)
+    }
+    clearPendingSubmission(options.flow)
+    if (outcome === 'not-landed') return 'clear'
+    return record.completesPlan ? 'landed' : 'landed-partial'
+  }
+
+  /** Arm tracking for one attempt. Must run before any wallet action. */
+  const begin = (input: { owner: Address, chainId: number }) => {
+    attempt = { owner: getAddress(input.owner), chainId: input.chainId }
+    unconfirmed = undefined
+  }
+
+  /** onBroadcast sink for executePreparedPlan / …WithPlainCalls. */
+  const track = (broadcast: PreparedPlanBroadcast) => {
+    unconfirmed = broadcast.status === 'submitted' ? broadcast : undefined
+  }
+
+  /**
+   * Persist the ambiguous submission after a failed attempt. Returns true
+   * when something was quarantined — only a value-moving submission (the
+   * Safe bundle or the EVC batch) qualifies; ambiguous approvals and plugin
+   * prerequisites are idempotent and safe to re-run.
+   */
+  const sealFailure = (): boolean => {
+    if (!attempt || !unconfirmed) return false
+    if (unconfirmed.item !== 'bundle' && unconfirmed.item !== 'evcBatch') return false
+    writePendingSubmission(options.flow, {
+      kind: unconfirmed.kind,
+      hash: unconfirmed.hash,
+      chainId: attempt.chainId,
+      owner: attempt.owner,
+      completesPlan: unconfirmed.completesPlan,
+      submittedAt: Date.now(),
+    })
+    return true
+  }
+
+  return { reconcileBeforeAttempt, begin, track, sealFailure }
+}

--- a/utils/directSubmissionQuarantine.ts
+++ b/utils/directSubmissionQuarantine.ts
@@ -3,10 +3,14 @@ import { getAddress } from 'viem'
 import type { PreparedPlanBroadcast } from '~/composables/useEulerTx'
 import type { ReceiptClientLike, WalletConnectorLike, WalletProviderLike } from '~/utils/safeWalletTransactions'
 import {
+  armPendingSubmission,
   clearPendingSubmission,
+  createPendingSubmissionAttemptId,
   readPendingSubmission,
+  releasePendingSubmission,
+  releaseUnverifiablePendingSubmission,
   resolvePendingSubmissionOutcome,
-  writePendingSubmission,
+  upgradePendingSubmissionToSubmitted,
   type PendingSubmissionFlow,
 } from '~/utils/pendingSubmissions'
 
@@ -31,27 +35,34 @@ const isValueMoving = (broadcast: PreparedPlanBroadcast) =>
   broadcast.item === 'bundle' || broadcast.item === 'evcBatch'
 
 /**
- * Replay protection for the direct (non-cart) migration flows. The record is
- * persisted at the wallet boundary, not after the failure:
+ * Replay protection for value-moving plan execution outside the batch cart
+ * (the direct forms and both migration pages). The record is persisted at the
+ * wallet boundary, not after the failure:
  *
- * - 'armed' is written before the wallet is invoked for a value-moving send —
- *   the wallet may accept the request and then fail to return its id, and a
- *   reload in that window must still find the quarantine.
- * - the record upgrades to 'submitted' the moment an id exists, and is
- *   released only on a terminal signal: the receipt confirmed, or the wallet
- *   definitively rejected the request before dispatching it.
+ * - 'armed' is reserved atomically (check + reserve under the per-wallet
+ *   lock, with this attempt's id) before the wallet is invoked for a
+ *   value-moving send — the wallet may accept the request and then fail to
+ *   return its id, and a reload in that window must still find the
+ *   quarantine. A reservation another attempt holds, or one that cannot be
+ *   proven durable, throws here and the wallet is never invoked.
+ * - the record upgrades to 'submitted' the moment an id exists
+ *   (ownership-checked), and is released only on a terminal signal: the
+ *   receipt confirmed, or the wallet definitively rejected the request.
  *
  * `reconcileBeforeAttempt` resolves the durable record on-chain before the
  * next attempt is allowed to send anything: an unresolved outcome throws and
  * blocks the retry. `sealFailure` merely reports whether the failed attempt
  * left a quarantined submission behind — persistence already happened.
+ * `releaseArmedAfterManualCheck` is the risk-labelled recovery for an armed
+ * record orphaned by a reload: it releases only after the user confirmed the
+ * wallet itself shows nothing pending, and refuses submitted records.
  */
 export const createDirectSubmissionQuarantine = (options: {
   flow: PendingSubmissionFlow
   getSafeWalletProvider: (connector?: WalletConnectorLike) => Promise<WalletProviderLike | undefined>
   safeStatusTimeoutMs?: number
 }) => {
-  let attempt: { owner: Address, chainId: number } | undefined
+  let attempt: { owner: Address, chainId: number, attemptId: string } | undefined
   // The executor re-fires each broadcast as 'confirmed' once its receipt
   // landed (and as 'rejected' when the wallet provably never accepted it),
   // so at most the single latest armed/submitted broadcast is ambiguous.
@@ -65,6 +76,7 @@ export const createDirectSubmissionQuarantine = (options: {
   }): Promise<DirectQuarantineVerdict> => {
     // Records are keyed by wallet and chain — a different wallet's record is
     // invisible here and stays quarantined for the wallet that owns it.
+    // An unreadable/corrupt record throws out of the read: fail closed.
     const record = readPendingSubmission(options.flow, input.owner, input.chainId)
     if (!record) return 'clear'
     const outcome = await resolvePendingSubmissionOutcome(record, {
@@ -76,43 +88,68 @@ export const createDirectSubmissionQuarantine = (options: {
     if (outcome === 'unknown') {
       throw new Error(record.phase === 'armed' ? PENDING_SUBMISSION_ARMED_ERROR : PENDING_SUBMISSION_UNRESOLVED_ERROR)
     }
-    clearPendingSubmission(options.flow, record.owner, record.chainId)
+    // Compare-and-delete: only the exact reconciled record is released — a
+    // record another attempt reserved during the on-chain check survives.
+    await clearPendingSubmission(options.flow, record.owner, record.chainId, { ifMatches: record })
     if (outcome === 'not-landed') return 'clear'
     return record.completesPlan ? 'landed' : 'landed-partial'
   }
 
   /** Arm tracking for one attempt. Must run before any wallet action. */
   const begin = (input: { owner: Address, chainId: number }) => {
-    attempt = { owner: getAddress(input.owner), chainId: input.chainId }
+    attempt = {
+      owner: getAddress(input.owner),
+      chainId: input.chainId,
+      attemptId: createPendingSubmissionAttemptId(),
+    }
     unconfirmed = undefined
   }
 
   /**
-   * onBroadcast sink for executePreparedPlan / …WithPlainCalls. Persists the
-   * quarantine synchronously at the wallet boundary; only value-moving items
-   * (the Safe bundle or the EVC batch) quarantine — ambiguous approvals and
-   * plugin prerequisites are idempotent and safe to re-run.
+   * onBroadcast sink for the plan executors. Persists the quarantine at the
+   * wallet boundary (the executor awaits the armed emission before invoking
+   * the wallet); only value-moving items (the Safe bundle or the EVC batch)
+   * quarantine — ambiguous approvals and plugin prerequisites are idempotent
+   * and safe to re-run. All record mutations are ownership-checked with this
+   * attempt's id, so a stale completion can never release or overwrite a
+   * reservation a newer attempt holds.
    */
-  const track = (broadcast: PreparedPlanBroadcast) => {
+  const track = async (broadcast: PreparedPlanBroadcast): Promise<void> => {
     if (broadcast.status === 'armed' || broadcast.status === 'submitted') {
-      unconfirmed = broadcast
+      // A submitted broadcast is ambiguous no matter what happens below — the
+      // wallet already returned an id. An armed one becomes ambiguous only
+      // once the reservation succeeded: a throw here aborts the attempt
+      // before the wallet is invoked, so nothing is outstanding.
+      if (broadcast.status === 'submitted') unconfirmed = broadcast
       if (attempt && isValueMoving(broadcast)) {
-        writePendingSubmission(options.flow, {
-          ...(broadcast.status === 'armed'
-            ? { phase: 'armed' as const }
-            : { phase: 'submitted' as const, kind: broadcast.kind, hash: broadcast.hash }),
-          chainId: attempt.chainId,
-          owner: attempt.owner,
-          completesPlan: broadcast.completesPlan,
-          submittedAt: Date.now(),
-        })
+        if (broadcast.status === 'armed') {
+          await armPendingSubmission(options.flow, {
+            owner: attempt.owner,
+            chainId: attempt.chainId,
+            completesPlan: broadcast.completesPlan,
+            attemptId: attempt.attemptId,
+          })
+        }
+        else {
+          await upgradePendingSubmissionToSubmitted(options.flow, {
+            owner: attempt.owner,
+            chainId: attempt.chainId,
+            attemptId: attempt.attemptId,
+            kind: broadcast.kind,
+            hash: broadcast.hash,
+            completesPlan: broadcast.completesPlan,
+          })
+        }
       }
+      if (broadcast.status === 'armed') unconfirmed = broadcast
       return
     }
     // 'rejected' (the wallet provably never accepted the armed request) and
     // 'confirmed' (the receipt landed) are both terminal for the record.
     if (attempt && isValueMoving(broadcast)) {
-      clearPendingSubmission(options.flow, attempt.owner, attempt.chainId)
+      await releasePendingSubmission(options.flow, attempt.owner, attempt.chainId, {
+        attemptId: attempt.attemptId,
+      })
     }
     unconfirmed = undefined
   }
@@ -127,5 +164,17 @@ export const createDirectSubmissionQuarantine = (options: {
     return isValueMoving(unconfirmed)
   }
 
-  return { reconcileBeforeAttempt, begin, track, sealFailure }
+  /**
+   * Risk-labelled manual recovery: release an armed (or corrupt) record that
+   * can never resolve on its own because the attempt that armed it is gone.
+   * Callers must only invoke this after the user explicitly confirmed the
+   * wallet shows no pending request. Submitted records are refused — they
+   * carry an id and are verified on-chain instead.
+   */
+  const releaseArmedAfterManualCheck = (input: { owner: Address, chainId: number }) =>
+    releaseUnverifiablePendingSubmission(options.flow, input.owner, input.chainId, {
+      userConfirmedWalletShowsNoPendingSubmission: true,
+    })
+
+  return { reconcileBeforeAttempt, begin, track, sealFailure, releaseArmedAfterManualCheck }
 }

--- a/utils/directSubmissionQuarantine.ts
+++ b/utils/directSubmissionQuarantine.ts
@@ -7,9 +7,11 @@ import {
   clearPendingSubmission,
   createPendingSubmissionAttemptId,
   readPendingSubmission,
+  registerActiveSubmissionAttempt,
   releasePendingSubmission,
   releaseUnverifiablePendingSubmission,
   resolvePendingSubmissionOutcome,
+  unregisterActiveSubmissionAttempt,
   upgradePendingSubmissionToSubmitted,
   type PendingSubmissionFlow,
 } from '~/utils/pendingSubmissions'
@@ -95,14 +97,31 @@ export const createDirectSubmissionQuarantine = (options: {
     return record.completesPlan ? 'landed' : 'landed-partial'
   }
 
-  /** Arm tracking for one attempt. Must run before any wallet action. */
+  /**
+   * Arm tracking for one attempt. Must run before any wallet action. The
+   * attempt id registers as live so the recovery UI never offers this
+   * attempt's own armed record for dismissal while it is still running —
+   * callers must pair every begin with `end()` in a finally.
+   */
   const begin = (input: { owner: Address, chainId: number }) => {
+    if (attempt) unregisterActiveSubmissionAttempt(attempt.attemptId)
     attempt = {
       owner: getAddress(input.owner),
       chainId: input.chainId,
       attemptId: createPendingSubmissionAttemptId(),
     }
+    registerActiveSubmissionAttempt(attempt.attemptId)
     unconfirmed = undefined
+  }
+
+  /**
+   * The attempt is over (success or failure): whatever record it left behind
+   * is now orphaned from any live execution, so the recovery UI may list it
+   * if it is armed with no observed id. Idempotent; keeps `attempt` so a
+   * late `sealFailure` still reports correctly.
+   */
+  const end = () => {
+    if (attempt) unregisterActiveSubmissionAttempt(attempt.attemptId)
   }
 
   /**
@@ -176,5 +195,5 @@ export const createDirectSubmissionQuarantine = (options: {
       userConfirmedWalletShowsNoPendingSubmission: true,
     })
 
-  return { reconcileBeforeAttempt, begin, track, sealFailure, releaseArmedAfterManualCheck }
+  return { reconcileBeforeAttempt, begin, end, track, sealFailure, releaseArmedAfterManualCheck }
 }

--- a/utils/migrationAuthorizationSignatures.ts
+++ b/utils/migrationAuthorizationSignatures.ts
@@ -1,0 +1,18 @@
+import type { Hex } from 'viem'
+import type { SignedMigrationAuthorization } from '@eulerxyz/euler-v2-sdk'
+import type { PreparedPlanSignatureSubstitution } from '~/utils/preparedPlanParity'
+
+export const PLACEHOLDER_MIGRATION_AUTHORIZATION_SIGNATURE = `0x${'00'.repeat(65)}` as Hex
+
+export const getMigrationAuthorizationSignatureSubstitutions = (
+  authorization: SignedMigrationAuthorization | undefined,
+): PreparedPlanSignatureSubstitution[] => {
+  if (!authorization) return []
+  return [
+    {
+      placeholder: PLACEHOLDER_MIGRATION_AUTHORIZATION_SIGNATURE,
+      signature: authorization.signature,
+    },
+    ...getMigrationAuthorizationSignatureSubstitutions(authorization.postMigrationAuthorization),
+  ]
+}

--- a/utils/migrationCeremonyDeadline.ts
+++ b/utils/migrationCeremonyDeadline.ts
@@ -1,0 +1,49 @@
+/**
+ * Deadline pinning for migration ceremonies.
+ *
+ * SDK migration connectors mint a fresh wall-clock verifier deadline on every
+ * plan build unless one is supplied. Every flow that builds a plan twice and
+ * requires the two builds to describe the same ceremony — review preview vs
+ * confirm-time execution, placeholder-signed preview vs signature-resolved
+ * rebuild — must therefore pin one deadline across both builds: the deadline
+ * is embedded in verifier calldata and in the EIP-712 authorization payload,
+ * so a re-minted value fails the plan-parity and payload-equality gates.
+ */
+
+const MIGRATION_CEREMONY_DEADLINE_TTL_SECONDS = 60 * 60
+
+/** A fresh wall-clock deadline for a ceremony no swap quote constrains. */
+export const mintMigrationCeremonyDeadline = (): bigint =>
+  BigInt(Math.floor(Date.now() / 1000) + MIGRATION_CEREMONY_DEADLINE_TTL_SECONDS)
+
+/** True once a pinned deadline can no longer be executed on-chain. */
+export const isMigrationCeremonyDeadlineExpired = (deadline: bigint): boolean =>
+  deadline <= BigInt(Math.floor(Date.now() / 1000))
+
+type SwapQuoteVerifyLike = {
+  verify: {
+    deadline?: number
+  }
+}
+
+export type InboundMigrationCeremonyQuotes = {
+  collateralSwapQuote?: SwapQuoteVerifyLike
+  debtSwapQuote?: SwapQuoteVerifyLike
+}
+
+/**
+ * The deadline an inbound (external-to-Euler) ceremony must pin.
+ *
+ * When a collateral swap quote is present, the SDK validates the supplied
+ * deadline for exact equality against the deadline embedded in the quote's
+ * immutable verifier data — any other value (earlier ones included) throws
+ * "SwapVerifier data mismatch" at planning. So the pin must BE that quote's
+ * deadline, mirroring the connectors' own `deadline ?? quote.verify.deadline`
+ * fallback. The debt swap quote keeps its own embedded expiry and never
+ * constrains the supplied deadline. Only when no collateral quote governs the
+ * verifier is a minted deadline valid.
+ */
+export const pinInboundMigrationCeremonyDeadline = (quotes: InboundMigrationCeremonyQuotes): bigint =>
+  quotes.collateralSwapQuote
+    ? BigInt(quotes.collateralSwapQuote.verify.deadline ?? 0)
+    : mintMigrationCeremonyDeadline()

--- a/utils/pendingSubmissionGate.ts
+++ b/utils/pendingSubmissionGate.ts
@@ -38,9 +38,18 @@ export const registerLandedBatchSubmissionHandler = (handler: LandedBatchSubmiss
   landedBatchSubmissionHandler = handler
 }
 
+const flowLabel = (flow: PendingSubmissionFlow) =>
+  flow === 'batch'
+    ? 'batch'
+    : flow === 'direct'
+      ? 'transaction'
+      : flow === 'cow-order'
+        ? 'CoW Swap order'
+        : 'migration'
+
 const conflictingSubmissionError = (flow: PendingSubmissionFlow, record: PendingSubmissionRecord) => {
-  const label = flow === 'batch' ? 'batch' : flow === 'direct' ? 'transaction' : 'migration'
-  if (record.phase === 'armed') {
+  const label = flowLabel(flow)
+  if (record.phase === 'armed' && !record.observedId) {
     return new Error(`A previous ${label} submission was handed to the wallet but no transaction id came back, so it cannot be verified automatically. Check the wallet's pending activity and let it resolve before sending new transactions.`)
   }
   return new Error(`A previous ${label} submission from this wallet may still confirm on-chain and could not be verified yet. Wait a moment and try again — it is re-checked before anything new is sent.`)
@@ -83,6 +92,10 @@ export const assertNoConflictingPendingSubmission = async (input: {
       // No cart is alive to retire the covered entries — keep the record so
       // the cart reconciles it when it next runs.
       throw new Error('A previous batch submission confirmed on-chain. Open the batch cart to reconcile it before sending new transactions.')
+    }
+    if (flow === 'cow-order') {
+      await clearPendingSubmission(flow, record.owner, record.chainId, { ifMatches: record })
+      throw new Error('A previous CoW Swap order from this wallet was executed. Review your positions before continuing — on-chain state changed since this action was prepared.')
     }
     await clearPendingSubmission(flow, record.owner, record.chainId, { ifMatches: record })
     throw new Error(`A previous ${flow === 'direct' ? 'transaction' : 'migration'} submission from this wallet confirmed on-chain. Review your positions before continuing — on-chain state changed since this action was prepared.`)

--- a/utils/pendingSubmissionGate.ts
+++ b/utils/pendingSubmissionGate.ts
@@ -1,0 +1,89 @@
+import type { Address } from 'viem'
+import { getAddress } from 'viem'
+import type { ReceiptClientLike, WalletConnectorLike, WalletProviderLike } from '~/utils/safeWalletTransactions'
+import {
+  PENDING_SUBMISSION_FLOWS,
+  clearPendingSubmission,
+  readPendingSubmission,
+  resolvePendingSubmissionOutcome,
+  type PendingSubmissionFlow,
+  type PendingSubmissionRecord,
+} from '~/utils/pendingSubmissions'
+
+/**
+ * Cross-surface enforcement of the pending-submission quarantine.
+ *
+ * Each flow (batch cart, outgoing migration, inbound migration) reconciles
+ * its own durable record before retrying itself — but an ambiguous
+ * submission must also block the *equivalent operation executed through a
+ * different surface*: clearing an ambiguously-submitted batch and re-running
+ * the borrow through the direct form, or re-adding a quarantined direct
+ * migration to the cart. This gate runs inside every plan executor, before
+ * anything reaches a wallet, and checks every flow's record for the
+ * attempting wallet and chain.
+ */
+
+/**
+ * The batch cart registers this so a landed batch record discovered from
+ * another surface can retire/reset the exact entries it tracks (the cart's
+ * own reconcile can never run for an emptied cart — executeBatch early-returns
+ * on zero entries). The handler must release the record, invalidate any
+ * standing review, and retire or reset the covered entries.
+ */
+export type LandedBatchSubmissionHandler = (record: PendingSubmissionRecord) => void
+
+let landedBatchSubmissionHandler: LandedBatchSubmissionHandler | undefined
+
+export const registerLandedBatchSubmissionHandler = (handler: LandedBatchSubmissionHandler) => {
+  landedBatchSubmissionHandler = handler
+}
+
+const conflictingSubmissionError = (flow: PendingSubmissionFlow, record: PendingSubmissionRecord) => {
+  const label = flow === 'batch' ? 'batch' : 'migration'
+  if (record.phase === 'armed') {
+    return new Error(`A previous ${label} submission was handed to the wallet but no transaction id came back, so it cannot be verified automatically. Check the wallet's pending activity and let it resolve before sending new transactions.`)
+  }
+  return new Error(`A previous ${label} submission from this wallet may still confirm on-chain and could not be verified yet. Wait a moment and try again — it is re-checked before anything new is sent.`)
+}
+
+export const assertNoConflictingPendingSubmission = async (input: {
+  owner: Address
+  chainId: number
+  provider: ReceiptClientLike | undefined
+  connector?: WalletConnectorLike
+  getSafeWalletProvider: (connector?: WalletConnectorLike) => Promise<WalletProviderLike | undefined>
+  safeStatusTimeoutMs?: number
+}): Promise<void> => {
+  const owner = getAddress(input.owner)
+  for (const flow of PENDING_SUBMISSION_FLOWS) {
+    const record = readPendingSubmission(flow, owner, input.chainId)
+    if (!record) continue
+    const outcome = await resolvePendingSubmissionOutcome(record, {
+      provider: input.provider,
+      getSafeWalletProvider: input.getSafeWalletProvider,
+      connector: input.connector,
+      safeStatusTimeoutMs: input.safeStatusTimeoutMs ?? 8_000,
+    })
+    if (outcome === 'not-landed') {
+      // Definitively cancelled/reverted — nothing this attempt sends can
+      // duplicate it.
+      clearPendingSubmission(flow, record.owner, record.chainId)
+      continue
+    }
+    if (outcome === 'unknown') {
+      throw conflictingSubmissionError(flow, record)
+    }
+    // Landed: on-chain state moved under whatever this attempt reviewed.
+    if (flow === 'batch') {
+      if (landedBatchSubmissionHandler) {
+        landedBatchSubmissionHandler(record)
+        throw new Error('A previous batch submission confirmed on-chain and the batch cart was reconciled. Review your positions before sending new transactions.')
+      }
+      // No cart is alive to retire the covered entries — keep the record so
+      // the cart reconciles it when it next runs.
+      throw new Error('A previous batch submission confirmed on-chain. Open the batch cart to reconcile it before sending new transactions.')
+    }
+    clearPendingSubmission(flow, record.owner, record.chainId)
+    throw new Error('A previous migration submission from this wallet confirmed on-chain. Review your positions before continuing — on-chain state changed since this action was prepared.')
+  }
+}

--- a/utils/pendingSubmissionGate.ts
+++ b/utils/pendingSubmissionGate.ts
@@ -39,7 +39,7 @@ export const registerLandedBatchSubmissionHandler = (handler: LandedBatchSubmiss
 }
 
 const conflictingSubmissionError = (flow: PendingSubmissionFlow, record: PendingSubmissionRecord) => {
-  const label = flow === 'batch' ? 'batch' : 'migration'
+  const label = flow === 'batch' ? 'batch' : flow === 'direct' ? 'transaction' : 'migration'
   if (record.phase === 'armed') {
     return new Error(`A previous ${label} submission was handed to the wallet but no transaction id came back, so it cannot be verified automatically. Check the wallet's pending activity and let it resolve before sending new transactions.`)
   }
@@ -66,8 +66,9 @@ export const assertNoConflictingPendingSubmission = async (input: {
     })
     if (outcome === 'not-landed') {
       // Definitively cancelled/reverted — nothing this attempt sends can
-      // duplicate it.
-      clearPendingSubmission(flow, record.owner, record.chainId)
+      // duplicate it. Compare-and-delete: only the exact reconciled record
+      // is released, never one another attempt reserved meanwhile.
+      await clearPendingSubmission(flow, record.owner, record.chainId, { ifMatches: record })
       continue
     }
     if (outcome === 'unknown') {
@@ -83,7 +84,7 @@ export const assertNoConflictingPendingSubmission = async (input: {
       // the cart reconciles it when it next runs.
       throw new Error('A previous batch submission confirmed on-chain. Open the batch cart to reconcile it before sending new transactions.')
     }
-    clearPendingSubmission(flow, record.owner, record.chainId)
-    throw new Error('A previous migration submission from this wallet confirmed on-chain. Review your positions before continuing — on-chain state changed since this action was prepared.')
+    await clearPendingSubmission(flow, record.owner, record.chainId, { ifMatches: record })
+    throw new Error(`A previous ${flow === 'direct' ? 'transaction' : 'migration'} submission from this wallet confirmed on-chain. Review your positions before continuing — on-chain state changed since this action was prepared.`)
   }
 }

--- a/utils/pendingSubmissions.ts
+++ b/utils/pendingSubmissions.ts
@@ -6,22 +6,33 @@ import { SafeTransactionStatusUnknownError, waitForSafeTransactionExecution } fr
 
 /**
  * Durable quarantine records for value-moving submissions whose outcome is
- * unknown: the wallet accepted the send (a transaction hash or Safe proposal
- * id exists) but no terminal receipt/status was observed before the attempt
- * failed. Such a submission can still confirm later, so re-running the flow
- * without first resolving it risks executing the migration twice.
+ * unknown. Two phases exist:
  *
- * Records persist in localStorage so they survive cart clearing, account
- * switches, and full page reloads; they are removed only once reconciliation
- * reaches a terminal verdict (landed or not landed).
+ * - 'armed': the wallet was invoked but no transaction hash / Safe proposal id
+ *   came back yet (or ever — the wallet may accept a request and then fail to
+ *   return its id). An armed record can never be verified on-chain, so it
+ *   resolves to 'unknown' until the same attempt upgrades it to 'submitted'
+ *   or the wallet definitively rejects the request.
+ * - 'submitted': the wallet accepted the send and returned an id, but no
+ *   terminal receipt/status was observed. The submission can still confirm
+ *   later, so re-running the flow without resolving it risks executing the
+ *   operation twice.
+ *
+ * Records are keyed by flow + chain + owner so one wallet's unresolved
+ * submission can never overwrite another's. They persist in localStorage so
+ * they survive cart clearing, account switches, and full page reloads — and
+ * when durable storage is unavailable or rejects the write, an in-memory
+ * fallback keeps the quarantine fail-closed for the rest of the session.
+ * Records are removed only once reconciliation reaches a terminal verdict
+ * (landed, not landed, or definitively rejected by the wallet).
  */
 
 export type PendingSubmissionFlow = 'batch' | 'outgoing-migration' | 'inbound-migration'
 
-export interface PendingSubmissionRecord {
-  /** 'transaction' = EOA send; 'proposal' = Safe proposal / bundle id. */
-  readonly kind: 'transaction' | 'proposal'
-  readonly hash: Hash
+export const PENDING_SUBMISSION_FLOWS: readonly PendingSubmissionFlow[]
+  = ['batch', 'outgoing-migration', 'inbound-migration']
+
+interface PendingSubmissionBase {
   readonly chainId: number
   readonly owner: Address
   /**
@@ -34,9 +45,30 @@ export interface PendingSubmissionRecord {
   readonly submittedAt: number
 }
 
+export interface ArmedPendingSubmission extends PendingSubmissionBase {
+  readonly phase: 'armed'
+  readonly kind?: undefined
+  readonly hash?: undefined
+}
+
+export interface SubmittedPendingSubmission extends PendingSubmissionBase {
+  readonly phase: 'submitted'
+  /** 'transaction' = EOA send; 'proposal' = Safe proposal / bundle id. */
+  readonly kind: 'transaction' | 'proposal'
+  readonly hash: Hash
+}
+
+export type PendingSubmissionRecord = ArmedPendingSubmission | SubmittedPendingSubmission
+
 export type PendingSubmissionOutcome = 'landed' | 'not-landed' | 'unknown'
 
-const storageKey = (flow: PendingSubmissionFlow) => `euler_pending_submission:${flow}`
+const STORAGE_PREFIX = 'euler_pending_submission'
+
+export const pendingSubmissionStorageKeyPrefix = (flow: PendingSubmissionFlow) =>
+  `${STORAGE_PREFIX}:${flow}:`
+
+const storageKey = (flow: PendingSubmissionFlow, owner: Address, chainId: number) =>
+  `${pendingSubmissionStorageKeyPrefix(flow)}${chainId}:${getAddress(owner)}`
 
 const getStorage = (): Storage | undefined => {
   try {
@@ -45,6 +77,81 @@ const getStorage = (): Storage | undefined => {
   catch {
     return undefined
   }
+}
+
+/**
+ * Fail-closed fallback: when localStorage is unavailable or a write does not
+ * stick, the record must still block this session's retries rather than
+ * silently degrade to "no quarantine".
+ */
+const memoryFallback = new Map<string, string>()
+
+/** Test-only: module state would otherwise leak between test files' cases. */
+export const resetPendingSubmissionMemoryFallback = () => {
+  memoryFallback.clear()
+}
+
+const writeRaw = (key: string, value: string) => {
+  const storage = getStorage()
+  if (storage) {
+    try {
+      storage.setItem(key, value)
+      // Read-back verification: a quota-exhausted or lying storage must not
+      // count as durable persistence.
+      if (storage.getItem(key) === value) {
+        memoryFallback.delete(key)
+        return
+      }
+    }
+    catch (err) {
+      logWarn('pendingSubmissions/write', err)
+    }
+  }
+  memoryFallback.set(key, value)
+}
+
+const readRaw = (key: string): string | null => {
+  const storage = getStorage()
+  if (storage) {
+    try {
+      const raw = storage.getItem(key)
+      if (raw !== null) return raw
+    }
+    catch {
+      // Fall through to the in-memory fallback.
+    }
+  }
+  return memoryFallback.get(key) ?? null
+}
+
+const removeRaw = (key: string) => {
+  try {
+    getStorage()?.removeItem(key)
+  }
+  catch {
+    // Ignore unavailable browser storage.
+  }
+  memoryFallback.delete(key)
+}
+
+const listRawKeys = (prefix: string): string[] => {
+  const keys = new Set<string>()
+  const storage = getStorage()
+  if (storage) {
+    try {
+      for (let i = 0; i < storage.length; i++) {
+        const key = storage.key(i)
+        if (key?.startsWith(prefix)) keys.add(key)
+      }
+    }
+    catch {
+      // Fall through to the in-memory fallback.
+    }
+  }
+  for (const key of memoryFallback.keys()) {
+    if (key.startsWith(prefix)) keys.add(key)
+  }
+  return [...keys]
 }
 
 const isHash = (value: unknown): value is Hash =>
@@ -60,8 +167,7 @@ const parseRecord = (raw: string): PendingSubmissionRecord | undefined => {
   }
   if (!parsed || typeof parsed !== 'object') return undefined
   const candidate = parsed as Record<string, unknown>
-  if (candidate.kind !== 'transaction' && candidate.kind !== 'proposal') return undefined
-  if (!isHash(candidate.hash)) return undefined
+  if (candidate.phase !== 'armed' && candidate.phase !== 'submitted') return undefined
   if (typeof candidate.chainId !== 'number' || !Number.isInteger(candidate.chainId) || candidate.chainId <= 0) return undefined
   if (typeof candidate.completesPlan !== 'boolean') return undefined
   if (candidate.refreshExternalPositions !== undefined && typeof candidate.refreshExternalPositions !== 'boolean') return undefined
@@ -73,54 +179,90 @@ const parseRecord = (raw: string): PendingSubmissionRecord | undefined => {
   catch {
     return undefined
   }
-  return {
-    kind: candidate.kind,
-    hash: candidate.hash,
+  const base = {
     chainId: candidate.chainId,
     owner,
     completesPlan: candidate.completesPlan,
     refreshExternalPositions: candidate.refreshExternalPositions as boolean | undefined,
     submittedAt: candidate.submittedAt,
   }
+  if (candidate.phase === 'armed') {
+    return { phase: 'armed', ...base }
+  }
+  if (candidate.kind !== 'transaction' && candidate.kind !== 'proposal') return undefined
+  if (!isHash(candidate.hash)) return undefined
+  return { phase: 'submitted', kind: candidate.kind, hash: candidate.hash, ...base }
 }
 
-export const readPendingSubmission = (flow: PendingSubmissionFlow): PendingSubmissionRecord | undefined => {
-  const storage = getStorage()
-  if (!storage) return undefined
-  let raw: string | null
-  try {
-    raw = storage.getItem(storageKey(flow))
-  }
-  catch {
-    return undefined
-  }
+const readRecordAtKey = (key: string, expected?: { owner: Address, chainId: number }): PendingSubmissionRecord | undefined => {
+  const raw = readRaw(key)
   if (raw === null) return undefined
   const record = parseRecord(raw)
-  if (!record) {
-    // A corrupt record cannot be reconciled — drop it rather than blocking
-    // the flow forever on unparseable state.
-    clearPendingSubmission(flow)
+  // A corrupt record (or one whose content disagrees with its key) cannot be
+  // reconciled — drop it rather than blocking the flow forever on
+  // unparseable state.
+  if (!record || (expected && (record.owner !== expected.owner || record.chainId !== expected.chainId))) {
+    removeRaw(key)
     return undefined
   }
   return record
 }
 
-export const writePendingSubmission = (flow: PendingSubmissionFlow, record: PendingSubmissionRecord) => {
-  try {
-    getStorage()?.setItem(storageKey(flow), JSON.stringify(record))
-  }
-  catch (err) {
-    logWarn('pendingSubmissions/write', err)
-  }
+export const readPendingSubmission = (
+  flow: PendingSubmissionFlow,
+  owner: Address,
+  chainId: number,
+): PendingSubmissionRecord | undefined => {
+  const normalizedOwner = getAddress(owner)
+  return readRecordAtKey(storageKey(flow, normalizedOwner, chainId), { owner: normalizedOwner, chainId })
 }
 
-export const clearPendingSubmission = (flow: PendingSubmissionFlow) => {
-  try {
-    getStorage()?.removeItem(storageKey(flow))
+/** Every wallet's unresolved record for a flow, corrupt entries dropped. */
+export const listPendingSubmissions = (flow: PendingSubmissionFlow): PendingSubmissionRecord[] => {
+  const records: PendingSubmissionRecord[] = []
+  for (const key of listRawKeys(pendingSubmissionStorageKeyPrefix(flow))) {
+    const record = readRecordAtKey(key)
+    if (record) records.push(record)
   }
-  catch {
-    // Ignore unavailable browser storage.
+  return records
+}
+
+export const writePendingSubmission = (flow: PendingSubmissionFlow, record: PendingSubmissionRecord) => {
+  writeRaw(storageKey(flow, record.owner, record.chainId), JSON.stringify(record))
+}
+
+export const clearPendingSubmission = (flow: PendingSubmissionFlow, owner: Address, chainId: number) => {
+  removeRaw(storageKey(flow, owner, chainId))
+}
+
+/**
+ * Whether an error thrown at the wallet boundary proves the wallet never
+ * accepted the request: an explicit user rejection, or a connector-level
+ * failure that occurs before the request is dispatched. Anything else —
+ * timeouts, malformed responses, dropped connections mid-request — leaves
+ * acceptance possible and must keep the armed record.
+ */
+export const walletNeverAcceptedSubmission = (error: unknown): boolean => {
+  const NEVER_DISPATCHED_NAMES = new Set([
+    'UserRejectedRequestError',
+    'ConnectorNotConnectedError',
+    'ConnectorAccountNotFoundError',
+    'ConnectorChainMismatchError',
+    'ConnectorUnavailableReconnectingError',
+  ])
+  let current: unknown = error
+  for (let depth = 0; depth < 10 && current; depth++) {
+    if (typeof current === 'object') {
+      const candidate = current as { name?: unknown, code?: unknown, cause?: unknown }
+      // EIP-1193 userRejectedRequest
+      if (candidate.code === 4001) return true
+      if (typeof candidate.name === 'string' && NEVER_DISPATCHED_NAMES.has(candidate.name)) return true
+      current = candidate.cause
+      continue
+    }
+    break
   }
+  return false
 }
 
 /**
@@ -129,7 +271,9 @@ export const clearPendingSubmission = (flow: PendingSubmissionFlow) => {
  * Fails toward 'unknown': only a definitive receipt (landed) or a definitive
  * negative signal (transaction unknown to the node / Safe reports cancelled
  * or failed) produces a terminal verdict. 'unknown' must keep the record and
- * block re-execution of the same plan.
+ * block re-execution of the same plan. An 'armed' record has no id to look
+ * up, so it is always 'unknown' — it can only be released by the attempt that
+ * armed it (rejection or confirmation).
  */
 export const resolvePendingSubmissionOutcome = async (
   record: PendingSubmissionRecord,
@@ -140,6 +284,7 @@ export const resolvePendingSubmissionOutcome = async (
     safeStatusTimeoutMs?: number
   },
 ): Promise<PendingSubmissionOutcome> => {
+  if (record.phase === 'armed') return 'unknown'
   const { provider } = options
   if (!provider) return 'unknown'
 

--- a/utils/pendingSubmissions.ts
+++ b/utils/pendingSubmissions.ts
@@ -1,0 +1,188 @@
+import type { Address, Hash } from 'viem'
+import { getAddress } from 'viem'
+import { logWarn } from '~/utils/errorHandling'
+import type { ReceiptClientLike, WalletConnectorLike, WalletProviderLike } from '~/utils/safeWalletTransactions'
+import { SafeTransactionStatusUnknownError, waitForSafeTransactionExecution } from '~/utils/safeWalletTransactions'
+
+/**
+ * Durable quarantine records for value-moving submissions whose outcome is
+ * unknown: the wallet accepted the send (a transaction hash or Safe proposal
+ * id exists) but no terminal receipt/status was observed before the attempt
+ * failed. Such a submission can still confirm later, so re-running the flow
+ * without first resolving it risks executing the migration twice.
+ *
+ * Records persist in localStorage so they survive cart clearing, account
+ * switches, and full page reloads; they are removed only once reconciliation
+ * reaches a terminal verdict (landed or not landed).
+ */
+
+export type PendingSubmissionFlow = 'batch' | 'outgoing-migration' | 'inbound-migration'
+
+export interface PendingSubmissionRecord {
+  /** 'transaction' = EOA send; 'proposal' = Safe proposal / bundle id. */
+  readonly kind: 'transaction' | 'proposal'
+  readonly hash: Hash
+  readonly chainId: number
+  readonly owner: Address
+  /**
+   * Whether this submission was the plan's final value-moving item. When it
+   * landed but did not complete the plan, the remainder must be re-reviewed
+   * rather than silently treated as done.
+   */
+  readonly completesPlan: boolean
+  readonly refreshExternalPositions?: boolean
+  readonly submittedAt: number
+}
+
+export type PendingSubmissionOutcome = 'landed' | 'not-landed' | 'unknown'
+
+const storageKey = (flow: PendingSubmissionFlow) => `euler_pending_submission:${flow}`
+
+const getStorage = (): Storage | undefined => {
+  try {
+    return globalThis.localStorage ?? undefined
+  }
+  catch {
+    return undefined
+  }
+}
+
+const isHash = (value: unknown): value is Hash =>
+  typeof value === 'string' && /^0x[0-9a-f]{64}$/i.test(value)
+
+const parseRecord = (raw: string): PendingSubmissionRecord | undefined => {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  }
+  catch {
+    return undefined
+  }
+  if (!parsed || typeof parsed !== 'object') return undefined
+  const candidate = parsed as Record<string, unknown>
+  if (candidate.kind !== 'transaction' && candidate.kind !== 'proposal') return undefined
+  if (!isHash(candidate.hash)) return undefined
+  if (typeof candidate.chainId !== 'number' || !Number.isInteger(candidate.chainId) || candidate.chainId <= 0) return undefined
+  if (typeof candidate.completesPlan !== 'boolean') return undefined
+  if (candidate.refreshExternalPositions !== undefined && typeof candidate.refreshExternalPositions !== 'boolean') return undefined
+  if (typeof candidate.submittedAt !== 'number' || !Number.isFinite(candidate.submittedAt)) return undefined
+  let owner: Address
+  try {
+    owner = getAddress(candidate.owner as string)
+  }
+  catch {
+    return undefined
+  }
+  return {
+    kind: candidate.kind,
+    hash: candidate.hash,
+    chainId: candidate.chainId,
+    owner,
+    completesPlan: candidate.completesPlan,
+    refreshExternalPositions: candidate.refreshExternalPositions as boolean | undefined,
+    submittedAt: candidate.submittedAt,
+  }
+}
+
+export const readPendingSubmission = (flow: PendingSubmissionFlow): PendingSubmissionRecord | undefined => {
+  const storage = getStorage()
+  if (!storage) return undefined
+  let raw: string | null
+  try {
+    raw = storage.getItem(storageKey(flow))
+  }
+  catch {
+    return undefined
+  }
+  if (raw === null) return undefined
+  const record = parseRecord(raw)
+  if (!record) {
+    // A corrupt record cannot be reconciled — drop it rather than blocking
+    // the flow forever on unparseable state.
+    clearPendingSubmission(flow)
+    return undefined
+  }
+  return record
+}
+
+export const writePendingSubmission = (flow: PendingSubmissionFlow, record: PendingSubmissionRecord) => {
+  try {
+    getStorage()?.setItem(storageKey(flow), JSON.stringify(record))
+  }
+  catch (err) {
+    logWarn('pendingSubmissions/write', err)
+  }
+}
+
+export const clearPendingSubmission = (flow: PendingSubmissionFlow) => {
+  try {
+    getStorage()?.removeItem(storageKey(flow))
+  }
+  catch {
+    // Ignore unavailable browser storage.
+  }
+}
+
+/**
+ * Resolve whether a quarantined submission reached the chain.
+ *
+ * Fails toward 'unknown': only a definitive receipt (landed) or a definitive
+ * negative signal (transaction unknown to the node / Safe reports cancelled
+ * or failed) produces a terminal verdict. 'unknown' must keep the record and
+ * block re-execution of the same plan.
+ */
+export const resolvePendingSubmissionOutcome = async (
+  record: PendingSubmissionRecord,
+  options: {
+    provider: ReceiptClientLike | undefined
+    getSafeWalletProvider: (connector?: WalletConnectorLike) => Promise<WalletProviderLike | undefined>
+    connector?: WalletConnectorLike
+    safeStatusTimeoutMs?: number
+  },
+): Promise<PendingSubmissionOutcome> => {
+  const { provider } = options
+  if (!provider) return 'unknown'
+
+  if (record.kind === 'transaction') {
+    try {
+      const receipt = await provider.getTransactionReceipt({ hash: record.hash })
+      return receipt.status === 'success' ? 'landed' : 'not-landed'
+    }
+    catch {
+      // viem throws TransactionReceiptNotFoundError while pending, but the
+      // node may also have simply dropped the transaction — either way there
+      // is no receipt, and a dropped transaction can still be re-broadcast
+      // from a mempool copy. Without an inclusion proof stay quarantined.
+      return 'unknown'
+    }
+  }
+
+  let walletProvider: WalletProviderLike | undefined
+  try {
+    walletProvider = await options.getSafeWalletProvider(options.connector)
+  }
+  catch {
+    walletProvider = undefined
+  }
+  if (!walletProvider) return 'unknown'
+  try {
+    const execution = await waitForSafeTransactionExecution({
+      submittedHash: record.hash,
+      walletProvider,
+      publicClient: provider,
+      timeoutMs: options.safeStatusTimeoutMs ?? 15_000,
+    })
+    return execution.receipt.status === 'success' ? 'landed' : 'not-landed'
+  }
+  catch (error) {
+    if (error instanceof SafeTransactionStatusUnknownError) return 'unknown'
+    if (error instanceof Error && (
+      error.message === 'Safe transaction was cancelled'
+      || error.message === 'Safe transaction failed'
+    )) {
+      return 'not-landed'
+    }
+    logWarn('pendingSubmissions/safe-status', error)
+    return 'unknown'
+  }
+}

--- a/utils/pendingSubmissions.ts
+++ b/utils/pendingSubmissions.ts
@@ -32,10 +32,10 @@ import { SafeTransactionStatusUnknownError, waitForSafeTransactionExecution } fr
  * an armed record).
  */
 
-export type PendingSubmissionFlow = 'batch' | 'outgoing-migration' | 'inbound-migration' | 'direct'
+export type PendingSubmissionFlow = 'batch' | 'outgoing-migration' | 'inbound-migration' | 'direct' | 'cow-order'
 
 export const PENDING_SUBMISSION_FLOWS: readonly PendingSubmissionFlow[]
-  = ['batch', 'outgoing-migration', 'inbound-migration', 'direct']
+  = ['batch', 'outgoing-migration', 'inbound-migration', 'direct', 'cow-order']
 
 interface PendingSubmissionBase {
   readonly chainId: number
@@ -56,10 +56,23 @@ interface PendingSubmissionBase {
   readonly attemptId?: string
 }
 
+/**
+ * A verifiable id observed for a record that is still stored as 'armed': the
+ * wallet returned the id, but the armed → submitted durable rewrite failed.
+ * Preserving the id on the armed record keeps the submission objectively
+ * verifiable (receipt / Safe status / orderbook lookup) and makes it
+ * unrecoverable through the hashless manual-release path.
+ */
+export type PendingSubmissionObservedId
+  = | { readonly kind: 'transaction' | 'proposal', readonly hash: Hash }
+    | { readonly kind: 'cow-order', readonly orderUid: string, readonly orderbookUrl?: string }
+
 export interface ArmedPendingSubmission extends PendingSubmissionBase {
   readonly phase: 'armed'
   readonly kind?: undefined
   readonly hash?: undefined
+  readonly orderUid?: undefined
+  readonly observedId?: PendingSubmissionObservedId
 }
 
 export interface SubmittedPendingSubmission extends PendingSubmissionBase {
@@ -67,9 +80,22 @@ export interface SubmittedPendingSubmission extends PendingSubmissionBase {
   /** 'transaction' = EOA send; 'proposal' = Safe proposal / bundle id. */
   readonly kind: 'transaction' | 'proposal'
   readonly hash: Hash
+  readonly orderUid?: undefined
+  readonly observedId?: undefined
 }
 
-export type PendingSubmissionRecord = ArmedPendingSubmission | SubmittedPendingSubmission
+export interface SubmittedCowOrderPendingSubmission extends PendingSubmissionBase {
+  readonly phase: 'submitted'
+  /** A CoW Swap order accepted by the orderbook, identified by its order uid. */
+  readonly kind: 'cow-order'
+  readonly orderUid: string
+  readonly orderbookUrl?: string
+  readonly hash?: undefined
+  readonly observedId?: undefined
+}
+
+export type PendingSubmissionRecord
+  = ArmedPendingSubmission | SubmittedPendingSubmission | SubmittedCowOrderPendingSubmission
 
 export type PendingSubmissionOutcome = 'landed' | 'not-landed' | 'unknown'
 
@@ -112,6 +138,48 @@ const getStorage = (): Storage | undefined => {
  * the read authority when the realm has no storage object at all.
  */
 const memoryFallback = new Map<string, string>()
+
+/**
+ * In-realm change feed so recovery surfaces can react to records being
+ * created, upgraded, or released without polling. Cross-tab changes are
+ * observed separately via the window 'storage' event.
+ */
+const changeListeners = new Set<() => void>()
+
+export const subscribeToPendingSubmissionChanges = (listener: () => void): (() => void) => {
+  changeListeners.add(listener)
+  return () => changeListeners.delete(listener)
+}
+
+const notifyPendingSubmissionChange = () => {
+  for (const listener of [...changeListeners]) {
+    try {
+      listener()
+    }
+    catch (err) {
+      logWarn('pendingSubmissions/change-listener', err)
+    }
+  }
+}
+
+/**
+ * Attempt ids whose execution flow is still live in this realm. Recovery
+ * surfaces use this to distinguish an orphaned armed record (owning attempt
+ * died in a reload/crash) from one whose wallet prompt is open right now.
+ */
+const activeAttemptIds = new Set<string>()
+
+export const registerActiveSubmissionAttempt = (attemptId: string) => {
+  activeAttemptIds.add(attemptId)
+  notifyPendingSubmissionChange()
+}
+
+export const unregisterActiveSubmissionAttempt = (attemptId: string) => {
+  if (activeAttemptIds.delete(attemptId)) notifyPendingSubmissionChange()
+}
+
+export const isSubmissionAttemptActive = (attemptId: string | undefined): boolean =>
+  attemptId !== undefined && activeAttemptIds.has(attemptId)
 
 /** Test-only: clears the in-realm guard AND purges quarantine keys from live
  * storage — module state and the storage polyfill would otherwise leak
@@ -191,6 +259,7 @@ const removeRaw = (key: string) => {
     // stale record keeps blocking until storage recovers.
   }
   memoryFallback.delete(key)
+  notifyPendingSubmissionChange()
 }
 
 const listRawKeys = (prefix: string): string[] => {
@@ -215,6 +284,27 @@ const listRawKeys = (prefix: string): string[] => {
 
 const isHash = (value: unknown): value is Hash =>
   typeof value === 'string' && /^0x[0-9a-f]{64}$/i.test(value)
+
+/** CoW order uids are 56 bytes: order digest + owner + validTo. */
+const isCowOrderUid = (value: unknown): value is string =>
+  typeof value === 'string' && /^0x[0-9a-f]{112}$/i.test(value)
+
+const parseObservedId = (value: unknown): { observedId?: PendingSubmissionObservedId, valid: boolean } => {
+  if (value === undefined) return { valid: true }
+  if (!value || typeof value !== 'object') return { valid: false }
+  const candidate = value as Record<string, unknown>
+  if (candidate.kind === 'transaction' || candidate.kind === 'proposal') {
+    if (!isHash(candidate.hash)) return { valid: false }
+    return { observedId: { kind: candidate.kind, hash: candidate.hash }, valid: true }
+  }
+  if (candidate.kind === 'cow-order') {
+    const orderUid = candidate.orderUid
+    if (!isCowOrderUid(orderUid)) return { valid: false }
+    if (candidate.orderbookUrl !== undefined && typeof candidate.orderbookUrl !== 'string') return { valid: false }
+    return { observedId: { kind: 'cow-order', orderUid, orderbookUrl: candidate.orderbookUrl as string | undefined }, valid: true }
+  }
+  return { valid: false }
+}
 
 const parseRecord = (raw: string): PendingSubmissionRecord | undefined => {
   let parsed: unknown
@@ -248,7 +338,18 @@ const parseRecord = (raw: string): PendingSubmissionRecord | undefined => {
     attemptId: candidate.attemptId as string | undefined,
   }
   if (candidate.phase === 'armed') {
-    return { phase: 'armed', ...base }
+    // An unparseable observedId must corrupt the record (fail closed): it may
+    // name a live submission, so it cannot degrade into a releasable hashless
+    // armed record.
+    const { observedId, valid } = parseObservedId(candidate.observedId)
+    if (!valid) return undefined
+    return { phase: 'armed', observedId, ...base }
+  }
+  if (candidate.kind === 'cow-order') {
+    const orderUid = candidate.orderUid
+    if (!isCowOrderUid(orderUid)) return undefined
+    if (candidate.orderbookUrl !== undefined && typeof candidate.orderbookUrl !== 'string') return undefined
+    return { phase: 'submitted', kind: 'cow-order', orderUid, orderbookUrl: candidate.orderbookUrl as string | undefined, ...base }
   }
   if (candidate.kind !== 'transaction' && candidate.kind !== 'proposal') return undefined
   if (!isHash(candidate.hash)) return undefined
@@ -311,8 +412,25 @@ export const listPendingSubmissions = (flow: PendingSubmissionFlow): PendingSubm
  * retries, but a reservation that would not survive a reload must stop the
  * attempt before the wallet is invoked.
  */
-export const writePendingSubmission = (flow: PendingSubmissionFlow, record: PendingSubmissionRecord) => {
-  const outcome = writeRaw(storageKey(flow, record.owner, record.chainId), JSON.stringify(record))
+/**
+ * Quota headroom reserved by armed-record writes. The later armed → submitted
+ * rewrite happens at the same key with a slightly larger payload (kind + id);
+ * padding the armed record makes that rewrite a same-size-or-smaller
+ * replacement, so a storage that accepted the reservation cannot refuse the
+ * upgrade on quota grounds. `parseRecord` ignores unknown fields.
+ */
+const UPGRADE_HEADROOM_PADDING = 'x'.repeat(512)
+
+export const writePendingSubmission = (
+  flow: PendingSubmissionFlow,
+  record: PendingSubmissionRecord,
+  options?: { reserveUpgradeHeadroom?: boolean },
+) => {
+  const serialized = options?.reserveUpgradeHeadroom
+    ? JSON.stringify({ ...record, padding: UPGRADE_HEADROOM_PADDING })
+    : JSON.stringify(record)
+  const outcome = writeRaw(storageKey(flow, record.owner, record.chainId), serialized)
+  notifyPendingSubmissionChange()
   if (outcome !== 'durable') {
     throw new PendingSubmissionStorageError(
       'Replay protection could not be durably saved, so nothing was handed to the wallet. Check that browser storage is available and try again.',
@@ -323,10 +441,98 @@ export const writePendingSubmission = (flow: PendingSubmissionFlow, record: Pend
 /**
  * Per-owner/chain critical section for check+reserve and ownership-checked
  * mutations. Uses the browser-wide Web Locks API when available (serializing
- * across tabs) and always chains through an in-realm FIFO queue (serializing
- * within this realm, and standing in entirely where Web Locks are absent).
+ * across tabs) and always chains through an in-realm FIFO queue. Where Web
+ * Locks are absent but records share a storage object with other contexts, a
+ * storage-token mutex serializes across those contexts — and when it cannot
+ * be acquired the attempt fails closed rather than running unserialized. Only
+ * a realm with no storage at all relies on the FIFO alone: its records live
+ * exclusively in this realm's memory map, so no other context can race them.
  */
 const realmLockTails = new Map<string, Promise<void>>()
+
+const STORAGE_LOCK_TTL_MS = 5_000
+const STORAGE_LOCK_ACQUIRE_TIMEOUT_MS = 10_000
+const STORAGE_LOCK_CONFIRM_DELAY_MS = 25
+const STORAGE_LOCK_RETRY_DELAY_MS = 40
+
+const sleep = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms))
+
+const storageLockUnavailableError = (cause?: unknown) => new PendingSubmissionStorageError(
+  'Replay protection could not take the cross-tab submission lock, so nothing was handed to the wallet. Close other tabs of this app (or wait a moment) and try again.',
+  cause === undefined ? undefined : { cause },
+)
+
+let storageLockTokenCounter = 0
+const createStorageLockToken = (): string => {
+  const uuid = (globalThis.crypto as Crypto | undefined)?.randomUUID?.()
+  if (uuid) return uuid
+  storageLockTokenCounter += 1
+  return `lock-${Date.now()}-${Math.random()}-${storageLockTokenCounter}`
+}
+
+const readStorageLockHolder = (storage: Storage, key: string): { token?: unknown, expiresAt?: unknown } | undefined => {
+  let raw: string | null
+  try {
+    raw = storage.getItem(key)
+  }
+  catch (err) {
+    throw storageLockUnavailableError(err)
+  }
+  if (raw === null) return undefined
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    return parsed && typeof parsed === 'object' ? parsed as { token?: unknown, expiresAt?: unknown } : undefined
+  }
+  catch {
+    // An unparseable lock value is treated as an expired holder: the token
+    // write below reclaims the slot, and the confirm re-read still arbitrates
+    // against any concurrent claimant.
+    return undefined
+  }
+}
+
+/**
+ * Cross-context mutex over the shared storage object: write a unique token
+ * with a TTL, wait, and confirm the token survived. The TTL bounds how long a
+ * crashed holder can block others; it is safe because every critical section
+ * run under this lock does only synchronous storage work, finishing far
+ * inside the TTL.
+ */
+const acquireStorageLock = async (storage: Storage, key: string): Promise<() => void> => {
+  const token = createStorageLockToken()
+  const deadline = Date.now() + STORAGE_LOCK_ACQUIRE_TIMEOUT_MS
+  for (;;) {
+    const holder = readStorageLockHolder(storage, key)
+    const holderExpired = !holder
+      || typeof holder.expiresAt !== 'number'
+      || holder.expiresAt <= Date.now()
+    if (holderExpired) {
+      try {
+        storage.setItem(key, JSON.stringify({ token, expiresAt: Date.now() + STORAGE_LOCK_TTL_MS }))
+      }
+      catch (err) {
+        throw storageLockUnavailableError(err)
+      }
+      // Two contexts can both observe the slot free and both write; the delay
+      // lets the racing writes settle so exactly one token survives re-read.
+      await sleep(STORAGE_LOCK_CONFIRM_DELAY_MS + Math.floor(Math.random() * 15))
+      const confirmed = readStorageLockHolder(storage, key)
+      if (confirmed?.token === token) {
+        return () => {
+          try {
+            const current = readStorageLockHolder(storage, key)
+            if (current?.token === token) storage.removeItem(key)
+          }
+          catch {
+            // Leave it to TTL expiry.
+          }
+        }
+      }
+    }
+    if (Date.now() >= deadline) throw storageLockUnavailableError()
+    await sleep(STORAGE_LOCK_RETRY_DELAY_MS + Math.floor(Math.random() * 20))
+  }
+}
 
 export const withPendingSubmissionLock = async <T>(
   owner: Address,
@@ -334,11 +540,23 @@ export const withPendingSubmissionLock = async <T>(
   fn: () => Promise<T>,
 ): Promise<T> => {
   const key = `${STORAGE_PREFIX}:lock:${chainId}:${getAddress(owner)}`
-  const runExclusive = (): Promise<T> => {
+  const runExclusive = async (): Promise<T> => {
     const locks = (globalThis.navigator as Navigator | undefined)?.locks
     if (locks?.request) {
       return locks.request(key, () => fn()) as Promise<T>
     }
+    const storage = getStorage()
+    if (storage) {
+      const releaseLock = await acquireStorageLock(storage, key)
+      try {
+        return await fn()
+      }
+      finally {
+        releaseLock()
+      }
+    }
+    // No storage object exists: records are realm-local, so the in-realm FIFO
+    // below already serializes every possible reader/writer.
     return fn()
   }
   const tail = realmLockTails.get(key) ?? Promise.resolve()
@@ -397,17 +615,32 @@ export const armPendingSubmission = async (
       submittedAt: Date.now(),
       attemptId: input.attemptId,
     }
-    writePendingSubmission(flow, record)
+    writePendingSubmission(flow, record, { reserveUpgradeHeadroom: true })
     return record
   })
 }
+
+export type PendingSubmissionUpgradeId
+  = | { kind: 'transaction' | 'proposal', hash: Hash }
+    | { kind: 'cow-order', orderUid: string, orderbookUrl?: string }
+
+const describeUpgradeId = (id: PendingSubmissionUpgradeId): string =>
+  id.kind === 'cow-order' ? `CoW Swap order ${id.orderUid}` : `transaction ${id.hash}`
 
 /**
  * Ownership-checked armed → submitted upgrade. When the stored record is
  * missing, unreadable, or belongs to a different attempt, the upgrade is
  * refused (returning undefined) rather than overwriting state this attempt
  * does not own — whatever record exists keeps blocking, which is the safe
- * direction. A refused durable write likewise leaves the armed record.
+ * direction.
+ *
+ * A failed durable write of the submitted record must NOT degrade silently:
+ * the wallet already accepted the submission and the returned id is the only
+ * verifiable link to it. The id is preserved on the armed record as
+ * `observedId` (best effort, retried) — which blocks the hashless
+ * manual-release path and lets reconciliation verify the outcome objectively
+ * — and the failure is thrown so the attempt surfaces it instead of
+ * continuing as if the id had been recorded.
  */
 export const upgradePendingSubmissionToSubmitted = async (
   flow: PendingSubmissionFlow,
@@ -415,12 +648,10 @@ export const upgradePendingSubmissionToSubmitted = async (
     owner: Address
     chainId: number
     attemptId: string
-    kind: 'transaction' | 'proposal'
-    hash: Hash
     completesPlan: boolean
     refreshExternalPositions?: boolean
-  },
-): Promise<SubmittedPendingSubmission | undefined> => {
+  } & PendingSubmissionUpgradeId,
+): Promise<SubmittedPendingSubmission | SubmittedCowOrderPendingSubmission | undefined> => {
   const owner = getAddress(input.owner)
   return withPendingSubmissionLock(owner, input.chainId, async () => {
     let existing: PendingSubmissionRecord | undefined
@@ -432,13 +663,10 @@ export const upgradePendingSubmissionToSubmitted = async (
       return undefined
     }
     if (!existing || existing.attemptId !== input.attemptId) {
-      logWarn('pendingSubmissions/upgrade', new Error('refused upgrade of a reservation this attempt does not own'))
+      logWarn('pendingSubmissions/upgrade', new Error(`refused upgrade of a reservation this attempt does not own (${describeUpgradeId(input)})`))
       return undefined
     }
-    const record: SubmittedPendingSubmission = {
-      phase: 'submitted',
-      kind: input.kind,
-      hash: input.hash,
+    const base = {
       chainId: input.chainId,
       owner,
       completesPlan: input.completesPlan,
@@ -446,14 +674,42 @@ export const upgradePendingSubmissionToSubmitted = async (
       submittedAt: Date.now(),
       attemptId: input.attemptId,
     }
+    const record: SubmittedPendingSubmission | SubmittedCowOrderPendingSubmission
+      = input.kind === 'cow-order'
+        ? { phase: 'submitted', kind: 'cow-order', orderUid: input.orderUid, orderbookUrl: input.orderbookUrl, ...base }
+        : { phase: 'submitted', kind: input.kind, hash: input.hash, ...base }
+    let writeError: unknown
+    for (let attempt = 0; attempt < 2; attempt++) {
+      try {
+        writePendingSubmission(flow, record)
+        return record
+      }
+      catch (err) {
+        writeError = err
+        logWarn('pendingSubmissions/upgrade', err)
+      }
+    }
+    // Preserve the observed id in the most durable form still available. The
+    // armed rewrite is same-size-or-smaller than the padded reservation, so a
+    // quota-bound storage that accepted the arm accepts this; even when it
+    // does not, the in-realm copy written on its failure path keeps blocking
+    // this realm's hashless release.
+    const preservedBase: ArmedPendingSubmission = existing.phase === 'armed'
+      ? existing
+      : { phase: 'armed', ...base }
+    const observedId: PendingSubmissionObservedId = input.kind === 'cow-order'
+      ? { kind: 'cow-order', orderUid: input.orderUid, orderbookUrl: input.orderbookUrl }
+      : { kind: input.kind, hash: input.hash }
     try {
-      writePendingSubmission(flow, record)
+      writePendingSubmission(flow, { ...preservedBase, observedId })
     }
     catch (err) {
       logWarn('pendingSubmissions/upgrade', err)
-      return undefined
     }
-    return record
+    throw new PendingSubmissionStorageError(
+      `The wallet accepted ${describeUpgradeId(input)}, but replay protection could not durably record its id. Do not retry — verify this submission's outcome before sending anything new.`,
+      writeError === undefined ? undefined : { cause: writeError },
+    )
   })
 }
 
@@ -492,6 +748,7 @@ const sameSubmissionRecord = (a: PendingSubmissionRecord, b: PendingSubmissionRe
   && a.submittedAt === b.submittedAt
   && a.attemptId === b.attemptId
   && a.hash === b.hash
+  && a.orderUid === b.orderUid
 
 /**
  * Remove a record after reconciliation reached a terminal verdict. With
@@ -549,15 +806,81 @@ export const releaseUnverifiablePendingSubmission = async (
     const key = storageKey(flow, normalizedOwner, chainId)
     const raw = readRaw(key)
     if (raw === null) return false
-    const record = parseRecord(raw)
-    if (record?.phase === 'submitted') {
+    // A submission id may have been observed even when the durable record
+    // does not show it (the submitted rewrite failed and left the id only on
+    // this realm's in-memory copy) — check both sources before treating the
+    // record as hashless.
+    const identifiedSubmission = [raw, memoryFallback.get(key)].some((source) => {
+      if (source === undefined) return false
+      const record = parseRecord(source)
+      return record?.phase === 'submitted' || record?.observedId !== undefined
+    })
+    if (identifiedSubmission) {
       throw new Error('This submission has a transaction id and may still confirm on-chain — it is verified automatically and cannot be dismissed. Wait a moment and try again.')
     }
-    // Armed or corrupt: no id will ever arrive, so only the user's own wallet
-    // check can rule acceptance out.
+    // Armed or corrupt with no observed id: no id will ever arrive, so only
+    // the user's own wallet check can rule acceptance out.
     removeRaw(key)
     return true
   })
+}
+
+export interface ReleasableArmedSubmission {
+  readonly flow: PendingSubmissionFlow
+  readonly chainId: number
+  readonly owner: Address
+  /** 'corrupt' entries block attempts but cannot be parsed into a record. */
+  readonly state: 'armed' | 'corrupt'
+  readonly record?: ArmedPendingSubmission
+}
+
+/**
+ * Every stuck record that only a user-acknowledged manual release can clear:
+ * armed records whose owning attempt is no longer live in this realm, plus
+ * corrupt entries. Records that carry a verifiable id (submitted, or armed
+ * with an observed id) are excluded — they resolve objectively and must never
+ * be offered for dismissal.
+ */
+export const listReleasableArmedSubmissions = (
+  flows: readonly PendingSubmissionFlow[],
+): ReleasableArmedSubmission[] => {
+  const entries: ReleasableArmedSubmission[] = []
+  for (const flow of flows) {
+    const prefix = pendingSubmissionStorageKeyPrefix(flow)
+    for (const key of listRawKeys(prefix)) {
+      const suffix = key.slice(prefix.length)
+      const separator = suffix.indexOf(':')
+      if (separator <= 0) continue
+      const chainId = Number(suffix.slice(0, separator))
+      if (!Number.isInteger(chainId) || chainId <= 0) continue
+      let owner: Address
+      try {
+        owner = getAddress(suffix.slice(separator + 1))
+      }
+      catch {
+        continue
+      }
+      let raw: string | null
+      try {
+        raw = readRaw(key)
+      }
+      catch {
+        // Storage itself is unreadable — a release could not verify what it
+        // removes, so nothing is offered.
+        continue
+      }
+      if (raw === null) continue
+      const record = parseRecord(raw)
+      if (!record || record.owner !== owner || record.chainId !== chainId) {
+        entries.push({ flow, chainId, owner, state: 'corrupt' })
+        continue
+      }
+      if (record.phase !== 'armed' || record.observedId !== undefined) continue
+      if (isSubmissionAttemptActive(record.attemptId)) continue
+      entries.push({ flow, chainId, owner, state: 'armed', record })
+    }
+  }
+  return entries
 }
 
 /**
@@ -595,11 +918,14 @@ export const walletNeverAcceptedSubmission = (error: unknown): boolean => {
  *
  * Fails toward 'unknown': only a definitive receipt (landed) or a definitive
  * negative signal (transaction unknown to the node / Safe reports cancelled
- * or failed) produces a terminal verdict. 'unknown' must keep the record and
- * block re-execution of the same plan. An 'armed' record has no id to look
+ * or failed / orderbook reports the order cancelled or expired) produces a
+ * terminal verdict. 'unknown' must keep the record and block re-execution of
+ * the same plan. An 'armed' record without an observed id has nothing to look
  * up, so it is always 'unknown' — it is released by the attempt that armed it
  * (rejection or confirmation) or by an explicit user-acknowledged manual
- * release after the wallet was checked.
+ * release after the wallet was checked. An armed record that does carry an
+ * observed id (the submitted rewrite failed after the wallet returned the id)
+ * is verified through that id exactly like a submitted record.
  */
 export const resolvePendingSubmissionOutcome = async (
   record: PendingSubmissionRecord,
@@ -610,13 +936,45 @@ export const resolvePendingSubmissionOutcome = async (
     safeStatusTimeoutMs?: number
   },
 ): Promise<PendingSubmissionOutcome> => {
-  if (record.phase === 'armed') return 'unknown'
+  const verifiable: PendingSubmissionObservedId | undefined = record.phase === 'armed'
+    ? record.observedId
+    : record.kind === 'cow-order'
+      ? { kind: 'cow-order', orderUid: record.orderUid, orderbookUrl: record.orderbookUrl }
+      : { kind: record.kind, hash: record.hash }
+  if (!verifiable) return 'unknown'
+
+  if (verifiable.kind === 'cow-order') {
+    try {
+      // Loaded lazily so quarantine consumers that never touch CoW do not pull
+      // the orderbook client into their module graph.
+      const { fetchCowSwapOrderStatus } = await import('~/entities/cowswap')
+      const status = await fetchCowSwapOrderStatus({
+        orderUid: verifiable.orderUid,
+        chainId: record.chainId,
+        orderbookUrl: verifiable.orderbookUrl,
+      })
+      if (status.terminal) {
+        // Terminal: traded/fulfilled means the swap settled on-chain;
+        // cancelled/expired means it never can.
+        return status.type === 'cancelled' || status.type === 'expired' ? 'not-landed' : 'landed'
+      }
+      // Open/scheduled/executing/…: the signed order is live and can still
+      // settle at any moment (bounded by its deadline) — keep quarantining.
+      return 'unknown'
+    }
+    catch {
+      // Orderbook unreachable or the uid is unknown to it — an order signed
+      // and possibly accepted elsewhere cannot be ruled out.
+      return 'unknown'
+    }
+  }
+
   const { provider } = options
   if (!provider) return 'unknown'
 
-  if (record.kind === 'transaction') {
+  if (verifiable.kind === 'transaction') {
     try {
-      const receipt = await provider.getTransactionReceipt({ hash: record.hash })
+      const receipt = await provider.getTransactionReceipt({ hash: verifiable.hash })
       return receipt.status === 'success' ? 'landed' : 'not-landed'
     }
     catch {
@@ -638,7 +996,7 @@ export const resolvePendingSubmissionOutcome = async (
   if (!walletProvider) return 'unknown'
   try {
     const execution = await waitForSafeTransactionExecution({
-      submittedHash: record.hash,
+      submittedHash: verifiable.hash,
       walletProvider,
       publicClient: provider,
       timeoutMs: options.safeStatusTimeoutMs ?? 15_000,

--- a/utils/pendingSubmissions.ts
+++ b/utils/pendingSubmissions.ts
@@ -19,18 +19,23 @@ import { SafeTransactionStatusUnknownError, waitForSafeTransactionExecution } fr
  *   operation twice.
  *
  * Records are keyed by flow + chain + owner so one wallet's unresolved
- * submission can never overwrite another's. They persist in localStorage so
- * they survive cart clearing, account switches, and full page reloads — and
- * when durable storage is unavailable or rejects the write, an in-memory
- * fallback keeps the quarantine fail-closed for the rest of the session.
- * Records are removed only once reconciliation reaches a terminal verdict
- * (landed, not landed, or definitively rejected by the wallet).
+ * submission can never overwrite another's, and each carries the attempt id
+ * that reserved it so only that attempt can upgrade or release it. They
+ * persist in localStorage and survive cart clearing, account switches, and
+ * full page reloads. Persistence is durable-or-abort: a reservation that
+ * cannot be proven durable (storage unavailable, write rejected, or read-back
+ * mismatch) throws before the wallet is ever invoked, and reads fail closed —
+ * unreadable or corrupt state blocks new submissions instead of being
+ * silently treated as "no quarantine". Records are removed only once
+ * reconciliation reaches a terminal verdict (landed, not landed, definitively
+ * rejected by the wallet, or an explicit user-acknowledged manual release of
+ * an armed record).
  */
 
-export type PendingSubmissionFlow = 'batch' | 'outgoing-migration' | 'inbound-migration'
+export type PendingSubmissionFlow = 'batch' | 'outgoing-migration' | 'inbound-migration' | 'direct'
 
 export const PENDING_SUBMISSION_FLOWS: readonly PendingSubmissionFlow[]
-  = ['batch', 'outgoing-migration', 'inbound-migration']
+  = ['batch', 'outgoing-migration', 'inbound-migration', 'direct']
 
 interface PendingSubmissionBase {
   readonly chainId: number
@@ -43,6 +48,12 @@ interface PendingSubmissionBase {
   readonly completesPlan: boolean
   readonly refreshExternalPositions?: boolean
   readonly submittedAt: number
+  /**
+   * Identity of the attempt that reserved this record. Upgrades and terminal
+   * releases are ownership-checked against it so one tab's completion can
+   * never delete or overwrite another tab's pending reservation.
+   */
+  readonly attemptId?: string
 }
 
 export interface ArmedPendingSubmission extends PendingSubmissionBase {
@@ -62,6 +73,21 @@ export type PendingSubmissionRecord = ArmedPendingSubmission | SubmittedPendingS
 
 export type PendingSubmissionOutcome = 'landed' | 'not-landed' | 'unknown'
 
+/**
+ * The quarantine's storage layer failed in a way that cannot be tolerated at
+ * a wallet boundary: a reservation write could not be proven durable, or an
+ * existing record could not be read or parsed. Both must stop the attempt
+ * before the wallet is invoked.
+ */
+export class PendingSubmissionStorageError extends Error {}
+
+/** Another attempt already holds this wallet/chain's reservation. */
+export class PendingSubmissionConflictError extends Error {
+  constructor() {
+    super('Another transaction from this wallet was just handed to the wallet. Wait for it to resolve before sending anything new.')
+  }
+}
+
 const STORAGE_PREFIX = 'euler_pending_submission'
 
 export const pendingSubmissionStorageKeyPrefix = (flow: PendingSubmissionFlow) =>
@@ -80,18 +106,39 @@ const getStorage = (): Storage | undefined => {
 }
 
 /**
- * Fail-closed fallback: when localStorage is unavailable or a write does not
- * stick, the record must still block this session's retries rather than
- * silently degrade to "no quarantine".
+ * Secondary in-realm guard. Reservations require durable storage — a write
+ * that lands only here still throws — but the copy kept here additionally
+ * blocks the current realm's retries after that throw is surfaced, and it is
+ * the read authority when the realm has no storage object at all.
  */
 const memoryFallback = new Map<string, string>()
 
-/** Test-only: module state would otherwise leak between test files' cases. */
+/** Test-only: clears the in-realm guard AND purges quarantine keys from live
+ * storage — module state and the storage polyfill would otherwise leak
+ * between test cases. */
 export const resetPendingSubmissionMemoryFallback = () => {
   memoryFallback.clear()
+  const storage = getStorage()
+  if (!storage) return
+  try {
+    const stale: string[] = []
+    for (let i = 0; i < storage.length; i++) {
+      const key = storage.key(i)
+      if (key?.startsWith(STORAGE_PREFIX)) stale.push(key)
+    }
+    for (const key of stale) storage.removeItem(key)
+  }
+  catch {
+    // Best-effort test cleanup only.
+  }
 }
 
-const writeRaw = (key: string, value: string) => {
+/**
+ * 'durable' only when the write stuck in real storage and read back exactly.
+ * Everything else keeps an in-realm copy and reports 'memory' so callers that
+ * require durability can abort before the wallet boundary.
+ */
+const writeRaw = (key: string, value: string): 'durable' | 'memory' => {
   const storage = getStorage()
   if (storage) {
     try {
@@ -100,7 +147,7 @@ const writeRaw = (key: string, value: string) => {
       // count as durable persistence.
       if (storage.getItem(key) === value) {
         memoryFallback.delete(key)
-        return
+        return 'durable'
       }
     }
     catch (err) {
@@ -108,18 +155,29 @@ const writeRaw = (key: string, value: string) => {
     }
   }
   memoryFallback.set(key, value)
+  return 'memory'
 }
 
+/**
+ * Fail-closed read: when a storage object exists but its getter throws, an
+ * existing durable record may be invisible — that cannot fall through to the
+ * (possibly empty) in-realm map, it must throw and block the attempt. Only a
+ * realm with no storage at all treats the in-realm map as the authority.
+ */
 const readRaw = (key: string): string | null => {
   const storage = getStorage()
   if (storage) {
+    let raw: string | null
     try {
-      const raw = storage.getItem(key)
-      if (raw !== null) return raw
+      raw = storage.getItem(key)
     }
-    catch {
-      // Fall through to the in-memory fallback.
+    catch (err) {
+      logWarn('pendingSubmissions/read', err)
+      throw new PendingSubmissionStorageError(
+        'Browser storage could not be read to verify pending submissions. Nothing was sent — resolve the storage issue (or restart the browser) and try again.',
+      )
     }
+    if (raw !== null) return raw
   }
   return memoryFallback.get(key) ?? null
 }
@@ -129,7 +187,8 @@ const removeRaw = (key: string) => {
     getStorage()?.removeItem(key)
   }
   catch {
-    // Ignore unavailable browser storage.
+    // A failed durable remove leaves the record in place — fail-closed: the
+    // stale record keeps blocking until storage recovers.
   }
   memoryFallback.delete(key)
 }
@@ -172,6 +231,7 @@ const parseRecord = (raw: string): PendingSubmissionRecord | undefined => {
   if (typeof candidate.completesPlan !== 'boolean') return undefined
   if (candidate.refreshExternalPositions !== undefined && typeof candidate.refreshExternalPositions !== 'boolean') return undefined
   if (typeof candidate.submittedAt !== 'number' || !Number.isFinite(candidate.submittedAt)) return undefined
+  if (candidate.attemptId !== undefined && typeof candidate.attemptId !== 'string') return undefined
   let owner: Address
   try {
     owner = getAddress(candidate.owner as string)
@@ -185,6 +245,7 @@ const parseRecord = (raw: string): PendingSubmissionRecord | undefined => {
     completesPlan: candidate.completesPlan,
     refreshExternalPositions: candidate.refreshExternalPositions as boolean | undefined,
     submittedAt: candidate.submittedAt,
+    attemptId: candidate.attemptId as string | undefined,
   }
   if (candidate.phase === 'armed') {
     return { phase: 'armed', ...base }
@@ -194,16 +255,23 @@ const parseRecord = (raw: string): PendingSubmissionRecord | undefined => {
   return { phase: 'submitted', kind: candidate.kind, hash: candidate.hash, ...base }
 }
 
+const corruptRecordError = () => new PendingSubmissionStorageError(
+  'A stored pending-submission record could not be read, so a previous submission cannot be ruled out. Check the wallet\'s pending activity; if it shows nothing pending, the stuck record can be dismissed.',
+)
+
+/**
+ * Fail-closed record read: corrupt or key-mismatched state throws instead of
+ * being deleted — an unparseable record may still describe a live submission,
+ * and silently dropping it would reopen the retry it exists to block. Only an
+ * explicit user-acknowledged release (or the corrupting party fixing the
+ * value) clears it.
+ */
 const readRecordAtKey = (key: string, expected?: { owner: Address, chainId: number }): PendingSubmissionRecord | undefined => {
   const raw = readRaw(key)
   if (raw === null) return undefined
   const record = parseRecord(raw)
-  // A corrupt record (or one whose content disagrees with its key) cannot be
-  // reconciled — drop it rather than blocking the flow forever on
-  // unparseable state.
   if (!record || (expected && (record.owner !== expected.owner || record.chainId !== expected.chainId))) {
-    removeRaw(key)
-    return undefined
+    throw corruptRecordError()
   }
   return record
 }
@@ -217,22 +285,279 @@ export const readPendingSubmission = (
   return readRecordAtKey(storageKey(flow, normalizedOwner, chainId), { owner: normalizedOwner, chainId })
 }
 
-/** Every wallet's unresolved record for a flow, corrupt entries dropped. */
+/**
+ * Every wallet's readable record for a flow. Display/mirror use only: entries
+ * that cannot be read or parsed are skipped (never deleted) so hydration at
+ * module init cannot crash — attempt-time reads go through
+ * `readPendingSubmission`, which fails closed on the same state.
+ */
 export const listPendingSubmissions = (flow: PendingSubmissionFlow): PendingSubmissionRecord[] => {
   const records: PendingSubmissionRecord[] = []
   for (const key of listRawKeys(pendingSubmissionStorageKeyPrefix(flow))) {
-    const record = readRecordAtKey(key)
-    if (record) records.push(record)
+    try {
+      const record = readRecordAtKey(key)
+      if (record) records.push(record)
+    }
+    catch {
+      // Unreadable/corrupt entries still block at attempt time.
+    }
   }
   return records
 }
 
+/**
+ * Durable-or-abort write: throws when the record cannot be proven durable.
+ * The in-realm copy written on the failure path still blocks this realm's
+ * retries, but a reservation that would not survive a reload must stop the
+ * attempt before the wallet is invoked.
+ */
 export const writePendingSubmission = (flow: PendingSubmissionFlow, record: PendingSubmissionRecord) => {
-  writeRaw(storageKey(flow, record.owner, record.chainId), JSON.stringify(record))
+  const outcome = writeRaw(storageKey(flow, record.owner, record.chainId), JSON.stringify(record))
+  if (outcome !== 'durable') {
+    throw new PendingSubmissionStorageError(
+      'Replay protection could not be durably saved, so nothing was handed to the wallet. Check that browser storage is available and try again.',
+    )
+  }
 }
 
-export const clearPendingSubmission = (flow: PendingSubmissionFlow, owner: Address, chainId: number) => {
-  removeRaw(storageKey(flow, owner, chainId))
+/**
+ * Per-owner/chain critical section for check+reserve and ownership-checked
+ * mutations. Uses the browser-wide Web Locks API when available (serializing
+ * across tabs) and always chains through an in-realm FIFO queue (serializing
+ * within this realm, and standing in entirely where Web Locks are absent).
+ */
+const realmLockTails = new Map<string, Promise<void>>()
+
+export const withPendingSubmissionLock = async <T>(
+  owner: Address,
+  chainId: number,
+  fn: () => Promise<T>,
+): Promise<T> => {
+  const key = `${STORAGE_PREFIX}:lock:${chainId}:${getAddress(owner)}`
+  const runExclusive = (): Promise<T> => {
+    const locks = (globalThis.navigator as Navigator | undefined)?.locks
+    if (locks?.request) {
+      return locks.request(key, () => fn()) as Promise<T>
+    }
+    return fn()
+  }
+  const tail = realmLockTails.get(key) ?? Promise.resolve()
+  const result = tail.then(runExclusive)
+  realmLockTails.set(key, result.then(() => undefined, () => undefined))
+  return result
+}
+
+let attemptIdCounter = 0
+/** Identity for one execution attempt's reservation. */
+export const createPendingSubmissionAttemptId = (): string => {
+  const uuid = (globalThis.crypto as Crypto | undefined)?.randomUUID?.()
+  if (uuid) return uuid
+  attemptIdCounter += 1
+  return `attempt-${Date.now()}-${attemptIdCounter}`
+}
+
+/**
+ * Atomic check+reserve at the wallet boundary. Inside the per-owner/chain
+ * lock it re-reads every flow's record and throws if any other attempt (any
+ * flow, any surface, any tab) already holds a reservation — two tabs that
+ * both passed the read-only gate cannot both invoke the wallet. Re-arming by
+ * the same attempt (same attemptId) overwrites its own record.
+ *
+ * Throws before the wallet is invoked when the reservation cannot be proven
+ * durable or existing state cannot be read.
+ */
+export const armPendingSubmission = async (
+  flow: PendingSubmissionFlow,
+  input: {
+    owner: Address
+    chainId: number
+    completesPlan: boolean
+    refreshExternalPositions?: boolean
+    attemptId: string
+  },
+): Promise<ArmedPendingSubmission> => {
+  const owner = getAddress(input.owner)
+  return withPendingSubmissionLock(owner, input.chainId, async () => {
+    for (const existingFlow of PENDING_SUBMISSION_FLOWS) {
+      const existing = readPendingSubmission(existingFlow, owner, input.chainId)
+      if (!existing) continue
+      // Even this attempt's own record refuses re-arming once it carries a
+      // submitted hash — overwriting it with a hashless armed record would
+      // destroy the only verifiable id.
+      if (existing.attemptId !== input.attemptId || existing.phase === 'submitted') {
+        throw new PendingSubmissionConflictError()
+      }
+    }
+    const record: ArmedPendingSubmission = {
+      phase: 'armed',
+      chainId: input.chainId,
+      owner,
+      completesPlan: input.completesPlan,
+      refreshExternalPositions: input.refreshExternalPositions,
+      submittedAt: Date.now(),
+      attemptId: input.attemptId,
+    }
+    writePendingSubmission(flow, record)
+    return record
+  })
+}
+
+/**
+ * Ownership-checked armed → submitted upgrade. When the stored record is
+ * missing, unreadable, or belongs to a different attempt, the upgrade is
+ * refused (returning undefined) rather than overwriting state this attempt
+ * does not own — whatever record exists keeps blocking, which is the safe
+ * direction. A refused durable write likewise leaves the armed record.
+ */
+export const upgradePendingSubmissionToSubmitted = async (
+  flow: PendingSubmissionFlow,
+  input: {
+    owner: Address
+    chainId: number
+    attemptId: string
+    kind: 'transaction' | 'proposal'
+    hash: Hash
+    completesPlan: boolean
+    refreshExternalPositions?: boolean
+  },
+): Promise<SubmittedPendingSubmission | undefined> => {
+  const owner = getAddress(input.owner)
+  return withPendingSubmissionLock(owner, input.chainId, async () => {
+    let existing: PendingSubmissionRecord | undefined
+    try {
+      existing = readPendingSubmission(flow, owner, input.chainId)
+    }
+    catch (err) {
+      logWarn('pendingSubmissions/upgrade', err)
+      return undefined
+    }
+    if (!existing || existing.attemptId !== input.attemptId) {
+      logWarn('pendingSubmissions/upgrade', new Error('refused upgrade of a reservation this attempt does not own'))
+      return undefined
+    }
+    const record: SubmittedPendingSubmission = {
+      phase: 'submitted',
+      kind: input.kind,
+      hash: input.hash,
+      chainId: input.chainId,
+      owner,
+      completesPlan: input.completesPlan,
+      refreshExternalPositions: input.refreshExternalPositions,
+      submittedAt: Date.now(),
+      attemptId: input.attemptId,
+    }
+    try {
+      writePendingSubmission(flow, record)
+    }
+    catch (err) {
+      logWarn('pendingSubmissions/upgrade', err)
+      return undefined
+    }
+    return record
+  })
+}
+
+/**
+ * Ownership-checked terminal release: removes the record only when it is
+ * still owned by the given attempt. A stale completion callback (this tab's
+ * attempt finishing after another tab reserved anew) is a no-op.
+ */
+export const releasePendingSubmission = async (
+  flow: PendingSubmissionFlow,
+  owner: Address,
+  chainId: number,
+  ownership: { attemptId: string },
+): Promise<boolean> => {
+  const normalizedOwner = getAddress(owner)
+  return withPendingSubmissionLock(normalizedOwner, chainId, async () => {
+    let existing: PendingSubmissionRecord | undefined
+    try {
+      existing = readPendingSubmission(flow, normalizedOwner, chainId)
+    }
+    catch {
+      // Unreadable/corrupt: ownership is unprovable — keep it blocking.
+      return false
+    }
+    if (!existing || existing.attemptId !== ownership.attemptId) return false
+    removeRaw(storageKey(flow, normalizedOwner, chainId))
+    return true
+  })
+}
+
+/** Same submission (not merely same key): the reconcile-time identity check. */
+const sameSubmissionRecord = (a: PendingSubmissionRecord, b: PendingSubmissionRecord) =>
+  a.phase === b.phase
+  && a.owner === b.owner
+  && a.chainId === b.chainId
+  && a.submittedAt === b.submittedAt
+  && a.attemptId === b.attemptId
+  && a.hash === b.hash
+
+/**
+ * Remove a record after reconciliation reached a terminal verdict. With
+ * `ifMatches` this is compare-and-delete: the key is cleared only while it
+ * still holds the exact record that was reconciled, so a record another
+ * attempt wrote in the meantime survives. Without `ifMatches` the clear is
+ * unconditional — reserved for tests and callers that provably hold no
+ * concurrent writer.
+ */
+export const clearPendingSubmission = async (
+  flow: PendingSubmissionFlow,
+  owner: Address,
+  chainId: number,
+  expected?: { ifMatches: PendingSubmissionRecord },
+): Promise<void> => {
+  const normalizedOwner = getAddress(owner)
+  await withPendingSubmissionLock(normalizedOwner, chainId, async () => {
+    if (expected) {
+      let existing: PendingSubmissionRecord | undefined
+      try {
+        existing = readPendingSubmission(flow, normalizedOwner, chainId)
+      }
+      catch {
+        // Unreadable/corrupt is not the reconciled record — keep it blocking.
+        return
+      }
+      if (!existing || !sameSubmissionRecord(existing, expected.ifMatches)) return
+    }
+    removeRaw(storageKey(flow, normalizedOwner, chainId))
+  })
+}
+
+/**
+ * Risk-labelled manual recovery for a reservation that can never resolve on
+ * its own: an armed record whose attempt died (reload/crash before the wallet
+ * answered) or a corrupt record. Both have no id to verify on-chain, so the
+ * only safe release signal is the user checking the wallet itself — the
+ * acknowledgement object exists to force call sites to present exactly that
+ * check. A 'submitted' record is refused: it has an id and can still confirm,
+ * so it must be verified on-chain, never dismissed.
+ *
+ * Returns true when a record was released, false when none existed.
+ */
+export const releaseUnverifiablePendingSubmission = async (
+  flow: PendingSubmissionFlow,
+  owner: Address,
+  chainId: number,
+  acknowledgement: { userConfirmedWalletShowsNoPendingSubmission: true },
+): Promise<boolean> => {
+  if (acknowledgement.userConfirmedWalletShowsNoPendingSubmission !== true) {
+    throw new Error('Manual release requires the user to confirm the wallet shows no pending submission')
+  }
+  const normalizedOwner = getAddress(owner)
+  return withPendingSubmissionLock(normalizedOwner, chainId, async () => {
+    const key = storageKey(flow, normalizedOwner, chainId)
+    const raw = readRaw(key)
+    if (raw === null) return false
+    const record = parseRecord(raw)
+    if (record?.phase === 'submitted') {
+      throw new Error('This submission has a transaction id and may still confirm on-chain — it is verified automatically and cannot be dismissed. Wait a moment and try again.')
+    }
+    // Armed or corrupt: no id will ever arrive, so only the user's own wallet
+    // check can rule acceptance out.
+    removeRaw(key)
+    return true
+  })
 }
 
 /**
@@ -272,8 +597,9 @@ export const walletNeverAcceptedSubmission = (error: unknown): boolean => {
  * negative signal (transaction unknown to the node / Safe reports cancelled
  * or failed) produces a terminal verdict. 'unknown' must keep the record and
  * block re-execution of the same plan. An 'armed' record has no id to look
- * up, so it is always 'unknown' — it can only be released by the attempt that
- * armed it (rejection or confirmation).
+ * up, so it is always 'unknown' — it is released by the attempt that armed it
+ * (rejection or confirmation) or by an explicit user-acknowledged manual
+ * release after the wallet was checked.
  */
 export const resolvePendingSubmissionOutcome = async (
   record: PendingSubmissionRecord,

--- a/utils/preparedPlanParity.ts
+++ b/utils/preparedPlanParity.ts
@@ -1,0 +1,118 @@
+import { getAddress, type Hex } from 'viem'
+import type { TransactionPlanPrepared } from '@eulerxyz/euler-v2-sdk'
+
+export interface PreparedPlanSignatureSubstitution {
+  placeholder: Hex
+  signature: Hex
+}
+
+const PLAN_DRIFT_ERROR = 'The transaction plan changed after review. Reopen review and try again.'
+
+const stripHexPrefix = (value: Hex): string => value.slice(2).toLowerCase()
+
+const assertValueParity = (
+  reviewed: unknown,
+  resolved: unknown,
+  substitutions: ReadonlyMap<string, { placeholder: string, expected: number }>,
+  observed: Map<string, number>,
+): void => {
+  if (typeof reviewed === 'string' && typeof resolved === 'string') {
+    const normalizedReviewed = reviewed.startsWith('0x') ? reviewed.toLowerCase() : reviewed
+    let normalizedResolved = resolved.startsWith('0x') ? resolved.toLowerCase() : resolved
+    if (normalizedReviewed === normalizedResolved) return
+    if (normalizedReviewed.startsWith('0x') && normalizedResolved.startsWith('0x')) {
+      for (const [signature, substitution] of substitutions) {
+        let searchFrom = 2
+        while (true) {
+          const index = normalizedResolved.indexOf(signature, searchFrom)
+          if (index < 0) break
+          if (normalizedReviewed.slice(index, index + substitution.placeholder.length) === substitution.placeholder) {
+            normalizedResolved = `${normalizedResolved.slice(0, index)}${substitution.placeholder}${normalizedResolved.slice(index + signature.length)}`
+            observed.set(signature, (observed.get(signature) ?? 0) + 1)
+          }
+          searchFrom = index + signature.length
+        }
+      }
+    }
+    if (normalizedReviewed !== normalizedResolved) throw new Error(PLAN_DRIFT_ERROR)
+    return
+  }
+  if (
+    reviewed === null
+    || resolved === null
+    || typeof reviewed !== 'object'
+    || typeof resolved !== 'object'
+  ) {
+    if (reviewed !== resolved) throw new Error(PLAN_DRIFT_ERROR)
+    return
+  }
+  if (Array.isArray(reviewed) || Array.isArray(resolved)) {
+    if (!Array.isArray(reviewed) || !Array.isArray(resolved) || reviewed.length !== resolved.length) {
+      throw new Error(PLAN_DRIFT_ERROR)
+    }
+    reviewed.forEach((item, index) => {
+      assertValueParity(item, resolved[index], substitutions, observed)
+    })
+    return
+  }
+  const reviewedRecord = reviewed as Record<string, unknown>
+  const resolvedRecord = resolved as Record<string, unknown>
+  const reviewedKeys = Object.keys(reviewedRecord).sort()
+  const resolvedKeys = Object.keys(resolvedRecord).sort()
+  if (reviewedKeys.length !== resolvedKeys.length || reviewedKeys.some((key, index) => key !== resolvedKeys[index])) {
+    throw new Error(PLAN_DRIFT_ERROR)
+  }
+  for (const key of reviewedKeys) {
+    assertValueParity(reviewedRecord[key], resolvedRecord[key], substitutions, observed)
+  }
+}
+
+const preparedAccountKey = (prepared: TransactionPlanPrepared): string => {
+  const account = prepared.account
+  return typeof account === 'string'
+    ? getAddress(account)
+    : `${account.chainId}:${getAddress(account.owner)}`
+}
+
+/**
+ * Confirm-time migration plans may replace only the reviewed placeholder
+ * signature bytes. The complete prepared envelope remains unchanged, including
+ * targets, values, call order, plugins, and resolved approvals.
+ */
+export const assertPreparedPlanSignatureParity = ({
+  reviewed,
+  resolved,
+  substitutions,
+}: {
+  reviewed: TransactionPlanPrepared
+  resolved: TransactionPlanPrepared
+  substitutions: readonly PreparedPlanSignatureSubstitution[]
+}): void => {
+  if (
+    reviewed.chainId !== resolved.chainId
+    || preparedAccountKey(reviewed) !== preparedAccountKey(resolved)
+    || reviewed.usePermit2 !== resolved.usePermit2
+    || reviewed.unlimitedApproval !== resolved.unlimitedApproval
+  ) {
+    throw new Error(PLAN_DRIFT_ERROR)
+  }
+
+  const bySignature = new Map<string, { placeholder: string, expected: number }>()
+  for (const { placeholder, signature } of substitutions) {
+    const signatureBytes = stripHexPrefix(signature)
+    const placeholderBytes = stripHexPrefix(placeholder)
+    if (!signatureBytes || signatureBytes === placeholderBytes) throw new Error(PLAN_DRIFT_ERROR)
+    const existing = bySignature.get(signatureBytes)
+    if (existing && existing.placeholder !== placeholderBytes) throw new Error(PLAN_DRIFT_ERROR)
+    bySignature.set(signatureBytes, {
+      placeholder: placeholderBytes,
+      expected: (existing?.expected ?? 0) + 1,
+    })
+  }
+
+  const observed = new Map<string, number>()
+  assertValueParity(reviewed.plan, resolved.plan, bySignature, observed)
+  for (const [signature, substitution] of bySignature) {
+    if ((observed.get(signature) ?? 0) !== substitution.expected) throw new Error(PLAN_DRIFT_ERROR)
+  }
+}

--- a/utils/preparedPlanParity.ts
+++ b/utils/preparedPlanParity.ts
@@ -10,10 +10,51 @@ const PLAN_DRIFT_ERROR = 'The transaction plan changed after review. Reopen revi
 
 const stripHexPrefix = (value: Hex): string => value.slice(2).toLowerCase()
 
+type SignaturePattern = {
+  reviewed: string
+  resolved: string
+}
+
+type SignatureSubstitutionGroup = {
+  expected: number
+  patterns: readonly SignaturePattern[]
+}
+
+const signatureWord = (value: number): string => value.toString(16).padStart(64, '0')
+
+const splitSignature = (signature: Hex): { r: string, s: string, v: number } => {
+  const bytes = stripHexPrefix(signature)
+  if (bytes.length !== 130) throw new Error(PLAN_DRIFT_ERROR)
+  let v = Number.parseInt(bytes.slice(128, 130), 16)
+  if (!Number.isFinite(v)) throw new Error(PLAN_DRIFT_ERROR)
+  if (v < 27) v += 27
+  return {
+    r: bytes.slice(0, 64),
+    s: bytes.slice(64, 128),
+    v,
+  }
+}
+
+const buildSignaturePatterns = (placeholder: Hex, signature: Hex): SignaturePattern[] => {
+  const reviewedBytes = stripHexPrefix(placeholder)
+  const resolvedBytes = stripHexPrefix(signature)
+  const reviewed = splitSignature(placeholder)
+  const resolved = splitSignature(signature)
+  return [
+    // Some authorizations retain the ordinary 65-byte signature.
+    { reviewed: reviewedBytes, resolved: resolvedBytes },
+    // Aave, Morpho, and MetaMorpho encode the signature as ABI v/r/s words.
+    {
+      reviewed: `${signatureWord(reviewed.v)}${reviewed.r}${reviewed.s}`,
+      resolved: `${signatureWord(resolved.v)}${resolved.r}${resolved.s}`,
+    },
+  ]
+}
+
 const assertValueParity = (
   reviewed: unknown,
   resolved: unknown,
-  substitutions: ReadonlyMap<string, { placeholder: string, expected: number }>,
+  substitutions: ReadonlyMap<string, SignatureSubstitutionGroup>,
   observed: Map<string, number>,
 ): void => {
   if (typeof reviewed === 'string' && typeof resolved === 'string') {
@@ -22,15 +63,17 @@ const assertValueParity = (
     if (normalizedReviewed === normalizedResolved) return
     if (normalizedReviewed.startsWith('0x') && normalizedResolved.startsWith('0x')) {
       for (const [signature, substitution] of substitutions) {
-        let searchFrom = 2
-        while (true) {
-          const index = normalizedResolved.indexOf(signature, searchFrom)
-          if (index < 0) break
-          if (normalizedReviewed.slice(index, index + substitution.placeholder.length) === substitution.placeholder) {
-            normalizedResolved = `${normalizedResolved.slice(0, index)}${substitution.placeholder}${normalizedResolved.slice(index + signature.length)}`
-            observed.set(signature, (observed.get(signature) ?? 0) + 1)
+        for (const pattern of substitution.patterns) {
+          let searchFrom = 2
+          while (true) {
+            const index = normalizedResolved.indexOf(pattern.resolved, searchFrom)
+            if (index < 0) break
+            if (normalizedReviewed.slice(index, index + pattern.reviewed.length) === pattern.reviewed) {
+              normalizedResolved = `${normalizedResolved.slice(0, index)}${pattern.reviewed}${normalizedResolved.slice(index + pattern.resolved.length)}`
+              observed.set(signature, (observed.get(signature) ?? 0) + 1)
+            }
+            searchFrom = index + pattern.resolved.length
           }
-          searchFrom = index + signature.length
         }
       }
     }
@@ -76,8 +119,9 @@ const preparedAccountKey = (prepared: TransactionPlanPrepared): string => {
 
 /**
  * Confirm-time migration plans may replace only the reviewed placeholder
- * signature bytes. The complete prepared envelope remains unchanged, including
- * targets, values, call order, plugins, and resolved approvals.
+ * signature representation, either raw bytes or ABI-encoded v/r/s words. The
+ * complete prepared envelope remains unchanged, including targets, values,
+ * call order, plugins, and resolved approvals.
  */
 export const assertPreparedPlanSignatureParity = ({
   reviewed,
@@ -97,16 +141,19 @@ export const assertPreparedPlanSignatureParity = ({
     throw new Error(PLAN_DRIFT_ERROR)
   }
 
-  const bySignature = new Map<string, { placeholder: string, expected: number }>()
+  const bySignature = new Map<string, SignatureSubstitutionGroup>()
   for (const { placeholder, signature } of substitutions) {
     const signatureBytes = stripHexPrefix(signature)
     const placeholderBytes = stripHexPrefix(placeholder)
     if (!signatureBytes || signatureBytes === placeholderBytes) throw new Error(PLAN_DRIFT_ERROR)
     const existing = bySignature.get(signatureBytes)
-    if (existing && existing.placeholder !== placeholderBytes) throw new Error(PLAN_DRIFT_ERROR)
+    const patterns = buildSignaturePatterns(placeholder, signature)
+    if (existing && existing.patterns.some((pattern, index) => pattern.reviewed !== patterns[index]?.reviewed)) {
+      throw new Error(PLAN_DRIFT_ERROR)
+    }
     bySignature.set(signatureBytes, {
-      placeholder: placeholderBytes,
       expected: (existing?.expected ?? 0) + 1,
+      patterns,
     })
   }
 

--- a/utils/preparedPlanParity.ts
+++ b/utils/preparedPlanParity.ts
@@ -15,11 +15,6 @@ type SignaturePattern = {
   resolved: string
 }
 
-type SignatureSubstitutionGroup = {
-  expected: number
-  patterns: readonly SignaturePattern[]
-}
-
 const signatureWord = (value: number): string => value.toString(16).padStart(64, '0')
 
 const splitSignature = (signature: Hex): { r: string, s: string, v: number } => {
@@ -51,33 +46,85 @@ const buildSignaturePatterns = (placeholder: Hex, signature: Hex): SignaturePatt
   ]
 }
 
+type OrderedSubstitution = {
+  patterns: readonly SignaturePattern[]
+}
+
+/**
+ * Consumption cursor into the ordered substitution list. Each reviewed
+ * placeholder occurrence, in deterministic traversal order, must be replaced
+ * by exactly the next substitution — two identical placeholders can never
+ * swap their signatures between call locations.
+ */
+type SubstitutionCursor = {
+  next: number
+}
+
+/**
+ * Find the queued substitution's pattern covering the first differing
+ * character. The window must reproduce the reviewed placeholder bytes on the
+ * reviewed side and the resolved signature bytes on the resolved side.
+ */
+const matchSubstitutionAt = (
+  reviewed: string,
+  resolved: string,
+  patterns: readonly SignaturePattern[],
+  diffIndex: number,
+): number | undefined => {
+  for (const pattern of patterns) {
+    const length = pattern.resolved.length
+    let from = Math.max(2, diffIndex - length + 1)
+    while (from <= diffIndex) {
+      const start = resolved.indexOf(pattern.resolved, from)
+      if (start < 0 || start > diffIndex) break
+      if (reviewed.startsWith(pattern.reviewed, start)) return start + length
+      from = start + 1
+    }
+  }
+  return undefined
+}
+
+const assertStringParity = (
+  reviewed: string,
+  resolved: string,
+  substitutions: readonly OrderedSubstitution[],
+  cursor: SubstitutionCursor,
+): void => {
+  const normalizedReviewed = reviewed.startsWith('0x') ? reviewed.toLowerCase() : reviewed
+  const normalizedResolved = resolved.startsWith('0x') ? resolved.toLowerCase() : resolved
+  if (normalizedReviewed === normalizedResolved) return
+  if (
+    !normalizedReviewed.startsWith('0x')
+    || !normalizedResolved.startsWith('0x')
+    // Both permitted representations replace like-for-like byte ranges, so any
+    // legitimate substitution preserves the string length.
+    || normalizedReviewed.length !== normalizedResolved.length
+  ) {
+    throw new Error(PLAN_DRIFT_ERROR)
+  }
+  let index = 2
+  while (index < normalizedReviewed.length) {
+    if (normalizedReviewed[index] === normalizedResolved[index]) {
+      index++
+      continue
+    }
+    const substitution = substitutions[cursor.next]
+    if (!substitution) throw new Error(PLAN_DRIFT_ERROR)
+    const end = matchSubstitutionAt(normalizedReviewed, normalizedResolved, substitution.patterns, index)
+    if (end === undefined) throw new Error(PLAN_DRIFT_ERROR)
+    cursor.next++
+    index = end
+  }
+}
+
 const assertValueParity = (
   reviewed: unknown,
   resolved: unknown,
-  substitutions: ReadonlyMap<string, SignatureSubstitutionGroup>,
-  observed: Map<string, number>,
+  substitutions: readonly OrderedSubstitution[],
+  cursor: SubstitutionCursor,
 ): void => {
   if (typeof reviewed === 'string' && typeof resolved === 'string') {
-    const normalizedReviewed = reviewed.startsWith('0x') ? reviewed.toLowerCase() : reviewed
-    let normalizedResolved = resolved.startsWith('0x') ? resolved.toLowerCase() : resolved
-    if (normalizedReviewed === normalizedResolved) return
-    if (normalizedReviewed.startsWith('0x') && normalizedResolved.startsWith('0x')) {
-      for (const [signature, substitution] of substitutions) {
-        for (const pattern of substitution.patterns) {
-          let searchFrom = 2
-          while (true) {
-            const index = normalizedResolved.indexOf(pattern.resolved, searchFrom)
-            if (index < 0) break
-            if (normalizedReviewed.slice(index, index + pattern.reviewed.length) === pattern.reviewed) {
-              normalizedResolved = `${normalizedResolved.slice(0, index)}${pattern.reviewed}${normalizedResolved.slice(index + pattern.resolved.length)}`
-              observed.set(signature, (observed.get(signature) ?? 0) + 1)
-            }
-            searchFrom = index + pattern.resolved.length
-          }
-        }
-      }
-    }
-    if (normalizedReviewed !== normalizedResolved) throw new Error(PLAN_DRIFT_ERROR)
+    assertStringParity(reviewed, resolved, substitutions, cursor)
     return
   }
   if (
@@ -94,7 +141,7 @@ const assertValueParity = (
       throw new Error(PLAN_DRIFT_ERROR)
     }
     reviewed.forEach((item, index) => {
-      assertValueParity(item, resolved[index], substitutions, observed)
+      assertValueParity(item, resolved[index], substitutions, cursor)
     })
     return
   }
@@ -106,7 +153,7 @@ const assertValueParity = (
     throw new Error(PLAN_DRIFT_ERROR)
   }
   for (const key of reviewedKeys) {
-    assertValueParity(reviewedRecord[key], resolvedRecord[key], substitutions, observed)
+    assertValueParity(reviewedRecord[key], resolvedRecord[key], substitutions, cursor)
   }
 }
 
@@ -122,6 +169,13 @@ const preparedAccountKey = (prepared: TransactionPlanPrepared): string => {
  * signature representation, either raw bytes or ABI-encoded v/r/s words. The
  * complete prepared envelope remains unchanged, including targets, values,
  * call order, plugins, and resolved approvals.
+ *
+ * `substitutions` is positional: its order must match the order in which the
+ * reviewed plan carries the placeholder occurrences (entry order, then each
+ * entry's primary authorization before its post-migration one). The k-th
+ * occurrence is only ever replaced by the k-th signature — signatures
+ * authorizing different typed-data messages cannot be transposed between
+ * structurally identical placeholder sites.
  */
 export const assertPreparedPlanSignatureParity = ({
   reviewed,
@@ -141,25 +195,13 @@ export const assertPreparedPlanSignatureParity = ({
     throw new Error(PLAN_DRIFT_ERROR)
   }
 
-  const bySignature = new Map<string, SignatureSubstitutionGroup>()
-  for (const { placeholder, signature } of substitutions) {
+  const ordered: OrderedSubstitution[] = substitutions.map(({ placeholder, signature }) => {
     const signatureBytes = stripHexPrefix(signature)
-    const placeholderBytes = stripHexPrefix(placeholder)
-    if (!signatureBytes || signatureBytes === placeholderBytes) throw new Error(PLAN_DRIFT_ERROR)
-    const existing = bySignature.get(signatureBytes)
-    const patterns = buildSignaturePatterns(placeholder, signature)
-    if (existing && existing.patterns.some((pattern, index) => pattern.reviewed !== patterns[index]?.reviewed)) {
-      throw new Error(PLAN_DRIFT_ERROR)
-    }
-    bySignature.set(signatureBytes, {
-      expected: (existing?.expected ?? 0) + 1,
-      patterns,
-    })
-  }
+    if (!signatureBytes || signatureBytes === stripHexPrefix(placeholder)) throw new Error(PLAN_DRIFT_ERROR)
+    return { patterns: buildSignaturePatterns(placeholder, signature) }
+  })
 
-  const observed = new Map<string, number>()
-  assertValueParity(reviewed.plan, resolved.plan, bySignature, observed)
-  for (const [signature, substitution] of bySignature) {
-    if ((observed.get(signature) ?? 0) !== substitution.expected) throw new Error(PLAN_DRIFT_ERROR)
-  }
+  const cursor: SubstitutionCursor = { next: 0 }
+  assertValueParity(reviewed.plan, resolved.plan, ordered, cursor)
+  if (cursor.next !== ordered.length) throw new Error(PLAN_DRIFT_ERROR)
 }

--- a/utils/walletExecutionContext.ts
+++ b/utils/walletExecutionContext.ts
@@ -35,3 +35,43 @@ export const assertWalletExecutionContext = ({
     throw new WalletExecutionContextChangedError('chain')
   }
 }
+
+/**
+ * Guard for the irreversible broadcast boundary of a direct Safe-bundle flow.
+ *
+ * Account and chain checks cannot see a same-account connector switch, and the
+ * confirm-entry checks run before authorization lookup, planning, preparation,
+ * and simulation all await. The factory captures the connector identity when
+ * the user confirms; the returned callback re-asserts the full reviewed
+ * context — account, chain, Safe classification, and connector — immediately
+ * before the proposal broadcast, so a wallet swapped during those awaits can
+ * never submit the reviewed ceremony.
+ */
+export const createSafeBundleBroadcastGuard = ({
+  expectedAccount,
+  expectedChainId,
+  currentAccount,
+  currentChainId,
+  isSafeWallet,
+  connectorContextKey,
+}: {
+  expectedAccount: Address
+  expectedChainId: number
+  currentAccount: () => Address | undefined
+  currentChainId: () => number | undefined
+  isSafeWallet: () => boolean
+  connectorContextKey: () => string | undefined
+}): (() => void) => {
+  const confirmedConnectorKey = connectorContextKey()
+  return () => {
+    assertWalletExecutionContext({
+      expectedAccount,
+      expectedChainId,
+      currentAccount: currentAccount(),
+      currentChainId: currentChainId(),
+    })
+    if (!isSafeWallet() || connectorContextKey() !== confirmedConnectorKey) {
+      throw new Error('Wallet changed since review — please review the migration again.')
+    }
+  }
+}

--- a/utils/walletExecutionContext.ts
+++ b/utils/walletExecutionContext.ts
@@ -36,18 +36,56 @@ export const assertWalletExecutionContext = ({
   }
 }
 
+export const WALLET_CHANGED_SINCE_REVIEW_ERROR
+  = 'Wallet changed since review — please review the migration again.'
+
 /**
- * Guard for the irreversible broadcast boundary of a direct Safe-bundle flow.
+ * Guard for the irreversible wallet-action boundaries (signature requests,
+ * grant broadcasts, plan broadcasts) of a flow reviewed under one connector.
  *
  * Account and chain checks cannot see a same-account connector switch, and
  * confirmation awaits (pending restoration, authorization lookup, planning,
- * preparation, simulation) all yield before the proposal broadcast. Snapshotting
+ * preparation, simulation) all yield before each wallet action. Snapshotting
  * the connector inside the confirmation flow would accept a connector swapped
  * during an earlier await as the baseline, so `expectedConnectorKey` must be
  * the key the reviewed preview captured when it was built. The returned
- * callback re-asserts the full reviewed context — account, chain, Safe
- * classification, and connector — immediately before the broadcast, and fails
- * closed when the review captured no connector at all.
+ * callback re-asserts the reviewed context — account, chain, and connector —
+ * immediately before each wallet action, and fails closed when the review
+ * captured no connector at all.
+ */
+export const createReviewedWalletContextGuard = ({
+  expectedAccount,
+  expectedChainId,
+  expectedConnectorKey,
+  currentAccount,
+  currentChainId,
+  connectorContextKey,
+}: {
+  expectedAccount: Address
+  expectedChainId: number
+  expectedConnectorKey: string | undefined
+  currentAccount: () => Address | undefined
+  currentChainId: () => number | undefined
+  connectorContextKey: () => string | undefined
+}): (() => void) => {
+  return () => {
+    assertWalletExecutionContext({
+      expectedAccount,
+      expectedChainId,
+      currentAccount: currentAccount(),
+      currentChainId: currentChainId(),
+    })
+    if (!expectedConnectorKey || connectorContextKey() !== expectedConnectorKey) {
+      throw new Error(WALLET_CHANGED_SINCE_REVIEW_ERROR)
+    }
+  }
+}
+
+/**
+ * Guard for the irreversible broadcast boundary of a direct Safe-bundle flow:
+ * the reviewed wallet context (account, chain, connector) plus the Safe
+ * classification the bundled review promised — a wallet that stopped
+ * classifying as a Safe cannot submit the reviewed single-proposal ceremony.
  */
 export const createSafeBundleBroadcastGuard = ({
   expectedAccount,
@@ -66,15 +104,18 @@ export const createSafeBundleBroadcastGuard = ({
   isSafeWallet: () => boolean
   connectorContextKey: () => string | undefined
 }): (() => void) => {
+  const assertReviewedContext = createReviewedWalletContextGuard({
+    expectedAccount,
+    expectedChainId,
+    expectedConnectorKey,
+    currentAccount,
+    currentChainId,
+    connectorContextKey,
+  })
   return () => {
-    assertWalletExecutionContext({
-      expectedAccount,
-      expectedChainId,
-      currentAccount: currentAccount(),
-      currentChainId: currentChainId(),
-    })
-    if (!isSafeWallet() || !expectedConnectorKey || connectorContextKey() !== expectedConnectorKey) {
-      throw new Error('Wallet changed since review — please review the migration again.')
+    assertReviewedContext()
+    if (!isSafeWallet()) {
+      throw new Error(WALLET_CHANGED_SINCE_REVIEW_ERROR)
     }
   }
 }

--- a/utils/walletExecutionContext.ts
+++ b/utils/walletExecutionContext.ts
@@ -39,17 +39,20 @@ export const assertWalletExecutionContext = ({
 /**
  * Guard for the irreversible broadcast boundary of a direct Safe-bundle flow.
  *
- * Account and chain checks cannot see a same-account connector switch, and the
- * confirm-entry checks run before authorization lookup, planning, preparation,
- * and simulation all await. The factory captures the connector identity when
- * the user confirms; the returned callback re-asserts the full reviewed
- * context — account, chain, Safe classification, and connector — immediately
- * before the proposal broadcast, so a wallet swapped during those awaits can
- * never submit the reviewed ceremony.
+ * Account and chain checks cannot see a same-account connector switch, and
+ * confirmation awaits (pending restoration, authorization lookup, planning,
+ * preparation, simulation) all yield before the proposal broadcast. Snapshotting
+ * the connector inside the confirmation flow would accept a connector swapped
+ * during an earlier await as the baseline, so `expectedConnectorKey` must be
+ * the key the reviewed preview captured when it was built. The returned
+ * callback re-asserts the full reviewed context — account, chain, Safe
+ * classification, and connector — immediately before the broadcast, and fails
+ * closed when the review captured no connector at all.
  */
 export const createSafeBundleBroadcastGuard = ({
   expectedAccount,
   expectedChainId,
+  expectedConnectorKey,
   currentAccount,
   currentChainId,
   isSafeWallet,
@@ -57,12 +60,12 @@ export const createSafeBundleBroadcastGuard = ({
 }: {
   expectedAccount: Address
   expectedChainId: number
+  expectedConnectorKey: string | undefined
   currentAccount: () => Address | undefined
   currentChainId: () => number | undefined
   isSafeWallet: () => boolean
   connectorContextKey: () => string | undefined
 }): (() => void) => {
-  const confirmedConnectorKey = connectorContextKey()
   return () => {
     assertWalletExecutionContext({
       expectedAccount,
@@ -70,7 +73,7 @@ export const createSafeBundleBroadcastGuard = ({
       currentAccount: currentAccount(),
       currentChainId: currentChainId(),
     })
-    if (!isSafeWallet() || connectorContextKey() !== confirmedConnectorKey) {
+    if (!isSafeWallet() || !expectedConnectorKey || connectorContextKey() !== expectedConnectorKey) {
       throw new Error('Wallet changed since review — please review the migration again.')
     }
   }


### PR DESCRIPTION
## Summary
- Use one immutable, generation-scoped ceremony for batch review, calldata export, gas estimation, and wallet submission.
- Reject stale work across cart, account, chain, connector-session, and Safe-classification changes, including at asynchronous wallet boundaries.
- Request migration authorization signatures only after confirmation and allow them to change only the exact placeholder representation reviewed by the user.

## Background and rationale

Batch execution has evolved in stages. The original flow captured operation plans, merged them for review, and then executed them. As support expanded to migrations, Safe proposals, dynamic authorization, connector changes, plugins, and confirmation-time signatures, more asynchronous preparation points were introduced. Earlier fixes pinned individual pieces—such as reviewed core plans and Safe/migration authorization payloads—but the complete transaction ceremony could still combine state captured at different times.

This PR completes that design: one immutable ceremony, bound to the current cart and wallet session, is the source of truth for review, copying, gas estimation, supported simulation, and submission. Material changes invalidate the ceremony and require a fresh review; confirmation-time signing can only complete the exact authorization placeholders represented during review. This preserves the core transaction-stack invariant that the plan approved by the user is the plan ultimately sent to the wallet.

Beyond closing the current race conditions, this creates a safer extension point for future connectors, authorization methods, plugins, migrations, and wallet execution modes. New functionality can contribute to the same ceremony instead of introducing another parallel preparation path. That reduces the combinations of mutable state and timing we need to reason about, makes parity testable at the final wallet boundary, and provides a fail-closed foundation as the batch stack grows.

## Changes
- Deduplicate preparation per cart generation and bind each ceremony to the normalized owner, chain, connector ID and UID, and resolved Safe classification.
- Derive authorization calls and rows from one resolution, preserving exact grant → prepared core → reverse restoration ordering and every duplicate wallet prompt.
- Compare confirm-time migrations with the reviewed prepared envelope, supporting both raw signatures and the ABI-encoded `v`/`r`/`s` representation used by Aave, Morpho, and MetaMorpho while rejecting all other plan drift.
- Estimate the frozen prepared envelope directly so plugins and approval resolution cannot produce a different call vector before broadcast.
- Scope asynchronous adds, resimulation data, snapshots, execution completion, errors, cart clearing, and redirects to their originating ceremony and wallet context.
- Derive expanded rows, unverified-vault disclosure, copied calldata, and Safe submission from the ceremony plan and shared encoder.
- Keep whole-batch third-party simulation unavailable because a single-transaction simulation cannot represent the complete reviewed ceremony. Per-operation simulation remains available.

## Test plan
- [x] Run targeted ESLint across all changed files.
- [x] Run `npm run typecheck`.
- [x] Run the production build.
- [x] Run `npm run test:run -- --silent --reporter=dot`: 1,797 tests passed across 183 files.
- [x] Run the focused ABI-parity and prepared-estimation cohort: 122 tests passed across 3 files.
- [x] Cover overlapping preparation, pending adds, wallet-context changes, stale snapshots, final wallet boundaries, late completion, deferred migration signatures, raw and ABI-encoded signature parity, prepared-envelope gas estimation, duplicate authorization prompts, unverified-vault disclosure, calldata/submission parity, and exact execution ordering.
