### PR TITLE
docs: point guard docs at the SDK plugin implementation

### DIFF
--- a/docs/keyring-hooks.md
+++ b/docs/keyring-hooks.md
@@ -50,23 +50,24 @@ The Keyring credentials contract (`entityExp(policyId, address)`) is used to che
 - Manages the Keyring Connect SDK browser extension flow
 - Returns reactive state: `isVerificationRequired`, `flowState`, `credentialData`, etc.
 
-**`composables/useOperationGuard.ts`** — wires keyring to the guard system:
+**`composables/useOperationGuard.ts`** — wires keyring to the SDK plugin and the guard registry:
 - Calls `useKeyring` for the first keyring-flagged vault address
 - Provides keyring state to `VaultFormSubmit` via `provide('keyring-guard', ...)`
-- Registers/unregisters plan transformers and blockers in the guard registry
+- Publishes verified credentials to the SDK keyring plugin store via `setSdkKeyringCredential()` (`utils/sdk-keyring.ts`) and sets credential-cost metadata
+- Registers/unregisters submit blockers in the guard registry while verification is pending
 
-### Operation Guard Registry
+### Guard registry and SDK plugin
 
-`utils/operationGuardRegistry.ts` provides a reactive system for automatic SDK `TransactionPlan` transformation:
+`utils/operationGuardRegistry.ts` holds reactive submit blockers and per-concern metadata. Plan transformation itself runs inside the SDK's keyring plugin (`createKeyringPlugin`, registered in `composables/useEulerSdk.ts`):
 
 ```text
 Page calls useOperationGuard([vaultAddresses])
   → useKeyring detects keyring vault
   → credential obtained from extension
-  → registerOperationGuard('keyring', transformFn)
+  → setSdkKeyringCredential(...) publishes it to the SDK plugin store
 
 Page calls executePlan(plan) as normal
-  → applyOperationGuards(plan) automatically prepends createCredential
+  → the SDK keyring plugin automatically prepends createCredential
   → transaction executes with credential registration + vault operation atomically
 ```
 
@@ -74,7 +75,12 @@ This means **pages need zero changes to their submit handlers** — they just ca
 
 ### Transaction injection
 
-`utils/keyring-injection.ts` contains the `injectKeyringCredential()` pure function that:
+The SDK's `createKeyringPlugin` performs the injection. It is registered in `composables/useEulerSdk.ts` with two inputs from `utils/sdk-keyring.ts`:
+
+- `hookTargets` from `buildSdkKeyringHookTargets()` — hook-target addresses derived from keyring-tagged vaults in the registry
+- `getCredentialData` from `getSdkKeyringCredential()` — serves credentials published by `useOperationGuard`, returning `null` for expired credentials or when the hook target's keyring contract address no longer matches the cached one
+
+When a plan touches a keyring hook target and a credential is available, the plugin:
 1. Creates a `createCredential` `EVCBatchItem` targeting the Keyring credentials contract
 2. Includes the ETH/native currency fee as the call's `value`
 3. Prepends it to every `evcBatch` item in the SDK `TransactionPlan`
@@ -120,8 +126,8 @@ useOperationGuard(computed(() => [fromVault?.address, toVault?.address].filter(B
 |------|------|
 | `abis/keyring.ts` | Hook target + credentials contract ABIs |
 | `composables/useKeyring/index.ts` | Main keyring composable |
-| `composables/useOperationGuard.ts` | Wires keyring to guard registry + provide/inject |
-| `utils/operationGuardRegistry.ts` | Reactive guard registry (register/unregister/apply) |
-| `utils/keyring-injection.ts` | SDK `TransactionPlan` transformer (prepend createCredential to EVC batch) |
+| `composables/useOperationGuard.ts` | Publishes credentials to the SDK plugin store, registers blockers, provide/inject |
+| `utils/operationGuardRegistry.ts` | Reactive submit blocker and metadata registry |
+| `utils/sdk-keyring.ts` | Credential store and hook-target config for the SDK `createKeyringPlugin` |
 | `components/keyring/*` | UI components (badge, alert, flow, modal) |
 | `components/entities/vault/VaultTypeBadges.vue` | Unified vault type + private badge display |

--- a/docs/keyring-hooks.md
+++ b/docs/keyring-hooks.md
@@ -75,7 +75,7 @@ This means **pages need zero changes to their submit handlers** — they just ca
 
 ### Transaction injection
 
-The SDK's `createKeyringPlugin` performs the injection. It is registered in `composables/useEulerSdk.ts` with two inputs from `utils/sdk-keyring.ts`:
+The SDK's [`createKeyringPlugin`](https://github.com/euler-xyz/euler-sdks/blob/main/packages/euler-v2-sdk/src/plugins/keyring/keyringPlugin.ts) performs the injection. It is registered in `composables/useEulerSdk.ts` with two inputs from `utils/sdk-keyring.ts`:
 
 - `hookTargets` from `buildSdkKeyringHookTargets()` — hook-target addresses derived from keyring-tagged vaults in the registry
 - `getCredentialData` from `getSdkKeyringCredential()` — serves credentials published by `useOperationGuard`, returning `null` for expired credentials or when the hook target's keyring contract address no longer matches the cached one

--- a/docs/keyring-hooks.md
+++ b/docs/keyring-hooks.md
@@ -80,7 +80,7 @@ The SDK's [`createKeyringPlugin`](https://github.com/euler-xyz/euler-sdks/blob/m
 - `hookTargets` from `buildSdkKeyringHookTargets()` — hook-target addresses derived from keyring-tagged vaults in the registry
 - `getCredentialData` from `getSdkKeyringCredential()` — serves credentials published by `useOperationGuard`, returning `null` for expired credentials or when the hook target's keyring contract address no longer matches the cached one
 
-When a plan touches a keyring hook target and a credential is available, the plugin:
+When a plan touches a keyring hook target, the plugin first re-checks `checkKeyringCredentialOrWildCard(sender)` on-chain (even when prefetched — validity can flip between prefetch and submit) and skips injection if the sender already has a valid credential. Otherwise, when the store returns a current credential, the plugin:
 1. Creates a `createCredential` `EVCBatchItem` targeting the Keyring credentials contract
 2. Includes the ETH/native currency fee as the call's `value`
 3. Prepends it to every `evcBatch` item in the SDK `TransactionPlan`

--- a/docs/tos-signing.md
+++ b/docs/tos-signing.md
@@ -85,9 +85,9 @@ See: `composables/guards/useTosGuard.ts`
 | File | Role |
 |------|------|
 | `composables/useTosData.ts` | Fetches TOS markdown, computes hashes |
-| `composables/guards/useTosGuard.ts` | Guard logic, on-chain signature check, blocker/guard registration |
-| `utils/tos-injection.ts` | Prepends `signTermsOfUse` call to EVC batch |
-| `utils/operationGuardRegistry.ts` | Generic guard registry (TOS guard registers here) |
+| `composables/guards/useTosGuard.ts` | Guard logic, on-chain signature check, blocker registration, publishes the signed message to `utils/sdk-tos.ts` |
+| `utils/sdk-tos.ts` | SDK plugin that prepends the `signTermsOfUse` call to every EVC batch |
+| `utils/operationGuardRegistry.ts` | Submit blocker and metadata registry (TOS blocker registers here) |
 | `server/api/internal/tos.get.ts` | Server proxy for TOS markdown with caching |
 | `abis/tos.ts` | `TermsOfUseSigner` contract ABIs |
 | `components/entities/operation/AcknowledgeTermsModal.vue` | Acceptance modal UI |

--- a/docs/transaction-building.md
+++ b/docs/transaction-building.md
@@ -60,12 +60,13 @@ The wrapper supplies the current SDK `Account`, wallet/sub-account owner, chain 
 ## Execution Flow
 
 1. A page or workflow composable builds a `TransactionPlan` with `useEulerTx()`.
-2. `useTransactionPlanSimulation().runSimulation(plan)` applies operation guards and calls `sdk.executionService.simulateTransactionPlan(...)`.
-3. The review modal prepares the plan with `preparePlanForReview(plan)`.
-4. `preparePlanForReview` applies operation guards and calls `sdk.executionService.resolveRequiredApprovals(...)`.
-5. The review modal renders the prepared plan via `utils/stepDecoding.ts`.
-6. Confirming calls the workflow callback, which executes the plan through `executePlan(plan)`.
-7. `executePlan` applies operation guards, calls `sdk.executionService.executeTransactionPlan(...)`, forwards wagmi `sendTransaction` / `signTypedData` callbacks, and refreshes portfolio state after receipts.
+2. `useTransactionPlanSimulation().runSimulation(plan)` calls `sdk.executionService.simulateTransactionPlan(...)`.
+3. The review modal prepares the plan with `prepareTransactionPlan(plan)` (unless the caller passes a pre-prepared envelope), which calls `sdk.executionService.prepareTransactionPlan(...)`.
+4. The review modal renders the prepared plan via `utils/stepDecoding.ts`.
+5. Confirming calls the workflow callback, which executes the plan through `executePlan(plan)`.
+6. `executePlan` calls `sdk.executionService.executeTransactionPlan(...)`, forwards wagmi `sendTransaction` / `signTypedData` callbacks, and refreshes portfolio state after receipts.
+
+Plan transformation (terms-of-use signing, Keyring credential injection) runs inside the SDK plugin pipeline on each of these paths — see Operation Guards below.
 
 The review modal is fail-closed: if preparation does not produce a plan, it shows an error and disables confirmation.
 
@@ -80,21 +81,18 @@ Plans may include `requiredApproval` items. During review and execution, `resolv
 
 ## Operation Guards
 
-`utils/operationGuardRegistry.ts` stores plan transformers and blockers. Guards are applied before simulation, review preparation, and execution.
+`utils/operationGuardRegistry.ts` stores reactive submit blockers and per-concern metadata. Blockers gate the submit button (pending Keyring verification, unverified-vault acknowledgement); metadata annotates failures (e.g. keyring credential cost in `tx-errors`).
 
-Current guard families include:
+Plan transformation runs as SDK `EulerPlugin`s registered in `composables/useEulerSdk.ts`, so simulation, review preparation, and execution all pass through the same pipeline:
 
-- Terms of use signing
-- Keyring credential injection for private vaults
-- Unverified-vault acknowledgement
-
-Transformers receive and return SDK `TransactionPlan` values. For example, `utils/keyring-injection.ts` prepends a Keyring `createCredential` `EVCBatchItem` to every `evcBatch` item.
+- Terms-of-use signing — `createLiteTosPlugin()` (`utils/sdk-tos.ts`) prepends a signed terms-of-use `EVCBatchItem` to every `evcBatch` item.
+- Keyring credential injection for private vaults — the SDK's `createKeyringPlugin`, configured with hook targets and a credential store from `utils/sdk-keyring.ts`. `composables/useOperationGuard.ts` publishes verified credentials into that store; the plugin prepends a Keyring `createCredential` `EVCBatchItem` when a plan touches a keyring hook target.
 
 ## Review Display
 
 `components/entities/operation/OperationReviewModal.vue` displays a prepared SDK plan. It uses:
 
-- `preparePlanForReview` for guard application and approval resolution
+- `prepareTransactionPlan` for SDK plan preparation (plugin pipeline and approval resolution)
 - `buildTransactionPlanDisplaySteps` for human-readable step labels and asset amounts
 - `flattenBatchEntries` and `encodeBatch` for calldata copy and Tenderly simulation
 - `deriveStateOverrides` for Tenderly state overrides
@@ -189,7 +187,7 @@ Lite still uses `utils/pyth.ts` for read-path lens simulations and visible vault
 | `composables/useTxBatch.ts` | Multi-tx cart: plan merge, resimulate, slot-hint reuse, execution |
 | `components/entities/operation/OperationReviewModal.vue` | Prepared-plan review, calldata copy, and Tenderly simulation |
 | `utils/stepDecoding.ts` | SDK plan item decoding for review display |
-| `utils/operationGuardRegistry.ts` | Guard transformer and blocker registry |
-| `utils/keyring-injection.ts` | Keyring credential batch-item injection |
-| `utils/tos-injection.ts` | Terms-of-use batch-item injection |
+| `utils/operationGuardRegistry.ts` | Submit blocker and operation metadata registry |
+| `utils/sdk-keyring.ts` | Credential store and hook-target config for the SDK keyring plugin |
+| `utils/sdk-tos.ts` | Terms-of-use SDK plugin (batch-item injection) |
 | `composables/useSwapApi.ts` | Swap API request building and quote normalization |

--- a/docs/transaction-building.md
+++ b/docs/transaction-building.md
@@ -85,8 +85,10 @@ Plans may include `requiredApproval` items. During review and execution, `resolv
 
 Plan transformation runs as SDK `EulerPlugin`s registered in `composables/useEulerSdk.ts`, so simulation, review preparation, and execution all pass through the same pipeline:
 
-- Terms-of-use signing — `createLiteTosPlugin()` (`utils/sdk-tos.ts`) prepends a signed terms-of-use `EVCBatchItem` to every `evcBatch` item.
-- Keyring credential injection for private vaults — the SDK's [`createKeyringPlugin`](https://github.com/euler-xyz/euler-sdks/blob/main/packages/euler-v2-sdk/src/plugins/keyring/keyringPlugin.ts), configured with hook targets and a credential store from `utils/sdk-keyring.ts`. `composables/useOperationGuard.ts` publishes verified credentials into that store; the plugin prepends a Keyring `createCredential` `EVCBatchItem` when a plan touches a keyring hook target.
+- Terms-of-use signing — `createLiteTosPlugin()` (`utils/sdk-tos.ts`) prepends a signed terms-of-use `EVCBatchItem` to every `evcBatch` item. Injection only happens when `useTosGuard` has published a signed message for the owner and the chain's deployment has a `termsOfUseSigner` address.
+- Keyring credential injection for private vaults — the SDK's [`createKeyringPlugin`](https://github.com/euler-xyz/euler-sdks/blob/main/packages/euler-v2-sdk/src/plugins/keyring/keyringPlugin.ts), configured with hook targets and a credential store from `utils/sdk-keyring.ts`. `composables/useOperationGuard.ts` publishes verified credentials into that store; the plugin prepends a Keyring `createCredential` `EVCBatchItem` when a plan touches a keyring hook target, the sender has no valid on-chain credential, and the store returns a current credential.
+
+The plugins fail open: when their data is missing they pass the plan through unchanged. Enforcement — making the user sign the TOS or complete Keyring verification before submitting — is the blockers' job, not the plugins'.
 
 See the SDK side: [plugins.md](https://github.com/euler-xyz/euler-sdks/blob/main/packages/euler-v2-sdk/docs/plugins.md).
 

--- a/docs/transaction-building.md
+++ b/docs/transaction-building.md
@@ -86,7 +86,9 @@ Plans may include `requiredApproval` items. During review and execution, `resolv
 Plan transformation runs as SDK `EulerPlugin`s registered in `composables/useEulerSdk.ts`, so simulation, review preparation, and execution all pass through the same pipeline:
 
 - Terms-of-use signing — `createLiteTosPlugin()` (`utils/sdk-tos.ts`) prepends a signed terms-of-use `EVCBatchItem` to every `evcBatch` item.
-- Keyring credential injection for private vaults — the SDK's `createKeyringPlugin`, configured with hook targets and a credential store from `utils/sdk-keyring.ts`. `composables/useOperationGuard.ts` publishes verified credentials into that store; the plugin prepends a Keyring `createCredential` `EVCBatchItem` when a plan touches a keyring hook target.
+- Keyring credential injection for private vaults — the SDK's [`createKeyringPlugin`](https://github.com/euler-xyz/euler-sdks/blob/main/packages/euler-v2-sdk/src/plugins/keyring/keyringPlugin.ts), configured with hook targets and a credential store from `utils/sdk-keyring.ts`. `composables/useOperationGuard.ts` publishes verified credentials into that store; the plugin prepends a Keyring `createCredential` `EVCBatchItem` when a plan touches a keyring hook target.
+
+See the SDK side: [plugins.md](https://github.com/euler-xyz/euler-sdks/blob/main/packages/euler-v2-sdk/docs/plugins.md).
 
 ## Review Display
 
@@ -129,7 +131,7 @@ Pass `background: true` for speculative page-load priming (lend/earn vault forms
 
 Chain switches clear the local `slotHints` ref synchronously. Late probes for an old chain must not restore into the new chain’s local ref (they may still update that chain’s registry bucket). Concurrent primes re-merge after each await so an in-flight probe cannot clobber hints that landed meanwhile.
 
-See the SDK side: `packages/euler-v2-sdk/docs/simulations-and-state-overrides.md` (performance tuning section) and `packages/euler-v2-sdk/docs/execution-service.md` (prefetching plugin data).
+See the SDK side: [simulations-and-state-overrides.md](https://github.com/euler-xyz/euler-sdks/blob/main/packages/euler-v2-sdk/docs/simulations-and-state-overrides.md) (performance tuning section) and [execution-service.md](https://github.com/euler-xyz/euler-sdks/blob/main/packages/euler-v2-sdk/docs/execution-service.md) (prefetching plugin data).
 
 ## Batch cart prefetch
 


### PR DESCRIPTION
## Problem

`docs/transaction-building.md`, `docs/keyring-hooks.md`, and `docs/tos-signing.md` referenced `utils/keyring-injection.ts` and `utils/tos-injection.ts`, which no longer exist. They also described an operation-guard flow (`preparePlanForReview`, `applyOperationGuards`, plan-transformer registration) that was removed when plan transformation moved into SDK plugins.

## Changes

- Replace `utils/keyring-injection.ts` references with the real implementation: the SDK's `createKeyringPlugin`, registered in `composables/useEulerSdk.ts` with hook targets and the credential store from `utils/sdk-keyring.ts` (fed by `composables/useOperationGuard.ts`).
- Replace `utils/tos-injection.ts` references with `utils/sdk-tos.ts` (`createLiteTosPlugin`), fed by `composables/guards/useTosGuard.ts`.
- Update the execution-flow and review-display sections to the current `prepareTransactionPlan` path and note that plan transformation runs inside the SDK plugin pipeline on the simulate/prepare/execute paths.
- Correct the guard-registry description to its remaining role: reactive submit blockers and per-concern metadata (matching the note at the top of `utils/operationGuardRegistry.ts`).

Docs-only change; all claims were verified against `composables/useEulerSdk.ts`, `composables/useEulerTx.ts`, `composables/useOperationGuard.ts`, `composables/guards/useTosGuard.ts`, `utils/sdk-keyring.ts`, `utils/sdk-tos.ts`, and `utils/operationGuardRegistry.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated transaction-building guidance to describe SDK-based simulation, review preparation, and execution.
  * Documented automatic terms-of-use signing and Keyring credential injection during transaction processing.
  * Clarified that operation guards provide submit blockers and transaction metadata.
  * Updated SDK links, referenced files, and module descriptions to reflect the current integration.
  * Added guidance on credential validation and transaction preparation through the shared SDK workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->