### PR TITLE
fix: hide collateral-only products from market discovery

### DIFF
--- a/composables/useMarketGroups.ts
+++ b/composables/useMarketGroups.ts
@@ -57,7 +57,8 @@ const getBorrowAPY = (vault: AnyVault): number => {
 
 // -- Step 1: Product-Label Groups --
 
-const buildProductGroups = (
+/** Exported for tests; production callers go through useMarketGroups. */
+export const buildProductGroups = (
   allVaults: AnyVault[],
   products: Record<string, EulerLabelProduct>,
   entities: Record<string, EulerLabelEntity>,
@@ -515,35 +516,51 @@ export const useMarketGroups = () => {
     const allAddresses = [...product.vaults, ...(product.deprecatedVaults || [])]
     if (allAddresses.length === 0) return null
 
-    const memberVaults: EVault[] = []
-
-    try {
-      const { chainId } = useEulerAddresses()
-      const { getEulerSdkForChain } = useEulerSdk()
-      // Capture the chain id once so the SDK backend selection and the fetch
-      // can't diverge if the user switches chains mid-await.
-      const targetChainId = chainId.value
-      const sdk = await getEulerSdkForChain(targetChainId)
-      const result = await sdk.eVaultService.fetchVaults(
-        targetChainId,
-        allAddresses.map(addr => getAddress(addr) as Address),
-        liteVaultFetchOptions,
-      )
-      result.errors.forEach(issue => logWarn('useMarketGroups/fetchMarketGroupOnDemand', issue))
-      const fetchedVaults = result.result.filter(Boolean) as EVault[]
-      await resolveEulerRouterGovernors(fetchedVaults, (router) => {
-        const provider = sdk.providerService.getProvider(targetChainId)
-        return provider.readContract({
-          address: router,
-          abi: governableGovernorAbi,
-          functionName: 'governor',
-          authorizationList: undefined,
-        })
-      })
-      memberVaults.push(...fetchedVaults)
+    // Satisfy members from the registry first: non-EVault members (e.g.
+    // Securitize collateral wrappers) are hydrated there at startup and must
+    // never be routed through the EVault lens below. Only the remainder —
+    // typically EVaults of product-level notExplorable products, which are
+    // excluded from the startup load — needs an on-demand fetch.
+    const registryByAddress = new Map(
+      registryVaults.value.map(vault => [getVaultAddress(vault).toLowerCase(), vault]),
+    )
+    const memberVaults: AnyVault[] = []
+    const missingAddresses: string[] = []
+    for (const address of allAddresses) {
+      const known = registryByAddress.get(address.toLowerCase())
+      if (known) memberVaults.push(known)
+      else missingAddresses.push(address)
     }
-    catch (e) {
-      logWarn('useMarketGroups/fetchMarketGroupOnDemand', e)
+
+    if (missingAddresses.length > 0) {
+      try {
+        const { chainId } = useEulerAddresses()
+        const { getEulerSdkForChain } = useEulerSdk()
+        // Capture the chain id once so the SDK backend selection and the fetch
+        // can't diverge if the user switches chains mid-await.
+        const targetChainId = chainId.value
+        const sdk = await getEulerSdkForChain(targetChainId)
+        const result = await sdk.eVaultService.fetchVaults(
+          targetChainId,
+          missingAddresses.map(addr => getAddress(addr) as Address),
+          liteVaultFetchOptions,
+        )
+        result.errors.forEach(issue => logWarn('useMarketGroups/fetchMarketGroupOnDemand', issue))
+        const fetchedVaults = result.result.filter(Boolean) as EVault[]
+        await resolveEulerRouterGovernors(fetchedVaults, (router) => {
+          const provider = sdk.providerService.getProvider(targetChainId)
+          return provider.readContract({
+            address: router,
+            abi: governableGovernorAbi,
+            functionName: 'governor',
+            authorizationList: undefined,
+          })
+        })
+        memberVaults.push(...fetchedVaults)
+      }
+      catch (e) {
+        logWarn('useMarketGroups/fetchMarketGroupOnDemand', e)
+      }
     }
 
     if (memberVaults.length === 0) return null

--- a/composables/useMarketGroups.ts
+++ b/composables/useMarketGroups.ts
@@ -9,6 +9,7 @@ import { isVaultNotExplorable, isVaultRecentlyAdded, isVaultDeprecated, getProdu
 import { isLiveCollateralEdge } from '~/utils/vault/ltv'
 import { isVaultBorrowable } from '~/utils/vault/classification'
 import { hasResolvedGovernorAdmin } from '~/utils/vault/governor-verification'
+import { groupHasExplorableMarket } from '~/utils/vault/market-group-visibility'
 import { liteVaultFetchOptions } from '~/utils/sdk-fetch-options'
 import { resolveEulerRouterGovernors } from '~/utils/vault/euler-router-governance'
 import { governableGovernorAbi } from '~/abis/oracle'
@@ -60,6 +61,7 @@ const buildProductGroups = (
   allVaults: AnyVault[],
   products: Record<string, EulerLabelProduct>,
   entities: Record<string, EulerLabelEntity>,
+  listNonMarketGroups: boolean,
 ): { groups: MarketGroup[], assignedAddresses: Set<string> } => {
   const vaultMap = new Map<string, AnyVault>()
   for (const vault of allVaults) {
@@ -82,6 +84,13 @@ const buildProductGroups = (
     }
 
     if (memberVaults.length === 0) continue
+
+    // Collateral-only products (every member hidden on both the lend and
+    // borrow side) get no discovery card. Their addresses stay assigned so
+    // the members don't fall into orphan clustering, they still resolve as
+    // externalCollateral in other groups' graphs, and a direct market URL
+    // still loads via fetchMarketGroupOnDemand.
+    if (!listNonMarketGroups && !groupHasExplorableMarket(memberVaults)) continue
 
     // Resolve curator entity
     const entityKeys = Array.isArray(product.entity) ? product.entity : [product.entity]
@@ -399,7 +408,7 @@ export const useMarketGroups = () => {
     if (vaults.length === 0) return []
 
     // Step 1: Product-label groups
-    const { groups: productGroups, assignedAddresses } = buildProductGroups(vaults, products, entities)
+    const { groups: productGroups, assignedAddresses } = buildProductGroups(vaults, products, entities, showAllLabelEntries.value)
 
     // Step 2: Augment with collateral graph — pass the full registry so active
     // LTVs targeting non-explorable vaults still resolve as externalCollateral

--- a/docs/vault-labels-and-verification.md
+++ b/docs/vault-labels-and-verification.md
@@ -341,10 +341,12 @@ Labels control which vaults appear on each discovery page:
 | Flag | Lend | Borrow | Explore |
 |------|------|--------|---------|
 | Product `notExplorable: true` | Hidden | Hidden | Hidden |
-| Override `notExplorableLend: true` | Hidden | Visible | Visible |
-| Override `notExplorableBorrow: true` | Visible | Hidden (both sides) | Visible |
+| Override `notExplorableLend: true` | Hidden | Visible | Visible* |
+| Override `notExplorableBorrow: true` | Visible | Hidden (both sides) | Visible* |
 | `deprecatedVaults` | Hidden | Hidden | Visible (dimmed) |
 | `recently added` tag | Sorted to top | Sorted to top | Sorted to top |
+
+*Explore lists a product only while it has an explorable market side: at least one member vault that is open on the lend side, or borrowable (including residual debt) and open on the borrow side. A collateral-only product — every member flagged `notExplorableLend` and not borrowable, e.g. issuer-governed Securitize collateral wrappers — gets no Explore card. Its vaults still render as external collateral in other markets' graphs, and its direct market URL still resolves on demand (members are satisfied from the vault registry first, so non-EVault members load correctly).
 
 Product-level `notExplorable` always takes precedence over per-vault overrides. Vaults hidden from discovery are still accessible via direct URL and remain visible in the user's portfolio.
 

--- a/tests/composables/useMarketGroups.test.ts
+++ b/tests/composables/useMarketGroups.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import type { EVault, SecuritizeCollateralVault } from '@eulerxyz/euler-v2-sdk'
+import { __setEulerLabelsDataForTest } from '~/composables/useEulerLabels'
+import { buildProductGroups } from '~/composables/useMarketGroups'
+import type { EulerLabelProduct } from '~/entities/euler/labels'
+import { normalizeAddress } from '~/utils/normalizeAddress'
+
+// computeMetricsSync reaches for Nuxt-auto-imported APY helpers; stub them the
+// same way tests/setup.ts stubs other unimport globals.
+const g = globalThis as unknown as Record<string, unknown>
+g.getVaultSupplyApy = () => 0
+g.getVaultBorrowApy = () => 0
+
+const LEND_VAULT = normalizeAddress('0x0000000000000000000000000000000000003001')
+const WRAPPER = normalizeAddress('0x0000000000000000000000000000000000003002')
+
+const makeEVault = (address: string): EVault =>
+  ({
+    type: 'EVault',
+    address,
+    isBorrowable: true,
+    totalBorrowed: 0n,
+    asset: { symbol: 'USDC' },
+  }) as unknown as EVault
+
+const makeWrapper = (address: string): SecuritizeCollateralVault =>
+  ({
+    type: 'SecuritizeCollateral',
+    address,
+    asset: { symbol: 'VBILL' },
+  }) as unknown as SecuritizeCollateralVault
+
+const products: Record<string, EulerLabelProduct> = {
+  'kpk-securitize': {
+    name: 'KPK x Securitize RWA Markets',
+    description: '',
+    entity: ['kpk', 'securitize'],
+    url: '',
+    vaults: [LEND_VAULT],
+  } as unknown as EulerLabelProduct,
+  'securitize': {
+    name: 'Securitize RWA Collateral',
+    description: '',
+    entity: ['securitize'],
+    url: '',
+    vaults: [WRAPPER],
+    vaultOverrides: {
+      [WRAPPER]: { notExplorableLend: true },
+    },
+  } as unknown as EulerLabelProduct,
+}
+
+describe('buildProductGroups', () => {
+  beforeEach(() => {
+    __setEulerLabelsDataForTest({ products })
+  })
+
+  it('skips a collateral-only product but keeps its addresses assigned', () => {
+    const { groups, assignedAddresses } = buildProductGroups(
+      [makeEVault(LEND_VAULT), makeWrapper(WRAPPER)],
+      products,
+      {},
+      false,
+    )
+
+    expect(groups.map(group => group.id)).toEqual(['kpk-securitize'])
+    // The invariant that keeps skipped members out of orphan clustering.
+    expect(assignedAddresses.has(WRAPPER.toLowerCase())).toBe(true)
+    expect(assignedAddresses.has(LEND_VAULT.toLowerCase())).toBe(true)
+  })
+
+  it('lists collateral-only products when show-all-label-entries is on', () => {
+    const { groups } = buildProductGroups(
+      [makeEVault(LEND_VAULT), makeWrapper(WRAPPER)],
+      products,
+      {},
+      true,
+    )
+
+    expect(groups.map(group => group.id)).toEqual(['kpk-securitize', 'securitize'])
+  })
+})

--- a/tests/utils/market-group-visibility.test.ts
+++ b/tests/utils/market-group-visibility.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest'
+import type { EVault, SecuritizeCollateralVault } from '@eulerxyz/euler-v2-sdk'
+import { __setEulerLabelsDataForTest } from '~/composables/useEulerLabels'
+import { groupHasExplorableMarket } from '~/utils/vault/market-group-visibility'
+import { normalizeAddress } from '~/utils/normalizeAddress'
+
+const LEND_VAULT = normalizeAddress('0x0000000000000000000000000000000000002001')
+const WRAPPER_A = normalizeAddress('0x0000000000000000000000000000000000002002')
+const WRAPPER_B = normalizeAddress('0x0000000000000000000000000000000000002003')
+const TERM_BORROW = normalizeAddress('0x0000000000000000000000000000000000002004')
+
+const makeEVault = (
+  address: string,
+  opts?: { isBorrowable?: boolean, totalBorrowed?: bigint },
+): EVault =>
+  ({
+    type: 'EVault',
+    address,
+    isBorrowable: opts?.isBorrowable ?? true,
+    totalBorrowed: opts?.totalBorrowed ?? 0n,
+  }) as unknown as EVault
+
+const makeWrapper = (address: string): SecuritizeCollateralVault =>
+  ({
+    type: 'SecuritizeCollateral',
+    address,
+  }) as unknown as SecuritizeCollateralVault
+
+const productBase = {
+  name: 'Test',
+  description: '',
+  url: '',
+}
+
+describe('groupHasExplorableMarket', () => {
+  it('lists a product whose members carry no explorability flags', () => {
+    __setEulerLabelsDataForTest({
+      products: {
+        test: { ...productBase, entity: ['curator'], vaults: [LEND_VAULT] },
+      },
+    })
+
+    expect(groupHasExplorableMarket([makeEVault(LEND_VAULT)])).toBe(true)
+  })
+
+  it('hides a collateral-only product of lend-hidden non-borrowable wrappers', () => {
+    __setEulerLabelsDataForTest({
+      products: {
+        securitize: {
+          ...productBase,
+          entity: ['securitize'],
+          vaults: [WRAPPER_A, WRAPPER_B],
+          vaultOverrides: {
+            [WRAPPER_A]: { notExplorableLend: true },
+            [WRAPPER_B]: { notExplorableLend: true },
+          },
+        },
+      },
+    })
+
+    expect(groupHasExplorableMarket([makeWrapper(WRAPPER_A), makeWrapper(WRAPPER_B)])).toBe(false)
+  })
+
+  it('keeps a borrow-only market listed when its lend side is hidden', () => {
+    __setEulerLabelsDataForTest({
+      products: {
+        term: {
+          ...productBase,
+          entity: ['curator'],
+          vaults: [TERM_BORROW],
+          vaultOverrides: {
+            [TERM_BORROW]: { notExplorableLend: true },
+          },
+        },
+      },
+    })
+
+    expect(groupHasExplorableMarket([makeEVault(TERM_BORROW)])).toBe(true)
+  })
+
+  it('hides every member of a product flagged notExplorable at the product level', () => {
+    __setEulerLabelsDataForTest({
+      products: {
+        hidden: {
+          ...productBase,
+          entity: ['curator'],
+          notExplorable: true,
+          vaults: [LEND_VAULT],
+        },
+      },
+    })
+
+    expect(groupHasExplorableMarket([makeEVault(LEND_VAULT)])).toBe(false)
+  })
+
+  it('treats residual debt as a live borrow market on a lend-hidden vault', () => {
+    __setEulerLabelsDataForTest({
+      products: {
+        term: {
+          ...productBase,
+          entity: ['curator'],
+          vaults: [TERM_BORROW],
+          vaultOverrides: {
+            [TERM_BORROW]: { notExplorableLend: true },
+          },
+        },
+      },
+    })
+
+    const rampedDown = makeEVault(TERM_BORROW, { isBorrowable: false, totalBorrowed: 1n })
+    const drained = makeEVault(TERM_BORROW, { isBorrowable: false, totalBorrowed: 0n })
+
+    expect(groupHasExplorableMarket([rampedDown])).toBe(true)
+    expect(groupHasExplorableMarket([drained])).toBe(false)
+  })
+})

--- a/utils/vault/market-group-visibility.ts
+++ b/utils/vault/market-group-visibility.ts
@@ -1,0 +1,26 @@
+import { isEVault } from '@eulerxyz/euler-v2-sdk'
+import type { AnyVault } from '~/composables/useVaultRegistry'
+import { isVaultNotExplorableBorrow, isVaultNotExplorableLend } from '~/utils/eulerLabelsUtils'
+import { isVaultBorrowable } from '~/utils/vault/classification'
+
+const getVaultAddress = (vault: AnyVault): string =>
+  isEVault(vault) ? vault.address : ('address' in vault ? (vault as { address: string }).address : '')
+
+/**
+ * Should this product group be listed as a market in discovery?
+ *
+ * A group earns a listing when at least one member vault is explorable on
+ * some side: open on the lend side, or borrowable (including residual debt,
+ * mirroring isVaultBorrowable) and open on the borrow side. A product whose
+ * every member is flagged away on both sides — e.g. issuer-governed
+ * collateral wrappers — stays out of Explore while its vaults remain
+ * resolvable as external collateral in other groups' graphs and via the
+ * direct market URL.
+ */
+export const groupHasExplorableMarket = (vaults: AnyVault[]): boolean =>
+  vaults.some((vault) => {
+    const address = getVaultAddress(vault)
+    if (!address) return false
+    if (!isVaultNotExplorableLend(address)) return true
+    return isEVault(vault) && isVaultBorrowable(vault) && !isVaultNotExplorableBorrow(address)
+  })

--- a/utils/vault/market-group-visibility.ts
+++ b/utils/vault/market-group-visibility.ts
@@ -1,10 +1,8 @@
 import { isEVault } from '@eulerxyz/euler-v2-sdk'
 import type { AnyVault } from '~/composables/useVaultRegistry'
+import { getVaultAddress } from '~/utils/discoveryCalculations'
 import { isVaultNotExplorableBorrow, isVaultNotExplorableLend } from '~/utils/eulerLabelsUtils'
 import { isVaultBorrowable } from '~/utils/vault/classification'
-
-const getVaultAddress = (vault: AnyVault): string =>
-  isEVault(vault) ? vault.address : ('address' in vault ? (vault as { address: string }).address : '')
 
 /**
  * Should this product group be listed as a market in discovery?


### PR DESCRIPTION
## Summary

A product whose every member vault is hidden on both the lend and borrow side gets no Explore card and no market/risk-manager filter entries. Concretely: the euler-labels restructure (euler-xyz/euler-labels#711) moves the Securitize collateral wrappers (VBILL/STAC/HINC) into their own `securitize` product with `notExplorableLend` set — those wrappers are issuer-governed collateral infrastructure, not markets, and the product card for them on `/explore` was noise.

## Behavior

- `buildProductGroups` skips a product when no member is explorable on some side: open on the lend side, or borrowable (including residual debt, mirroring `isVaultBorrowable`) and open on the borrow side. Note the consequence: this is chain-state-dependent by design — a borrow-only product whose LTVs have fully ramped to zero drops off Explore once its last debt is repaid, matching how `isVaultBorrowable` gates borrow-side display everywhere else.
- Skipped members stay in `assignedAddresses`, so they don't fall back into orphan clustering (covered by a test).
- They still resolve as `externalCollateral` in other groups' market graphs (the collateral graph reads the full registry).
- **Direct market URLs work for non-EVault members**: `fetchMarketGroupOnDemand` now satisfies members from the vault registry first and only fetches the remainder through `eVaultService`. Previously it routed everything through the EVault lens, so a direct URL to the securitize product (e.g. the market link on a wrapper's vault overview) would have rendered market-not-found once the group stopped being listed.
- The show-all-label-entries toggle bypasses the rule (covered by a test), like every other explorability filter.
- Borrow-only products stay listed: KPK ETH Yield Term (all members `notExplorableLend` but borrowable) keeps its card — covered by a test.
- The Discovery Page Filtering table in `docs/vault-labels-and-verification.md` is updated for the new rule.

## Test plan

- [x] Unit tests for `groupHasExplorableMarket` (5 cases: unflagged, collateral-only, borrow-only with hidden lend side, product-level `notExplorable`, residual-debt ramp-down).
- [x] Wiring tests for `buildProductGroups` (assigned-addresses invariant, show-all bypass).
- [x] Full test suite passes (1797 tests), `nuxt typecheck` clean, eslint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved market discovery to show products only when they have at least one explorable lending or borrowing market.
  * Added an option to display hidden or non-market products when “show all” is enabled.
  * Continued making collateral-only vaults available for external collateral use and direct links.
  * Improved on-demand product loading, including support for non-EVault members.

* **Documentation**
  * Clarified how market visibility overrides affect Explore listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->