### PR TITLE
chore: dependency audit fixes + drop unused @tanstack/query-core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@nuxt/eslint": "1.16.0",
         "@reown/appkit": "1.8.23",
         "@reown/appkit-adapter-wagmi": "1.8.23",
-        "@tanstack/query-core": "5.101.4",
         "@tanstack/vue-query": "5.101.4",
         "@vueuse/nuxt": "14.4.0",
         "@wagmi/core": "3.6.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -596,18 +596,6 @@
         }
       }
     },
-    "node_modules/@coinbase/cdp-sdk/node_modules/axios": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
-      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.5",
-        "proxy-from-env": "^2.1.0"
-      }
-    },
     "node_modules/@coinbase/wallet-sdk": {
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/@coinbase/wallet-sdk/-/wallet-sdk-4.3.6.tgz",
@@ -1657,27 +1645,6 @@
         }
       }
     },
-    "node_modules/@eulerxyz/euler-v2-sdk/node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@floating-ui/core": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
@@ -2493,27 +2460,6 @@
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/@nuxt/devtools/node_modules/ws": {
-      "version": "8.21.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.2.tgz",
-      "integrity": "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/@nuxt/eslint": {
@@ -7835,27 +7781,6 @@
         "@walletconnect/safe-json": "^1.0.2",
         "events": "^3.3.0",
         "ws": "^7.5.1"
-      }
-    },
-    "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/@walletconnect/keyvaluestorage": {
@@ -13488,9 +13413,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -16786,9 +16711,9 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.4.tgz",
-      "integrity": "sha512-DuGdB+Po43Q5Jxwpzt1lhyFSYKryqoNjQSA9M92tyw0lyHIOur+XCalOUe0KTJpyqzT8+fQ5A0Jf7vCx/NKmIg==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.1.0.tgz",
+      "integrity": "sha512-RNEqWOyhhUQYN9V1GfHwu9AR/g+NTciH6Z5u3/no6X3/w+04J2lVDL+svFQVXgXrEGBMG2puMVN3gq2SNGuTGw==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=20.0.0"
@@ -19462,9 +19387,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "@nuxt/eslint": "1.16.0",
     "@reown/appkit": "1.8.23",
     "@reown/appkit-adapter-wagmi": "1.8.23",
-    "@tanstack/query-core": "5.101.4",
     "@tanstack/vue-query": "5.101.4",
     "@vueuse/nuxt": "14.4.0",
     "@wagmi/core": "3.6.4",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,11 @@
   "overrides": {
     "@base-org/account": "2.5.1",
     "@wagmi/connectors": "8.0.26",
-    "serialize-javascript": "7.0.4"
+    "serialize-javascript": "7.1.0",
+    "ws": "8.21.3",
+    "@coinbase/cdp-sdk": {
+      "axios": "1.19.0"
+    }
   },
   "license": "MIT"
 }


### PR DESCRIPTION
## Summary

Dependency audit pass on master, ahead of the scheduled Dependency Audit workflow (Mondays 09:00) which would otherwise go red on 2026-08-24 — the tree had 12 advisories (3 high), including the same nanoid advisory (GHSA-2v37-7h3g-55p8) that broke euler-docs-v2 CI today.

**Commit 1 — drop `@tanstack/query-core`**
Zero direct imports, no peer requires it; it remains available transitively via `@tanstack/vue-query` and `@wagmi/core`.

**Commit 2 — clear all audit advisories (now 0, prod and dev)**
- `npm audit fix`: nanoid (high) and other in-range bumps; root `axios` → 1.19.0
- `ws` override → 8.21.3: viem pins 8.18.3 exactly (uninitialized memory disclosure + DoS advisories)
- existing `serialize-javascript` override bumped 7.0.4 → 7.1.0 (7.0.4 fell into the vulnerable range of a new advisory)
- scoped `axios` 1.19.0 override under `@coinbase/cdp-sdk` (it pins 1.16.0 exactly)

Notes from the wider audit: `wagmi` (React pkg) and `@wagmi/core` stay despite zero imports — peer-required by `@reown/appkit-adapter-wagmi`. If this merges to master directly, `development` likely wants the same change to avoid a lockfile conflict at next promotion.

## Test plan

- [x] `npm audit --omit=dev --audit-level=moderate` (the CI gate) exits clean — 0 vulnerabilities incl. dev
- [x] `nuxt typecheck` passes
- [x] `vitest run`: 1612 passed, 1 skipped