### PR TITLE
fix: bind reviewed and copied calldata to the executed transaction plan

### DIFF
--- a/components/BatchContents.vue
+++ b/components/BatchContents.vue
@@ -11,6 +11,7 @@ import { useModal } from '~/components/ui/composables/useModal'
 const {
   entries,
   layers,
+  hasPendingAdds,
   isSimulated,
   isSimulating,
   simError,
@@ -182,11 +183,11 @@ const simEyeLabel = computed(() =>
       <button
         type="button"
         class="w-full h-40 rounded-12 bg-accent-600 hover:bg-accent-700 text-black text-p2 font-semibold shadow-accent-sm transition-colors disabled:opacity-50 disabled:cursor-not-allowed disabled:shadow-none"
-        :disabled="!entries.length || isSimulating"
+        :disabled="!entries.length || isSimulating || hasPendingAdds"
         data-testid="batch-review"
         @click="openBatchReview"
       >
-        {{ isSimulating ? 'Simulating…' : 'Review batch' }}
+        {{ hasPendingAdds ? 'Adding operation…' : isSimulating ? 'Simulating…' : 'Review batch' }}
       </button>
     </div>
   </div>

--- a/components/BatchReviewModal.vue
+++ b/components/BatchReviewModal.vue
@@ -1,24 +1,25 @@
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref } from 'vue'
-import { encodeFunctionData, getAddress } from 'viem'
+import { computed, onMounted, onUnmounted, ref, shallowRef } from 'vue'
+import { getAddress } from 'viem'
 import { flattenBatchEntries, getSubAccountId, type TransactionPlan } from '@eulerxyz/euler-v2-sdk'
 import { getEulerSdkForChain } from '~/composables/useEulerSdk'
-import { buildModifiedPositionKeySets, buildRemovedPositionKeySets, filterPositionKeysByOwner, useTxBatch } from '~/composables/useTxBatch'
+import { buildModifiedPositionKeySets, buildRemovedPositionKeySets, filterPositionKeysByOwner, type PreparedBatchExecution, useTxBatch } from '~/composables/useTxBatch'
 import { useTokenSymbolResolver } from '~/composables/useTokenSymbolResolver'
 import { useVaultRegistry } from '~/composables/useVaultRegistry'
 import { getAssetLogoUrl } from '~/composables/useTokenList'
 import { buildTransactionPlanDisplaySteps, type DisplayStep, type StepDecodingContext } from '~/utils/stepDecoding'
 import { logWarn } from '~/utils/errorHandling'
 import { buildBatchHealthSummary } from '~/utils/batchHealthSummary'
-import { consolidateRestorationSummaryRows, getAuthorizationStepDisplay, groupRestorationSummaryRows, isBundledReviewEntry } from '~/utils/batchReviewDisplay'
+import { getAuthorizationStepDisplay, getBatchReviewDisplayPlan, groupRestorationSummaryRows, isBundledReviewEntry } from '~/utils/batchReviewDisplay'
 import { hasPermit2TokenApproval } from '~/utils/transactionPlanApprovals'
 import { isPlanBundleable } from '~/utils/transaction-plan-calls'
 import type { TrackedExecutionHandle } from '~/composables/useSafeExecutionDetachment'
 import { formatNumber } from '~/utils/string-utils'
+import { buildBatchReviewCalldata } from '~/utils/batchReviewCalldata'
 
 // Whole-batch review: required approvals, then the operations as rows that roll
-// down to their details, the net wallet changes, a Tenderly simulation link,
-// and one atomic Execute. Opened from the "Review batch" button in the drawer
+// down to their details, the net wallet changes, and one atomic Execute. Opened
+// from the "Review batch" button in the drawer
 // (and mobile page). The per-operation detail is the data captured at add-time;
 // execution is delegated to the composable's executeBatch.
 const emit = defineEmits(['close'])
@@ -36,29 +37,22 @@ const {
   hasInsufficientBalance,
   insufficientBalanceMessage,
   executeBatch,
-  prepareBatchPlan,
   entryPlans,
   marketByEntryId,
-  tenderlyEnabled,
-  isTenderlySimulating,
-  tenderlyUrl,
-  tenderlyError,
-  fetchTenderlyEnabled,
-  simulateOnTenderly,
   dismissExecutionError,
-  prepareBundledExecution,
-  latchedBundledExecution,
+  prepareBatchExecution,
+  isBatchExecutionCurrent,
 } = useTxBatch()
 
+const executionCeremonyRef = shallowRef<PreparedBatchExecution | null>(null)
+
 const { isSpyMode, effectiveAddress } = useEffectiveAddress()
-const { chainId: wagmiChainId } = useWagmi()
 const { isSafeWallet } = useSafeWallet()
-const { chainId: addressesChainId, eulerCoreAddresses } = useEulerAddresses()
+const { eulerCoreAddresses } = useEulerAddresses()
 const { buildKnownSymbols, resolveSymbol } = useTokenSymbolResolver()
 const { getVault, isVerifiedVault } = useVaultRegistry()
 const { copied, copyToClipboard } = useClipboardCopy()
 const owner = computed(() => effectiveAddress.value || '')
-const chainId = computed(() => wagmiChainId.value ?? addressesChainId.value)
 const ownerSubAccountKey = computed(() => {
   try {
     return owner.value ? getAddress(owner.value).toLowerCase() : undefined
@@ -90,14 +84,14 @@ type ReviewWithSteps = StepDecodingContext & {
 const isExternalProtocolMigrationReview = (review: ReviewWithSteps | undefined): boolean =>
   review?.type === 'migration'
 
-const normalizeDisplaySteps = (steps: DisplayStep[] | undefined): DisplayStep[] =>
+const normalizeDisplaySteps = (steps: readonly DisplayStep[] | undefined): DisplayStep[] =>
   (steps ?? []).map((step, idx) => ({ ...step, index: idx + 1 }))
 
-// Bundled styling follows the ceremony latched when this modal opened. Live
+// Bundled styling follows the ceremony owned by this modal. Live
 // Safe detection can resolve later, but it cannot change what this review will
 // execute without a fresh review.
 const isBundledEntry = (entry: typeof entries.value[number]): boolean =>
-  isBundledReviewEntry(latchedBundledExecution.value !== null, !!entry.buildBundledExecution)
+  isBundledReviewEntry(executionCeremonyRef.value?.mode === 'safe-bundled', entry.bundleExecutionCeremony === true)
 
 const overrideBundled = (steps: DisplayStep[], entry: typeof entries.value[number]): DisplayStep[] =>
   isBundledEntry(entry)
@@ -105,11 +99,9 @@ const overrideBundled = (steps: DisplayStep[], entry: typeof entries.value[numbe
     : steps
 
 const getEntrySignatureSteps = (entry: typeof entries.value[number]): DisplayStep[] => {
-  // A latched bundled ceremony carries its own rows, derived from the SAME
-  // authorization resolution the proposal executes — the add-time captures
-  // can be stale (authorization state drifts between add and review).
-  const latchedSteps = latchedBundledExecution.value?.stepsByEntryId[entry.id]
-  if (latchedSteps) return normalizeDisplaySteps(latchedSteps.grantSteps)
+  // Ceremony-owned rows and execution calls share one authorization resolution.
+  const ceremonySteps = executionCeremonyRef.value?.reviewByEntryId[entry.id]
+  if (ceremonySteps) return normalizeDisplaySteps(ceremonySteps.grantSteps)
   const review = entry.review as unknown as ReviewWithSteps | undefined
   return isExternalProtocolMigrationReview(review)
     ? overrideBundled(normalizeDisplaySteps(review?.signatureSteps), entry)
@@ -117,8 +109,8 @@ const getEntrySignatureSteps = (entry: typeof entries.value[number]): DisplaySte
 }
 
 const getEntryPostSteps = (entry: typeof entries.value[number]): DisplayStep[] => {
-  const latchedSteps = latchedBundledExecution.value?.stepsByEntryId[entry.id]
-  if (latchedSteps) return normalizeDisplaySteps(latchedSteps.revokeSteps)
+  const ceremonySteps = executionCeremonyRef.value?.reviewByEntryId[entry.id]
+  if (ceremonySteps) return normalizeDisplaySteps(ceremonySteps.revokeSteps)
   const review = entry.review as unknown as ReviewWithSteps | undefined
   return isExternalProtocolMigrationReview(review)
     ? overrideBundled(normalizeDisplaySteps(review?.postSteps), entry)
@@ -132,7 +124,11 @@ const getEntryPostSteps = (entry: typeof entries.value[number]): DisplayStep[] =
 const stepsByEntryId = computed<Record<string, DisplayStep[]>>(() => {
   const out: Record<string, DisplayStep[]> = {}
   for (const entry of entries.value) {
-    const plan = (entry.review as unknown as ReviewWithSteps | undefined)?.displayPlan ?? entryPlans.value[entry.id]
+    const plan = getBatchReviewDisplayPlan(
+      executionCeremonyRef.value?.reviewByEntryId[entry.id]?.plan,
+      (entry.review as unknown as ReviewWithSteps | undefined)?.displayPlan,
+      entryPlans.value[entry.id],
+    )
     const ctx = entry.review as unknown as StepDecodingContext | undefined
     if (!plan?.length || !ctx) continue
     try {
@@ -201,15 +197,13 @@ const authorizationSummaryGroups = computed(() => {
 //
 // Rows render in EXECUTION order: restorations unwind in reverse entry order
 // (each entry's own steps are already reversed by the encoder). Identical
-// standalone restorations are consolidated because sequential prerequisite
-// resolution sends them once. Bundled Safe restorations are already collected
-// proposal calls, so every call remains visible. Labels are NOT identity: two
-// different aTokens can share a label while representing distinct transactions.
+// standalone and bundled restorations both remain one row per wallet prompt or
+// proposal call. Labels are NOT identity: two different aTokens can share a
+// label while representing distinct transactions.
 const restorationSummaryRows = computed(() => {
-  const rows = [...entries.value].reverse().flatMap(entry =>
+  return [...entries.value].reverse().flatMap(entry =>
     (postStepsByEntryId.value[entry.id] ?? []).map(step => ({ entry, step })),
   )
-  return consolidateRestorationSummaryRows(rows)
 })
 
 const restorationSummaryGroups = computed(() => {
@@ -224,13 +218,16 @@ const restorationSummaryGroups = computed(() => {
   ]
 })
 
-// Unverified vaults the batch touches — surfaced as a warning. A vault is the
-// target of an op's core action; we read targets off each op's contextual plan
-// and check the registry's verification flag (same source the forms use).
+// Unverified-vault disclosure follows the ceremony plan used by review and
+// execution. The add-time entry plan is only a fallback before preparation.
 const unverifiedVaultNames = computed<string[]>(() => {
   const names = new Set<string>()
   for (const entry of entries.value) {
-    const plan = entryPlans.value[entry.id]
+    const plan = getBatchReviewDisplayPlan(
+      executionCeremonyRef.value?.reviewByEntryId[entry.id]?.plan,
+      (entry.review as unknown as ReviewWithSteps | undefined)?.displayPlan,
+      entryPlans.value[entry.id],
+    )
     if (!plan) continue
     for (const item of plan) {
       if (item.type !== 'evcBatch') continue
@@ -369,21 +366,26 @@ const hasPermit2Approval = computed(() =>
 // Mirrors execution eligibility: only claim bundling when the merged plan
 // would actually submit as one Safe bundle.
 const bundlesApprovals = computed(() =>
-  isSafeWallet.value && !!preparedPlanRef.value && isPlanBundleable(preparedPlanRef.value),
+  (executionCeremonyRef.value?.safeWallet ?? isSafeWallet.value)
+  && !!preparedPlanRef.value
+  && isPlanBundleable(preparedPlanRef.value),
+)
+const isReviewCurrent = computed(() =>
+  !!executionCeremonyRef.value && isBatchExecutionCurrent(executionCeremonyRef.value),
 )
 
 onMounted(async () => {
   nowTimer = setInterval(() => {
     nowMs.value = Date.now()
   }, 1000)
-  void fetchTenderlyEnabled()
   isPreparing.value = true
   prepareError.value = ''
   try {
-    // Resolve the bundled ceremony once for this review session: the same
-    // resolution drives the rows, Copy calldata, and execution.
-    await prepareBundledExecution()
-    const prepared = await prepareBatchPlan()
+    // Resolve one ceremony for this review session. Its exact prepared core,
+    // prerequisite calls, rows, calldata export, and execution stay together.
+    const executionCeremony = await prepareBatchExecution()
+    executionCeremonyRef.value = executionCeremony
+    const prepared = executionCeremony.prepared
     preparedPlanRef.value = prepared?.plan
     const known = buildKnownSymbols()
     const out: Array<{ kind: 'approve' | 'permit', symbol: string }> = []
@@ -411,65 +413,41 @@ onUnmounted(() => {
   }
 })
 
-// Copy the exact batch calldata (one entry per on-chain tx: approvals + the EVC
-// batch), matching the per-operation review modals. This requires the prepared
-// plan so approval txs are included.
+// Copy the reviewed batch calldata (one entry per on-chain tx: approvals + the
+// EVC batch), matching the per-operation review modals. Signature-mode
+// migrations disclose that their copied authorization bytes are placeholders.
 const isCalldataCopyDisabled = computed(() =>
-  isPreparing.value || !!prepareError.value || !preparedPlanRef.value?.length,
+  isPreparing.value || !!prepareError.value || !isReviewCurrent.value || !preparedPlanRef.value?.length,
 )
 const copyCalldata = async () => {
-  const plan = preparedPlanRef.value
+  const executionCeremony = executionCeremonyRef.value
+  const plan = executionCeremony?.prepared.plan ?? preparedPlanRef.value
   if (!plan?.length) return
   try {
-    const cid = chainId.value
+    if (!executionCeremony || !isBatchExecutionCurrent(executionCeremony)) return
+    const cid = executionCeremony.chainId
     const sdk = await getEulerSdkForChain(cid)
-    const out: { to: string, data: string, value: string }[] = []
-    // The latched Safe proposal wraps the plan with grants/revocations —
-    // the copied JSON must match the actual submission.
-    const latched = latchedBundledExecution.value
-    for (const call of latched?.grants ?? []) {
-      out.push({ to: call.to, data: call.data, value: (call.value ?? 0n).toString() })
-    }
-    for (const item of plan) {
-      if (item.type === 'requiredApproval') {
-        for (const r of item.resolved ?? []) {
-          if (r.type === 'approve') out.push({ to: r.token, data: r.data, value: '0' })
-        }
-        continue
-      }
-      if (item.type === 'evcBatch' && cid) {
-        const items = flattenBatchEntries(item.items)
-        const evc = sdk.deploymentService.getDeployment(cid).addresses.coreAddrs.evc
-        const data = sdk.executionService.encodeBatch(items)
-        const value = items.reduce((sum, it) => sum + it.value, 0n)
-        out.push({ to: evc, data, value: value.toString() })
-        continue
-      }
-      if (item.type === 'contractCall') {
-        out.push({
-          to: item.to,
-          data: encodeFunctionData({ abi: item.abi, functionName: item.functionName, args: item.args }),
-          value: item.value.toString(),
-        })
-      }
-    }
-    for (const call of latched?.revokes ?? []) {
-      out.push({ to: call.to, data: call.data, value: (call.value ?? 0n).toString() })
-    }
-    copyToClipboard(JSON.stringify(out, null, 2), 'calldata')
+    if (!isBatchExecutionCurrent(executionCeremony)) return
+    const out = buildBatchReviewCalldata({
+      plan,
+      before: executionCeremony.grants,
+      after: executionCeremony.revokes,
+      sdk,
+      chainId: cid,
+    })
+    await copyToClipboard(JSON.stringify(out, null, 2), 'calldata')
   }
   catch (error) {
     logWarn('BatchReviewModal/copyCalldata', error)
   }
 }
 
-const hasTenderlyFailed = computed(() => Boolean(tenderlyUrl.value && tenderlyError.value))
-
 const isConfirmDisabled = computed(() =>
-  isSpyMode.value || isExecuting.value || hasPendingDetachedExecution.value || isPreparing.value || isSimulating.value || !canExecuteBatch.value || !!prepareError.value,
+  isSpyMode.value || isExecuting.value || hasPendingDetachedExecution.value || isPreparing.value || isSimulating.value || !canExecuteBatch.value || !!prepareError.value || !isReviewCurrent.value,
 )
 const blockedReason = computed(() => {
   if (isSpyMode.value) return 'Connect a wallet to execute — disabled in spy mode'
+  if (!isReviewCurrent.value) return 'Batch or wallet changed — reopen review to continue'
   if (hasFailedOps.value) return 'Resolve the reverting operation to execute'
   if (hasInsufficientBalance.value) return insufficientBalanceMessage.value || 'Not enough balance to execute this batch'
   if (simError.value) return 'This batch would revert — resolve the flagged error'
@@ -487,7 +465,7 @@ const handleExecute = async () => {
   // rejects new submissions while a detached proposal is pending.
   const handle = beginTrackedExecution({ safeAtSubmit: isSafeWallet.value })
   if (!handle) return
-  const run = executeBatch(handle.scope)
+  const run = executeBatch(handle.scope, executionCeremonyRef.value ?? undefined)
   pendingBatchExecution = run
   executionHandle = handle
   try {
@@ -808,7 +786,17 @@ const onCloseRequested = () => {
         :description="prepareError"
       />
 
-      <!-- Secondary actions: copy calldata + Tenderly -->
+      <UiAlert
+        v-if="executionCeremonyRef?.usesPlaceholderSignatures"
+        variant="info"
+        size="compact"
+        title="Authorization signatures required"
+        description="Copied calldata contains placeholder authorization signatures. Your wallet requests the reviewed signatures only after you confirm the batch."
+      />
+
+      <!-- Secondary action: copy the reviewed call vector. Whole-batch
+           third-party simulation is intentionally unavailable because it
+           cannot preserve the complete reviewed wallet ceremony. -->
       <div class="flex items-center justify-center gap-16">
         <button
           type="button"
@@ -823,40 +811,6 @@ const onCloseRequested = () => {
           />
           {{ copied ? 'Copied!' : isPreparing ? 'Preparing calldata…' : 'Copy calldata' }}
         </button>
-        <template v-if="tenderlyEnabled">
-          <a
-            v-if="tenderlyUrl"
-            :href="tenderlyUrl"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="flex items-center gap-6 text-p3 transition-colors"
-            :class="hasTenderlyFailed ? 'text-error-500' : 'text-success-500 hover:text-success-600'"
-          >
-            <SvgIcon
-              :name="hasTenderlyFailed ? 'warning-circle' : 'check-circle'"
-              class="!w-16 !h-16"
-            />
-            {{ hasTenderlyFailed ? 'Simulation reverted — view on Tenderly' : 'View simulation on Tenderly' }}
-            <SvgIcon
-              name="arrow-top-right"
-              class="!w-14 !h-14"
-            />
-          </a>
-          <button
-            v-else
-            type="button"
-            class="flex items-center gap-6 text-p3 text-content-secondary hover:text-content-primary transition-colors disabled:opacity-50"
-            :disabled="isTenderlySimulating"
-            @click="simulateOnTenderly"
-          >
-            <SvgIcon
-              :name="isTenderlySimulating ? 'loading' : 'arrow-top-right'"
-              class="!w-16 !h-16"
-              :class="{ 'animate-spin': isTenderlySimulating }"
-            />
-            {{ isTenderlySimulating ? 'Simulating…' : 'Simulate on Tenderly' }}
-          </button>
-        </template>
       </div>
 
       <div class="flex flex-col items-center gap-8">

--- a/composables/useEulerTx.ts
+++ b/composables/useEulerTx.ts
@@ -1040,7 +1040,14 @@ export const useEulerTx = () => {
       currentChainId: currentAccount.chainId,
     })
     options?.beforeSignature?.()
-    const signature = await signTypedDataAsync(request.typedData as unknown as Parameters<typeof signTypedDataAsync>[0])
+    // Pin the signature request to the connector that just passed the wallet
+    // context check. Without it wagmi resolves the currently-active connector
+    // at request time, so a connector switched in the check-to-sign gap would
+    // receive the request despite never being validated.
+    const signature = await signTypedDataAsync({
+      ...(request.typedData as unknown as Parameters<typeof signTypedDataAsync>[0]),
+      ...(currentAccount.connector ? { connector: currentAccount.connector } : {}),
+    })
     const postMigrationAuthorization = request.postMigrationAuthorization
       ? await signMigrationAuthorization(request.postMigrationAuthorization, options)
       : undefined
@@ -1632,7 +1639,12 @@ export const useEulerTx = () => {
       usePermit2: isKnownSafe ? false : signaturesEnabled.value,
       sendTransaction,
       signTypedData: async (typedData) => {
-        const signature = await signTypedDataAsync(typedData as unknown as Parameters<typeof signTypedDataAsync>[0])
+        // Same pinning as sendTransaction: sign through the captured
+        // connector, never the currently-active one.
+        const signature = await signTypedDataAsync({
+          ...(typedData as unknown as Parameters<typeof signTypedDataAsync>[0]),
+          ...(connector ? { connector } : {}),
+        })
         return signature as Hex
       },
       onProgress: (_progress: TransactionPlanExecutionProgress) => {},
@@ -1744,7 +1756,12 @@ export const useEulerTx = () => {
       sendTransaction,
       signTypedData: async (typedData) => {
         options?.beforeBroadcast?.()
-        const signature = await signTypedDataAsync(typedData as unknown as Parameters<typeof signTypedDataAsync>[0])
+        // Same pinning as sendTransaction: sign through the captured
+        // connector, never the currently-active one.
+        const signature = await signTypedDataAsync({
+          ...(typedData as unknown as Parameters<typeof signTypedDataAsync>[0]),
+          ...(connector ? { connector } : {}),
+        })
         return signature as Hex
       },
       onProgress: (_progress: TransactionPlanExecutionProgress) => {},

--- a/composables/useEulerTx.ts
+++ b/composables/useEulerTx.ts
@@ -70,10 +70,10 @@ import {
   assertWalletExecutionContext,
   type WalletExecutionContext,
 } from '~/utils/walletExecutionContext'
+import { PLACEHOLDER_MIGRATION_AUTHORIZATION_SIGNATURE } from '~/utils/migrationAuthorizationSignatures'
 
 const OKX_POST_APPROVE_DELAY_MS = 3000
 const ERC20_APPROVE_SELECTOR = '0x095ea7b3'
-const PLACEHOLDER_AUTHORIZATION_SIGNATURE = `0x${'00'.repeat(65)}` as Hex
 const SUB_ACCOUNT_SNAPSHOT_FETCH_OPTIONS = {
   populateVaults: false,
   populateMarketPrices: false,
@@ -97,6 +97,16 @@ const isOkxWallet = async (connector?: { id?: string, name?: string, getProvider
     }
   }
   return false
+}
+
+/**
+ * A plan submission the wallet has accepted but whose confirmation is still
+ * pending: an on-chain transaction hash for standard wallets, or a safeTxHash
+ * proposal id for Safes (resolvable only through the Safe wallet provider).
+ */
+export interface PreparedPlanBroadcast {
+  kind: 'transaction' | 'proposal'
+  hash: Hash
 }
 
 export interface PlanDepositInput {
@@ -1014,6 +1024,7 @@ export const useEulerTx = () => {
 
   const signMigrationAuthorization = async (
     request: MigrationAuthorizationRequest,
+    options?: { beforeSignature?: () => void },
   ): Promise<SignedMigrationAuthorization> => {
     if (isSpyMode.value) {
       throw new Error('Authorization signatures are disabled in spy mode')
@@ -1028,9 +1039,10 @@ export const useEulerTx = () => {
       currentAccount: currentAccount.address,
       currentChainId: currentAccount.chainId,
     })
+    options?.beforeSignature?.()
     const signature = await signTypedDataAsync(request.typedData as unknown as Parameters<typeof signTypedDataAsync>[0])
     const postMigrationAuthorization = request.postMigrationAuthorization
-      ? await signMigrationAuthorization(request.postMigrationAuthorization)
+      ? await signMigrationAuthorization(request.postMigrationAuthorization, options)
       : undefined
     return {
       request,
@@ -1048,7 +1060,7 @@ export const useEulerTx = () => {
 
     return {
       request,
-      signature: PLACEHOLDER_AUTHORIZATION_SIGNATURE,
+      signature: PLACEHOLDER_MIGRATION_AUTHORIZATION_SIGNATURE,
       ...(postMigrationAuthorization ? { postMigrationAuthorization } : {}),
     }
   }
@@ -1172,6 +1184,12 @@ export const useEulerTx = () => {
     return sdk.executionService.estimateGasForTransactionPlan(cid, owner, plan)
   }
 
+  /** Estimate the exact prepared envelope without rerunning plan plugins. */
+  const estimateGasForPreparedPlan = async (prepared: TransactionPlanPrepared): Promise<bigint> => {
+    const sdk = await getEulerSdkForChain(prepared.chainId)
+    return sdk.executionService.estimateGasForPreparedTransactionPlan(prepared)
+  }
+
   /**
    * Resolve each plugin's prefetch payload for a representative plan once per
    * form-load. Pass the returned record to prepare/simulate/estimate via the
@@ -1217,6 +1235,8 @@ export const useEulerTx = () => {
     expectedChainId,
     connector,
     resolveHash,
+    beforeBroadcast,
+    onBroadcast,
   }: {
     isOkx: boolean
     expectedAccount: Address
@@ -1229,6 +1249,15 @@ export const useEulerTx = () => {
      */
     connector?: ReturnType<typeof getAccount>['connector']
     resolveHash?: (hash: Hash) => Promise<Hash>
+    /** Final caller-owned freshness check at the wallet submission boundary. */
+    beforeBroadcast?: () => void
+    /**
+     * Fires as soon as the wallet accepted the submission, before any
+     * confirmation wait — from here on the transaction may land even if
+     * everything after this point fails, so callers use it to stop treating
+     * a later error as "never sent".
+     */
+    onBroadcast?: (hash: Hash) => void
   }) => {
     let okxDelayPending = false
     const send = async ({ to, data, value }: { to: Address, data: Hex, value?: bigint }) => {
@@ -1243,6 +1272,7 @@ export const useEulerTx = () => {
         currentAccount: currentAccount.address,
         currentChainId: currentAccount.chainId,
       })
+      beforeBroadcast?.()
       const hash = await sendTransactionAsync({
         account: expectedAccount,
         chainId: expectedChainId,
@@ -1255,6 +1285,7 @@ export const useEulerTx = () => {
         okxDelayPending = true
       }
       const submittedHash = hash as Hash
+      onBroadcast?.(submittedHash)
       return resolveHash ? resolveHash(submittedHash) : submittedHash
     }
     return send
@@ -1273,6 +1304,7 @@ export const useEulerTx = () => {
     options?: {
       onBroadcast?: (index: number, walletContext: WalletExecutionContext) => void
       walletContext?: WalletExecutionContext
+      beforeBroadcast?: () => void
     },
   ): Promise<TransactionReceipt[]> => {
     if (isSpyMode.value) {
@@ -1302,6 +1334,7 @@ export const useEulerTx = () => {
       expectedAccount: owner,
       expectedChainId: cid,
       connector,
+      beforeBroadcast: options?.beforeBroadcast,
     })
 
     const receipts: TransactionReceipt[] = []
@@ -1349,12 +1382,14 @@ export const useEulerTx = () => {
   const executeMigrationAuthorizationGrants = async (
     request: MigrationAuthorizationRequest,
     broadcastRevokes: MigrationAuthorizationRevoke[] = [],
+    options?: { beforeBroadcast?: () => void },
   ): Promise<MigrationAuthorizationRevoke[]> => {
     const { grants, revokesByGrant } = encodeMigrationAuthorizationTxs(request)
     await sendPlainTransactions(grants, {
       // The request was prepared for this exact owner/network. Do not let a
       // wallet switch during the preceding SDK reads retarget the grant.
       walletContext: { account: request.owner, chainId: request.chainId },
+      beforeBroadcast: options?.beforeBroadcast,
       onBroadcast: (index, walletContext) => {
         const revoke = revokesByGrant[index]
         if (revoke) {
@@ -1430,7 +1465,7 @@ export const useEulerTx = () => {
    * bundling brings no benefit (fewer than two calls) — callers fall back to
    * sequential execution.
    */
-  const executePlanAsSafeBundle = async ({ plan, chainId, owner, provider, connector, safeWalletProvider, sdk, extraCalls, allowSingleCall }: {
+  const executePlanAsSafeBundle = async ({ plan, chainId, owner, provider, connector, safeWalletProvider, sdk, extraCalls, allowSingleCall, beforeBroadcast, onBroadcast }: {
     plan: TransactionPlan
     chainId: number
     owner: Address
@@ -1449,6 +1484,15 @@ export const useEulerTx = () => {
      * "no Safe context" — with it set, undefined strictly means the latter.
      */
     allowSingleCall?: boolean
+    /** Final caller-owned freshness check at the Safe submission boundary. */
+    beforeBroadcast?: () => void
+    /**
+     * Fires once the Safe accepted the proposal (safeTxHash exists), before
+     * the execution wait — from here on the proposal may execute even if
+     * status polling fails, so callers use it to stop treating a later error
+     * as "never submitted".
+     */
+    onBroadcast?: (safeTxHash: Hash) => void
   }) => {
     let planCalls
     try {
@@ -1483,6 +1527,7 @@ export const useEulerTx = () => {
       currentAccount: currentAccount.address,
       currentChainId: currentAccount.chainId,
     })
+    beforeBroadcast?.()
 
     // Pin submission to the connector whose provider was identified as Safe.
     // Without it, wagmi resolves the currently-active connector, and a
@@ -1500,6 +1545,7 @@ export const useEulerTx = () => {
     if (!/^0x[0-9a-f]{64}$/i.test(id)) {
       throw new Error('Safe wallet returned an unexpected call bundle id')
     }
+    onBroadcast?.(id as Hash)
 
     const execution = await waitForSafeTransactionExecution({
       submittedHash: id as Hash,
@@ -1596,7 +1642,20 @@ export const useEulerTx = () => {
     return result
   }
 
-  const executePreparedPlan = async (prepared: TransactionPlanPrepared) => {
+  const executePreparedPlan = async (
+    prepared: TransactionPlanPrepared,
+    options?: {
+      beforeBroadcast?: () => void
+      /**
+       * Fires as soon as the wallet accepted a plan submission (a transaction
+       * hash for standard wallets, a safeTxHash proposal id for Safes),
+       * before any confirmation wait. From that point the submission may land
+       * even when a later step throws, so callers use it to distinguish
+       * "never sent" from "sent but unconfirmed".
+       */
+      onBroadcast?: (broadcast: PreparedPlanBroadcast) => void
+    },
+  ) => {
     if (isSpyMode.value) {
       throw new Error('Transactions are disabled in spy mode')
     }
@@ -1650,6 +1709,8 @@ export const useEulerTx = () => {
         connector,
         safeWalletProvider,
         sdk,
+        beforeBroadcast: options?.beforeBroadcast,
+        onBroadcast: hash => options?.onBroadcast?.({ kind: 'proposal', hash }),
       })
       if (bundled) {
         finalizeExecution(bundled)
@@ -1662,6 +1723,13 @@ export const useEulerTx = () => {
       expectedAccount: preparedOwner,
       expectedChainId: prepared.chainId,
       connector,
+      beforeBroadcast: options?.beforeBroadcast,
+      // A Safe's sequential fallback submits through the Safe app, so the
+      // wallet returns a safeTxHash proposal id, not an on-chain hash.
+      onBroadcast: hash => options?.onBroadcast?.({
+        kind: safeWalletProvider ? 'proposal' : 'transaction',
+        hash,
+      }),
       resolveHash: safeWalletProvider
         ? async submittedHash => (await waitForSafeTransactionExecution({
           submittedHash,
@@ -1675,6 +1743,7 @@ export const useEulerTx = () => {
       prepared: effectivePrepared,
       sendTransaction,
       signTypedData: async (typedData) => {
+        options?.beforeBroadcast?.()
         const signature = await signTypedDataAsync(typedData as unknown as Parameters<typeof signTypedDataAsync>[0])
         return signature as Hex
       },
@@ -1703,7 +1772,12 @@ export const useEulerTx = () => {
       before?: readonly PlainTxRequest[]
       after?: readonly PlainTxRequest[]
     },
-    options?: { allowSingleCall?: boolean },
+    options?: {
+      allowSingleCall?: boolean
+      beforeBroadcast?: () => void
+      /** See executePreparedPlan — fires with the safeTxHash proposal id. */
+      onBroadcast?: (broadcast: PreparedPlanBroadcast) => void
+    },
   ) => {
     if (isSpyMode.value) {
       throw new Error('Transactions are disabled in spy mode')
@@ -1747,6 +1821,8 @@ export const useEulerTx = () => {
       sdk,
       extraCalls,
       allowSingleCall: options?.allowSingleCall,
+      beforeBroadcast: options?.beforeBroadcast,
+      onBroadcast: hash => options?.onBroadcast?.({ kind: 'proposal', hash }),
     })
     if (!bundled) return undefined
     finalizeExecution(bundled)
@@ -1811,6 +1887,7 @@ export const useEulerTx = () => {
     simulatePlan,
     prepareTransactionPlan,
     estimateGasForPlan,
+    estimateGasForPreparedPlan,
     prefetchPluginData,
     simulatePreparedPlan,
     executePreparedPlanWithPlainCalls,

--- a/composables/useMigrationAuthorizationFlow.ts
+++ b/composables/useMigrationAuthorizationFlow.ts
@@ -62,15 +62,23 @@ export const useMigrationAuthorizationFlow = () => {
     return false
   }
 
-  const revokeAfterSuccess = async (revokes: readonly MigrationAuthorizationRevoke[]) => {
+  const revokeAfterSuccess = async (
+    revokes: readonly MigrationAuthorizationRevoke[],
+    options?: { shouldNotify?: () => boolean },
+  ) => {
     queueRevokes(revokes)
     if (await restorePendingRevokes()) return
+    if (options?.shouldNotify?.() === false) return
     showWarning('Migration succeeded, but restoring your previous authorization failed or was cancelled. You can restore it manually later.')
   }
 
-  const revokeAfterAbort = async (revokes: readonly MigrationAuthorizationRevoke[]) => {
+  const revokeAfterAbort = async (
+    revokes: readonly MigrationAuthorizationRevoke[],
+    options?: { shouldNotify?: () => boolean },
+  ) => {
     queueRevokes(revokes)
     if (await restorePendingRevokes()) return
+    if (options?.shouldNotify?.() === false) return
     showWarning('The temporary authorization granted for this migration is still standing. Retry the migration or restore your previous authorization manually.')
   }
 

--- a/composables/useTxBatch.ts
+++ b/composables/useTxBatch.ts
@@ -1,5 +1,5 @@
 import { computed, effectScope, ref, shallowRef, watch, type EffectScope, type Ref } from 'vue'
-import { formatUnits, getAddress, type Address, type Hex, type StateOverride } from 'viem'
+import { formatUnits, getAddress, type Address, type Hash, type Hex, type StateOverride } from 'viem'
 import { Account, fetchErc20SlotHints, getEulerLabelProductByVault, mergeStateOverrides } from '@eulerxyz/euler-v2-sdk'
 import type {
   IHasVaultAddress,
@@ -8,6 +8,7 @@ import type {
   PortfolioSavingsPosition,
   SlotHints,
   TransactionPlan,
+  TransactionPlanPrepared,
   VaultEntity,
 } from '@eulerxyz/euler-v2-sdk'
 import { getEulerSdkFresh } from '~/composables/useEulerSdk'
@@ -19,14 +20,12 @@ import {
 } from '~/composables/batchPrefetchState'
 import { getCurrentEulerLabelsData } from '~/composables/useEulerLabels'
 import type { TrackedExecutionScope } from '~/composables/useSafeExecutionDetachment'
-import { useTenderlySimulation } from '~/composables/useTenderlySimulation'
 import {
   activeLayerVaultsRef,
   collectAccountVaults,
   mergeLayeredVaults,
   type LayeredVaultMap,
 } from '~/composables/useLayeredVaults'
-import { buildTenderlySimulationPayload } from '~/utils/tenderly-plan'
 import { buildPlanMarketLabel, type DisplayStep } from '~/utils/stepDecoding'
 import { formatSmartAmount } from '~/utils/string-utils'
 import { formatSimulationFailure, getTxErrorMessage } from '~/utils/tx-errors'
@@ -34,6 +33,17 @@ import { logWarn } from '~/utils/errorHandling'
 import { buildVisiblePortfolioPositionFilter } from '~/utils/portfolioPositionFilter'
 import type { MigrationAuthorizationRevoke } from '~/utils/migrationAuthorizationTxs'
 import type { WalletExecutionContext } from '~/utils/walletExecutionContext'
+import type { PreparedPlanBroadcast } from '~/composables/useEulerTx'
+import {
+  getSafeWalletProvider,
+  SafeTransactionStatusUnknownError,
+  waitForSafeTransactionExecution,
+  type ReceiptClientLike,
+} from '~/utils/safeWalletTransactions'
+import {
+  assertPreparedPlanSignatureParity,
+  type PreparedPlanSignatureSubstitution,
+} from '~/utils/preparedPlanParity'
 
 export interface BatchWalletChange {
   token: string
@@ -79,7 +89,7 @@ export interface BatchEntryExternalTx {
 }
 
 export interface BatchEntryExecutionPrerequisites {
-  /** Sent and mined before the merged plan is built. */
+  /** Sent and mined before the reviewed prepared core is executed. */
   preTxs: BatchEntryExternalTx[]
   /** Wallet context used to build the prerequisite request. */
   walletContext: WalletExecutionContext
@@ -89,25 +99,65 @@ export interface BatchEntryExecutionPrerequisites {
   postTxsByPreTx?: Array<BatchEntryExternalTx | undefined>
 }
 
-export interface BatchEntryBundledExecution {
+export interface BatchEntryExecutionCeremony {
   /**
-   * Execution payload built WITHOUT live authorization reads (the
-   * simulation-variant plan) — the grants ride in the same Safe proposal
-   * and are not mined when this plan is built.
+   * Execution payload built from the same authorization resolution as the
+   * prerequisite calls and review rows.
    */
   plan: TransactionPlan
-  /** Grant calls to prepend to the proposal, in dependency order. */
-  grants: BatchEntryExternalTx[]
-  /** Revocation calls to append, already in unwind order for this entry. */
-  revokes: BatchEntryExternalTx[]
+  /** One authorization resolution shared by standard and Safe execution. */
+  prerequisites?: BatchEntryExecutionPrerequisites
   /**
-   * Review rows for the grants above, derived from the SAME authorization
-   * resolution — the modal renders these, never the add-time captures, so
-   * the displayed ceremony cannot drift from the executed one.
+   * Review rows for the prerequisite grants, derived from this ceremony's
+   * authorization resolution.
    */
   grantSteps: DisplayStep[]
-  /** Review rows for the revocations above, same resolution. */
+  /** Review rows for the prerequisite revocations, from the same resolution. */
   revokeSteps: DisplayStep[]
+  /**
+   * Resolve wallet signatures only after the user confirms this reviewed
+   * ceremony. The callback receives the ceremony freshness guard and returns
+   * the same plan with real signature bytes.
+   */
+  resolveExecutionPlan?: (beforeWalletAction: () => void) => Promise<{
+    plan: TransactionPlan
+    signatureSubstitutions: readonly PreparedPlanSignatureSubstitution[]
+  }>
+  /** The review/copy plan contains placeholder authorization signatures. */
+  usesPlaceholderSignatures?: boolean
+  /**
+   * Re-resolve this entry's prerequisite authorization against current chain
+   * state and throw when it no longer matches what the review displayed.
+   * The ceremony's prerequisites are frozen at review time, so on-chain drift
+   * (an allowance granted or revoked elsewhere) would otherwise broadcast
+   * grant/revoke calls the user never reviewed. Invoked at the last
+   * pre-broadcast boundary of the batch execution.
+   */
+  revalidatePrerequisites?: () => Promise<void>
+}
+
+/** One immutable batch review ceremony used for display, export, and execution. */
+export interface PreparedBatchExecution {
+  readonly generation: number
+  readonly owner: Address
+  readonly chainId: number
+  readonly safeWallet: boolean
+  readonly safeWalletResolved: boolean
+  readonly connectorKey?: string
+  readonly mode: 'standard' | 'safe-bundled'
+  readonly prepared: TransactionPlanPrepared
+  readonly resolvePreparedPlan?: (beforeWalletAction: () => void) => Promise<TransactionPlanPrepared>
+  readonly usesPlaceholderSignatures: boolean
+  readonly grants: readonly BatchEntryExternalTx[]
+  readonly revokes: readonly BatchEntryExternalTx[]
+  readonly prerequisites: readonly Readonly<BatchEntryExecutionPrerequisites>[]
+  /** Per-entry prerequisite drift checks, run before anything irreversible. */
+  readonly prerequisiteRevalidations: readonly (() => Promise<void>)[]
+  readonly reviewByEntryId: Readonly<Record<string, {
+    readonly plan: TransactionPlan
+    readonly grantSteps: readonly DisplayStep[]
+    readonly revokeSteps: readonly DisplayStep[]
+  }>>
 }
 
 export interface BatchEntry {
@@ -117,20 +167,14 @@ export interface BatchEntry {
   plan: TransactionPlan
   /** Optional real execution payload builder for entries whose preview plan uses simulation-only state. */
   buildExecutionPlan?: (account: Account<IHasVaultAddress>) => Promise<TransactionPlan>
-  /** Standalone transactions this entry needs around the merged batch, resolved
-   *  at execution time. Migrations without message signatures use this to grant
-   *  their authorization before the batch and revoke it after: the grants cannot
-   *  be plan items (`mergePlans` rejects contractCall, and the EVC would be the
-   *  msg.sender), and must be mined before the plan is built. */
-  buildExecutionPrerequisites?: (
+  /** Resolve the execution plan, authorization calls, and review rows together.
+   *  Standard wallets broadcast the prerequisite calls around the prepared core;
+   *  Safe wallets include the same calls in one atomic proposal. */
+  buildExecutionCeremony?: (
     account: Account<IHasVaultAddress>,
-  ) => Promise<BatchEntryExecutionPrerequisites | undefined>
-  /** Bundled-mode counterpart of the two builders above: plan + grant/revoke
-   *  calls for ONE atomic Safe proposal. Entries providing this let the cart
-   *  skip the standalone grant broadcasts entirely when a Safe executes. */
-  buildBundledExecution?: (
-    account: Account<IHasVaultAddress>,
-  ) => Promise<BatchEntryBundledExecution>
+  ) => Promise<BatchEntryExecutionCeremony>
+  /** This entry's prerequisite calls belong inside one atomic Safe proposal. */
+  bundleExecutionCeremony?: boolean
   /** Extra simulation-only overrides required by this entry, e.g. migration authorization. */
   stateOverrides?: StateOverride
   /** Props for the per-operation review modal (OperationReviewModal), captured at
@@ -226,21 +270,35 @@ export interface WalletShortfall {
 // --- module-scoped state (single shared cart for the session) ---
 const entries: Ref<BatchEntry[]> = ref([])
 const layers = shallowRef<BatchLayer[]>([])
-/**
- * Bundled ceremony resolved ONCE when the review modal opens, displayed,
- * copied, and executed verbatim — the latch that keeps the reviewed
- * ceremony, the copied payload, and the submitted proposal identical. A
- * cart edit or account/chain reset clears it; executeBatch treats its
- * presence as the reviewed promise of ONE proposal. Module-scoped like the
- * rest of the cart state so every component instance shares it.
- */
-const latchedBundledExecution = shallowRef<{
-  plans: TransactionPlan[]
-  grants: BatchEntryExternalTx[]
-  revokes: BatchEntryExternalTx[]
-  /** Per-entry review rows from the same resolution, for the modal to render. */
-  stepsByEntryId: Record<string, { grantSteps: DisplayStep[], revokeSteps: DisplayStep[] }>
-} | null>(null)
+const batchGeneration = ref(0)
+const pendingAddCount = ref(0)
+let addContextGeneration = 0
+let batchPreparation: {
+  generation: number
+  promise: Promise<PreparedBatchExecution>
+} | null = null
+
+const invalidateBatchReview = () => {
+  batchGeneration.value++
+  batchPreparation = null
+}
+
+const invalidatePendingAddContext = () => {
+  addContextGeneration++
+}
+
+interface BatchAddContext {
+  generation: number
+  owner?: Address
+  chainId?: number
+}
+
+class BatchAddContextChangedError extends Error {
+  constructor() {
+    super('Wallet or batch changed while adding this operation — add it again.')
+    this.name = 'BatchAddContextChangedError'
+  }
+}
 // Per-entry fixed plan (keyed by entry id), used by the review modal and by the
 // merged whole-batch plan. These are captured once when the entry is added.
 const entryPlans = computed<Record<string, TransactionPlan>>(() =>
@@ -253,6 +311,20 @@ const isSimulating = ref(false)
 const simError = ref<string | undefined>(undefined)
 const isExecuting = ref(false)
 const execError = ref<string | undefined>(undefined)
+/**
+ * A core batch submission the wallet accepted but whose confirmation failed —
+ * it may still land. While set, the cart is quarantined against blind replays
+ * (re-executing could duplicate every entry the submission covered): the next
+ * execute attempt first reconciles this submission on-chain, and proceeds only
+ * when it definitively did not land. Landed submissions retire their entries.
+ */
+const pendingCoreSubmission = shallowRef<{
+  kind: PreparedPlanBroadcast['kind']
+  hash: Hash
+  chainId: number
+  ceremony: PreparedBatchExecution
+  shouldRefreshExternalMigrationPositions: boolean
+} | null>(null)
 // Drawer expanded/collapsed state, shared so the mobile nav's "Batch" item and
 // the drawer header toggle the same thing. On laptop this collapses the body; on
 // mobile it shows/hides the whole bottom sheet (the nav item is the entry point).
@@ -261,15 +333,6 @@ const drawerOpen = ref(true)
 // executeBatch so the executed batch is exactly what was simulated.
 let lastMerged: TransactionPlan | null = null
 let baseAccountSnapshot: Account<IHasVaultAddress> | null = null
-
-// "Simulate on Tenderly" for the whole batch — runs the exact merged plan
-// through the server-side Tenderly endpoint and returns a shareable dashboard
-// URL. Shared (module-level) so the result persists across the laptop drawer
-// and the mobile full-page view. Mirrors the per-operation flow in
-// OperationReviewModal, just fed the batch's merged plan instead of one op.
-const tenderly = useTenderlySimulation()
-const tenderlyEnabled = ref(false)
-let tenderlyEnabledFetched = false
 
 /**
  * Module-level overlay ref read by `useEulerAccount` so the portfolio is
@@ -478,7 +541,11 @@ const collectRequiredApprovalTokens = (plan: TransactionPlan): Address[] => {
   return tokens
 }
 
-const primeBatchSlotHintsFor = async (chainId: number, tokens: Address[]): Promise<void> => {
+const primeBatchSlotHintsFor = async (
+  chainId: number,
+  tokens: Address[],
+  isCurrent: () => boolean = () => true,
+): Promise<void> => {
   if (!tokens.length) return
   try {
     const sdk = await getEulerSdkFresh()
@@ -496,8 +563,10 @@ const primeBatchSlotHintsFor = async (chainId: number, tokens: Address[]): Promi
         logWarn('useTxBatch/primeBatchSlotHintsFor', error)
       }
     }))
-    batchSlotHints = next
-    mergeBatchPrefetchedSlotHints(chainId, next)
+    if (isCurrent()) {
+      batchSlotHints = next
+      mergeBatchPrefetchedSlotHints(chainId, next)
+    }
   }
   catch (error) {
     logWarn('useTxBatch/primeBatchSlotHintsFor', error)
@@ -1736,7 +1805,7 @@ export const awaitFinalPlanningLayer = async <T>(opts: {
 }
 
 export const useTxBatch = () => {
-  const { chainId: wagmiChainId } = useWagmi()
+  const { chainId: wagmiChainId, connector } = useWagmi()
   const { effectiveAddress } = useEffectiveAddress()
   const { chainId: addressesChainId } = useEulerAddresses()
   const { scheduleExternalMigrationRefreshes } = useExternalMigrationRefresh()
@@ -1745,8 +1814,12 @@ export const useTxBatch = () => {
     () => effectiveAddress.value as Address | undefined,
   )
   const chainId = computed(() => wagmiChainId.value ?? addressesChainId.value)
-  const { prepareTransactionPlan, executePreparedPlan, executePreparedPlanWithPlainCalls, estimateGasForPlan, sendPlainTransactions } = useEulerTx()
-  const { isSafeWallet } = useSafeWallet()
+  const { prepareTransactionPlan, executePreparedPlan, executePreparedPlanWithPlainCalls, estimateGasForPreparedPlan, sendPlainTransactions } = useEulerTx()
+  const { isSafeWallet, isSafeWalletResolved } = useSafeWallet()
+  const connectorKey = computed(() => {
+    const current = connector.value
+    return current ? `${current.id}:${current.uid}` : undefined
+  })
   const { restorePendingBeforeRetry, revokeAfterSuccess, revokeAfterAbort } = useMigrationAuthorizationFlow()
   const { getTokenByAddress } = useTokenList()
   const ownerSubAccountKey = computed(() => {
@@ -1781,6 +1854,17 @@ export const useTxBatch = () => {
       return
     }
 
+    const ownerAddr = getAddress(o)
+    const isResimulationContextCurrent = (): boolean => {
+      if (token !== resimToken || chainId.value !== cid || !owner.value) return false
+      try {
+        return getAddress(owner.value) === ownerAddr
+      }
+      catch {
+        return false
+      }
+    }
+
     isSimulating.value = true
     // NOTE: deliberately do NOT clear simError / walletShortfalls here. A new
     // simulation runs on every add/remove/reorder; clearing up-front would make a
@@ -1788,13 +1872,16 @@ export const useTxBatch = () => {
     // atomically on completion below (and cleared on the empty-batch path above).
     try {
       const sdk = await getEulerSdkFresh()
-      const ownerAddr = getAddress(o)
       // Keep the real base state fixed for the lifetime of the cart. Entry plans
       // are immutable add-time payloads; later real-state drift should not cause
       // the whole batch to rebuild around a different base account.
       const baseAccount = baseAccountSnapshot
         ?? resolvePrefetchedAccounts(cid, ownerAddr).baseAccount
         ?? await fetchBaseAccountSnapshot(sdk, cid, ownerAddr)
+      if (!isResimulationContextCurrent()) {
+        logBatchDiag('resimulate:superseded-after-base-fetch', { token, supersededBy: resimToken }, 'error')
+        return
+      }
       baseAccountSnapshot = baseAccount
 
       const plans = entries.value.map(entry => entry.plan)
@@ -1806,7 +1893,6 @@ export const useTxBatch = () => {
       // operation and returns simulatedAccounts = [base, afterOp0, afterOp1, …]
       // plus per-operation revert attribution via failedBatchItems.
       const merged = sdk.executionService.mergePlans(plans)
-      lastMerged = merged
       const sim = await sdk.executionService.simulateTransactionPlan(
         cid,
         ownerAddr,
@@ -1827,7 +1913,7 @@ export const useTxBatch = () => {
         },
       )
 
-      if (token !== resimToken) {
+      if (!isResimulationContextCurrent()) {
         // A newer resimulation superseded this one after the sim resolved, so this
         // run bails before populating layers. When that happens during a plan-time
         // await it's exactly what surfaces as the misleading "Batch simulation not
@@ -1836,6 +1922,7 @@ export const useTxBatch = () => {
         logBatchDiag('resimulate:superseded-after-sim', { token, supersededBy: resimToken }, 'error')
         return
       }
+      lastMerged = merged
 
       // Two distinct failure shapes, both blocking but handled differently:
       //  - simulationError: the EVC call reverted at the top level (couldn't even
@@ -1996,7 +2083,7 @@ export const useTxBatch = () => {
           logWarn('useTxBatch/fetchWallet', error)
         }
       }
-      if (token !== resimToken) {
+      if (!isResimulationContextCurrent()) {
         // Superseded during the post-sim wallet fetch — same race as above, just a
         // later checkpoint. Bails before populating layers.
         logBatchDiag('resimulate:superseded-after-wallet-fetch', { token, supersededBy: resimToken }, 'error')
@@ -2094,7 +2181,7 @@ export const useTxBatch = () => {
       )
     }
     catch (error) {
-      if (token !== resimToken) {
+      if (!isResimulationContextCurrent()) {
         logBatchDiag('resimulate:superseded-in-catch', { token, supersededBy: resimToken }, 'error')
         return
       }
@@ -2104,7 +2191,7 @@ export const useTxBatch = () => {
       simError.value = error instanceof Error ? error.message : String(error)
     }
     finally {
-      if (token === resimToken) isSimulating.value = false
+      if (isResimulationContextCurrent()) isSimulating.value = false
     }
   }
 
@@ -2129,23 +2216,18 @@ export const useTxBatch = () => {
   if (!scope) {
     scope = effectScope(true)
     scope.run(() => {
-      // Any edit to the cart invalidates a prior Tenderly run (it simulated a
-      // different fixed plan list), so drop the stale URL before re-simulating.
       watch(entries, () => {
         logBatchDiag('watch:entries-changed')
-        tenderly.clearSimulation()
-        // A cart edit invalidates the latched bundled ceremony — the modal
-        // re-latches on next open.
-        latchedBundledExecution.value = null
         void runResimulate()
       })
       watch([activeLayer, layers], syncOverlay)
       // Reset the cart when the account or chain changes — layers would be stale.
       watch([owner, chainId], () => {
         logBatchDiag('watch:owner-or-chain-reset', {}, 'error')
+        invalidatePendingAddContext()
+        invalidateBatchReview()
         resimToken++
         entries.value = []
-        latchedBundledExecution.value = null
         layers.value = []
         activeLayer.value = 0
         isSimulating.value = false
@@ -2156,13 +2238,19 @@ export const useTxBatch = () => {
         baseAccountSnapshot = null
         batchSlotHints = {}
         resimulatePromise = null
-        tenderly.clearSimulation()
         syncOverlay()
+      })
+      // Safe classification is part of a bundled ceremony's wallet context.
+      // Connector detection can change without changing the owner or chain.
+      watch([isSafeWallet, isSafeWalletResolved, connectorKey], () => {
+        invalidateBatchReview()
       })
     })
   }
 
-  const getEntryPlanningAccount = async (): Promise<Account<IHasVaultAddress>> => {
+  const getEntryPlanningAccount = async (
+    isAddContextCurrent: () => boolean,
+  ): Promise<Account<IHasVaultAddress>> => {
     const getCurrentFinalLayer = () => (
       entries.value.length > 0 && layers.value.length === entries.value.length + 1
         ? layers.value[layers.value.length - 1]?.account
@@ -2232,19 +2320,57 @@ export const useTxBatch = () => {
 
     logBatchDiag('getEntryPlanningAccount:base-snapshot-fetch', { owner: o, chainId: cid })
     const sdk = await getEulerSdkFresh()
-    baseAccountSnapshot = await fetchBaseAccountSnapshot(sdk, cid, ownerAddress)
-    return baseAccountSnapshot
+    const fetched = await fetchBaseAccountSnapshot(sdk, cid, ownerAddress)
+    if (!isAddContextCurrent()) throw new BatchAddContextChangedError()
+    baseAccountSnapshot = fetched
+    return fetched
+  }
+
+  const captureAddContext = (): BatchAddContext => {
+    let currentOwner: Address | undefined
+    try {
+      currentOwner = owner.value ? getAddress(owner.value) : undefined
+    }
+    catch {
+      currentOwner = undefined
+    }
+    return {
+      generation: addContextGeneration,
+      owner: currentOwner,
+      chainId: chainId.value,
+    }
+  }
+
+  const isAddContextCurrent = (context: BatchAddContext): boolean => {
+    if (context.generation !== addContextGeneration || context.chainId !== chainId.value) return false
+    try {
+      const currentOwner = owner.value ? getAddress(owner.value) : undefined
+      return currentOwner === context.owner
+    }
+    catch {
+      return context.owner === undefined
+    }
+  }
+
+  const assertAddContextCurrent = (context: BatchAddContext) => {
+    if (!isAddContextCurrent(context)) throw new BatchAddContextChangedError()
   }
 
   const addEntry = async (entry: BatchEntryInput) => {
+    const addContext = captureAddContext()
     // Ignore a rapid duplicate click while an identical add is still in flight
     // (same target sub-account + label). Sequential re-adds are unaffected — the
     // signature is released once the add settles.
-    const signature = `${entry.subAccount ?? ''}|${entry.label}`
+    const signature = `${addContext.generation}|${addContext.owner ?? ''}|${addContext.chainId ?? ''}|${entry.subAccount ?? ''}|${entry.label}`
     if (pendingAddSignatures.has(signature)) return
     pendingAddSignatures.add(signature)
+    pendingAddCount.value++
+    // Invalidate synchronously when the edit starts, not after its async plan
+    // build finishes, so an open review cannot execute while an add is pending.
+    invalidateBatchReview()
 
     const add = async () => {
+      assertAddContextCurrent(addContext)
       execError.value = undefined
       logBatchDiag('addEntry:building', {
         label: entry.label,
@@ -2265,9 +2391,15 @@ export const useTxBatch = () => {
           // The simulator will surface the normal account-loading error later.
         }
       }
+      let planningAccount: Account<IHasVaultAddress> | undefined
+      if (entry.requiresPlanningAccount !== false) {
+        planningAccount = await getEntryPlanningAccount(() => isAddContextCurrent(addContext))
+        assertAddContextCurrent(addContext)
+      }
       const buildResult = entry.requiresPlanningAccount === false
         ? await entry.buildPlan()
-        : await entry.buildPlan(await getEntryPlanningAccount())
+        : await entry.buildPlan(planningAccount!)
+      assertAddContextCurrent(addContext)
       const plan = Array.isArray(buildResult) ? buildResult : buildResult.plan
       const builtStateOverrides = Array.isArray(buildResult) ? undefined : buildResult.stateOverrides
       const cid = chainId.value
@@ -2279,14 +2411,19 @@ export const useTxBatch = () => {
         // Probe only what no form or earlier batch entry has resolved yet.
         const missingSlotHintTokens = collectRequiredApprovalTokens(plan)
           .filter(token => batchSlotHints[token] === undefined)
-        await primeBatchSlotHintsFor(cid, missingSlotHintTokens)
+        await primeBatchSlotHintsFor(cid, missingSlotHintTokens, () => isAddContextCurrent(addContext))
       }
+      assertAddContextCurrent(addContext)
       const {
         buildPlan: _buildPlan,
         requiresPlanningAccount: _requiresPlanningAccount,
         ...fixedEntry
       } = entry
       registerReviewAssetMeta(fixedEntry.review)
+      // A ceremony can be prepared while this async add is building against
+      // the prior cart. Advance again at the commit edge so that ceremony is
+      // stale before the completed entry becomes visible.
+      invalidateBatchReview()
       entries.value = [...entries.value, {
         ...fixedEntry,
         ...(builtStateOverrides ? { stateOverrides: builtStateOverrides } : {}),
@@ -2308,17 +2445,23 @@ export const useTxBatch = () => {
         error: error instanceof Error ? error.message : String(error),
       }, 'error')
       logWarn('useTxBatch/addEntry', error)
-      simError.value = error instanceof Error ? error.message : String(error)
+      if (!(error instanceof BatchAddContextChangedError)) {
+        simError.value = error instanceof Error ? error.message : String(error)
+      }
       throw error
     }
     finally {
       pendingAddSignatures.delete(signature)
+      pendingAddCount.value = Math.max(0, pendingAddCount.value - 1)
     }
   }
 
   const removeEntry = (id: string) => {
     const nextEntries = entries.value.filter(entry => entry.id !== id)
     execError.value = undefined
+    if (nextEntries.length === entries.value.length) return
+    invalidatePendingAddContext()
+    invalidateBatchReview()
     entries.value = nextEntries
     if (nextEntries.length === 0) {
       resimToken++
@@ -2331,12 +2474,16 @@ export const useTxBatch = () => {
       baseAccountSnapshot = null
       batchSlotHints = {}
       resimulatePromise = null
-      tenderly.clearSimulation()
       syncOverlay()
     }
   }
 
   const clearBatch = () => {
+    invalidatePendingAddContext()
+    invalidateBatchReview()
+    // Emptying the cart discards the entries a quarantined submission covered,
+    // so a replay can no longer duplicate them — the quarantine is moot.
+    pendingCoreSubmission.value = null
     resimToken++
     entries.value = []
     layers.value = []
@@ -2349,8 +2496,41 @@ export const useTxBatch = () => {
     baseAccountSnapshot = null
     batchSlotHints = {}
     resimulatePromise = null
-    tenderly.clearSimulation()
     syncOverlay()
+  }
+
+  /**
+   * Remove exactly the entries a landed execution covered, keeping any the
+   * user added while the broadcast was in flight. Runs when execution
+   * succeeded but the cart is no longer the reviewed generation for the same
+   * wallet: clearing everything would discard unexecuted work, while keeping
+   * everything would leave already-executed entries queued to run again. The
+   * ceremony's review index carries the executed entry ids. A wallet-context
+   * change is already handled by the owner/chain watcher emptying the cart, so
+   * this only ever filters same-wallet successors, and the surviving entries
+   * resimulate through the entries watcher.
+   */
+  const retireExecutedEntries = (ceremony: PreparedBatchExecution) => {
+    const executedIds = new Set(Object.keys(ceremony.reviewByEntryId))
+    const nextEntries = entries.value.filter(entry => !executedIds.has(entry.id))
+    if (nextEntries.length === entries.value.length) return
+    execError.value = undefined
+    invalidatePendingAddContext()
+    invalidateBatchReview()
+    entries.value = nextEntries
+    if (nextEntries.length === 0) {
+      resimToken++
+      layers.value = []
+      activeLayer.value = 0
+      isSimulating.value = false
+      simError.value = undefined
+      walletShortfalls.value = []
+      lastMerged = null
+      baseAccountSnapshot = null
+      batchSlotHints = {}
+      resimulatePromise = null
+      syncOverlay()
+    }
   }
 
   const setActiveLayer = (layer: number) => {
@@ -2362,51 +2542,6 @@ export const useTxBatch = () => {
     execError.value = undefined
   }
 
-  /** Lazily check (once) whether the server has Tenderly credentials configured,
-   *  so the UI can hide the button when simulation isn't available. */
-  const fetchTenderlyEnabled = async (): Promise<boolean> => {
-    if (tenderlyEnabledFetched) return tenderlyEnabled.value
-    tenderlyEnabledFetched = true
-    tenderlyEnabled.value = await tenderly.fetchEnabled()
-    return tenderlyEnabled.value
-  }
-
-  /**
-   * Run the whole batch through Tenderly using the preview plan and the SDK's
-   * derived state overrides (so approvals/permits don't make it revert). Returns
-   * a dashboard URL surfaced via `tenderlyUrl`. Works in spy mode too — it's a
-   * read-only simulation, no signature required.
-   */
-  const simulateOnTenderly = async (): Promise<void> => {
-    if (!lastMerged) return
-    const o = owner.value
-    const cid = chainId.value
-    if (!o || !cid) return
-    tenderly.clearSimulation()
-    try {
-      const sdk = await getEulerSdkFresh()
-      const extraStateOverrides = mergeStateOverrides(
-        entries.value.flatMap(entry => entry.stateOverrides ?? []),
-      )
-      const payload = await buildTenderlySimulationPayload({
-        plan: lastMerged,
-        owner: getAddress(o),
-        chainId: cid,
-        sdk,
-        extraStateOverrides,
-      })
-      if (!payload) {
-        tenderly.simulationError.value = 'Tenderly simulation is not available for this batch.'
-        return
-      }
-      await tenderly.simulate(payload)
-    }
-    catch (error) {
-      logWarn('useTxBatch/simulateOnTenderly', error)
-      tenderly.simulationError.value = 'Tenderly simulation failed.'
-    }
-  }
-
   /** The latest merged preview plan (null until a successful simulation).
    *  The review modal prepares & decodes this to surface approvals. */
   const getMergedPlan = (): TransactionPlan | null => lastMerged
@@ -2415,7 +2550,7 @@ export const useTxBatch = () => {
    *  modal can list the approvals the user will be asked to sign. */
   const prepareBatchPlan = async () => {
     if (!lastMerged) return null
-    return prepareTransactionPlan(lastMerged)
+    return (await prepareBatchExecution()).prepared
   }
 
   const getExecutionPlanningAccount = async (entryIndex: number): Promise<Account<IHasVaultAddress>> => {
@@ -2436,49 +2571,233 @@ export const useTxBatch = () => {
     const o = owner.value
     const cid = chainId.value
     if (!o || !cid) throw new Error('Account not loaded')
+    const executionOwner = getAddress(o)
+    const executionGeneration = batchGeneration.value
     const sdk = await getEulerSdkFresh()
-    baseAccountSnapshot = await fetchBaseAccountSnapshot(sdk, cid, getAddress(o))
-    return baseAccountSnapshot
-  }
-
-  const buildMergedExecutionPlan = async (): Promise<TransactionPlan> => {
-    const sdk = await getEulerSdkFresh()
-    const plans: TransactionPlan[] = []
-    for (const [index, entry] of entries.value.entries()) {
-      plans.push(entry.buildExecutionPlan
-        ? await entry.buildExecutionPlan(await getExecutionPlanningAccount(index))
-        : entry.plan)
+    const fetched = await fetchBaseAccountSnapshot(sdk, cid, executionOwner)
+    if (
+      executionGeneration !== batchGeneration.value
+      || chainId.value !== cid
+      || !owner.value
+      || getAddress(owner.value) !== executionOwner
+    ) {
+      throw new Error('Batch or wallet changed since review preparation — reopen review and try again.')
     }
-    return sdk.executionService.mergePlans(plans)
+    baseAccountSnapshot = fetched
+    return fetched
   }
 
   /**
-   * A Safe executes the cart's prerequisites inside the batch proposal when
-   * every prerequisite-bearing entry provides a bundled builder — mixed
-   * carts (a prerequisite entry without bundled support) keep the sequential
-   * ceremony for all entries, so the review never half-describes it.
+   * A Safe executes ceremony prerequisites inside the batch proposal.
    */
   const willBundlePrerequisites = computed(() =>
     isSafeWallet.value
-    && entries.value.some(entry => entry.buildBundledExecution)
-    && entries.value.every(entry => !entry.buildExecutionPrerequisites || entry.buildBundledExecution),
+    && entries.value.some(entry => entry.bundleExecutionCeremony),
   )
 
-  /**
-   * Bundled ceremony resolved ONCE when the review modal opens, displayed,
-   * copied, and executed verbatim — the latch that keeps the reviewed
-   * ceremony, the copied payload, and the submitted proposal identical. A
-   * cart edit or account/chain reset clears it; executeBatch treats its
-   * presence as the reviewed promise of ONE proposal.
-   */
-  const prepareBundledExecution = async () => {
-    if (!willBundlePrerequisites.value) {
-      latchedBundledExecution.value = null
-      return null
+  const isBatchExecutionCurrent = (ceremony: PreparedBatchExecution): boolean => {
+    if (
+      pendingAddCount.value > 0
+      || ceremony.generation !== batchGeneration.value
+    ) {
+      return false
     }
-    const collected = await collectBundledExecution()
-    latchedBundledExecution.value = collected
-    return collected
+    return isBatchExecutionWalletCurrent(ceremony)
+  }
+
+  const isBatchExecutionWalletCurrent = (ceremony: PreparedBatchExecution): boolean => {
+    if (
+      ceremony.chainId !== chainId.value
+      || ceremony.safeWallet !== isSafeWallet.value
+      || !isSafeWalletResolved.value
+      || ceremony.safeWalletResolved !== isSafeWalletResolved.value
+      || ceremony.connectorKey !== connectorKey.value
+      || !owner.value
+    ) return false
+    try {
+      return getAddress(owner.value) === ceremony.owner
+    }
+    catch {
+      return false
+    }
+  }
+
+  const assertBatchExecutionCurrent = (ceremony: PreparedBatchExecution) => {
+    if (!isBatchExecutionCurrent(ceremony)) {
+      throw new Error('Batch or wallet changed since review preparation — reopen review and try again.')
+    }
+  }
+
+  /**
+   * Resolve one ceremony per cart generation for every wallet/execution mode.
+   * Concurrent review modals share the same in-flight promise and immutable
+   * result; stale work can finish but cannot be used after a cart or wallet
+   * context change.
+   */
+  const prepareBatchExecution = (): Promise<PreparedBatchExecution> => {
+    if (pendingAddCount.value > 0) {
+      return Promise.reject(new Error('An operation is still being added — wait for the batch to finish updating.'))
+    }
+    if (!lastMerged || entries.value.length === 0) {
+      return Promise.reject(new Error('Batch simulation not loaded'))
+    }
+    if (!isSafeWalletResolved.value) {
+      return Promise.reject(new Error('Wallet type is still loading — wait before reviewing the batch.'))
+    }
+
+    const generation = batchGeneration.value
+    if (batchPreparation?.generation === generation) return batchPreparation.promise
+
+    const currentOwner = owner.value
+    const currentChainId = chainId.value
+    if (!currentOwner || !currentChainId) return Promise.reject(new Error('Account not loaded'))
+    const reviewOwner = getAddress(currentOwner)
+    const reviewSafeWallet = isSafeWallet.value
+    const reviewSafeWalletResolved = isSafeWalletResolved.value
+    const reviewConnectorKey = connectorKey.value
+    const mode = willBundlePrerequisites.value ? 'safe-bundled' : 'standard'
+
+    const preparationPromise = (async (): Promise<PreparedBatchExecution> => {
+      const { plans, planResolvers, usesPlaceholderSignatures, grants, revokes, prerequisites, prerequisiteRevalidations, reviewByEntryId } = mode === 'safe-bundled'
+        ? await collectBundledExecution()
+        : await collectStandardExecution()
+      const sdk = await getEulerSdkFresh()
+      const executionPlan = sdk.executionService.mergePlans(plans)
+      const prepared = await prepareTransactionPlan(executionPlan)
+      const resolvePreparedPlan = planResolvers.some(Boolean)
+        ? async (beforeWalletAction: () => void): Promise<TransactionPlanPrepared> => {
+          const resolvedPlans: TransactionPlan[] = []
+          const signatureSubstitutions: PreparedPlanSignatureSubstitution[] = []
+          for (const [index, plan] of plans.entries()) {
+            beforeWalletAction()
+            const resolver = planResolvers[index]
+            if (resolver) {
+              const resolved = await resolver(beforeWalletAction)
+              resolvedPlans.push(resolved.plan)
+              signatureSubstitutions.push(...resolved.signatureSubstitutions)
+            }
+            else {
+              resolvedPlans.push(plan)
+            }
+            beforeWalletAction()
+          }
+          const resolvedPlan = sdk.executionService.mergePlans(resolvedPlans)
+          const resolvedPrepared = await prepareTransactionPlan(resolvedPlan)
+          beforeWalletAction()
+          assertPreparedPlanSignatureParity({
+            reviewed: prepared,
+            resolved: resolvedPrepared,
+            substitutions: signatureSubstitutions,
+          })
+          return resolvedPrepared
+        }
+        : undefined
+      const frozenReview = Object.freeze(Object.fromEntries(
+        Object.entries(reviewByEntryId).map(([entryId, review]) => [entryId, Object.freeze({
+          plan: review.plan,
+          grantSteps: Object.freeze([...review.grantSteps]),
+          revokeSteps: Object.freeze([...review.revokeSteps]),
+        })]),
+      ))
+      const frozenPrerequisites = Object.freeze(prerequisites.map(prerequisite => Object.freeze({
+        ...prerequisite,
+        preTxs: Object.freeze(prerequisite.preTxs.map(tx => Object.freeze({ ...tx }))),
+        postTxs: Object.freeze(prerequisite.postTxs.map(tx => Object.freeze({ ...tx }))),
+        postTxsByPreTx: prerequisite.postTxsByPreTx
+          ? Object.freeze(prerequisite.postTxsByPreTx.map(tx => tx ? Object.freeze({ ...tx }) : undefined))
+          : undefined,
+        walletContext: Object.freeze({ ...prerequisite.walletContext }),
+      })))
+      const ceremony: PreparedBatchExecution = Object.freeze({
+        generation,
+        owner: reviewOwner,
+        chainId: currentChainId,
+        safeWallet: reviewSafeWallet,
+        safeWalletResolved: reviewSafeWalletResolved,
+        connectorKey: reviewConnectorKey,
+        mode,
+        prepared,
+        resolvePreparedPlan,
+        usesPlaceholderSignatures,
+        grants: Object.freeze(grants.map(tx => Object.freeze({ ...tx }))),
+        revokes: Object.freeze(revokes.map(tx => Object.freeze({ ...tx }))),
+        prerequisites: frozenPrerequisites,
+        prerequisiteRevalidations: Object.freeze([...prerequisiteRevalidations]),
+        reviewByEntryId: frozenReview,
+      })
+      assertBatchExecutionCurrent(ceremony)
+      return ceremony
+    })()
+
+    const trackedPromise = preparationPromise.catch((error) => {
+      if (batchPreparation?.promise === trackedPromise) batchPreparation = null
+      throw error
+    })
+    batchPreparation = { generation, promise: trackedPromise }
+    return trackedPromise
+  }
+
+  /**
+   * Build the exact standard ceremony. Prerequisite-bearing entries use their
+   * simulation variant for the prepared core and freeze the standalone grants
+   * that make that core executable. Entries without prerequisites resolve their
+   * ordinary execution plan during review.
+   */
+  const collectStandardExecution = async () => {
+    const plans: TransactionPlan[] = []
+    const planResolvers: Array<BatchEntryExecutionCeremony['resolveExecutionPlan']> = []
+    let usesPlaceholderSignatures = false
+    const grants: BatchEntryExternalTx[] = []
+    const revokes: BatchEntryExternalTx[] = []
+    const prerequisites: BatchEntryExecutionPrerequisites[] = []
+    const prerequisiteRevalidations: Array<() => Promise<void>> = []
+    const reviewByEntryId: Record<string, {
+      plan: TransactionPlan
+      grantSteps: DisplayStep[]
+      revokeSteps: DisplayStep[]
+    }> = {}
+
+    for (const [index, entry] of entries.value.entries()) {
+      if (entry.buildExecutionCeremony) {
+        const execution = await entry.buildExecutionCeremony(await getExecutionPlanningAccount(index))
+        const prerequisite = execution.prerequisites
+        plans.push(execution.plan)
+        planResolvers.push(execution.resolveExecutionPlan)
+        usesPlaceholderSignatures ||= execution.usesPlaceholderSignatures === true
+        if (execution.revalidatePrerequisites) prerequisiteRevalidations.push(execution.revalidatePrerequisites)
+        if (prerequisite) {
+          prerequisites.push(prerequisite)
+          grants.push(...prerequisite.preTxs)
+          if (prerequisite.postTxsByPreTx) {
+            for (const revoke of prerequisite.postTxsByPreTx) {
+              if (revoke) revokes.unshift(revoke)
+            }
+          }
+          else {
+            revokes.push(...prerequisite.postTxs)
+          }
+        }
+        reviewByEntryId[entry.id] = {
+          plan: execution.plan,
+          grantSteps: prerequisite
+            ? execution.grantSteps.map(step => ({ ...step, isSeparateTx: true }))
+            : execution.grantSteps,
+          revokeSteps: prerequisite
+            ? execution.revokeSteps.map(step => ({ ...step, isSeparateTx: true }))
+            : execution.revokeSteps,
+        }
+        continue
+      }
+
+      const plan = entry.buildExecutionPlan
+        ? await entry.buildExecutionPlan(await getExecutionPlanningAccount(index))
+        : entry.plan
+      plans.push(plan)
+      planResolvers.push(undefined)
+      reviewByEntryId[entry.id] = { plan, grantSteps: [], revokeSteps: [] }
+    }
+
+    return { plans, planResolvers, usesPlaceholderSignatures, grants, revokes, prerequisites, prerequisiteRevalidations, reviewByEntryId }
   }
 
   /**
@@ -2488,46 +2807,61 @@ export const useTxBatch = () => {
    */
   const collectBundledExecution = async () => {
     const plans: TransactionPlan[] = []
+    const planResolvers: Array<BatchEntryExecutionCeremony['resolveExecutionPlan']> = []
+    let usesPlaceholderSignatures = false
     const grants: BatchEntryExternalTx[] = []
     const revokesByEntry: BatchEntryExternalTx[][] = []
-    const stepsByEntryId: Record<string, { grantSteps: DisplayStep[], revokeSteps: DisplayStep[] }> = {}
+    const prerequisiteRevalidations: Array<() => Promise<void>> = []
+    const reviewByEntryId: Record<string, {
+      plan: TransactionPlan
+      grantSteps: DisplayStep[]
+      revokeSteps: DisplayStep[]
+    }> = {}
     for (const [index, entry] of entries.value.entries()) {
-      if (entry.buildBundledExecution) {
-        const bundled = await entry.buildBundledExecution(await getExecutionPlanningAccount(index))
+      if (entry.buildExecutionCeremony) {
+        const bundled = await entry.buildExecutionCeremony(await getExecutionPlanningAccount(index))
+        const prerequisite = bundled.prerequisites
         plans.push(bundled.plan)
-        grants.push(...bundled.grants)
-        revokesByEntry.push(bundled.revokes)
-        stepsByEntryId[entry.id] = { grantSteps: bundled.grantSteps, revokeSteps: bundled.revokeSteps }
+        planResolvers.push(bundled.resolveExecutionPlan)
+        usesPlaceholderSignatures ||= bundled.usesPlaceholderSignatures === true
+        if (bundled.revalidatePrerequisites) prerequisiteRevalidations.push(bundled.revalidatePrerequisites)
+        grants.push(...(prerequisite?.preTxs ?? []))
+        revokesByEntry.push(prerequisite?.postTxs ?? [])
+        reviewByEntryId[entry.id] = {
+          plan: bundled.plan,
+          grantSteps: bundled.grantSteps,
+          revokeSteps: bundled.revokeSteps,
+        }
         continue
       }
-      plans.push(entry.buildExecutionPlan
+      const plan = entry.buildExecutionPlan
         ? await entry.buildExecutionPlan(await getExecutionPlanningAccount(index))
-        : entry.plan)
+        : entry.plan
+      plans.push(plan)
+      planResolvers.push(undefined)
       revokesByEntry.push([])
+      reviewByEntryId[entry.id] = { plan, grantSteps: [], revokeSteps: [] }
     }
-    return { plans, grants, revokes: revokesByEntry.reverse().flat(), stepsByEntryId }
+    return { plans, planResolvers, usesPlaceholderSignatures, grants, revokes: revokesByEntry.reverse().flat(), prerequisites: [], prerequisiteRevalidations, reviewByEntryId }
   }
 
   /**
-   * Send each entry's prerequisite grants, mined, before the merged plan is
-   * built — plan builders read live on-chain allowances to decide whether their
-   * batch still needs an authorization item.
-   *
-   * Sequential on purpose: a later entry needing the same grant sees the earlier
-   * one already on-chain and resolves to no prerequisite at all.
+   * Send the ceremony's frozen prerequisite grants before its prepared core.
+   * Each call is sent separately so ceremony freshness is checked immediately
+   * before and after every irreversible broadcast.
    */
   const sendExecutionPrerequisites = async (
+    ceremony: PreparedBatchExecution,
     grantedRevokes: MigrationAuthorizationRevoke[],
   ): Promise<void> => {
-    for (const [index, entry] of entries.value.entries()) {
-      if (!entry.buildExecutionPrerequisites) continue
-      const prerequisites = await entry.buildExecutionPrerequisites(await getExecutionPlanningAccount(index))
-      if (!prerequisites) continue
+    for (const prerequisites of ceremony.prerequisites) {
       let grantWalletContext: WalletExecutionContext | undefined
-      if (prerequisites.preTxs.length) {
-        await sendPlainTransactions(prerequisites.preTxs, {
+      for (const [preTxIndex, preTx] of prerequisites.preTxs.entries()) {
+        assertBatchExecutionCurrent(ceremony)
+        await sendPlainTransactions([preTx], {
           walletContext: prerequisites.walletContext,
-          onBroadcast: (preTxIndex, walletContext) => {
+          beforeBroadcast: () => assertBatchExecutionCurrent(ceremony),
+          onBroadcast: (_index, walletContext) => {
             grantWalletContext = walletContext
             const revoke = prerequisites.postTxsByPreTx?.[preTxIndex]
             if (revoke) {
@@ -2535,6 +2869,7 @@ export const useTxBatch = () => {
             }
           },
         })
+        assertBatchExecutionCurrent(ceremony)
       }
       // Entries without a one-to-one mapping retain the original all-or-nothing
       // behavior. Migration entries always provide postTxsByPreTx so partial or
@@ -2552,11 +2887,87 @@ export const useTxBatch = () => {
   }
 
   /**
-   * Execute the whole batch as one atomic transaction. Entries normally reuse
-   * the preview plan; entries with simulation-only preview state can rebuild a
-   * signed execution plan before the merged batch is prepared and sent.
+   * Resolve a quarantined core submission before anything new is sent.
+   * Returns true only when the submission definitively did not land (or none
+   * exists). A landed submission retires its entries here instead; an
+   * unverifiable one keeps the quarantine — replaying while the original may
+   * still confirm would duplicate every entry it covered.
    */
-  const executeBatch = async (scope?: TrackedExecutionScope) => {
+  const reconcilePendingCoreSubmission = async (scope?: TrackedExecutionScope): Promise<boolean> => {
+    const submission = pendingCoreSubmission.value
+    if (!submission) return true
+
+    const finalizeLandedSubmission = () => {
+      pendingCoreSubmission.value = null
+      execError.value = undefined
+      retireExecutedEntries(submission.ceremony)
+      if (submission.shouldRefreshExternalMigrationPositions) scheduleExternalMigrationRefreshes()
+      scope?.markSucceeded()
+    }
+    const keepQuarantined = () => {
+      execError.value = 'A previous batch submission may still confirm on-chain and could not be verified yet. Wait a moment and execute again — the submission is re-checked before anything is re-sent.'
+      return false
+    }
+
+    const sdk = await getEulerSdkFresh()
+    const provider = sdk.providerService?.getProvider(submission.chainId) as ReceiptClientLike | undefined
+    if (!provider) return keepQuarantined()
+
+    if (submission.kind === 'transaction') {
+      const receipt = await provider.getTransactionReceipt({ hash: submission.hash }).catch(() => undefined)
+      if (!receipt) return keepQuarantined()
+      if (receipt.status === 'success') {
+        finalizeLandedSubmission()
+        return false
+      }
+      // Definitively reverted on-chain — the retry cannot duplicate anything.
+      pendingCoreSubmission.value = null
+      return true
+    }
+
+    // Safe proposal: only the Safe app knows whether the proposal executed
+    // and under which final transaction hash.
+    const walletProvider = await getSafeWalletProvider(connector.value)
+    if (!walletProvider) return keepQuarantined()
+    try {
+      const { receipt } = await waitForSafeTransactionExecution({
+        submittedHash: submission.hash,
+        walletProvider,
+        publicClient: provider,
+        timeoutMs: 8_000,
+      })
+      if (receipt.status === 'success') {
+        finalizeLandedSubmission()
+        return false
+      }
+      pendingCoreSubmission.value = null
+      return true
+    }
+    catch (error) {
+      if (error instanceof SafeTransactionStatusUnknownError) return keepQuarantined()
+      if (error instanceof Error && (
+        error.message === 'Safe transaction was cancelled'
+        || error.message === 'Safe transaction failed'
+      )) {
+        pendingCoreSubmission.value = null
+        return true
+      }
+      // Anything else is not a definitive verdict — fail closed and keep the
+      // quarantine rather than risk a duplicate submission.
+      logWarn('useTxBatch/reconcilePendingCoreSubmission', error)
+      return keepQuarantined()
+    }
+  }
+
+  /** Execute the immutable ceremony produced for the current batch review. */
+  const executeBatch = async (
+    scope?: TrackedExecutionScope,
+    reviewedExecution?: PreparedBatchExecution,
+  ) => {
+    if (pendingAddCount.value > 0) {
+      execError.value = 'An operation is still being added — wait for the batch to finish updating.'
+      return
+    }
     if (isExecuting.value || entries.value.length === 0 || !lastMerged) return
     // simError covers both a top-level EVC revert and a deferred status-check
     // failure; walletShortfalls covers an under-funded wallet. Either way the
@@ -2564,63 +2975,163 @@ export const useTxBatch = () => {
     if (simError.value || walletShortfalls.value.length > 0 || hasFailedOps.value) return
     execError.value = undefined
     isExecuting.value = true
+    const attemptGeneration = batchGeneration.value
+    const attemptOwner = owner.value ? getAddress(owner.value) : undefined
+    const attemptChainId = chainId.value
+    const attemptConnectorKey = connectorKey.value
+    const attemptSafeWallet = isSafeWallet.value
+    const attemptSafeWalletResolved = isSafeWalletResolved.value
+    const isAttemptCurrent = () => {
+      if (
+        attemptGeneration !== batchGeneration.value
+        || attemptChainId !== chainId.value
+        || attemptConnectorKey !== connectorKey.value
+        || attemptSafeWallet !== isSafeWallet.value
+        || attemptSafeWalletResolved !== isSafeWalletResolved.value
+        || !attemptOwner
+        || !owner.value
+      ) return false
+      try {
+        return attemptOwner === getAddress(owner.value)
+      }
+      catch {
+        return false
+      }
+    }
     const grantedRevokes: MigrationAuthorizationRevoke[] = []
+    let execution = reviewedExecution
+    // Set once the wallet accepts the core submission — from that point a
+    // failure no longer means "nothing was sent".
+    let coreBroadcast: PreparedPlanBroadcast | undefined
+    // Set when this attempt itself invalidated the review (quarantine or
+    // prerequisite drift): the error must still surface even though the
+    // ceremony's generation check now fails.
+    let ceremonyInvalidatedForRetry = false
     try {
       if (!await restorePendingBeforeRetry()) return
-      // Final on-chain gas estimate before asking the user to sign. If the batch
-      // would revert (against the current chain state, which may have moved since
-      // the last simulation), surface the decoded reason and don't send.
+      if (!await reconcilePendingCoreSubmission(scope)) return
+      execution ??= await prepareBatchExecution()
+      assertBatchExecutionCurrent(execution)
       const shouldRefreshExternalMigrationPositions = entries.value.some(entry => entry.refreshExternalMigrationPositions)
-
-      if (latchedBundledExecution.value) {
-        // The review modal latched and displayed ONE atomic proposal built
-        // from this exact resolution — execute it verbatim (payload
-        // identity), even when the grants resolved empty: the provider-bound
-        // Safe path must not silently degrade into anything else.
-        if (!isSafeWallet.value) {
-          throw new Error('Wallet changed since review — please review the batch again.')
+      // Prerequisite requirements were captured at review time; on-chain state
+      // (granted operators, existing approvals) can drift during the wallet
+      // waits above. Re-derive them immediately before anything irreversible
+      // and force a fresh review on any mismatch.
+      const revalidateCeremonyPrerequisites = async () => {
+        for (const revalidate of execution!.prerequisiteRevalidations) {
+          assertBatchExecutionCurrent(execution!)
+          try {
+            await revalidate()
+          }
+          catch (error) {
+            ceremonyInvalidatedForRetry = true
+            invalidateBatchReview()
+            throw error
+          }
+          assertBatchExecutionCurrent(execution!)
         }
-        const collected = latchedBundledExecution.value
+      }
+      const prepared = execution.resolvePreparedPlan
+        ? await execution.resolvePreparedPlan(() => assertBatchExecutionCurrent(execution!))
+        : execution.prepared
+      assertBatchExecutionCurrent(execution)
+
+      if (execution.mode === 'safe-bundled') {
         // No standalone gas estimate — grants are unmined until the
         // proposal executes; the cart's continuous simulation (which runs
         // with the entries' authorization state overrides) is the
         // pre-flight validation. Atomicity also removes the unwind
         // bookkeeping: a failed proposal reverts its grants with it.
-        const sdk = await getEulerSdkFresh()
-        const executionPlan = sdk.executionService.mergePlans(collected.plans)
-        const prepared = await prepareTransactionPlan(executionPlan)
+        assertBatchExecutionCurrent(execution)
+        await revalidateCeremonyPrerequisites()
         const result = await executePreparedPlanWithPlainCalls(prepared, {
-          before: collected.grants,
-          after: collected.revokes,
-        }, { allowSingleCall: true })
+          before: execution.grants,
+          after: execution.revokes,
+        }, {
+          allowSingleCall: true,
+          beforeBroadcast: () => assertBatchExecutionCurrent(execution),
+          onBroadcast: (broadcast) => {
+            coreBroadcast = broadcast
+          },
+        })
         if (!result) {
           // The review described ONE proposal; never silently degrade to
           // the sequential multi-proposal ceremony.
           throw new Error('Safe connection unavailable — the reviewed single-proposal submission cannot run. Reconnect your Safe and retry.')
         }
-        latchedBundledExecution.value = null
+        if (!isBatchExecutionCurrent(execution)) {
+          retireExecutedEntries(execution)
+          scope?.markSucceeded()
+          return
+        }
         clearBatch()
         if (shouldRefreshExternalMigrationPositions) scheduleExternalMigrationRefreshes()
         await redirectAfterBatchExecution(scope)
         return
       }
 
-      await sendExecutionPrerequisites(grantedRevokes)
-      const executionPlan = await buildMergedExecutionPlan()
-      await estimateGasForPlan(executionPlan)
-      const prepared = await prepareTransactionPlan(executionPlan)
-      await executePreparedPlan(prepared)
+      await revalidateCeremonyPrerequisites()
+      await sendExecutionPrerequisites(execution, grantedRevokes)
+      assertBatchExecutionCurrent(execution)
+      // Final on-chain gas estimate before the irreversible core broadcast. If
+      // chain state moved since review, surface the decoded reason and retain
+      // the cart. A pending edit during this await invalidates the ceremony.
+      await estimateGasForPreparedPlan(prepared)
+      assertBatchExecutionCurrent(execution)
+      await executePreparedPlan(prepared, {
+        beforeBroadcast: () => assertBatchExecutionCurrent(execution),
+        onBroadcast: (broadcast) => {
+          coreBroadcast = broadcast
+        },
+      })
+      await revokeAfterSuccess(grantedRevokes, {
+        shouldNotify: () => isBatchExecutionWalletCurrent(execution!),
+      })
+      if (!isBatchExecutionCurrent(execution)) {
+        retireExecutedEntries(execution)
+        scope?.markSucceeded()
+        return
+      }
       clearBatch()
       if (shouldRefreshExternalMigrationPositions) scheduleExternalMigrationRefreshes()
-      await revokeAfterSuccess(grantedRevokes)
       await redirectAfterBatchExecution(scope)
     }
     catch (error) {
       logWarn('useTxBatch/executeBatch', error)
-      // The batch never landed, so no granted authorization should be left
-      // standing. Entries stay in the cart for a retry, which re-grants.
-      await revokeAfterAbort(grantedRevokes)
-      execError.value = await describeExecError(error)
+      if (coreBroadcast && execution) {
+        // The wallet accepted the core submission but confirmation failed —
+        // it may still land. Quarantine the cart against a blind replay (it
+        // would duplicate every covered entry) and force reconciliation on
+        // the next execute attempt.
+        pendingCoreSubmission.value = {
+          kind: coreBroadcast.kind,
+          hash: coreBroadcast.hash,
+          chainId: execution.chainId,
+          ceremony: execution,
+          shouldRefreshExternalMigrationPositions: entries.value.some(entry =>
+            entry.refreshExternalMigrationPositions && entry.id in execution!.reviewByEntryId),
+        }
+        ceremonyInvalidatedForRetry = true
+        invalidateBatchReview()
+      }
+      // Unwinding granted authorizations is safe regardless of whether the
+      // core landed: after a landed core it is the normal success-order
+      // cleanup, and before a still-pending core it cleanly reverts that
+      // core, resolving the ambiguity in the safe direction.
+      await revokeAfterAbort(grantedRevokes, {
+        shouldNotify: () => !execution || isBatchExecutionWalletCurrent(execution),
+      })
+      let decodedError = await describeExecError(error)
+      if (coreBroadcast && execution) {
+        decodedError = `${decodedError} The submission may still confirm — executing again first verifies it on-chain before anything is re-sent.`
+      }
+      const shouldSurfaceError = execution
+        ? isBatchExecutionCurrent(execution)
+        || (ceremonyInvalidatedForRetry && isBatchExecutionWalletCurrent(execution))
+        : isAttemptCurrent()
+      if (shouldSurfaceError) {
+        execError.value = decodedError
+      }
     }
     finally {
       isExecuting.value = false
@@ -2650,6 +3161,7 @@ export const useTxBatch = () => {
   // when this is false — this only gates the Execute action.
   const canExecuteBatch = computed(() =>
     entries.value.length > 0
+    && pendingAddCount.value === 0
     && !isSimulating.value
     && !isExecuting.value
     && !hasFailedOps.value
@@ -2724,6 +3236,7 @@ export const useTxBatch = () => {
     simError,
     isExecuting,
     execError,
+    hasPendingCoreSubmission: computed(() => !!pendingCoreSubmission.value),
     hasFailedOps,
     canExecuteBatch,
     hasInsufficientBalance,
@@ -2735,6 +3248,7 @@ export const useTxBatch = () => {
     removedKeys: activeLayerRemovedKeysRef,
     walletChanges,
     entryCount,
+    hasPendingAdds: computed(() => pendingAddCount.value > 0),
     marketByEntryId,
     isDrawerOpen: drawerOpen,
     toggleDrawer: () => { drawerOpen.value = !drawerOpen.value },
@@ -2746,15 +3260,10 @@ export const useTxBatch = () => {
     setActiveLayer,
     executeBatch,
     willBundlePrerequisites,
-    prepareBundledExecution,
-    latchedBundledExecution,
-    // Tenderly "Simulate on Tenderly" for the whole batch.
-    tenderlyEnabled,
-    isTenderlySimulating: tenderly.isSimulating,
-    tenderlyUrl: tenderly.simulationUrl,
-    tenderlyError: tenderly.simulationError,
-    fetchTenderlyEnabled,
-    simulateOnTenderly,
+    prepareBatchExecution,
+    isBatchExecutionCurrent,
+    prepareBundledExecution: prepareBatchExecution,
+    isBundledExecutionCurrent: isBatchExecutionCurrent,
     // For the Review batch modal.
     getMergedPlan,
     prepareBatchPlan,

--- a/docs/batch-review-modal-handoff.md
+++ b/docs/batch-review-modal-handoff.md
@@ -17,8 +17,7 @@ transaction. It must show, in order:
    permit2 signatures the user will be asked to sign.
 2. **Operations** — each queued op as a row that **rolls down** to reveal that op's details.
 3. **Wallet changes** — the net effect of the whole batch on the wallet.
-4. **Simulate on Tenderly** — a link/button (Tenderly lives ONLY here, not in the drawer).
-5. **Execute batch** — one atomic execute, with a disabled reason when it can't run.
+4. **Execute batch** — execute the reviewed ceremony, with a disabled reason when it can't run.
 
 It is opened via `useModal().open(BatchReviewModal)` and dismisses by emitting `close`.
 
@@ -50,7 +49,6 @@ below (never hardcode hex). Values shown are the **dark theme** for reference on
 | `text-content-primary` | `#f7f7f8` | Primary labels (op title, amounts) |
 | `text-content-secondary` | `#ddfbf4` | Secondary text (asset symbol, position tag) |
 | `text-content-tertiary` | `#a1acb8` | Section labels, muted meta, disabled reason |
-| `text-success-500` | `#62ad4f` | Tenderly "view simulation" success link |
 | `text-error-500` / `bg-error-100` | `#c02723` / `rgba(192,39,35,.2)` | Revert chip text / fill |
 | Radius `rounded-8` / `rounded-12` / `rounded-16` | 8 / 12 / 16px | Rows / cards / modal |
 | Type `text-p2` / `text-p3` / `text-h6` | 16/400, 14/400, 14/600 | Body / meta / row title |
@@ -69,7 +67,6 @@ width). Pass `title="Review batch"`. Body content is a single vertical stack:
     [Operations]            always (≥1 entry)
     [Wallet changes]        v-if walletChanges.length
     [Top-level batch error] v-if simError || execError
-    [Tenderly]              v-if tenderlyEnabled
     [Execute + reason]      always
   </div>
 </BaseModalWrapper>
@@ -93,7 +90,6 @@ All data comes from `useTxBatch()`. The composable already exposes everything ne
 | `executeBatch()` | `() => Promise` | Atomic execute (clears batch on success) |
 | `prepareBatchPlan()` | `() => Promise<TransactionPlanPrepared\|null>` | Resolve approvals for the approvals section |
 | `getMergedPlan()` | `() => TransactionPlan\|null` | The exact plan that will execute |
-| `tenderlyEnabled`, `isTenderlySimulating`, `tenderlyUrl`, `tenderlyError`, `fetchTenderlyEnabled()`, `simulateOnTenderly()` | — | Tenderly section |
 
 `BatchEntry` (see `composables/useTxBatch.ts`) carries:
 `label`, `review?` (`{ type, asset:{symbol}, amount, swapToAsset:{symbol} }`), and
@@ -179,13 +175,11 @@ text-content-tertiary mb-6`). One row per token: symbol left (`text-content-seco
 signed amount right (`tabular-nums`), positive `text-accent-500`, negative `text-error-500`.
 Format `−`/`+` + `formatSmartAmount(formatUnits(abs, decimals))` + symbol.
 
-## Tenderly
-Centered. Before run: button "Simulate on Tenderly" (`arrow-top-right` icon, swap to
-spinning `loading` while `isTenderlySimulating`) → `simulateOnTenderly()`. After run: link to
-`tenderlyUrl` (`target=_blank rel=noopener`). If `tenderlyUrl && tenderlyError` →
-"Simulation reverted — view on Tenderly" in `text-error-500` with `warning-circle`; else
-"View simulation on Tenderly" in `text-success-500` with `check-circle` + `arrow-top-right`.
-Call `fetchTenderlyEnabled()` on mount; hide the whole section when `!tenderlyEnabled`.
+## External simulation
+Whole-batch Tenderly simulation is not exposed from this modal. The reviewed ceremony can
+contain sequential authorization transactions, prepared plugin/approval/core calls, and
+restorations. The single-transaction simulation endpoint cannot preserve that complete call
+vector, so presenting its result as a whole-batch simulation would be misleading.
 
 ## States & interactions
 
@@ -216,25 +210,34 @@ Execute is `UiButton variant="primary" size="xlarge" rounded` full-width.
 - **Long asset symbol / op label** → row title `truncate`; never let it push the chevron.
 - **Fresh-position deposit** → no `subAccount` → no Position tag (by design).
 - **Many operations** → `BaseModalWrapper` handles scroll; do not add a nested scroll.
-- **Spy mode** → everything renders; only Execute is disabled (read-only review still works,
-  including Tenderly which is a read-only simulation).
+- **Spy mode** → everything renders; only Execute is disabled.
+- **Cart edited during broadcast** → a same-wallet add while the execution is in flight
+  makes the ceremony stale; on success only the executed entries are removed from the
+  cart (the mid-flight addition survives and resimulates), instead of clearing everything.
+- **Prerequisite drift** → non-signature migration entries re-derive their authorization
+  requirement immediately before anything irreversible is sent; if the grant/revoke set no
+  longer matches what was reviewed (an allowance granted or revoked elsewhere), execution
+  aborts, the review is invalidated, and the error asks the user to reopen review.
+- **Submitted but unconfirmed** → once the wallet accepts the core submission (the batch
+  transaction or the Safe proposal), a confirmation failure no longer offers a blind
+  replay. The cart is quarantined with the submitted hash; the next Execute press first
+  verifies it on-chain — a landed submission retires its entries, a reverted/cancelled one
+  releases the retry, an unverifiable one keeps the quarantine and explains why.
 
 ## Accessibility
 - Row header is a real `<button>`; expose `aria-expanded` bound to the open state and
   `aria-controls` pointing at the detail region id.
-- Focus order: close → (approvals are static text) → operation row buttons in order →
-  Tenderly → Execute.
-- Tenderly link: `rel="noopener noreferrer"`, descriptive text (already states pass/fail).
+- Focus order: close → (approvals are static text) → operation row buttons in order → Execute.
 - Revert chips are persistent text (not hover-only) so they're announced.
 - Icon-only controls (close, chevrons) need `aria-label` / `title`.
 
 ## Files
 - `components/BatchReviewModal.vue` — the modal (exists; extend detail fields per the gap).
-- `composables/useTxBatch.ts` — data + `prepareBatchPlan` / `getMergedPlan` / tenderly API.
+- `composables/useTxBatch.ts` — ceremony preparation, review data, and execution.
 - `components/BatchContents.vue` — opens the modal via the "Review batch" button.
 - Reference for tokens/patterns: `components/entities/portfolio/PortfolioBorrowItem.vue`
   (position tag), `components/entities/operation/OperationReviewModal.vue` (approvals
-  decode, Tenderly, `UiButton` usage), `assets/styles/variables.scss` (token values).
+  decode and `UiButton` usage), `assets/styles/variables.scss` (token values).
 
 ## Definition of done
 - Borders/dividers use `*-line-default` (no white borders anywhere).
@@ -242,5 +245,5 @@ Execute is `UiButton variant="primary" size="xlarge" rounded` full-width.
 - Operation rows roll down; first row open by default; detail includes at least Amount +
   Vault (+ Receive for swaps, + Position when applicable).
 - Approvals appear only when the prepared plan requires them, with resolved token symbols.
-- Wallet changes, Tenderly, and the gated Execute (with reason) all behave per the tables.
+- Wallet changes and the gated Execute (with reason) behave per the tables.
 - Spy-mode, revert, preparing, and success states all verified live in the running app.

--- a/docs/transaction-building.md
+++ b/docs/transaction-building.md
@@ -64,7 +64,7 @@ The wrapper supplies the current SDK `Account`, wallet/sub-account owner, and ch
 3. The review modal prepares the plan with `prepareTransactionPlan(plan)` (unless the caller passes a pre-prepared envelope), which calls `sdk.executionService.prepareTransactionPlan(...)`.
 4. The review modal renders the prepared plan via `utils/stepDecoding.ts`.
 5. Confirming calls the workflow callback, which executes the plan through `executePlan(plan)`.
-6. `executePlan` calls `sdk.executionService.executeTransactionPlan(...)`, forwards wagmi `sendTransaction` / `signTypedData` callbacks, and refreshes portfolio state after receipts.
+6. `executePlan` calls `sdk.executionService.executeTransactionPlan(...)`, forwards wagmi `sendTransaction` / `signTypedData` callbacks, and refreshes portfolio state after receipts. Both callbacks are pinned to the connector captured when execution's wallet-context check passed (as is `signMigrationAuthorization`) — a connector switched mid-plan never receives a broadcast or signature request it was not validated for.
 
 Plan transformation (terms-of-use signing, Keyring credential injection) runs inside the SDK plugin pipeline on each of these paths — see Operation Guards below.
 

--- a/pages/position/[number]/borrow/swap.vue
+++ b/pages/position/[number]/borrow/swap.vue
@@ -83,8 +83,15 @@ import {
 import { logWarn } from '~/utils/errorHandling'
 import { isOperationBlocked, registerOperationBlocker, unregisterOperationBlocker } from '~/utils/operationGuardRegistry'
 import { BATCH_ACTIVE_REASON } from '~/utils/tx-batch-messages'
-import { assertWalletExecutionContext } from '~/utils/walletExecutionContext'
+import { assertPreparedPlanSignatureParity } from '~/utils/preparedPlanParity'
+import { assertWalletExecutionContext, createReviewedWalletContextGuard, createSafeBundleBroadcastGuard } from '~/utils/walletExecutionContext'
 import type { CollateralOption } from '~/types/collateral-option'
+import { getMigrationAuthorizationSignatureSubstitutions } from '~/utils/migrationAuthorizationSignatures'
+import {
+  isMigrationCeremonyDeadlineExpired,
+  mintMigrationCeremonyDeadline,
+  pinInboundMigrationCeremonyDeadline,
+} from '~/utils/migrationCeremonyDeadline'
 import {
   getProjectedYieldState,
   mergeProjectedRewardCampaigns,
@@ -99,7 +106,7 @@ const route = useRoute()
 const router = useRouter()
 const modal = useModal()
 const { error: showError } = useToast()
-const { isConnected, address, chainId: walletChainId } = useWagmi()
+const { isConnected, address, chainId: walletChainId, connector: walletConnector } = useWagmi()
 const { isSpyMode, spyAddress } = useSpyMode()
 const { isPositionsLoaded, isPositionsLoading, getPositionBySubAccountIndex, refreshAllPositions } = useEulerAccount()
 const { chainId: currentChainId, eulerPeripheryAddresses } = useEulerAddresses()
@@ -2638,6 +2645,20 @@ type InboundExternalMigrationPreview = {
   bundledReview: boolean
   input: InboundExternalMigrationInput
   account: Account<IHasVaultAddress>
+  /**
+   * The verifier/authorization deadline every build of this preview pinned.
+   * Confirmation must reuse it: the deadline is embedded in the EIP-712
+   * payload (so a re-mint always fails the payload-equality gate) and in the
+   * plan's verifier calldata (so a re-mint diverges from the reviewed plan).
+   */
+  authorizationDeadline: bigint
+  /**
+   * The connector identity (`id:uid`) the review was built under. The direct
+   * Safe-bundle broadcast guard validates against this reviewed key — never a
+   * snapshot taken inside the confirmation flow, which would accept a
+   * connector swapped during an earlier confirmation await as its baseline.
+   */
+  connectorContextKey: string | undefined
   tenderlySimulation: PreparedMigrationTenderlySimulation
   calldataPrepared: TransactionPlanPrepared
   authorizationRequest?: MigrationAuthorizationRequest
@@ -2749,15 +2770,24 @@ const buildInboundExternalMigrationInput = async (): Promise<InboundExternalMigr
 const shouldRemoveInboundExternalAuthorization = (connectorId: string, useSignatures: boolean) =>
   connectorId === MORPHO_CONNECTOR_ID && useSignatures
 
+// Identity of the wallet connector a Safe proposal would submit through.
+// Account and chain checks cannot see a same-account connector switch, so the
+// direct Safe-bundle flow captures this at confirmation and re-asserts it
+// immediately before the irreversible proposal broadcast.
+const walletConnectorContextKey = (): string | undefined => {
+  const current = walletConnector.value
+  return current ? `${current.id}:${current.uid}` : undefined
+}
+
 const getInboundExternalMigrationAuthorizationRequest = async (
   input: InboundExternalMigrationInput,
   useSignatures = signaturesEnabled.value,
+  deadline: bigint = mintMigrationCeremonyDeadline(),
 ): Promise<MigrationAuthorizationRequest | undefined> => {
   if (!chainId.value) {
     throw new Error('Migration inputs are incomplete')
   }
   const migrationChainId = input.position.chainId
-  const deadline = BigInt(Math.floor(Date.now() / 1000) + 60 * 60)
   return getMigrationAuthorization({
     direction: 'external-to-euler',
     connectorId: input.source.connectorId,
@@ -2783,6 +2813,7 @@ const buildInboundExternalMigrationExecutionPlan = async (
   input: InboundExternalMigrationInput,
   authorization?: SignedMigrationAuthorization,
   useSignatures = signaturesEnabled.value,
+  deadline?: bigint,
 ): Promise<TransactionPlan> => {
   if (!chainId.value) {
     throw new Error('Migration inputs are incomplete')
@@ -2802,6 +2833,7 @@ const buildInboundExternalMigrationExecutionPlan = async (
     collateralSwapQuote: input.collateralSwapQuote,
     debtSwapQuote: input.debtSwapQuote,
     operationName: `${input.source.connectorId}ToEulerMigration`,
+    deadline,
   })
 }
 
@@ -2811,6 +2843,7 @@ const buildInboundExternalMigrationCalldataPreview = async (
   authorizationRequest: MigrationAuthorizationRequest | undefined,
   useSignatures: boolean,
   prefetch?: PluginPrefetchData,
+  deadline?: bigint,
 ): Promise<TransactionPlanPrepared> => {
   if (!chainId.value) {
     throw new Error('Migration inputs are incomplete')
@@ -2832,6 +2865,7 @@ const buildInboundExternalMigrationCalldataPreview = async (
     collateralSwapQuote: input.collateralSwapQuote,
     debtSwapQuote: input.debtSwapQuote,
     operationName: `${input.source.connectorId}ToEulerMigration`,
+    deadline,
   })
   return prepareTransactionPlan(plan, {
     account,
@@ -2852,16 +2886,17 @@ const resolveInboundExternalMigrationAuthorization = async (
   authorizationRequest: MigrationAuthorizationRequest | undefined,
   revokeTxs: MigrationAuthorizationRevoke[],
   useSignatures: boolean,
+  beforeWalletAction?: () => void,
 ): Promise<SignedMigrationAuthorization | undefined> => {
   // No request means the grant is already live on-chain: nothing to sign, and
   // nothing of ours to revoke afterwards.
   if (!authorizationRequest) return undefined
   if (useSignatures) {
-    return signMigrationAuthorization(authorizationRequest)
+    return signMigrationAuthorization(authorizationRequest, { beforeSignature: beforeWalletAction })
   }
   // Must be mined before the plan is built: the connector reads the live
   // allowance to decide whether the batch still needs an authorization.
-  await executeMigrationAuthorizationGrants(authorizationRequest, revokeTxs)
+  await executeMigrationAuthorizationGrants(authorizationRequest, revokeTxs, { beforeBroadcast: beforeWalletAction })
   return undefined
 }
 
@@ -2870,6 +2905,7 @@ const buildInboundExternalMigrationSimulationResult = async (
   authorizationRequest?: MigrationAuthorizationRequest,
   account?: Account<IHasVaultAddress>,
   useSignatures = signaturesEnabled.value,
+  deadline?: bigint,
 ) => {
   if (!chainId.value) {
     throw new Error('Migration inputs are incomplete')
@@ -2889,6 +2925,7 @@ const buildInboundExternalMigrationSimulationResult = async (
     debtSwapQuote: input.debtSwapQuote,
     account,
     operationName: `${input.source.connectorId}ToEulerMigration`,
+    deadline,
   })
 }
 
@@ -2922,8 +2959,12 @@ const prepareInboundExternalMigrationPreview = async (): Promise<InboundExternal
     const input = await buildInboundExternalMigrationInput()
     const account = currentPlanAccount()
     if (!account) throw new Error('Migration inputs are incomplete')
-    const authorizationRequest = await getInboundExternalMigrationAuthorizationRequest(input, useSignatures)
-    const simulationResult = await buildInboundExternalMigrationSimulationResult(input, authorizationRequest, account, useSignatures)
+    // Pinned once for the preview's whole lifetime: every build here and the
+    // confirm-time rebuild must embed this same deadline, or the payload and
+    // plan gates reject the confirmation as drift.
+    const authorizationDeadline = pinInboundMigrationCeremonyDeadline(input)
+    const authorizationRequest = await getInboundExternalMigrationAuthorizationRequest(input, useSignatures, authorizationDeadline)
+    const simulationResult = await buildInboundExternalMigrationSimulationResult(input, authorizationRequest, account, useSignatures, authorizationDeadline)
     const prefetch = await prefetchInboundExternalMigrationPlugins(simulationResult.plan, account)
     // Without signatures the authorization is granted by a standalone tx, so the
     // simulation plan (authorization item filtered out) is already the exact
@@ -2936,7 +2977,7 @@ const prepareInboundExternalMigrationPreview = async (): Promise<InboundExternal
         usePermit2: useSignatures,
       }),
       useSignatures
-        ? buildInboundExternalMigrationCalldataPreview(input, account, authorizationRequest, useSignatures, prefetch)
+        ? buildInboundExternalMigrationCalldataPreview(input, account, authorizationRequest, useSignatures, prefetch, authorizationDeadline)
         : Promise.resolve(undefined),
     ])
     const calldataPrepared = previewPrepared ?? tenderlyPrepared
@@ -2951,6 +2992,8 @@ const prepareInboundExternalMigrationPreview = async (): Promise<InboundExternal
       bundledReview: !useSignatures && isSafeWallet.value && !!authorizationRequest,
       input,
       account,
+      authorizationDeadline,
+      connectorContextKey: walletConnectorContextKey(),
       tenderlySimulation: {
         plan: simulationResult.plan,
         prepared: tenderlyPrepared,
@@ -3406,6 +3449,30 @@ const reviewInboundExternalMigration = async () => {
   }
 }
 
+/**
+ * Prove the confirm-time prepared plan is byte-identical to the reviewed
+ * calldata outside the authorized signature substitutions. Any other
+ * divergence drops the cached preview and forces a re-review — the wallet
+ * must never receive calldata the modal did not display.
+ */
+const assertInboundMigrationPreparedParity = (
+  preview: InboundExternalMigrationPreview,
+  resolved: TransactionPlanPrepared,
+  authorization: SignedMigrationAuthorization | undefined,
+) => {
+  try {
+    assertPreparedPlanSignatureParity({
+      reviewed: preview.calldataPrepared,
+      resolved,
+      substitutions: getMigrationAuthorizationSignatureSubstitutions(authorization),
+    })
+  }
+  catch (err) {
+    inboundExternalMigrationPreview.value = null
+    throw err
+  }
+}
+
 const sendInboundExternalMigration = async (execution: TrackedExecutionScope, preview: InboundExternalMigrationPreview) => {
   isSubmitting.value = true
   clearSimulationError()
@@ -3420,7 +3487,14 @@ const sendInboundExternalMigration = async (execution: TrackedExecutionScope, pr
     })
     if (!await restorePendingBeforeRetry()) return
     inboundExternalPreparedPlan.value = null
-    const authorizationRequest = await getInboundExternalMigrationAuthorizationRequest(input, useSignatures)
+    // The reviewed deadline is embedded in the displayed payload and plan, so
+    // an expired one can only produce an on-chain revert — force a re-review
+    // that mints a fresh ceremony instead.
+    if (isMigrationCeremonyDeadlineExpired(preview.authorizationDeadline)) {
+      inboundExternalMigrationPreview.value = null
+      throw new Error('The reviewed authorization expired — please review the migration again.')
+    }
+    const authorizationRequest = await getInboundExternalMigrationAuthorizationRequest(input, useSignatures, preview.authorizationDeadline)
     inboundExternalAuthorizationConnector.value = authorizationRequest ? input.source.connectorId : null
 
     // The reviewed ceremony is defined by the authorization payload the modal
@@ -3452,19 +3526,41 @@ const sendInboundExternalMigration = async (execution: TrackedExecutionScope, pr
           inboundExternalMigrationPreview.value = null
           throw new Error('Authorization requirements changed since review — please review the migration again.')
         }
-        const outcome = await sendInboundExternalMigrationAsSafeBundle(input, authorizationRequest, account, useSignatures)
+        const beforeBroadcast = createSafeBundleBroadcastGuard({
+          expectedAccount: input.owner,
+          expectedChainId: migrationChainId,
+          expectedConnectorKey: preview.connectorContextKey,
+          currentAccount: () => address.value as Address | undefined,
+          currentChainId: () => walletChainId.value,
+          isSafeWallet: () => isSafeWallet.value,
+          connectorContextKey: walletConnectorContextKey,
+        })
+        const outcome = await sendInboundExternalMigrationAsSafeBundle(preview, authorizationRequest, account, beforeBroadcast)
         if (outcome === 'aborted') return
         finishInboundExternalMigrationSuccess(execution, input)
         return
       }
 
-      const authorization = await resolveInboundExternalMigrationAuthorization(authorizationRequest, revokeTxs, useSignatures)
-      inboundExternalPlan.value = await buildInboundExternalMigrationExecutionPlan(input, authorization, useSignatures)
+      // Every wallet action below (signature request, grant broadcasts, plan
+      // broadcast) re-asserts the reviewed account/chain/connector — the
+      // awaits between them are where a delayed wallet switch can land.
+      const assertReviewedWalletContext = createReviewedWalletContextGuard({
+        expectedAccount: input.owner,
+        expectedChainId: migrationChainId,
+        expectedConnectorKey: preview.connectorContextKey,
+        currentAccount: () => address.value as Address | undefined,
+        currentChainId: () => walletChainId.value,
+        connectorContextKey: walletConnectorContextKey,
+      })
+      const authorization = await resolveInboundExternalMigrationAuthorization(authorizationRequest, revokeTxs, useSignatures, assertReviewedWalletContext)
+      inboundExternalPlan.value = await buildInboundExternalMigrationExecutionPlan(input, authorization, useSignatures, preview.authorizationDeadline)
       inboundExternalPreparedPlan.value = await prepareTransactionPlan(inboundExternalPlan.value, {
         account,
         chainId: migrationChainId,
+        prefetch: preview.prefetch,
         usePermit2: useSignatures,
       })
+      assertInboundMigrationPreparedParity(preview, inboundExternalPreparedPlan.value, authorization)
       const ok = await runPreparedSimulation(inboundExternalPreparedPlan.value, buildRefinanceStateOverrideOptions())
       if (!ok) {
         await revokeAfterAbort(revokeTxs)
@@ -3472,7 +3568,7 @@ const sendInboundExternalMigration = async (execution: TrackedExecutionScope, pr
       }
       // executePreparedPlan resolves once the migration tx is mined (it returns
       // receipts), so everything below runs after on-chain confirmation.
-      await executePreparedPlan(inboundExternalPreparedPlan.value)
+      await executePreparedPlan(inboundExternalPreparedPlan.value, { beforeBroadcast: assertReviewedWalletContext })
     }
     catch (err) {
       // Covers a rejected batch, a failed prepare, and a stale grant.
@@ -3543,18 +3639,23 @@ function finishInboundExternalMigrationSuccess(execution: TrackedExecutionScope,
  * is no Safe bundle context — the caller falls back to sequential grants.
  */
 const sendInboundExternalMigrationAsSafeBundle = async (
-  input: InboundExternalMigrationInput,
+  preview: InboundExternalMigrationPreview,
   authorizationRequest: MigrationAuthorizationRequest,
   account: Account<IHasVaultAddress> | undefined,
-  useSignatures: boolean,
+  beforeBroadcast: () => void,
 ): Promise<'executed' | 'aborted'> => {
+  const { input, useSignatures, authorizationDeadline: deadline } = preview
   const { grants, revokes } = encodeMigrationAuthorizationTxs(authorizationRequest)
-  const simulation = await buildInboundExternalMigrationSimulationResult(input, authorizationRequest, account, useSignatures)
+  const simulation = await buildInboundExternalMigrationSimulationResult(input, authorizationRequest, account, useSignatures, deadline)
   const prepared = await prepareTransactionPlan(simulation.plan, {
     account,
     chainId: input.position.chainId,
+    prefetch: preview.prefetch,
     usePermit2: false,
   })
+  // Bundled reviews are always no-signature, so the reviewed calldata is the
+  // simulation-variant plan itself: parity holds with zero substitutions.
+  assertInboundMigrationPreparedParity(preview, prepared, undefined)
   inboundExternalPlan.value = simulation.plan
   inboundExternalPreparedPlan.value = prepared
   const ok = await runPreparedSimulation(
@@ -3564,7 +3665,8 @@ const sendInboundExternalMigrationAsSafeBundle = async (
   )
   if (!ok) return 'aborted'
 
-  const result = await executePreparedPlanWithPlainCalls(prepared, { before: grants, after: revokes }, { allowSingleCall: true })
+  beforeBroadcast()
+  const result = await executePreparedPlanWithPlainCalls(prepared, { before: grants, after: revokes }, { allowSingleCall: true, beforeBroadcast })
   if (!result) {
     // The review showed ONE atomic proposal. A Safe whose provider cannot be
     // acquired at confirm time must abort loudly, never silently degrade
@@ -3601,47 +3703,65 @@ const addInboundExternalMigrationToBatch = async () => {
     const batchEntry = {
       label: `Migrate ${positionLabel} to Euler`,
       nameOverride: `Migrate ${positionLabel}`,
-      buildExecutionPlan: async () => {
-        const authorizationRequest = useSignatures
-          ? await getInboundExternalMigrationAuthorizationRequest(input, useSignatures)
-          : undefined
-        const authorization = authorizationRequest
-          ? await signMigrationAuthorization(authorizationRequest)
-          : undefined
-        // Without signatures the grant was already mined by the batch's
-        // pre-phase, so the connector omits the authorization item.
-        return buildInboundExternalMigrationExecutionPlan(input, authorization, useSignatures)
-      },
       ...(useSignatures
-        ? {}
-        : {
-            buildExecutionPrerequisites: async () => {
-              const request = await getInboundExternalMigrationAuthorizationRequest(input, useSignatures)
-              if (!request) return undefined
-              const { grants, revokes, revokesByGrant } = encodeMigrationAuthorizationTxs(request)
+        ? {
+            // Review uses placeholder signature bytes. Real wallet signatures
+            // are requested only after confirmation.
+            buildExecutionCeremony: async (account: Account<IHasVaultAddress>) => {
+              // The confirm-time rebuild must differ from the reviewed preview
+              // plan only in the signature bytes. Connectors mint a wall-clock
+              // verifier deadline on every build unless one is supplied, so the
+              // ceremony pins a single deadline across both builds.
+              const ceremonyDeadline = pinInboundMigrationCeremonyDeadline(input)
+              const request = await getInboundExternalMigrationAuthorizationRequest(input, useSignatures, ceremonyDeadline)
+              const simulation = await buildInboundExternalMigrationSimulationResult(input, request, account, useSignatures, ceremonyDeadline)
               return {
-                preTxs: grants,
-                walletContext: { account: request.owner, chainId: request.chainId },
-                postTxs: revokes,
-                postTxsByPreTx: revokesByGrant,
+                plan: simulation.previewPlan,
+                resolveExecutionPlan: async (beforeWalletAction: () => void) => {
+                  const authorization = request
+                    ? await signMigrationAuthorization(request, { beforeSignature: beforeWalletAction })
+                    : undefined
+                  beforeWalletAction()
+                  return {
+                    plan: await buildInboundExternalMigrationExecutionPlan(input, authorization, useSignatures, ceremonyDeadline),
+                    signatureSubstitutions: getMigrationAuthorizationSignatureSubstitutions(authorization),
+                  }
+                },
+                usesPlaceholderSignatures: !!request,
+                grantSteps: buildInboundExternalMigrationSignatureSteps(request, true, false, input.source.connectorId),
+                revokeSteps: [],
               }
             },
-            // Bundled counterpart for Safe execution: the simulation-variant
-            // plan validates the grant instead of reading the live
-            // allowance, so nothing needs to mine before the proposal is
-            // assembled. The review rows come from the SAME resolution so
-            // the modal cannot display a ceremony other than the one that
-            // executes.
-            buildBundledExecution: async (account: Account<IHasVaultAddress>) => {
+          }
+        : {
+            bundleExecutionCeremony: true,
+            // Resolve authorization once so the reviewed rows, exported calls,
+            // standalone flow, and Safe proposal all describe one ceremony.
+            buildExecutionCeremony: async (account: Account<IHasVaultAddress>) => {
               const request = await getInboundExternalMigrationAuthorizationRequest(input, useSignatures)
-              const { grants, revokes } = request
+              const { grants, revokes, revokesByGrant } = request
                 ? encodeMigrationAuthorizationTxs(request)
-                : { grants: [], revokes: [] }
+                : { grants: [], revokes: [], revokesByGrant: [] }
               const simulation = await buildInboundExternalMigrationSimulationResult(input, request, account, useSignatures)
               return {
                 plan: simulation.plan,
-                grants,
-                revokes,
+                prerequisites: request
+                  ? {
+                      preTxs: grants,
+                      walletContext: { account: request.owner, chainId: request.chainId },
+                      postTxs: revokes,
+                      postTxsByPreTx: revokesByGrant,
+                    }
+                  : undefined,
+                // Authorization state can drift between review and execution
+                // (an allowance granted or revoked elsewhere) — the reviewed
+                // grant/revoke set would no longer match what should run.
+                revalidatePrerequisites: async () => {
+                  const fresh = await getInboundExternalMigrationAuthorizationRequest(input, useSignatures)
+                  if (migrationAuthorizationPayloadKey(fresh) !== migrationAuthorizationPayloadKey(request)) {
+                    throw new Error('Authorization requirements changed since review — reopen review and try again.')
+                  }
+                },
                 grantSteps: buildMigrationAuthorizationTxSteps(request, 'grant', 1, { bundled: true }),
                 revokeSteps: buildMigrationAuthorizationTxSteps(request, 'revoke', 1, { bundled: true }),
               }
@@ -3654,8 +3774,7 @@ const addInboundExternalMigrationToBatch = async () => {
         type: 'migration',
         asset: reviewAsset,
         amount: formatUnits(reviewAsset.amount, Number(reviewAsset.decimals)),
-        // Add-time rows describe the sequential fallback. A latched Safe review
-        // uses rows from the exact bundled resolution instead.
+        // Ceremony-owned rows replace these captured rows during batch review.
         signatureSteps: buildInboundExternalMigrationSignatureSteps(preview.authorizationRequest, useSignatures, false),
         postSteps: buildInboundExternalMigrationRevokeSteps(preview.authorizationRequest, useSignatures, false),
         displayPlan: preview.calldataPrepared.plan,
@@ -3684,6 +3803,7 @@ const addInboundExternalMigrationToBatch = async () => {
           preview.authorizationRequest,
           account,
           useSignatures,
+          preview.authorizationDeadline,
         )
         return {
           plan: simulationResult.plan,
@@ -4017,13 +4137,14 @@ function buildInboundExternalMigrationSignatureSteps(
   authorizationRequest: MigrationAuthorizationRequest | undefined,
   useSignatures: boolean,
   bundled: boolean,
+  connectorId = inboundExternalAuthorizationConnector.value,
 ): DisplayStep[] {
   const sourceCollateral = externalCollateralAsset.value
   if (!sourceCollateral) return []
   if (!useSignatures) {
     return buildMigrationAuthorizationTxSteps(authorizationRequest, 'grant', 1, { bundled })
   }
-  if (inboundExternalAuthorizationConnector.value === AAVE_CONNECTOR_ID) {
+  if (connectorId === AAVE_CONNECTOR_ID) {
     const permitValue = getTypedDataAuthorizationValue(authorizationRequest)
     return [{
       index: 1,
@@ -4032,7 +4153,7 @@ function buildInboundExternalMigrationSignatureSteps(
       assetInfo: migrationStepAssetInfo(sourceCollateral, permitValue ?? sourceCollateral.amount),
     }]
   }
-  if (inboundExternalAuthorizationConnector.value === MORPHO_CONNECTOR_ID) {
+  if (connectorId === MORPHO_CONNECTOR_ID) {
     return flattenMigrationAuthorizationRequests(authorizationRequest).map((request, index) => ({
       index: index + 1,
       label: request.kind === 'typedData' && request.typedData.message.isAuthorized === false
@@ -4041,7 +4162,7 @@ function buildInboundExternalMigrationSignatureSteps(
       isSeparateTx: false,
     }))
   }
-  if (inboundExternalAuthorizationConnector.value === METAMORPHO_CONNECTOR_ID) {
+  if (connectorId === METAMORPHO_CONNECTOR_ID) {
     // The permit value is denominated in vault shares, so display the
     // underlying position amount as an estimate instead.
     return [{

--- a/pages/position/[number]/migrate.vue
+++ b/pages/position/[number]/migrate.vue
@@ -42,10 +42,13 @@ import { logWarn } from '~/utils/errorHandling'
 import { isOperationBlocked } from '~/utils/operationGuardRegistry'
 import { BATCH_ACTIVE_REASON } from '~/utils/tx-batch-messages'
 import { assertReviewedExecutionCurrent } from '~/utils/reviewedExecution'
-import { assertWalletExecutionContext } from '~/utils/walletExecutionContext'
+import { assertPreparedPlanSignatureParity } from '~/utils/preparedPlanParity'
+import { assertWalletExecutionContext, createReviewedWalletContextGuard, createSafeBundleBroadcastGuard } from '~/utils/walletExecutionContext'
 import type { TrackedExecutionScope } from '~/composables/useSafeExecutionDetachment'
 import { useModal } from '~/components/ui/composables/useModal'
 import { useToast } from '~/components/ui/composables/useToast'
+import { getMigrationAuthorizationSignatureSubstitutions } from '~/utils/migrationAuthorizationSignatures'
+import { isMigrationCeremonyDeadlineExpired, mintMigrationCeremonyDeadline } from '~/utils/migrationCeremonyDeadline'
 
 type AaveOutgoingMigrationTarget = MigrationTarget<AaveMigrationTargetRaw, AavePositionRef, AaveMigrationTargetExtraData>
 
@@ -83,9 +86,29 @@ type OutgoingMigrationPreview = {
   input: OutgoingMigrationInput
   account: Account<IHasVaultAddress>
   position: MigrationPosition
+  /**
+   * The verifier/authorization deadline every build of this preview pinned.
+   * Confirmation must reuse it: the deadline is embedded in the EIP-712
+   * payload (so a re-mint always fails the payload-equality gate) and in the
+   * plan's verifier calldata (so a re-mint diverges from the reviewed plan).
+   */
+  authorizationDeadline: bigint
+  /**
+   * The connector identity (`id:uid`) the review was built under. The direct
+   * Safe-bundle broadcast guard validates against this reviewed key — never a
+   * snapshot taken inside the confirmation flow, which would accept a
+   * connector swapped during an earlier confirmation await as its baseline.
+   */
+  connectorContextKey: string | undefined
   authorizationRequest?: MigrationAuthorizationRequest
   tenderlySimulation: PreparedMigrationTenderlySimulation
   calldataPrepared: TransactionPlanPrepared
+  /**
+   * The plugin payloads the reviewed calldata was prepared with. Confirm-time
+   * rebuilds must prepare with the same payloads so the parity proof compares
+   * plans that differ only in the authorized signature substitutions.
+   */
+  prefetch?: PluginPrefetchData
 }
 
 type MigrationTargetAssetLike = {
@@ -103,7 +126,7 @@ const route = useRoute()
 const router = useRouter()
 const modal = useModal()
 const { error: showError } = useToast()
-const { isConnected, address, chainId: walletChainId } = useWagmi()
+const { isConnected, address, chainId: walletChainId, connector: walletConnector } = useWagmi()
 const { isSpyMode, spyAddress } = useSpyMode()
 const { isPositionsLoading, getPositionBySubAccountIndex, refreshAllPositions } = useEulerAccount()
 const { chainId } = useEulerAddresses()
@@ -609,13 +632,22 @@ function buildMigrationInput(
   }
 }
 
+// Identity of the wallet connector a Safe proposal would submit through.
+// Account and chain checks cannot see a same-account connector switch, so the
+// direct Safe-bundle flow captures this at confirmation and re-asserts it
+// immediately before the irreversible proposal broadcast.
+function walletConnectorContextKey(): string | undefined {
+  const current = walletConnector.value
+  return current ? `${current.id}:${current.uid}` : undefined
+}
+
 async function getAuthorizationRequest(
   input: OutgoingMigrationInput,
   migrationPosition?: MigrationPosition,
   account?: Account<IHasVaultAddress>,
   useSignatures = signaturesEnabled.value,
+  deadline: bigint = mintMigrationCeremonyDeadline(),
 ): Promise<MigrationAuthorizationRequest | undefined> {
-  const deadline = BigInt(Math.floor(Date.now() / 1000) + 60 * 60)
   return getMigrationAuthorization({
     direction: 'euler-to-external',
     connectorId: input.target.connectorId,
@@ -639,6 +671,7 @@ async function buildMigrationPlan(
   authorization?: SignedMigrationAuthorization,
   migrationPosition?: MigrationPosition,
   account: Account<IHasVaultAddress> | undefined = planAccount.value,
+  deadline?: bigint,
 ): Promise<TransactionPlan> {
   return planCrossProtocolMigration({
     direction: 'euler-to-external',
@@ -654,6 +687,7 @@ async function buildMigrationPlan(
     account,
     cleanupEulerPosition: input.cleanupEulerPosition,
     operationName: `${input.target.connectorId}OutgoingMigration`,
+    deadline,
   })
 }
 
@@ -662,6 +696,7 @@ async function buildMigrationSimulation(
   migrationPosition: MigrationPosition,
   authorizationRequest: MigrationAuthorizationRequest | undefined,
   account?: Account<IHasVaultAddress>,
+  deadline?: bigint,
 ) {
   return planCrossProtocolMigrationSimulation({
     direction: 'euler-to-external',
@@ -677,6 +712,7 @@ async function buildMigrationSimulation(
     account,
     cleanupEulerPosition: input.cleanupEulerPosition,
     operationName: `${input.target.connectorId}OutgoingMigration`,
+    deadline,
   })
 }
 
@@ -755,6 +791,10 @@ async function prepareOutgoingMigrationPreview(
       positionRef: input.target.ref,
     })
 
+    // Pinned once for the preview's whole lifetime: every build here and the
+    // confirm-time rebuild must embed this same deadline, or the payload and
+    // plan gates reject the confirmation as drift.
+    const authorizationDeadline = mintMigrationCeremonyDeadline()
     // Match the inbound migration flow: resolve the exact authorization form
     // first, then pass it into simulation. In no-signature mode this must be a
     // standalone transaction request so the review can list its grant/revoke
@@ -764,6 +804,7 @@ async function prepareOutgoingMigrationPreview(
       migrationPosition,
       account,
       useSignatures,
+      authorizationDeadline,
     )
     // One batch build returns both plans: the simulation plan (auth item
     // stripped, replaced by state overrides) and the stub-signed preview
@@ -773,6 +814,7 @@ async function prepareOutgoingMigrationPreview(
       migrationPosition,
       authorizationRequest,
       account,
+      authorizationDeadline,
     )
 
     // Resolve plugin payloads (Pyth Hermes pull, Keyring reads, TOS) once,
@@ -812,12 +854,15 @@ async function prepareOutgoingMigrationPreview(
       input,
       account,
       position: migrationPosition,
+      authorizationDeadline,
+      connectorContextKey: walletConnectorContextKey(),
       tenderlySimulation: {
         plan: simulationResult.plan,
         prepared: tenderlyPrepared,
         stateOverrides: simulationResult.stateOverrides,
       },
       calldataPrepared,
+      ...(prefetch ? { prefetch } : {}),
       ...(authorizationRequest
         ? { authorizationRequest }
         : {}),
@@ -895,6 +940,30 @@ async function reviewMigration(target: OutgoingMigrationTarget) {
   }
 }
 
+/**
+ * Prove the confirm-time prepared plan is byte-identical to the reviewed
+ * calldata outside the authorized signature substitutions. Any other
+ * divergence evicts the cached preview and forces a re-review — the wallet
+ * must never receive calldata the modal did not display.
+ */
+function assertMigrationPreparedParity(
+  preview: OutgoingMigrationPreview,
+  resolved: TransactionPlanPrepared,
+  authorization: SignedMigrationAuthorization | undefined,
+) {
+  try {
+    assertPreparedPlanSignatureParity({
+      reviewed: preview.calldataPrepared,
+      resolved,
+      substitutions: getMigrationAuthorizationSignatureSubstitutions(authorization),
+    })
+  }
+  catch (err) {
+    invalidateOutgoingMigrationPreview(preview.key)
+    throw err
+  }
+}
+
 async function sendMigration(execution: TrackedExecutionScope, preview: OutgoingMigrationPreview) {
   const { input: reviewedInput, account: reviewedAccount, position: migrationPosition, useSignatures } = preview
   const { target } = reviewedInput
@@ -913,7 +982,14 @@ async function sendMigration(execution: TrackedExecutionScope, preview: Outgoing
     })
     if (!await restorePendingBeforeRetry()) return
     const input = reviewedInput
-    const authorizationRequest = await getAuthorizationRequest(input, migrationPosition, reviewedAccount, useSignatures)
+    // The reviewed deadline is embedded in the displayed payload and plan, so
+    // an expired one can only produce an on-chain revert — force a re-review
+    // that mints a fresh ceremony instead.
+    if (isMigrationCeremonyDeadlineExpired(preview.authorizationDeadline)) {
+      invalidateOutgoingMigrationPreview(preview.key)
+      throw new Error('The reviewed authorization expired — please review the migration again.')
+    }
+    const authorizationRequest = await getAuthorizationRequest(input, migrationPosition, reviewedAccount, useSignatures, preview.authorizationDeadline)
 
     // The reviewed ceremony is defined by the authorization payload the modal
     // displayed and copied. Authorization state can drift between review and
@@ -947,34 +1023,56 @@ async function sendMigration(execution: TrackedExecutionScope, preview: Outgoing
           invalidateOutgoingMigrationPreview(preview.key)
           throw new Error('Authorization requirements changed since review — please review the migration again.')
         }
-        const outcome = await sendMigrationAsSafeBundle(input, migrationPosition, authorizationRequest, reviewedAccount)
+        const beforeBroadcast = createSafeBundleBroadcastGuard({
+          expectedAccount: reviewedInput.owner,
+          expectedChainId: target.chainId,
+          expectedConnectorKey: preview.connectorContextKey,
+          currentAccount: () => address.value as Address | undefined,
+          currentChainId: () => walletChainId.value,
+          isSafeWallet: () => isSafeWallet.value,
+          connectorContextKey: walletConnectorContextKey,
+        })
+        const outcome = await sendMigrationAsSafeBundle(preview, migrationPosition, authorizationRequest, reviewedAccount, beforeBroadcast)
         if (outcome === 'aborted') return
         finishMigrationSuccess(execution)
         return
       }
 
+      // Every wallet action below (signature request, grant broadcasts, plan
+      // broadcast) re-asserts the reviewed account/chain/connector — the
+      // awaits between them are where a delayed wallet switch can land.
+      const assertReviewedWalletContext = createReviewedWalletContextGuard({
+        expectedAccount: reviewedInput.owner,
+        expectedChainId: target.chainId,
+        expectedConnectorKey: preview.connectorContextKey,
+        currentAccount: () => address.value as Address | undefined,
+        currentChainId: () => walletChainId.value,
+        connectorContextKey: walletConnectorContextKey,
+      })
       if (authorizationRequest) {
         if (useSignatures) {
-          authorization = await signMigrationAuthorization(authorizationRequest)
+          authorization = await signMigrationAuthorization(authorizationRequest, { beforeSignature: assertReviewedWalletContext })
         }
         else {
           // Record each revoke as soon as its grant is broadcast so partial or
           // receipt-ambiguous failures can still unwind what may have landed.
-          await executeMigrationAuthorizationGrants(authorizationRequest, revokeTxs)
+          await executeMigrationAuthorizationGrants(authorizationRequest, revokeTxs, { beforeBroadcast: assertReviewedWalletContext })
         }
       }
-      const plan = await buildMigrationPlan(input, authorization, migrationPosition, reviewedAccount)
+      const plan = await buildMigrationPlan(input, authorization, migrationPosition, reviewedAccount, preview.authorizationDeadline)
       const prepared = await prepareTransactionPlan(plan, {
         account: reviewedAccount,
         chainId: input.target.chainId,
+        prefetch: preview.prefetch,
         usePermit2: useSignatures,
       })
+      assertMigrationPreparedParity(preview, prepared, authorization)
       const ok = await runPreparedSimulation(prepared, buildStateOverrideOptions({ noBalanceOverride: true }))
       if (!ok) {
         await revokeAfterAbort(revokeTxs)
         return
       }
-      await executePreparedPlan(prepared)
+      await executePreparedPlan(prepared, { beforeBroadcast: assertReviewedWalletContext })
     }
     catch (err) {
       // Covers a rejected batch, a failed prepare, and a stale grant.
@@ -1039,18 +1137,24 @@ function finishMigrationSuccess(execution: TrackedExecutionScope) {
  * Safe bundle context throws instead of silently splitting the ceremony.
  */
 async function sendMigrationAsSafeBundle(
-  input: OutgoingMigrationInput,
+  preview: OutgoingMigrationPreview,
   migrationPosition: MigrationPosition,
   authorizationRequest: MigrationAuthorizationRequest,
-  account?: Account<IHasVaultAddress>,
+  account: Account<IHasVaultAddress> | undefined,
+  beforeBroadcast: () => void,
 ): Promise<'executed' | 'aborted'> {
+  const { input, authorizationDeadline: deadline } = preview
   const { grants, revokes } = encodeMigrationAuthorizationTxs(authorizationRequest)
-  const simulation = await buildMigrationSimulation(input, migrationPosition, authorizationRequest, account)
+  const simulation = await buildMigrationSimulation(input, migrationPosition, authorizationRequest, account, deadline)
   const prepared = await prepareTransactionPlan(simulation.plan, {
     account,
     chainId: input.target.chainId,
+    prefetch: preview.prefetch,
     usePermit2: false,
   })
+  // Bundled reviews are always no-signature, so the reviewed calldata is the
+  // simulation-variant plan itself: parity holds with zero substitutions.
+  assertMigrationPreparedParity(preview, prepared, undefined)
   const ok = await runPreparedSimulation(
     prepared,
     buildStateOverrideOptions({ noBalanceOverride: true }),
@@ -1058,7 +1162,8 @@ async function sendMigrationAsSafeBundle(
   )
   if (!ok) return 'aborted'
 
-  const result = await executePreparedPlanWithPlainCalls(prepared, { before: grants, after: revokes }, { allowSingleCall: true })
+  beforeBroadcast()
+  const result = await executePreparedPlanWithPlainCalls(prepared, { before: grants, after: revokes }, { allowSingleCall: true, beforeBroadcast })
   if (!result) {
     throw new Error('Safe connection unavailable — the reviewed single-proposal submission cannot run. Reconnect your Safe and retry.')
   }
@@ -1095,46 +1200,65 @@ async function addPreparedMigrationToBatch(preview: OutgoingMigrationPreview) {
   const batchEntry = {
     label: `Migrate ${sourceCollateralSymbol}/${sourceDebtSymbol} to ${targetProtocolDisplay(input.target)}`,
     nameOverride: `Migrate ${sourceCollateralSymbol}/${sourceDebtSymbol}`,
-    buildExecutionPlan: async (account: Account<IHasVaultAddress>) => {
-      const executionAuthorizationRequest = useSignatures
-        ? await getAuthorizationRequest(input, migrationPosition, account, useSignatures)
-        : undefined
-      const authorization = executionAuthorizationRequest
-        ? await signMigrationAuthorization(executionAuthorizationRequest)
-        : undefined
-      // Without signatures the grant was already mined by the batch's pre-phase,
-      // so the connector omits the authorization item from the plan.
-      return buildMigrationPlan(input, authorization, migrationPosition, account)
-    },
     ...(useSignatures
-      ? {}
-      : {
-          buildExecutionPrerequisites: async (account: Account<IHasVaultAddress>) => {
-            const request = await getAuthorizationRequest(input, migrationPosition, account, useSignatures)
-            if (!request) return undefined
-            const { grants, revokes, revokesByGrant } = encodeMigrationAuthorizationTxs(request)
+      ? {
+          // Review uses placeholder signature bytes. Real wallet signatures are
+          // requested only after the user confirms this exact authorization.
+          buildExecutionCeremony: async (account: Account<IHasVaultAddress>) => {
+            // The confirm-time rebuild must differ from the reviewed preview
+            // plan only in the signature bytes. Connectors mint a wall-clock
+            // verifier deadline on every build unless one is supplied, so the
+            // ceremony pins a single deadline across both builds.
+            const ceremonyDeadline = mintMigrationCeremonyDeadline()
+            const request = await getAuthorizationRequest(input, migrationPosition, account, useSignatures, ceremonyDeadline)
+            const simulation = await buildMigrationSimulation(input, migrationPosition, request, account, ceremonyDeadline)
             return {
-              preTxs: grants,
-              walletContext: { account: request.owner, chainId: request.chainId },
-              postTxs: revokes,
-              postTxsByPreTx: revokesByGrant,
+              plan: simulation.previewPlan,
+              resolveExecutionPlan: async (beforeWalletAction: () => void) => {
+                const authorization = request
+                  ? await signMigrationAuthorization(request, { beforeSignature: beforeWalletAction })
+                  : undefined
+                beforeWalletAction()
+                return {
+                  plan: await buildMigrationPlan(input, authorization, migrationPosition, account, ceremonyDeadline),
+                  signatureSubstitutions: getMigrationAuthorizationSignatureSubstitutions(authorization),
+                }
+              },
+              usesPlaceholderSignatures: !!request,
+              grantSteps: buildSignatureSteps(input.target, request, true, false),
+              revokeSteps: [],
             }
           },
-          // Bundled counterpart for Safe execution: the simulation-variant
-          // plan validates the grant instead of reading the live allowance,
-          // so nothing needs to mine before the proposal is assembled. The
-          // review rows come from the SAME resolution so the modal cannot
-          // display a ceremony other than the one that executes.
-          buildBundledExecution: async (account: Account<IHasVaultAddress>) => {
+        }
+      : {
+          bundleExecutionCeremony: true,
+          // Resolve authorization once so the reviewed rows, exported calls,
+          // standalone flow, and Safe proposal all describe one ceremony.
+          buildExecutionCeremony: async (account: Account<IHasVaultAddress>) => {
             const request = await getAuthorizationRequest(input, migrationPosition, account, useSignatures)
-            const { grants, revokes } = request
+            const { grants, revokes, revokesByGrant } = request
               ? encodeMigrationAuthorizationTxs(request)
-              : { grants: [], revokes: [] }
+              : { grants: [], revokes: [], revokesByGrant: [] }
             const simulation = await buildMigrationSimulation(input, migrationPosition, request, account)
             return {
               plan: simulation.plan,
-              grants,
-              revokes,
+              prerequisites: request
+                ? {
+                    preTxs: grants,
+                    walletContext: { account: request.owner, chainId: request.chainId },
+                    postTxs: revokes,
+                    postTxsByPreTx: revokesByGrant,
+                  }
+                : undefined,
+              // Authorization state can drift between review and execution
+              // (an allowance granted or revoked elsewhere) — the reviewed
+              // grant/revoke set would no longer match what should run.
+              revalidatePrerequisites: async () => {
+                const fresh = await getAuthorizationRequest(input, migrationPosition, account, useSignatures)
+                if (migrationAuthorizationPayloadKey(fresh) !== migrationAuthorizationPayloadKey(request)) {
+                  throw new Error('Authorization requirements changed since review — reopen review and try again.')
+                }
+              },
               grantSteps: buildMigrationAuthorizationTxSteps(request, 'grant', 1, { bundled: true }),
               revokeSteps: buildMigrationAuthorizationTxSteps(request, 'revoke', 1, { bundled: true }),
             }
@@ -1151,8 +1275,7 @@ async function addPreparedMigrationToBatch(preview: OutgoingMigrationPreview) {
       type: 'migration',
       asset: sourceDebtAsset,
       amount: debtAmount,
-      // Add-time rows describe the sequential fallback. A latched Safe review
-      // uses rows from the exact bundled resolution instead.
+      // Ceremony-owned rows replace these captured rows during batch review.
       signatureSteps: buildSignatureSteps(input.target, authorizationRequest, useSignatures, false),
       postSteps: buildRevokeSteps(authorizationRequest, useSignatures, false),
       displayPlan: preview.calldataPrepared.plan,

--- a/tests/components/batchReviewModal.test.ts
+++ b/tests/components/batchReviewModal.test.ts
@@ -1,0 +1,64 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const source = readFileSync(
+  join(process.cwd(), 'components/BatchReviewModal.vue'),
+  'utf8',
+)
+
+const sectionBetween = (start: string, end: string): string => {
+  const startIndex = source.indexOf(start)
+  const endIndex = source.indexOf(end, startIndex)
+  expect(startIndex, `missing start marker: ${start}`).toBeGreaterThanOrEqual(0)
+  expect(endIndex, `missing end marker: ${end}`).toBeGreaterThan(startIndex)
+  return source.slice(startIndex, endIndex)
+}
+
+const expectCeremonyPlanFirst = (section: string) => {
+  const selectorIndex = section.indexOf('getBatchReviewDisplayPlan(')
+  const ceremonyIndex = section.indexOf('executionCeremonyRef.value?.reviewByEntryId[entry.id]?.plan')
+  const capturedPlanIndex = section.indexOf('entryPlans.value[entry.id]')
+
+  expect(selectorIndex).toBeGreaterThanOrEqual(0)
+  expect(ceremonyIndex).toBeGreaterThan(selectorIndex)
+  expect(capturedPlanIndex).toBeGreaterThan(ceremonyIndex)
+}
+
+describe('BatchReviewModal ceremony wiring', () => {
+  it('derives expanded operation rows from the ceremony plan', () => {
+    const displaySection = sectionBetween(
+      'const stepsByEntryId = computed',
+      'const signatureStepsByEntryId = computed',
+    )
+
+    expectCeremonyPlanFirst(displaySection)
+    expect(source).toContain(':steps="stepsByEntryId[entry.id]"')
+  })
+
+  it('derives unverified-vault disclosure from the ceremony plan', () => {
+    const disclosureSection = sectionBetween(
+      'const unverifiedVaultNames = computed',
+      'const hasUnverified = computed',
+    )
+
+    expectCeremonyPlanFirst(disclosureSection)
+    expect(source).toContain('v-if="hasUnverified"')
+    expect(source).toContain('unverifiedVaultNames.join(\', \')')
+  })
+
+  it('keeps one restoration summary row per reviewed wallet action', () => {
+    const restorationSection = sectionBetween(
+      'const restorationSummaryRows = computed',
+      'const restorationSummaryGroups = computed',
+    )
+
+    expect(restorationSection).toContain('postStepsByEntryId.value[entry.id]')
+    expect(restorationSection).not.toContain('consolidate')
+  })
+
+  it('does not offer a whole-batch simulation for a different call vector', () => {
+    expect(source).not.toContain('simulateOnTenderly')
+    expect(source).not.toContain('Simulate on Tenderly')
+  })
+})

--- a/tests/composables/useEulerTx.test.ts
+++ b/tests/composables/useEulerTx.test.ts
@@ -144,6 +144,32 @@ describe('useEulerTx migration authorization cleanup', () => {
     expect(wagmiMocks.signTypedDataAsync).not.toHaveBeenCalled()
   })
 
+  it('signs through the connector that passed the context check, not the live one', async () => {
+    const reviewedConnector = { id: 'io.metamask', name: 'MetaMask' }
+    const swappedConnector = { id: 'io.rabby', name: 'Rabby' }
+    let activeConnector: unknown = reviewedConnector
+    vi.mocked(getAccount).mockImplementation(() => ({
+      address: currentAccount,
+      chainId: currentChainId,
+      connector: activeConnector,
+    }) as never)
+    wagmiMocks.signTypedDataAsync.mockResolvedValue(`0x${'ab'.repeat(65)}`)
+    const { signMigrationAuthorization } = useEulerTx()
+
+    await signMigrationAuthorization(typedAuthorizationRequest, {
+      // A connector switch in the check-to-sign gap: the swapped connector
+      // was never validated and must not receive the signature request.
+      beforeSignature: () => {
+        activeConnector = swappedConnector
+      },
+    })
+
+    expect(wagmiMocks.signTypedDataAsync).toHaveBeenCalledTimes(1)
+    expect(wagmiMocks.signTypedDataAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ connector: reviewedConnector }),
+    )
+  })
+
   it('prepares the transaction plan with the caller-pinned signature mode', async () => {
     const prepare = vi.fn().mockResolvedValue({ kind: 'prepared' })
     vi.mocked(getEulerSdkForChain).mockResolvedValue({
@@ -204,6 +230,46 @@ describe('useEulerTx migration authorization cleanup', () => {
     await expect(executePreparedPlan(prepared))
       .rejects.toMatchObject({ name: WalletExecutionContextChangedError.name, kind: 'account' })
     expect(wagmiMocks.sendTransactionAsync).not.toHaveBeenCalled()
+  })
+
+  it('pins mid-plan typed-data signatures to the connector captured at execution start', async () => {
+    const reviewedConnector = { id: 'io.metamask', name: 'MetaMask' }
+    const swappedConnector = { id: 'io.rabby', name: 'Rabby' }
+    let activeConnector: unknown = reviewedConnector
+    vi.mocked(getAccount).mockImplementation(() => ({
+      address: currentAccount,
+      chainId: currentChainId,
+      connector: activeConnector,
+    }) as never)
+    wagmiMocks.signTypedDataAsync.mockResolvedValue(`0x${'ab'.repeat(65)}`)
+    const executePreparedTransactionPlan = vi.fn(async ({ signTypedData }: {
+      signTypedData: (typedData: unknown) => Promise<Hex>
+    }) => {
+      // The wallet switches connectors while the executor is mid-plan; the
+      // permit signature must still go to the connector that was validated.
+      activeConnector = swappedConnector
+      await signTypedData({ domain: {}, types: {}, primaryType: 'PermitSingle', message: {} })
+      return { receipts: [] }
+    })
+    vi.mocked(getEulerSdkFresh).mockResolvedValue({
+      providerService: { getProvider: vi.fn(() => ({ waitForTransactionReceipt: vi.fn() })) },
+      executionService: { executePreparedTransactionPlan },
+    } as never)
+    const { executePreparedPlan } = useEulerTx()
+
+    await executePreparedPlan({
+      __prepared: true,
+      plan: [],
+      chainId: 1,
+      account: OWNER,
+      usePermit2: true,
+      unlimitedApproval: false,
+    } as TransactionPlanPrepared)
+
+    expect(wagmiMocks.signTypedDataAsync).toHaveBeenCalledTimes(1)
+    expect(wagmiMocks.signTypedDataAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ connector: reviewedConnector }),
+    )
   })
 
   it('runs the caller freshness guard after async setup and before a plain broadcast', async () => {

--- a/tests/composables/useEulerTx.test.ts
+++ b/tests/composables/useEulerTx.test.ts
@@ -156,6 +156,27 @@ describe('useEulerTx migration authorization cleanup', () => {
     expect(prepare).toHaveBeenCalledWith(expect.objectContaining({ usePermit2: false }))
   })
 
+  it('estimates a prepared envelope without rerunning the raw plan pipeline', async () => {
+    const estimatePrepared = vi.fn().mockResolvedValue(123n)
+    vi.mocked(getEulerSdkForChain).mockResolvedValue({
+      executionService: { estimateGasForPreparedTransactionPlan: estimatePrepared },
+    } as never)
+    const prepared = {
+      __prepared: true,
+      plan: [],
+      chainId: 8453,
+      account: OWNER,
+      usePermit2: false,
+      unlimitedApproval: false,
+    } as TransactionPlanPrepared
+    const { estimateGasForPreparedPlan } = useEulerTx()
+
+    await expect(estimateGasForPreparedPlan(prepared)).resolves.toBe(123n)
+
+    expect(getEulerSdkForChain).toHaveBeenCalledWith(8453)
+    expect(estimatePrepared).toHaveBeenCalledWith(prepared)
+  })
+
   it('does not broadcast a reviewed migration after account drift', async () => {
     const executePreparedTransactionPlan = vi.fn(async ({ sendTransaction }: {
       sendTransaction: (tx: { to: Address, data: Hex }) => Promise<Hash>
@@ -182,6 +203,31 @@ describe('useEulerTx migration authorization cleanup', () => {
 
     await expect(executePreparedPlan(prepared))
       .rejects.toMatchObject({ name: WalletExecutionContextChangedError.name, kind: 'account' })
+    expect(wagmiMocks.sendTransactionAsync).not.toHaveBeenCalled()
+  })
+
+  it('runs the caller freshness guard after async setup and before a plain broadcast', async () => {
+    const provider = {
+      waitForTransactionReceipt: vi.fn(),
+    }
+    let resolveSdk!: (sdk: unknown) => void
+    const sdkPromise = new Promise<unknown>((resolve) => {
+      resolveSdk = resolve
+    })
+    vi.mocked(getEulerSdkFresh).mockReturnValue(sdkPromise as never)
+    let current = true
+    const { sendPlainTransactions } = useEulerTx()
+    const execution = sendPlainTransactions([{ to: TOKEN, data: '0x1234' }], {
+      beforeBroadcast: () => {
+        if (!current) throw new Error('review became stale')
+      },
+    })
+    await vi.waitFor(() => expect(getEulerSdkFresh).toHaveBeenCalledTimes(1))
+
+    current = false
+    resolveSdk({ providerService: { getProvider: vi.fn(() => provider) } })
+
+    await expect(execution).rejects.toThrow('review became stale')
     expect(wagmiMocks.sendTransactionAsync).not.toHaveBeenCalled()
   })
 
@@ -582,9 +628,8 @@ describe('useEulerTx Safe wallet bundling', () => {
 
   it('wraps the plan with plain calls inside one Safe bundle in order', async () => {
     const { executePreparedPlanWithPlainCalls } = useEulerTx()
-    const batchOnly = [approvedPlan[1]] as TransactionPlan
 
-    const result = await executePreparedPlanWithPlainCalls(buildPrepared(batchOnly), {
+    const result = await executePreparedPlanWithPlainCalls(buildPrepared(approvedPlan), {
       before: [GRANT_CALL],
       after: [REVOKE_CALL],
     })
@@ -598,6 +643,7 @@ describe('useEulerTx Safe wallet bundling', () => {
       calls: [
         // Grants before the batch, revocations after — one atomic proposal.
         { to: TOKEN, data: '0x11ff', value: 0n },
+        { to: TOKEN, data: APPROVE_DATA, value: 0n },
         { to: EVC, data: BATCH_DATA, value: 0n },
         { to: TOKEN, data: '0x22ff', value: 0n },
       ],
@@ -605,6 +651,42 @@ describe('useEulerTx Safe wallet bundling', () => {
     expect(result?.hashes).toEqual([SAFE_TX_HASH])
     expect(result?.receipts[0].transactionHash).toBe(SAFE_TX_HASH)
     expect(executePreparedTransactionPlan).not.toHaveBeenCalled()
+  })
+
+  it('runs the caller freshness guard after Safe provider setup and before submission', async () => {
+    let resolveSafeProvider!: (provider: { request: ReturnType<typeof vi.fn> }) => void
+    const safeProviderPromise = new Promise<{ request: ReturnType<typeof vi.fn> }>((resolve) => {
+      resolveSafeProvider = resolve
+    })
+    const deferredSafeConnector = {
+      id: 'safe',
+      name: 'Safe',
+      getProvider: vi.fn(() => safeProviderPromise),
+    }
+    vi.mocked(getAccount).mockImplementation(() => ({
+      address: currentAccount,
+      chainId: currentChainId,
+      connector: deferredSafeConnector,
+    }) as never)
+    let current = true
+    const { executePreparedPlanWithPlainCalls } = useEulerTx()
+    const execution = executePreparedPlanWithPlainCalls(
+      buildPrepared([approvedPlan[1]] as TransactionPlan),
+      { before: [GRANT_CALL], after: [REVOKE_CALL] },
+      {
+        allowSingleCall: true,
+        beforeBroadcast: () => {
+          if (!current) throw new Error('review became stale')
+        },
+      },
+    )
+    await vi.waitFor(() => expect(deferredSafeConnector.getProvider).toHaveBeenCalledTimes(1))
+
+    current = false
+    resolveSafeProvider({ request: vi.fn() })
+
+    await expect(execution).rejects.toThrow('review became stale')
+    expect(wagmiMocks.sendCalls).not.toHaveBeenCalled()
   })
 
   it('rejects wrapper calls around a plan that encodes no calls', async () => {

--- a/tests/composables/useMigrationAuthorizationFlow.test.ts
+++ b/tests/composables/useMigrationAuthorizationFlow.test.ts
@@ -58,4 +58,21 @@ describe('useMigrationAuthorizationFlow pending cleanup', () => {
 
     expect(flow.pendingRevokes.value).toEqual([revoke])
   })
+
+  it.each(['revokeAfterSuccess', 'revokeAfterAbort'] as const)(
+    'keeps failed cleanup queued without notifying a successor wallet from %s',
+    async (method) => {
+      mocks.sendMigrationAuthorizationRevokes.mockResolvedValue({
+        restored: [],
+        failed: [revoke],
+      })
+      const flow = useMigrationAuthorizationFlow()
+
+      await flow[method]([revoke], { shouldNotify: () => false })
+
+      expect(mocks.sendMigrationAuthorizationRevokes).toHaveBeenCalledWith([revoke])
+      expect(flow.pendingRevokes.value).toEqual([revoke])
+      expect(mocks.showWarning).not.toHaveBeenCalled()
+    },
+  )
 })

--- a/tests/composables/useTxBatch.test.ts
+++ b/tests/composables/useTxBatch.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
+import { nextTick, ref } from 'vue'
 import { Account, Portfolio, type IAccountPosition, type IHasVaultAddress, type IAccountLiquidity, type TransactionPlan } from '@eulerxyz/euler-v2-sdk'
 import { getAddress, type Address, type Hex } from 'viem'
 import { getEulerSdkFresh } from '~/composables/useEulerSdk'
@@ -13,10 +13,24 @@ import {
 import { activeLayerVaultsRef } from '~/composables/useLayeredVaults'
 import { WalletExecutionContextChangedError } from '~/utils/walletExecutionContext'
 import type { WalletExecutionContext } from '~/utils/walletExecutionContext'
+import { buildBatchReviewCalldata } from '~/utils/batchReviewCalldata'
+import { PLACEHOLDER_MIGRATION_AUTHORIZATION_SIGNATURE } from '~/utils/migrationAuthorizationSignatures'
 
 vi.mock('~/composables/useEulerSdk', () => ({
   getEulerSdkFresh: vi.fn(),
 }))
+
+const txErrorMocks = vi.hoisted(() => ({
+  getTxErrorMessage: vi.fn(async (error: unknown) => error instanceof Error ? error.message : String(error)),
+}))
+
+vi.mock('~/utils/tx-errors', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return {
+    ...actual,
+    getTxErrorMessage: txErrorMocks.getTxErrorMessage,
+  }
+})
 
 const owner = getAddress('0x1000000000000000000000000000000000000000')
 const subAccount = getAddress('0x8A54C278D117854486db0F6460D901a180Fff517')
@@ -32,20 +46,29 @@ const eulerTxMocks = {
   prepareTransactionPlan: vi.fn(),
   executePreparedPlan: vi.fn(),
   executePreparedPlanWithPlainCalls: vi.fn(),
-  estimateGasForPlan: vi.fn(),
+  estimateGasForPreparedPlan: vi.fn(),
   sendPlainTransactions: vi.fn(),
 }
 const isSafeWalletRef = ref(false)
+const isSafeWalletResolvedRef = ref(true)
+const walletConnectorRef = ref({ id: 'mock', uid: 'mock:1' })
+const walletAddressRef = ref<Address | undefined>(owner)
+const walletChainIdRef = ref<number | undefined>(1)
+const effectiveAddressRef = ref<Address | undefined>(owner)
 const grantWalletContext: WalletExecutionContext = { account: owner, chainId: 1 }
 type PlainTxSendOptions = {
   onBroadcast?: (index: number, walletContext: WalletExecutionContext) => void
   walletContext?: WalletExecutionContext
+  beforeBroadcast?: () => void
 }
 const broadcastAllTransactions = async (
   txs: Array<{ data: Hex }>,
   options?: PlainTxSendOptions,
 ) => {
-  txs.forEach((_tx, index) => options?.onBroadcast?.(index, options?.walletContext ?? grantWalletContext))
+  txs.forEach((_tx, index) => {
+    options?.beforeBroadcast?.()
+    options?.onBroadcast?.(index, options?.walletContext ?? grantWalletContext)
+  })
   return []
 }
 const migrationFlowMocks = {
@@ -263,19 +286,20 @@ const accountWithPositions = (
 })
 
 const stubBatchComposableGlobals = () => {
-  vi.stubGlobal('useWagmi', () => ({ address: ref(owner), chainId: ref(1) }))
+  vi.stubGlobal('useWagmi', () => ({ address: walletAddressRef, chainId: walletChainIdRef, connector: walletConnectorRef }))
   vi.stubGlobal('useSpyMode', () => ({ isSpyMode: ref(false), spyAddress: ref(undefined) }))
   vi.stubGlobal('useEffectiveAddress', () => ({
-    address: ref(owner),
+    address: effectiveAddressRef,
     isConnected: ref(true),
     isSpyMode: ref(false),
     spyAddress: ref(undefined),
-    effectiveAddress: ref(owner),
+    effectiveAddress: effectiveAddressRef,
   }))
   vi.stubGlobal('useEulerAddresses', () => ({ chainId: ref(1) }))
   vi.stubGlobal('useEulerTx', () => eulerTxMocks)
   isSafeWalletRef.value = false
-  vi.stubGlobal('useSafeWallet', () => ({ isSafeWallet: isSafeWalletRef, isSafeWalletResolved: ref(true) }))
+  isSafeWalletResolvedRef.value = true
+  vi.stubGlobal('useSafeWallet', () => ({ isSafeWallet: isSafeWalletRef, isSafeWalletResolved: isSafeWalletResolvedRef }))
   vi.stubGlobal('useMigrationAuthorizationFlow', () => migrationFlowMocks)
   vi.stubGlobal('useExternalMigrationRefresh', () => ({ scheduleExternalMigrationRefreshes }))
   vi.stubGlobal('useRouter', () => ({ replace: routerReplace }))
@@ -315,9 +339,11 @@ beforeEach(() => {
   eulerTxMocks.prepareTransactionPlan.mockReset()
   eulerTxMocks.executePreparedPlan.mockReset()
   eulerTxMocks.executePreparedPlanWithPlainCalls.mockReset()
-  eulerTxMocks.estimateGasForPlan.mockReset()
+  eulerTxMocks.estimateGasForPreparedPlan.mockReset()
   eulerTxMocks.sendPlainTransactions.mockReset()
   eulerTxMocks.sendPlainTransactions.mockImplementation(broadcastAllTransactions)
+  txErrorMocks.getTxErrorMessage.mockReset()
+  txErrorMocks.getTxErrorMessage.mockImplementation(async error => error instanceof Error ? error.message : String(error))
   migrationFlowMocks.revokeAfterSuccess.mockReset()
   migrationFlowMocks.revokeAfterAbort.mockReset()
   migrationFlowMocks.restorePendingBeforeRetry.mockReset()
@@ -325,6 +351,10 @@ beforeEach(() => {
   scheduleExternalMigrationRefreshes.mockReset()
   routerReplace.mockReset()
   routeQuery.network = '1'
+  walletAddressRef.value = owner
+  walletChainIdRef.value = 1
+  effectiveAddressRef.value = owner
+  walletConnectorRef.value = { id: 'mock', uid: 'mock:1' }
   stubBatchComposableGlobals()
   vi.mocked(getEulerSdkFresh).mockResolvedValue(createMockSdk() as never)
   resetBatchPrefetchState()
@@ -919,6 +949,49 @@ describe('useTxBatch execution errors', () => {
     expect(buildAccount?.owner).toBe(owner)
   })
 
+  it('does not publish a stale resimulation snapshot after an account reset', async () => {
+    const sdk = createMockSdk()
+    const oldAccount = accountWithPosition(subAccount, subAccount, 11n)
+    const nextOwner = getAddress('0x2000000000000000000000000000000000000002')
+    const nextAccount = accountWithPosition(subAccount, subAccount, 22n)
+    nextAccount.owner = nextOwner
+    let resolveOldFetch!: (value: { result: Account<IHasVaultAddress>, errors: never[] }) => void
+    const oldFetch = new Promise<{ result: Account<IHasVaultAddress>, errors: never[] }>((resolve) => {
+      resolveOldFetch = resolve
+    })
+    sdk.accountService.fetchAccount
+      .mockImplementationOnce(() => oldFetch)
+      .mockResolvedValueOnce({ result: nextAccount, errors: [] })
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+
+    const batch = useTxBatch()
+    await batch.addEntry({
+      label: 'Account A operation',
+      buildPlan: async () => [] as TransactionPlan,
+      requiresPlanningAccount: false,
+    })
+    await vi.waitFor(() => expect(sdk.accountService.fetchAccount).toHaveBeenCalledTimes(1))
+
+    effectiveAddressRef.value = nextOwner
+    walletAddressRef.value = nextOwner
+    await nextTick()
+    resolveOldFetch({ result: oldAccount, errors: [] })
+    await Promise.resolve()
+
+    let planningAccount: Account<IHasVaultAddress> | undefined
+    await batch.addEntry({
+      label: 'Account B operation',
+      buildPlan: async (account) => {
+        planningAccount = account
+        return [] as TransactionPlan
+      },
+    })
+
+    expect(sdk.accountService.fetchAccount).toHaveBeenCalledTimes(2)
+    expect(planningAccount).toBe(nextAccount)
+    expect(planningAccount).not.toBe(oldAccount)
+  })
+
   it('publishes per-layer simulated vault state even without an enriched account position', async () => {
     const sdk = createMockSdk()
     const simulatedVault = {
@@ -1204,7 +1277,7 @@ describe('useTxBatch execution errors', () => {
     const prepared = { kind: 'prepared' }
     const plan: TransactionPlan = []
     routeQuery.network = '8453'
-    eulerTxMocks.estimateGasForPlan.mockResolvedValue(undefined)
+    eulerTxMocks.estimateGasForPreparedPlan.mockResolvedValue(undefined)
     eulerTxMocks.prepareTransactionPlan.mockResolvedValue(prepared)
     eulerTxMocks.executePreparedPlan.mockResolvedValue(undefined)
 
@@ -1215,7 +1288,11 @@ describe('useTxBatch execution errors', () => {
     })
     await batch.executeBatch()
 
-    expect(eulerTxMocks.executePreparedPlan).toHaveBeenCalledWith(prepared)
+    expect(eulerTxMocks.estimateGasForPreparedPlan).toHaveBeenCalledWith(prepared)
+    expect(eulerTxMocks.executePreparedPlan).toHaveBeenCalledWith(prepared, {
+      beforeBroadcast: expect.any(Function),
+      onBroadcast: expect.any(Function),
+    })
     expect(scheduleExternalMigrationRefreshes).toHaveBeenCalledTimes(1)
     expect(batch.entryCount.value).toBe(0)
     expect(routerReplace).toHaveBeenCalledWith({
@@ -1255,7 +1332,7 @@ describe('useTxBatch execution errors', () => {
     const migrationPreviewPlan = singleOpPlan('migration-preview')
     const migrationExecutionPlan = singleOpPlan('migration-execution')
     let executionAccount: Account<IHasVaultAddress> | undefined
-    eulerTxMocks.estimateGasForPlan.mockResolvedValue(undefined)
+    eulerTxMocks.estimateGasForPreparedPlan.mockResolvedValue(undefined)
     eulerTxMocks.prepareTransactionPlan.mockResolvedValue(prepared)
     eulerTxMocks.executePreparedPlan.mockResolvedValue(undefined)
 
@@ -1302,7 +1379,13 @@ describe('useTxBatch execution prerequisites', () => {
     await batch.addEntry({
       label: 'Migrate Aave position',
       buildPlan: async () => [] as TransactionPlan,
-      buildExecutionPrerequisites: async () => prerequisites,
+      bundleExecutionCeremony: true,
+      buildExecutionCeremony: async () => ({
+        plan: [] as TransactionPlan,
+        prerequisites,
+        grantSteps: [],
+        revokeSteps: [],
+      }),
       refreshExternalMigrationPositions: true,
     })
   }
@@ -1332,21 +1415,452 @@ describe('useTxBatch execution prerequisites', () => {
     batch.addEntry({
       label: 'Migrate Aave position',
       buildPlan: async () => singleOpBundledPlan,
-      buildExecutionPrerequisites: async () => ({
-        preTxs: [grantTx],
-        walletContext: grantWalletContext,
-        postTxs: [revokeTx],
-        postTxsByPreTx: [revokeTx],
-      }),
-      buildBundledExecution: async () => ({
+      bundleExecutionCeremony: true,
+      buildExecutionCeremony: async () => ({
         plan: singleOpBundledPlan,
-        grants: [grantTx],
-        revokes: [revokeTx],
+        prerequisites: {
+          preTxs: [grantTx],
+          walletContext: grantWalletContext,
+          postTxs: [revokeTx],
+          postTxsByPreTx: [revokeTx],
+        },
         grantSteps: [bundledGrantStep],
         revokeSteps: [bundledRevokeStep],
       }),
       refreshExternalMigrationPositions: true,
     })
+
+  it('resolves an authorization-bearing entry once for plan, calls, and review rows', async () => {
+    const sdk = createMockSdk()
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    isSafeWalletRef.value = false
+    const prepared = { kind: 'prepared', plan: singleOpBundledPlan, chainId: 1, account: owner }
+    eulerTxMocks.prepareTransactionPlan.mockResolvedValue(prepared)
+    const buildExecutionCeremony = vi.fn(async () => ({
+      plan: singleOpBundledPlan,
+      prerequisites: {
+        preTxs: [grantTx],
+        walletContext: grantWalletContext,
+        postTxs: [revokeTx],
+        postTxsByPreTx: [revokeTx],
+      },
+      grantSteps: [bundledGrantStep],
+      revokeSteps: [bundledRevokeStep],
+    }))
+
+    const batch = useTxBatch()
+    await batch.addEntry({
+      label: 'Migrate Aave position',
+      buildPlan: async () => singleOpBundledPlan,
+      bundleExecutionCeremony: true,
+      buildExecutionCeremony,
+    })
+    const ceremony = await batch.prepareBatchExecution()
+    const entryId = batch.entries.value[0]!.id
+
+    expect(buildExecutionCeremony).toHaveBeenCalledTimes(1)
+    expect(ceremony.prepared).toBe(prepared)
+    expect(ceremony.grants).toEqual([grantTx])
+    expect(ceremony.revokes).toEqual([revokeTx])
+    expect(ceremony.reviewByEntryId[entryId]).toEqual({
+      plan: singleOpBundledPlan,
+      grantSteps: [{ ...bundledGrantStep, isSeparateTx: true }],
+      revokeSteps: [{ ...bundledRevokeStep, isSeparateTx: true }],
+    })
+  })
+
+  it('reviews placeholder migration signatures and requests the real signatures only after confirmation', async () => {
+    const sdk = createMockSdk()
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    const signedAuthorization = `0x${'11'.repeat(65)}` as Hex
+    const buildSignaturePlan = (authorization: Hex) => [{
+      type: 'evcBatch',
+      items: [{
+        type: 'operation',
+        name: 'migration-authorization',
+        items: [{
+          targetContract: vault,
+          onBehalfOfAccount: owner,
+          value: 0n,
+          data: `0x1234${authorization.slice(2)}` as Hex,
+        }],
+      }],
+    }] as unknown as TransactionPlan
+    const placeholderPlan = buildSignaturePlan(PLACEHOLDER_MIGRATION_AUTHORIZATION_SIGNATURE)
+    const signedPlan = buildSignaturePlan(signedAuthorization)
+    const signatureStep = { index: 1, label: 'Sign migration authorization', isSeparateTx: false }
+    const requestWalletSignature = vi.fn()
+    const resolveExecutionPlan = vi.fn(async (beforeWalletAction: () => void) => {
+      beforeWalletAction()
+      requestWalletSignature()
+      return {
+        plan: signedPlan,
+        signatureSubstitutions: [{
+          placeholder: PLACEHOLDER_MIGRATION_AUTHORIZATION_SIGNATURE,
+          signature: signedAuthorization,
+        }],
+      }
+    })
+    eulerTxMocks.prepareTransactionPlan.mockImplementation(async plan => ({ plan, chainId: 1, account: owner }))
+    eulerTxMocks.estimateGasForPreparedPlan.mockResolvedValue(undefined)
+    eulerTxMocks.executePreparedPlan.mockResolvedValue(undefined)
+
+    const batch = useTxBatch()
+    await batch.addEntry({
+      label: 'Signature migration',
+      buildPlan: async () => placeholderPlan,
+      buildExecutionCeremony: async () => ({
+        plan: placeholderPlan,
+        resolveExecutionPlan,
+        usesPlaceholderSignatures: true,
+        grantSteps: [signatureStep],
+        revokeSteps: [],
+      }),
+      requiresPlanningAccount: false,
+    })
+    await vi.waitFor(() => expect(batch.layers.value).toHaveLength(2))
+
+    const ceremony = await batch.prepareBatchExecution()
+    const entryId = batch.entries.value[0]!.id
+
+    expect(requestWalletSignature).not.toHaveBeenCalled()
+    expect(resolveExecutionPlan).not.toHaveBeenCalled()
+    expect(ceremony.usesPlaceholderSignatures).toBe(true)
+    expect(ceremony.reviewByEntryId[entryId]).toEqual({
+      plan: placeholderPlan,
+      grantSteps: [signatureStep],
+      revokeSteps: [],
+    })
+
+    await batch.executeBatch(undefined, ceremony)
+
+    expect(requestWalletSignature).toHaveBeenCalledTimes(1)
+    expect(resolveExecutionPlan).toHaveBeenCalledTimes(1)
+    expect(eulerTxMocks.prepareTransactionPlan).toHaveBeenNthCalledWith(1, placeholderPlan)
+    expect(eulerTxMocks.prepareTransactionPlan).toHaveBeenNthCalledWith(2, signedPlan)
+    expect(eulerTxMocks.executePreparedPlan).toHaveBeenCalledWith(
+      expect.objectContaining({ plan: signedPlan }),
+      { beforeBroadcast: expect.any(Function), onBroadcast: expect.any(Function) },
+    )
+  })
+
+  it('rejects a confirm-time migration plan that changes beyond reviewed signature bytes', async () => {
+    const sdk = createMockSdk()
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    const signedAuthorization = `0x${'22'.repeat(65)}` as Hex
+    const placeholderPlan = [{
+      type: 'evcBatch',
+      items: [{
+        targetContract: vault,
+        onBehalfOfAccount: owner,
+        value: 0n,
+        data: `0x1234${PLACEHOLDER_MIGRATION_AUTHORIZATION_SIGNATURE.slice(2)}` as Hex,
+      }],
+    }] as unknown as TransactionPlan
+    const changedPlan = [{
+      type: 'evcBatch',
+      items: [{
+        targetContract: targetVault,
+        onBehalfOfAccount: owner,
+        value: 1n,
+        data: `0x1234${signedAuthorization.slice(2)}` as Hex,
+      }],
+    }] as unknown as TransactionPlan
+    eulerTxMocks.prepareTransactionPlan.mockImplementation(async plan => ({ plan, chainId: 1, account: owner }))
+
+    const batch = useTxBatch()
+    await batch.addEntry({
+      label: 'Signature migration',
+      buildPlan: async () => placeholderPlan,
+      buildExecutionCeremony: async () => ({
+        plan: placeholderPlan,
+        resolveExecutionPlan: async () => ({
+          plan: changedPlan,
+          signatureSubstitutions: [{
+            placeholder: PLACEHOLDER_MIGRATION_AUTHORIZATION_SIGNATURE,
+            signature: signedAuthorization,
+          }],
+        }),
+        usesPlaceholderSignatures: true,
+        grantSteps: [],
+        revokeSteps: [],
+      }),
+      requiresPlanningAccount: false,
+    })
+    await vi.waitFor(() => expect(batch.layers.value).toHaveLength(2))
+    const ceremony = await batch.prepareBatchExecution()
+
+    await batch.executeBatch(undefined, ceremony)
+
+    expect(eulerTxMocks.executePreparedPlan).not.toHaveBeenCalled()
+    expect(eulerTxMocks.executePreparedPlanWithPlainCalls).not.toHaveBeenCalled()
+    expect(batch.execError.value).toContain('transaction plan changed after review')
+  })
+
+  it('requires resolved wallet classification and invalidates review on connector changes', async () => {
+    const sdk = createMockSdk()
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    eulerTxMocks.prepareTransactionPlan.mockResolvedValue({ kind: 'prepared' })
+
+    const batch = useTxBatch()
+    await addBundledMigrationEntry(batch)
+    isSafeWalletResolvedRef.value = false
+    await nextTick()
+    await expect(batch.prepareBatchExecution()).rejects.toThrow('Wallet type is still loading')
+
+    isSafeWalletResolvedRef.value = true
+    await nextTick()
+    const ceremony = await batch.prepareBatchExecution()
+    expect(batch.isBatchExecutionCurrent(ceremony)).toBe(true)
+
+    walletConnectorRef.value = { id: 'safe', uid: 'safe:2' }
+    expect(batch.isBatchExecutionCurrent(ceremony)).toBe(false)
+    await batch.executeBatch(undefined, ceremony)
+    expect(eulerTxMocks.executePreparedPlan).not.toHaveBeenCalled()
+    expect(eulerTxMocks.executePreparedPlanWithPlainCalls).not.toHaveBeenCalled()
+  })
+
+  it('rechecks standard ceremony freshness at the helper broadcast boundary', async () => {
+    const sdk = createMockSdk()
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    const prepared = { kind: 'prepared', plan: singleOpBundledPlan, chainId: 1, account: owner }
+    eulerTxMocks.prepareTransactionPlan.mockResolvedValue(prepared)
+    eulerTxMocks.estimateGasForPreparedPlan.mockResolvedValue(undefined)
+    let releaseHelper!: () => void
+    const helperGate = new Promise<void>((resolve) => {
+      releaseHelper = resolve
+    })
+    let broadcasted = false
+    eulerTxMocks.executePreparedPlan.mockImplementation(async (_prepared, options) => {
+      await helperGate
+      options.beforeBroadcast()
+      broadcasted = true
+      return { receipts: [] }
+    })
+
+    const batch = useTxBatch()
+    await batch.addEntry({
+      label: 'Standard operation',
+      buildPlan: async () => singleOpBundledPlan,
+      requiresPlanningAccount: false,
+    })
+    await vi.waitFor(() => expect(batch.layers.value).toHaveLength(2))
+    const ceremony = await batch.prepareBatchExecution()
+    const execution = batch.executeBatch(undefined, ceremony)
+    await vi.waitFor(() => expect(eulerTxMocks.executePreparedPlan).toHaveBeenCalledTimes(1))
+
+    batch.clearBatch()
+    releaseHelper()
+    await execution
+
+    expect(broadcasted).toBe(false)
+    expect(batch.execError.value).toBeUndefined()
+  })
+
+  it('rechecks prerequisite freshness at the helper broadcast boundary', async () => {
+    const sdk = createMockSdk()
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    const prepared = { kind: 'prepared', plan: singleOpBundledPlan, chainId: 1, account: owner }
+    eulerTxMocks.prepareTransactionPlan.mockResolvedValue(prepared)
+    eulerTxMocks.estimateGasForPreparedPlan.mockResolvedValue(undefined)
+    let releaseHelper!: () => void
+    const helperGate = new Promise<void>((resolve) => {
+      releaseHelper = resolve
+    })
+    let broadcasted = false
+    eulerTxMocks.sendPlainTransactions.mockImplementation(async (_txs, options) => {
+      await helperGate
+      options?.beforeBroadcast?.()
+      broadcasted = true
+      return []
+    })
+
+    const batch = useTxBatch()
+    await addBundledMigrationEntry(batch)
+    const ceremony = await batch.prepareBatchExecution()
+    const execution = batch.executeBatch(undefined, ceremony)
+    await vi.waitFor(() => expect(eulerTxMocks.sendPlainTransactions).toHaveBeenCalledTimes(1))
+
+    batch.clearBatch()
+    releaseHelper()
+    await execution
+
+    expect(broadcasted).toBe(false)
+    expect(eulerTxMocks.executePreparedPlan).not.toHaveBeenCalled()
+    expect(batch.execError.value).toBeUndefined()
+  })
+
+  it.each([
+    ['successful', undefined],
+    ['failed', new Error('old wallet execution failed')],
+  ])('does not let a late %s execution completion mutate a successor wallet cart', async (_outcome, completionError) => {
+    const sdk = createMockSdk()
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    const prepared = { kind: 'prepared', plan: singleOpBundledPlan, chainId: 1, account: owner }
+    eulerTxMocks.prepareTransactionPlan.mockResolvedValue(prepared)
+    eulerTxMocks.estimateGasForPreparedPlan.mockResolvedValue(undefined)
+    let releaseCompletion!: () => void
+    const completionGate = new Promise<void>((resolve) => {
+      releaseCompletion = resolve
+    })
+    eulerTxMocks.executePreparedPlan.mockImplementation(async (_prepared, options) => {
+      options.beforeBroadcast()
+      await completionGate
+      if (completionError) throw completionError
+      return { receipts: [] }
+    })
+
+    const batch = useTxBatch()
+    await batch.addEntry({
+      label: 'Old wallet operation',
+      buildPlan: async () => singleOpBundledPlan,
+      requiresPlanningAccount: false,
+    })
+    await vi.waitFor(() => expect(batch.layers.value).toHaveLength(2))
+    const ceremony = await batch.prepareBatchExecution()
+    const execution = batch.executeBatch(undefined, ceremony)
+    await vi.waitFor(() => expect(eulerTxMocks.executePreparedPlan).toHaveBeenCalledTimes(1))
+
+    const successor = getAddress('0x2000000000000000000000000000000000000000')
+    effectiveAddressRef.value = successor
+    walletAddressRef.value = successor
+    await nextTick()
+    await batch.addEntry({
+      label: 'Successor wallet operation',
+      buildPlan: async () => singleOpBundledPlan,
+      requiresPlanningAccount: false,
+    })
+    expect(batch.entries.value.map(entry => entry.label)).toEqual(['Successor wallet operation'])
+
+    releaseCompletion()
+    await execution
+
+    expect(batch.entries.value.map(entry => entry.label)).toEqual(['Successor wallet operation'])
+    expect(batch.execError.value).toBeUndefined()
+  })
+
+  it('retires executed entries but keeps a same-wallet entry added during the broadcast', async () => {
+    const sdk = createMockSdk()
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    eulerTxMocks.prepareTransactionPlan.mockImplementation(async plan => ({ plan, chainId: 1, account: owner }))
+    eulerTxMocks.estimateGasForPreparedPlan.mockResolvedValue(undefined)
+    let releaseCompletion!: () => void
+    const completionGate = new Promise<void>((resolve) => {
+      releaseCompletion = resolve
+    })
+    eulerTxMocks.executePreparedPlan.mockImplementation(async (_prepared, options) => {
+      options.beforeBroadcast()
+      await completionGate
+      return { receipts: [] }
+    })
+
+    const batch = useTxBatch()
+    await batch.addEntry({
+      label: 'Executed operation',
+      buildPlan: async () => singleOpBundledPlan,
+      requiresPlanningAccount: false,
+    })
+    await vi.waitFor(() => expect(batch.layers.value).toHaveLength(2))
+    const executedId = batch.entries.value[0]!.id
+    const ceremony = await batch.prepareBatchExecution()
+    const execution = batch.executeBatch(undefined, ceremony)
+    await vi.waitFor(() => expect(eulerTxMocks.executePreparedPlan).toHaveBeenCalledTimes(1))
+
+    // Same wallet, cart edited while the broadcast is in flight: the ceremony
+    // goes stale, but the executed entry still lands on-chain.
+    await batch.addEntry({
+      label: 'Added during broadcast',
+      buildPlan: async () => singleOpBundledPlan,
+      requiresPlanningAccount: false,
+    })
+    expect(batch.entries.value.map(entry => entry.label)).toEqual(['Executed operation', 'Added during broadcast'])
+
+    releaseCompletion()
+    await execution
+
+    // Only the executed entry retires — leaving it queued would re-execute it
+    // on the next send; clearing everything would discard the new entry.
+    expect(batch.entries.value.map(entry => entry.label)).toEqual(['Added during broadcast'])
+    expect(batch.entries.value.some(entry => entry.id === executedId)).toBe(false)
+    expect(batch.execError.value).toBeUndefined()
+  })
+
+  it('retires executed entries after a stale safe-bundled proposal lands', async () => {
+    const sdk = createMockSdk()
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    isSafeWalletRef.value = true
+    eulerTxMocks.prepareTransactionPlan.mockImplementation(async plan => ({ plan, chainId: 1, account: owner }))
+    let releaseCompletion!: () => void
+    const completionGate = new Promise<void>((resolve) => {
+      releaseCompletion = resolve
+    })
+    eulerTxMocks.executePreparedPlanWithPlainCalls.mockImplementation(async (_prepared, _wrappers, options) => {
+      options?.beforeBroadcast?.()
+      await completionGate
+      return { receipts: [] }
+    })
+
+    const batch = useTxBatch()
+    await addBundledMigrationEntry(batch)
+    const executedId = batch.entries.value[0]!.id
+    const ceremony = await batch.prepareBatchExecution()
+    const execution = batch.executeBatch(undefined, ceremony)
+    await vi.waitFor(() => expect(eulerTxMocks.executePreparedPlanWithPlainCalls).toHaveBeenCalledTimes(1))
+
+    await batch.addEntry({
+      label: 'Added during proposal',
+      buildPlan: async () => singleOpBundledPlan,
+      requiresPlanningAccount: false,
+    })
+    expect(batch.entries.value).toHaveLength(2)
+
+    releaseCompletion()
+    await execution
+
+    expect(batch.entries.value.map(entry => entry.label)).toEqual(['Added during proposal'])
+    expect(batch.entries.value.some(entry => entry.id === executedId)).toBe(false)
+    expect(batch.execError.value).toBeUndefined()
+  })
+
+  it('does not publish a decoded execution error after the wallet context changes', async () => {
+    const sdk = createMockSdk()
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    const prepared = { kind: 'prepared', plan: singleOpBundledPlan, chainId: 1, account: owner }
+    eulerTxMocks.prepareTransactionPlan.mockResolvedValue(prepared)
+    eulerTxMocks.estimateGasForPreparedPlan.mockResolvedValue(undefined)
+    eulerTxMocks.executePreparedPlan.mockRejectedValue(new Error('old wallet execution failed'))
+    let resolveDecodedError!: (message: string) => void
+    txErrorMocks.getTxErrorMessage.mockReturnValue(new Promise<string>((resolve) => {
+      resolveDecodedError = resolve
+    }))
+
+    const batch = useTxBatch()
+    await batch.addEntry({
+      label: 'Old wallet operation',
+      buildPlan: async () => singleOpBundledPlan,
+      requiresPlanningAccount: false,
+    })
+    await vi.waitFor(() => expect(batch.layers.value).toHaveLength(2))
+    const ceremony = await batch.prepareBatchExecution()
+    const execution = batch.executeBatch(undefined, ceremony)
+    await vi.waitFor(() => expect(txErrorMocks.getTxErrorMessage).toHaveBeenCalledTimes(1))
+
+    const successor = getAddress('0x2000000000000000000000000000000000000000')
+    effectiveAddressRef.value = successor
+    walletAddressRef.value = successor
+    await nextTick()
+    await batch.addEntry({
+      label: 'Successor wallet operation',
+      buildPlan: async () => singleOpBundledPlan,
+      requiresPlanningAccount: false,
+    })
+
+    resolveDecodedError('decoded old-wallet revert')
+    await execution
+
+    expect(batch.entries.value.map(entry => entry.label)).toEqual(['Successor wallet operation'])
+    expect(batch.execError.value).toBeUndefined()
+  })
 
   it('bundles grants + batch + revokes into one safe proposal', async () => {
     const sdk = createMockSdk()
@@ -1358,22 +1872,623 @@ describe('useTxBatch execution prerequisites', () => {
 
     const batch = useTxBatch()
     await addBundledMigrationEntry(batch)
-    // The review modal latches the ceremony at open; execution consumes it.
-    await batch.prepareBundledExecution()
-    await batch.executeBatch()
+    const ceremony = await batch.prepareBundledExecution()
+    await batch.executeBatch(undefined, ceremony ?? undefined)
 
     // Grants ride in the proposal — no standalone broadcasts, no unwind
     // bookkeeping, no standalone gas estimate against unmined grants.
     expect(eulerTxMocks.sendPlainTransactions).not.toHaveBeenCalled()
-    expect(eulerTxMocks.estimateGasForPlan).not.toHaveBeenCalled()
+    expect(eulerTxMocks.estimateGasForPreparedPlan).not.toHaveBeenCalled()
     expect(eulerTxMocks.executePreparedPlanWithPlainCalls).toHaveBeenCalledWith(prepared, {
       before: [grantTx],
       after: [revokeTx],
-    }, { allowSingleCall: true })
+    }, {
+      allowSingleCall: true,
+      beforeBroadcast: expect.any(Function),
+      onBroadcast: expect.any(Function),
+    })
     expect(eulerTxMocks.executePreparedPlan).not.toHaveBeenCalled()
     // Revokes rode in the proposal — nothing standalone to send afterwards.
     expect(migrationFlowMocks.revokeAfterSuccess).not.toHaveBeenCalled()
     expect(batch.entryCount.value).toBe(0)
+  })
+
+  it('deduplicates overlapping review preparations for one cart generation', async () => {
+    const sdk = createMockSdk()
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    isSafeWalletRef.value = true
+    eulerTxMocks.prepareTransactionPlan.mockResolvedValue({ kind: 'prepared' })
+    let resolveBundled!: (value: {
+      plan: TransactionPlan
+      prerequisites?: {
+        preTxs: typeof grantTx[]
+        walletContext: WalletExecutionContext
+        postTxs: typeof revokeTx[]
+        postTxsByPreTx: typeof revokeTx[]
+      }
+      grantSteps: typeof bundledGrantStep[]
+      revokeSteps: typeof bundledRevokeStep[]
+    }) => void
+    const bundledResult = new Promise<Parameters<typeof resolveBundled>[0]>((resolve) => {
+      resolveBundled = resolve
+    })
+    const buildExecutionCeremony = vi.fn(() => bundledResult)
+
+    const batch = useTxBatch()
+    await batch.addEntry({
+      label: 'Migrate Aave position',
+      buildPlan: async () => singleOpBundledPlan,
+      bundleExecutionCeremony: true,
+      buildExecutionCeremony,
+    })
+
+    const preparationA = batch.prepareBundledExecution()
+    const preparationB = batch.prepareBundledExecution()
+    await vi.waitFor(() => expect(buildExecutionCeremony).toHaveBeenCalledTimes(1))
+    resolveBundled({
+      plan: singleOpBundledPlan,
+      prerequisites: {
+        preTxs: [grantTx],
+        walletContext: grantWalletContext,
+        postTxs: [revokeTx],
+        postTxsByPreTx: [revokeTx],
+      },
+      grantSteps: [bundledGrantStep],
+      revokeSteps: [bundledRevokeStep],
+    })
+
+    const [ceremonyA, ceremonyB] = await Promise.all([preparationA, preparationB])
+    const ceremonyC = await batch.prepareBundledExecution()
+    expect(ceremonyA).toBe(ceremonyB)
+    expect(ceremonyC).toBe(ceremonyA)
+    expect(Object.isFrozen(ceremonyA)).toBe(true)
+    expect(Object.isFrozen(ceremonyA?.grants)).toBe(true)
+  })
+
+  it('invalidates the current ceremony while another entry is building', async () => {
+    const sdk = createMockSdk()
+    sdk.executionService.simulateTransactionPlan.mockImplementation(async (...args: unknown[]) => ({
+      simulatedAccounts: Array.from(
+        { length: countPlanOperations(args[2] as TransactionPlan) },
+        (_, index) => accountWithPosition(subAccount, subAccount, BigInt(index + 2)),
+      ),
+      simulatedWalletBalances: [],
+      simulatedVaults: [],
+      failedBatchItems: [],
+      insufficientWalletAssets: [],
+    }))
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    isSafeWalletRef.value = true
+    eulerTxMocks.prepareTransactionPlan.mockImplementation(async plan => ({ plan, chainId: 1, account: owner }))
+    eulerTxMocks.executePreparedPlanWithPlainCalls.mockResolvedValue({ receipts: [] })
+
+    const batch = useTxBatch()
+    await addBundledMigrationEntry(batch)
+    const oldCartCeremony = await batch.prepareBundledExecution()
+    expect(oldCartCeremony?.reviewByEntryId).toHaveProperty(batch.entries.value[0]!.id)
+    expect(Object.keys(oldCartCeremony?.reviewByEntryId ?? {})).toHaveLength(1)
+
+    let resolveSecondPlan!: (plan: TransactionPlan) => void
+    const secondPlan = new Promise<TransactionPlan>((resolve) => {
+      resolveSecondPlan = resolve
+    })
+    const buildSecondPlan = vi.fn(() => secondPlan)
+    const pendingAdd = batch.addEntry({
+      label: 'Second migration',
+      buildPlan: buildSecondPlan,
+      bundleExecutionCeremony: true,
+      buildExecutionCeremony: async () => ({
+        plan: singleOpBundledPlan,
+        grantSteps: [],
+        revokeSteps: [],
+      }),
+    })
+    await vi.waitFor(() => expect(buildSecondPlan).toHaveBeenCalledTimes(1))
+
+    expect(batch.isBundledExecutionCurrent(oldCartCeremony!)).toBe(false)
+    await expect(batch.prepareBundledExecution()).rejects.toThrow('still being added')
+
+    resolveSecondPlan(singleOpBundledPlan)
+    await pendingAdd
+    await vi.waitFor(() => expect(batch.layers.value).toHaveLength(3))
+
+    expect(batch.entryCount.value).toBe(2)
+    expect(batch.isBundledExecutionCurrent(oldCartCeremony!)).toBe(false)
+    await batch.executeBatch(undefined, oldCartCeremony!)
+    expect(eulerTxMocks.executePreparedPlanWithPlainCalls).not.toHaveBeenCalled()
+    expect(batch.execError.value).toBeUndefined()
+  })
+
+  it('keeps review unavailable until every queued add settles', async () => {
+    const sdk = createMockSdk()
+    sdk.executionService.simulateTransactionPlan.mockImplementation(async (...args: unknown[]) => ({
+      simulatedAccounts: Array.from(
+        { length: countPlanOperations(args[2] as TransactionPlan) },
+        (_, index) => accountWithPosition(subAccount, subAccount, BigInt(index + 2)),
+      ),
+      simulatedWalletBalances: [],
+      simulatedVaults: [],
+      failedBatchItems: [],
+      insufficientWalletAssets: [],
+    }))
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    isSafeWalletRef.value = true
+
+    let resolveFirstPlan!: (plan: TransactionPlan) => void
+    let resolveSecondPlan!: (plan: TransactionPlan) => void
+    const firstPlan = new Promise<TransactionPlan>((resolve) => {
+      resolveFirstPlan = resolve
+    })
+    const secondPlan = new Promise<TransactionPlan>((resolve) => {
+      resolveSecondPlan = resolve
+    })
+    const buildFirstPlan = vi.fn(() => firstPlan)
+    const buildSecondPlan = vi.fn(() => secondPlan)
+    const bundled = async () => ({
+      plan: singleOpBundledPlan,
+      grantSteps: [],
+      revokeSteps: [],
+    })
+
+    const batch = useTxBatch()
+    const firstAdd = batch.addEntry({
+      label: 'First migration',
+      buildPlan: buildFirstPlan,
+      requiresPlanningAccount: false,
+      bundleExecutionCeremony: true,
+      buildExecutionCeremony: bundled,
+    })
+    await vi.waitFor(() => expect(buildFirstPlan).toHaveBeenCalledTimes(1))
+    const secondAdd = batch.addEntry({
+      label: 'Second migration',
+      buildPlan: buildSecondPlan,
+      requiresPlanningAccount: false,
+      bundleExecutionCeremony: true,
+      buildExecutionCeremony: bundled,
+    })
+
+    resolveFirstPlan(singleOpBundledPlan)
+    await firstAdd
+    await vi.waitFor(() => expect(buildSecondPlan).toHaveBeenCalledTimes(1))
+    await vi.waitFor(() => expect(batch.layers.value).toHaveLength(2))
+
+    expect(batch.entryCount.value).toBe(1)
+    expect(batch.hasPendingAdds.value).toBe(true)
+    expect(batch.canExecuteBatch.value).toBe(false)
+    await expect(batch.prepareBundledExecution()).rejects.toThrow('still being added')
+    await batch.executeBatch()
+    expect(eulerTxMocks.executePreparedPlanWithPlainCalls).not.toHaveBeenCalled()
+    expect(eulerTxMocks.executePreparedPlan).not.toHaveBeenCalled()
+
+    resolveSecondPlan(singleOpBundledPlan)
+    await secondAdd
+    await vi.waitFor(() => expect(batch.layers.value).toHaveLength(3))
+
+    expect(batch.hasPendingAdds.value).toBe(false)
+    const ceremony = await batch.prepareBundledExecution()
+    expect(Object.keys(ceremony?.reviewByEntryId ?? {})).toHaveLength(2)
+  })
+
+  it('does not execute an old ceremony when an add starts during retry restoration', async () => {
+    const sdk = createMockSdk()
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    eulerTxMocks.prepareTransactionPlan.mockImplementation(async plan => ({ plan, chainId: 1, account: owner }))
+    eulerTxMocks.executePreparedPlan.mockResolvedValue(undefined)
+    let releaseRestore!: (value: boolean) => void
+    migrationFlowMocks.restorePendingBeforeRetry.mockImplementation(() => new Promise<boolean>((resolve) => {
+      releaseRestore = resolve
+    }))
+
+    const batch = useTxBatch()
+    await batch.addEntry({
+      label: 'Reviewed operation',
+      buildPlan: async () => singleOpBundledPlan,
+      requiresPlanningAccount: false,
+    })
+    await vi.waitFor(() => expect(batch.layers.value).toHaveLength(2))
+    const ceremony = await batch.prepareBatchExecution()
+    const execution = batch.executeBatch(undefined, ceremony)
+    await vi.waitFor(() => expect(migrationFlowMocks.restorePendingBeforeRetry).toHaveBeenCalledTimes(1))
+
+    let resolvePendingPlan!: (plan: TransactionPlan) => void
+    const pendingPlan = new Promise<TransactionPlan>((resolve) => {
+      resolvePendingPlan = resolve
+    })
+    const pendingAdd = batch.addEntry({
+      label: 'Pending operation',
+      buildPlan: () => pendingPlan,
+      requiresPlanningAccount: false,
+    })
+    await vi.waitFor(() => expect(batch.hasPendingAdds.value).toBe(true))
+    releaseRestore(true)
+    await execution
+
+    expect(eulerTxMocks.executePreparedPlan).not.toHaveBeenCalled()
+    expect(batch.execError.value).toBeUndefined()
+
+    resolvePendingPlan(singleOpBundledPlan)
+    await pendingAdd
+  })
+
+  it('rechecks ceremony freshness after the final gas-estimate await', async () => {
+    const sdk = createMockSdk()
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    eulerTxMocks.prepareTransactionPlan.mockImplementation(async plan => ({ plan, chainId: 1, account: owner }))
+    let releaseEstimate!: () => void
+    eulerTxMocks.estimateGasForPreparedPlan.mockImplementation(() => new Promise<void>((resolve) => {
+      releaseEstimate = resolve
+    }))
+    eulerTxMocks.executePreparedPlan.mockResolvedValue(undefined)
+
+    const batch = useTxBatch()
+    await batch.addEntry({
+      label: 'Reviewed operation',
+      buildPlan: async () => singleOpBundledPlan,
+      requiresPlanningAccount: false,
+    })
+    await vi.waitFor(() => expect(batch.layers.value).toHaveLength(2))
+    const ceremony = await batch.prepareBatchExecution()
+    const execution = batch.executeBatch(undefined, ceremony)
+    await vi.waitFor(() => expect(eulerTxMocks.estimateGasForPreparedPlan).toHaveBeenCalledTimes(1))
+
+    let resolvePendingPlan!: (plan: TransactionPlan) => void
+    const pendingPlan = new Promise<TransactionPlan>((resolve) => {
+      resolvePendingPlan = resolve
+    })
+    const pendingAdd = batch.addEntry({
+      label: 'Pending operation',
+      buildPlan: () => pendingPlan,
+      requiresPlanningAccount: false,
+    })
+    await vi.waitFor(() => expect(batch.hasPendingAdds.value).toBe(true))
+    releaseEstimate()
+    await execution
+
+    expect(eulerTxMocks.executePreparedPlan).not.toHaveBeenCalled()
+    expect(batch.execError.value).toBeUndefined()
+
+    resolvePendingPlan(singleOpBundledPlan)
+    await pendingAdd
+  })
+
+  it.each([
+    ['account', async () => {
+      effectiveAddressRef.value = getAddress('0x2000000000000000000000000000000000000000')
+      await nextTick()
+    }],
+    ['chain', async () => {
+      walletChainIdRef.value = 2
+      await nextTick()
+    }],
+    ['account switch away and back', async () => {
+      effectiveAddressRef.value = getAddress('0x2000000000000000000000000000000000000000')
+      await nextTick()
+      effectiveAddressRef.value = owner
+      await nextTick()
+    }],
+  ])('rejects a plan built across an %s change', async (_label, changeContext) => {
+    let resolvePlan!: (plan: TransactionPlan) => void
+    const deferredPlan = new Promise<TransactionPlan>((resolve) => {
+      resolvePlan = resolve
+    })
+    const buildPlan = vi.fn(() => deferredPlan)
+    const batch = useTxBatch()
+    const pendingAdd = batch.addEntry({
+      label: 'Context-bound operation',
+      buildPlan,
+      requiresPlanningAccount: false,
+    })
+    await vi.waitFor(() => expect(buildPlan).toHaveBeenCalledTimes(1))
+
+    await changeContext()
+    resolvePlan(singleOpBundledPlan)
+
+    await expect(pendingAdd).rejects.toThrow('Wallet or batch changed while adding this operation')
+    expect(batch.entryCount.value).toBe(0)
+    expect(batch.hasPendingAdds.value).toBe(false)
+  })
+
+  it.each(['clear', 'remove'] as const)('rejects a pending plan after a cart %s', async (edit) => {
+    const batch = useTxBatch()
+    await addBundledMigrationEntry(batch)
+
+    let resolvePlan!: (plan: TransactionPlan) => void
+    const deferredPlan = new Promise<TransactionPlan>((resolve) => {
+      resolvePlan = resolve
+    })
+    const buildPlan = vi.fn(() => deferredPlan)
+    const pendingAdd = batch.addEntry({
+      label: 'Pending migration',
+      buildPlan,
+      requiresPlanningAccount: false,
+    })
+    await vi.waitFor(() => expect(buildPlan).toHaveBeenCalledTimes(1))
+
+    if (edit === 'clear') batch.clearBatch()
+    else batch.removeEntry(batch.entries.value[0]!.id)
+    resolvePlan(singleOpBundledPlan)
+
+    await expect(pendingAdd).rejects.toThrow('Wallet or batch changed while adding this operation')
+    expect(batch.entryCount.value).toBe(0)
+    expect(batch.hasPendingAdds.value).toBe(false)
+  })
+
+  it('rejects an older preparation that resolves after a new cart ceremony', async () => {
+    const sdk = createMockSdk()
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    isSafeWalletRef.value = true
+    eulerTxMocks.prepareTransactionPlan.mockImplementation(async plan => ({ plan }))
+    let resolveOld!: (value: {
+      plan: TransactionPlan
+      prerequisites?: {
+        preTxs: typeof grantTx[]
+        walletContext: WalletExecutionContext
+        postTxs: typeof revokeTx[]
+        postTxsByPreTx: typeof revokeTx[]
+      }
+      grantSteps: typeof bundledGrantStep[]
+      revokeSteps: typeof bundledRevokeStep[]
+    }) => void
+    const oldResult = new Promise<Parameters<typeof resolveOld>[0]>((resolve) => {
+      resolveOld = resolve
+    })
+    const buildOld = vi.fn(() => oldResult)
+
+    const batch = useTxBatch()
+    await batch.addEntry({
+      label: 'Old migration',
+      buildPlan: async () => singleOpBundledPlan,
+      bundleExecutionCeremony: true,
+      buildExecutionCeremony: buildOld,
+    })
+    const oldPreparation = batch.prepareBundledExecution()
+    await vi.waitFor(() => expect(buildOld).toHaveBeenCalledTimes(1))
+
+    batch.clearBatch()
+    const newGrant = { to: morphoBlue, data: '0xnewgrant' as Hex }
+    await batch.addEntry({
+      label: 'New migration',
+      buildPlan: async () => singleOpBundledPlan,
+      bundleExecutionCeremony: true,
+      buildExecutionCeremony: async () => ({
+        plan: singleOpBundledPlan,
+        prerequisites: {
+          preTxs: [newGrant],
+          walletContext: grantWalletContext,
+          postTxs: [],
+          postTxsByPreTx: [],
+        },
+        grantSteps: [],
+        revokeSteps: [],
+      }),
+    })
+    const newCeremony = await batch.prepareBundledExecution()
+
+    resolveOld({
+      plan: singleOpBundledPlan,
+      prerequisites: {
+        preTxs: [grantTx],
+        walletContext: grantWalletContext,
+        postTxs: [revokeTx],
+        postTxsByPreTx: [revokeTx],
+      },
+      grantSteps: [bundledGrantStep],
+      revokeSteps: [bundledRevokeStep],
+    })
+
+    await expect(oldPreparation).rejects.toThrow('Batch or wallet changed since review preparation')
+    expect(newCeremony?.grants).toEqual([newGrant])
+    expect(batch.isBundledExecutionCurrent(newCeremony!)).toBe(true)
+  })
+
+  it('rejects preparation that finishes after the account changes', async () => {
+    const sdk = createMockSdk()
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    isSafeWalletRef.value = true
+    eulerTxMocks.prepareTransactionPlan.mockResolvedValue({ kind: 'prepared' })
+    let resolveBundled!: (value: {
+      plan: TransactionPlan
+      prerequisites?: {
+        preTxs: typeof grantTx[]
+        walletContext: WalletExecutionContext
+        postTxs: typeof revokeTx[]
+        postTxsByPreTx: typeof revokeTx[]
+      }
+      grantSteps: typeof bundledGrantStep[]
+      revokeSteps: typeof bundledRevokeStep[]
+    }) => void
+    const bundledResult = new Promise<Parameters<typeof resolveBundled>[0]>((resolve) => {
+      resolveBundled = resolve
+    })
+    const buildExecutionCeremony = vi.fn(() => bundledResult)
+
+    const batch = useTxBatch()
+    await batch.addEntry({
+      label: 'Migrate Aave position',
+      buildPlan: async () => singleOpBundledPlan,
+      bundleExecutionCeremony: true,
+      buildExecutionCeremony,
+    })
+    const preparation = batch.prepareBundledExecution()
+    await vi.waitFor(() => expect(buildExecutionCeremony).toHaveBeenCalledTimes(1))
+
+    const nextOwner = getAddress('0x9000000000000000000000000000000000000009')
+    effectiveAddressRef.value = nextOwner
+    walletAddressRef.value = nextOwner
+    resolveBundled({
+      plan: singleOpBundledPlan,
+      prerequisites: {
+        preTxs: [grantTx],
+        walletContext: grantWalletContext,
+        postTxs: [revokeTx],
+        postTxsByPreTx: [revokeTx],
+      },
+      grantSteps: [bundledGrantStep],
+      revokeSteps: [bundledRevokeStep],
+    })
+
+    await expect(preparation).rejects.toThrow('Batch or wallet changed since review preparation')
+  })
+
+  it.each([
+    ['ordinary Safe', true],
+    ['EOA', false],
+  ])('executes the exact reviewed prepared core for %s batches', async (_label, safeWallet) => {
+    const sdk = createMockSdk()
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    isSafeWalletRef.value = safeWallet
+    const reviewedPlan = [{
+      type: 'evcBatch',
+      items: [{ type: 'operation', name: 'reviewed-standard-core', items: [] }],
+    }] as unknown as TransactionPlan
+    const reviewedPrepared = { kind: 'reviewed', plan: reviewedPlan, chainId: 1, account: owner }
+    eulerTxMocks.prepareTransactionPlan.mockResolvedValue(reviewedPrepared)
+    eulerTxMocks.estimateGasForPreparedPlan.mockResolvedValue(undefined)
+    eulerTxMocks.executePreparedPlan.mockResolvedValue(undefined)
+
+    const batch = useTxBatch()
+    await batch.addEntry({
+      label: 'Standard operation',
+      buildPlan: async () => reviewedPlan,
+      requiresPlanningAccount: false,
+    })
+    await vi.waitFor(() => expect(batch.layers.value).toHaveLength(2))
+
+    const ceremony = await batch.prepareBatchExecution()
+    await batch.executeBatch(undefined, ceremony)
+
+    expect(ceremony.mode).toBe('standard')
+    expect(ceremony.safeWallet).toBe(safeWallet)
+    expect(eulerTxMocks.prepareTransactionPlan).toHaveBeenCalledTimes(1)
+    expect(eulerTxMocks.executePreparedPlan).toHaveBeenCalledWith(reviewedPrepared, {
+      beforeBroadcast: expect.any(Function),
+      onBroadcast: expect.any(Function),
+    })
+  })
+
+  it('uses one prepared core plan for review export and safe execution', async () => {
+    const sdk = createMockSdk()
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    isSafeWalletRef.value = true
+    const previewPlan = [{
+      type: 'evcBatch',
+      items: [{ type: 'operation', name: 'stale-preview', items: [] }],
+    }] as unknown as TransactionPlan
+    const latchedPlan = [{
+      type: 'evcBatch',
+      items: [{ type: 'operation', name: 'fresh-latched-execution', items: [] }],
+    }] as unknown as TransactionPlan
+    const latchedPrepared = { plan: latchedPlan, chainId: 1, account: owner }
+    eulerTxMocks.prepareTransactionPlan.mockResolvedValue(latchedPrepared)
+    eulerTxMocks.executePreparedPlanWithPlainCalls.mockResolvedValue({ receipts: [] })
+
+    const batch = useTxBatch()
+    await batch.addEntry({
+      label: 'Migrate Aave position',
+      buildPlan: async () => previewPlan,
+      bundleExecutionCeremony: true,
+      buildExecutionCeremony: async () => ({
+        plan: latchedPlan,
+        prerequisites: {
+          preTxs: [grantTx],
+          walletContext: grantWalletContext,
+          postTxs: [revokeTx],
+          postTxsByPreTx: [revokeTx],
+        },
+        grantSteps: [bundledGrantStep],
+        revokeSteps: [bundledRevokeStep],
+      }),
+    })
+
+    const ceremony = await batch.prepareBundledExecution()
+    const entryId = batch.entries.value[0]!.id
+    await batch.executeBatch(undefined, ceremony ?? undefined)
+
+    expect(eulerTxMocks.prepareTransactionPlan).toHaveBeenCalledTimes(1)
+    expect(eulerTxMocks.prepareTransactionPlan).toHaveBeenCalledWith(latchedPlan)
+    expect(ceremony?.prepared).toBe(latchedPrepared)
+    expect(ceremony?.reviewByEntryId[entryId]?.plan).toBe(latchedPlan)
+    expect(eulerTxMocks.executePreparedPlanWithPlainCalls).toHaveBeenCalledWith(latchedPrepared, {
+      before: [grantTx],
+      after: [revokeTx],
+    }, {
+      allowSingleCall: true,
+      beforeBroadcast: expect.any(Function),
+      onBroadcast: expect.any(Function),
+    })
+  })
+
+  it('keeps copied and submitted before, prepared plugin/approval/core, after vectors identical', async () => {
+    const sdk = createMockSdk()
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    isSafeWalletRef.value = true
+    const plugin = getAddress('0x2000000000000000000000000000000000000002')
+    const pingAbi = [{
+      type: 'function',
+      name: 'ping',
+      inputs: [],
+      outputs: [],
+      stateMutability: 'payable',
+    }] as const
+    const preparedPlan = [{
+      type: 'contractCall',
+      chainId: 1,
+      to: plugin,
+      abi: pingAbi,
+      functionName: 'ping',
+      args: [],
+      value: 7n,
+    }, {
+      type: 'requiredApproval',
+      token: aToken,
+      owner,
+      spender: vault,
+      amount: 9n,
+      resolved: [{ type: 'approve', token: aToken, data: '0xapprove' as Hex }],
+    }, {
+      type: 'evcBatch',
+      items: [{ targetContract: vault, onBehalfOfAccount: owner, value: 11n, data: '0xcore' as Hex }],
+    }] as unknown as TransactionPlan
+    const prepared = { plan: preparedPlan, chainId: 1, account: owner }
+    const encodingSdk = {
+      deploymentService: {
+        getDeployment: () => ({ addresses: { coreAddrs: { evc: vault } } }),
+      },
+      executionService: { encodeBatch: () => '0xbatch' as Hex },
+    }
+    eulerTxMocks.prepareTransactionPlan.mockResolvedValue(prepared)
+    let submittedVector: ReturnType<typeof buildBatchReviewCalldata> | undefined
+    eulerTxMocks.executePreparedPlanWithPlainCalls.mockImplementation(async (submittedPrepared, wrappers) => {
+      submittedVector = buildBatchReviewCalldata({
+        plan: submittedPrepared.plan,
+        before: wrappers.before,
+        after: wrappers.after,
+        sdk: encodingSdk,
+        chainId: 1,
+      })
+      return { receipts: [] }
+    })
+
+    const batch = useTxBatch()
+    await addBundledMigrationEntry(batch)
+    const ceremony = await batch.prepareBundledExecution()
+    const copiedVector = buildBatchReviewCalldata({
+      plan: ceremony!.prepared.plan,
+      before: ceremony!.grants,
+      after: ceremony!.revokes,
+      sdk: encodingSdk,
+      chainId: 1,
+    })
+    await batch.executeBatch(undefined, ceremony!)
+
+    expect(submittedVector).toEqual(copiedVector)
+    expect(submittedVector?.map(call => call.to)).toEqual([
+      grantTx.to,
+      plugin,
+      aToken,
+      vault,
+      revokeTx.to,
+    ])
   })
 
   it('throws instead of degrading when the safe bundle context is unavailable', async () => {
@@ -1385,15 +2500,16 @@ describe('useTxBatch execution prerequisites', () => {
 
     const batch = useTxBatch()
     await addBundledMigrationEntry(batch)
-    await batch.prepareBundledExecution()
-    await batch.executeBatch()
+    const ceremony = await batch.prepareBundledExecution()
+    await batch.executeBatch(undefined, ceremony ?? undefined)
 
     expect(batch.execError.value).toBeTruthy()
     // Nothing broadcast standalone, nothing to unwind, cart retained.
     expect(eulerTxMocks.sendPlainTransactions).not.toHaveBeenCalled()
-    expect(migrationFlowMocks.revokeAfterAbort).toHaveBeenCalledWith([])
+    expect(migrationFlowMocks.revokeAfterAbort).toHaveBeenCalledWith([], {
+      shouldNotify: expect.any(Function),
+    })
     expect(batch.entryCount.value).toBe(1)
-    batch.latchedBundledExecution.value = null
   })
 
   it('bundles a latched ceremony even when its grants resolved empty', async () => {
@@ -1408,19 +2524,22 @@ describe('useTxBatch execution prerequisites', () => {
     await batch.addEntry({
       label: 'Migrate Aave position',
       buildPlan: async () => singleOpBundledPlan,
-      buildExecutionPrerequisites: async () => undefined,
-      // Grant already live: nothing to wrap — but the reviewed ceremony is
-      // still ONE provider-bound proposal, never a silent executePreparedPlan
-      // whose internals could degrade to sequential sends.
-      buildBundledExecution: async () => ({ plan: singleOpBundledPlan, grants: [], revokes: [], grantSteps: [], revokeSteps: [] }),
+      bundleExecutionCeremony: true,
+      // A ceremony remains one provider-bound proposal even when its
+      // authorization calls are empty.
+      buildExecutionCeremony: async () => ({ plan: singleOpBundledPlan, grantSteps: [], revokeSteps: [] }),
     })
-    await batch.prepareBundledExecution()
-    await batch.executeBatch()
+    const ceremony = await batch.prepareBundledExecution()
+    await batch.executeBatch(undefined, ceremony ?? undefined)
 
     expect(eulerTxMocks.executePreparedPlanWithPlainCalls).toHaveBeenCalledWith(prepared, {
       before: [],
       after: [],
-    }, { allowSingleCall: true })
+    }, {
+      allowSingleCall: true,
+      beforeBroadcast: expect.any(Function),
+      onBroadcast: expect.any(Function),
+    })
     expect(eulerTxMocks.executePreparedPlan).not.toHaveBeenCalled()
   })
 
@@ -1437,11 +2556,11 @@ describe('useTxBatch execution prerequisites', () => {
     // resolution the proposal executes — never the add-time captures, which
     // can be stale by the time the review opens.
     const entryId = batch.entries.value[0]!.id
-    expect(latched?.stepsByEntryId[entryId]).toEqual({
+    expect(latched?.reviewByEntryId[entryId]).toEqual({
+      plan: singleOpBundledPlan,
       grantSteps: [bundledGrantStep],
       revokeSteps: [bundledRevokeStep],
     })
-    batch.latchedBundledExecution.value = null
   })
 
   it('keeps duplicate bundled restoration rows in parity with proposal calls', async () => {
@@ -1466,14 +2585,69 @@ describe('useTxBatch execution prerequisites', () => {
     const latched = await batch.prepareBundledExecution()
 
     expect(latched?.revokes).toEqual([revokeTx, revokeTx])
-    expect(Object.values(latched?.stepsByEntryId ?? {}).flatMap(steps => steps.revokeSteps)).toEqual([
+    expect(Object.values(latched?.reviewByEntryId ?? {}).flatMap(review => review.revokeSteps)).toEqual([
       bundledRevokeStep,
       bundledRevokeStep,
     ])
-    batch.latchedBundledExecution.value = null
   })
 
-  it('throws a re-review error when the wallet stopped being a safe after latching', async () => {
+  it('submits grants in entry order and restorations in exact reverse entry order', async () => {
+    const sdk = createMockSdk()
+    sdk.executionService.simulateTransactionPlan.mockImplementation(async (...args: unknown[]) => ({
+      simulatedAccounts: Array.from(
+        { length: countPlanOperations(args[2] as TransactionPlan) },
+        (_, index) => accountWithPosition(subAccount, subAccount, BigInt(index + 2)),
+      ),
+      simulatedWalletBalances: [],
+      simulatedVaults: [],
+      failedBatchItems: [],
+      insufficientWalletAssets: [],
+    }))
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    isSafeWalletRef.value = true
+    const secondGrant = { to: morphoBlue, data: '0xgrant2' as Hex }
+    const secondRevoke = { to: morphoBlue, data: '0xrevoke2' as Hex }
+    const prepared = { kind: 'prepared', plan: singleOpBundledPlan, chainId: 1, account: owner }
+    eulerTxMocks.prepareTransactionPlan.mockResolvedValue(prepared)
+    eulerTxMocks.executePreparedPlanWithPlainCalls.mockResolvedValue({ receipts: [] })
+
+    const batch = useTxBatch()
+    await addBundledMigrationEntry(batch)
+    await batch.addEntry({
+      label: 'Second migration',
+      buildPlan: async () => singleOpBundledPlan,
+      bundleExecutionCeremony: true,
+      buildExecutionCeremony: async () => ({
+        plan: singleOpBundledPlan,
+        prerequisites: {
+          preTxs: [secondGrant],
+          walletContext: grantWalletContext,
+          postTxs: [secondRevoke],
+          postTxsByPreTx: [secondRevoke],
+        },
+        grantSteps: [],
+        revokeSteps: [],
+      }),
+    })
+    await vi.waitFor(() => expect(batch.layers.value).toHaveLength(3))
+
+    const ceremony = await batch.prepareBundledExecution()
+    expect(ceremony?.grants).toEqual([grantTx, secondGrant])
+    expect(ceremony?.revokes).toEqual([secondRevoke, revokeTx])
+
+    await batch.executeBatch(undefined, ceremony)
+
+    expect(eulerTxMocks.executePreparedPlanWithPlainCalls).toHaveBeenCalledWith(prepared, {
+      before: [grantTx, secondGrant],
+      after: [secondRevoke, revokeTx],
+    }, {
+      allowSingleCall: true,
+      beforeBroadcast: expect.any(Function),
+      onBroadcast: expect.any(Function),
+    })
+  })
+
+  it('rejects the ceremony when the wallet stopped being a safe after review', async () => {
     const sdk = createMockSdk()
     vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
     isSafeWalletRef.value = true
@@ -1481,22 +2655,26 @@ describe('useTxBatch execution prerequisites', () => {
 
     const batch = useTxBatch()
     await addBundledMigrationEntry(batch)
-    await batch.prepareBundledExecution()
+    const ceremony = await batch.prepareBundledExecution()
     // Safe disconnected between review and confirm.
     isSafeWalletRef.value = false
-    await batch.executeBatch()
+    await nextTick()
 
-    expect(batch.execError.value).toBeTruthy()
+    expect(batch.isBundledExecutionCurrent(ceremony!)).toBe(false)
+    await batch.executeBatch(undefined, ceremony ?? undefined)
+
+    expect(batch.execError.value).toBeUndefined()
     expect(eulerTxMocks.executePreparedPlanWithPlainCalls).not.toHaveBeenCalled()
     expect(eulerTxMocks.sendPlainTransactions).not.toHaveBeenCalled()
-    batch.latchedBundledExecution.value = null
   })
 
   it('keeps the sequential ceremony for non-safe wallets', async () => {
     const sdk = createMockSdk()
     vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
     isSafeWalletRef.value = false
-    eulerTxMocks.prepareTransactionPlan.mockResolvedValue({ kind: 'prepared' })
+    const prepared = { kind: 'prepared', plan: singleOpBundledPlan, chainId: 1, account: owner }
+    eulerTxMocks.prepareTransactionPlan.mockResolvedValue(prepared)
+    eulerTxMocks.estimateGasForPreparedPlan.mockResolvedValue(undefined)
     eulerTxMocks.executePreparedPlan.mockResolvedValue(undefined)
     eulerTxMocks.sendPlainTransactions.mockImplementation(async (txs: { data: Hex }[], options?: PlainTxSendOptions) => {
       txs.forEach((_tx, index) => options?.onBroadcast?.(index, grantWalletContext))
@@ -1505,12 +2683,67 @@ describe('useTxBatch execution prerequisites', () => {
 
     const batch = useTxBatch()
     await addBundledMigrationEntry(batch)
-    await batch.prepareBundledExecution()
-    await batch.executeBatch()
+    const ceremony = await batch.prepareBatchExecution()
+    await batch.executeBatch(undefined, ceremony)
 
+    expect(ceremony.mode).toBe('standard')
+    expect(ceremony.grants).toEqual([grantTx])
+    expect(ceremony.revokes).toEqual([revokeTx])
+    expect(eulerTxMocks.prepareTransactionPlan).toHaveBeenCalledTimes(1)
     expect(eulerTxMocks.executePreparedPlanWithPlainCalls).not.toHaveBeenCalled()
-    expect(eulerTxMocks.sendPlainTransactions).toHaveBeenCalled()
-    expect(eulerTxMocks.executePreparedPlan).toHaveBeenCalled()
+    expect(eulerTxMocks.sendPlainTransactions).toHaveBeenCalledWith(
+      [grantTx],
+      expect.objectContaining({ walletContext: grantWalletContext }),
+    )
+    expect(eulerTxMocks.executePreparedPlan).toHaveBeenCalledWith(prepared, {
+      beforeBroadcast: expect.any(Function),
+      onBroadcast: expect.any(Function),
+    })
+  })
+
+  it('keeps duplicate standalone authorization prompts in parity with execution', async () => {
+    const sdk = createMockSdk()
+    sdk.executionService.simulateTransactionPlan.mockImplementation(async (...args: unknown[]) => ({
+      simulatedAccounts: Array.from(
+        { length: countPlanOperations(args[2] as TransactionPlan) },
+        (_, index) => accountWithPosition(subAccount, subAccount, BigInt(index + 2)),
+      ),
+      simulatedWalletBalances: [],
+      simulatedVaults: [],
+      failedBatchItems: [],
+      insufficientWalletAssets: [],
+    }))
+    vi.mocked(getEulerSdkFresh).mockResolvedValue(sdk as never)
+    isSafeWalletRef.value = false
+    const prepared = { kind: 'prepared', plan: singleOpBundledPlan, chainId: 1, account: owner }
+    eulerTxMocks.prepareTransactionPlan.mockResolvedValue(prepared)
+    eulerTxMocks.estimateGasForPreparedPlan.mockResolvedValue(undefined)
+    eulerTxMocks.executePreparedPlan.mockResolvedValue(undefined)
+
+    const batch = useTxBatch()
+    await addBundledMigrationEntry(batch)
+    await addBundledMigrationEntry(batch)
+    await vi.waitFor(() => expect(batch.layers.value).toHaveLength(3))
+    const ceremony = await batch.prepareBatchExecution()
+    const entryIds = batch.entries.value.map(entry => entry.id)
+
+    expect(entryIds).toHaveLength(2)
+    expect(entryIds.map(id => ceremony.reviewByEntryId[id]?.revokeSteps)).toEqual([
+      [{ ...bundledRevokeStep, isSeparateTx: true }],
+      [{ ...bundledRevokeStep, isSeparateTx: true }],
+    ])
+
+    await batch.executeBatch(undefined, ceremony)
+
+    expect(eulerTxMocks.sendPlainTransactions).toHaveBeenCalledTimes(2)
+    expect(eulerTxMocks.sendPlainTransactions).toHaveBeenNthCalledWith(1, [grantTx], expect.any(Object))
+    expect(eulerTxMocks.sendPlainTransactions).toHaveBeenNthCalledWith(2, [grantTx], expect.any(Object))
+    expect(migrationFlowMocks.revokeAfterSuccess).toHaveBeenCalledWith([
+      trackedRevoke(revokeTx),
+      trackedRevoke(revokeTx),
+    ], {
+      shouldNotify: expect.any(Function),
+    })
   })
 
   it('revokes an already-granted entry when a later entry\'s grant is rejected', async () => {
@@ -1554,7 +2787,9 @@ describe('useTxBatch execution prerequisites', () => {
 
     // The first grant is mined and standing. Leaving it would orphan the
     // allowance: a retry sees it already granted, so it registers no revoke.
-    expect(migrationFlowMocks.revokeAfterAbort).toHaveBeenCalledWith([trackedRevoke(revokeTx)])
+    expect(migrationFlowMocks.revokeAfterAbort).toHaveBeenCalledWith([trackedRevoke(revokeTx)], {
+      shouldNotify: expect.any(Function),
+    })
     expect(eulerTxMocks.executePreparedPlan).not.toHaveBeenCalled()
     expect(batch.entryCount.value).toBe(2)
   })
@@ -1573,7 +2808,7 @@ describe('useTxBatch execution prerequisites', () => {
       txs.forEach((_tx, index) => options?.onBroadcast?.(index, grantWalletContext))
       return []
     })
-    eulerTxMocks.estimateGasForPlan.mockImplementation(async () => void calls.push('estimateGasForPlan'))
+    eulerTxMocks.estimateGasForPreparedPlan.mockImplementation(async () => void calls.push('estimateGasForPreparedPlan'))
     eulerTxMocks.prepareTransactionPlan.mockResolvedValue({ kind: 'prepared' })
     eulerTxMocks.executePreparedPlan.mockImplementation(async () => void calls.push('executePreparedPlan'))
     migrationFlowMocks.restorePendingBeforeRetry.mockImplementation(async () => {
@@ -1587,13 +2822,13 @@ describe('useTxBatch execution prerequisites', () => {
     calls.length = 0
     await batch.executeBatch()
 
-    // The grant must be mined before the plan is built: the connector reads the
-    // live allowance to decide whether the batch needs an authorization item.
+    // The exact core is prepared once, then its prerequisite grant is mined
+    // before that reviewed core is estimated and executed.
     expect(calls).toEqual([
       'restorePendingBeforeRetry',
-      'sendPlainTransactions',
       'mergePlans',
-      'estimateGasForPlan',
+      'sendPlainTransactions',
+      'estimateGasForPreparedPlan',
       'executePreparedPlan',
       'revokeAfterSuccess',
     ])
@@ -1604,7 +2839,9 @@ describe('useTxBatch execution prerequisites', () => {
         onBroadcast: expect.any(Function),
       }),
     )
-    expect(migrationFlowMocks.revokeAfterSuccess).toHaveBeenCalledWith([trackedRevoke(revokeTx)])
+    expect(migrationFlowMocks.revokeAfterSuccess).toHaveBeenCalledWith([trackedRevoke(revokeTx)], {
+      shouldNotify: expect.any(Function),
+    })
     expect(migrationFlowMocks.revokeAfterAbort).not.toHaveBeenCalled()
   })
 
@@ -1619,7 +2856,9 @@ describe('useTxBatch execution prerequisites', () => {
     expect(batch.entryCount.value).toBe(1)
     expect(batch.execError.value).toBeDefined()
     // Nothing landed, so there is nothing of ours to revoke.
-    expect(migrationFlowMocks.revokeAfterAbort).toHaveBeenCalledWith([])
+    expect(migrationFlowMocks.revokeAfterAbort).toHaveBeenCalledWith([], {
+      shouldNotify: expect.any(Function),
+    })
   })
 
   it('revokes a broadcast grant when receipt confirmation fails before later grants', async () => {
@@ -1639,7 +2878,9 @@ describe('useTxBatch execution prerequisites', () => {
     })
     await batch.executeBatch()
 
-    expect(migrationFlowMocks.revokeAfterAbort).toHaveBeenCalledWith([trackedRevoke(revokeTx)])
+    expect(migrationFlowMocks.revokeAfterAbort).toHaveBeenCalledWith([trackedRevoke(revokeTx)], {
+      shouldNotify: expect.any(Function),
+    })
     expect(eulerTxMocks.executePreparedPlan).not.toHaveBeenCalled()
     expect(batch.entryCount.value).toBe(1)
   })
@@ -1649,14 +2890,16 @@ describe('useTxBatch execution prerequisites', () => {
     async (kind) => {
       const batch = useTxBatch()
       eulerTxMocks.sendPlainTransactions.mockImplementation(broadcastAllTransactions)
-      eulerTxMocks.estimateGasForPlan.mockResolvedValue(undefined)
+      eulerTxMocks.estimateGasForPreparedPlan.mockResolvedValue(undefined)
       eulerTxMocks.prepareTransactionPlan.mockResolvedValue({ kind: 'prepared' })
       eulerTxMocks.executePreparedPlan.mockRejectedValue(new WalletExecutionContextChangedError(kind))
 
       await addGrantingMigrationEntry(batch)
       await batch.executeBatch()
 
-      expect(migrationFlowMocks.revokeAfterAbort).toHaveBeenCalledWith([trackedRevoke(revokeTx)])
+      expect(migrationFlowMocks.revokeAfterAbort).toHaveBeenCalledWith([trackedRevoke(revokeTx)], {
+        shouldNotify: expect.any(Function),
+      })
       expect(batch.entryCount.value).toBe(1)
     },
   )
@@ -1667,7 +2910,7 @@ describe('useTxBatch execution prerequisites', () => {
       .mockResolvedValueOnce(true)
       .mockResolvedValueOnce(false)
     eulerTxMocks.sendPlainTransactions.mockImplementation(broadcastAllTransactions)
-    eulerTxMocks.estimateGasForPlan.mockResolvedValue(undefined)
+    eulerTxMocks.estimateGasForPreparedPlan.mockResolvedValue(undefined)
     eulerTxMocks.prepareTransactionPlan.mockResolvedValue({ kind: 'prepared' })
     eulerTxMocks.executePreparedPlan.mockRejectedValue(new Error('User rejected the request.'))
 
@@ -1678,13 +2921,15 @@ describe('useTxBatch execution prerequisites', () => {
     expect(migrationFlowMocks.restorePendingBeforeRetry).toHaveBeenCalledTimes(2)
     expect(eulerTxMocks.sendPlainTransactions).toHaveBeenCalledTimes(1)
     expect(eulerTxMocks.executePreparedPlan).toHaveBeenCalledTimes(1)
-    expect(migrationFlowMocks.revokeAfterAbort).toHaveBeenCalledWith([trackedRevoke(revokeTx)])
+    expect(migrationFlowMocks.revokeAfterAbort).toHaveBeenCalledWith([trackedRevoke(revokeTx)], {
+      shouldNotify: expect.any(Function),
+    })
     expect(batch.entryCount.value).toBe(1)
   })
 
   it('sends no transactions when an entry reports no prerequisites', async () => {
     const batch = useTxBatch()
-    eulerTxMocks.estimateGasForPlan.mockResolvedValue(undefined)
+    eulerTxMocks.estimateGasForPreparedPlan.mockResolvedValue(undefined)
     eulerTxMocks.prepareTransactionPlan.mockResolvedValue({ kind: 'prepared' })
     eulerTxMocks.executePreparedPlan.mockResolvedValue(undefined)
 
@@ -1694,14 +2939,16 @@ describe('useTxBatch execution prerequisites', () => {
     await batch.executeBatch()
 
     expect(eulerTxMocks.sendPlainTransactions).not.toHaveBeenCalled()
-    expect(migrationFlowMocks.revokeAfterSuccess).toHaveBeenCalledWith([])
+    expect(migrationFlowMocks.revokeAfterSuccess).toHaveBeenCalledWith([], {
+      shouldNotify: expect.any(Function),
+    })
     expect(batch.entryCount.value).toBe(0)
   })
 
   it('still clears the batch when the revoke fails after a successful execution', async () => {
     const batch = useTxBatch()
     eulerTxMocks.sendPlainTransactions.mockImplementation(broadcastAllTransactions)
-    eulerTxMocks.estimateGasForPlan.mockResolvedValue(undefined)
+    eulerTxMocks.estimateGasForPreparedPlan.mockResolvedValue(undefined)
     eulerTxMocks.prepareTransactionPlan.mockResolvedValue({ kind: 'prepared' })
     eulerTxMocks.executePreparedPlan.mockResolvedValue(undefined)
     // revokeAfterSuccess swallows failures internally; it must never throw.

--- a/tests/pages/safeBundleBroadcastGuardBinding.test.ts
+++ b/tests/pages/safeBundleBroadcastGuardBinding.test.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+// The direct Safe-bundle flows have no component harness, so this pins the
+// call-site binding as source text: the broadcast guard's expected connector
+// key must come from the reviewed preview (captured when the preview was
+// built), never from a snapshot taken inside the confirmation flow — a
+// confirmation-time snapshot runs after awaits the wallet can change under,
+// so a connector swapped during those awaits would become the guard's
+// accepted baseline.
+const FLOWS = [
+  {
+    direction: 'outgoing',
+    path: 'pages/position/[number]/migrate.vue',
+  },
+  {
+    direction: 'inbound',
+    path: 'pages/position/[number]/borrow/swap.vue',
+  },
+] as const
+
+describe('direct Safe-bundle broadcast guard binding', () => {
+  it.each(FLOWS)('$direction: the preview captures the connector key at build time', ({ path }) => {
+    const source = readFileSync(join(process.cwd(), path), 'utf8')
+    expect(source).toContain('connectorContextKey: walletConnectorContextKey(),')
+  })
+
+  it.each(FLOWS)('$direction: the guard validates against the reviewed preview key', ({ path }) => {
+    const source = readFileSync(join(process.cwd(), path), 'utf8')
+    expect(source).toContain('expectedConnectorKey: preview.connectorContextKey,')
+    // The live-state reader stays a thunk for the broadcast-time comparison;
+    // an invoked form here would reintroduce the confirmation-time snapshot.
+    expect(source).not.toContain('expectedConnectorKey: walletConnectorContextKey()')
+  })
+
+  it.each(FLOWS)('$direction: the standard direct flow binds the reviewed-context guard', ({ path }) => {
+    const source = readFileSync(join(process.cwd(), path), 'utf8')
+    // The standard (non-bundled) confirmation must also guard its signature
+    // requests, grant broadcasts, and plan broadcast against the reviewed key.
+    expect(source).toContain('createReviewedWalletContextGuard({')
+  })
+})

--- a/tests/utils/batchReviewCalldata.test.ts
+++ b/tests/utils/batchReviewCalldata.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+import { encodeFunctionData, type Address, type Hex } from 'viem'
+import type { TransactionPlan } from '@eulerxyz/euler-v2-sdk'
+import { buildBatchReviewCalldata } from '~/utils/batchReviewCalldata'
+
+const BEFORE = '0x1000000000000000000000000000000000000001' as Address
+const PLUGIN = '0x2000000000000000000000000000000000000002' as Address
+const TOKEN = '0x3000000000000000000000000000000000000003' as Address
+const EVC = '0x4000000000000000000000000000000000000004' as Address
+const AFTER = '0x5000000000000000000000000000000000000005' as Address
+const ACCOUNT = '0x6000000000000000000000000000000000000006' as Address
+const BATCH_TARGET = '0x7000000000000000000000000000000000000007' as Address
+
+const pingAbi = [{
+  type: 'function',
+  name: 'ping',
+  inputs: [],
+  outputs: [],
+  stateMutability: 'payable',
+}] as const
+
+describe('buildBatchReviewCalldata', () => {
+  it('preserves the exact before, prepared plugin/approval/core, after vector', () => {
+    const pluginData = encodeFunctionData({ abi: pingAbi, functionName: 'ping' })
+    const plan = [{
+      type: 'contractCall',
+      chainId: 1,
+      to: PLUGIN,
+      abi: pingAbi,
+      functionName: 'ping',
+      args: [],
+      value: 7n,
+    }, {
+      type: 'requiredApproval',
+      token: TOKEN,
+      owner: ACCOUNT,
+      spender: BATCH_TARGET,
+      amount: 9n,
+      resolved: [{
+        type: 'approve',
+        token: TOKEN,
+        owner: ACCOUNT,
+        spender: BATCH_TARGET,
+        amount: 9n,
+        data: '0xapprove' as Hex,
+      }],
+    }, {
+      type: 'evcBatch',
+      items: [{
+        targetContract: BATCH_TARGET,
+        onBehalfOfAccount: ACCOUNT,
+        value: 11n,
+        data: '0xcore' as Hex,
+      }],
+    }] as unknown as TransactionPlan
+
+    const calldata = buildBatchReviewCalldata({
+      plan,
+      before: [{ to: BEFORE, data: '0xbefore' as Hex, value: 3n }],
+      after: [{ to: AFTER, data: '0xafter' as Hex }],
+      sdk: {
+        deploymentService: {
+          getDeployment: () => ({ addresses: { coreAddrs: { evc: EVC } } }),
+        },
+        executionService: { encodeBatch: () => '0xbatch' as Hex },
+      },
+      chainId: 1,
+    })
+
+    expect(calldata).toEqual([
+      { to: BEFORE, data: '0xbefore', value: '3' },
+      { to: PLUGIN, data: pluginData, value: '7' },
+      { to: TOKEN, data: '0xapprove', value: '0' },
+      { to: EVC, data: '0xbatch', value: '11' },
+      { to: AFTER, data: '0xafter', value: '0' },
+    ])
+  })
+})

--- a/tests/utils/batchReviewDisplay.test.ts
+++ b/tests/utils/batchReviewDisplay.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import { consolidateRestorationSummaryRows, getAuthorizationStepDisplay, groupRestorationSummaryRows, isBundledReviewEntry } from '~/utils/batchReviewDisplay'
+import type { TransactionPlan } from '@eulerxyz/euler-v2-sdk'
+import { getAuthorizationStepDisplay, getBatchReviewDisplayPlan, groupRestorationSummaryRows, isBundledReviewEntry } from '~/utils/batchReviewDisplay'
 
 describe('getAuthorizationStepDisplay', () => {
   it('describes signature-mode authorization rows as signatures', () => {
@@ -27,6 +28,16 @@ describe('isBundledReviewEntry', () => {
   })
 })
 
+describe('getBatchReviewDisplayPlan', () => {
+  it('uses the ceremony plan for display and disclosure instead of a stale captured preview', () => {
+    const freshCeremonyPlan = [{ type: 'evcBatch', items: [{ name: 'fresh-execution' }] }] as unknown as TransactionPlan
+    const stalePreviewPlan = [{ type: 'evcBatch', items: [{ name: 'stale-preview' }] }] as unknown as TransactionPlan
+    const entryPlan = [{ type: 'evcBatch', items: [{ name: 'entry-plan' }] }] as unknown as TransactionPlan
+
+    expect(getBatchReviewDisplayPlan(freshCeremonyPlan, stalePreviewPlan, entryPlan)).toBe(freshCeremonyPlan)
+  })
+})
+
 describe('groupRestorationSummaryRows', () => {
   it('separates in-proposal restorations from post-execution transactions', () => {
     const bundled = { id: 'bundled', step: { isSeparateTx: false } }
@@ -43,21 +54,5 @@ describe('groupRestorationSummaryRows', () => {
       bundled: [],
       postExecution: [],
     })
-  })
-})
-
-describe('consolidateRestorationSummaryRows', () => {
-  it('keeps every bundled Safe call visible', () => {
-    const first = { id: 'first', step: { isSeparateTx: false, txKey: 'same-transaction' } }
-    const second = { id: 'second', step: { isSeparateTx: false, txKey: 'same-transaction' } }
-
-    expect(consolidateRestorationSummaryRows([first, second])).toEqual([first, second])
-  })
-
-  it('consolidates identical standalone restorations resolved sequentially', () => {
-    const first = { id: 'first', step: { isSeparateTx: true, txKey: 'same-transaction' } }
-    const second = { id: 'second', step: { isSeparateTx: true, txKey: 'same-transaction' } }
-
-    expect(consolidateRestorationSummaryRows([first, second])).toEqual([first])
   })
 })

--- a/tests/utils/migrationCeremonyDeadline.test.ts
+++ b/tests/utils/migrationCeremonyDeadline.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { MigrationAuthorizationRequest } from '@eulerxyz/euler-v2-sdk'
+import {
+  isMigrationCeremonyDeadlineExpired,
+  mintMigrationCeremonyDeadline,
+  pinInboundMigrationCeremonyDeadline,
+} from '~/utils/migrationCeremonyDeadline'
+import { migrationAuthorizationPayloadKey } from '~/utils/migrationAuthorizationTxs'
+
+const NOW_SECONDS = 1_800_000_000
+
+describe('migrationCeremonyDeadline', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(NOW_SECONDS * 1000)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('mints a wall-clock deadline one hour out', () => {
+    expect(mintMigrationCeremonyDeadline()).toBe(BigInt(NOW_SECONDS + 3600))
+  })
+
+  it('pins exactly the collateral quote deadline, ignoring an earlier debt quote expiry', () => {
+    // Regression: clamping to the earliest quote deadline fails the SDK's
+    // exact-equality check against the collateral quote's immutable embedded
+    // verifier data ("SwapVerifier data mismatch").
+    const deadline = pinInboundMigrationCeremonyDeadline({
+      collateralSwapQuote: { verify: { deadline: 2000 } },
+      debtSwapQuote: { verify: { deadline: 1000 } },
+    })
+    expect(deadline).toBe(2000n)
+  })
+
+  it('pins the collateral quote deadline even when later builds would mint fresher ones', () => {
+    const quotes = { collateralSwapQuote: { verify: { deadline: NOW_SECONDS + 120 } } }
+    const first = pinInboundMigrationCeremonyDeadline(quotes)
+    vi.setSystemTime((NOW_SECONDS + 90) * 1000)
+    const second = pinInboundMigrationCeremonyDeadline(quotes)
+    expect(first).toBe(BigInt(NOW_SECONDS + 120))
+    expect(second).toBe(first)
+  })
+
+  it('mints only when no collateral quote governs the verifier', () => {
+    expect(pinInboundMigrationCeremonyDeadline({
+      debtSwapQuote: { verify: { deadline: 1000 } },
+    })).toBe(BigInt(NOW_SECONDS + 3600))
+    expect(pinInboundMigrationCeremonyDeadline({})).toBe(BigInt(NOW_SECONDS + 3600))
+  })
+
+  it('falls back to the SDK sentinel when the collateral quote carries no deadline', () => {
+    expect(pinInboundMigrationCeremonyDeadline({
+      collateralSwapQuote: { verify: {} },
+    })).toBe(0n)
+  })
+
+  it('reports expiry once the deadline is no longer executable', () => {
+    const deadline = mintMigrationCeremonyDeadline()
+    expect(isMigrationCeremonyDeadlineExpired(deadline)).toBe(false)
+    vi.setSystemTime((NOW_SECONDS + 3599) * 1000)
+    expect(isMigrationCeremonyDeadlineExpired(deadline)).toBe(false)
+    vi.setSystemTime((NOW_SECONDS + 3600) * 1000)
+    expect(isMigrationCeremonyDeadlineExpired(deadline)).toBe(true)
+  })
+
+  it('keeps the authorization payload key stable across builds only under a pinned deadline', () => {
+    // Signature-form requests embed the deadline in the typed-data message, so
+    // the review/confirm payload-equality gate can only pass when both builds
+    // received the same pinned deadline. A re-minted deadline changes the key
+    // and would reject every confirmation once the clock advances.
+    const requestWithDeadline = (deadline: bigint): MigrationAuthorizationRequest => ({
+      kind: 'typedData',
+      name: 'morphoAuthorization',
+      owner: '0x1000000000000000000000000000000000000000',
+      chainId: 1,
+      typedData: {
+        domain: { name: 'Morpho', chainId: 1 },
+        types: { Authorization: [{ name: 'deadline', type: 'uint256' }] },
+        primaryType: 'Authorization',
+        message: { deadline },
+      },
+    } as unknown as MigrationAuthorizationRequest)
+
+    const pinned = mintMigrationCeremonyDeadline()
+    const reviewKey = migrationAuthorizationPayloadKey(requestWithDeadline(pinned))
+
+    vi.setSystemTime((NOW_SECONDS + 30) * 1000)
+    expect(migrationAuthorizationPayloadKey(requestWithDeadline(pinned))).toBe(reviewKey)
+    expect(migrationAuthorizationPayloadKey(requestWithDeadline(mintMigrationCeremonyDeadline()))).not.toBe(reviewKey)
+  })
+})

--- a/tests/utils/preparedPlanParity.test.ts
+++ b/tests/utils/preparedPlanParity.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it } from 'vitest'
+import { encodeFunctionData, type Address, type Hex } from 'viem'
+import type { TransactionPlan, TransactionPlanPrepared } from '@eulerxyz/euler-v2-sdk'
+import { assertPreparedPlanSignatureParity } from '~/utils/preparedPlanParity'
+
+const owner = '0x1000000000000000000000000000000000000000' as Address
+const target = '0x2000000000000000000000000000000000000000' as Address
+const otherTarget = '0x3000000000000000000000000000000000000000' as Address
+const placeholder = `0x${'00'.repeat(65)}` as Hex
+const signature = `0x${'11'.repeat(32)}${'22'.repeat(32)}01` as Hex
+const secondSignature = `0x${'33'.repeat(32)}${'44'.repeat(32)}1c` as Hex
+
+const permitAbi = [{
+  type: 'function',
+  name: 'permit',
+  inputs: [
+    { name: 'owner', type: 'address' },
+    { name: 'spender', type: 'address' },
+    { name: 'value', type: 'uint256' },
+    { name: 'deadline', type: 'uint256' },
+    { name: 'v', type: 'uint8' },
+    { name: 'r', type: 'bytes32' },
+    { name: 's', type: 'bytes32' },
+  ],
+  outputs: [],
+  stateMutability: 'nonpayable',
+}] as const
+
+const splitSignature = (authorization: Hex) => {
+  let v = Number.parseInt(authorization.slice(130, 132), 16)
+  if (v < 27) v += 27
+  return {
+    r: authorization.slice(0, 66) as Hex,
+    s: `0x${authorization.slice(66, 130)}` as Hex,
+    v,
+  }
+}
+
+const planWithSignature = (authorization: Hex): TransactionPlan => [{
+  type: 'evcBatch',
+  items: [{
+    type: 'operation',
+    name: 'migration',
+    items: [{
+      targetContract: target,
+      onBehalfOfAccount: owner,
+      value: 7n,
+      data: `0x1234${authorization.slice(2)}abcd` as Hex,
+    }],
+  }],
+}]
+
+// Two structurally identical placeholder sites: only the signature bytes can
+// tell the resolved items apart.
+const planWithTwoSignatures = (first: Hex, second: Hex): TransactionPlan => [{
+  type: 'evcBatch',
+  items: [{
+    type: 'operation',
+    name: 'migration',
+    items: [
+      {
+        targetContract: target,
+        onBehalfOfAccount: owner,
+        value: 7n,
+        data: `0x1234${first.slice(2)}abcd` as Hex,
+      },
+      {
+        targetContract: target,
+        onBehalfOfAccount: owner,
+        value: 7n,
+        data: `0x1234${second.slice(2)}abcd` as Hex,
+      },
+    ],
+  }],
+}]
+
+const planWithAbiSignature = (authorization: Hex): TransactionPlan => {
+  const { r, s, v } = splitSignature(authorization)
+  return [{
+    type: 'evcBatch',
+    items: [{
+      type: 'operation',
+      name: 'aave-migration',
+      items: [{
+        targetContract: target,
+        onBehalfOfAccount: owner,
+        value: 0n,
+        data: encodeFunctionData({
+          abi: permitAbi,
+          functionName: 'permit',
+          args: [owner, otherTarget, 7n, 123n, v, r, s],
+        }),
+      }],
+    }],
+  }]
+}
+
+const prepared = (plan: TransactionPlan): TransactionPlanPrepared => ({
+  __prepared: true,
+  plan,
+  chainId: 1,
+  account: owner,
+  usePermit2: true,
+  unlimitedApproval: false,
+})
+
+const assertParity = (resolvedPlan: TransactionPlan) => assertPreparedPlanSignatureParity({
+  reviewed: prepared(planWithSignature(placeholder)),
+  resolved: prepared(resolvedPlan),
+  substitutions: [{ placeholder, signature }],
+})
+
+describe('assertPreparedPlanSignatureParity', () => {
+  it('accepts exactly one reviewed placeholder-to-signature substitution', () => {
+    expect(() => assertParity(planWithSignature(signature))).not.toThrow()
+  })
+
+  it('accepts the production ABI v/r/s encoding at the reviewed offsets', () => {
+    expect(() => assertPreparedPlanSignatureParity({
+      reviewed: prepared(planWithAbiSignature(placeholder)),
+      resolved: prepared(planWithAbiSignature(signature)),
+      substitutions: [{ placeholder, signature }],
+    })).not.toThrow()
+  })
+
+  it('rejects an unrelated change beside a production ABI v/r/s substitution', () => {
+    const resolved = planWithAbiSignature(signature)
+    const batch = resolved[0] as Extract<TransactionPlan[number], { type: 'evcBatch' }>
+    const operation = batch.items[0]
+    if ('items' in operation) operation.items[0]!.value = 1n
+
+    expect(() => assertPreparedPlanSignatureParity({
+      reviewed: prepared(planWithAbiSignature(placeholder)),
+      resolved: prepared(resolved),
+      substitutions: [{ placeholder, signature }],
+    })).toThrow('transaction plan changed after review')
+  })
+
+  it.each([
+    ['target', () => {
+      const plan = planWithSignature(signature)
+      const operation = plan[0] as Extract<TransactionPlan[number], { type: 'evcBatch' }>
+      const item = operation.items[0]
+      if ('items' in item) item.items[0]!.targetContract = otherTarget
+      return plan
+    }],
+    ['value', () => {
+      const plan = planWithSignature(signature)
+      const operation = plan[0] as Extract<TransactionPlan[number], { type: 'evcBatch' }>
+      const item = operation.items[0]
+      if ('items' in item) item.items[0]!.value = 8n
+      return plan
+    }],
+    ['order', () => {
+      const plan = planWithSignature(signature)
+      const operation = plan[0] as Extract<TransactionPlan[number], { type: 'evcBatch' }>
+      const item = operation.items[0]
+      if ('items' in item) {
+        item.items.push({ ...item.items[0]!, data: '0xbeef' })
+        item.items.reverse()
+      }
+      return plan
+    }],
+    ['approval', () => [{
+      type: 'requiredApproval',
+      token: target,
+      owner,
+      spender: otherTarget,
+      amount: 1n,
+      resolved: [{ type: 'approve', token: target, data: '0x1234' }],
+    }, ...planWithSignature(signature)] as TransactionPlan],
+    ['plugin call', () => [{
+      type: 'contractCall',
+      chainId: 1,
+      to: otherTarget,
+      abi: [],
+      functionName: 'unexpected',
+      args: [],
+      value: 0n,
+    }, ...planWithSignature(signature)] as TransactionPlan],
+  ])('rejects a confirm-time %s change', (_label, mutate) => {
+    expect(() => assertParity(mutate())).toThrow('transaction plan changed after review')
+  })
+
+  it('accepts two ordered substitutions across identical placeholder sites', () => {
+    expect(() => assertPreparedPlanSignatureParity({
+      reviewed: prepared(planWithTwoSignatures(placeholder, placeholder)),
+      resolved: prepared(planWithTwoSignatures(signature, secondSignature)),
+      substitutions: [
+        { placeholder, signature },
+        { placeholder, signature: secondSignature },
+      ],
+    })).not.toThrow()
+  })
+
+  it('rejects signatures transposed between identical placeholder sites', () => {
+    expect(() => assertPreparedPlanSignatureParity({
+      reviewed: prepared(planWithTwoSignatures(placeholder, placeholder)),
+      resolved: prepared(planWithTwoSignatures(secondSignature, signature)),
+      substitutions: [
+        { placeholder, signature },
+        { placeholder, signature: secondSignature },
+      ],
+    })).toThrow('transaction plan changed after review')
+  })
+
+  it('binds substitution order within a single calldata string', () => {
+    const dataWith = (first: Hex, second: Hex): TransactionPlan => [{
+      type: 'evcBatch',
+      items: [{
+        type: 'operation',
+        name: 'migration',
+        items: [{
+          targetContract: target,
+          onBehalfOfAccount: owner,
+          value: 7n,
+          data: `0x${first.slice(2)}${second.slice(2)}` as Hex,
+        }],
+      }],
+    }]
+    const substitutions = [
+      { placeholder, signature },
+      { placeholder, signature: secondSignature },
+    ]
+    expect(() => assertPreparedPlanSignatureParity({
+      reviewed: prepared(dataWith(placeholder, placeholder)),
+      resolved: prepared(dataWith(signature, secondSignature)),
+      substitutions,
+    })).not.toThrow()
+    expect(() => assertPreparedPlanSignatureParity({
+      reviewed: prepared(dataWith(placeholder, placeholder)),
+      resolved: prepared(dataWith(secondSignature, signature)),
+      substitutions,
+    })).toThrow('transaction plan changed after review')
+  })
+
+  it('rejects a missing or extra signature occurrence', () => {
+    expect(() => assertParity(planWithSignature(placeholder))).toThrow('transaction plan changed after review')
+    const duplicated = planWithSignature(signature)
+    const batch = duplicated[0] as Extract<TransactionPlan[number], { type: 'evcBatch' }>
+    const operation = batch.items[0]
+    if ('items' in operation) operation.items.push({ ...operation.items[0]! })
+    expect(() => assertParity(duplicated)).toThrow('transaction plan changed after review')
+  })
+})

--- a/tests/utils/walletExecutionContext.test.ts
+++ b/tests/utils/walletExecutionContext.test.ts
@@ -1,6 +1,6 @@
 import type { Address } from 'viem'
 import { describe, expect, it } from 'vitest'
-import { assertWalletExecutionContext } from '~/utils/walletExecutionContext'
+import { assertWalletExecutionContext, createReviewedWalletContextGuard, createSafeBundleBroadcastGuard } from '~/utils/walletExecutionContext'
 import type { WalletExecutionContextChangedError } from '~/utils/walletExecutionContext'
 
 const OWNER = '0x1111111111111111111111111111111111111111' as Address
@@ -35,6 +35,182 @@ describe('assertWalletExecutionContext', () => {
       currentAccount: OWNER,
       currentChainId: 8453,
     })).toThrow(expect.objectContaining<Partial<WalletExecutionContextChangedError>>({
+      name: 'WalletExecutionContextChangedError',
+      kind: 'chain',
+    }))
+  })
+})
+
+describe('createReviewedWalletContextGuard', () => {
+  const REVIEWED_CONNECTOR_KEY = 'metamask:uid-1'
+  const WALLET_CHANGED = 'Wallet changed since review — please review the migration again.'
+
+  const walletState = () => ({
+    account: OWNER as Address | undefined,
+    chainId: 1 as number | undefined,
+    connectorKey: REVIEWED_CONNECTOR_KEY as string | undefined,
+  })
+
+  const guardFor = (
+    state: ReturnType<typeof walletState>,
+    expectedConnectorKey: string | undefined = REVIEWED_CONNECTOR_KEY,
+  ) => createReviewedWalletContextGuard({
+    expectedAccount: OWNER,
+    expectedChainId: 1,
+    expectedConnectorKey,
+    currentAccount: () => state.account,
+    currentChainId: () => state.chainId,
+    connectorContextKey: () => state.connectorKey,
+  })
+
+  it('passes when the reviewed context is intact at the wallet-action boundary', () => {
+    const state = walletState()
+    const guard = guardFor(state)
+    expect(() => guard()).not.toThrow()
+  })
+
+  it('rejects a connector switch completed before guard construction (delayed authorization lookup)', () => {
+    const state = walletState()
+    // The switch lands while confirmation awaits pending restoration or the
+    // fresh authorization lookup — BEFORE the guard exists. Because the
+    // expected key comes from the reviewed preview, the replacement connector
+    // can never become the guard's accepted baseline.
+    state.connectorKey = 'walletconnect:uid-2'
+    const guard = guardFor(state)
+    expect(() => guard()).toThrow(WALLET_CHANGED)
+  })
+
+  it('rejects a same-account connector switch between wallet actions', () => {
+    const state = walletState()
+    const guard = guardFor(state)
+    expect(() => guard()).not.toThrow()
+    // Same owner, same chain — only the connector changed while a signature
+    // request or grant broadcast was in flight.
+    state.connectorKey = 'walletconnect:uid-2'
+    expect(() => guard()).toThrow(WALLET_CHANGED)
+  })
+
+  it('rejects a disconnected connector during delayed planning', () => {
+    const state = walletState()
+    const guard = guardFor(state)
+    state.connectorKey = undefined
+    expect(() => guard()).toThrow(WALLET_CHANGED)
+  })
+
+  it('fails closed when the review captured no connector key', () => {
+    const state = walletState()
+    state.connectorKey = undefined
+    const guard = guardFor(state, undefined)
+    expect(() => guard()).toThrow(WALLET_CHANGED)
+  })
+
+  it('still rejects account and chain drift through the wallet context assertion', () => {
+    const accountState = walletState()
+    const accountGuard = guardFor(accountState)
+    accountState.account = OTHER_OWNER
+    expect(() => accountGuard()).toThrow(expect.objectContaining<Partial<WalletExecutionContextChangedError>>({
+      name: 'WalletExecutionContextChangedError',
+      kind: 'account',
+    }))
+
+    const chainState = walletState()
+    const chainGuard = guardFor(chainState)
+    chainState.chainId = 8453
+    expect(() => chainGuard()).toThrow(expect.objectContaining<Partial<WalletExecutionContextChangedError>>({
+      name: 'WalletExecutionContextChangedError',
+      kind: 'chain',
+    }))
+  })
+})
+
+describe('createSafeBundleBroadcastGuard', () => {
+  const REVIEWED_CONNECTOR_KEY = 'safe:uid-1'
+  const WALLET_CHANGED = 'Wallet changed since review — please review the migration again.'
+
+  // Mutable wallet state standing in for the reactive refs the pages read.
+  // The reviewed connector key is captured when the preview is built; the
+  // guard is constructed inside the confirmation flow — after awaits the
+  // wallet can change under — and invoked at the broadcast boundary.
+  const walletState = () => ({
+    account: OWNER as Address | undefined,
+    chainId: 1 as number | undefined,
+    safeWallet: true,
+    connectorKey: REVIEWED_CONNECTOR_KEY as string | undefined,
+  })
+
+  const guardFor = (
+    state: ReturnType<typeof walletState>,
+    expectedConnectorKey: string | undefined = REVIEWED_CONNECTOR_KEY,
+  ) => createSafeBundleBroadcastGuard({
+    expectedAccount: OWNER,
+    expectedChainId: 1,
+    expectedConnectorKey,
+    currentAccount: () => state.account,
+    currentChainId: () => state.chainId,
+    isSafeWallet: () => state.safeWallet,
+    connectorContextKey: () => state.connectorKey,
+  })
+
+  it('passes when the reviewed context is intact at the broadcast boundary', () => {
+    const state = walletState()
+    const guard = guardFor(state)
+    expect(() => guard()).not.toThrow()
+  })
+
+  it('rejects a connector switch completed before guard construction (delayed authorization lookup)', () => {
+    const state = walletState()
+    // The switch lands while confirmation awaits pending restoration or the
+    // fresh authorization lookup — BEFORE the guard exists. Because the
+    // expected key comes from the reviewed preview, the replacement connector
+    // can never become the guard's accepted baseline.
+    state.connectorKey = 'safe:uid-2'
+    const guard = guardFor(state)
+    expect(() => guard()).toThrow(WALLET_CHANGED)
+  })
+
+  it('rejects a same-account connector switch during delayed preparation', () => {
+    const state = walletState()
+    const guard = guardFor(state)
+    // Same owner, same chain, still classified as a Safe — only the connector
+    // submitting the proposal changed while preparation was in flight.
+    state.connectorKey = 'safe:uid-2'
+    expect(() => guard()).toThrow(WALLET_CHANGED)
+  })
+
+  it('rejects a wallet that lost its Safe classification during the awaits', () => {
+    const state = walletState()
+    const guard = guardFor(state)
+    state.safeWallet = false
+    expect(() => guard()).toThrow(WALLET_CHANGED)
+  })
+
+  it('rejects a disconnected connector during delayed preparation', () => {
+    const state = walletState()
+    const guard = guardFor(state)
+    state.connectorKey = undefined
+    expect(() => guard()).toThrow(WALLET_CHANGED)
+  })
+
+  it('fails closed when the review captured no connector key', () => {
+    const state = walletState()
+    state.connectorKey = undefined
+    const guard = guardFor(state, undefined)
+    expect(() => guard()).toThrow(WALLET_CHANGED)
+  })
+
+  it('still rejects account and chain drift through the wallet context assertion', () => {
+    const accountState = walletState()
+    const accountGuard = guardFor(accountState)
+    accountState.account = OTHER_OWNER
+    expect(() => accountGuard()).toThrow(expect.objectContaining<Partial<WalletExecutionContextChangedError>>({
+      name: 'WalletExecutionContextChangedError',
+      kind: 'account',
+    }))
+
+    const chainState = walletState()
+    const chainGuard = guardFor(chainState)
+    chainState.chainId = 8453
+    expect(() => chainGuard()).toThrow(expect.objectContaining<Partial<WalletExecutionContextChangedError>>({
       name: 'WalletExecutionContextChangedError',
       kind: 'chain',
     }))

--- a/utils/batchReviewCalldata.ts
+++ b/utils/batchReviewCalldata.ts
@@ -1,0 +1,41 @@
+import type { TransactionPlan } from '@eulerxyz/euler-v2-sdk'
+import type { BatchEntryExternalTx } from '~/composables/useTxBatch'
+import { transactionPlanToCalls, type PlanEncodingSdk } from '~/utils/transaction-plan-calls'
+
+export interface BatchReviewCalldataEntry {
+  to: string
+  data: string
+  value: string
+}
+
+interface BuildBatchReviewCalldataOptions {
+  plan: TransactionPlan
+  before?: readonly BatchEntryExternalTx[]
+  after?: readonly BatchEntryExternalTx[]
+  sdk: PlanEncodingSdk
+  chainId: number
+}
+
+const plainCallToCalldata = (call: BatchEntryExternalTx): BatchReviewCalldataEntry => ({
+  to: call.to,
+  data: call.data,
+  value: (call.value ?? 0n).toString(),
+})
+
+/** Build the exact ordered call vector shown by Copy calldata. */
+export const buildBatchReviewCalldata = ({
+  plan,
+  before = [],
+  after = [],
+  sdk,
+  chainId,
+}: BuildBatchReviewCalldataOptions): BatchReviewCalldataEntry[] => {
+  const out = before.map(plainCallToCalldata)
+  out.push(...transactionPlanToCalls(plan, sdk, chainId).map(call => ({
+    to: call.to,
+    data: call.data,
+    value: call.value.toString(),
+  })))
+  out.push(...after.map(plainCallToCalldata))
+  return out
+}

--- a/utils/batchReviewDisplay.ts
+++ b/utils/batchReviewDisplay.ts
@@ -1,4 +1,5 @@
 import type { DisplayStep } from '~/utils/stepDecoding'
+import type { TransactionPlan } from '@eulerxyz/euler-v2-sdk'
 
 export interface AuthorizationStepsDisplay {
   detailHeading: 'Authorization transactions' | 'Signatures'
@@ -10,6 +11,13 @@ export const isBundledReviewEntry = (
   hasLatchedBundledExecution: boolean,
   hasBundledExecutionBuilder: boolean,
 ): boolean => hasLatchedBundledExecution && hasBundledExecutionBuilder
+
+/** Prefer the fresh per-entry plan owned by the Safe review ceremony. */
+export const getBatchReviewDisplayPlan = (
+  ceremonyPlan: TransactionPlan | undefined,
+  capturedDisplayPlan: TransactionPlan | undefined,
+  entryPlan: TransactionPlan | undefined,
+): TransactionPlan | undefined => ceremonyPlan ?? capturedDisplayPlan ?? entryPlan
 
 export const groupRestorationSummaryRows = <TRow extends { step: Pick<DisplayStep, 'isSeparateTx'> }>(
   rows: readonly TRow[],
@@ -32,25 +40,4 @@ export const getAuthorizationStepDisplay = (
         summaryHeading: 'Signatures needed',
         itemCountLabel: '1 signature',
       }
-}
-
-type RestorationSummaryRow = {
-  step: Pick<DisplayStep, 'isSeparateTx' | 'txKey'>
-}
-
-/**
- * Standalone prerequisites resolve sequentially, so a repeated restoration
- * transaction is sent only once. Bundled Safe calls are already resolved and
- * every collected call remains in the proposal, so every row stays visible.
- */
-export const consolidateRestorationSummaryRows = <TRow extends RestorationSummaryRow>(
-  rows: readonly TRow[],
-): TRow[] => {
-  const seenStandaloneTransactions = new Set<string>()
-  return rows.filter(({ step }) => {
-    if (!step.isSeparateTx || !step.txKey) return true
-    if (seenStandaloneTransactions.has(step.txKey)) return false
-    seenStandaloneTransactions.add(step.txKey)
-    return true
-  })
 }

--- a/utils/migrationAuthorizationSignatures.ts
+++ b/utils/migrationAuthorizationSignatures.ts
@@ -1,0 +1,18 @@
+import type { Hex } from 'viem'
+import type { SignedMigrationAuthorization } from '@eulerxyz/euler-v2-sdk'
+import type { PreparedPlanSignatureSubstitution } from '~/utils/preparedPlanParity'
+
+export const PLACEHOLDER_MIGRATION_AUTHORIZATION_SIGNATURE = `0x${'00'.repeat(65)}` as Hex
+
+export const getMigrationAuthorizationSignatureSubstitutions = (
+  authorization: SignedMigrationAuthorization | undefined,
+): PreparedPlanSignatureSubstitution[] => {
+  if (!authorization) return []
+  return [
+    {
+      placeholder: PLACEHOLDER_MIGRATION_AUTHORIZATION_SIGNATURE,
+      signature: authorization.signature,
+    },
+    ...getMigrationAuthorizationSignatureSubstitutions(authorization.postMigrationAuthorization),
+  ]
+}

--- a/utils/migrationCeremonyDeadline.ts
+++ b/utils/migrationCeremonyDeadline.ts
@@ -1,0 +1,49 @@
+/**
+ * Deadline pinning for migration ceremonies.
+ *
+ * SDK migration connectors mint a fresh wall-clock verifier deadline on every
+ * plan build unless one is supplied. Every flow that builds a plan twice and
+ * requires the two builds to describe the same ceremony — review preview vs
+ * confirm-time execution, placeholder-signed preview vs signature-resolved
+ * rebuild — must therefore pin one deadline across both builds: the deadline
+ * is embedded in verifier calldata and in the EIP-712 authorization payload,
+ * so a re-minted value fails the plan-parity and payload-equality gates.
+ */
+
+const MIGRATION_CEREMONY_DEADLINE_TTL_SECONDS = 60 * 60
+
+/** A fresh wall-clock deadline for a ceremony no swap quote constrains. */
+export const mintMigrationCeremonyDeadline = (): bigint =>
+  BigInt(Math.floor(Date.now() / 1000) + MIGRATION_CEREMONY_DEADLINE_TTL_SECONDS)
+
+/** True once a pinned deadline can no longer be executed on-chain. */
+export const isMigrationCeremonyDeadlineExpired = (deadline: bigint): boolean =>
+  deadline <= BigInt(Math.floor(Date.now() / 1000))
+
+type SwapQuoteVerifyLike = {
+  verify: {
+    deadline?: number
+  }
+}
+
+export type InboundMigrationCeremonyQuotes = {
+  collateralSwapQuote?: SwapQuoteVerifyLike
+  debtSwapQuote?: SwapQuoteVerifyLike
+}
+
+/**
+ * The deadline an inbound (external-to-Euler) ceremony must pin.
+ *
+ * When a collateral swap quote is present, the SDK validates the supplied
+ * deadline for exact equality against the deadline embedded in the quote's
+ * immutable verifier data — any other value (earlier ones included) throws
+ * "SwapVerifier data mismatch" at planning. So the pin must BE that quote's
+ * deadline, mirroring the connectors' own `deadline ?? quote.verify.deadline`
+ * fallback. The debt swap quote keeps its own embedded expiry and never
+ * constrains the supplied deadline. Only when no collateral quote governs the
+ * verifier is a minted deadline valid.
+ */
+export const pinInboundMigrationCeremonyDeadline = (quotes: InboundMigrationCeremonyQuotes): bigint =>
+  quotes.collateralSwapQuote
+    ? BigInt(quotes.collateralSwapQuote.verify.deadline ?? 0)
+    : mintMigrationCeremonyDeadline()

--- a/utils/preparedPlanParity.ts
+++ b/utils/preparedPlanParity.ts
@@ -1,0 +1,207 @@
+import { getAddress, type Hex } from 'viem'
+import type { TransactionPlanPrepared } from '@eulerxyz/euler-v2-sdk'
+
+export interface PreparedPlanSignatureSubstitution {
+  placeholder: Hex
+  signature: Hex
+}
+
+const PLAN_DRIFT_ERROR = 'The transaction plan changed after review. Reopen review and try again.'
+
+const stripHexPrefix = (value: Hex): string => value.slice(2).toLowerCase()
+
+type SignaturePattern = {
+  reviewed: string
+  resolved: string
+}
+
+const signatureWord = (value: number): string => value.toString(16).padStart(64, '0')
+
+const splitSignature = (signature: Hex): { r: string, s: string, v: number } => {
+  const bytes = stripHexPrefix(signature)
+  if (bytes.length !== 130) throw new Error(PLAN_DRIFT_ERROR)
+  let v = Number.parseInt(bytes.slice(128, 130), 16)
+  if (!Number.isFinite(v)) throw new Error(PLAN_DRIFT_ERROR)
+  if (v < 27) v += 27
+  return {
+    r: bytes.slice(0, 64),
+    s: bytes.slice(64, 128),
+    v,
+  }
+}
+
+const buildSignaturePatterns = (placeholder: Hex, signature: Hex): SignaturePattern[] => {
+  const reviewedBytes = stripHexPrefix(placeholder)
+  const resolvedBytes = stripHexPrefix(signature)
+  const reviewed = splitSignature(placeholder)
+  const resolved = splitSignature(signature)
+  return [
+    // Some authorizations retain the ordinary 65-byte signature.
+    { reviewed: reviewedBytes, resolved: resolvedBytes },
+    // Aave, Morpho, and MetaMorpho encode the signature as ABI v/r/s words.
+    {
+      reviewed: `${signatureWord(reviewed.v)}${reviewed.r}${reviewed.s}`,
+      resolved: `${signatureWord(resolved.v)}${resolved.r}${resolved.s}`,
+    },
+  ]
+}
+
+type OrderedSubstitution = {
+  patterns: readonly SignaturePattern[]
+}
+
+/**
+ * Consumption cursor into the ordered substitution list. Each reviewed
+ * placeholder occurrence, in deterministic traversal order, must be replaced
+ * by exactly the next substitution — two identical placeholders can never
+ * swap their signatures between call locations.
+ */
+type SubstitutionCursor = {
+  next: number
+}
+
+/**
+ * Find the queued substitution's pattern covering the first differing
+ * character. The window must reproduce the reviewed placeholder bytes on the
+ * reviewed side and the resolved signature bytes on the resolved side.
+ */
+const matchSubstitutionAt = (
+  reviewed: string,
+  resolved: string,
+  patterns: readonly SignaturePattern[],
+  diffIndex: number,
+): number | undefined => {
+  for (const pattern of patterns) {
+    const length = pattern.resolved.length
+    let from = Math.max(2, diffIndex - length + 1)
+    while (from <= diffIndex) {
+      const start = resolved.indexOf(pattern.resolved, from)
+      if (start < 0 || start > diffIndex) break
+      if (reviewed.startsWith(pattern.reviewed, start)) return start + length
+      from = start + 1
+    }
+  }
+  return undefined
+}
+
+const assertStringParity = (
+  reviewed: string,
+  resolved: string,
+  substitutions: readonly OrderedSubstitution[],
+  cursor: SubstitutionCursor,
+): void => {
+  const normalizedReviewed = reviewed.startsWith('0x') ? reviewed.toLowerCase() : reviewed
+  const normalizedResolved = resolved.startsWith('0x') ? resolved.toLowerCase() : resolved
+  if (normalizedReviewed === normalizedResolved) return
+  if (
+    !normalizedReviewed.startsWith('0x')
+    || !normalizedResolved.startsWith('0x')
+    // Both permitted representations replace like-for-like byte ranges, so any
+    // legitimate substitution preserves the string length.
+    || normalizedReviewed.length !== normalizedResolved.length
+  ) {
+    throw new Error(PLAN_DRIFT_ERROR)
+  }
+  let index = 2
+  while (index < normalizedReviewed.length) {
+    if (normalizedReviewed[index] === normalizedResolved[index]) {
+      index++
+      continue
+    }
+    const substitution = substitutions[cursor.next]
+    if (!substitution) throw new Error(PLAN_DRIFT_ERROR)
+    const end = matchSubstitutionAt(normalizedReviewed, normalizedResolved, substitution.patterns, index)
+    if (end === undefined) throw new Error(PLAN_DRIFT_ERROR)
+    cursor.next++
+    index = end
+  }
+}
+
+const assertValueParity = (
+  reviewed: unknown,
+  resolved: unknown,
+  substitutions: readonly OrderedSubstitution[],
+  cursor: SubstitutionCursor,
+): void => {
+  if (typeof reviewed === 'string' && typeof resolved === 'string') {
+    assertStringParity(reviewed, resolved, substitutions, cursor)
+    return
+  }
+  if (
+    reviewed === null
+    || resolved === null
+    || typeof reviewed !== 'object'
+    || typeof resolved !== 'object'
+  ) {
+    if (reviewed !== resolved) throw new Error(PLAN_DRIFT_ERROR)
+    return
+  }
+  if (Array.isArray(reviewed) || Array.isArray(resolved)) {
+    if (!Array.isArray(reviewed) || !Array.isArray(resolved) || reviewed.length !== resolved.length) {
+      throw new Error(PLAN_DRIFT_ERROR)
+    }
+    reviewed.forEach((item, index) => {
+      assertValueParity(item, resolved[index], substitutions, cursor)
+    })
+    return
+  }
+  const reviewedRecord = reviewed as Record<string, unknown>
+  const resolvedRecord = resolved as Record<string, unknown>
+  const reviewedKeys = Object.keys(reviewedRecord).sort()
+  const resolvedKeys = Object.keys(resolvedRecord).sort()
+  if (reviewedKeys.length !== resolvedKeys.length || reviewedKeys.some((key, index) => key !== resolvedKeys[index])) {
+    throw new Error(PLAN_DRIFT_ERROR)
+  }
+  for (const key of reviewedKeys) {
+    assertValueParity(reviewedRecord[key], resolvedRecord[key], substitutions, cursor)
+  }
+}
+
+const preparedAccountKey = (prepared: TransactionPlanPrepared): string => {
+  const account = prepared.account
+  return typeof account === 'string'
+    ? getAddress(account)
+    : `${account.chainId}:${getAddress(account.owner)}`
+}
+
+/**
+ * Confirm-time migration plans may replace only the reviewed placeholder
+ * signature representation, either raw bytes or ABI-encoded v/r/s words. The
+ * complete prepared envelope remains unchanged, including targets, values,
+ * call order, plugins, and resolved approvals.
+ *
+ * `substitutions` is positional: its order must match the order in which the
+ * reviewed plan carries the placeholder occurrences (entry order, then each
+ * entry's primary authorization before its post-migration one). The k-th
+ * occurrence is only ever replaced by the k-th signature — signatures
+ * authorizing different typed-data messages cannot be transposed between
+ * structurally identical placeholder sites.
+ */
+export const assertPreparedPlanSignatureParity = ({
+  reviewed,
+  resolved,
+  substitutions,
+}: {
+  reviewed: TransactionPlanPrepared
+  resolved: TransactionPlanPrepared
+  substitutions: readonly PreparedPlanSignatureSubstitution[]
+}): void => {
+  if (
+    reviewed.chainId !== resolved.chainId
+    || preparedAccountKey(reviewed) !== preparedAccountKey(resolved)
+    || reviewed.usePermit2 !== resolved.usePermit2
+    || reviewed.unlimitedApproval !== resolved.unlimitedApproval
+  ) {
+    throw new Error(PLAN_DRIFT_ERROR)
+  }
+
+  const ordered: OrderedSubstitution[] = substitutions.map(({ placeholder, signature }) => {
+    const signatureBytes = stripHexPrefix(signature)
+    if (!signatureBytes || signatureBytes === stripHexPrefix(placeholder)) throw new Error(PLAN_DRIFT_ERROR)
+    return { patterns: buildSignaturePatterns(placeholder, signature) }
+  })
+
+  const cursor: SubstitutionCursor = { next: 0 }
+  assertValueParity(reviewed.plan, resolved.plan, ordered, cursor)
+  if (cursor.next !== ordered.length) throw new Error(PLAN_DRIFT_ERROR)
+}

--- a/utils/walletExecutionContext.ts
+++ b/utils/walletExecutionContext.ts
@@ -35,3 +35,87 @@ export const assertWalletExecutionContext = ({
     throw new WalletExecutionContextChangedError('chain')
   }
 }
+
+export const WALLET_CHANGED_SINCE_REVIEW_ERROR
+  = 'Wallet changed since review — please review the migration again.'
+
+/**
+ * Guard for the irreversible wallet-action boundaries (signature requests,
+ * grant broadcasts, plan broadcasts) of a flow reviewed under one connector.
+ *
+ * Account and chain checks cannot see a same-account connector switch, and
+ * confirmation awaits (pending restoration, authorization lookup, planning,
+ * preparation, simulation) all yield before each wallet action. Snapshotting
+ * the connector inside the confirmation flow would accept a connector swapped
+ * during an earlier await as the baseline, so `expectedConnectorKey` must be
+ * the key the reviewed preview captured when it was built. The returned
+ * callback re-asserts the reviewed context — account, chain, and connector —
+ * immediately before each wallet action, and fails closed when the review
+ * captured no connector at all.
+ */
+export const createReviewedWalletContextGuard = ({
+  expectedAccount,
+  expectedChainId,
+  expectedConnectorKey,
+  currentAccount,
+  currentChainId,
+  connectorContextKey,
+}: {
+  expectedAccount: Address
+  expectedChainId: number
+  expectedConnectorKey: string | undefined
+  currentAccount: () => Address | undefined
+  currentChainId: () => number | undefined
+  connectorContextKey: () => string | undefined
+}): (() => void) => {
+  return () => {
+    assertWalletExecutionContext({
+      expectedAccount,
+      expectedChainId,
+      currentAccount: currentAccount(),
+      currentChainId: currentChainId(),
+    })
+    if (!expectedConnectorKey || connectorContextKey() !== expectedConnectorKey) {
+      throw new Error(WALLET_CHANGED_SINCE_REVIEW_ERROR)
+    }
+  }
+}
+
+/**
+ * Guard for the irreversible broadcast boundary of a direct Safe-bundle flow:
+ * the reviewed wallet context (account, chain, connector) plus the Safe
+ * classification the bundled review promised — a wallet that stopped
+ * classifying as a Safe cannot submit the reviewed single-proposal ceremony.
+ */
+export const createSafeBundleBroadcastGuard = ({
+  expectedAccount,
+  expectedChainId,
+  expectedConnectorKey,
+  currentAccount,
+  currentChainId,
+  isSafeWallet,
+  connectorContextKey,
+}: {
+  expectedAccount: Address
+  expectedChainId: number
+  expectedConnectorKey: string | undefined
+  currentAccount: () => Address | undefined
+  currentChainId: () => number | undefined
+  isSafeWallet: () => boolean
+  connectorContextKey: () => string | undefined
+}): (() => void) => {
+  const assertReviewedContext = createReviewedWalletContextGuard({
+    expectedAccount,
+    expectedChainId,
+    expectedConnectorKey,
+    currentAccount,
+    currentChainId,
+    connectorContextKey,
+  })
+  return () => {
+    assertReviewedContext()
+    if (!isSafeWallet()) {
+      throw new Error(WALLET_CHANGED_SINCE_REVIEW_ERROR)
+    }
+  }
+}


### PR DESCRIPTION
## Problem

Safe users verify calldata at review time, but the copyable export, the displayed plan, and the executed proposal were produced by separate encoding passes that could diverge. A plan silently rebuilt between review and confirm — fresh ceremony deadlines, approvals re-resolved at execution, cart entries edited after review, or wallet account/chain/connector drift — meant "Copy calldata" could encode a different core transaction plan from the Safe proposal ultimately executed, and confirmation could broadcast a plan the user never reviewed.

## Fix

- **One envelope from review to broadcast.** The review modal latches the exact prepared plan it displays and simulates; copy calldata exports from that same envelope; execution runs the latched envelope rather than re-preparing.
- **Parity enforced, not assumed.** Prepared envelopes are structurally compared against the reviewed ones before anything irreversible (`utils/preparedPlanParity.ts`), with migration ceremony deadlines pinned (`utils/migrationCeremonyDeadline.ts`) so re-preparation cannot re-encode the plan under the same review.
- **Stale reviews die instead of executing.** Any cart edit or wallet account/chain change invalidates the standing review; direct and batched migration executors re-run the freshness guard after async setup, immediately before broadcast.
- **Safe bundles bound to the reviewed context.** The Safe-bundle broadcast guard (`utils/walletExecutionContext.ts`) revalidates the reviewed connector's Safe context immediately before proposing.
- **Typed-data signing pinned to the validated connector** (separate commit, droppable if preferred): `signMigrationAuthorization` and both plan executors previously let wagmi resolve the currently-active connector at request time, so a connector switched in the check-to-sign gap received a signature request it was never validated for. All `signTypedData` callbacks now sign through the captured connector, matching the pinning `sendTransaction` already applies.

## Scope

Deliberately limited to review/execution parity. No submission-replay protection, cross-tab coordination, or persistent quarantine state is introduced — that concern is separable and left for its own design.

## Testing

`npm run typecheck` clean; full vitest suite green (188 files, 1872 tests). New regressions cover calldata-export parity, ceremony-deadline pinning, review invalidation on cart/wallet drift, Safe-bundle guard binding on both migration pages, executor freshness ordering, and connector-pinned typed-data signing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Batch reviews now use a single reviewed execution plan for consistent operation details, approvals, and calldata.
  - Migration reviews pin authorization deadlines and support safer signature handling.
  - Execution now reports transaction or Safe proposal identifiers promptly.
  - Gas estimation is available for prepared plans.

- **Bug Fixes**
  - Prevented execution when the wallet, network, Safe status, or reviewed batch changes.
  - Added protection against stale operations, duplicate broadcasts, and expired reviews.
  - Batch action buttons remain disabled while operations are being added.

- **Changes**
  - Whole-batch simulation controls were removed and replaced with an availability notice.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->