### PR TITLE
fix: include Securitize intrinsic APY on lend pages

### DIFF
--- a/pages/lend/[vault]/index.vue
+++ b/pages/lend/[vault]/index.vue
@@ -5,7 +5,7 @@ import { isSecuritizeVault } from '~/utils/vault/categories'
 import { getHookDisabledWarning, getUtilisationWarning, getSupplyCapWarning } from '~/composables/useVaultWarnings'
 import { getAssetOraclePrice, getTokenUsdPrice } from '~/utils/sdk-prices'
 import { useEulerProductOfVault } from '~/composables/useEulerLabels'
-import { getVaultIntrinsicApy, getVaultIntrinsicApyInfo, combineApyWithIntrinsic } from '~/utils/vault-intrinsic-apy'
+import { getVaultIntrinsicApy, getVaultIntrinsicApyInfo, combineApyWithIntrinsic, resolveVaultIntrinsicApySource } from '~/utils/vault-intrinsic-apy'
 import { isVaultBlockedByCountry, isVaultRestrictedByCountry, isAssetBlockedByCountry } from '~/composables/useGeoBlock'
 import { useVaultRegistry } from '~/composables/useVaultRegistry'
 import { useSwapQuotesParallel } from '~/composables/useSwapQuotesParallel'
@@ -365,7 +365,12 @@ const hasRewards = computed(() => {
   void rewardsVersion.value
   return hasSupplyRewards(vaultAddress)
 })
-const intrinsicApy = computed(() => getVaultIntrinsicApy(projectionEVault.value ?? vault.value, enableIntrinsicApy.value))
+const intrinsicApyVault = computed(() => resolveVaultIntrinsicApySource(
+  projectionEVault.value,
+  eVault.value,
+  securitizeVault.value,
+))
+const intrinsicApy = computed(() => getVaultIntrinsicApy(intrinsicApyVault.value, enableIntrinsicApy.value))
 
 const baseSupplyApy = computed(() => {
   if (!features.value.hasInterestRate) return 0
@@ -754,7 +759,7 @@ const supplyApyModalData = computed(() => ({
     mode: 'supply',
     lendingAPY: baseSupplyApy.value,
     intrinsicAPY: intrinsicApy.value,
-    intrinsicApyInfo: getVaultIntrinsicApyInfo(projectionEVault.value ?? vault.value, enableIntrinsicApy.value),
+    intrinsicApyInfo: getVaultIntrinsicApyInfo(intrinsicApyVault.value, enableIntrinsicApy.value),
     campaigns: getSupplyRewardCampaigns(vaultAddress),
     rewardVaultAddress: vaultAddress,
   },

--- a/tests/utils/vault-intrinsic-apy.test.ts
+++ b/tests/utils/vault-intrinsic-apy.test.ts
@@ -28,6 +28,7 @@ import {
   EMPTY_INTRINSIC_APY,
   getVaultIntrinsicApy,
   getVaultIntrinsicApyInfo,
+  resolveVaultIntrinsicApySource,
   withProjectedVaultIntrinsicApy,
   withVaultIntrinsicApy,
 } from '~/utils/vault-intrinsic-apy'
@@ -45,6 +46,26 @@ const vaultWith = (intrinsicApy: IntrinsicApyInfo | undefined) => ({
   intrinsicApy,
   // The address is read by no helper but appears in fixtures for realism.
   asset: { address: '0x1111111111111111111111111111111111111111' as const },
+})
+
+describe('resolveVaultIntrinsicApySource', () => {
+  it('falls back to a populated Securitize vault when EVault sources are unavailable', () => {
+    const securitizeVault = vaultWith(apyInfo(2.632044, 'SECURITIZE'))
+
+    const resolved = resolveVaultIntrinsicApySource(undefined, undefined, securitizeVault)
+
+    expect(resolved).toBe(securitizeVault)
+    expect(getVaultIntrinsicApyInfo(resolved, true)).toEqual(apyInfo(2.632044, 'SECURITIZE'))
+  })
+
+  it('keeps the projected EVault ahead of the base and Securitize fallbacks', () => {
+    const projectedVault = vaultWith(apyInfo(3, 'projected'))
+    const baseVault = vaultWith(apyInfo(2, 'base'))
+    const securitizeVault = vaultWith(apyInfo(1, 'SECURITIZE'))
+
+    expect(resolveVaultIntrinsicApySource(projectedVault, baseVault, securitizeVault))
+      .toBe(projectedVault)
+  })
 })
 
 describe('getVaultIntrinsicApyInfo', () => {

--- a/tests/utils/vault-intrinsic-apy.test.ts
+++ b/tests/utils/vault-intrinsic-apy.test.ts
@@ -66,6 +66,17 @@ describe('resolveVaultIntrinsicApySource', () => {
     expect(resolveVaultIntrinsicApySource(projectedVault, baseVault, securitizeVault))
       .toBe(projectedVault)
   })
+
+  it('falls back to the populated base EVault when the projection has no intrinsic APY', () => {
+    const projectedVault = vaultWith(undefined)
+    const baseVault = vaultWith(apyInfo(2, 'base'))
+    const securitizeVault = vaultWith(apyInfo(1, 'SECURITIZE'))
+
+    const resolved = resolveVaultIntrinsicApySource(projectedVault, baseVault, securitizeVault)
+
+    expect(resolved).toBe(baseVault)
+    expect(getVaultIntrinsicApyInfo(resolved, true)).toEqual(apyInfo(2, 'base'))
+  })
 })
 
 describe('getVaultIntrinsicApyInfo', () => {

--- a/utils/vault-intrinsic-apy.ts
+++ b/utils/vault-intrinsic-apy.ts
@@ -6,6 +6,12 @@ export interface VaultWithIntrinsicApy {
   intrinsicApy?: IntrinsicApyInfo
 }
 
+export function resolveVaultIntrinsicApySource(
+  ...vaults: Array<VaultWithIntrinsicApy | undefined>
+): VaultWithIntrinsicApy | undefined {
+  return vaults.find(vault => vault !== undefined)
+}
+
 export function getVaultIntrinsicApyInfo(
   vault: VaultWithIntrinsicApy | undefined,
   enabled: boolean,

--- a/utils/vault-intrinsic-apy.ts
+++ b/utils/vault-intrinsic-apy.ts
@@ -9,7 +9,7 @@ export interface VaultWithIntrinsicApy {
 export function resolveVaultIntrinsicApySource(
   ...vaults: Array<VaultWithIntrinsicApy | undefined>
 ): VaultWithIntrinsicApy | undefined {
-  return vaults.find(vault => vault !== undefined)
+  return vaults.find(vault => vault?.intrinsicApy !== undefined)
 }
 
 export function getVaultIntrinsicApyInfo(


### PR DESCRIPTION
## Summary
- Include the active Securitize vault when resolving intrinsic APY on the lend form.
- Keep the headline, projected estimate, and APY breakdown modal aligned to one resolved vault source.

## Changes
- Resolve intrinsic APY sources in projected EVault, base EVault, then Securitize order.
- Reuse the resolved source for both the numeric APY and provider metadata.
- Cover Securitize fallback and projected-EVault precedence with regression tests.

## Test plan
- [x] Production build with Node 24
- [x] Typecheck with Node 24
- [x] Full Vitest suite: 184 files, 1,799 tests
- [x] ESLint on all changed files
- [x] Regression test for the 2.632044% SECURITIZE fallback
- [ ] Verify the HINC lend headline and APY breakdown with Intrinsic APY enabled

## Validation note
The repository-wide lint command also scans unrelated nested `.claude/worktrees` in this checkout and reports pre-existing errors there. All changed files pass ESLint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved intrinsic APY selection across projected, EVault, and Securitize vaults.
  * Updated the APY details modal to display information from the same resolved vault source.
  * Added fallback behavior when the primary vault source lacks APY data.

* **Tests**
  * Added coverage for vault-source fallback and precedence scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->