### PR TITLE
fix: verify portfolio vault badges with router governance

### DIFF
--- a/components/entities/vault/VaultTypeBadges.vue
+++ b/components/entities/vault/VaultTypeBadges.vue
@@ -11,7 +11,7 @@ const { vault, layout = 'inline', size = 'small', nudge = false, summaryOnly = f
 }>()
 
 const vaultRef = computed(() => vault)
-const { badges, governanceType, summaryBadges, summaryGovernanceType } = useVaultTypeBadges(vaultRef)
+const { badges, governanceType, summaryBadges, summaryGovernanceType, verificationVault } = useVaultTypeBadges(vaultRef)
 
 const isStacked = computed(() => layout === 'stacked')
 const tagElement = computed(() => isStacked.value ? 'button' : 'span')
@@ -30,7 +30,7 @@ const hasAnyBadge = computed(() => visibleBadges.value.length > 0)
   >
     <VaultTypeChip
       v-if="showGovernanceType"
-      :vault="vault"
+      :vault="verificationVault"
       :type="visibleGovernanceType"
       :size="size"
       :block="isStacked"
@@ -39,7 +39,7 @@ const hasAnyBadge = computed(() => visibleBadges.value.length > 0)
     />
     <VaultTypeChip
       v-if="hasVisibleBadge('securitize')"
-      :vault="vault"
+      :vault="verificationVault"
       type="securitize"
       :size="size"
       :block="isStacked"

--- a/components/entities/vault/overview/VaultOverviewBlockGeneral.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockGeneral.vue
@@ -23,7 +23,6 @@ const emit = defineEmits<{
 const route = useRoute()
 const { enableEntityBranding: enableEntityBrandingDisplay, enableVaultType: enableVaultTypeDisplay } = useDeployConfig()
 
-const { isVaultGovernorVerified } = useVaults()
 const { get: registryGet } = useVaultRegistry()
 const {
   load: loadOpenInterest,
@@ -39,7 +38,8 @@ const vaultAddress = computed(() => getAddress(vault.address))
 const vaultRef = computed(() => vault)
 const product = useEulerProductOfVault(vaultAddress)
 const entities = useEulerEntitiesOfVault(vault)
-const { badges, governanceType } = useVaultTypeBadges(vaultRef)
+const { badges, governanceType, isVerified: isGovernorVerified, verificationVault } = useVaultTypeBadges(vaultRef)
+const governanceVault = computed(() => verificationVault.value as EVault)
 const marketProductKey = computed(() => getProductKeyByVault(vault.address))
 const marketProductName = computed(() => getProductByVault(vault.address).name)
 const description = computed(() => {
@@ -51,7 +51,6 @@ const isDeprecated = computed(() => {
 })
 const deprecationReason = computed(() => isDeprecated.value ? product.deprecationReason || '' : '')
 const isRestricted = computed(() => isVaultBlockedByCountry(vault.address))
-const isGovernorVerified = computed(() => isVaultGovernorVerified(vault))
 const isGovernanceLimited = computed(() => isVaultGovernanceLimited(vault.address) && isGovernorVerified.value)
 
 // Count how many borrow pairs have this vault as the liability (borrow) side
@@ -186,7 +185,7 @@ watchEffect(() => {
         label="Vault type"
       >
         <VaultTypeChip
-          :vault="vault"
+          :vault="governanceVault"
           :type="governanceType"
           nudge
           class="w-fit"
@@ -213,7 +212,7 @@ watchEffect(() => {
       >
         <VaultTypeChip
           v-if="!isGovernorVerified"
-          :vault="vault"
+          :vault="governanceVault"
           type="unknown"
           nudge
           class="w-fit"

--- a/composables/useVaultTypeBadges.ts
+++ b/composables/useVaultTypeBadges.ts
@@ -3,6 +3,7 @@ import { isEVault, type EulerEarn, type EVault, type SecuritizeCollateralVault }
 import type { Ref } from 'vue'
 import { getEntitiesByEarnVault, getEntitiesByVault, isVaultAccessControlled, isVaultCyclicalNote, isVaultGovernanceLimited, isVaultKeyring } from '~/utils/eulerLabelsUtils'
 import { useVaultRegistry } from '~/composables/useVaultRegistry'
+import type { EulerRouterGovernanceCarrier } from '~/utils/vault/euler-router-governance'
 
 type VaultTypeBadgeVault = EVault | EulerEarn | SecuritizeCollateralVault
 
@@ -12,7 +13,7 @@ export type VaultTypeSummaryBadge = Extract<VaultTypeBadge, 'cyclicalNote' | 'pr
 
 export const useVaultTypeBadges = (vault: Ref<VaultTypeBadgeVault>) => {
   const { isVaultGovernorVerified, isSecuritizeGovernorVerified, isEarnVaultOwnerVerified } = useVaults()
-  const { getVaultCategory } = useVaultRegistry()
+  const { getVault, getVaultCategory } = useVaultRegistry()
 
   const addressRef = computed(() => vault.value.address)
 
@@ -24,10 +25,35 @@ export const useVaultTypeBadges = (vault: Ref<VaultTypeBadgeVault>) => {
     return getEntitiesByVault(vault.value as EVault | SecuritizeCollateralVault)
   })
 
+  const verificationVault = computed<VaultTypeBadgeVault>(() => {
+    const current = vault.value
+    if (!isEVault(current) || current.oracle?.name !== 'EulerRouter') return current
+
+    const currentGovernance = current as EVault & EulerRouterGovernanceCarrier
+    if (currentGovernance.eulerRouterGovernor !== undefined) return current
+
+    const registered = getVault(current.address)
+    if (!registered || !isEVault(registered) || registered.oracle?.name !== 'EulerRouter') return current
+
+    const currentRouter = current.oracle.oracle?.toLowerCase()
+    const registeredRouter = registered.oracle.oracle?.toLowerCase()
+    if (!currentRouter || currentRouter !== registeredRouter) return current
+
+    const registeredGovernance = registered as EVault & EulerRouterGovernanceCarrier
+    if (registeredGovernance.eulerRouterGovernor === undefined) return current
+
+    const enriched = Object.assign(
+      Object.create(Object.getPrototypeOf(current)) as EVault & EulerRouterGovernanceCarrier,
+      current,
+    )
+    enriched.eulerRouterGovernor = registeredGovernance.eulerRouterGovernor
+    return enriched
+  })
+
   const isVerified = computed(() => {
     if (isEarn.value) return isEarnVaultOwnerVerified(vault.value as EulerEarn)
     if (isSecuritize.value) return isSecuritizeGovernorVerified(vault.value as SecuritizeCollateralVault)
-    return isVaultGovernorVerified(vault.value as EVault)
+    return isVaultGovernorVerified(verificationVault.value as EVault)
   })
 
   const governanceType = computed<VaultGovernanceBadge>(() => {

--- a/composables/useVaultTypeBadges.ts
+++ b/composables/useVaultTypeBadges.ts
@@ -119,5 +119,6 @@ export const useVaultTypeBadges = (vault: Ref<VaultTypeBadgeVault>) => {
     isVerified,
     summaryBadges,
     summaryGovernanceType,
+    verificationVault,
   }
 }

--- a/tests/composables/useVaultTypeBadges.test.ts
+++ b/tests/composables/useVaultTypeBadges.test.ts
@@ -12,6 +12,8 @@ const state = vi.hoisted(() => ({
   governanceLimitedVaults: new Set<string>(),
   keyringVaults: new Set<string>(),
   cyclicalNoteVaults: new Set<string>(),
+  registryVaults: new Map<string, EVault>(),
+  requiredRouterGovernors: new Map<string, string>(),
   verifiedEarnVaults: new Set<string>(),
   verifiedVaults: new Set<string>(),
 }))
@@ -29,6 +31,7 @@ vi.mock('~/utils/eulerLabelsUtils', () => ({
 
 vi.mock('~/composables/useVaultRegistry', () => ({
   useVaultRegistry: () => ({
+    getVault: (address: string) => state.registryVaults.get(address.toLowerCase()),
     getVaultCategory: () => 'evk',
     isVerifiedVault: (address: string) => state.verifiedVaults.has(address.toLowerCase()),
   }),
@@ -62,8 +65,12 @@ const setupVaultsMock = () => {
   ;(globalThis as unknown as { useVaults: unknown }).useVaults = () => ({
     isEarnVaultOwnerVerified: (vault: { address: string }) =>
       state.verifiedEarnVaults.has(vault.address.toLowerCase()),
-    isVaultGovernorVerified: (vault: { address: string }) =>
-      state.verifiedVaults.has(vault.address.toLowerCase()),
+    isVaultGovernorVerified: (vault: { address: string, eulerRouterGovernor?: string | null }) => {
+      const address = vault.address.toLowerCase()
+      const requiredRouterGovernor = state.requiredRouterGovernors.get(address)
+      return state.verifiedVaults.has(address)
+        && (!requiredRouterGovernor || vault.eulerRouterGovernor?.toLowerCase() === requiredRouterGovernor)
+    },
   })
 }
 
@@ -80,6 +87,8 @@ describe('useVaultTypeBadges', () => {
     state.governanceLimitedVaults.clear()
     state.keyringVaults.clear()
     state.cyclicalNoteVaults.clear()
+    state.registryVaults.clear()
+    state.requiredRouterGovernors.clear()
     state.verifiedEarnVaults.clear()
     state.verifiedVaults.clear()
     setupVaultsMock()
@@ -170,6 +179,47 @@ describe('useVaultTypeBadges', () => {
     expect(badges.value).toEqual(['governed'])
     expect(summaryBadges.value).toEqual(['unknown'])
     expect(summaryGovernanceType.value).toBe('unknown')
+  })
+
+  it('uses matching registry EulerRouter governance to verify a portfolio vault copy', () => {
+    const router = '0x4000000000000000000000000000000000000004'
+    const routerGovernor = '0x5000000000000000000000000000000000000005'
+    const portfolioVault = makeVault({
+      oracle: { oracle: router, name: 'EulerRouter' },
+    })
+    const registryVault = Object.assign(makeVault({
+      oracle: { oracle: router, name: 'EulerRouter' },
+    }), { eulerRouterGovernor: routerGovernor })
+
+    verify(portfolioVault)
+    state.registryVaults.set(portfolioVault.address.toLowerCase(), registryVault)
+    state.requiredRouterGovernors.set(portfolioVault.address.toLowerCase(), routerGovernor.toLowerCase())
+
+    const { isVerified, summaryBadges } = useVaultTypeBadges(shallowRef(portfolioVault))
+
+    expect(isVerified.value).toBe(true)
+    expect(summaryBadges.value).toEqual([])
+  })
+
+  it('does not borrow registry governance from a different EulerRouter', () => {
+    const portfolioVault = makeVault({
+      oracle: { oracle: '0x4000000000000000000000000000000000000004', name: 'EulerRouter' },
+    })
+    const registryVault = Object.assign(makeVault({
+      oracle: { oracle: '0x6000000000000000000000000000000000000006', name: 'EulerRouter' },
+    }), { eulerRouterGovernor: '0x5000000000000000000000000000000000000005' })
+
+    verify(portfolioVault)
+    state.registryVaults.set(portfolioVault.address.toLowerCase(), registryVault)
+    state.requiredRouterGovernors.set(
+      portfolioVault.address.toLowerCase(),
+      '0x5000000000000000000000000000000000000005',
+    )
+
+    const { isVerified, summaryBadges } = useVaultTypeBadges(shallowRef(portfolioVault))
+
+    expect(isVerified.value).toBe(false)
+    expect(summaryBadges.value).toEqual(['unknown'])
   })
 
   it('keeps unverified ungoverned vaults out of the pair summary', () => {

--- a/tests/composables/useVaultTypeBadges.test.ts
+++ b/tests/composables/useVaultTypeBadges.test.ts
@@ -195,10 +195,13 @@ describe('useVaultTypeBadges', () => {
     state.registryVaults.set(portfolioVault.address.toLowerCase(), registryVault)
     state.requiredRouterGovernors.set(portfolioVault.address.toLowerCase(), routerGovernor.toLowerCase())
 
-    const { isVerified, summaryBadges } = useVaultTypeBadges(shallowRef(portfolioVault))
+    const { isVerified, summaryBadges, verificationVault } = useVaultTypeBadges(shallowRef(portfolioVault))
 
     expect(isVerified.value).toBe(true)
     expect(summaryBadges.value).toEqual([])
+    expect(verificationVault.value).not.toBe(portfolioVault)
+    expect(verificationVault.value).toHaveProperty('eulerRouterGovernor', routerGovernor)
+    expect(portfolioVault).not.toHaveProperty('eulerRouterGovernor')
   })
 
   it('does not borrow registry governance from a different EulerRouter', () => {
@@ -216,10 +219,11 @@ describe('useVaultTypeBadges', () => {
       '0x5000000000000000000000000000000000000005',
     )
 
-    const { isVerified, summaryBadges } = useVaultTypeBadges(shallowRef(portfolioVault))
+    const { isVerified, summaryBadges, verificationVault } = useVaultTypeBadges(shallowRef(portfolioVault))
 
     expect(isVerified.value).toBe(false)
     expect(summaryBadges.value).toEqual(['unknown'])
+    expect(verificationVault.value).toBe(portfolioVault)
   })
 
   it('keeps unverified ungoverned vaults out of the pair summary', () => {


### PR DESCRIPTION
## Summary
- Ensure portfolio-sourced EVault copies use resolved EulerRouter governor data when computing vault type badges.
- Keep governed vaults from displaying Unknown in position information while preserving fail-closed verification.

## Changes
- Read the missing EulerRouter governor from the same-address registry vault only when both vault copies reference the same router.
- Verify against an ephemeral enriched vault so fresh portfolio data remains authoritative and unmodified.
- Cover matching and mismatched router cases to prevent governance data from crossing router boundaries.

## Test plan
- [x] npm run test:run -- tests/composables/useVaultTypeBadges.test.ts tests/utils/vault/governor-verification.test.ts
- [x] npx eslint composables/useVaultTypeBadges.ts tests/composables/useVaultTypeBadges.test.ts
- [ ] npm run typecheck — locally blocked during Nuxt preparation by a Maximum call stack size exceeded error in @gvade/nuxt3-svg-sprite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved verification for Euler Router vaults by using registry governance data when portfolio details are incomplete.
  * Added validation to ensure registry and portfolio vaults use the same Euler Router.
  * Updated governance, risk-manager, and Securitize indicators to use the most accurate vault verification data.
  * Preserved existing verification behavior for other vault types and improved governance-limited status accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->