### PR TITLE
fix: say market instead of vault in recently added tooltip on market pages

### DIFF
--- a/components/entities/vault/RecentlyAddedBadge.vue
+++ b/components/entities/vault/RecentlyAddedBadge.vue
@@ -1,7 +1,17 @@
+<script setup lang="ts">
+const props = withDefaults(defineProps<{
+  entity?: 'vault' | 'market'
+}>(), {
+  entity: 'vault',
+})
+
+const tooltipText = computed(() => `This ${props.entity} was added recently.`)
+</script>
+
 <template>
   <UiHoverPreviewTooltip
     title="Recently added"
-    text="This vault was added recently."
+    :text="tooltipText"
     placement="top-start"
   >
     <span

--- a/components/entities/vault/discovery/DiscoveryMarketCard.vue
+++ b/components/entities/vault/discovery/DiscoveryMarketCard.vue
@@ -94,6 +94,7 @@ const getMaxRoeModalData = (result: BestMaxRoeResult) => ({
             </template>
             <RecentlyAddedBadge
               v-if="market.metrics.hasRecentlyAdded"
+              entity="market"
             />
             <GovernanceLimitedBadge v-if="isGovernanceLimited" />
           </div>


### PR DESCRIPTION
## Summary

The `RecentlyAddedBadge` tooltip hardcoded "This vault was added recently." even when the badge is rendered on market cards (explore list and market detail pages), where it should say "market".

- Add an `entity` prop (`'vault' | 'market'`, default `'vault'`) to `RecentlyAddedBadge.vue` and derive the tooltip text from it
- Pass `entity="market"` from `DiscoveryMarketCard.vue`, covering both the explore list and `/explore/[market]` detail page

Vault contexts (`VaultItem`, `VaultEarnItem`, `VaultBorrowItem`) are unchanged via the default.

## Test plan

- [ ] Hover the "Recently added" badge on a market detail page — tooltip reads "This market was added recently."
- [ ] Hover the badge on the explore list — same market wording
- [ ] Hover the badge on lend/earn/borrow vault rows — tooltip still reads "This vault was added recently."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added context-aware “Recently Added” tooltip text for vaults and markets.
  * Market discovery cards now display market-specific messaging on the badge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->