### PR TITLE
fix: request all-chains address screening explicitly

### DIFF
--- a/server/utils/screening.ts
+++ b/server/utils/screening.ts
@@ -95,9 +95,9 @@ function isAllowedScreeningUri(uri: string): boolean {
  * timeouts, redirects, malformed or ambiguous verdicts, and verdicts echoing
  * a different address included.
  *
- * `chain` is deliberately omitted from the request: the upstream defaults to
- * `ethereum`, and unknown chain names would only trigger its provider
- * fallback path.
+ * `chain` is sent as `all` explicitly: TRM screens the address across every
+ * chain it supports in one request, and the explicit value keeps that
+ * coverage independent of the upstream's default.
  */
 export async function screenAddressUpstream(
   address: string,
@@ -146,7 +146,7 @@ export async function screenAddressUpstream(
         'Content-Type': 'application/json',
         'X-API-Key': apiKey,
       },
-      body: JSON.stringify({ address, vpnIsUsed }),
+      body: JSON.stringify({ address, chain: 'all', vpnIsUsed }),
       redirect: 'error',
     })
 

--- a/tests/server/screen-address.test.ts
+++ b/tests/server/screen-address.test.ts
@@ -188,7 +188,7 @@ describe('POST /api/internal/screen-address', () => {
     }
   })
 
-  it('sends the API key, blocks redirects, and omits chain from the upstream body', async () => {
+  it('sends the API key, blocks redirects, and requests all-chains screening', async () => {
     stubScreeningEnv()
     const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) => cleanVerdict())
     vi.stubGlobal('fetch', fetchMock)
@@ -199,7 +199,7 @@ describe('POST /api/internal/screen-address', () => {
     expect(url).toBe(SCREENING_URI)
     expect((init?.headers as Record<string, string>)['X-API-Key']).toBe(SCREENING_API_KEY)
     expect(init?.redirect).toBe('error')
-    expect(JSON.parse(String(init?.body))).toEqual({ address: USER, vpnIsUsed: null })
+    expect(JSON.parse(String(init?.body))).toEqual({ address: USER, chain: 'all', vpnIsUsed: null })
   })
 
   it('rejects invalid addresses without calling upstream', async () => {


### PR DESCRIPTION
## Summary

Sends `chain: 'all'` explicitly in the upstream body of the data-v3 compliance screening call. TRM accepts `all` as a cross-chain scope on its v2 screening endpoint (verified against the live API), screening the address across every chain TRM supports in one request.

## Context

The data-v3 migration (e96b15f9) omitted `chain` on the stale assumption that unknown chain names only trigger the upstream's ethereum fallback — true before TRM shipped all-chains support in May 2025, not true since. The omission narrowed screening coverage to ethereum-only (visible in the TRM dashboard as ETH-scoped rows). Pinning `all` explicitly restores full coverage immediately and keeps it independent of the upstream default, which is being flipped to `all` in euler-data-v3#524.

## Test plan

- [x] Updated server test asserts the upstream body pins `chain: 'all'`
- [x] `tests/server/screen-address.test.ts` green (13 tests)
- [ ] After deploy: new TRM dashboard rows for app screenings show All Chains

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Screening requests now explicitly check all supported chains, providing consistent results beyond the default Ethereum network.
* **Tests**
  * Added coverage to verify that all-chain screening is requested correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->