### PR TITLE
fix: use hexadecimal build hashes

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -391,7 +391,16 @@ export default defineNuxtConfig({
   },
 
   vite: {
-    build: { target: 'esnext' },
+    build: {
+      target: 'esnext',
+      rolldownOptions: {
+        output: {
+          // Hex hashes cannot contain the case-insensitive "oast" signature
+          // blocked by edge security rules on static asset request paths.
+          hashCharacters: 'hex',
+        },
+      },
+    },
     server: {
       watch: {
         ignored: [

--- a/tests/utils/build-hash-characters.test.ts
+++ b/tests/utils/build-hash-characters.test.ts
@@ -1,0 +1,34 @@
+import { existsSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const CLIENT_BUNDLE_DIR = join(process.cwd(), '.output', 'public', '_nuxt')
+
+describe('client bundle chunk hashes', () => {
+  if (!existsSync(CLIENT_BUNDLE_DIR)) {
+    if (process.env.CI) {
+      it('FAILS — .output/public/_nuxt/ missing under CI (build step likely missing)', () => {
+        expect(false).toBe(true)
+      })
+      return
+    }
+    it.skip('skipped — .output/public/_nuxt/ missing (run `npm run build` first)', () => {})
+    return
+  }
+
+  const jsFiles = readdirSync(CLIENT_BUNDLE_DIR)
+    .filter(file => file.endsWith('.js'))
+
+  it('found at least one client JavaScript chunk to inspect', () => {
+    expect(jsFiles.length).toBeGreaterThan(0)
+  })
+
+  it('uses only hexadecimal characters in JavaScript chunk names', () => {
+    const nonHexFiles = jsFiles.filter(file => !/^[a-f0-9]+\.js$/.test(file))
+
+    expect(
+      nonHexFiles,
+      `found ${nonHexFiles.length} client chunk(s) with non-hexadecimal names`,
+    ).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary
- Prevent edge security rules from rejecting valid static asset requests when generated hashes contain blocked signatures.
- Keep build assets content-addressed while limiting generated hash characters to hexadecimal values.

## Changes
- Configure the Vite 8 Rolldown output to use hexadecimal content hashes.
- Verify production JavaScript chunk names in CI and fail if the required build output is missing.

## Test plan
- [x] Run the production build and inspect emitted client chunk names.
- [x] Run the full Vitest suite.
- [x] Run typecheck.
- [x] Run lint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated production builds to use consistent hexadecimal characters in generated asset filenames.
  * Improved build targeting for modern browsers.

* **Tests**
  * Added automated checks to verify that generated JavaScript bundle filenames follow the expected format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->