### PR TITLE
fix: show oracle route separately from feed label

### DIFF
--- a/components/entities/vault/overview/VaultOverviewBlockOracleAdapters.vue
+++ b/components/entities/vault/overview/VaultOverviewBlockOracleAdapters.vue
@@ -49,6 +49,7 @@ const knownSymbols = computed(() => {
 
   props.collateralVaults?.forEach((vault) => {
     map.set(vault.address.toLowerCase(), vault.asset.symbol)
+    map.set(vault.asset.address.toLowerCase(), vault.asset.symbol)
   })
 
   return map
@@ -203,7 +204,7 @@ const getChecksModalData = (adapter: OracleAdapterView) => ({
             </button>
           </div>
         </div>
-        <div class="grid grid-cols-2 md:grid-cols-4 gap-12 text-p3">
+        <div class="grid grid-cols-2 md:grid-cols-5 gap-12 text-p3">
           <div class="flex flex-col gap-4">
             <span class="text-content-tertiary">Provider</span>
             <div class="flex items-center gap-8">
@@ -221,13 +222,13 @@ const getChecksModalData = (adapter: OracleAdapterView) => ({
               <span class="text-content-primary">{{ adapter.provider || 'Unknown' }}</span>
             </div>
           </div>
-          <div class="flex flex-col gap-4 order-3 md:order-2">
+          <div class="flex flex-col gap-4">
             <span class="text-content-tertiary">Methodology</span>
             <span class="text-content-primary">{{ adapter.methodology || 'Unknown' }}</span>
           </div>
           <UiModalPreviewTrigger
             v-if="adapter.checks?.length"
-            class="flex flex-col gap-4 order-4 md:order-3 items-start cursor-default text-left"
+            class="flex flex-col gap-4 items-start cursor-default text-left"
             :component="OracleAdapterChecksModal"
             :modal-data="getChecksModalData(adapter)"
             aria-label="Show oracle adapter checks"
@@ -257,7 +258,7 @@ const getChecksModalData = (adapter: OracleAdapterView) => ({
           </UiModalPreviewTrigger>
           <div
             v-else
-            class="flex flex-col gap-4 order-4 md:order-3"
+            class="flex flex-col gap-4"
           >
             <span class="text-content-tertiary">Checks</span>
             <span
@@ -269,7 +270,13 @@ const getChecksModalData = (adapter: OracleAdapterView) => ({
               class="text-content-secondary"
             >N/A</span>
           </div>
-          <div class="flex flex-col gap-4 order-2 md:order-4">
+          <div class="flex flex-col gap-4">
+            <span class="text-content-tertiary">Route</span>
+            <span class="text-content-primary">
+              {{ resolveSymbol(adapter.base) }}/{{ resolveSymbol(adapter.quote) }}
+            </span>
+          </div>
+          <div class="flex flex-col gap-4">
             <span class="text-content-tertiary">Price</span>
             <span
               v-if="isPriceLoading"

--- a/tests/utils/oracle-adapter-views.test.ts
+++ b/tests/utils/oracle-adapter-views.test.ts
@@ -7,6 +7,7 @@ import { buildOracleAdapterView, collectOracleRouteSteps } from '~/utils/oracle-
 
 const oracle = '0x000000000000000000000000000000000000A111' as Address
 const weth = '0x000000000000000000000000000000000000E711' as Address
+const psUsdc = '0x000000000000000000000000000000000000C011' as Address
 const usd = '0x0000000000000000000000000000000000000051' as Address
 
 const adapterStep = (overrides: Partial<OracleRouteStep> = {}): OracleRouteStep => ({
@@ -52,6 +53,24 @@ describe('buildOracleAdapterView', () => {
     expect(view.logo).toBeUndefined()
     expect(view.label).toBeUndefined()
     expect(view.checksStatus).toBeNull()
+  })
+
+  it('keeps the configured route separate from a proxy feed label', () => {
+    const meta: Record<string, OracleAdapterMeta> = {
+      [oracle.toLowerCase()]: {
+        oracle,
+        base: psUsdc,
+        quote: usd,
+        provider: 'Chainlink',
+        methodology: 'Market Price',
+        label: 'USDC / USD (0.25%, 82800s)',
+      },
+    }
+    const view = buildOracleAdapterView(adapterStep({ base: psUsdc }), meta)
+
+    expect(view.label).toEqual({ primary: 'USDC / USD', suffix: '(0.25%, 82800s)' })
+    expect(view.base).toBe(psUsdc)
+    expect(view.quote).toBe(usd)
   })
 
   it('keeps the decoded name and "Exchange Rate" methodology for vault (ERC-4626) steps', () => {


### PR DESCRIPTION
## Summary
- Show each oracle adapter's configured base/quote route independently from its curated feed label.
- Make proxy-feed configurations clear without changing the feed identity, methodology, checks, or price.

## Changes
- Add a Route field between Checks and Price on oracle adapter cards.
- Resolve collateral underlying asset addresses to their symbols for route display.
- Cover a ps-USDC/USD route backed by a USDC/USD feed label with regression coverage.

## Test plan
- [x] `npm run lint` (0 errors; 6 existing warnings)
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm run test:run` (184 files, 1,816 tests)
- [x] Smoke-test the ps-USDC/USDC borrow pair at desktop and mobile widths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visible Route field to vault oracle adapter details.
  * Improved collateral asset identification by displaying asset symbols.

* **UI Improvements**
  * Expanded the adapter details layout to five columns.
  * Updated field ordering for methodology, checks, and price information.

* **Tests**
  * Added coverage for proxy-feed oracle routes and asset metadata handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->