### PR TITLE
Restore spy-mode transaction review preparation

### DIFF
--- a/components/BatchReviewModal.vue
+++ b/components/BatchReviewModal.vue
@@ -433,10 +433,11 @@ const hasTenderlyFailed = computed(() => Boolean(tenderlyUrl.value && tenderlyEr
 const simulateOnTenderly = () => simulateBatchOnTenderly(preparedExecution.value ?? undefined)
 
 const isConfirmDisabled = computed(() =>
-  isSpyMode.value || isExecuting.value || hasPendingDetachedExecution.value || isPreparing.value || isSimulating.value || !canExecuteBatch.value || !!prepareError.value,
+  isSpyMode.value || preparedExecution.value?.readOnly === true || isExecuting.value || hasPendingDetachedExecution.value || isPreparing.value || isSimulating.value || !canExecuteBatch.value || !!prepareError.value,
 )
 const blockedReason = computed(() => {
   if (isSpyMode.value) return 'Connect a wallet to execute — disabled in spy mode'
+  if (preparedExecution.value?.readOnly) return 'This read-only review cannot be executed'
   if (hasFailedOps.value) return 'Resolve the reverting operation to execute'
   if (hasInsufficientBalance.value) return insufficientBalanceMessage.value || 'Not enough balance to execute this batch'
   if (simError.value) return 'This batch would revert — resolve the flagged error'
@@ -451,7 +452,7 @@ let executionHandle: TrackedExecutionHandle | null = null
 const handleExecute = async () => {
   if (isConfirmDisabled.value) return
   const prepared = preparedExecution.value
-  if (!prepared) return
+  if (!prepared || prepared.readOnly) return
   // Latch the wallet classification at submission time; the single-slot gate
   // rejects new submissions while a detached proposal is pending.
   const handle = beginTrackedExecution({ safeAtSubmit: prepared.execution.requestSet.wallet.walletKind === 'safe' })

--- a/components/entities/operation/OperationReviewModal.vue
+++ b/components/entities/operation/OperationReviewModal.vue
@@ -25,7 +25,7 @@ interface REULUnlockInfo {
   daysUntilMaturity: number
 }
 
-const { type, asset, assetIconUrl, reulUnlockInfo, amount, reviewId, reviewDigest, reviewedAccount, reviewedWalletKind, reviewedRequests, reviewedSignatureSlots, externalSubmitting, plan, prepared, calldataPrepared, calldataUsesPlaceholderSignatures, calldataWrapCalls, tenderlyPrepared, tenderlyPlan, tenderlyStateOverrides, displayPlan, signatureSteps: providedSignatureSteps, postSteps, swapFromAsset, swapFromAmount, swapToAsset, swapToAmount, swapMode, swapEstimatedSide, supplyingAssetForBorrow, supplyingAmount, transferAmounts, vaultAmounts, knownAssets, swapQuoteOutputs, confirmLabel: providedConfirmLabel, submittingLabel, quoteFetchedAt, hideExecute, subAccount, marketLabel, allowConfirmWithoutPlan } = defineProps<{
+const { type, asset, assetIconUrl, reulUnlockInfo, amount, reviewId, reviewDigest, reviewedAccount, reviewedWalletKind, reviewedRequests, reviewedSignatureSlots, externalSubmitting, plan, prepared, calldataPrepared, calldataUsesPlaceholderSignatures, calldataWrapCalls, tenderlyPrepared, tenderlyPlan, tenderlyStateOverrides, displayPlan, signatureSteps: providedSignatureSteps, postSteps, swapFromAsset, swapFromAmount, swapToAsset, swapToAmount, swapMode, swapEstimatedSide, supplyingAssetForBorrow, supplyingAmount, transferAmounts, vaultAmounts, knownAssets, swapQuoteOutputs, confirmLabel: providedConfirmLabel, submittingLabel, quoteFetchedAt, hideExecute, readOnly, subAccount, marketLabel, allowConfirmWithoutPlan } = defineProps<{
   type?: 'supply' | 'withdraw' | 'borrow' | 'repay' | 'swap' | 'transfer' | 'refinance' | 'migration' | 'reward' | 'brevis-reward' | 'fuul-reward' | 'turtle-reward' | 'reul-unlock' | 'disableCollateral' | 'swap-supply' | 'swap-withdraw' | 'swap-borrow'
   asset: VaultAsset
   assetIconUrl?: string
@@ -86,6 +86,8 @@ const { type, asset, assetIconUrl, reulUnlockInfo, amount, reviewId, reviewDiges
   quoteFetchedAt?: number | null
   /** Read-only review (e.g. opened from a batch item): hides the execute button. */
   hideExecute?: boolean
+  /** Prepared without a live wallet binding; it can be inspected but not submitted. */
+  readOnly?: boolean
   /** Overrides the inferred Euler product name for non-product contexts, such as Earn vaults. */
   marketLabel?: string
   /** Allow display-step-only reviews when the executable plan needs a confirm-time wallet authorization first. */
@@ -414,10 +416,11 @@ const isSwapQuoteStale = computed(() => {
 
 const permit2DisclaimerText = 'You are granting the Permit2 contract an unlimited token allowance. Permit2 is a Uniswap contract used to authorize future transfers with signatures. Each future transfer still requires your explicit signature and can be limited by amount and duration.'
 const hasDisplayOnlyConfirmation = computed(() => allowConfirmWithoutPlan && (displaySteps.value.length > 0 || signatureSteps.value.length > 0))
-const isConfirmDisabled = computed(() => isSpyMode.value || internalSubmitting.value || hasPendingDetachedExecution.value || isPreparingPlan.value || isResolvingStateOverrideHints.value || !!prepareError.value || (!reviewPlan.value?.length && !hasDisplayOnlyConfirmation.value))
+const isConfirmDisabled = computed(() => readOnly || isSpyMode.value || internalSubmitting.value || hasPendingDetachedExecution.value || isPreparingPlan.value || isResolvingStateOverrideHints.value || !!prepareError.value || (!reviewPlan.value?.length && !hasDisplayOnlyConfirmation.value))
 const isTenderlyPreparing = computed(() => isTenderlySimulating.value || isBuildingTenderlyPayload.value)
 const confirmLabel = computed(() => {
   if (isSpyMode.value) return 'Spy mode (read-only)'
+  if (readOnly) return 'Read-only review'
   if (hasPendingDetachedExecution.value && !internalSubmitting.value) return 'Awaiting Safe signatures…'
   if (isPreparingPlan.value || isResolvingStateOverrideHints.value) return 'Preparing...'
   return internalSubmitting.value && submittingLabel ? submittingLabel : (providedConfirmLabel || btnLabel.value)

--- a/composables/useExecutionReview.ts
+++ b/composables/useExecutionReview.ts
@@ -1,6 +1,6 @@
 import type { Hash, StateOverride } from 'viem'
 import type { TransactionPlanPrepared } from '@eulerxyz/euler-v2-sdk'
-import { ReviewedOperationModal } from '#components'
+import { OperationReviewModal, ReviewedOperationModal } from '#components'
 import { useModal } from '~/components/ui/composables/useModal'
 import type { OperationIntent } from '~/features/reviewed-execution/domain/intents'
 import type { SubmissionResult } from '~/features/reviewed-execution/coordinator/coordinator'
@@ -30,11 +30,37 @@ export interface OpenExecutionReviewOptions {
 export const useExecutionReview = () => {
   const modal = useModal()
   const execution = useReviewedExecution()
+  const { isSpyMode } = useEffectiveAddress()
 
   const open = async (
     intents: readonly OperationIntent[],
     options: OpenExecutionReviewOptions,
   ): Promise<{ reviewId: Hash, reviewDigest: Hash }> => {
+    if (isSpyMode.value) {
+      const prepared = await execution.prepareReadOnly(intents, {
+        presentationKind: options.presentationKind,
+        presentationInputs: options.review,
+      })
+      modal.open(OperationReviewModal, {
+        props: {
+          ...options.review,
+          plan: undefined,
+          prepared: prepared.prepared,
+          calldataPrepared: prepared.prepared,
+          tenderlyPrepared: options.tenderlyPrepared ?? prepared.prepared,
+          tenderlyStateOverrides: options.tenderlyStateOverrides,
+          reviewedAccount: prepared.execution.requestSet.wallet.account,
+          reviewedWalletKind: prepared.execution.requestSet.wallet.walletKind,
+          reviewedRequests: prepared.execution.requestSet.requests,
+          reviewedSignatureSlots: prepared.execution.requestSet.signatureSlots,
+          readOnly: true,
+        },
+      })
+      return {
+        reviewId: prepared.execution.reviewId,
+        reviewDigest: prepared.execution.reviewDigest,
+      }
+    }
     const prepared = await execution.prepare(intents, {
       presentationKind: options.presentationKind,
       presentationInputs: options.review,

--- a/composables/useReviewedExecution.ts
+++ b/composables/useReviewedExecution.ts
@@ -42,6 +42,8 @@ const COMPILER_VERSION = 'lite-reviewed-execution-v2'
 const CLASSIFICATION_VERSION = 'safe-classification-v2'
 const POLICY_VERSION = 'lite-policy-v2'
 const PREPARATION_CACHE_TTL_MS = 60_000
+const READ_ONLY_CONNECTOR_ID = 'spy-mode-read-only'
+const READ_ONLY_CLASSIFICATION_VERSION = 'spy-mode-read-only-v1'
 
 const PERMIT2_ALLOWANCE_ABI = [{
   type: 'function',
@@ -80,6 +82,8 @@ export interface PreparedExecutionReview {
   execution: Readonly<ReviewedExecution>
   previewPlan: TransactionPlan
   prepared: TransactionPlanPrepared
+  /** Read-only previews are never registered as execution authority. */
+  readOnly?: true
 }
 
 const cache = new PreparationCache()
@@ -157,6 +161,32 @@ const captureWalletBinding = async (
   }
 }
 
+export const createReadOnlyWalletBinding = ({
+  account,
+  chainId,
+  subAccounts,
+}: {
+  account: Address
+  chainId: number
+  subAccounts: readonly Address[]
+}): WalletBinding => {
+  const normalizedAccount = getAddress(account)
+  const normalizedSubAccounts = subAccounts.map(getAddress)
+  return {
+    chainId,
+    account: normalizedAccount,
+    subAccounts: normalizedSubAccounts,
+    connectorId: READ_ONLY_CONNECTOR_ID,
+    connectorSessionId: canonicalDigest('spy-mode-read-only-session-v1', toCanonicalValue({
+      account: normalizedAccount,
+      chainId,
+    })),
+    walletKind: 'eoa',
+    classificationVersion: READ_ONLY_CLASSIFICATION_VERSION,
+    approvalMode: 'approve',
+  }
+}
+
 const loadPlanningAccount = async (owner: Address, chainId: number): Promise<Account<IHasVaultAddress>> => {
   const warmed = useFreshAccount().account.value
   if (warmed) {
@@ -201,20 +231,39 @@ export const useReviewedExecution = () => {
   const { signTypedDataAsync } = useSignTypedData()
   const { signaturesEnabled } = useSignaturePreference()
   const { triggerPortfolioRefresh } = usePortfolioRefresh()
+  const { isSpyMode, effectiveAddress } = useEffectiveAddress()
+  const { chainId: browsedChainId } = useEulerAddresses()
 
-  const prepare = async (intents: readonly OperationIntent[], options: PrepareReviewedExecutionOptions): Promise<PreparedExecutionReview> => {
+  const prepareForMode = async (
+    intents: readonly OperationIntent[],
+    options: PrepareReviewedExecutionOptions,
+    readOnly: boolean,
+  ): Promise<PreparedExecutionReview> => {
     validateIntentSet(intents)
     const publisher = options.generation ?? new GenerationPublisher()
     const cartGeneration = options.cartGeneration ?? publisher.advance()
     if (options.cartGeneration !== undefined) publisher.assertCurrent(cartGeneration)
-    const captured = await captureWalletBinding(config, signaturesEnabled.value)
-    publisher.assertCurrent(cartGeneration)
     const requirements = collectPlanningRequirements(intents)
+    const capturePreparationBinding = async (): Promise<WalletBinding> => {
+      if (!readOnly) return captureWalletBinding(config, signaturesEnabled.value)
+      const currentAccount = effectiveAddress.value
+      const currentChainId = browsedChainId.value
+      if (!isSpyMode.value || !currentAccount || !currentChainId) {
+        throw new Error('Spy-mode review context is unavailable')
+      }
+      return createReadOnlyWalletBinding({
+        account: getAddress(currentAccount),
+        chainId: currentChainId,
+        subAccounts: requirements.accounts,
+      })
+    }
+    const captured = await capturePreparationBinding()
+    publisher.assertCurrent(cartGeneration)
     if (requirements.chainId !== captured.chainId || requirements.owner !== captured.account) throw new Error('Intent context does not match the connected wallet')
     const wallet: WalletBinding = { ...captured, subAccounts: requirements.accounts }
     const assertPreparationContext = async () => {
       publisher.assertCurrent(cartGeneration)
-      const current = await captureWalletBinding(config, signaturesEnabled.value)
+      const current = await capturePreparationBinding()
       publisher.assertCurrent(cartGeneration)
       assertExactWalletBinding(wallet, { ...current, subAccounts: wallet.subAccounts })
     }
@@ -427,11 +476,8 @@ export const useReviewedExecution = () => {
       after: migrationAfter,
       assertContext: assertPreparationContext,
     })
-    executions.set(execution.reviewId, execution)
-    runtimePluginPlans.set(execution.reviewId, pluginPlans)
-    reviewGenerations.set(execution.reviewId, { publisher, generation: cartGeneration })
     const previewPlan = pluginPlans.previewPlan as unknown as TransactionPlan
-    return {
+    const preparedReview: PreparedExecutionReview = {
       execution,
       previewPlan,
       prepared: {
@@ -443,7 +489,22 @@ export const useReviewedExecution = () => {
         unlimitedApproval: false,
       },
     }
+    if (readOnly) return { ...preparedReview, readOnly: true }
+    executions.set(execution.reviewId, execution)
+    runtimePluginPlans.set(execution.reviewId, pluginPlans)
+    reviewGenerations.set(execution.reviewId, { publisher, generation: cartGeneration })
+    return preparedReview
   }
+
+  const prepare = (
+    intents: readonly OperationIntent[],
+    options: PrepareReviewedExecutionOptions,
+  ): Promise<PreparedExecutionReview> => prepareForMode(intents, options, false)
+
+  const prepareReadOnly = (
+    intents: readonly OperationIntent[],
+    options: PrepareReviewedExecutionOptions,
+  ): Promise<PreparedExecutionReview> => prepareForMode(intents, options, true)
 
   const getReviewedExecution = (reviewId: Hash) => executions.get(reviewId)
 
@@ -684,6 +745,7 @@ export const useReviewedExecution = () => {
 
   return {
     prepare,
+    prepareReadOnly,
     compilePreview,
     compilePreviewForSimulation,
     accept,

--- a/composables/useTxBatch.ts
+++ b/composables/useTxBatch.ts
@@ -259,6 +259,7 @@ let batchExecutionPreparation: {
   generation: number
   intentSetHash: `0x${string}`
   presentationDigest: `0x${string}`
+  readOnly: boolean
   promise: Promise<PreparedExecutionReview>
 } | undefined
 
@@ -1680,7 +1681,7 @@ export const useTxBatch = () => {
   const { compilePreviewForSimulation } = executionService
   const { scheduleExternalMigrationRefreshes } = useExternalMigrationRefresh()
   const { chainId: wagmiChainId } = useWagmi()
-  const { effectiveAddress } = useEffectiveAddress()
+  const { effectiveAddress, isSpyMode } = useEffectiveAddress()
   const { chainId: addressesChainId } = useEulerAddresses()
 
   const owner = computed(
@@ -2352,19 +2353,22 @@ export const useTxBatch = () => {
     const presentationInputs = batchPresentationInputs()
     const intentSetHash = intentSetDigest(intents)
     const presentationDigest = reviewPresentationCacheDigest('batch', presentationInputs)
+    const readOnly = isSpyMode.value
     if (batchExecutionPreparation
       && batchExecutionPreparation.generation === cartGeneration
       && batchExecutionPreparation.intentSetHash === intentSetHash
-      && batchExecutionPreparation.presentationDigest === presentationDigest) {
+      && batchExecutionPreparation.presentationDigest === presentationDigest
+      && batchExecutionPreparation.readOnly === readOnly) {
       return batchExecutionPreparation.promise
     }
-    const promise = executionService.prepare(intents, {
+    const prepare = readOnly ? executionService.prepareReadOnly : executionService.prepare
+    const promise = prepare(intents, {
       presentationKind: 'batch',
       presentationInputs,
       generation: batchGenerationPublisher,
       cartGeneration,
     })
-    batchExecutionPreparation = { generation: cartGeneration, intentSetHash, presentationDigest, promise }
+    batchExecutionPreparation = { generation: cartGeneration, intentSetHash, presentationDigest, readOnly, promise }
     void promise.catch(() => {
       if (batchExecutionPreparation?.promise === promise) batchExecutionPreparation = undefined
     })

--- a/features/reviewed-execution/inventory/registry.ts
+++ b/features/reviewed-execution/inventory/registry.ts
@@ -128,6 +128,7 @@ export const REVIEW_SOURCE_INVENTORY: readonly SourceCountInventoryRow[] = [
   { source: 'composables/repay/useSavingsRepay.ts', expectedOccurrences: 1 },
   { source: 'composables/repay/useWalletRepay.ts', expectedOccurrences: 1 },
   { source: 'composables/repay/useWalletSwapRepay.ts', expectedOccurrences: 1 },
+  { source: 'composables/useExecutionReview.ts', expectedOccurrences: 1 },
   { source: 'composables/useSwapPageLogic.ts', expectedOccurrences: 1 },
   { source: 'pages/earn/[vault]/[subAccount]/withdraw.vue', expectedOccurrences: 1 },
   { source: 'pages/earn/[vault]/index.vue', expectedOccurrences: 1 },

--- a/tests/composables/useExecutionReview.test.ts
+++ b/tests/composables/useExecutionReview.test.ts
@@ -3,9 +3,17 @@ import type { Hash, StateOverride } from 'viem'
 import type { TransactionPlanPrepared } from '@eulerxyz/euler-v2-sdk'
 import { useExecutionReview } from '~/composables/useExecutionReview'
 
-const { modalOpen } = vi.hoisted(() => ({ modalOpen: vi.fn() }))
+const { modalOpen, operationModal, reviewedOperationModal, isSpyMode } = vi.hoisted(() => ({
+  modalOpen: vi.fn(),
+  operationModal: { name: 'OperationReviewModal' },
+  reviewedOperationModal: { name: 'ReviewedOperationModal' },
+  isSpyMode: { value: false },
+}))
 
-vi.mock('#components', () => ({ ReviewedOperationModal: {} }))
+vi.mock('#components', () => ({
+  OperationReviewModal: operationModal,
+  ReviewedOperationModal: reviewedOperationModal,
+}))
 vi.mock('~/components/ui/composables/useModal', () => ({
   useModal: () => ({ open: modalOpen }),
 }))
@@ -16,6 +24,8 @@ const reviewDigest = `0x${'2'.repeat(64)}` as Hash
 describe('useExecutionReview', () => {
   beforeEach(() => {
     modalOpen.mockReset()
+    isSpyMode.value = false
+    vi.stubGlobal('useEffectiveAddress', () => ({ isSpyMode }))
   })
 
   afterEach(() => {
@@ -58,6 +68,68 @@ describe('useExecutionReview', () => {
       calldataPrepared: executablePrepared,
       tenderlyPrepared,
       tenderlyStateOverrides,
+    })
+  })
+
+  it('opens a non-executable prepared preview in spy mode', async () => {
+    isSpyMode.value = true
+    const readOnlyPrepared = { chainId: 1, plan: [{ type: 'preview' }] } as unknown as TransactionPlanPrepared
+    const requests = [{
+      requestId: `0x${'3'.repeat(64)}`,
+      chainId: 1,
+      from: '0x1000000000000000000000000000000000000000',
+      to: '0x2000000000000000000000000000000000000000',
+      data: '0x1234',
+      value: 0n,
+      effectIds: [],
+      phase: 'core',
+    }]
+    const prepare = vi.fn()
+    const prepareReadOnly = vi.fn(async () => ({
+      execution: {
+        reviewId,
+        reviewDigest,
+        requestSet: {
+          wallet: {
+            account: '0x1000000000000000000000000000000000000000',
+            walletKind: 'eoa',
+          },
+          requests,
+          signatureSlots: [],
+        },
+      },
+      prepared: readOnlyPrepared,
+      readOnly: true,
+    }))
+    vi.stubGlobal('useReviewedExecution', () => ({ prepare, prepareReadOnly }))
+    const review = {
+      asset: { address: '0x2000000000000000000000000000000000000000', symbol: 'USDC', decimals: 6 },
+      amount: '1',
+      type: 'repay',
+    }
+
+    await useExecutionReview().open([], {
+      presentationKind: 'repay',
+      review,
+    })
+
+    expect(prepare).not.toHaveBeenCalled()
+    expect(prepareReadOnly).toHaveBeenCalledWith([], {
+      presentationKind: 'repay',
+      presentationInputs: review,
+    })
+    expect(modalOpen).toHaveBeenCalledWith(operationModal, {
+      props: expect.objectContaining({
+        ...review,
+        prepared: readOnlyPrepared,
+        calldataPrepared: readOnlyPrepared,
+        tenderlyPrepared: readOnlyPrepared,
+        reviewedAccount: '0x1000000000000000000000000000000000000000',
+        reviewedWalletKind: 'eoa',
+        reviewedRequests: requests,
+        reviewedSignatureSlots: [],
+        readOnly: true,
+      }),
     })
   })
 })

--- a/tests/composables/useTxBatch.test.ts
+++ b/tests/composables/useTxBatch.test.ts
@@ -56,6 +56,7 @@ const executionMocks = {
     return { reviewedPlan: plan, plan }
   }),
   prepare: vi.fn(async () => { throw new Error('authoritative preparation not configured in batch unit test') }),
+  prepareReadOnly: vi.fn(async () => { throw new Error('read-only preparation not configured in batch unit test') }),
 }
 const scheduleExternalMigrationRefreshes = vi.fn()
 const position = (account: Address, shares: bigint) => ({
@@ -312,6 +313,7 @@ beforeEach(() => {
   executionMocks.compilePreview.mockClear()
   executionMocks.compilePreviewForSimulation.mockClear()
   executionMocks.prepare.mockClear()
+  executionMocks.prepareReadOnly.mockClear()
   scheduleExternalMigrationRefreshes.mockReset()
   testIntentPlans.clear()
   testIntentSequence = 0
@@ -1476,6 +1478,31 @@ describe('useTxBatch execution errors', () => {
 
     await expect(batch.prepareBatchExecutionReview()).resolves.toBe(warmed)
     expect(executionMocks.prepare).toHaveBeenCalledOnce()
+  })
+
+  it('warms and adopts read-only multi-operation batch preparation in spy mode', async () => {
+    const spyMode = ref(true)
+    vi.stubGlobal('useEffectiveAddress', () => ({
+      address: ref(undefined),
+      isConnected: ref(false),
+      isSpyMode: spyMode,
+      spyAddress: ref(owner),
+      effectiveAddress: ref(owner),
+    }))
+    const batch = useTxBatch()
+    const firstIntent = intentFor([] as TransactionPlan, [subAccount])
+    const warmed = { execution: { reviewId: '0x01' }, previewPlan: [], prepared: {}, readOnly: true }
+    executionMocks.prepareReadOnly.mockResolvedValue(warmed as never)
+
+    await batch.addEntry({ intent: firstIntent, label: 'Repay USDC', subAccount, review: { type: 'repay' } })
+    await vi.waitFor(() => expect(executionMocks.prepareReadOnly).toHaveBeenCalledOnce())
+    const secondIntent = intentFor([] as TransactionPlan, [subAccount])
+    await batch.addEntry({ intent: secondIntent, label: 'Repay RLUSD', subAccount, review: { type: 'repay' } })
+    await vi.waitFor(() => expect(executionMocks.prepareReadOnly).toHaveBeenCalledTimes(2))
+
+    await expect(batch.prepareBatchExecutionReview()).resolves.toBe(warmed)
+    expect(executionMocks.prepare).not.toHaveBeenCalled()
+    expect(executionMocks.prepareReadOnly).toHaveBeenCalledTimes(2)
   })
 
   it('clears failed execution messages when the batch is cleared', () => {

--- a/tests/reviewed-execution/reviewed-execution.test.ts
+++ b/tests/reviewed-execution/reviewed-execution.test.ts
@@ -12,6 +12,7 @@ import { PreparationCache, type PreparationCacheIdentity } from '~/features/revi
 import { assertPolicyVersionsMatch, buildReviewedPolicy, collectPolicyRequirements, collectPolicySubjects, type PolicyResultInput } from '~/features/reviewed-execution/policy/engine'
 import { buildReviewedSimulation, validateSimulationCoverage } from '~/features/reviewed-execution/simulation/coverage'
 import { createOperationIntent } from '~/features/reviewed-execution/domain/factory'
+import { createReadOnlyWalletBinding } from '~/composables/useReviewedExecution'
 import { makeSwapQuote } from './swap-quote.test-fixture'
 
 const ACCOUNT = getAddress('0x1000000000000000000000000000000000000000')
@@ -61,6 +62,29 @@ const policyResultsFor = (requestSet: ReturnType<typeof materializePreparedPlan>
   collectPolicyRequirements(requestSet).map(requirement => ({ ...requirement, result: allowed() }))
 
 describe('reviewed execution semantic kernel', () => {
+  it('uses a deterministic approval-only wallet binding for spy previews', () => {
+    const binding = createReadOnlyWalletBinding({
+      account: ACCOUNT,
+      chainId: 1,
+      subAccounts: [ACCOUNT, VAULT],
+    })
+
+    expect(binding).toMatchObject({
+      chainId: 1,
+      account: ACCOUNT,
+      subAccounts: [ACCOUNT, VAULT],
+      connectorId: 'spy-mode-read-only',
+      walletKind: 'eoa',
+      classificationVersion: 'spy-mode-read-only-v1',
+      approvalMode: 'approve',
+    })
+    expect(binding.connectorSessionId).toBe(createReadOnlyWalletBinding({
+      account: ACCOUNT,
+      chainId: 1,
+      subAccounts: [ACCOUNT],
+    }).connectorSessionId)
+  })
+
   it('rejects unbounded variable intents and mixed contexts', () => {
     expect(() => validateIntentSet([{ ...intent, constraints: [] }])).toThrow(/no bounded outcome/)
     expect(() => validateIntentSet([intent, { ...intent, intentId: 'intent-2', account: VAULT }])).toThrow(/mixes wallet/)


### PR DESCRIPTION
## Summary
- restore direct and multi-operation batch review preparation for spy-mode accounts
- prepare complete read-only calldata and Tenderly inputs without requiring a connected wallet
- keep spy-mode preparations outside executable reviewed-execution authority

## Root cause
PR #822 routed review through strict connected-wallet capture. Spy mode has an effective account but no connector, so preparation failed before the review modal could render.

## Changes
- add deterministic approval-only wallet binding for spy-mode preparation
- route direct and batch spy reviews through the read-only path
- retain independent execution guards in both review surfaces
- add direct and two-operation batch regression coverage

## Test plan
- [x] npm run build
- [x] npm run lint
- [x] npm run typecheck
- [x] npm run test:run
- [x] local spy-mode direct review renders with Copy calldata and Tenderly available
- [x] local spy-mode batch review renders without Preparation failed while Execute remains disabled